### PR TITLE
Normalize missionStatus and currentMission

### DIFF
--- a/scripts/commands/checkmissionstatus.lua
+++ b/scripts/commands/checkmissionstatus.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- func: checkmissionstatus <Log ID> <Player>
--- desc: Prints current MissionStatus for the given LogID and target Player to the in game chatlog
+-- desc: Prints current missionStatus for the given LogID and target Player to the in game chatlog
 -----------------------------------
 
 require("scripts/globals/missions")
@@ -52,8 +52,8 @@ function onTrigger(player, target, logId, statusIndex)
     -- report mission
     local currentMissionStatus = targ:getMissionStatus(logId, statusIndex)
     if statusIndex then
-        player:PrintToPlayer( string.format( "MissionStatus for %s (%s index %s): %s", targ:getName(), logName, statusIndex, currentMissionStatus) )
+        player:PrintToPlayer( string.format( "missionStatus for %s (%s index %s): %s", targ:getName(), logName, statusIndex, currentMissionStatus) )
     else
-        player:PrintToPlayer( string.format( "MissionStatus for %s (%s): %s", targ:getName(), logName, currentMissionStatus) )
+        player:PrintToPlayer( string.format( "missionStatus for %s (%s): %s", targ:getName(), logName, currentMissionStatus) )
     end
 end

--- a/scripts/commands/setmissionstatus.lua
+++ b/scripts/commands/setmissionstatus.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- func: setmissionstatus {Player} {value} {LogID} {index}
--- desc: Sets MissionStatus for the given LogID and target Player
+-- desc: Sets missionStatus for the given LogID and target Player
 -----------------------------------
 
 require("scripts/globals/missions")
@@ -52,8 +52,8 @@ function onTrigger(player, target, value, logId, statusIndex)
     -- set mission
     targ:setMissionStatus(logId, value, statusIndex)
     if statusIndex then
-        player:PrintToPlayer( string.format( "MissionStatus for %s (%s index %s) set to %s", targ:getName(), logName, statusIndex, value) )
+        player:PrintToPlayer( string.format( "missionStatus for %s (%s index %s) set to %s", targ:getName(), logName, statusIndex, value) )
     else
-        player:PrintToPlayer( string.format( "MissionStatus for %s (%s) set to %s", targ:getName(), logName, value) )
+        player:PrintToPlayer( string.format( "missionStatus for %s (%s) set to %s", targ:getName(), logName, value) )
     end
 end

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -1077,7 +1077,7 @@ function getMissionMask(player)
     return mission_mask, repeat_mission
 end
 
-function getMissionOffset(player, guard, pMission, MissionStatus)
+function getMissionOffset(player, guard, pMission, missionStatus)
 
     offset = 0 cs = 0 params = {0, 0, 0, 0, 0, 0, 0, 0}
     nation = player:getNation()
@@ -1090,22 +1090,22 @@ function getMissionOffset(player, guard, pMission, MissionStatus)
 
         switch (pMission) : caseof {
             [0] = function (x) offset = 0 end, -- Mission 1-1
-            [1] = function (x) if (MissionStatus == 2) then cs = GuardCS[1] else cs = GuardCS[2] end end, -- Mission 1-2 (1) after check tombstone
-            [2] = function (x) if (MissionStatus == 0) then cs = GuardCS[3] -- Mission 1-3 before Battlefield
-                           elseif (MissionStatus == 4 and player:hasCompletedMission(0, 2) == false) then cs = GuardCS[4] -- Mission 1-3 after Battlefield
-                           elseif (MissionStatus == 4) then cs = GuardCS[5] else offset = 24 end end, -- Mission 1-3 after Battlefield (Finish Quest)
-            [3] = function (x) if (MissionStatus == 11) then cs = GuardCS[6] else offset = 36 end end,
-            [4] = function (x) if (MissionStatus == 3 and player:hasCompletedMission(0, 4)) then cs = GuardCS[7]
-                           elseif (MissionStatus == 3) then cs = GuardCS[8] params = {0, 0, 0, 44} else offset = 44 end end,
-            [5] = function (x) if (MissionStatus == 0) then offset = 50 else offset = 51 end end,
-            [10] = function (x) if (MissionStatus == 0) then cs = GuardCS[9]
-                            elseif (MissionStatus == 4) then offset = 55
-                            elseif (MissionStatus == 5) then offset = 60
-                            elseif (MissionStatus == 10) then cs = GuardCS[10] end end,
-            [11] = function (x) if (MissionStatus == 0) then offset = 68
-                            elseif (MissionStatus == 2) then cs = GuardCS[11] end end,
-            [12] = function (x) if (MissionStatus == 0) then offset = 74 end end,
-            [14] = function (x) if (MissionStatus == 0) then cs = 61 end end,
+            [1] = function (x) if (missionStatus == 2) then cs = GuardCS[1] else cs = GuardCS[2] end end, -- Mission 1-2 (1) after check tombstone
+            [2] = function (x) if (missionStatus == 0) then cs = GuardCS[3] -- Mission 1-3 before Battlefield
+                           elseif (missionStatus == 4 and player:hasCompletedMission(0, 2) == false) then cs = GuardCS[4] -- Mission 1-3 after Battlefield
+                           elseif (missionStatus == 4) then cs = GuardCS[5] else offset = 24 end end, -- Mission 1-3 after Battlefield (Finish Quest)
+            [3] = function (x) if (missionStatus == 11) then cs = GuardCS[6] else offset = 36 end end,
+            [4] = function (x) if (missionStatus == 3 and player:hasCompletedMission(0, 4)) then cs = GuardCS[7]
+                           elseif (missionStatus == 3) then cs = GuardCS[8] params = {0, 0, 0, 44} else offset = 44 end end,
+            [5] = function (x) if (missionStatus == 0) then offset = 50 else offset = 51 end end,
+            [10] = function (x) if (missionStatus == 0) then cs = GuardCS[9]
+                            elseif (missionStatus == 4) then offset = 55
+                            elseif (missionStatus == 5) then offset = 60
+                            elseif (missionStatus == 10) then cs = GuardCS[10] end end,
+            [11] = function (x) if (missionStatus == 0) then offset = 68
+                            elseif (missionStatus == 2) then cs = GuardCS[11] end end,
+            [12] = function (x) if (missionStatus == 0) then offset = 74 end end,
+            [14] = function (x) if (missionStatus == 0) then cs = 61 end end,
         }
         return cs, params, offset
 
@@ -1145,7 +1145,7 @@ function getMissionOffset(player, guard, pMission, MissionStatus)
         switch (pMission) : caseof {
             [0] = function (x) cs = GuardCS[1] end,
             [1] = function (x) cs = GuardCS[2] end,
-            [2] = function (x) if (MissionStatus <= 2) then cs = GuardCS[3] else cs = GuardCS[4] end end,
+            [2] = function (x) if (missionStatus <= 2) then cs = GuardCS[3] else cs = GuardCS[4] end end,
             [3] = function (x) cs = GuardCS[5] end,
             [4] = function (x) cs = GuardCS[6] end,
             [5] = function (x) cs = GuardCS[7] end,

--- a/scripts/zones/Bastok_Markets/npcs/Cleades.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Cleades.lua
@@ -13,17 +13,17 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(BASTOK)
+    local currentMission = player:getCurrentMission(BASTOK)
     local Count = trade:getItemCount()
 
-    if (CurrentMission ~= xi.mission.id.bastok.NONE) then
-        if (CurrentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+    if (currentMission ~= xi.mission.id.bastok.NONE) then
+        if (currentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1008) -- Finish Mission "Fetichism" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+        elseif (currentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1005) -- Finish Mission "Fetichism" (Repeat)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1010) -- Finish Mission "To the forsaken mines" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1006) -- Finish Mission "To the forsaken mines" (Repeat)
         end
     end
@@ -35,21 +35,21 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.BASTOK) then
         player:startEvent(1003) -- For non-Bastokian
     else
-        local CurrentMission = player:getCurrentMission(BASTOK)
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, player:getMissionStatus(player:getNation()))
+        local currentMission = player:getCurrentMission(BASTOK)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, player:getMissionStatus(player:getNation()))
 
-        if (cs ~= 0 or offset ~= 0 or ((CurrentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
-                                        CurrentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
-            if (CurrentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+        if (cs ~= 0 or offset ~= 0 or ((currentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
+                                        currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
+            if (currentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 1~5)
-            elseif (CurrentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+            elseif (currentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.EXTENDED_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 6~10)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
         elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
-        elseif (CurrentMission ~= xi.mission.id.bastok.NONE) then
+        elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated
         else
             local flagMission, repeatMission = getMissionMask(player)

--- a/scripts/zones/Bastok_Mines/npcs/Rashid.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Rashid.lua
@@ -13,17 +13,17 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(BASTOK)
+    local currentMission = player:getCurrentMission(BASTOK)
     local Count = trade:getItemCount()
 
-    if (CurrentMission ~= xi.mission.id.bastok.NONE) then
-        if (CurrentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+    if (currentMission ~= xi.mission.id.bastok.NONE) then
+        if (currentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1008) -- Finish Mission "Fetichism" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+        elseif (currentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1005) -- Finish Mission "Fetichism" (Repeat)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1010) -- Finish Mission "To the forsaken mines" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1006) -- Finish Mission "To the forsaken mines" (Repeat)
         end
     end
@@ -35,21 +35,21 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.BASTOK) then
         player:startEvent(1003) -- For non-Bastokian
     else
-        local CurrentMission = player:getCurrentMission(BASTOK)
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, player:getMissionStatus(player:getNation()))
+        local currentMission = player:getCurrentMission(BASTOK)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, player:getMissionStatus(player:getNation()))
 
-        if (cs ~= 0 or offset ~= 0 or ((CurrentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
-                                        CurrentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
-            if (CurrentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+        if (cs ~= 0 or offset ~= 0 or ((currentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
+                                        currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
+            if (currentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 1~5)
-            elseif (CurrentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+            elseif (currentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.EXTENDED_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 6~10)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
         elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
-        elseif (CurrentMission ~= xi.mission.id.bastok.NONE) then
+        elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated
         else
             local flagMission, repeatMission = getMissionMask(player)

--- a/scripts/zones/Chamber_of_Oracles/Zone.lua
+++ b/scripts/zones/Chamber_of_Oracles/Zone.lua
@@ -19,15 +19,15 @@ zone_object.onConquestUpdate = function(zone, updatetype)
 end
 
 zone_object.onZoneIn = function(player, prevZone)
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getMissionStatus(player:getNation())
     local cs = -1
 
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         player:setPos(-177.804, -2.765, -37.893, 179)
     end
 
-    if (prevZone == xi.zone.QUICKSAND_CAVES and CurrentMission == xi.mission.id.windurst.MOON_READING and MissionStatus >= 1) then
+    if (prevZone == xi.zone.QUICKSAND_CAVES and currentMission == xi.mission.id.windurst.MOON_READING and missionStatus >= 1) then
         cs = 3
     end
 

--- a/scripts/zones/Chateau_dOraguille/Zone.lua
+++ b/scripts/zones/Chateau_dOraguille/Zone.lua
@@ -18,7 +18,7 @@ end
 zone_object.onZoneIn = function(player, prevZone)
 
     local currentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local cs = -1
 
     if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
@@ -30,11 +30,11 @@ zone_object.onZoneIn = function(player, prevZone)
         player:getMissionStatus(player:getNation()) == 2
     then
         cs = 555
-    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 1 then
+    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 1 then
         cs = 10
     elseif prevZone == xi.zone.NORTHERN_SAN_DORIA and player:hasKeyItem(xi.ki.MESSAGE_TO_JEUNO_SANDORIA) then
         cs = 509
-    elseif currentMission == xi.mission.id.sandoria.COMING_OF_AGE and MissionStatus == 0 then
+    elseif currentMission == xi.mission.id.sandoria.COMING_OF_AGE and missionStatus == 0 then
         cs = 116
     end
 

--- a/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
@@ -27,7 +27,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local currentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local circleOfTime = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_CIRCLE_OF_TIME)
     local circleProgress = player:getCharVar("circleTime")
     local lureOfTheWildcat = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT)
@@ -35,11 +35,11 @@ entity.onTrigger = function(player, npc)
     local herMajestysGarden = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
 
     -- THE CRYSTAL SPRING (San d'Oria 3-2)
-    if (currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and MissionStatus == 3) then
+    if (currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and missionStatus == 3) then
         player:startEvent(556)
 
     -- LEAUTE'S LAST WISHES (San d'Oria 6-1)
-    elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and MissionStatus == 4 and player:hasKeyItem(xi.ki.DREAMROSE)) then
+    elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and missionStatus == 4 and player:hasKeyItem(xi.ki.DREAMROSE)) then
         player:startEvent(111)
 
     -- CIRCLE OF TIME (Bard AF3)

--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -23,7 +23,7 @@ entity.onTrigger = function(player, npc)
     local pNation = player:getNation()
     local currentMission = player:getCurrentMission(pNation)
     local WildcatSandy = player:getCharVar("WildcatSandy")
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
 
     -- Lure of the Wildcat San d'Oria
     if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatSandy, 16)) then
@@ -51,59 +51,59 @@ entity.onTrigger = function(player, npc)
         if player:getRank() == 10 then
             player:startEvent(31)
         -- Mission San D'Oria 9-2 The Heir to the Light
-        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 7) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 7) then
             player:startEvent(9)
-        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus > 5) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus > 5) then
             player:startEvent(30)
-        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus > 4) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus > 4) then
             player:showText(npc, ID.text.HEIR_TO_LIGHT_EXTRA)
-        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus > 1) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus > 1) then
             player:startEvent(29)
         -- Mission San d'Oria 9-1 Lightbringer (optional)
-        elseif (currentMission == xi.mission.id.sandoria.BREAKING_BARRIERS and MissionStatus == 0) then
+        elseif (currentMission == xi.mission.id.sandoria.BREAKING_BARRIERS and missionStatus == 0) then
             player:startEvent(26)
-        elseif (currentMission == xi.mission.id.sandoria.BREAKING_BARRIERS and MissionStatus == 1) then
+        elseif (currentMission == xi.mission.id.sandoria.BREAKING_BARRIERS and missionStatus == 1) then
             player:startEvent(1)
         -- Mission San d'Oria 8-2 Lightbringer (optional)
-        elseif (currentMission == xi.mission.id.sandoria.LIGHTBRINGER and MissionStatus == 6) then
+        elseif (currentMission == xi.mission.id.sandoria.LIGHTBRINGER and missionStatus == 6) then
             player:showText(npc, ID.text.LIGHTBRINGER_EXTRA)
         -- Mission San d'Oria 8-1 Coming of Age
-        elseif (currentMission == xi.mission.id.sandoria.COMING_OF_AGE and MissionStatus == 3 and player:hasKeyItem(xi.ki.DROPS_OF_AMNIO)) then
+        elseif (currentMission == xi.mission.id.sandoria.COMING_OF_AGE and missionStatus == 3 and player:hasKeyItem(xi.ki.DROPS_OF_AMNIO)) then
             player:startEvent(102)
-        elseif (currentMission == xi.mission.id.sandoria.COMING_OF_AGE and MissionStatus == 1) then
+        elseif (currentMission == xi.mission.id.sandoria.COMING_OF_AGE and missionStatus == 1) then
             player:startEvent(58)
         -- Mission San D'Oria 6-1 Leaute's last wishes
-        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and MissionStatus == 3) then
+        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and missionStatus == 3) then
             player:startEvent(22)
-        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and MissionStatus == 2) then
+        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and missionStatus == 2) then
             player:startEvent(24)
-        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and MissionStatus == 1) then
+        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and missionStatus == 1) then
             player:startEvent(23)
-        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and MissionStatus == 0) then
+        elseif (currentMission == xi.mission.id.sandoria.LEAUTE_S_LAST_WISHES and missionStatus == 0) then
             player:startEvent(25)
         -- Mission San D'Oria 5-2 The Shadow Lord
         elseif (player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.THE_SHADOW_LORD) and currentMission == xi.mission.id.sandoria.NONE) then
             player:showText(npc, ID.text.HALVER_OFFSET+500)
-        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and MissionStatus == 5) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and missionStatus == 5) then
             player:showText(npc, ID.text.HALVER_OFFSET+471)
-        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and MissionStatus == 4 and player:hasKeyItem(xi.ki.SHADOW_FRAGMENT)) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and missionStatus == 4 and player:hasKeyItem(xi.ki.SHADOW_FRAGMENT)) then
             player:startEvent(548)
-        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and MissionStatus == 0) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_SHADOW_LORD and missionStatus == 0) then
             player:startEvent(546)
             -- Mission San D'Oria 5-1 The Ruins of Fei'Yin
-        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and MissionStatus == 12 and player:hasKeyItem(xi.ki.BURNT_SEAL)) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and missionStatus == 12 and player:hasKeyItem(xi.ki.BURNT_SEAL)) then
             player:startEvent(534)
-        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and MissionStatus == 10) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and missionStatus == 10) then
             player:showText(npc, ID.text.HALVER_OFFSET+334)
-        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and MissionStatus == 9) then
+        elseif (currentMission == xi.mission.id.sandoria.THE_RUINS_OF_FEI_YIN and missionStatus == 9) then
             player:startEvent(533)
         -- Mission San D'Oria 3-3 Appointment to Jeuno
-        elseif (currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and MissionStatus == 0) then
+        elseif (currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 0) then
             player:startEvent(508)
         -- Mission San D'Oria 2-3 Journey Abroad
-        elseif (currentMission == xi.mission.id.sandoria.JOURNEY_ABROAD and MissionStatus == 11) then
+        elseif (currentMission == xi.mission.id.sandoria.JOURNEY_ABROAD and missionStatus == 11) then
             player:startEvent(507)
-        elseif (currentMission == xi.mission.id.sandoria.JOURNEY_ABROAD and MissionStatus == 0) then
+        elseif (currentMission == xi.mission.id.sandoria.JOURNEY_ABROAD and missionStatus == 0) then
             player:startEvent(505)
         elseif (currentMission == xi.mission.id.sandoria.JOURNEY_ABROAD) then
             player:startEvent(532)
@@ -114,7 +114,7 @@ entity.onTrigger = function(player, npc)
     elseif (pNation == xi.nation.BASTOK) then
         -- Bastok 2-3 San -> Win
         if (currentMission == xi.mission.id.bastok.THE_EMISSARY) then
-            if (MissionStatus == 3) then
+            if (missionStatus == 3) then
                 player:startEvent(501)
             end
         -- Bastok 2-3 San -> Win, report to consulate
@@ -122,9 +122,9 @@ entity.onTrigger = function(player, npc)
             player:showText(npc, ID.text.HALVER_OFFSET+279)
         -- Bastok 2-3 Win -> San
         elseif (currentMission == xi.mission.id.bastok.THE_EMISSARY_SANDORIA2) then
-            if (MissionStatus == 8) then
+            if (missionStatus == 8) then
                 player:startEvent(503)
-            elseif (MissionStatus <= 10) then
+            elseif (missionStatus <= 10) then
                 player:showText(npc, ID.text.HALVER_OFFSET+279)
             end
         else
@@ -132,12 +132,12 @@ entity.onTrigger = function(player, npc)
         end
     elseif (pNation == xi.nation.WINDURST) then
         -- Windurst 2-3
-        if (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS and MissionStatus < 3) then
+        if (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS and missionStatus < 3) then
             player:startEvent(532)
         elseif (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA or currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA2) then
-            if (MissionStatus == 3) then
+            if (missionStatus == 3) then
                 player:startEvent(502)
-            elseif (MissionStatus == 8) then
+            elseif (missionStatus == 8) then
                 player:startEvent(504)
             else
                 player:showText(npc, ID.text.HALVER_OFFSET+279)

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
@@ -83,7 +83,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 61 then
         finishMissionTimeline(player, 3, csid, option)
     elseif csid == 87 then
-        player:setCharVar('MissionStatus', 2)
+        player:setCharVar('missionStatus', 2)
     elseif csid == 100 then
         player:setCharVar("Mission8-1Completed", 0) -- dont need this var anymore. JP midnight is done and prev mission completed.
         player:setMissionStatus(player:getNation(), 1)

--- a/scripts/zones/Davoi/npcs/!.lua
+++ b/scripts/zones/Davoi/npcs/!.lua
@@ -15,27 +15,27 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local CurrentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local currentMission = player:getCurrentMission(SANDORIA)
+    local missionStatus = player:getMissionStatus(player:getNation())
 
-    if (CurrentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:getMissionStatus(player:getNation()) == 1) then
+    if (currentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:getMissionStatus(player:getNation()) == 1) then
         player:setMissionStatus(player:getNation(), 2)
         player:addKeyItem(xi.ki.LOST_DOCUMENT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.LOST_DOCUMENT)
-    elseif (CurrentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and player:getMissionStatus(player:getNation()) >= 6 and player:getMissionStatus(player:getNation()) <= 9) then
+    elseif (currentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and player:getMissionStatus(player:getNation()) >= 6 and player:getMissionStatus(player:getNation()) <= 9) then
         local X = npc:getXPos()
         local Z = npc:getZPos()
 
         if (X >= 292 and X <= 296 and Z >= -30 and Z <= -26 and player:hasKeyItem(xi.ki.EAST_BLOCK_CODE) == false) then
-            player:setMissionStatus(player:getNation(), MissionStatus + 1)
+            player:setMissionStatus(player:getNation(), missionStatus + 1)
             player:addKeyItem(xi.ki.EAST_BLOCK_CODE)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.EAST_BLOCK_CODE)
         elseif (X >= 333 and X <= 337 and Z >= -138 and Z <= -134 and player:hasKeyItem(xi.ki.SOUTH_BLOCK_CODE) == false) then
-            player:setMissionStatus(player:getNation(), MissionStatus + 1)
+            player:setMissionStatus(player:getNation(), missionStatus + 1)
             player:addKeyItem(xi.ki.SOUTH_BLOCK_CODE)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SOUTH_BLOCK_CODE)
         elseif (X >= 161 and X <= 165 and Z >= -20 and Z <= -16 and player:hasKeyItem(xi.ki.NORTH_BLOCK_CODE) == false) then
-            player:setMissionStatus(player:getNation(), MissionStatus + 1)
+            player:setMissionStatus(player:getNation(), missionStatus + 1)
             player:addKeyItem(xi.ki.NORTH_BLOCK_CODE)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.NORTH_BLOCK_CODE)
         else

--- a/scripts/zones/Davoi/npcs/Zantaviat.lua
+++ b/scripts/zones/Davoi/npcs/Zantaviat.lua
@@ -15,16 +15,16 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local CurrentMission = player:getCurrentMission(SANDORIA)
+    local currentMission = player:getCurrentMission(SANDORIA)
     local infiltrateDavoi = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.INFILTRATE_DAVOI)
 
-    if (CurrentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:getMissionStatus(player:getNation()) == 0) then
+    if (currentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:getMissionStatus(player:getNation()) == 0) then
         player:startEvent(100)
-    elseif (CurrentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:hasKeyItem(xi.ki.LOST_DOCUMENT)) then
+    elseif (currentMission == xi.mission.id.sandoria.THE_DAVOI_REPORT and player:hasKeyItem(xi.ki.LOST_DOCUMENT)) then
         player:startEvent(104)
-    elseif (CurrentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and infiltrateDavoi and player:getMissionStatus(player:getNation()) == 0) then
+    elseif (currentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and infiltrateDavoi and player:getMissionStatus(player:getNation()) == 0) then
         player:startEvent(102)
-    elseif (CurrentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and player:getMissionStatus(player:getNation()) == 9) then
+    elseif (currentMission == xi.mission.id.sandoria.INFILTRATE_DAVOI and player:getMissionStatus(player:getNation()) == 9) then
         player:startEvent(105)
     else
         player:startEvent(101)

--- a/scripts/zones/East_Sarutabaruta/npcs/Pore-Ohre.lua
+++ b/scripts/zones/East_Sarutabaruta/npcs/Pore-Ohre.lua
@@ -17,10 +17,10 @@ entity.onTrigger = function(player, npc)
 
     -- Check if we are on Windurst Mission 1-2
     if (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HEART_OF_THE_MATTER) then
-        MissionStatus = player:getMissionStatus(player:getNation())
-        if (MissionStatus == 1) then
+        missionStatus = player:getMissionStatus(player:getNation())
+        if (missionStatus == 1) then
             player:startEvent(46)
-        elseif (MissionStatus == 2) then
+        elseif (missionStatus == 2) then
             player:startEvent(47)
         end
     end

--- a/scripts/zones/FeiYin/Zone.lua
+++ b/scripts/zones/FeiYin/Zone.lua
@@ -22,7 +22,7 @@ end
 
 zone_object.onZoneIn = function(player, prevZone)
     local currentMission = player:getCurrentMission(player:getNation())
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local cs = -1
 
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
@@ -33,9 +33,9 @@ zone_object.onZoneIn = function(player, prevZone)
         SpawnMob(ID.mob.MISER_MURPHY) -- RDM AF
     end
 
