### PR TITLE
Add localvar to WS quest event trigger to Cid

### DIFF
--- a/scripts/zones/Metalworks/npcs/Cid.lua
+++ b/scripts/zones/Metalworks/npcs/Cid.lua
@@ -56,7 +56,8 @@ entity.onTrigger = function(player, npc)
     local threePathArg = 0
 
     -- SHOOT FIRST, ASK QUESTIONS LATER
-    if wsQuestEvent ~= nil then
+    if wsQuestEvent ~= nil and player:getLocalVar("wsQuestCheck") == 0 then
+        player:setLocalVar("wsQuestCheck", 1)
         player:startEvent(wsQuestEvent)
 
     -- DAWN


### PR DESCRIPTION
The WS quest trigger blocks any mission progression if the quest is active. This quick LocalVar fix allows them to access more dialogues if the quest is present after the initial interaction.

![image](https://user-images.githubusercontent.com/61239975/116148588-12cf5f80-a6af-11eb-8257-c43b674d4d9b.png)

Fixes #36.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits