### PR TITLE
5-1 Fei'Yin CS fire on any method of arriving

### DIFF
--- a/scripts/zones/FeiYin/Zone.lua
+++ b/scripts/zones/FeiYin/Zone.lua
@@ -33,7 +33,7 @@ zone_object.onZoneIn = function(player, prevZone)
         SpawnMob(ID.mob.MISER_MURPHY) -- RDM AF
     end
 
-    if (prevZone == xi.zone.BEAUCEDINE_GLACIER and currentMission == xi.mission.id.nation.ARCHLICH and MissionStatus == 10) then
+    if (currentMission == xi.mission.id.nation.ARCHLICH and MissionStatus == 10) then
         cs = 1 -- MISSION 5-1
     elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and MissionStatus == 2) then
         cs = 23 -- San d'Oria 9-2


### PR DESCRIPTION
Apparently, retail does not (at least as of more recently) require players to zone in from Glacier to fire the 5-1 mission CS in Fei'Yin.

As reported by Aslenta recently in Canaria Discord.

Proof: https://youtu.be/AROflvxzmzo?t=13643

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