-    if (prevZone == xi.zone.BEAUCEDINE_GLACIER and currentMission == xi.mission.id.nation.ARCHLICH and MissionStatus == 10) then
+    if (prevZone == xi.zone.BEAUCEDINE_GLACIER and currentMission == xi.mission.id.nation.ARCHLICH and missionStatus == 10) then
         cs = 1 -- MISSION 5-1
-    elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 2) then
+    elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 2) then
         cs = 23 -- San d'Oria 9-2
     elseif (player:getCurrentMission(ACP) == xi.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_I) then
         cs = 29

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
@@ -17,7 +17,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local MakingHeadlines = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.MAKING_HEADLINES)
+    local makingHeadlines = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.MAKING_HEADLINES)
     local currentMission = player:getCurrentMission(WINDURST)
     local missionStatus = player:getMissionStatus(player:getNation())
 

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ca.lua
@@ -18,8 +18,8 @@ end
 
 entity.onTrigger = function(player, npc)
     local MakingHeadlines = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.MAKING_HEADLINES)
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getMissionStatus(player:getNation())
 
     -- bitmask of progress: 0 = Kyume-Romeh, 1 = Yuyuju, 2 = Hiwom-Gomoi, 3 = Umumu, 4 = Mahogany Door
     local prog = player:getCharVar("QuestMakingHeadlines_var")

--- a/scripts/zones/La_Theine_Plateau/npcs/Augevinne.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Augevinne.lua
@@ -15,13 +15,13 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus >= 5 and MissionStatus <= 7 then
+        if missionStatus >= 5 and missionStatus <= 7 then
             player:startEvent(103)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             player:showText(npc, ID.text.RESCUE_DRILL + 21)
-        elseif MissionStatus >= 9 then
+        elseif missionStatus >= 9 then
             player:showText(npc, ID.text.RESCUE_DRILL + 26)
         else
             player:showText(npc, ID.text.RESCUE_DRILL + 6)

--- a/scripts/zones/La_Theine_Plateau/npcs/Deaufrain.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Deaufrain.lua
@@ -15,25 +15,25 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 3 then
+        if missionStatus == 3 then
             player:startEvent(102)
-        elseif MissionStatus == 4 then
+        elseif missionStatus == 4 then
             player:showText(npc, ID.text.RESCUE_DRILL + 4)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             if player:getCharVar("theRescueDrillRandomNPC") == 3 then
                 player:startEvent(113)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 21)
             end
-        elseif MissionStatus == 9 then
+        elseif missionStatus == 9 then
             if player:getCharVar("theRescueDrillRandomNPC") == 3 then
                 player:showText(npc, ID.text.RESCUE_DRILL + 25)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 26)
             end
-        elseif MissionStatus >= 10 then
+        elseif missionStatus >= 10 then
             player:showText(npc, ID.text.RESCUE_DRILL + 30)
         else
             player:showText(npc, ID.text.RESCUE_DRILL)

--- a/scripts/zones/La_Theine_Plateau/npcs/Equesobillot.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Equesobillot.lua
@@ -15,25 +15,25 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 2 then
+        if missionStatus == 2 then
             player:startEvent(101)
-        elseif MissionStatus == 3 then
+        elseif missionStatus == 3 then
             player:showText(npc, ID.text.RESCUE_DRILL + 3)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             if player:getCharVar("theRescueDrillRandomNPC") == 2 then
                 player:startEvent(112)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 21)
             end
-        elseif MissionStatus == 9 then
+        elseif missionStatus == 9 then
             if player:getCharVar("theRescueDrillRandomNPC") == 2 then
                 player:showText(npc, ID.text.RESCUE_DRILL + 25)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 26)
             end
-        elseif MissionStatus >= 10 then
+        elseif missionStatus >= 10 then
             player:showText(npc, ID.text.RESCUE_DRILL + 30)
         else
             player:showText(npc, ID.text.RESCUE_DRILL)

--- a/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
@@ -15,25 +15,25 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 0 then
+        if missionStatus == 0 then
             player:startEvent(110)
-        elseif MissionStatus == 2 then
+        elseif missionStatus == 2 then
             player:showText(npc, ID.text.RESCUE_DRILL + 16)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             if player:getCharVar("theRescueDrillRandomNPC") == 1 then
                 player:startEvent(114)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 21)
             end
-        elseif MissionStatus == 9 then
+        elseif missionStatus == 9 then
             if player:getCharVar("theRescueDrillRandomNPC") == 1 then
                 player:showText(npc, ID.text.RESCUE_DRILL + 25)
             else
                 player:showText(npc, ID.text.RESCUE_DRILL + 26)
             end
-        elseif MissionStatus >= 10 then
+        elseif missionStatus >= 10 then
             player:showText(npc, ID.text.RESCUE_DRILL + 30)
         else
             player:showText(npc, ID.text.RESCUE_DRILL)

--- a/scripts/zones/La_Theine_Plateau/npcs/Laurisse.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Laurisse.lua
@@ -15,15 +15,15 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 5 then
+        if missionStatus == 5 then
             player:startEvent(106)
-        elseif MissionStatus >= 6 and MissionStatus <= 7 then
+        elseif missionStatus >= 6 and missionStatus <= 7 then
             player:startEvent(109)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             player:showText(npc, ID.text.RESCUE_DRILL + 21)
-        elseif MissionStatus >= 9 then
+        elseif missionStatus >= 9 then
             player:showText(npc, ID.text.RESCUE_DRILL + 26)
         else
             player:showText(npc, ID.text.RESCUE_DRILL)

--- a/scripts/zones/La_Theine_Plateau/npcs/Narvecaint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Narvecaint.lua
@@ -15,15 +15,15 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 6 then
+        if missionStatus == 6 then
             player:startEvent(107)
-        elseif MissionStatus == 7 then
+        elseif missionStatus == 7 then
             player:showText(npc, ID.text.RESCUE_DRILL + 14)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             player:showText(npc, ID.text.RESCUE_DRILL + 21)
-        elseif MissionStatus >= 9 then
+        elseif missionStatus >= 9 then
             player:showText(npc, ID.text.RESCUE_DRILL + 26)
         else
             player:showText(npc, ID.text.RESCUE_DRILL)

--- a/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
@@ -16,19 +16,19 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus == 4 then
+        if missionStatus == 4 then
             player:startEvent(108)
-        elseif MissionStatus >= 5 and MissionStatus <= 7 then
+        elseif missionStatus >= 5 and missionStatus <= 7 then
             player:showText(npc, ID.text.RESCUE_DRILL + 19)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             player:showText(npc, ID.text.RESCUE_DRILL + 21)
-        elseif MissionStatus == 9 then
+        elseif missionStatus == 9 then
             player:showText(npc, ID.text.RESCUE_DRILL + 26)
-        elseif MissionStatus == 10 then
+        elseif missionStatus == 10 then
             player:startEvent(115)
-        elseif MissionStatus == 11 then
+        elseif missionStatus == 11 then
             player:showText(npc, ID.text.RESCUE_DRILL + 29, xi.ki.RESCUE_TRAINING_CERTIFICATE)
         else
             player:startEvent(5)

--- a/scripts/zones/La_Theine_Plateau/npcs/Yaucevouchat.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Yaucevouchat.lua
@@ -15,13 +15,13 @@ end
 entity.onTrigger = function(player, npc)
 
     if (player:getCurrentMission(SANDORIA) == xi.mission.id.sandoria.THE_RESCUE_DRILL) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if MissionStatus >= 5 and MissionStatus <= 7 then
+        if missionStatus >= 5 and missionStatus <= 7 then
             player:startEvent(104)
-        elseif MissionStatus == 8 then
+        elseif missionStatus == 8 then
             player:showText(npc, ID.text.RESCUE_DRILL + 21)
-        elseif MissionStatus >= 9 then
+        elseif missionStatus >= 9 then
             player:showText(npc, ID.text.RESCUE_DRILL + 26)
         else
             player:showText(npc, ID.text.RESCUE_DRILL + 7)

--- a/scripts/zones/Metalworks/npcs/Malduc.lua
+++ b/scripts/zones/Metalworks/npcs/Malduc.lua
@@ -13,17 +13,17 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(BASTOK)
+    local currentMission = player:getCurrentMission(BASTOK)
     local Count = trade:getItemCount()
 
