### PR TITLE
Remove Dia spells attribute and remove duplicate params.

### DIFF
--- a/scripts/globals/spells/dia.lua
+++ b/scripts/globals/spells/dia.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 1
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 2, should always do at least 1
     dmg = utils.clamp(dmg, 1, 2)
     -- Get resist multiplier (1x if no resist)

--- a/scripts/globals/spells/dia.lua
+++ b/scripts/globals/spells/dia.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 1
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 3
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 3
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 8, should always do at least 1
     dmg = utils.clamp(dmg, 1, 8)
     -- Get resist multiplier (1x if no resist)

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 5
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 5
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 32, should always do at least 1
     dmg = utils.clamp(dmg, 1, 32)
     -- Get resist multiplier (1x if no resist)

--- a/scripts/globals/spells/diaga.lua
+++ b/scripts/globals/spells/diaga.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 1
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/diaga.lua
+++ b/scripts/globals/spells/diaga.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 1
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 12, should always do at least 1
     dmg = utils.clamp(dmg, 1, 12)
     -- Get resist multiplier (1x if no resist)

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 3
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 3
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 40, should always do at least 1
     dmg = utils.clamp(dmg, 1, 40)
     -- Get resist multiplier (1x if no resist)

--- a/scripts/globals/spells/diaga_iii.lua
+++ b/scripts/globals/spells/diaga_iii.lua
@@ -20,11 +20,9 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 5
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.INT
+    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.ENFEEBLING_MAGIC
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
     params.bonus = 1.0
 
     -- Calculate raw damage

--- a/scripts/globals/spells/diaga_iii.lua
+++ b/scripts/globals/spells/diaga_iii.lua
@@ -20,13 +20,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     params.dmg = basedmg
     params.multiplier = 5
     params.skillType = xi.skill.ENFEEBLING_MAGIC
-    params.attribute = xi.mod.MND
     params.hasMultipleTargetReduction = false
-    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.diff = 0
     params.bonus = 1.0
 
     -- Calculate raw damage
-    local dmg = calculateMagicDamage(caster, target, spell, params)
+    local dmg = basedmg
     -- Softcaps at 60, should always do at least 1
     dmg = utils.clamp(dmg, 1, 60)
     -- Get resist multiplier (1x if no resist)


### PR DESCRIPTION
Removed all 6 Dia spells attribute. 
Source: https://translate.google.com/translate?hl=en&sl=ja&tl=en&u=http%3A%2F%2Fwiki.ffo.jp%2Fhtml%2F338.html

Also removed from all 6 scripts 2 duplicate params, becouse why not.
It hasn't broken anything from my testing.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/release/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
