### PR TITLE
No (or at least fewer) Job Ability shenanigans

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -751,6 +751,12 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
         case 0x09: // jobability
         {
             uint16 JobAbilityID = data.ref<uint16>(0x0C);
+            uint8 currentAnimation = PChar->animation;
+            if (currentAnimation != ANIMATION_NONE && currentAnimation != ANIMATION_ATTACK)
+            {
+                ShowExploit(CL_YELLOW "SmallPacket0x009: Player %s trying to use a Job Ability from invalid state\n" CL_RESET, PChar->GetName());
+                return;
+            }
             PChar->PAI->Ability(TargID, JobAbilityID);
         }
         break;
@@ -1181,14 +1187,14 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         ShowDebug(CL_CYAN "%s initiated trade request with %s\n" CL_RESET, PChar->GetName(), PTarget->GetName());
 
         // If PChar is invisible don't allow the trade, but you are able to initiate a trade TO an invisible player
-        if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE)) 
+        if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
         {
             // 155 = "You cannot perform that action on the specified target."
             // TODO: Correct message is "You cannot use that command while invisible."
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
             return;
         }
-        
+
         // If either player is in prison don't allow the trade.
         if (jailutils::InPrison(PChar) || jailutils::InPrison(PTarget))
         {


### PR DESCRIPTION
This is something I shared with Teo privately a little while ago. Its method is based on how Zach locked down shady Ranged Attacks in the same file.

This prevents users from forcing Job Abilities through means that are NOT possible on retail. So this isn't blocking something like drive-by packet WS, which IS possible on retail (and super fun!). Previously, players could force their characters to use a job ability like Meditate, even if they were mounted on a chocobo.

This isn't a critical exploit, so just making a PR in broad daylight.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