-    if (CurrentMission ~= xi.mission.id.bastok.NONE) then
-        if (CurrentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+    if (currentMission ~= xi.mission.id.bastok.NONE) then
+        if (currentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1008) -- Finish Mission "Fetichism" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+        elseif (currentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1005) -- Finish Mission "Fetichism" (Repeat)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1010) -- Finish Mission "To the forsaken mines" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1006) -- Finish Mission "To the forsaken mines" (Repeat)
         end
     end
@@ -35,21 +35,21 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.BASTOK) then
         player:startEvent(1003) -- For non-Bastokian
     else
-        local CurrentMission = player:getCurrentMission(BASTOK)
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, player:getMissionStatus(player:getNation()))
+        local currentMission = player:getCurrentMission(BASTOK)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, player:getMissionStatus(player:getNation()))
 
-        if (cs ~= 0 or offset ~= 0 or ((CurrentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
-                                        CurrentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
-            if (CurrentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+        if (cs ~= 0 or offset ~= 0 or ((currentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
+                                        currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
+            if (currentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 1~5)
-            elseif (CurrentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+            elseif (currentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.EXTENDED_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 6~10)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
         elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
-        elseif (CurrentMission ~= xi.mission.id.bastok.NONE) then
+        elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated
         else
             local flagMission, repeatMission = getMissionMask(player)

--- a/scripts/zones/Metalworks/npcs/Patt-Pott.lua
+++ b/scripts/zones/Metalworks/npcs/Patt-Pott.lua
@@ -21,20 +21,20 @@ end
 entity.onTrigger = function(player, npc)
 
     currentMission = player:getCurrentMission(WINDURST)
-    MissionStatus = player:getMissionStatus(player:getNation())
+    missionStatus = player:getMissionStatus(player:getNation())
 
     if (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS) then
-        if (MissionStatus == 1) then
+        if (missionStatus == 1) then
             player:startEvent(254)
-        elseif (MissionStatus == 6) then
+        elseif (missionStatus == 6) then
             player:startEvent(256)
-        elseif (MissionStatus == 7) then
+        elseif (missionStatus == 7) then
             player:startEvent(258)
-        elseif (MissionStatus == 11) then
+        elseif (missionStatus == 11) then
             player:startEvent(259)
         end
     elseif (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) then
-        if (MissionStatus == 11) then
+        if (missionStatus == 11) then
             player:startEvent(257)
         else
             player:startEvent(258)

--- a/scripts/zones/Metalworks/npcs/Pius.lua
+++ b/scripts/zones/Metalworks/npcs/Pius.lua
@@ -13,22 +13,22 @@ end
 
 entity.onTrigger = function(player, npc)
     local Mission = player:getCurrentMission(player:getNation())
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
 
     if
-        Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK and MissionStatus == 3 or
-        Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK2 and MissionStatus == 8
+        Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK and missionStatus == 3 or
+        Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK2 and missionStatus == 8
     then
         player:startEvent(355)
     elseif
-        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK and MissionStatus == 3 or
-        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2 and MissionStatus == 8
+        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK and missionStatus == 3 or
+        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2 and missionStatus == 8
     then
         player:startEvent(355, 1)
     elseif
         Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK or
         Mission == xi.mission.id.sandoria.JOURNEY_TO_BASTOK2 or
-        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2 and MissionStatus < 11
+        Mission == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2 and missionStatus < 11
     then
         player:startEvent(356)
     else

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -28,7 +28,7 @@ end
 zone_object.onZoneIn = function(player, prevZone)
 
     local currentMission = player:getCurrentMission(SANDORIA)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local cs = -1
 
     -- FIRST LOGIN (START CS)
@@ -43,7 +43,7 @@ zone_object.onZoneIn = function(player, prevZone)
     elseif
         player:getCurrentMission(ROV) == xi.mission.id.rov.FATES_CALL and
         (player:getRank(player:getNation()) > 5 or
-        (player:getCurrentMission(player:getNation()) == xi.mission.id.nation.SHADOW_LORD and MissionStatus >= 4))
+        (player:getCurrentMission(player:getNation()) == xi.mission.id.nation.SHADOW_LORD and missionStatus >= 4))
     then
         cs = 30036
     -- SOA 1-1 Optional CS
@@ -59,9 +59,9 @@ zone_object.onZoneIn = function(player, prevZone)
     elseif player:getCurrentMission(COP) == xi.mission.id.cop.THE_ROAD_FORKS and player:getCharVar("EMERALD_WATERS_Status") == 1 then --EMERALD_WATERS-- COP 3-3A: San d'Oria Route
         player:setCharVar("EMERALD_WATERS_Status", 2)
         cs = 14
-    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 0 then
+    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 0 then
         cs = 1
-    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 4 then
+    elseif currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 4 then
         cs = 0
     elseif player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.COMING_OF_AGE) then
         local waitDate = player:getCharVar("Wait1DayM8-1_date")

--- a/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
@@ -12,25 +12,25 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(SANDORIA)
+    local currentMission = player:getCurrentMission(SANDORIA)
     local OrcishScoutCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS)
     local BatHuntCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.BAT_HUNT)
     local TheCSpringCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.THE_CRYSTAL_SPRING)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local Count = trade:getItemCount()
 
-    if CurrentMission ~= xi.mission.id.sandoria.NONE then
-        if CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
+    if currentMission ~= xi.mission.id.sandoria.NONE then
+        if currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
             player:startEvent(1020) -- Finish Mission "Smash the Orcish scouts" (First Time)
-        elseif CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
+        elseif currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
             player:startEvent(1002) -- Finish Mission "Smash the Orcish scouts" (Repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and MissionStatus == 2 then -- Trade Orcish Mail Scales
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and missionStatus == 2 then -- Trade Orcish Mail Scales
             player:startEvent(1023) -- Finish Mission "Bat Hunt"
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted and MissionStatus == 2 then -- Trade Bat Fang
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted and missionStatus == 2 then -- Trade Bat Fang
             player:startEvent(1003) -- Finish Mission "Bat Hunt" (repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
             player:startEvent(1030) -- Dialog During Mission "The Crystal Spring"
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
             player:startEvent(1013) -- Finish Mission "The Crystal Spring" (repeat)
         else
             player:startEvent(1008) -- Wrong Item
@@ -48,12 +48,12 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.SANDORIA) then
         player:startEvent(1011) -- for Non-San d'Orians
     else
-        local CurrentMission = player:getCurrentMission(SANDORIA)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(SANDORIA)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
-        if CurrentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
+        if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
             if (cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -61,21 +61,21 @@ entity.onTrigger = function(player, npc)
             end
         elseif pRank == 1 and player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false then
             player:startEvent(1000) -- Start First Mission "Smash the Orcish scouts"
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035)
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1037)
             else
                 player:startEvent(1039)
             end
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
             player:startEvent(1033)
-        elseif CurrentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
+        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
             player:startEvent(1041)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
+        elseif currentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
             player:startEvent(1043)
-        elseif CurrentMission ~= xi.mission.id.sandoria.NONE then
+        elseif currentMission ~= xi.mission.id.sandoria.NONE then
             player:startEvent(1001) -- Have mission already activated
         else
             local mission_mask, repeat_mask = getMissionMask(player)

--- a/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
@@ -19,30 +19,30 @@ entity.onTrigger = function(player, npc)
     local pNation = player:getNation()
     if (pNation == xi.nation.WINDURST) then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
         if (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS) then
-            if (MissionStatus == 2) then
+            if (missionStatus == 2) then
                 player:startEvent(546)
-            elseif (MissionStatus == 6) then
+            elseif (missionStatus == 6) then
                 player:showText(npc, ID.text.KASARORO_DIALOG + 7)
-            elseif (MissionStatus == 7) then
+            elseif (missionStatus == 7) then
                 player:startEvent(547)
-            elseif (MissionStatus == 11) then
+            elseif (missionStatus == 11) then
                 player:showText(npc, ID.text.KASARORO_DIALOG + 20)
             end
         elseif (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA) then
-            if (MissionStatus == 3) then
+            if (missionStatus == 3) then
                 player:showText(npc, ID.text.KASARORO_DIALOG)
-            elseif (MissionStatus == 4) then
+            elseif (missionStatus == 4) then
                 player:startEvent(549)
-            elseif (MissionStatus == 5) then
+            elseif (missionStatus == 5) then
                 player:startEvent(550) -- done with Sandy first path, now go to bastok
             end
         elseif (currentMission == xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA2) then
-            if (MissionStatus == 8) then
+            if (missionStatus == 8) then
                 player:showText(npc, ID.text.KASARORO_DIALOG)
-            elseif (MissionStatus == 10) then
+            elseif (missionStatus == 10) then
                 player:startEvent(551)
             end
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS)) then

--- a/scripts/zones/Port_Bastok/npcs/Argus.lua
+++ b/scripts/zones/Port_Bastok/npcs/Argus.lua
@@ -13,17 +13,17 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(BASTOK)
+    local currentMission = player:getCurrentMission(BASTOK)
     local Count = trade:getItemCount()
 
-    if (CurrentMission ~= xi.mission.id.bastok.NONE) then
-        if (CurrentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+    if (currentMission ~= xi.mission.id.bastok.NONE) then
+        if (currentMission == xi.mission.id.bastok.FETICHISM and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.FETICHISM) == false and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1008) -- Finish Mission "Fetichism" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
+        elseif (currentMission == xi.mission.id.bastok.FETICHISM and trade:hasItemQty(606, 1) and trade:hasItemQty(607, 1) and trade:hasItemQty(608, 1) and trade:hasItemQty(609, 1) and Count == 4) then
             player:startEvent(1005) -- Finish Mission "Fetichism" (Repeat)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.TO_THE_FORSAKEN_MINES) == false and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1010) -- Finish Mission "To the forsaken mines" (First Time)
