### PR TITLE
fix error in volt gun attachment

### DIFF
--- a/scripts/globals/abilities/pets/attachments/volt_gun.lua
+++ b/scripts/globals/abilities/pets/attachments/volt_gun.lua
@@ -34,7 +34,7 @@ attachment_object.onManeuverLose = function(pet, maneuvers)
         pet:delMod(xi.mod.ENSPELL, pet:getMod(xi.mod.ENSPELL))
         pet:delMod(xi.mod.ENSPELL_DMG, pet:getMod(xi.mod.ENSPELL_DMG))
         pet:delMod(xi.mod.ENSPELL_CHANCE, pet:getMod(xi.mod.ENSPELL_CHANCE))
-        onEquip(pet)
+        attachment_object.onEquip(pet)
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes error
```
[Error] luautils::onManeuverLose: ./scripts/globals/abilities/pets/attachments/volt_gun.lua:38: attempt to call global 'onEquip' (a nil value)
stack traceback:
        ./scripts/globals/abilities/pets/attachments/volt_gun.lua:38: in function <./scripts/globals/abilities/pets/attachments/volt_gun.lua:27>
```