### PR TITLE
Fix magic.lua parentheses errors

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -649,7 +649,7 @@ end
     end
 
     local skill = spell:getSkillType()
-    if skill == xi.skill.ELEMENTAL_MAGIC) then
+    if skill == xi.skill.ELEMENTAL_MAGIC then
         dmg = dmg * ELEMENTAL_POWER
     elseif skill == xi.skill.DARK_MAGIC then
         dmg = dmg * DARK_POWER
@@ -971,9 +971,9 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     end
 
     if params ~= nil and params.bonusmab ~= nil and params.includemab == true then
-        mab = 100 + caster:getMod(xi.mod.MATT) + params.bonusmab) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus
+        mab = (100 + caster:getMod(xi.mod.MATT) + params.bonusmab) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
     elseif params == nil or (params ~= nil and params.includemab == true) then
-        mab = 100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus
+        mab = (100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
     end
 
     if mab < 0 then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes some formatting errors for magic.lua, and corrects formula for MATT v MDEF