-        elseif (CurrentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
+        elseif (currentMission == xi.mission.id.bastok.TO_THE_FORSAKEN_MINES and trade:hasItemQty(563, 1) and Count == 1) then
             player:startEvent(1006) -- Finish Mission "To the forsaken mines" (Repeat)
         end
     end
@@ -35,21 +35,21 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.BASTOK) then
         player:startEvent(1003) -- For non-Bastokian
     else
-        local CurrentMission = player:getCurrentMission(BASTOK)
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, player:getMissionStatus(player:getNation()))
+        local currentMission = player:getCurrentMission(BASTOK)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, player:getMissionStatus(player:getNation()))
 
-        if (cs ~= 0 or offset ~= 0 or ((CurrentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
-                                        CurrentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
-            if (CurrentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+        if (cs ~= 0 or offset ~= 0 or ((currentMission == xi.mission.id.bastok.THE_ZERUHN_REPORT or
+                                        currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER) and offset == 0)) then
+            if (currentMission <= xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 1~5)
-            elseif (CurrentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
+            elseif (currentMission > xi.mission.id.bastok.XARCABARD_LAND_OF_TRUTHS and cs == 0) then
                 player:showText(npc, ID.text.EXTENDED_MISSION_OFFSET + offset) -- dialog after accepting mission (Rank 6~10)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
         elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
-        elseif (CurrentMission ~= xi.mission.id.bastok.NONE) then
+        elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated
         else
             local flagMission, repeatMission = getMissionMask(player)

--- a/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
@@ -51,12 +51,12 @@ entity.onTrigger = function(player, npc)
         player:startEvent(457)
     -- Check if we are on Windurst Mission 1-1
     elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
-        MissionStatus = player:getMissionStatus(player:getNation())
-        if (MissionStatus == 0) then
+        missionStatus = player:getMissionStatus(player:getNation())
+        if (missionStatus == 0) then
             player:startEvent(90)
-        elseif (MissionStatus == 1) then
+        elseif (missionStatus == 1) then
             player:startEvent(91)
-        elseif (MissionStatus == 3) then
+        elseif (missionStatus == 3) then
             player:startEvent(94, 0, xi.ki.CRACKED_MANA_ORBS) -- Finish Mission 1-1
         end
     elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.TO_EACH_HIS_OWN_RIGHT and player:getMissionStatus(player:getNation()) == 2) then

--- a/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
+++ b/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
@@ -17,18 +17,18 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.WINDURST) then
         player:startEvent(71) -- for other nation
     else
-        local CurrentMission = player:getCurrentMission(WINDURST)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(WINDURST)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 3, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 3, currentMission, missionStatus)
 
-        if (CurrentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= xi.mission.id.windurst.NONE) then
+        elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(76)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
             player:startEvent(83)

--- a/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/QuHau_Spring.lua
@@ -26,12 +26,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local CurrentMission = player:getCurrentMission(WINDURST)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getMissionStatus(player:getNation())
 
-    if (CurrentMission == xi.mission.id.windurst.VAIN and MissionStatus >= 1) then
+    if (currentMission == xi.mission.id.windurst.VAIN and missionStatus >= 1) then
         player:startEvent(2)
-    elseif (CurrentMission == xi.mission.id.windurst.MOON_READING and MissionStatus >= 1) then
+    elseif (currentMission == xi.mission.id.windurst.MOON_READING and missionStatus >= 1) then
         player:startEvent(4)
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)

--- a/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
@@ -17,25 +17,25 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.BASTOK then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.bastok.JEUNO and MissionStatus == 1 then
+        if currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 1 then
             player:startEvent(41)
-        elseif currentMission == xi.mission.id.bastok.JEUNO and MissionStatus == 2 then
+        elseif currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 2 then
             player:startEvent(66)
-        elseif currentMission == xi.mission.id.bastok.JEUNO and MissionStatus == 3 then
+        elseif currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 3 then
             player:startEvent(139)
-        elseif player:getRank() == 4 and MissionStatus == 0 then
+        elseif player:getRank() == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(3)
             else
                 player:startEvent(4)
             end
-        elseif currentMission == xi.mission.id.bastok.MAGICITE and MissionStatus == 1 then
+        elseif currentMission == xi.mission.id.bastok.MAGICITE and missionStatus == 1 then
             player:startEvent(132)
-        elseif currentMission == xi.mission.id.bastok.MAGICITE and MissionStatus <= 5 then
+        elseif currentMission == xi.mission.id.bastok.MAGICITE and missionStatus <= 5 then
             player:startEvent(135)
-        elseif currentMission == xi.mission.id.bastok.MAGICITE and MissionStatus == 6 then
+        elseif currentMission == xi.mission.id.bastok.MAGICITE and missionStatus == 6 then
             player:startEvent(35)
         elseif player:hasKeyItem(xi.ki.MESSAGE_TO_JEUNO_BASTOK) then
             player:startEvent(55)

--- a/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
@@ -17,25 +17,25 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.SANDORIA then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and MissionStatus == 3 then
+        if currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 3 then
             player:startEvent(42)
-        elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and MissionStatus == 4 then
+        elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 4 then
             player:startEvent(67)
-        elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and MissionStatus == 5 then
+        elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 5 then
             player:startEvent(140)
-        elseif player:getRank() == 4 and MissionStatus == 0 then
+        elseif player:getRank() == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(45)
             else
                 player:startEvent(49)
             end
-        elseif currentMission == xi.mission.id.sandoria.MAGICITE and MissionStatus == 1 then
+        elseif currentMission == xi.mission.id.sandoria.MAGICITE and missionStatus == 1 then
             player:startEvent(133)
-        elseif currentMission == xi.mission.id.sandoria.MAGICITE and MissionStatus <= 5 then
+        elseif currentMission == xi.mission.id.sandoria.MAGICITE and missionStatus <= 5 then
             player:startEvent(136)
-        elseif currentMission == xi.mission.id.sandoria.MAGICITE and MissionStatus == 6 then
+        elseif currentMission == xi.mission.id.sandoria.MAGICITE and missionStatus == 6 then
             player:startEvent(36)
         elseif player:hasKeyItem(xi.ki.MESSAGE_TO_JEUNO_SANDORIA) then
             player:startEvent(56)

--- a/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
@@ -17,25 +17,25 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.WINDURST then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and MissionStatus == 1 then
+        if currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 1 then
             player:startEvent(43)
-        elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and MissionStatus == 2 then
+        elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 2 then
             player:startEvent(68)
-        elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and MissionStatus == 3 then
+        elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 3 then
             player:startEvent(141)
-        elseif player:getRank() == 4 and MissionStatus == 0 then
+        elseif player:getRank() == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(50)
             else
                 player:startEvent(54)
             end
-        elseif currentMission == xi.mission.id.windurst.MAGICITE and MissionStatus == 1 then
+        elseif currentMission == xi.mission.id.windurst.MAGICITE and missionStatus == 1 then
             player:startEvent(134)
-        elseif currentMission == xi.mission.id.windurst.MAGICITE and MissionStatus <= 5 then
+        elseif currentMission == xi.mission.id.windurst.MAGICITE and missionStatus <= 5 then
             player:startEvent(137)
-        elseif currentMission == xi.mission.id.windurst.MAGICITE and MissionStatus == 6 then
+        elseif currentMission == xi.mission.id.windurst.MAGICITE and missionStatus == 6 then
             player:startEvent(37)
         elseif player:hasKeyItem(xi.ki.MESSAGE_TO_JEUNO_WINDURST) then
             player:startEvent(57)

--- a/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
@@ -17,9 +17,9 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.BASTOK then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.bastok.JEUNO and MissionStatus == 4 then
+        if currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 4 then
             player:startEvent(38)
         elseif player:getRank() == 4 and
             currentMission == xi.mission.id.bastok.NONE and

--- a/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
@@ -17,14 +17,14 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.SANDORIA then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and MissionStatus == 6 then
+        if currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 6 then
             player:startEvent(39)
         elseif player:getRank() == 4 and
             currentMission == xi.mission.id.sandoria.NONE and
             getMissionRankPoints(player, 13) == 1 and
-            MissionStatus == 0
+            missionStatus == 0
         then
             if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
                 player:startEvent(130, 1)

--- a/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
@@ -18,9 +18,9 @@ entity.onTrigger = function(player, npc)
 
     if pNation == xi.nation.WINDURST then
         local currentMission = player:getCurrentMission(pNation)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
 
-        if currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and MissionStatus == 4 then
+        if currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 4 then
             player:startEvent(40)
         elseif player:getRank() == 4 and
             currentMission == xi.mission.id.windurst.NONE and

--- a/scripts/zones/RuLude_Gardens/npcs/_6r9.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r9.lua
@@ -17,10 +17,10 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    CurrentMission = player:getCurrentMission(player:getNation())
+    currentMission = player:getCurrentMission(player:getNation())
     if ( player:getCurrentMission(COP) == xi.mission.id.cop.MORE_QUESTIONS_THAN_ANSWERS and player:getCharVar("PromathiaStatus")==1) then
         player:startEvent(10050)
-    elseif (player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and CurrentMission == xi.mission.id.nation.NONE and player:getMissionStatus(player:getNation()) == 1) then
+    elseif (player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and currentMission == xi.mission.id.nation.NONE and player:getMissionStatus(player:getNation()) == 1) then
         player:startEvent(128)
     elseif (player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)) then
         if (player:hasKeyItem(xi.ki.AIRSHIP_PASS)) then

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -12,25 +12,25 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    local CurrentMission = player:getCurrentMission(SANDORIA)
+    local currentMission = player:getCurrentMission(SANDORIA)
     local OrcishScoutCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS)
     local BatHuntCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.BAT_HUNT)
     local TheCSpringCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.THE_CRYSTAL_SPRING)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local Count = trade:getItemCount()
 
-    if CurrentMission ~= xi.mission.id.sandoria.NONE then
-        if CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
+    if currentMission ~= xi.mission.id.sandoria.NONE then
+        if currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
             player:startEvent(2020) -- Finish Mission "Smash the Orcish scouts" (First Time)
-        elseif CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
+        elseif currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
             player:startEvent(2002) -- Finish Mission "Smash the Orcish scouts" (Repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and MissionStatus == 2 then -- Trade Orcish Mail Scales
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and missionStatus == 2 then -- Trade Orcish Mail Scales
             player:startEvent(2023) -- Finish Mission "Bat Hunt"
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted and MissionStatus == 2 then -- Trade Bat Fang
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted and missionStatus == 2 then -- Trade Bat Fang
             player:startEvent(2003) -- Finish Mission "Bat Hunt" (repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
             player:startEvent(2030) -- Dialog During Mission "The Crystal Spring"
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
             player:startEvent(2013) -- Finish Mission "The Crystal Spring" (repeat)
         else
             player:startEvent(2008) -- Wrong Item
@@ -48,12 +48,12 @@ entity.onTrigger = function(player, npc)
     if player:getNation() ~= xi.nation.SANDORIA then
         player:startEvent(2011) -- for Non-San d'Orians
     else
-        local CurrentMission = player:getCurrentMission(SANDORIA)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(SANDORIA)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 2, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 2, currentMission, missionStatus)
 
-        if CurrentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
+        if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
             if cs == 0 then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -61,21 +61,21 @@ entity.onTrigger = function(player, npc)
             end
         elseif pRank == 1 and player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false then
             player:startEvent(2000) -- Start First Mission "Smash the Orcish scouts"
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1036)
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1038)
             else
                 player:startEvent(1040)
             end
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
             player:startEvent(1034)
-        elseif CurrentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
+        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
             player:startEvent(1042)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
+        elseif currentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
             player:startEvent(1044)
-        elseif CurrentMission ~= xi.mission.id.sandoria.NONE then
+        elseif currentMission ~= xi.mission.id.sandoria.NONE then
             player:startEvent(2001) -- Have mission already activated
         else
             local mission_mask, repeat_mask = getMissionMask(player)

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -11,25 +11,25 @@ require("scripts/globals/missions")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local CurrentMission = player:getCurrentMission(SANDORIA)
+    local currentMission = player:getCurrentMission(SANDORIA)
     local OrcishScoutCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS)
     local BatHuntCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.BAT_HUNT)
     local TheCSpringCompleted = player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.THE_CRYSTAL_SPRING)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local Count = trade:getItemCount()
 
-    if CurrentMission ~= xi.mission.id.sandoria.NONE then
-        if CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
+    if currentMission ~= xi.mission.id.sandoria.NONE then
+        if currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 and OrcishScoutCompleted == false then -- Trade Orcish Axe
             player:startEvent(1020) -- Finish Mission "Smash the Orcish scouts" (First Time)
-        elseif CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
+        elseif currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and trade:hasItemQty(16656, 1) and Count == 1 then -- Trade Orcish Axe
             player:startEvent(1002) -- Finish Mission "Smash the Orcish scouts" (Repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and MissionStatus == 2 then -- Trade Orcish Mail Scales
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(1112, 1) and Count == 1 and BatHuntCompleted == false and missionStatus == 2 then -- Trade Orcish Mail Scales
             player:startEvent(1023) -- Finish Mission "Bat Hunt"
-        elseif CurrentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted == true then -- Trade Bat Fang
+        elseif currentMission == xi.mission.id.sandoria.BAT_HUNT and trade:hasItemQty(891, 1) and Count == 1 and BatHuntCompleted == true then -- Trade Bat Fang
             player:startEvent(1003) -- Finish Mission "Bat Hunt" (repeat)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted == false then -- Trade Crystal Bass
             player:startEvent(1030) -- Dialog During Mission "The Crystal Spring"
-        elseif CurrentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
+        elseif currentMission == xi.mission.id.sandoria.THE_CRYSTAL_SPRING and trade:hasItemQty(4528, 1) and Count == 1 and TheCSpringCompleted then -- Trade Crystal Bass
             player:startEvent(1013) -- Finish Mission "The Crystal Spring" (repeat)
         else
             player:startEvent(1008) -- Wrong Item
@@ -47,12 +47,12 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.SANDORIA) then
         player:startEvent(1011) -- for Non-San d'Orians
     else
-        local CurrentMission = player:getCurrentMission(SANDORIA)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(SANDORIA)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
-        if CurrentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
+        if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then
             if (cs == 0) then
                 player:showText(npc, ID.text.ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -60,21 +60,21 @@ entity.onTrigger = function(player, npc)
             end
         elseif pRank == 1 and player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS) == false then
             player:startEvent(1000) -- Start First Mission "Smash the Orcish scouts"
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:hasKeyItem(xi.ki.ANCIENT_SANDORIAN_BOOK) then
             player:startEvent(1035)
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 4 then
             if player:getLocalVar("RanperresRest") == 1 then -- Requires player to zone.
                 player:startEvent(1037)
             else
                 player:startEvent(1039)
             end
-        elseif CurrentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
+        elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
             player:startEvent(1033)
-        elseif CurrentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
+        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
             player:startEvent(1041)
-        elseif CurrentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
+        elseif currentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
             player:startEvent(1043)
-        elseif CurrentMission ~= xi.mission.id.sandoria.NONE then
+        elseif currentMission ~= xi.mission.id.sandoria.NONE then
             player:startEvent(1001) -- Have mission already activated
         else
             local mission_mask, repeat_mask = getMissionMask(player)

--- a/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
+++ b/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
@@ -36,7 +36,7 @@ battlefield_object.onEventUpdate = function(player, csid, option)
 end
 
 battlefield_object.onEventFinish = function(player, csid, option)
