### PR TITLE
Fix PUP onMobSkillCheck for certain abilities, and skillup if type is nil

### DIFF
--- a/scripts/globals/abilities/pets/arcuballista.lua
+++ b/scripts/globals/abilities/pets/arcuballista.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.FIRE_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/armor_piercer.lua
+++ b/scripts/globals/abilities/pets/armor_piercer.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.DARK_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/armor_shatterer.lua
+++ b/scripts/globals/abilities/pets/armor_shatterer.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.WIND_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/bone_crusher.lua
+++ b/scripts/globals/abilities/pets/bone_crusher.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.LIGHT_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/cannibal_blade.lua
+++ b/scripts/globals/abilities/pets/cannibal_blade.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.DARK_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/chimera_ripper.lua
+++ b/scripts/globals/abilities/pets/chimera_ripper.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.FIRE_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/daze.lua
+++ b/scripts/globals/abilities/pets/daze.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.THUNDER_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/disruptor.lua
+++ b/scripts/globals/abilities/pets/disruptor.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/economizer.lua
+++ b/scripts/globals/abilities/pets/economizer.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/eraser.lua
+++ b/scripts/globals/abilities/pets/eraser.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/flashbulb.lua
+++ b/scripts/globals/abilities/pets/flashbulb.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/heat_capacitor.lua
+++ b/scripts/globals/abilities/pets/heat_capacitor.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/knockout.lua
+++ b/scripts/globals/abilities/pets/knockout.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.WIND_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/magic_mortar.lua
+++ b/scripts/globals/abilities/pets/magic_mortar.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.LIGHT_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/mana_converter.lua
+++ b/scripts/globals/abilities/pets/mana_converter.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/provoke.lua
+++ b/scripts/globals/abilities/pets/provoke.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/ranged_attack.lua
+++ b/scripts/globals/abilities/pets/ranged_attack.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, mob, skill)
+ability_object.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/reactive_shield.lua
+++ b/scripts/globals/abilities/pets/reactive_shield.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/replicator.lua
+++ b/scripts/globals/abilities/pets/replicator.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/shield_bash.lua
+++ b/scripts/globals/abilities/pets/shield_bash.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/shock_absorber.lua
+++ b/scripts/globals/abilities/pets/shock_absorber.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     return 0
 end
 

--- a/scripts/globals/abilities/pets/slapstick.lua
+++ b/scripts/globals/abilities/pets/slapstick.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.THUNDER_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/string_clipper.lua
+++ b/scripts/globals/abilities/pets/string_clipper.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.THUNDER_MANEUVER)
 end

--- a/scripts/globals/abilities/pets/string_shredder.lua
+++ b/scripts/globals/abilities/pets/string_shredder.lua
@@ -8,7 +8,7 @@ require("scripts/globals/automatonweaponskills")
 -----------------------------------
 local ability_object = {}
 
-function onMobSkillCheck(target, automaton, skill)
+ability_object.onMobSkillCheck = function(target, automaton, skill)
     local master = automaton:getMaster()
     return master:countEffect(xi.effect.THUNDER_MANEUVER)
 end

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -204,7 +204,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         hitdmg = modifyMeleeHitDamage(attacker, target, calcParams.attackInfo, wsParams, hitdmg)
     end
 
-    if hitdmg > 0 then
+    if calcParams.skillType and hitdmg > 0 then
         attacker:trySkillUp(calcParams.skillType, targetLvl)
     end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to Topaz Next's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #103 
* TrySkillUp only called if skillType is not nil (pup ranged ability is handled in core for skill)
* onMobSkillCheck for certain PUP abilitys moved to their ability_object (was being overwritten as global)