### PR TITLE
create xi.expansionRegion.ORIGINAL_ROTZ using set constructor

### DIFF
--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -5,6 +5,7 @@
 --
 -----------------------------------
 require('scripts/globals/settings')
+require('scripts/globals/common')
 -----------------------------------
 
 xi = xi or {}
@@ -398,29 +399,28 @@ xi.zone =
 }
 
 xi.expansionRegion = xi.expansionRegion or {}
-xi.expansionRegion.ORIGINAL_ROTZ =
-{
-    [xi.region.RONFAURE]        = true,
-    [xi.region.ZULKHEIM]        = true,
-    [xi.region.NORVALLEN]       = true,
-    [xi.region.GUSTABERG]       = true,
-    [xi.region.DERFLAND]        = true,
-    [xi.region.SARUTABARUTA]    = true,
-    [xi.region.KOLSHUSHU]       = true,
-    [xi.region.ARAGONEU]        = true,
-    [xi.region.FAUREGANDI]      = true,
-    [xi.region.VALDEAUNIA]      = true,
-    [xi.region.QUFIMISLAND]     = true,
-    [xi.region.LITELOR]         = true,
-    [xi.region.KUZOTZ]          = true,
-    [xi.region.VOLLBOW]         = true,
-    [xi.region.ELSHIMOLOWLANDS] = true,
-    [xi.region.ELSHIMOUPLANDS]  = true,
-    [xi.region.SANDORIA]        = true,
-    [xi.region.BASTOK]          = true,
-    [xi.region.WINDURST]        = true,
-    [xi.region.JEUNO]           = true,
-    [xi.region.DYNAMIS]         = true
+xi.expansionRegion.ORIGINAL_ROTZ = set{
+    xi.region.RONFAURE,
+    xi.region.ZULKHEIM,
+    xi.region.NORVALLEN,
+    xi.region.GUSTABERG,
+    xi.region.DERFLAND,
+    xi.region.SARUTABARUTA,
+    xi.region.KOLSHUSHU,
+    xi.region.ARAGONEU,
+    xi.region.FAUREGANDI,
+    xi.region.VALDEAUNIA,
+    xi.region.QUFIMISLAND,
+    xi.region.LITELOR,
+    xi.region.KUZOTZ,
+    xi.region.VOLLBOW,
+    xi.region.ELSHIMOLOWLANDS,
+    xi.region.ELSHIMOUPLANDS,
+    xi.region.SANDORIA,
+    xi.region.BASTOK,
+    xi.region.WINDURST,
+    xi.region.JEUNO,
+    xi.region.DYNAMIS,
 }
 
 -----------------------------------


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
