### PR TITLE
allow account_ip_record to build on db reset

### DIFF
--- a/sql/account_ip_record.sql
+++ b/sql/account_ip_record.sql
@@ -1,3 +1,5 @@
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+
 --
 -- Table structure for table `account_ip_record`
 --


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This account_ip_record table will now be created when db is reset or updated.

Without this fix, the table isn't built:

![image](https://user-images.githubusercontent.com/21246949/118380554-a90cec00-b5b0-11eb-95a4-e773aa2c7dbb.png)
