### PR TITLE
Add the Wiki as a submodule, enabling local copies of the wiki

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "navmeshes"]
 	path = navmeshes
 	url = https://github.com/DerpyProjectGroup/xiNavmeshes.git
+[submodule "documentation/wiki"]
+	path = documentation/wiki
+	url = https://github.com/DerpyProjectGroup/topaz.wiki.git


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Don't try to follow the links as git presents them here in the PR, that won't work. It IS pull-able however, as gollum based wikis are a valid repository in their own right. Which means you could do this without a submodule if you knew about it, but most people wouldn't know.