### PR TITLE
QC and cleanup for "Methods Create Madness"

### DIFF
--- a/scripts/quests/sandoria/Methods_Create_Madness.lua
+++ b/scripts/quests/sandoria/Methods_Create_Madness.lua
@@ -40,7 +40,7 @@ quest.sections = {
 
             onEventFinish = {
                 [8] = function(player, csid, option, npc)
-                    if option == 1 and npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS) then
+                    if option == 1 and (player:hasItem(xi.items.SPEAR_OF_TRIALS) or npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS)) then
                         npcUtil.giveKeyItem(player, xi.keyItem.WEAPON_TRAINING_GUIDE)
                         quest:begin(player)
                     end
@@ -68,7 +68,7 @@ quest.sections = {
                     elseif player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) then
                         return quest:event(12) -- cont 2
                     else
-                        return quest:event(11) -- cont 1
+                        return quest:event(11, player:hasItem(xi.items.SPEAR_OF_TRIALS) and 1 or 0) -- cont 1
                     end
                 end,
 
@@ -87,7 +87,7 @@ quest.sections = {
 
             onEventFinish = {
                 [11] = function(player, csid, option, npc)
-                    if option == 1 then
+                    if option == 1 and not player:hasItem(xi.items.SPEAR_OF_TRIALS) then
                         npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS)
                     elseif option == 2 then
                         player:delQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.METHODS_CREATE_MADNESS)

--- a/scripts/quests/sandoria/Methods_Create_Madness.lua
+++ b/scripts/quests/sandoria/Methods_Create_Madness.lua
@@ -3,11 +3,16 @@
 -- Balasiel !pos -136 -11 64 230
 -- qm1 !pos 107 0.7 -125.25 176
 -----------------------------------
-require("scripts/globals/items")
-require("scripts/globals/quests")
-require("scripts/globals/npc_util")
 require('scripts/globals/interaction/quest')
 require("scripts/globals/weaponskillids")
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
+require("scripts/globals/status")
+require("scripts/globals/items")
+-----------------------------------
+local southernSandOriaID = require("scripts/zones/Southern_San_dOria/IDs")
+local seaSerpentGrottoID = require("scripts/zones/Sea_Serpent_Grotto/IDs")
 -----------------------------------
 
 local quest = Quest:new(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.METHODS_CREATE_MADNESS)
@@ -17,7 +22,7 @@ quest.reward = {
 }
 
 quest.sections = {
-
+    -- Talk to Balasiel in Southern San d'Oria who will give you the Spear of Trials and the Weapon Training Guide.
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
@@ -29,13 +34,13 @@ quest.sections = {
         [xi.zone.SOUTHERN_SAN_DORIA] = {
             ['Balasiel'] = {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(8) -- start
+                    return quest:event(8):oncePerZone() -- start
                 end,
             },
 
             onEventFinish = {
                 [8] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS)and option == 1 then
+                    if option == 1 and npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS) then
                         npcUtil.giveKeyItem(player, xi.keyItem.WEAPON_TRAINING_GUIDE)
                         quest:begin(player)
                     end
@@ -44,6 +49,12 @@ quest.sections = {
         },
     },
 
+    -- Perform Weapon Skills with the Spear of Trials on monsters that grant XP until the latent effect disappears.
+    -- Once you no longer receive the latent effect bonus, trade the Spear of Trials back to Balasiel, who will
+    -- take the weapon from you and give you a Map to the Annals of Truth and tell you to head to Sea Serpent Grotto.
+    -- Click the ??? to spawn the NM Water Leaper.
+    -- Once the NM is dead, reexamine the ??? to obtain the Annals of Truth.
+    -- Bring this back to Balasiel for your reward.
     {
         check = function(player, status, vars)
             return status == QUEST_ACCEPTED
@@ -62,8 +73,9 @@ quest.sections = {
                 end,
 
                 onTrade = function(player, npc, trade)
-                    local wsPoints = (trade:getItem(0):getWeaponskillPoints())
                     if npcUtil.tradeHasExactly(trade, xi.items.SPEAR_OF_TRIALS) then
+                        local wsPoints = trade:getItem(0):getWeaponskillPoints()
+
                         if wsPoints < 300 then
                             return quest:event(10) -- unfinished weapon
                         else
@@ -78,21 +90,23 @@ quest.sections = {
                     if option == 1 then
                         npcUtil.giveItem(player, xi.items.SPEAR_OF_TRIALS)
                     elseif option == 2 then
-                        player:delQuest(SANDORIA, METHODS_CREATE_MADNESS)
+                        player:delQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.METHODS_CREATE_MADNESS)
                         player:delKeyItem(xi.ki.WEAPON_TRAINING_GUIDE)
                         player:delKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH)
                     end
                 end,
+
                 [9] = function(player, csid, option, npc)
                     player:confirmTrade()
                     npcUtil.giveKeyItem(player, xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH)
                 end,
+
                 [13] = function(player, csid, option, npc)
                     player:delKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH)
                     player:delKeyItem(xi.ki.ANNALS_OF_TRUTH)
                     player:delKeyItem(xi.ki.WEAPON_TRAINING_GUIDE)
                     player:addLearnedWeaponskill(xi.ws_unlock.IMPULSE_DRIVE)
-                    player:messageSpecial(zones[player:getZoneID()].text.IMPULSE_DRIVE_LEARNED)
+                    player:messageSpecial(southernSandOriaID.text.IMPULSE_DRIVE_LEARNED)
                     quest:complete(player)
                 end,
             },
