### PR TITLE
fix list of folders checked by !reloadquest

### DIFF
--- a/scripts/commands/reloadquest.lua
+++ b/scripts/commands/reloadquest.lua
@@ -22,13 +22,14 @@ function fileExists(path)
 end
 
 local folders = {
-    "San_dOria",
-    "Bastok",
-    "Windurst",
-    "Jeuno",
-    "Other_Areas",
-    "Outlands",
-    "Aht_Urhgan",
+    "sandoria",
+    "bastok",
+    "windurst",
+    "jeuno",
+    "otherAreas",
+    "outlands",
+    "ahtUrhgan",
+    "hiddenQuests",
 }
 
 function onTrigger(player, questName)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fix the list of folders that !reloadquest looks in for given script.