### PR TITLE
fix typo in Voidwalker textID

### DIFF
--- a/scripts/globals/voidwalker.lua
+++ b/scripts/globals/voidwalker.lua
@@ -37,7 +37,7 @@ local abyssiteMessage = {
 local function getCurrentKIsBitsFromPlayer(player)
     local results = 0
     local count = 8
-    for i, keyitem in ipairs(abyssiteKeyitems) do 
+    for i, keyitem in ipairs(abyssiteKeyitems) do
         local currentBit = 0
         if player:hasKeyItem(keyitem) then
             currentBit = 1
@@ -49,7 +49,7 @@ end
 
 local function getCurrentKIsFromPlayer(player)
     local results = {}
-    for i, keyitem in ipairs(abyssiteKeyitems) do 
+    for i, keyitem in ipairs(abyssiteKeyitems) do
         if player:hasKeyItem(keyitem) then
             table.insert(results, keyitem)
         end
@@ -97,7 +97,7 @@ local function setRandomPos(zoneId, mobId)
         return
     end
     local pos = searchEmptyPos(zoneId)
-    
+
     xi.voidwalker.pos[zoneId][pos].mobId = mobId
     local vPos = xi.voidwalker.pos[zoneId][pos].pos
     mob:setSpawn(vPos[1], vPos[2], vPos[3])
@@ -129,7 +129,7 @@ local getDirection = function(player, mob, distance)
 
     local tan = math.atan(diffz / diffx)
     local degree = math.deg(tan)
-    if degree < 0 then 
+    if degree < 0 then
         degree = degree * -1
     end
     local minDegree = 20
@@ -150,12 +150,12 @@ local getDirection = function(player, mob, distance)
         return 3
     elseif diffz <= 0 and diffx >= 0 and degree <= maxDegree and degree >= minDegree then
         return 1
-    end    
+    end
 end
 
---
+-----------------------------------
 -- check keyitem upgrade
---
+-----------------------------------
 local function checkUpgrade(player, mob, nextKeyItem)
     if player and mob:getZoneID() == player:getZoneID() then
         local TEXT = zones[mob:getZoneID()].text
@@ -172,16 +172,16 @@ local function checkUpgrade(player, mob, nextKeyItem)
                 elseif currentKeyItem == xi.keyItem.COLORFUL_ABYSSITE then
                     player:messageSpecial(TEXT.VOIDWALKER_UPGRADE_KI_2, currentKeyItem, nextKeyItem)
                 elseif nextKeyItem == xi.keyItem.BLACK_ABYSSITE then
-                    player:messageSpecial(TEXT.VOIDWALKER_OPTAIN_KI, nextKeyItem)
+                    player:messageSpecial(TEXT.VOIDWALKER_OBTAIN_KI, nextKeyItem)
                 end
             end
         end
     end
 end
 
--- 
+-----------------------------------
 -- NPC Assai Nybaem
--- 
+-----------------------------------
 xi.voidwalker.npcOnTrigger = function(player, npc)
     if ENABLE_VOIDWALKER ~= 1 then
         return
@@ -220,9 +220,9 @@ xi.voidwalker.npcOnEventFinish = function(player, csid, option)
     end
 end
 
---
+-----------------------------------
 -- Zone On Init
---
+-----------------------------------
 xi.voidwalker.zoneOnInit = function(zone)
     local zoneId = zone:getID()
     local VWMobs = zones[zoneId].mob.VOIDWALKER
@@ -235,8 +235,8 @@ end
 
 local mobIsBusy = function(mob)
     local act = mob:getCurrentAction()
-    return  act == xi.act.MOBABILITY_START or 
-            act == xi.act.MOBABILITY_USING or 
+    return  act == xi.act.MOBABILITY_START or
+            act == xi.act.MOBABILITY_USING or
             act == xi.act.MOBABILITY_FINISH or
             act == xi.act.MAGIC_START or
             act == xi.act.MAGIC_CASTING or
@@ -251,7 +251,7 @@ local function doMobSkillEveryHPP(mob, every, start, mobskill, condition)
         local isSame = startHppModulo == mobHppModulo
         if isSame and mob:getLocalVar('MOB_SKILL_' .. mobhpp) == 0 then
             mob:useMobAbility(mobskill)
-            mob:setLocalVar('MOB_SKILL_' .. mobhpp, 1)    
+            mob:setLocalVar('MOB_SKILL_' .. mobhpp, 1)
         end
     end
 end
@@ -333,9 +333,9 @@ local mixinByMobName = {
     end
 }
 
---
+-----------------------------------
 -- Mob On Init
---
+-----------------------------------
 xi.voidwalker.onMobInitialize = function(mob)
 end
 
@@ -410,15 +410,15 @@ xi.voidwalker.onMobDeath = function(mob, player, isKiller, keyItem)
                 checkUpgrade(playerpoped, mob, keyItem)
             end
         end
-        if player:hasKeyItem(popkeyitem) and not player:hasKeyItem(keyItem) then 
+        if player:hasKeyItem(popkeyitem) and not player:hasKeyItem(keyItem) then
             checkUpgrade(player, mob, keyItem)
         end
     end
 end
 
---
+-----------------------------------
 -- onHealing : trigg when player /heal
---
+-----------------------------------
 xi.voidwalker.onHealing = function(player)
     if ENABLE_VOIDWALKER ~= 1 then
         return

--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.BATALLIA_DOWNS] =
         VOIDWALKER_UPGRADE_KI_1  = 11341, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 11342, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 11343, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 11344, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 11344, -- Obtained key item: <keyitem>!
 
     },
     mob =

--- a/scripts/zones/Batallia_Downs_[S]/IDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/IDs.lua
@@ -28,7 +28,7 @@ zones[xi.zone.BATALLIA_DOWNS_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8308, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8309, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8310, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8311, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8311, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Beaucedine_Glacier/IDs.lua
+++ b/scripts/zones/Beaucedine_Glacier/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.BEAUCEDINE_GLACIER] =
         VOIDWALKER_UPGRADE_KI_1         = 11887, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2         = 11888, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI             = 11889, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI            = 11890, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI            = 11890, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Beaucedine_Glacier_[S]/IDs.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/IDs.lua
@@ -26,7 +26,7 @@ zones[xi.zone.BEAUCEDINE_GLACIER_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8660, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8661, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8662, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8663, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8663, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/East_Ronfaure/IDs.lua
+++ b/scripts/zones/East_Ronfaure/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.EAST_RONFAURE] =
         VOIDWALKER_UPGRADE_KI_1  = 11062, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 11063, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 11064, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 11065, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 11065, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/East_Ronfaure_[S]/IDs.lua
+++ b/scripts/zones/East_Ronfaure_[S]/IDs.lua
@@ -29,7 +29,7 @@ zones[xi.zone.EAST_RONFAURE_S] =
         VOIDWALKER_UPGRADE_KI_1  = 8045, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 8046, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 8047, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 8048, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 8048, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Jugner_Forest/IDs.lua
+++ b/scripts/zones/Jugner_Forest/IDs.lua
@@ -42,7 +42,7 @@ zones[xi.zone.JUGNER_FOREST] =
         VOIDWALKER_UPGRADE_KI_1  = 12094, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 12095, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 12096, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 12097, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 12097, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Jugner_Forest_[S]/IDs.lua
+++ b/scripts/zones/Jugner_Forest_[S]/IDs.lua
@@ -31,7 +31,7 @@ zones[xi.zone.JUGNER_FOREST_S] =
         VOIDWALKER_UPGRADE_KI_1  = 8603, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 8604, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 8605, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 8606, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 8606, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Konschtat_Highlands/IDs.lua
+++ b/scripts/zones/Konschtat_Highlands/IDs.lua
@@ -45,7 +45,7 @@ zones[xi.zone.KONSCHTAT_HIGHLANDS] =
         VOIDWALKER_UPGRADE_KI_1      = 10977, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2      = 10978, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI          = 10979, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI         = 10980, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI         = 10980, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/La_Theine_Plateau/IDs.lua
+++ b/scripts/zones/La_Theine_Plateau/IDs.lua
@@ -56,7 +56,7 @@ zones[xi.zone.LA_THEINE_PLATEAU] =
         VOIDWALKER_UPGRADE_KI_1      = 11315, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2      = 11316, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI          = 11317, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI         = 11318, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI         = 11318, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Meriphataud_Mountains/IDs.lua
+++ b/scripts/zones/Meriphataud_Mountains/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS] =
         VOIDWALKER_UPGRADE_KI_1  = 11728, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 11729, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 11730, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 11731, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 11731, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
@@ -28,7 +28,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS_S] =
         VOIDWALKER_UPGRADE_KI_1 = 7913, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 7914, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 7915, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 7916, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 7916, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/North_Gustaberg/IDs.lua
+++ b/scripts/zones/North_Gustaberg/IDs.lua
@@ -49,7 +49,7 @@ zones[xi.zone.NORTH_GUSTABERG] =
         VOIDWALKER_UPGRADE_KI_1       = 11536, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2       = 11537, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI           = 11538, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI          = 11539, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI          = 11539, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/North_Gustaberg_[S]/IDs.lua
+++ b/scripts/zones/North_Gustaberg_[S]/IDs.lua
@@ -29,7 +29,7 @@ zones[xi.zone.NORTH_GUSTABERG_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8182, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8183, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8184, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8185, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8185, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Pashhow_Marshlands/IDs.lua
+++ b/scripts/zones/Pashhow_Marshlands/IDs.lua
@@ -42,7 +42,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS] =
         VOIDWALKER_UPGRADE_KI_1  = 11849, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 11850, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 11851, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 11852, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 11852, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
@@ -29,7 +29,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8040, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8041, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8042, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8043, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8043, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Rolanberry_Fields/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields/IDs.lua
@@ -42,7 +42,7 @@ zones[xi.zone.ROLANBERRY_FIELDS] =
         VOIDWALKER_UPGRADE_KI_1  = 10964, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 10965, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 10966, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 10967, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 10967, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
@@ -27,7 +27,7 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8042, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8043, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8044, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8045, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8045, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Sauromugue_Champaign/IDs.lua
+++ b/scripts/zones/Sauromugue_Champaign/IDs.lua
@@ -44,7 +44,7 @@ zones[xi.zone.SAUROMUGUE_CHAMPAIGN] =
         VOIDWALKER_UPGRADE_KI_1  = 11003, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2  = 11004, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI      = 11005, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI     = 11006, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI     = 11006, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
@@ -26,7 +26,7 @@ zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8668, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8669, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8670, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8671, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8671, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Tahrongi_Canyon/IDs.lua
+++ b/scripts/zones/Tahrongi_Canyon/IDs.lua
@@ -54,7 +54,7 @@ zones[xi.zone.TAHRONGI_CANYON] =
         VOIDWALKER_UPGRADE_KI_1      = 11015, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2      = 11016, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI          = 11017, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI         = 11018, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI         = 11018, -- Obtained key item: <keyitem>!
 
     },
     mob =

--- a/scripts/zones/West_Sarutabaruta/IDs.lua
+++ b/scripts/zones/West_Sarutabaruta/IDs.lua
@@ -59,7 +59,7 @@ zones[xi.zone.WEST_SARUTABARUTA] =
         VOIDWALKER_UPGRADE_KI_1     = 11367, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2     = 11368, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI         = 11369, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI        = 11370, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI        = 11370, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/West_Sarutabaruta_[S]/IDs.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/IDs.lua
@@ -29,7 +29,7 @@ zones[xi.zone.WEST_SARUTABARUTA_S] =
         VOIDWALKER_UPGRADE_KI_1     = 8364, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2     = 8365, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI         = 8366, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI        = 8367, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI        = 8367, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Xarcabard/IDs.lua
+++ b/scripts/zones/Xarcabard/IDs.lua
@@ -47,7 +47,7 @@ zones[xi.zone.XARCABARD] =
         VOIDWALKER_UPGRADE_KI_1        = 11489, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2        = 11490, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI            = 11491, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI           = 11492, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI           = 11492, -- Obtained key item: <keyitem>!
     },
     mob =
     {

--- a/scripts/zones/Xarcabard_[S]/IDs.lua
+++ b/scripts/zones/Xarcabard_[S]/IDs.lua
@@ -26,7 +26,7 @@ zones[xi.zone.XARCABARD_S] =
         VOIDWALKER_UPGRADE_KI_1 = 8574, -- The <keyitem> takes on a slightly deeper hue and becomes <keyitem>!
         VOIDWALKER_UPGRADE_KI_2 = 8575, -- The <keyitem> takes on a deeper, richer hue and becomes <keyitem>!
         VOIDWALKER_BREAK_KI     = 8576, -- The <keyitem> shatters into tiny fragments.
-        VOIDWALKER_OPTAIN_KI    = 8577, -- Obtained key item: <keyitem>!
+        VOIDWALKER_OBTAIN_KI    = 8577, -- Obtained key item: <keyitem>!
     },
     mob =
     {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/DerpyProjectGroup/topaz/blob/info/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/DerpyProjectGroup/topaz/blob/info/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* rename textID from VOIDWALKER_OPTAIN_KI to VOIDWALKER_OBTAIN_KI
