### PR TITLE
Fix commands/setmobflags.lua

### DIFF
--- a/scripts/commands/getmobflags.lua
+++ b/scripts/commands/getmobflags.lua
@@ -34,5 +34,6 @@ function onTrigger(player, target)
 
     -- set flags
     local flags = targ:getMobFlags()
-    player:PrintToPlayer(string.format("%s's flags: %u", targ:getName(), flags))
+    local hex = "0x" .. string.format("%08x", flags)
+    player:PrintToPlayer(string.format("%s's flags: %s (%u)", targ:getName(), hex, flags))
 end

--- a/scripts/commands/setmobflags.lua
+++ b/scripts/commands/setmobflags.lua
@@ -17,14 +17,16 @@ end
 
 function onTrigger(player, flags, target)
     -- validate flags
-    if (flags == nil) then
+    if flags ~= nil and tonumber(flags) ~= nil then
+        flags = tonumber(flags)
+    else
         error(player, "You must supply a flags value.")
         return
     end
 
     -- validate target
     local targ
-    if (target == nil) then
+    if target == nil then
         targ = player:getCursorTarget()
         if (targ == nil or not targ:isMob()) then
             error(player, "You must either supply a mob ID or target a mob.")
@@ -32,7 +34,7 @@ function onTrigger(player, flags, target)
         end
     else
         targ = GetMobByID(target)
-        if (targ == nil) then
+        if targ == nil then
             error(player, "Invalid mob ID.")
             return
         end

--- a/scripts/commands/setmobflags.lua
+++ b/scripts/commands/setmobflags.lua
@@ -42,5 +42,6 @@ function onTrigger(player, flags, target)
 
     -- set flags
     player:setMobFlags(flags, targ:getID())
-    player:PrintToPlayer( string.format("Set %s %i flags to %i.", targ:getName(), targ:getID(), flags) )
+    local hex = "0x" .. string.format("%08x", flags)
+    player:PrintToPlayer( string.format("Set %s %i flags to %s (%i).", targ:getName(), targ:getID(), hex, flags) )
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Core said it wasn't a number, it was technically correct (hex input) and needed to be a string input so that we don't convert garbage input to zero.
![image](https://user-images.githubusercontent.com/6871475/116823653-a7c0d580-ab53-11eb-9b5f-c4525aaf9c09.png)
