### PR TITLE
Fix one bad hunt entry; add hunt check to Voidwalker NMs

### DIFF
--- a/scripts/globals/hunts.lua
+++ b/scripts/globals/hunts.lua
@@ -299,7 +299,7 @@ local hunts =
     [430] = { bounty = 20, fee =   0 }, -- Antican Proconsul
     [431] = { bounty = 20, fee =   0 }, -- Antican Praefectus
     [432] = { bounty = 20, fee =   0 }, -- Antican Tribunus
-    [433] = { bounty = 20, fee =   0 }, -- Sabotender Bailarina
+    [433] = { bounty = 20, fee =   0 }, -- Sabotender Bailarin
     [434] = { bounty = 25, fee =   0 }, -- Tribunus VII-I
     [435] = { bounty = 30, fee =   0 }, -- Nussknacker
     [436] = { bounty = 30, fee =   0 }, -- Triarius X-XV

--- a/scripts/zones/Batallia_Downs/mobs/Skuld.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs/mobs/Urd.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs/mobs/Verthandi.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs/mobs/Yilbegan.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Skuld.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Urd.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Erebus.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Erebus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 557)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Feuerunke.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Feuerunke.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 558)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Lord_Ruthven.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.RUTHVEN_ENTOMBER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 556)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Yilbegan.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Erebus.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Erebus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 557)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Feuerunke.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Feuerunke.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 558)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Lord_Ruthven.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.RUTHVEN_ENTOMBER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 556)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Capricornus.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Capricornus.lua
@@ -1,7 +1,10 @@
 -----------------------------------
 --  Mob: Capricornus
 -----------------------------------
+require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -28,6 +31,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 546)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Krabkatoa.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Krabkatoa.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.KRABKATOA_STEAMER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 544)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Yacumama.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Yacumama.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 --  Mob: Yacumama
 -----------------------------------
+require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -28,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 545)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Yilbegan.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Capricornus.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Capricornus.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
 mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 546)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Krabkatoa.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Krabkatoa.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.KRABKATOA_STEAMER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 544)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Yacumama.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Yacumama.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 545)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest/mobs/Capricornus.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Capricornus.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
 mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 546)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest/mobs/Krabkatoa.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Krabkatoa.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.KRABKATOA_STEAMER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 544)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest/mobs/Yacumama.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Yacumama.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 545)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest/mobs/Yilbegan.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Capricornus.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Capricornus.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
 mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 546)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Krabkatoa.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Krabkatoa.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/keyitems")
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.KRABKATOA_STEAMER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 544)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Yacumama.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Yacumama.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLUE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 545)
 end
 
 return entity

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Yilbegan.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
@@ -2,11 +2,10 @@
 -- Area: La Theine Plateau
 --  Mob: Lumbering Lambert
 -----------------------------------
-require("scripts/globals/hunts")
 local ID = require("scripts/zones/La_Theine_Plateau/IDs")
------------------------------------
-require("scripts/globals/mobs")
 require("scripts/quests/tutorial")
+require("scripts/globals/hunts")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/La_Theine_Plateau/mobs/Yilbegan.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Farruca_Fly.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Farruca_Fly.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 552)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Jyeshtha.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Jyeshtha.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 551)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Orcus.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Orcus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 550)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Yilbegan.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Farruca_Fly.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Farruca_Fly.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 552)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Jyeshtha.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Jyeshtha.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 551)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Orcus.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Orcus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 550)
 end
 
 return entity

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Blobdingnag.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Blobdingnag.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 547)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Lamprey_Lord.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Lamprey_Lord.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 549)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Shoggoth.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Shoggoth.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 548)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Yilbegan.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Blobdingnag.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Blobdingnag.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 547)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Lamprey_Lord.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Lamprey_Lord.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 549)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Shoggoth.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Shoggoth.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 548)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Blobdingnag.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Blobdingnag.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 547)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Lamprey_Lord.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Lamprey_Lord.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 549)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Shoggoth.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Shoggoth.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 548)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Yilbegan.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Blobdingnag.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Blobdingnag.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 547)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Lamprey_Lord.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Lamprey_Lord.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 549)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Shoggoth.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Shoggoth.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.ORANGE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 548)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Quicksand_Caves/mobs/Sabotender_Bailarin.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Sabotender_Bailarin.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Quicksand Caves
---   NM: Sabotender Bailarina
+--   NM: Sabotender Bailarin
 -----------------------------------
 require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    xi.hunts.checkHunt(mob, player, 438)
+    xi.hunts.checkHunt(mob, player, 433)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Skuld.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Urd.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Verthandi.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Yilbegan.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Skuld.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Urd.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Skuld.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Urd.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Verthandi.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign/mobs/Yilbegan.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Skuld.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Skuld.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 555)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Urd.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Urd.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -29,6 +30,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.YELLOW_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 554)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Verthandi.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Verthandi.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/keyitems")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 
 local entity = {}
@@ -30,6 +31,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.VERTHANDI_ENSNARER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 553)
 end
 
 return entity

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Yilbegan.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Farruca_Fly.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Farruca_Fly.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 552)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Jyeshtha.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Jyeshtha.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 551)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Orcus.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Orcus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 550)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Yilbegan.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Farruca_Fly.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Farruca_Fly.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 552)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Jyeshtha.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Jyeshtha.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BROWN_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 551)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Orcus.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Orcus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.ORCUS_TROPHY_HUNTER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 550)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Erebus.lua
+++ b/scripts/zones/Xarcabard/mobs/Erebus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 557)
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Feuerunke.lua
+++ b/scripts/zones/Xarcabard/mobs/Feuerunke.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 558)
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Xarcabard/mobs/Lord_Ruthven.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.RUTHVEN_ENTOMBER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 556)
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Yilbegan.lua
+++ b/scripts/zones/Xarcabard/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Erebus.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Erebus.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 557)
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Feuerunke.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Feuerunke.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -28,6 +29,7 @@ end
 
 entity.onMobDeath = function(mob, player, isKiller)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.PURPLE_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 558)
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Lord_Ruthven.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Lord_Ruthven.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.RUTHVEN_ENTOMBER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, xi.keyItem.BLACK_ABYSSITE)
+    xi.hunts.checkHunt(mob, player, 556)
 end
 
 return entity

--- a/scripts/zones/Xarcabard_[S]/mobs/Yilbegan.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Yilbegan.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/titles")
 require("scripts/globals/voidwalker")
+require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
@@ -29,6 +30,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
     player:addTitle(xi.title.YILBEGAN_HIDEFLAYER)
     xi.voidwalker.onMobDeath(mob, player, isKiller, nil)
+    xi.hunts.checkHunt(mob, player, 559)
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Fix mixed-up hunt entries for Sabotender Bailarin vs Sabotender Bailarina
* Add hunt check to Voidwalker NMs
* Clean up requires on Lumbering Lambert
