### PR TITLE
Fix Jobmaster display for other characters, add RoE capacity point rewards

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -233,6 +233,10 @@ local function completeRecord(player, record)
         player:addExp(rewards["xp"] * ROE_EXP_RATE)
     end
 
+    if rewards["capacity"] ~= nil and type(rewards["capacity"]) == "number" then
+        player:addCapacityPoints(rewards["capacity"])
+    end
+
     if
         player:getUnityLeader() > 0 and
         rewards["accolades"] ~= nil and

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -6299,6 +6299,25 @@ void CLuaBaseEntity::addExp(uint32 exp)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     charutils::AddExperiencePoints(false, PChar, m_PBaseEntity, exp);
+}
+
+/************************************************************************
+ *  Function: addCapacityPoints()
+ *  Purpose : Adds a set amount of Capacity Points to the player
+ *  Example : player:addCapacity(1000)
+ *  Notes   : Used for RoE rewards
+ ************************************************************************/
+
+void CLuaBaseEntity::addCapacityPoints(uint32 capacity)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+    charutils::AddCapacityPoints(PChar, m_PBaseEntity, capacity);
 }
 
 /************************************************************************
@@ -12942,6 +12961,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setMerits", CLuaBaseEntity::setMerits);
 
     SOL_REGISTER("getJobPointLevel", CLuaBaseEntity::getJobPointLevel);
+    SOL_REGISTER("addCapacityPoints", CLuaBaseEntity::addCapacityPoints);
     SOL_REGISTER("setCapacityPoints", CLuaBaseEntity::setCapacityPoints);
     SOL_REGISTER("setJobPoints", CLuaBaseEntity::setJobPoints);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -357,6 +357,7 @@ public:
 
     // Player Points
     void  addExp(uint32 exp);
+    void  addCapacityPoints(uint32 capacity);
     void  delExp(uint32 exp);
     int32 getMerit(uint16 merit);
     uint8 getMeritCount();

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -129,7 +129,8 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
 
             if (PChar->getMod(Mod::SUPERIOR_LEVEL) == 5 && PChar->m_jobMasterDisplay)
             {
-                ref<uint8>(0x42) = 0x80;
+                // TODO: This bitfield may be used more, update to shift
+                ref<uint8>(0x33) = 0x40;
             }
 
             ref<uint8>(0x43)  = 0x04;

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -80,7 +80,7 @@ namespace charutils
                              bool isexpchain = false);
 
     uint16 AddCapacityBonus(CCharEntity* PChar, uint16 capacityPoints);
-    void   AddCapacityPoints(CCharEntity* PChar, CBaseEntity* PMob, uint32 capacityPoints, int16 levelDiff, bool isCapacityChain);
+    void   AddCapacityPoints(CCharEntity* PChar, CBaseEntity* PMob, uint32 capacityPoints, int16 levelDiff = 0, bool isCapacityChain = false);
     void   DistributeCapacityPoints(CCharEntity* PChar, CMobEntity* PMob);
 
     void TrySkillUP(CCharEntity* PChar, SKILLTYPE SkillID, uint8 lvl, bool forceSkillUp = false, bool useSubSkill = false);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #35 and adds support for capacity point rewards (previously defined).