### PR TITLE
add fameArea to otherAreas quests that reward fame

### DIFF
--- a/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
+++ b/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
@@ -18,6 +18,7 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.RYCH
 quest.reward =
 {
     fame  = 120,
+    fameArea = MHAURA,
     title = xi.title.PURVEYOR_IN_TRAINING,
     gil   = 1500,
 }
@@ -80,7 +81,7 @@ quest.sections =
                     if option == 71 or option == 72 then -- Accept quest.
                         quest:begin(player)
                     elseif option == 70 then -- Decline quest.
-                        quest:setVar(player, 'Prog', 3)      
+                        quest:setVar(player, 'Prog', 3)
                     end
                 end,
             },

--- a/scripts/quests/otherAreas/RQ2_Way_of_the_Cook.lua
+++ b/scripts/quests/otherAreas/RQ2_Way_of_the_Cook.lua
@@ -20,6 +20,7 @@ local totalHoursLeft = 0
 quest.reward =
 {
     fame  = 120,
+    fameArea = MHAURA,
     title = xi.title.ONESTAR_PURVEYOR,
 }
 

--- a/scripts/quests/otherAreas/RQ3_Unending_Chase.lua
+++ b/scripts/quests/otherAreas/RQ3_Unending_Chase.lua
@@ -17,6 +17,7 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.UNEN
 quest.reward =
 {
     fame  = 120,
+    fameArea = MHAURA,
     title = xi.title.TWOSTAR_PURVEYOR,
     gil   = 2100,
 }

--- a/scripts/quests/otherAreas/RQ4_His_Name_is_Valgeir.lua
+++ b/scripts/quests/otherAreas/RQ4_His_Name_is_Valgeir.lua
@@ -22,6 +22,7 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.HIS_
 quest.reward =
 {
     fame    = 120,
+    fameArea = MHAURA,
     gil     = 2000,
     keyItem = xi.ki.MAP_OF_THE_TORAIMARAI_CANAL,
 }

--- a/scripts/quests/otherAreas/RQ6_The_Clue.lua
+++ b/scripts/quests/otherAreas/RQ6_The_Clue.lua
@@ -17,6 +17,7 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.THE_
 quest.reward =
 {
     fame  = 120,
+    fameArea = MHAURA,
     title = xi.title.FOURSTAR_PURVEYOR,
     gil   = 3000,
 }

--- a/scripts/quests/otherAreas/RQ7_The_Basics.lua
+++ b/scripts/quests/otherAreas/RQ7_The_Basics.lua
@@ -21,6 +21,7 @@ local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.THE_
 quest.reward =
 {
     fame    = 120,
+    fameArea = MHAURA,
     item    = xi.items.TEA_SET,
     title   = xi.title.FIVESTAR_PURVEYOR,
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Because xi.quest.log_id.OTHER_AREAS doesn't have its own fame_area