-    player:setMissionStatus(player:getNation(), 2) -- This should be MissionStatus..But all battlefields of same var need updated.
+    player:setMissionStatus(player:getNation(), 2) -- This should be missionStatus..But all battlefields of same var need updated.
 end
 
 return battlefield_object

--- a/scripts/zones/Windurst_Walls/npcs/Yoran-Oran.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Yoran-Oran.lua
@@ -38,10 +38,10 @@ entity.onTrigger = function(player, npc)
     local turmoil = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
     local MEMORIES_OF_A_MAIDEN = player:getCharVar("MEMORIES_OF_A_MAIDEN_Status")
     local LouverancePath = player:getCharVar("COP_Louverance_s_Path")
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
 
     --optional windy 9-1
-    if player:getCurrentMission(WINDURST) == xi.mission.id.windurst.DOLL_OF_THE_DEAD and MissionStatus == 4 then
+    if player:getCurrentMission(WINDURST) == xi.mission.id.windurst.DOLL_OF_THE_DEAD and missionStatus == 4 then
         player:startEvent(439, 0, 17868, 1181)
     elseif player:getCurrentMission(COP) == xi.mission.id.cop.THE_ROAD_FORKS and MEMORIES_OF_A_MAIDEN == 3 then
         player:startEvent(469)

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -17,18 +17,18 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.WINDURST) then
         player:startEvent(87) -- for other nation
     else
-        local CurrentMission = player:getCurrentMission(WINDURST)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(WINDURST)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 4, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 4, currentMission, missionStatus)
 
-        if (CurrentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= xi.mission.id.windurst.NONE) then
+        elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(91)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
             player:startEvent(96)

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -26,16 +26,16 @@ end
 entity.onTrigger = function(player, npc)
     local moonlitPath = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_MOONLIT_PATH)
     local realday = tonumber(os.date("%j")) -- %M for next minute, %j for next day
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
     local tuningIn = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN)
     local tuningOut = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_OUT)
     local turmoil = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
 
     -- Check if we are on Windurst Mission 1-3 and haven't already delivered both offerings.
-    if (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_PRICE_OF_PEACE and MissionStatus < 3) then
+    if (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_PRICE_OF_PEACE and missionStatus < 3) then
         if (player:hasKeyItem(xi.ki.FOOD_OFFERINGS) == false and player:hasKeyItem(xi.ki.DRINK_OFFERINGS) == false) then
             player:startEvent(140)
-        elseif (MissionStatus >= 1) then
+        elseif (missionStatus >= 1) then
             player:startEvent(142) -- Keep displaying the instructions
         end
     -- Check if we are on Windurst Mission 7-2

--- a/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
@@ -17,18 +17,18 @@ entity.onTrigger = function(player, npc)
     if (player:getNation() ~= xi.nation.WINDURST) then
         player:startEvent(103) -- for other nation
     else
-        local CurrentMission = player:getCurrentMission(WINDURST)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(WINDURST)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 2, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 2, currentMission, missionStatus)
 
-        if (CurrentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= xi.mission.id.windurst.NONE) then
+        elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(109)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
             player:startEvent(118)

--- a/scripts/zones/Windurst_Waters/npcs/Moreno-Toeno.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Moreno-Toeno.lua
@@ -32,15 +32,15 @@ entity.onTrigger = function(player, npc)
             player:startEvent(758)
         end
     elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.A_TESTING_TIME) then
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local missionStatus = player:getMissionStatus(player:getNation())
         local alreadyCompleted = player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.A_TESTING_TIME)
-        if (MissionStatus == 0) then
+        if (missionStatus == 0) then
             if (alreadyCompleted == false) then
                 player:startEvent(182) -- First start at tahrongi
             else
                 player:startEvent(687) -- Repeat at buburimu
             end
-        elseif (MissionStatus == 1) then
+        elseif (missionStatus == 1) then
             start_time = player:getCharVar("testingTime_start_time")
             seconds_passed = os.time() - start_time
 

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -16,18 +16,18 @@ entity.onTrigger = function(player, npc)
     if player:getNation() ~= xi.nation.WINDURST then
         player:startEvent(105) -- for other nation
     else
-        local CurrentMission = player:getCurrentMission(WINDURST)
-        local MissionStatus = player:getMissionStatus(player:getNation())
+        local currentMission = player:getCurrentMission(WINDURST)
+        local missionStatus = player:getMissionStatus(player:getNation())
         local pRank = player:getRank()
-        local cs, p, offset = getMissionOffset(player, 1, CurrentMission, MissionStatus)
+        local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
-        if (CurrentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (CurrentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
             if cs == 0 then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (CurrentMission ~= xi.mission.id.windurst.NONE) then
+        elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(112)
         elseif not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             player:startEvent(121)

--- a/scripts/zones/Zeruhn_Mines/npcs/Drake_Fang.lua
+++ b/scripts/zones/Zeruhn_Mines/npcs/Drake_Fang.lua
@@ -14,19 +14,19 @@ end
 
 entity.onTrigger = function(player, npc)
     local currentMission = player:getCurrentMission(BASTOK)
-    local MissionStatus = player:getMissionStatus(player:getNation())
+    local missionStatus = player:getMissionStatus(player:getNation())
 
     -- Enter the Talekeeper 8-2
-    if currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and MissionStatus == 4 then
+    if currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and missionStatus == 4 then
         player:startEvent(204)
-    elseif currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and MissionStatus > 1 and MissionStatus < 4 then
+    elseif currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and missionStatus > 1 and missionStatus < 4 then
         player:startEvent(203)
-    elseif currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and MissionStatus == 0 then
+    elseif currentMission == xi.mission.id.bastok.ENTER_THE_TALEKEEPER and missionStatus == 0 then
         player:startEvent(202)
     -- Return of the Talekeeper 6-1
-    elseif currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER and MissionStatus > 1 then
+    elseif currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER and missionStatus > 1 then
         player:startEvent(201)
-    elseif currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER and MissionStatus == 1 then
+    elseif currentMission == xi.mission.id.bastok.RETURN_OF_THE_TALEKEEPER and missionStatus == 1 then
         player:startEvent(200)
     else
         player:startEvent(108)

--- a/tools/migrations/convert_mission_status.py
+++ b/tools/migrations/convert_mission_status.py
@@ -8,14 +8,14 @@ def check_preconditions(cur):
     return
 
 def needs_to_run(cur):
-    cur.execute("SELECT COUNT(*) FROM char_vars INNER JOIN chars ON char_vars.varname = 'MissionStatus' AND char_vars.charid = chars.charid AND chars.missions IS NOT NULL;")
+    cur.execute("SELECT COUNT(*) FROM char_vars INNER JOIN chars ON char_vars.varname = 'missionStatus' AND char_vars.charid = chars.charid AND chars.missions IS NOT NULL;")
     row = cur.fetchone()[0]
     if row and row > 0:
         return True
     return False
 
 def migrate(cur, db):
-    cur.execute("SELECT chars.charid, chars.nation, chars.missions, char_vars.value FROM chars INNER JOIN char_vars ON char_vars.varname = 'MissionStatus' AND char_vars.charid = chars.charid AND chars.missions IS NOT NULL;")
+    cur.execute("SELECT chars.charid, chars.nation, chars.missions, char_vars.value FROM chars INNER JOIN char_vars ON char_vars.varname = 'missionStatus' AND char_vars.charid = chars.charid AND chars.missions IS NOT NULL;")
     rows = cur.fetchall()
     for row in rows:
         charid = row[0]
@@ -26,7 +26,7 @@ def migrate(cur, db):
         missions[nation_status_index:nation_status_index+2] = mission_status.to_bytes(2, 'little')
         try:
             cur.execute("UPDATE chars SET missions = %s WHERE charid = %s", (missions, charid))
-            cur.execute("DELETE char_vars FROM char_vars WHERE charid = {} AND varname = 'MissionStatus';".format(charid))
+            cur.execute("DELETE char_vars FROM char_vars WHERE charid = {} AND varname = 'missionStatus';".format(charid))
             db.commit()
         except mysql.connector.Error as err:
             print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Normalize both variables names, so we dont have both:
- missionStatus AND MissionStatus
- currentMission AND CurrentMission

floating arround

Also fixes a typo that affected "Making Headlines" Windurst quest

Tested on my end, but I recommend further testing.
I'll PR a cleaning of this files once this gets merged. Becouse it's needed.