### PR TITLE
Convert Warrior abilities to job_utils script

### DIFF
--- a/scripts/globals/abilities/aggressor.lua
+++ b/scripts/globals/abilities/aggressor.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkAggressor(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/aggressor.lua
+++ b/scripts/globals/abilities/aggressor.lua
@@ -1,22 +1,17 @@
 -----------------------------------
 -- Ability: Aggressor
--- Enhances accuracy but impairs evasion.
--- Obtained: Warrior Level 45
--- Recast Time: 5:00
--- Duration: 3:00
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkAggressor(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    local merits = player:getMerit(xi.merit.AGGRESSIVE_AIM)
-    player:addStatusEffect(xi.effect.AGGRESSOR, merits, 0, 180 + player:getMod(xi.mod.AGGRESSOR_DURATION))
+    xi.job_utils.warrior.useAggressor(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/berserk.lua
+++ b/scripts/globals/abilities/berserk.lua
@@ -1,23 +1,17 @@
 -----------------------------------
 -- Ability: Berserk
--- Enhances attacks but weakens defense.
--- Obtained: Warrior Level 15
--- Recast Time: 5:00
--- Duration: 3:00
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkBerserk(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.BERSERK, 25 + player:getMod(xi.mod.BERSERK_EFFECT), 0, 180 + player:getMod(xi.mod.BERSERK_DURATION))
-
-    return xi.effect.BERSERK
+    xi.job_utils.warrior.useBerserk(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/berserk.lua
+++ b/scripts/globals/abilities/berserk.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkBerserk(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/blood_rage.lua
+++ b/scripts/globals/abilities/blood_rage.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkBloodRage(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/blood_rage.lua
+++ b/scripts/globals/abilities/blood_rage.lua
@@ -1,21 +1,17 @@
 -----------------------------------
 -- Ability: Blood Rage
--- Description: Enhances critical hit rate for party members within area of effect.
--- Obtained: WAR Level 87
--- Recast Time: 00:05:00
--- Duration: 0:00:30
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkBloodRage(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.BLOOD_RAGE, 1, 0, 30)
+    xi.job_utils.warrior.useBloodRage(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/defender.lua
+++ b/scripts/globals/abilities/defender.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkDefender(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/defender.lua
+++ b/scripts/globals/abilities/defender.lua
@@ -1,21 +1,17 @@
 -----------------------------------
 -- Ability: Defender
--- Enhances defense but weakens attacks.
--- Obtained: Warrior Level 25
--- Recast Time: 3:00
--- Duration: 3:00
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkDefender(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.DEFENDER, 1, 0, 180 + player:getMod(xi.mod.DEFENDER_DURATION))
+    xi.job_utils.warrior.useDefender(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/mighty_strikes.lua
+++ b/scripts/globals/abilities/mighty_strikes.lua
@@ -1,22 +1,17 @@
 -----------------------------------
 -- Ability: Mighty Strikes
--- Turns all melee attacks into critical hits.
--- Obtained: Warrior Level 1
--- Recast Time: 1:00:00
--- Duration: 0:00:45
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
-    return 0, 0
+    return xi.job_utils.warrior.checkMightyStrikes(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.MIGHTY_STRIKES, 1, 0, 45)
+    xi.job_utils.warrior.useMightyStrikes(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/provoke.lua
+++ b/scripts/globals/abilities/provoke.lua
@@ -1,18 +1,17 @@
 -----------------------------------
 -- Ability: Provoke
--- Goads an enemy into attacking you.
--- Obtained: Warrior Level 5
--- Recast Time: 0:30
--- Duration: 30 seconds
+-- Job: Warrior
+-----------------------------------
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkProvoke(player, target, ability)
 end
 
 ability_object.onUseAbility = function(user, target, ability)
-    --leave blank please! This file will be deleted when the core is updated.
+    xi.job_utils.warrior.useProvoke(user, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/provoke.lua
+++ b/scripts/globals/abilities/provoke.lua
@@ -7,11 +7,11 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkProvoke(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(user, target, ability)
-    xi.job_utils.warrior.useProvoke(user, target, ability)
+    --Leave blank.
 end
 
 return ability_object

--- a/scripts/globals/abilities/provoke.lua
+++ b/scripts/globals/abilities/provoke.lua
@@ -2,8 +2,6 @@
 -- Ability: Provoke
 -- Job: Warrior
 -----------------------------------
-require("scripts/globals/job_utils/warrior")
------------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)

--- a/scripts/globals/abilities/restraint.lua
+++ b/scripts/globals/abilities/restraint.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Ability: Brazen Rush
+-- Ability: Restraint
 -- Job: Warrior
 -----------------------------------
 require("scripts/globals/job_utils/warrior")
@@ -7,11 +7,11 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkBrazenRush(player, target, ability)
+    return xi.job_utils.warrior.checkRestraint(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useBrazenRush(player, target, ability)
+    xi.job_utils.warrior.useRestraint(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/restraint.lua
+++ b/scripts/globals/abilities/restraint.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkRestraint(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/retaliation.lua
+++ b/scripts/globals/abilities/retaliation.lua
@@ -1,20 +1,17 @@
 -----------------------------------
 -- Ability: Retaliation
--- Allows you to counterattack but reduces movement speed.
--- Obtained: Warrior Level 60
--- Recast Time: 3:00
--- Duration: 3:00
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkRetaliation(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.RETALIATION, 1, 0, 180)
+    xi.job_utils.warrior.useRetaliation(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/retaliation.lua
+++ b/scripts/globals/abilities/retaliation.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkRetaliation(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/tomahawk.lua
+++ b/scripts/globals/abilities/tomahawk.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Ability: Brazen Rush
+-- Ability: Tomahawk
 -- Job: Warrior
 -----------------------------------
 require("scripts/globals/job_utils/warrior")
@@ -7,11 +7,11 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkBrazenRush(player, target, ability)
+    return xi.job_utils.warrior.checkTomahawk(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useBrazenRush(player, target, ability)
+    xi.job_utils.warrior.useTomahawk(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/warcry.lua
+++ b/scripts/globals/abilities/warcry.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkWarcry(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/warcry.lua
+++ b/scripts/globals/abilities/warcry.lua
@@ -1,34 +1,17 @@
 -----------------------------------
 -- Ability: Warcry
--- Enhances attacks of party members within area of effect.
--- Obtained: Warrior Level 35
--- Recast Time: 5:00
--- Duration: 0:30
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkWarcry(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    local merit = player:getMerit(xi.merit.SAVAGERY)
-    local power = 0
-    local duration = 30
-
-    if player:getMainJob() == xi.job.WAR then
-        power = math.floor((player:getMainLvl()/4)+4.75)/256
-    else
-        power = math.floor((player:getSubLvl()/4)+4.75)/256
-    end
-
-    power = power * 100
-    duration = duration + player:getMod(xi.mod.WARCRY_DURATION)
-
-
-    target:addStatusEffect(xi.effect.WARCRY, power, 0, duration, 0, merit)
+    xi.job_utils.warrior.useWarcry(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/warriors_charge.lua
+++ b/scripts/globals/abilities/warriors_charge.lua
@@ -1,22 +1,17 @@
 -----------------------------------
 -- Ability: Warrior's Charge
--- Will double your next attack.
--- Obtained: Warrior Level 75 (Merit)
--- Recast Time: 5:00
--- Duration: 1:00 or next attack
+-- Job: Warrior
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/warrior")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.warrior.checkWarriorsCharge(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    local merits = player:getMerit(xi.merit.WARRIORS_CHARGE)
-    player:addStatusEffect(xi.effect.WARRIOR_S_CHARGE, merits-5, 0, 60)
+    xi.job_utils.warrior.useWarriorsCharge(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/warriors_charge.lua
+++ b/scripts/globals/abilities/warriors_charge.lua
@@ -7,7 +7,7 @@ require("scripts/globals/job_utils/warrior")
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.warrior.checkWarriorsCharge(player, target, ability)
+    return 0, 0
 end
 
 ability_object.onUseAbility = function(player, target, ability)

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -1,0 +1,126 @@
+-----------------------------------
+-- Warrior Job Utilities
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+-----------------------------------
+xi = xi or {}
+xi.job_utils = xi.job_utils or {}
+xi.job_utils.warrior = xi.job_utils.warrior or {}
+
+-----------------------------------
+-- Ability Check Functions
+-----------------------------------
+xi.job_utils.warrior.checkAggressor = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkBerserk = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkBloodRage = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkBrazenRush = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkDefender = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkMightyStrikes = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkProvoke = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkRestraint = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkRetaliation = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkTomahawk = function(player, target, ability)
+    --placeholder
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkWarcry = function(player, target, ability)
+    return 0, 0
+end
+
+xi.job_utils.warrior.checkWarriorsCharge = function(player, target, ability)
+    return 0, 0
+end
+
+-----------------------------------
+-- Ability Use Functions
+-----------------------------------
+xi.job_utils.warrior.useAggressor = function(player, target, ability)
+    local merits = player:getMerit(xi.merit.AGGRESSIVE_AIM)
+    player:addStatusEffect(xi.effect.AGGRESSOR, merits, 0, 180 + player:getMod(xi.mod.AGGRESSOR_DURATION))
+end
+
+xi.job_utils.warrior.useBerserk = function(player, target, ability)
+    player:addStatusEffect(xi.effect.BERSERK, 25 + player:getMod(xi.mod.BERSERK_EFFECT), 0, 180 + player:getMod(xi.mod.BERSERK_DURATION))
+end
+
+xi.job_utils.warrior.useBloodRage = function(player, target, ability)
+    player:addStatusEffect(xi.effect.BLOOD_RAGE, 1, 0, 30)
+end
+
+xi.job_utils.warrior.useBrazenRush = function(player, target, ability)
+    player:addStatusEffect(xi.effect.BRAZEN_STRENGTH, 1, 368, 30)
+end
+
+xi.job_utils.warrior.useDefender = function(player, target, ability)
+    player:addStatusEffect(xi.effect.DEFENDER, 1, 0, 180 + player:getMod(xi.mod.DEFENDER_DURATION))
+end
+
+xi.job_utils.warrior.useMightyStrikes = function(player, target, ability)
+    player:addStatusEffect(xi.effect.MIGHTY_STRIKES, 1, 0, 45)
+end
+
+xi.job_utils.warrior.useProvoke = function(user, target, ability)
+    --Leave blank
+end
+
+xi.job_utils.warrior.useRestraint = function(player, target, ability)
+    --placeholder
+end
+
+xi.job_utils.warrior.useRetaliation = function(player, target, ability)
+    player:addStatusEffect(xi.effect.RETALIATION, 1, 0, 180)
+end
+
+xi.job_utils.warrior.useTomahawk = function(player, target, ability)
+    --placeholder
+end
+
+xi.job_utils.warrior.useWarcry = function(player, target, ability)
+    local merit = player:getMerit(xi.merit.SAVAGERY)
+    local power = 0
+    local duration = 30
+
+    if player:getMainJob() == xi.job.WAR then
+        power = math.floor((player:getMainLvl()/4)+4.75)/256
+    else
+        power = math.floor((player:getSubLvl()/4)+4.75)/256
+    end
+
+    power = power * 100
+    duration = duration + player:getMod(xi.mod.WARCRY_DURATION)
+    target:addStatusEffect(xi.effect.WARCRY, power, 0, duration, 0, merit)
+end
+
+xi.job_utils.warrior.useWarriorsCharge = function(player, target, ability)
+    local merits = player:getMerit(xi.merit.WARRIORS_CHARGE)
+    player:addStatusEffect(xi.effect.WARRIOR_S_CHARGE, merits-5, 0, 60)
+end

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -11,52 +11,18 @@ xi.job_utils.warrior = xi.job_utils.warrior or {}
 -----------------------------------
 -- Ability Check Functions
 -----------------------------------
-xi.job_utils.warrior.checkAggressor = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkBerserk = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkBloodRage = function(player, target, ability)
-    return 0, 0
-end
-
 xi.job_utils.warrior.checkBrazenRush = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkDefender = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
     return 0, 0
 end
 
 xi.job_utils.warrior.checkMightyStrikes = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkProvoke = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkRestraint = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkRetaliation = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
     return 0, 0
 end
 
 xi.job_utils.warrior.checkTomahawk = function(player, target, ability)
-    --placeholder
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkWarcry = function(player, target, ability)
-    return 0, 0
-end
-
-xi.job_utils.warrior.checkWarriorsCharge = function(player, target, ability)
+    --Placeholder code. Needs to check for direction and equiped ammo.
     return 0, 0
 end
 
@@ -77,7 +43,7 @@ xi.job_utils.warrior.useBloodRage = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useBrazenRush = function(player, target, ability)
-    player:addStatusEffect(xi.effect.BRAZEN_STRENGTH, 1, 368, 30)
+    player:addStatusEffect(xi.effect.BRAZEN_RUSH, 100, 3, 30)
 end
 
 xi.job_utils.warrior.useDefender = function(player, target, ability)
@@ -86,10 +52,6 @@ end
 
 xi.job_utils.warrior.useMightyStrikes = function(player, target, ability)
     player:addStatusEffect(xi.effect.MIGHTY_STRIKES, 1, 0, 45)
-end
-
-xi.job_utils.warrior.useProvoke = function(user, target, ability)
-    --Leave blank
 end
 
 xi.job_utils.warrior.useRestraint = function(player, target, ability)


### PR DESCRIPTION
Aiming for consistency, following the steps of far more talented ppl.

2 abilities are yet to be coded, but thats out of the scope of this particular PR. Ability scripts were added anyway, so only warrior.lua has to be edited when they are coded in a not so distant future.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/release/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/release/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
