### PR TITLE
Fixes and cleaning

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -67,16 +67,16 @@ function BluePhysicalSpell(caster, target, spell, params)
     -- worked out from http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
     -- Final D value ??= floor(D+fSTR+WSC) * Multiplier
 
-    local D =  math.floor((magicskill * 0.11)) * 2 + 3
+    local D =  math.floor(magicskill * 0.11) * 2 + 3
     -- cap D
-    if (D > params.duppercap) then
+    if D > params.duppercap then
         D = params.duppercap
     end
 
     -- print("D val is ".. D)
 
     local fStr = BluefSTR(caster:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT))
-    if (fStr > 22) then
+    if fStr > 22 then
         fStr = 22 -- TODO: Smite of Rage doesn't have this cap applied.
     end
 
@@ -108,7 +108,7 @@ function BluePhysicalSpell(caster, target, spell, params)
     -----------------------------------
     -- Get the possible pDIF range and hit rate
     -----------------------------------
-    if (params.offcratiomod == nil) then -- default to attack. Pretty much every physical spell will use this, Cannonball being the exception.
+    if params.offcratiomod == nil then -- default to attack. Pretty much every physical spell will use this, Cannonball being the exception.
         params.offcratiomod = caster:getStat(xi.mod.ATT)
     end
     -- print(params.offcratiomod)
@@ -125,17 +125,17 @@ function BluePhysicalSpell(caster, target, spell, params)
     local hitslanded = 0
     local finaldmg = 0
 
-    while (hitsdone < params.numhits) do
+    while hitsdone < params.numhits do
         local chance = math.random()
-        if (chance <= hitrate) then -- it hit
+        if chance <= hitrate then -- it hit
             -- TODO: Check for shadow absorbs.
 
             -- Generate a random pDIF between min and max
             local pdif = math.random((cratio[1]*1000), (cratio[2]*1000))
-            pdif = pdif/1000
+            pdif = pdif / 1000
 
             -- Apply it to our final D
-            if (hitsdone == 0) then -- only the first hit benefits from multiplier
+            if hitsdone == 0 then -- only the first hit benefits from multiplier
                 finaldmg = finaldmg + (finalD * pdif)
             else
                 finaldmg = finaldmg + ((math.floor(D + fStr + WSC)) * pdif) -- same as finalD but without multiplier (it should be 1.0)
@@ -144,7 +144,9 @@ function BluePhysicalSpell(caster, target, spell, params)
             hitslanded = hitslanded + 1
 
             -- increment target's TP (100TP per hit landed)
-            target:addTP(100)
+            if finaldmg > 0 then
+                target:addTP(100)
+            end
         end
 
         hitsdone = hitsdone + 1
@@ -160,7 +162,7 @@ end
 function BlueMagicalSpell(caster, target, spell, params, statMod)
     local D = caster:getMainLvl() + 2
 
-    if (D > params.duppercap) then
+    if D > params.duppercap then
         D = params.duppercap
     end
 
@@ -171,32 +173,32 @@ function BlueMagicalSpell(caster, target, spell, params, statMod)
     end
 
     local convergenceBonus = 1.0
-    if (caster:hasStatusEffect(xi.effect.CONVERGENCE)) then
+    if caster:hasStatusEffect(xi.effect.CONVERGENCE) then
         convergenceEffect = getStatusEffect(xi.effect.CONVERGENCE)
         local convLvl = convergenceEffect:getPower()
-        if (convLvl == 1) then
+        if convLvl == 1 then
             convergenceBonus = 1.05
-        elseif (convLvl == 2) then
+        elseif convLvl == 2 then
             convergenceBonus = 1.1
-        elseif (convLvl == 3) then
+        elseif convLvl == 3 then
             convergenceBonus = 1.15
         end
     end
 
     local statBonus = 0
     local dStat = 0 -- Please make sure to add an additional stat check if there is to be a spell that uses neither INT, MND, or CHR. None currently exist.
-    if (statMod == INT_BASED) then -- Stat mod is INT
+    if statMod == INT_BASED then -- Stat mod is INT
         dStat = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-        statBonus = (dStat)* params.tMultiplier
-    elseif (statMod == CHR_BASED) then -- Stat mod is CHR
+        statBonus = dStat * params.tMultiplier
+    elseif statMod == CHR_BASED then -- Stat mod is CHR
         dStat = caster:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR)
-        statBonus = (dStat)* params.tMultiplier
-    elseif (statMod == MND_BASED) then -- Stat mod is MND
+        statBonus = dStat * params.tMultiplier
+    elseif statMod == MND_BASED then -- Stat mod is MND
         dStat = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
-        statBonus = (dStat)* params.tMultiplier
+        statBonus = dStat * params.tMultiplier
     end
 
-    D =(((D + ST) * params.multiplier * convergenceBonus) + statBonus)
+    D = ((D + ST) * params.multiplier * convergenceBonus) + statBonus
 
     -- At this point according to wiki we apply standard magic attack calculations
 
@@ -217,14 +219,14 @@ function BlueMagicalSpell(caster, target, spell, params, statMod)
 end
 
 function BlueFinalAdjustments(caster, target, spell, dmg, params)
-    if (dmg < 0) then
+    if dmg < 0 then
         dmg = 0
     end
 
     dmg = dmg * BLUE_POWER
 
     dmg = dmg - target:getMod(xi.mod.PHALANX)
-    if (dmg < 0) then
+    if dmg < 0 then
         dmg = 0
     end
 
@@ -256,39 +258,39 @@ end
 function BluecRatio(ratio, atk_lvl, def_lvl)
     -- Level penalty...
     local levelcor = 0
-    if (atk_lvl < def_lvl) then
+    if atk_lvl < def_lvl then
         levelcor = 0.05 * (def_lvl - atk_lvl)
     end
     ratio = ratio - levelcor
 
     -- apply caps
-    if (ratio<0) then
+    if ratio < 0 then
         ratio = 0
-    elseif (ratio>2) then
+    elseif ratio > 2 then
         ratio = 2
     end
 
     -- Obtaining cRatio_MIN
     local cratiomin = 0
-    if (ratio<1.25) then
+    if ratio < 1.25 then
         cratiomin = 1.2 * ratio - 0.5
-    elseif (ratio>=1.25 and ratio<=1.5) then
+    elseif ratio >= 1.25 and ratio <= 1.5 then
         cratiomin = 1
-    elseif (ratio>1.5 and ratio<=2) then
+    elseif ratio > 1.5 and ratio <= 2 then
         cratiomin = 1.2 * ratio - 0.8
     end
 
     -- Obtaining cRatio_MAX
     local cratiomax = 0
-    if (ratio<0.5) then
+    if ratio < 0.5 then
         cratiomax = 0.4 + 1.2 * ratio
-    elseif (ratio<=0.833 and ratio>=0.5) then
+    elseif ratio <= 0.833 and ratio >= 0.5 then
         cratiomax = 1
-    elseif (ratio<=2 and ratio>0.833) then
+    elseif ratio <= 2 and ratio > 0.833 then
         cratiomax = 1.2 * ratio
     end
     cratio = {}
-    if (cratiomin < 0) then
+    if cratiomin < 0 then
         cratiomin = 0
     end
     cratio[1] = cratiomin
@@ -302,11 +304,11 @@ end
 -- ftp2 - The TP 150% value
 -- ftp3 - The TP 300% value
 function BluefTP(tp, ftp1, ftp2, ftp3)
-    if (tp >= 0 and tp < 1500) then
-        return ftp1 + ( ((ftp2-ftp1)/100) * (tp / 10))
-    elseif (tp >= 1500 and tp <= 3000) then
+    if tp >= 0 and tp < 1500 then
+        return ftp1 + ( ((ftp2 - ftp1) / 100) * (tp / 10))
+    elseif tp >= 1500 and tp <= 3000 then
         -- generate a straight line between ftp2 and ftp3 and find point @ tp
-        return ftp2 + ( ((ftp3-ftp2)/100) * ((tp-1500) / 10))
+        return ftp2 + ( ((ftp3 - ftp2) / 100) * ((tp - 1500) / 10))
     else
         print("blue fTP error: TP value is not between 0-3000!")
     end
@@ -315,22 +317,22 @@ end
 
 function BluefSTR(dSTR)
     local fSTR2 = nil
-    if (dSTR >= 12) then
-        fSTR2 = ((dSTR+4)/2)
-    elseif (dSTR >= 6) then
-        fSTR2 = ((dSTR+6)/2)
-    elseif (dSTR >= 1) then
-        fSTR2 = ((dSTR+7)/2)
-    elseif (dSTR >= -2) then
-        fSTR2 = ((dSTR+8)/2)
-    elseif (dSTR >= -7) then
-        fSTR2 = ((dSTR+9)/2)
-    elseif (dSTR >= -15) then
-        fSTR2 = ((dSTR+10)/2)
-    elseif (dSTR >= -21) then
-        fSTR2 = ((dSTR+12)/2)
+    if dSTR >= 12 then
+        fSTR2 = (dSTR + 4) / 2
+    elseif dSTR >= 6 then
+        fSTR2 = (dSTR + 6) / 2
+    elseif dSTR >= 1 then
+        fSTR2 = (dSTR + 7) / 2
+    elseif dSTR >= -2 then
+        fSTR2 = (dSTR + 8) / 2
+    elseif dSTR >= -7 then
+        fSTR2 = (dSTR + 9) / 2
+    elseif dSTR >= -15 then
+        fSTR2 = (dSTR + 10) / 2
+    elseif dSTR >= -21 then
+        fSTR2 = (dSTR + 12) / 2
     else
-        fSTR2 = ((dSTR+13)/2)
+        fSTR2 = (dSTR + 13) / 2
     end
 
     return fSTR2
@@ -340,31 +342,31 @@ function BlueGetHitRate(attacker, target, capHitRate)
     local acc = attacker:getACC()
     local eva = target:getEVA()
 