@@ -104,12 +118,17 @@ quest.sections = {
                     if player:getLocalVar('killed_wsnm') == 1 then
                         player:setLocalVar('killed_wsnm', 0)
                         player:addKeyItem(xi.ki.ANNALS_OF_TRUTH)
-                        return quest:messageSpecial(zones[player:getZoneID()].text.KEYITEM_OBTAINED, xi.ki.ANNALS_OF_TRUTH)
-                    elseif player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) and not player:hasKeyItem(xi.keyItem.ANNALS_OF_TRUTH) and npcUtil.popFromQM(player, npc, zones[player:getZoneID()].mob.WATER_LEAPER, {hide = 0}) then
-                        return quest:messageSpecial(zones[player:getZoneID()].text.SENSE_OMINOUS_PRESENCE)
+                        return quest:messageSpecial(seaSerpentGrottoID.text.KEYITEM_OBTAINED, xi.ki.ANNALS_OF_TRUTH)
+                    elseif
+                        player:hasKeyItem(xi.ki.MAP_TO_THE_ANNALS_OF_TRUTH) and
+                        not player:hasKeyItem(xi.keyItem.ANNALS_OF_TRUTH) and
+                        npcUtil.popFromQM(player, npc, seaSerpentGrottoID.mob.WATER_LEAPER, {hide = 0})
+                    then
+                        return quest:messageSpecial(seaSerpentGrottoID.text.SENSE_OMINOUS_PRESENCE)
                     end
                 end,
             },
+
             ['Water_Leaper'] = {
                 onMobDeath = function(mob, player, isKiller, firstCall)
                     player:setLocalVar('killed_wsnm', 1)
@@ -117,21 +136,6 @@ quest.sections = {
             },
         },
     },
-
-    {
-        check = function(player, status, vars)
-            return status >= QUEST_AVAILABLE
-        end,
-
-        [xi.zone.SEA_SERPENT_GROTTO] = {
-            ['qm1'] = {
-                onTrigger = function(player, npc)
-                    return quest:messageSpecial(zones[player:getZoneID()].text.NOTHING_OUT_OF_ORDINARY)
-                end,
-            },
-        },
-    },
 }
-
 
 return quest

--- a/scripts/zones/Sea_Serpent_Grotto/DefaultActions.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/DefaultActions.lua
@@ -1,0 +1,5 @@
+local ID = require("scripts/zones/Sea_Serpent_Grotto/IDs")
+
+return {
+    ['qm1'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+}

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Water_Leaper.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Water_Leaper.lua
@@ -5,7 +5,6 @@
 -- !pos 112.5 0.8 -126.2 176
 -- Involved in Quest: Methods Create Madness
 -----------------------------------
-require("scripts/globals/wsquest")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
@@ -16,7 +15,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    xi.wsquest.handleWsnmDeath(xi.wsquest.impulse_drive, player)
 end
 
 return entity

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/qm1.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/qm1.lua
@@ -4,13 +4,9 @@
 -- Quests: Methods Create Madness (Impulse Drive WSNM "Water Leaper")
 -- !pos 107 0.7 -125.25 176
 -----------------------------------
-local ID = require("scripts/zones/Sea_Serpent_Grotto/IDs")
-require("scripts/globals/wsquest")
------------------------------------
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    xi.wsquest.handleQmTrigger(xi.wsquest.impulse_drive, player, ID.mob.WATER_LEAPER)
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
@@ -10,35 +10,24 @@ require("scripts/globals/settings")
 require("scripts/globals/quests")
 require("scripts/globals/status")
 require("scripts/globals/titles")
-require("scripts/globals/wsquest")
 -----------------------------------
 local entity = {}
 
-local wsQuest = xi.wsquest.impulse_drive
-
 entity.onTrade = function(player, npc, trade)
-    local wsQuestEvent = xi.wsquest.getTradeEvent(wsQuest, player, trade)
-
-    if (wsQuestEvent ~= nil) then
-        player:startEvent(wsQuestEvent)
-    elseif (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST) == QUEST_ACCEPTED) then
+    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST) == QUEST_ACCEPTED) then
         if (trade:hasItemQty(940, 1) and trade:getItemCount() == 1) then
             player:startEvent(617)
         end
     end
-
 end
 
 entity.onTrigger = function(player, npc)
-    local wsQuestEvent = xi.wsquest.getTriggerEvent(wsQuest, player)
     local lvl = player:getMainLvl()
     local aSquiresTest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST)
     local aSquiresTestII = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II)
     local aKnightsTest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_KNIGHT_S_TEST)
 
-    if (wsQuestEvent ~= nil) then
-        player:startEvent(wsQuestEvent)
-    elseif (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER) == QUEST_ACCEPTED and player:getCharVar("KnightStalker_Progress") == 2) then
+    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER) == QUEST_ACCEPTED and player:getCharVar("KnightStalker_Progress") == 2) then
         player:startEvent(63) -- DRG AF3 cutscene, doesn't appear to have a follow up.
     elseif (lvl < 7) then
         player:startEvent(668)
@@ -147,8 +136,6 @@ entity.onEventFinish = function(player, csid, option)
         end
     elseif (csid == 63) then
         player:setCharVar("KnightStalker_Progress", 3)
-    else
-        xi.wsquest.handleEventFinish(wsQuest, player, csid, option, ID.text.IMPULSE_DRIVE_LEARNED)
     end
 
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* make start quest event once per zone, so it does not block other quests (wiki also indicates this should happen once per zone)
* check option before giving item
* when player has spear, do not show menu option about having lost the spear
* fix delQuest arguments
* replace final quest section with DefaultAction
* remove old quest code from NPCs
