### PR TITLE
Add Against All Odds server midnight wait timer 

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -237,7 +237,7 @@ zone_object.onEventFinish = function(player, csid, option)
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) -- Start of af 3 not completed yet
         player:addKeyItem(xi.ki.LIFE_FLOAT) -- BCNM KEY ITEM TO ENTER BCNM
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.LIFE_FLOAT)
-        player:setCharVar("AgainstTimer", getMidnight())
+        player:setCharVar("AgainstAllOddsTimer", getMidnight())
     end
 end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -237,6 +237,7 @@ zone_object.onEventFinish = function(player, csid, option)
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS) -- Start of af 3 not completed yet
         player:addKeyItem(xi.ki.LIFE_FLOAT) -- BCNM KEY ITEM TO ENTER BCNM
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.LIFE_FLOAT)
+        player:setCharVar("AgainstTimer", getMidnight())
     end
 end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(552)
     elseif player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
         player:startEvent(772)
-    if (player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0)) then
+    if player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0) then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
     else
         player:startEvent(603)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -44,6 +44,7 @@ entity.onEventFinish = function(player, csid, option)
         npcUtil.completeQuest(player, AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS, {item = 18702, var = {"EquippedforAllOccasions", "LuckOfTheDraw"}})
     elseif csid == 604 then
         npcUtil.giveKeyItem(player, xi.ki.LIFE_FLOAT)
+        player:setCharVar("AgainstTimer", getMidnight())
     end
 end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(552)
     elseif player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
         player:startEvent(772)
-    if (player:getVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstTimer") < os.time() or player:getCharVar("AgainstTimer") == 0)) then
+    if (player:getVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0)) then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
     else
         player:startEvent(603)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(552)
     elseif player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
         player:startEvent(772)
-    if (player:getVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0)) then
+    if (player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0)) then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
     else
         player:startEvent(603)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -24,8 +24,8 @@ entity.onTrigger = function(player, npc)
         player:startEvent(552)
     elseif player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
         player:startEvent(772)
-    elseif againstAllOdds == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.LIFE_FLOAT) then
-        player:startEvent(604)
+    if (player:getVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstTimer") < os.time() or player:getCharVar("AgainstTimer") == 0)) then
+        player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
     else
         player:startEvent(603)
     end

--- a/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
@@ -50,6 +50,7 @@ instance_object.onInstanceComplete = function(instance)
     for i, v in pairs(chars) do
         if v:getCharVar("AgainstAllOdds") == 2 then
             v:setCharVar("AgainstAllOdds", 3)
+            v:setCharVar("AgainstAllOddsTimer",0)
         end
         v:startEvent(101)
     end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Had an issue with this NPC elsewhere, discovered the timer wasn't in place for the JP midnight wait for re-acquiring another KI for the battle. This adds a timer on the initial CS, adds a check for it but also accounts for characters that didn't get it set previously on the NPC to re-acquire the KI, and clears it on the battlefield victory.

https://www.bg-wiki.com/ffxi/Against_All_Odds
https://ffxiclopedia.fandom.com/wiki/Against_All_Odds