### PR TITLE
Remove TPZ branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN apt clean
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set env variables to override the configuration settings
-ENV TPZ_DB_HOST=db
-ENV TPZ_DB_PORT=3306
-ENV TPZ_DB_USER=xiadmin
-ENV TPZ_DB_USER_PASSWD=notarealpassword
-ENV TPZ_DB_NAME=xidb
+ENV XI_DB_HOST=db
+ENV XI_DB_PORT=3306
+ENV XI_DB_USER=xiadmin
+ENV XI_DB_USER_PASSWD=notarealpassword
+ENV XI_DB_NAME=xidb
 
 # Working directory will be /topaz meaning that the contents of topaz will exist in /topaz
 WORKDIR /topaz

--- a/wait_for_db_then_launch.sh
+++ b/wait_for_db_then_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while ! mysql --host=$TPZ_DB_HOST --port=$TPZ_DB_PORT --user=$TPZ_DB_USER --password=$TPZ_DB_USER_PASSWD -e "USE $TPZ_DB_NAME; SELECT 1 FROM zone_weather LIMIT 1"; do
+while ! mysql --host=$XI_DB_HOST --port=$XI_DB_PORT --user=$XI_DB_USER --password=$XI_DB_USER_PASSWD -e "USE $XI_DB_NAME; SELECT 1 FROM zone_weather LIMIT 1"; do
     sleep 5
 done
 sleep 5


### PR DESCRIPTION
Remove TPZ brand from Dockerfile and wait_for_db_then_launch.sh

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/release/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