-    if (attacker:getMainLvl() > target:getMainLvl()) then -- acc bonus!
-        acc = acc + ((attacker:getMainLvl()-target:getMainLvl())*4)
-    elseif (attacker:getMainLvl() < target:getMainLvl()) then -- acc penalty :(
-        acc = acc - ((target:getMainLvl()-attacker:getMainLvl())*4)
+    if attacker:getMainLvl() > target:getMainLvl() then -- acc bonus!
+        acc = acc + ((attacker:getMainLvl() - target:getMainLvl()) * 4)
+    elseif attacker:getMainLvl() < target:getMainLvl() then -- acc penalty :(
+        acc = acc - ((target:getMainLvl() - attacker:getMainLvl()) * 4)
     end
 
     local hitdiff = 0
     local hitrate = 75
-    if (acc>eva) then
-    hitdiff = (acc-eva)/2
+    if acc > eva then
+        hitdiff = (acc - eva) / 2
     end
-    if (eva>acc) then
-    hitdiff = ((-1)*(eva-acc))/2
+    if eva > acc then
+        hitdiff = (-1 * (eva - acc)) / 2
     end
 
-    hitrate = hitrate+hitdiff
-    hitrate = hitrate/100
+    hitrate = hitrate + hitdiff
+    hitrate = hitrate / 100
 
 
     -- Applying hitrate caps
-    if (capHitRate) then -- this isn't capped for when acc varies with tp, as more penalties are due
-        if (hitrate>0.95) then
+    if capHitRate then -- this isn't capped for when acc varies with tp, as more penalties are due
+        if hitrate > 0.95 then
             hitrate = 0.95
         end
-        if (hitrate<0.2) then
+        if hitrate < 0.2 then
             hitrate = 0.2
         end
     end
@@ -375,30 +377,30 @@ end
 function getBlueEffectDuration(caster, resist, effect)
     local duration = 0
 
-    if (resist == 0.125) then
+    if resist == 0.125 then
         resist = 1
-    elseif (resist == 0.25) then
+    elseif resist == 0.25 then
         resist = 2
-    elseif (resist == 0.5) then
+    elseif resist == 0.5 then
         resist = 3
     else
         resist = 4
     end
 
-    if (effect == xi.effect.BIND) then
+    if effect == xi.effect.BIND then
         duration = math.random(0, 5) + resist * 5
-    elseif (effect == xi.effect.STUN) then
+    elseif effect == xi.effect.STUN then
         duration = math.random(2, 3) + resist
         -- printf("Duration of stun is %i", duration)
-    elseif (effect == xi.effect.WEIGHT) then
+    elseif effect == xi.effect.WEIGHT then
         duration = math.random(20, 24) + resist * 9 -- 20-24
-    elseif (effect == xi.effect.PARALYSIS) then
+    elseif effect == xi.effect.PARALYSIS then
         duration = math.random(50, 60) + resist * 15 -- 50- 60
-    elseif (effect == xi.effect.SLOW) then
+    elseif effect == xi.effect.SLOW then
         duration = math.random(60, 120) + resist * 15 -- 60- 120 -- Needs confirmation but capped max duration based on White Magic Spell Slow
-    elseif (effect == xi.effect.SILENCE) then
+    elseif effect == xi.effect.SILENCE then
         duration = math.random(60, 180) + resist * 15 -- 60- 180 -- Needs confirmation but capped max duration based on White Magic Spell Silence
-    elseif (effect == xi.effect.POISON) then
+    elseif effect == xi.effect.POISON then
         duration = math.random(20, 30) + resist * 9 -- 20-30 -- based on magic spell poison
     end
 
@@ -408,43 +410,43 @@ end
 -- obtains alpha, used for working out WSC
 function BlueGetAlpha(level)
     local alpha = 1.00
-    if (level <= 5) then
+    if level <= 5 then
         alpha = 1.00
-    elseif (level <= 11) then
+    elseif level <= 11 then
         alpha = 0.99
-    elseif (level <= 17) then
+    elseif level <= 17 then
         alpha = 0.98
-    elseif (level <= 23) then
+    elseif level <= 23 then
         alpha = 0.97
-    elseif (level <= 29) then
+    elseif level <= 29 then
         alpha = 0.96
-    elseif (level <= 35) then
+    elseif level <= 35 then
         alpha = 0.95
-    elseif (level <= 41) then
+    elseif level <= 41 then
         alpha = 0.94
-    elseif (level <= 47) then
+    elseif level <= 47 then
         alpha = 0.93
-    elseif (level <= 53) then
+    elseif level <= 53 then
         alpha = 0.92
-    elseif (level <= 59) then
+    elseif level <= 59 then
         alpha = 0.91
-    elseif (level <= 61) then
+    elseif level <= 61 then
         alpha = 0.90
-    elseif (level <= 63) then
+    elseif level <= 63 then
         alpha = 0.89
-    elseif (level <= 65) then
+    elseif level <= 65 then
         alpha = 0.88
-    elseif (level <= 67) then
+    elseif level <= 67 then
         alpha = 0.87
-    elseif (level <= 69) then
+    elseif level <= 69 then
         alpha = 0.86
-    elseif (level <= 71) then
+    elseif level <= 71 then
         alpha = 0.85
-    elseif (level <= 73) then
+    elseif level <= 73 then
         alpha = 0.84
-    elseif (level <= 75) then
+    elseif level <= 75 then
         alpha = 0.83
-    elseif (level <= 99) then
+    elseif level <= 99 then
         alpha = 0.85
     end
     return alpha

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -17,21 +17,21 @@ xi.magic = xi.magic or {}
 xi.magic.dayStrong           = {xi.day.FIRESDAY,              xi.day.ICEDAY,               xi.day.WINDSDAY,               xi.day.EARTHSDAY,              xi.day.LIGHTNINGDAY,               xi.day.WATERSDAY,               xi.day.LIGHTSDAY,           xi.day.DARKSDAY}
 xi.magic.singleWeatherStrong = {xi.weather.HOT_SPELL,         xi.weather.SNOW,             xi.weather.WIND,               xi.weather.DUST_STORM,         xi.weather.THUNDER,                xi.weather.RAIN,                xi.weather.AURORAS,         xi.weather.GLOOM}
 xi.magic.doubleWeatherStrong = {xi.weather.HEAT_WAVE,         xi.weather.BLIZZARDS,        xi.weather.GALES,              xi.weather.SAND_STORM,         xi.weather.THUNDERSTORMS,          xi.weather.SQUALL,              xi.weather.STELLAR_GLARE,   xi.weather.DARKNESS}
-local elementalObi            = {xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS}
-local spellAcc                = {xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC}
-local strongAffinityDmg       = {xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG}
-local strongAffinityAcc       = {xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC}
+local elementalObi           = {xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS}
+local spellAcc               = {xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC}
+local strongAffinityDmg      = {xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG}
+local strongAffinityAcc      = {xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC}
 xi.magic.resistMod           = {xi.mod.FIRERES,               xi.mod.ICERES,               xi.mod.WINDRES,                xi.mod.EARTHRES,               xi.mod.THUNDERRES,                 xi.mod.WATERRES,                xi.mod.LIGHTRES,            xi.mod.DARKRES}
 xi.magic.defenseMod          = {xi.mod.FIREDEF,               xi.mod.ICEDEF,               xi.mod.WINDDEF,                xi.mod.EARTHDEF,               xi.mod.THUNDERDEF,                 xi.mod.WATERDEF,                xi.mod.LIGHTDEF,            xi.mod.DARKDEF}
 xi.magic.absorbMod           = {xi.mod.FIRE_ABSORB,           xi.mod.ICE_ABSORB,           xi.mod.WIND_ABSORB,            xi.mod.EARTH_ABSORB,           xi.mod.LTNG_ABSORB,                xi.mod.WATER_ABSORB,            xi.mod.LIGHT_ABSORB,        xi.mod.DARK_ABSORB}
-local nullMod                 = {xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL}
-local blmMerit                = {xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY}
-local rdmMerit                = {xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY}
+local nullMod                = {xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL}
+local blmMerit               = {xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY}
+local rdmMerit               = {xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY}
 xi.magic.barSpell            = {xi.effect.BARFIRE,            xi.effect.BARBLIZZARD,       xi.effect.BARAERO,             xi.effect.BARSTONE,            xi.effect.BARTHUNDER,              xi.effect.BARWATER}
 
-xi.magic.dayWeak             = {xi.day.WATERSDAY,             xi.day.FIRESDAY,            xi.day.ICEDAY,                  xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY           }
-xi.magic.singleWeatherWeak   = {xi.weather.RAIN,              xi.weather.HOT_SPELL,       xi.weather.SNOW,                xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS         }
-xi.magic.doubleWeatherWeak   = {xi.weather.SQUALL,            xi.weather.HEAT_WAVE,       xi.weather.BLIZZARDS,           xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE   }
+xi.magic.dayWeak             = {xi.day.WATERSDAY,             xi.day.FIRESDAY,             xi.day.ICEDAY,                 xi.day.WINDSDAY,               xi.day.EARTHSDAY,                  xi.day.LIGHTNINGDAY,            xi.day.DARKSDAY,            xi.day.LIGHTSDAY           }
+xi.magic.singleWeatherWeak   = {xi.weather.RAIN,              xi.weather.HOT_SPELL,        xi.weather.SNOW,               xi.weather.WIND,               xi.weather.DUST_STORM,             xi.weather.THUNDER,             xi.weather.GLOOM,           xi.weather.AURORAS         }
+xi.magic.doubleWeatherWeak   = {xi.weather.SQUALL,            xi.weather.HEAT_WAVE,        xi.weather.BLIZZARDS,          xi.weather.GALES,              xi.weather.SAND_STORM,             xi.weather.THUNDERSTORMS,       xi.weather.DARKNESS,        xi.weather.STELLAR_GLARE   }
 
 -- USED FOR DAMAGING MAGICAL SPELLS (Stages 1 and 2 in Calculating Magic Damage on wiki)
 --Calculates magic damage using the standard magic damage calc.
@@ -53,21 +53,21 @@ function calculateMagicDamage(caster, target, spell, params)
     local dINT = caster:getStat(params.attribute) - target:getStat(params.attribute)
     local dmg = params.dmg
 
-    if (dINT <= 0) then --if dINT penalises, it's always M=1
+    if dINT <= 0 then --if dINT penalises, it's always M=1
         dmg = dmg + dINT
-        if (dmg <= 0) then --dINT penalty cannot result in negative damage (target absorption)
+        if dmg <= 0 then --dINT penalty cannot result in negative damage (target absorption)
             return 0
         end
-    elseif (dINT > 0 and dINT <= SOFT_CAP) then --The standard calc, most spells hit this
+    elseif dINT > 0 and dINT <= SOFT_CAP then --The standard calc, most spells hit this
         dmg = dmg + (dINT * params.multiplier)
-    elseif (dINT > 0 and dINT > SOFT_CAP and dINT < HARD_CAP) then --After SOFT_CAP, INT is only half effective
+    elseif dINT > 0 and dINT > SOFT_CAP and dINT < HARD_CAP then --After SOFT_CAP, INT is only half effective
         dmg = dmg + SOFT_CAP * params.multiplier + ((dINT - SOFT_CAP) * params.multiplier) / 2
-    elseif (dINT > 0 and dINT > SOFT_CAP and dINT >= HARD_CAP) then --After HARD_CAP, INT has no xi.effect.
+    elseif dINT > 0 and dINT > SOFT_CAP and dINT >= HARD_CAP then --After HARD_CAP, INT has no xi.effect.
         dmg = dmg + HARD_CAP * params.multiplier
     end
 
 
-    if (params.skillType == xi.skill.DIVINE_MAGIC and target:isUndead()) then
+    if params.skillType == xi.skill.DIVINE_MAGIC and target:isUndead() then
         -- 150% bonus damage
         dmg = dmg * 1.5
     end
@@ -125,7 +125,7 @@ function doEnspell(caster, target, spell, effect)
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     --calculate potency
-    local magicskill = target:getSkillLevel(xi.skill.ENHANCING_MAGIC)
+    local magicskill = caster:getSkillLevel(xi.skill.ENHANCING_MAGIC)
 
     local potency = 3 + math.floor(6 * magicskill / 100)
     if magicskill > 200 then
@@ -156,7 +156,7 @@ function getCurePowerOld(caster)
     local MND = caster:getStat(xi.mod.MND)
     local VIT = caster:getStat(xi.mod.VIT)
     local skill = caster:getSkillLevel(xi.skill.HEALING_MAGIC) -- it's healing magic skill for the BLU cures as well
-    local power = ((3 * MND) + VIT + (3 * math.floor(skill/5)))
+    local power = (3 * MND) + VIT + (3 * math.floor(skill/5))
     return power
 end
 
@@ -178,13 +178,13 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     local potency = 1 + curePot + curePotII
 
     local dSeal = 1
-    if (caster:hasStatusEffect(xi.effect.DIVINE_SEAL)) then
+    if caster:hasStatusEffect(xi.effect.DIVINE_SEAL) then
         dSeal = 2
     end
 
     local rapture = 1
-    if (isBlueMagic == false) then --rapture doesn't affect BLU cures as they're not white magic
-        if (caster:hasStatusEffect(xi.effect.RAPTURE)) then
+    if isBlueMagic == false then --rapture doesn't affect BLU cures as they're not white magic
+        if caster:hasStatusEffect(xi.effect.RAPTURE) then
             rapture = 1.5 + caster:getMod(xi.mod.RAPTURE_AMOUNT)/100
             caster:delStatusEffectSilent(xi.effect.RAPTURE)
         end
@@ -195,46 +195,46 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
 
     local castersWeather = caster:getWeather()
 
-    if (castersWeather == xi.magic.singleWeatherStrong[ele]) then
-        if (caster:getMod(xi.mod.IRIDESCENCE) >= 1) then
-            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    if castersWeather == xi.magic.singleWeatherStrong[ele] then
+        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
+            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
                 dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.10
         end
-    elseif (castersWeather == xi.magic.singleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif castersWeather == xi.magic.singleWeatherWeak[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end
-    elseif (castersWeather == xi.magic.doubleWeatherStrong[ele]) then
-        if (caster:getMod(xi.mod.IRIDESCENCE) >= 1) then
-            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif castersWeather == xi.magic.doubleWeatherStrong[ele] then
+        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
+            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
                 dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.25
         end
-    elseif (castersWeather == xi.magic.doubleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif castersWeather == xi.magic.doubleWeatherWeak[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
     local dayElement = VanadielDayElement()
-    if (dayElement == ele) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    if dayElement == ele then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.10
         end
-    elseif (dayElement == xi.magic.elementDescendant[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif dayElement == xi.magic.elementDescendant[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
 
-    if (dayWeatherBonus > 1.4) then
+    if dayWeatherBonus > 1.4 then
         dayWeatherBonus = 1.4
     end
 
@@ -304,15 +304,15 @@ function applyResistanceEffect(caster, target, spell, params)
     local effect = params.effect
 
     -- If Stymie is active, as long as the mob is not immune then the effect is not resisted
-    if (effect ~= nil) then -- Dispel's script doesn't have an "effect" to send here, nor should it.
-        if (skill == xi.skill.ENFEEBLING_MAGIC and caster:hasStatusEffect(xi.effect.STYMIE) and target:canGainStatusEffect(effect)) then
+    if effect ~= nil then -- Dispel's script doesn't have an "effect" to send here, nor should it.
+        if skill == xi.skill.ENFEEBLING_MAGIC and caster:hasStatusEffect(xi.effect.STYMIE) and target:canGainStatusEffect(effect) then
             caster:delStatusEffect(xi.effect.STYMIE)
             return 1
         end
     end
 
-    if (skill == xi.skill.SINGING and caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        if (math.random(0, 99) < caster:getMerit(xi.merit.TROUBADOUR)-25) then
+    if skill == xi.skill.SINGING and caster:hasStatusEffect(xi.effect.TROUBADOUR) then
+        if math.random(0, 99) < caster:getMerit(xi.merit.TROUBADOUR)-25 then
             return 1.0
         end
     end
@@ -321,17 +321,17 @@ function applyResistanceEffect(caster, target, spell, params)
     local percentBonus = 0
     local magicaccbonus = getSpellBonusAcc(caster, target, spell, params)
 
-    if (diff > 10) then
+    if diff > 10 then
         magicaccbonus = magicaccbonus + 10 + (diff - 10)/2
     else
         magicaccbonus = magicaccbonus + diff
     end
 
-    if (bonus ~= nil) then
+    if bonus ~= nil then
         magicaccbonus = magicaccbonus + bonus
     end
 
-    if (effect ~= nil) then
+    if effect ~= nil then
         percentBonus = percentBonus - getEffectResistance(target, effect)
     end
 
@@ -357,20 +357,20 @@ end
 
 function getMagicHitRate(caster, target, skillType, element, percentBonus, bonusAcc)
     -- resist everything if magic shield is active
-    if (target:hasStatusEffect(xi.effect.MAGIC_SHIELD, 0)) then
+    if target:hasStatusEffect(xi.effect.MAGIC_SHIELD, 0) then
         return 0
     end
 
     local magiceva = 0
 
-    if (bonusAcc == nil) then
+    if bonusAcc == nil then
         bonusAcc = 0
     end
 
     local magicacc = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
 
     -- Get the base acc (just skill + skill mod (79 + skillID = ModID) + magic acc mod)
-    if (skillType ~= 0) then
+    if skillType ~= 0 then
         magicacc = magicacc + caster:getSkillLevel(skillType)
     else
         -- for mob skills / additional effects which don't have a skill
@@ -378,7 +378,7 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
     end
 
     local resMod = 0 -- Some spells may possibly be non elemental, but have status effects.
-    if (element ~= xi.magic.ele.NONE) then
+    if element ~= xi.magic.ele.NONE then
         resMod = target:getMod(xi.magic.resistMod[element])
 
         -- Add acc for elemental affinity accuracy and element specific accuracy
@@ -433,16 +433,16 @@ function getMagicResist(magicHitRate)
     local resvar = math.random()
 
     -- Determine final resist based on which thresholds have been crossed.
-    if (resvar <= sixteenth) then
+    if resvar <= sixteenth then
         resist = 0.0625
         --printf("Spell resisted to 1/16!!!  Threshold = %u", sixteenth)
-    elseif (resvar <= eighth) then
+    elseif resvar <= eighth then
         resist = 0.125
         --printf("Spell resisted to 1/8!  Threshold = %u", eighth)
-    elseif (resvar <= quart) then
+    elseif resvar <= quart then
         resist = 0.25
         --printf("Spell resisted to 1/4.  Threshold = %u", quart)
-    elseif (resvar <= half) then
+    elseif resvar <= half then
         resist = 0.5
         --printf("Spell resisted to 1/2.  Threshold = %u", half)
     else
@@ -458,39 +458,39 @@ end
 function getEffectResistance(target, effect)
     local effectres = 0
     local statusres = target:getMod(xi.mod.STATUSRES)
-    if (effect == xi.effect.SLEEP_I or effect == xi.effect.SLEEP_II) then
+    if effect == xi.effect.SLEEP_I or effect == xi.effect.SLEEP_II then
         effectres = xi.mod.SLEEPRES
-    elseif (effect == xi.effect.LULLABY) then
+    elseif effect == xi.effect.LULLABY then
         effectres = xi.mod.LULLABYRES
-    elseif (effect == xi.effect.POISON) then
+    elseif effect == xi.effect.POISON then
         effectres = xi.mod.POISONRES
-    elseif (effect == xi.effect.PARALYSIS) then
+    elseif effect == xi.effect.PARALYSIS then
         effectres = xi.mod.PARALYZERES
-    elseif (effect == xi.effect.BLINDNESS) then
+    elseif effect == xi.effect.BLINDNESS then
         effectres = xi.mod.BLINDRES
-    elseif (effect == xi.effect.SILENCE) then
+    elseif effect == xi.effect.SILENCE then
         effectres = xi.mod.SILENCERES
-    elseif (effect == xi.effect.PLAGUE or effect == xi.effect.DISEASE) then
+    elseif effect == xi.effect.PLAGUE or effect == xi.effect.DISEASE then
         effectres = xi.mod.VIRUSRES
-    elseif (effect == xi.effect.PETRIFICATION) then
+    elseif effect == xi.effect.PETRIFICATION then
         effectres = xi.mod.PETRIFYRES
-    elseif (effect == xi.effect.BIND) then
+    elseif effect == xi.effect.BIND then
         effectres = xi.mod.BINDRES
-    elseif (effect == xi.effect.CURSE_I or effect == xi.effect.CURSE_II or effect == xi.effect.BANE) then
+    elseif effect == xi.effect.CURSE_I or effect == xi.effect.CURSE_II or effect == xi.effect.BANE then
         effectres = xi.mod.CURSERES
-    elseif (effect == xi.effect.WEIGHT) then
+    elseif effect == xi.effect.WEIGHT then
         effectres = xi.mod.GRAVITYRES
-    elseif (effect == xi.effect.SLOW or effect == xi.effect.ELEGY) then
+    elseif effect == xi.effect.SLOW or effect == xi.effect.ELEGY then
         effectres = xi.mod.SLOWRES
-    elseif (effect == xi.effect.STUN) then
+    elseif effect == xi.effect.STUN then
         effectres = xi.mod.STUNRES
-    elseif (effect == xi.effect.CHARM) then
+    elseif effect == xi.effect.CHARM then
         effectres = xi.mod.CHARMRES
-    elseif (effect == xi.effect.AMNESIA) then
+    elseif effect == xi.effect.AMNESIA then
         effectres = xi.mod.AMNESIARES
     end
 
-    if (effectres ~= 0) then
+    if effectres ~= 0 then
         return target:getMod(effectres) + statusres
     end
 
@@ -595,7 +595,7 @@ function getSpellBonusAcc(caster, target, spell, params)
 end
 
 function handleAfflatusMisery(caster, spell, dmg)
-    if (caster:hasStatusEffect(xi.effect.AFFLATUS_MISERY)) then
+    if caster:hasStatusEffect(xi.effect.AFFLATUS_MISERY) then
         local misery = caster:getMod(xi.mod.AFFLATUS_MISERY)
         -- According to BGWiki Caps at 300 magic damage.
         local miseryMax = 300
@@ -603,7 +603,7 @@ function handleAfflatusMisery(caster, spell, dmg)
         miseryMax = miseryMax * (1 - caster:getMerit(xi.merit.ANIMUS_MISERY)/100)
 
         -- BGwiki puts the boost capping at 200% bonus at 1/4th max HP.
-        if (misery > miseryMax) then
+        if misery > miseryMax then
             misery = miseryMax
         end
 
@@ -624,13 +624,13 @@ end
     --Handles target's HP adjustment and returns UNSIGNED dmg (absorb message is set in this function)
 
     -- handle multiple targets
-    if (caster:isSpellAoE(spell:getID())) then
+    if caster:isSpellAoE(spell:getID()) then
         local total = spell:getTotalTargets()
 
-        if (total > 9) then
+        if total > 9 then
             -- ga spells on 10+ targets = 0.4
             dmg = dmg * 0.4
-        elseif (total > 1) then
+        elseif total > 1 then
             -- -ga spells on 2 to 9 targets = 0.9 - 0.05T where T = number of targets
             dmg = dmg * (0.9 - 0.05 * total)
         end
@@ -649,19 +649,19 @@ end
     end
 
     local skill = spell:getSkillType()
-    if (skill == xi.skill.ELEMENTAL_MAGIC) then
+    if skill == xi.skill.ELEMENTAL_MAGIC) then
         dmg = dmg * ELEMENTAL_POWER
-    elseif (skill == xi.skill.DARK_MAGIC) then
+    elseif skill == xi.skill.DARK_MAGIC then
         dmg = dmg * DARK_POWER
-    elseif (skill == xi.skill.NINJUTSU) then
+    elseif skill == xi.skill.NINJUTSU then
         dmg = dmg * NINJUTSU_POWER
-    elseif (skill == xi.skill.DIVINE_MAGIC) then
+    elseif skill == xi.skill.DIVINE_MAGIC then
         dmg = dmg * DIVINE_POWER
     end
 
     dmg = target:magicDmgTaken(dmg)
 
-    if (dmg > 0) then
+    if dmg > 0 then
         dmg = dmg - target:getMod(xi.mod.PHALANX)
         dmg = utils.clamp(dmg, 0, 99999)
     end
@@ -670,7 +670,7 @@ end
     dmg = utils.stoneskin(target, dmg)
     dmg = utils.clamp(dmg, -99999, 99999)
 
-    if (dmg < 0) then
+    if dmg < 0 then
         dmg = target:addHP(-dmg)
         spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
     else
@@ -678,7 +678,7 @@ end
         target:handleAfflatusMiseryDamage(dmg)
         target:updateEnmityFromDamage(caster, dmg)
         -- Only add TP if the target is a mob
-        if (target:getObjType() ~= xi.objType.PC) then
+        if target:getObjType() ~= xi.objType.PC and dmg > 0 then
             target:addTP(100)
         end
     end
@@ -691,7 +691,7 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
 
     dmg = target:magicDmgTaken(dmg)
 
-    if (dmg > 0) then
+    if dmg > 0 then
         dmg = dmg - target:getMod(xi.mod.PHALANX)
         dmg = utils.clamp(dmg, 0, 99999)
     end
@@ -701,7 +701,7 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
 
     dmg = utils.clamp(dmg, -99999, 99999)
 
-    if (dmg < 0) then
+    if dmg < 0 then
         dmg = -(target:addHP(-dmg))
     else
         target:takeDamage(dmg, caster, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + ele)
@@ -714,10 +714,10 @@ function finalMagicNonSpellAdjustments(caster, target, ele, dmg)
 end
 
 function adjustForTarget(target, dmg, ele)
-    if (dmg > 0 and math.random(0, 99) < target:getMod(xi.magic.absorbMod[ele])) then
+    if dmg > 0 and math.random(0, 99) < target:getMod(xi.magic.absorbMod[ele]) then
         return -dmg
     end
-    if (math.random(0, 99) < target:getMod(nullMod[ele])) then
+    if math.random(0, 99) < target:getMod(nullMod[ele]) then
         return 0
     end
     --Moved non element specific absorb and null mod checks to core
@@ -731,7 +731,7 @@ function calculateMagicBurst(caster, spell, target, params)
     local skillchainburst = 1.0
     local modburst = 1.0
 
-    if (spell:getSpellGroup() == 3 and not caster:hasStatusEffect(xi.effect.BURST_AFFINITY)) then
+    if spell:getSpellGroup() == 3 and not caster:hasStatusEffect(xi.effect.BURST_AFFINITY) then
         return burst
     end
 
@@ -746,7 +746,7 @@ function calculateMagicBurst(caster, spell, target, params)
     modburst = modburst + (caster:getJobPointLevel(xi.jp.MAGIC_BURST_DMG_BONUS) / 100)
 
     -- Cap bonuses from first multiplier at 40% or 1.4
-    if (modburst > 1.4) then
+    if modburst > 1.4 then
         modburst = 1.4
     end
 
@@ -754,16 +754,16 @@ function calculateMagicBurst(caster, spell, target, params)
     -- Starts at 35% damage bonus, increases by 10% for every additional weaponskill in the chain
     local skillchainTier, skillchainCount = FormMagicBurst(spell:getElement(), target)
 
-    if (skillchainTier > 0) then
-        if (skillchainCount == 1) then -- two weaponskills
+    if skillchainTier > 0 then
+        if skillchainCount == 1 then -- two weaponskills
             skillchainburst = 1.35
-        elseif (skillchainCount == 2) then -- three weaponskills
+        elseif skillchainCount == 2 then -- three weaponskills
             skillchainburst = 1.45
-        elseif (skillchainCount == 3) then -- four weaponskills
+        elseif skillchainCount == 3 then -- four weaponskills
              skillchainburst = 1.55
-        elseif (skillchainCount == 4) then -- five weaponskills
+        elseif skillchainCount == 4 then -- five weaponskills
             skillchainburst = 1.65
-        elseif (skillchainCount == 5) then -- six weaponskills
+        elseif skillchainCount == 5 then -- six weaponskills
             skillchainburst = 1.75
         else
             -- Something strange is going on if this occurs.
@@ -772,7 +772,7 @@ function calculateMagicBurst(caster, spell, target, params)
     end
 
     -- Multiply
-    if (skillchainburst > 1) then
+    if skillchainburst > 1 then
         burst = burst * modburst * skillchainburst
     end
 
@@ -914,42 +914,42 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     local dayWeatherBonus = 1.00
     local weather = caster:getWeather()
 
-    if (weather == xi.magic.singleWeatherStrong[ele]) then
-        if (caster:getMod(xi.mod.IRIDESCENCE) >= 1) then
-            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    if weather == xi.magic.singleWeatherStrong[ele] then
+        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
+            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
                 dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.10
         end
-    elseif (caster:getWeather() == xi.magic.singleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif caster:getWeather() == xi.magic.singleWeatherWeak[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end
-    elseif (weather == xi.magic.doubleWeatherStrong[ele]) then
-        if (caster:getMod(xi.mod.IRIDESCENCE) >= 1) then
-            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif weather == xi.magic.doubleWeatherStrong[ele] then
+        if caster:getMod(xi.mod.IRIDESCENCE) >= 1 then
+            if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
                 dayWeatherBonus = dayWeatherBonus + 0.10
             end
         end
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.25
         end
-    elseif (weather == xi.magic.doubleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif weather == xi.magic.doubleWeatherWeak[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.25
         end
     end
 
     local dayElement = VanadielDayElement()
-    if (dayElement == ele) then
+    if dayElement == ele then
         dayWeatherBonus = dayWeatherBonus + caster:getMod(xi.mod.DAY_NUKE_BONUS)/100 -- sorc. tonban(+1)/zodiac ring
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus + 0.10
         end
-    elseif (dayElement == xi.magic.elementDescendant[ele]) then
-        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
+    elseif dayElement == xi.magic.elementDescendant[ele] then
+        if math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 then
             dayWeatherBonus = dayWeatherBonus - 0.10
         end
     end
@@ -970,13 +970,13 @@ function addBonusesAbility(caster, ele, target, dmg, params)
         mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[ele]):getSubPower()
     end
 
-    if (params ~= nil and params.bonusmab ~= nil and params.includemab == true) then
-        mab = (100 + caster:getMod(xi.mod.MATT) + params.bonusmab) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
-    elseif (params == nil or (params ~= nil and params.includemab == true)) then
-        mab = (100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
+    if params ~= nil and params.bonusmab ~= nil and params.includemab == true then
+        mab = 100 + caster:getMod(xi.mod.MATT) + params.bonusmab) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus
+    elseif params == nil or (params ~= nil and params.includemab == true) then
+        mab = 100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus
     end
 
-    if (mab < 0) then
+    if mab < 0 then
         mab = 0
     end
 
@@ -995,7 +995,7 @@ end
 -- get elemental damage reduction
 function getElementalDamageReduction(target, element)
     local defense = 1
-    if (element > 0) then
+    if element > 0 then
         defense = 1 - (target:getMod(xi.magic.defenseMod[element]) / 256)
 
         return utils.clamp(defense, 0.0, 2.0)
@@ -1010,13 +1010,13 @@ end
 
 function getElementalDebuffDOT(INT)
     local DOT = 0
-    if (INT<= 39) then
+    if INT<= 39 then
         DOT = 1
-    elseif (INT <= 69) then
+    elseif INT <= 69 then
         DOT = 2
-    elseif (INT <= 99) then
+    elseif INT <= 99 then
         DOT = 3
-    elseif (INT <= 149) then
+    elseif INT <= 149 then
         DOT = 4
     else
         DOT = 5
@@ -1035,11 +1035,11 @@ function getHelixDuration(caster)
 
     local casterLevel = caster:getMainLvl()
     local duration = 30 --fallthrough
-    if (casterLevel <= 39) then
+    if casterLevel <= 39 then
         duration = 30
-    elseif (casterLevel <= 59) then
+    elseif casterLevel <= 59 then
         duration = 60
-    elseif (casterLevel <= 99) then
+    elseif casterLevel <= 99 then
         duration = 90
     end
 
@@ -1076,7 +1076,7 @@ function handleThrenody(caster, target, spell, basePower, baseDuration, modifier
     local resm = applyResistance(caster, target, spell, params)
     -- print("rsem=" .. resm)
 
-    if (resm < 0.5) then
+    if resm < 0.5 then
         -- print("resm resist")
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return xi.effect.THRENODY
@@ -1089,13 +1089,13 @@ function handleThrenody(caster, target, spell, basePower, baseDuration, modifier
     local power = basePower + iBoost*5
     local duration = baseDuration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
 
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
         power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
         power = power * 1.5
     end
 
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
         duration = duration * 2
     end
 
@@ -1119,12 +1119,12 @@ function canOverwrite(target, effect, power, mod)
     local statusEffect = target:getStatusEffect(effect)
 
     -- effect not found so overwrite
-    if (statusEffect == nil) then
+    if statusEffect == nil then
         return true
     end
 
     -- overwrite if its weaker
-    if (statusEffect:getPower()*mod > power) then
+    if statusEffect:getPower()*mod > power then
         return false
     end
 
@@ -1192,26 +1192,26 @@ function doElementalNuke(caster, spell, target, spellParams)
                 For dINT reduce by amount factored into the V value (example: at 134 INT, when using V100 in the calculation, use dINT = 134-100 = 34)
         ]]
 
-        if (dINT <= 49) then
+        if dINT <= 49 then
             V = spellParams.V0
             M = spellParams.M0
             DMG = math.floor(DMG + mDMG + V + (dINT * M))
 
-            if (DMG <= 0) then
+            if DMG <= 0 then
                 return 0
             end
 
-        elseif (dINT >= 50 and dINT <= 99) then
+        elseif dINT >= 50 and dINT <= 99 then
             V = spellParams.V50
             M = spellParams.M50
             DMG = math.floor(DMG + mDMG + V + ((dINT - 50) * M))
 
-        elseif (dINT >= 100 and dINT <= 199) then
+        elseif dINT >= 100 and dINT <= 199 then
             V = spellParams.V100
             M = spellParams.M100
             DMG = math.floor(DMG + mDMG + V + ((dINT - 100) * M))
 
-        elseif (dINT > 199) then
+        elseif dINT > 199 then
             V = spellParams.V200
             M = spellParams.M200
             DMG = math.floor(DMG + mDMG + V + ((dINT - 200) * M))
@@ -1255,7 +1255,7 @@ function doNinjutsuNuke(caster, target, spell, params)
     mabBonus = mabBonus or 0
 
     mabBonus = mabBonus + caster:getMod(xi.mod.NIN_NUKE_BONUS) -- "enhances ninjutsu damage" bonus
-    if (caster:hasStatusEffect(xi.effect.INNIN) and caster:isBehind(target, 23)) then -- Innin mag atk bonus from behind, guesstimating angle at 23 degrees
+    if caster:hasStatusEffect(xi.effect.INNIN) and caster:isBehind(target, 23) then -- Innin mag atk bonus from behind, guesstimating angle at 23 degrees
         mabBonus = mabBonus + caster:getStatusEffect(xi.effect.INNIN):getPower()
     end
     params.skillType = xi.skill.NINJUTSU
@@ -1327,7 +1327,7 @@ function doDivineBanishNuke(caster, target, spell, params)
 end
 
 function calculateDurationForLvl(duration, spellLvl, targetLvl)
-    if (targetLvl < spellLvl) then
+    if targetLvl < spellLvl then
         return duration * targetLvl / spellLvl
     end
 
@@ -1412,7 +1412,7 @@ function outputMagicHitRateInfo()
 
             local targetLvl = casterLvl + lvlMod
 
-            if (targetLvl >= 0) then
+            if targetLvl >= 0 then
                 -- assume BLM spell, A+
                 local magicAcc = utils.getSkillLvl(6, casterLvl)
                 -- assume default monster magic eva, D
@@ -1423,7 +1423,7 @@ function outputMagicHitRateInfo()
 
                 local dINT = (lvlMod + 1) * -1
 
-                if (dINT > 10) then
+                if dINT > 10 then
                     magicAcc = magicAcc + 10 + (dINT - 10)/2
                 else
                     magicAcc = magicAcc + dINT


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

- Cleans magic.lua and bluemagic.lua
- Fixes Spells giving TP when doing 0 dmg. Credit to Mattyg