### PR TITLE
Fix Promyvion - Vahzl Black Screen

### DIFF
--- a/scripts/zones/PsoXja/npcs/_i99.lua
+++ b/scripts/zones/PsoXja/npcs/_i99.lua
@@ -51,7 +51,7 @@ entity.onEventFinish = function(player, csid, option)
             player:setPos(-14.744, 0.036, -119.736, 1, 22) -- To Floor 1 {R}
         elseif (option == 2) then --floor 3
             player:setPos(183.546, 0, -59.906, 0, 22) -- To Floor 3 (Propagator) {R}
-        elseif (option == 2) then
+        elseif (option == 3) then
             player:setPos(415.757, 0, 139.977, 128, 22) -- To Floor 4 (Solicitor) {R}
         end
     elseif (csid == 112) then


### PR DESCRIPTION
We had nothing scripted for option 3 here, which lead players to a dark place. Whoopsie.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits