### PR TITLE
Fix capacity chains using incorrect variable

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3949,13 +3949,13 @@ namespace charutils
                 else
                 {
                     // TODO: Capacity Chain Timer is reduced after Chain 30
-                    PMember->expChain.chainTime   = gettick() + 30000;
-                    PMember->expChain.chainNumber = 1;
+                    PMember->capacityChain.chainTime   = gettick() + 30000;
+                    PMember->capacityChain.chainNumber = 1;
                 }
 
                 if (chainActive)
                 {
-                    PMember->expChain.chainTime = gettick() + 30000;
+                    PMember->capacityChain.chainTime = gettick() + 30000;
                 }
 
                 capacityPoints = AddCapacityBonus(PMember, capacityPoints);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes capacity chain using expChain variable.