### PR TITLE
Convert COR Job Unlock and AF1 quests to Interaction Framework

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -96,4 +96,5 @@ xi.items =
     BOW_OF_TRIALS                   = 18144,
     GUN_OF_TRIALS                   = 18146,
     BIBIKI_SEASHELL                 = 18257,
+    TRUMP_GUN                       = 18702,
 }

--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -60,6 +60,7 @@ xi.items =
     MERCANBALIGI                    = 5454,
     AHTAPOT                         = 5455,
     ISTIRIDYE                       = 5456,
+    CORSAIR_DIE                     = 5493,
     POT_OF_WHITE_HONEY              = 5562,
     IRMIK_HELVASI                   = 5572,
     BOWL_OF_SUTLAC                  = 5577,

--- a/scripts/quests/ahtUrhgan/Equipped_for_All_Occasions.lua
+++ b/scripts/quests/ahtUrhgan/Equipped_for_All_Occasions.lua
@@ -73,7 +73,7 @@ quest.sections =
 
             ['Lost_Soul'] =
             {
-                onMobDeath = function()
+                onMobDeath = function(mob, player, isKiller, noKiller)
                     if quest:getVar(player, 'Prog') == 1 then
                         quest:setVar(player, 'Prog', 2)
                     end
@@ -114,7 +114,7 @@ quest.sections =
             ['Ratihb'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 3 and quest:getVar(player, 'HasSeenDialog') then
+                    if quest:getVar(player, 'Prog') == 4 and quest:getVar(player, 'Stage') == 1 then
                         return quest:progressEvent(772)
                     end
                 end,

--- a/scripts/quests/ahtUrhgan/Equipped_for_All_Occasions.lua
+++ b/scripts/quests/ahtUrhgan/Equipped_for_All_Occasions.lua
@@ -1,0 +1,133 @@
+-----------------------------------
+-- Equipped for All Occasions
+-- Corsair AF1 Quest
+-----------------------------------
+-- Log ID: 6, Quest ID: 24
+-- qm6 (H-10/Boat)  : !pos 468.767 -12.292 111.817 54
+-- _5i0 (Iron Door) : !pos 247.735 18.499 -142.267 198
+-- Ratihb           : !pos 75.225 -6.000 -137.203 50
+-----------------------------------
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
+require("scripts/globals/settings")
+require('scripts/globals/interaction/quest')
+-----------------------------------
+local mazeID = require("scripts/zones/Maze_of_Shakhrami/IDs")
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
+
+quest.reward =
+{
+    item  = xi.items.TRUMP_GUN,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+                player:getMainJob() == xi.job.COR and
+                player:getMainLvl() >= AF1_QUEST_LEVEL
+        end,
+
+        [xi.zone.ARRAPAGO_REEF] =
+        {
+            ['qm6'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(228)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [228] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.MAZE_OF_SHAKHRAMI] =
+        {
+            ['_5i0'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 1 then
+                        npcUtil.popFromQM(player, npc, mazeID.mob.LOST_SOUL, {hide = 0})
+                    elseif questProgress == 2 then
+                        return quest:progressEvent(66)
+                    end
+                end,
+            },
+
+            ['Lost_Soul'] =
+            {
+                onMobDeath = function()
+                    if quest:getVar(player, 'Prog') == 1 then
+                        quest:setVar(player, 'Prog', 2)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [66] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.WHEEL_LOCK_TRIGGER)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+            },
+        },
+
+        [xi.zone.ARRAPAGO_REEF] =
+        {
+            ['qm6'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        return quest:progressEvent(231)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [231] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.WHEEL_LOCK_TRIGGER)
+                    quest:setVar(player, 'Prog', 4)
+                end,
+            },
+        },
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Ratihb'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 and quest:getVar(player, 'HasSeenDialog') then
+                        return quest:progressEvent(772)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [772] = function(player, csid, option, npc)
+                    quest:complete(player)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
+++ b/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
@@ -6,13 +6,15 @@
 -- Ratihb           : !pos 75.225 -6.000 -137.203 50
 -- Mafwahb          : !pos 149.11 -2.000 -2.7127 50
 -- qm6 (H-10 / Boat): !pos 468.767 -12.292 111.817 54
--- qm1              : !pos 490.819 -2.370 167.028 54
+-- qm1              : !pos -62.239 -7.9619 -137.1251
 -- _1l0 (Rock Slab) : !pos -99 -7 -91 57
 -----------------------------------
 require("scripts/globals/items")
 require("scripts/globals/quests")
 require("scripts/globals/settings")
 require('scripts/globals/interaction/quest')
+-----------------------------------
+local talaccaCoveID = require("scripts/zones/Talacca_Cove/IDs")
 -----------------------------------
 
 local quest = Quest:new(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.LUCK_OF_THE_DRAW)
@@ -85,6 +87,17 @@ quest.sections =
                 end,
             },
 
+            onEventFinish =
+            {
+                [211] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+            },
+        },
+
+        [xi.zone.TALACCA_COVE] =
+        {
             ['qm1'] =
             {
                 onTrigger = function(player, npc)
@@ -94,22 +107,6 @@ quest.sections =
                 end,
             },
 
-            onEventFinish =
-            {
-                [211] = function(player, csid, option, npc)
-                    quest:begin(player)
-                    quest:setVar(player, 'Prog', 3)
-                end,
-
-                [2] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 4)
-                    npcUtil.giveKeyItem(player, xi.ki.FORGOTTEN_HEXAGUN)
-                end,
-            },
-        },
-
-        [xi.zone.TALACCA_COVE] =
-        {
             ['_1l0'] =
             {
                 onTrigger = function(player, npc)
@@ -121,14 +118,16 @@ quest.sections =
 
             onEventFinish =
             {
+                [2] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                    npcUtil.giveKeyItem(player, xi.ki.FORGOTTEN_HEXAGUN)
+                end,
+
                 [3] = function(player, csid, option, npc)
-                    if player:getFreeSlotsCount() == 0 then
-                        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.items.CORSAIR_DIE)
-                    else
-                        player:delKeyItem(xi.ki.FORGOTTEN_HEXAGUN)
+                    if quest:complete(player) then
+	                    player:delKeyItem(xi.ki.FORGOTTEN_HEXAGUN)
                         player:unlockJob(xi.job.COR)
-                        quest:complete(player)
-                        player:messageSpecial(ID.text.YOU_CAN_NOW_BECOME_A_CORSAIR)
+                        player:messageSpecial(talaccaCoveID.text.YOU_CAN_NOW_BECOME_A_CORSAIR)
                     end
                 end,
             },
@@ -139,9 +138,9 @@ quest.sections =
         check = function(player, status, vars)
             -- Event 552 is a once event that can occur after completing "Luck of the Draw"
             -- but before finishing Equipped for all Occasions.  This charvar is cleaned up
-            -- on complete of Equipped for all Occassions when quest:complete() is called.
+            -- on complete of Equipped for all Occasions when quest:complete() is called.
             return status == QUEST_COMPLETED and
-                not player:getCharVar("Quest[6][24]HasSeenDialog") and
+                player:getCharVar("Quest[6][24]Stage") == 0 and
                 not player:hasCompletedQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
         end,
 
@@ -156,8 +155,8 @@ quest.sections =
 
             onEventFinish =
             {
-                [547] = function(player, csid, option, npc)
-                    player:setCharVar("Quest[6][24]HasSeenDialog", 1)
+                [552] = function(player, csid, option, npc)
+                    player:setCharVar("Quest[6][24]Stage", 1)
                 end,
             },
         },

--- a/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
+++ b/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
@@ -1,0 +1,167 @@
+-----------------------------------
+-- Luck of the Draw
+-- Corsair Job Flag Quest
+-----------------------------------
+-- Log ID: 6, Quest ID: 6
+-- Ratihb           : !pos 75.225 -6.000 -137.203 50
+-- Mafwahb          : !pos 149.11 -2.000 -2.7127 50
+-- qm6 (H-10 / Boat): !pos 468.767 -12.292 111.817 54
+-- qm1              : !pos 490.819 -2.370 167.028 54
+-- _1l0 (Rock Slab) : !pos -99 -7 -91 57
+-----------------------------------
+require("scripts/globals/items")
+require("scripts/globals/quests")
+require("scripts/globals/settings")
+require('scripts/globals/interaction/quest')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.LUCK_OF_THE_DRAW)
+
+quest.reward =
+{
+    item  = xi.items.CORSAIR_DIE,
+    title = SEAGULL_PHRATRIE_CREW_MEMBER,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and player:getMainLvl() >= ADVANCED_JOB_LEVEL
+        end,
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Ratihb'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(547)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [547] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Mafwahb'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(548)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [548] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+            },
+        },
+
+        [xi.zone.ARRAPAGO_REEF] =
+        {
+            ['qm6'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 2 then
+                        return quest:progressEvent(211)
+                    end
+                end,
+            },
+
+            ['qm1'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        return quest:progressEvent(2)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [211] = function(player, csid, option, npc)
+                    quest:begin(player)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [2] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                    npcUtil.giveKeyItem(player, xi.ki.FORGOTTEN_HEXAGUN)
+                end,
+            },
+        },
+
+        [xi.zone.TALACCA_COVE] =
+        {
+            ['_1l0'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 4 then
+                        return quest:progressEvent(3)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [3] = function(player, csid, option, npc)
+                    if player:getFreeSlotsCount() == 0 then
+                        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.items.CORSAIR_DIE)
+                    else
+                        player:delKeyItem(xi.ki.FORGOTTEN_HEXAGUN)
+                        player:unlockJob(xi.job.COR)
+                        quest:complete(player)
+                        player:messageSpecial(ID.text.YOU_CAN_NOW_BECOME_A_CORSAIR)
+                    end
+                end,
+            },
+        }
+    },
+
+    {
+        check = function(player, status, vars)
+            -- Event 552 is a once event that can occur after completing "Luck of the Draw"
+            -- but before finishing Equipped for all Occasions.  This charvar is cleaned up
+            -- on complete of Equipped for all Occassions when quest:complete() is called.
+            return status == QUEST_COMPLETED and
+                not player:getCharVar("Quest[6][24]HasSeenDialog") and
+                not player:hasCompletedQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
+        end,
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Ratihb'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(552)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [547] = function(player, csid, option, npc)
+                    player:setCharVar("Quest[6][24]HasSeenDialog", 1)
+                end,
+            },
+        },
+    }
+}
+
+return quest

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Mafwahb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Mafwahb.lua
@@ -9,16 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    local LuckOfTheDraw = player:getCharVar("LuckOfTheDraw")
-
-    if LuckOfTheDraw ==1 then
-        player:startEvent(548)
-        player:setCharVar("LuckOfTheDraw", 2)
-    else
-        player:startEvent(647)
-    end
-
+    player:startEvent(647)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -15,9 +15,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
-        player:startEvent(772)
-    elseif player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0) then
+    if player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0) then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
     else
         player:startEvent(603)
@@ -28,9 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 772 then
-        npcUtil.completeQuest(player, AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS, {item = 18702, var = {"EquippedforAllOccasions", "LuckOfTheDraw"}})
-    elseif csid == 604 then
+    if csid == 604 then
         npcUtil.giveKeyItem(player, xi.ki.LIFE_FLOAT)
         player:setCharVar("AgainstTimer", getMidnight())
     end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -15,14 +15,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local luckOfTheDraw = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.LUCK_OF_THE_DRAW)
-    local againstAllOdds = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.AGAINST_ALL_ODDS)
-
-    if luckOfTheDraw == QUEST_AVAILABLE and player:getMainLvl() >= ADVANCED_JOB_LEVEL then
-        player:startEvent(547)
-    elseif luckOfTheDraw == QUEST_COMPLETED and player:getCharVar("LuckOfTheDraw") == 5 then
-        player:startEvent(552)
-    elseif player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
+    if player:getCharVar("EquippedforAllOccasions") == 4 and player:getCharVar("LuckOfTheDraw") == 6 then
         player:startEvent(772)
     elseif player:getCharVar("AgainstAllOdds") == 2 and (player:getCharVar("AgainstAllOddsTimer") < os.time() or player:getCharVar("AgainstAllOddsTimer") == 0) then
         player:startEvent(604) -- reacquire life float, account for chars on quest previously without a var
@@ -35,12 +28,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 547 then
-        player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.LUCK_OF_THE_DRAW)
-        player:setCharVar("LuckOfTheDraw", 1)
-    elseif csid == 552 then
-        player:setCharVar("LuckOfTheDraw", 6)
-    elseif csid == 772 then
+    if csid == 772 then
         npcUtil.completeQuest(player, AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS, {item = 18702, var = {"EquippedforAllOccasions", "LuckOfTheDraw"}})
     elseif csid == 604 then
         npcUtil.giveKeyItem(player, xi.ki.LIFE_FLOAT)

--- a/scripts/zones/Arrapago_Reef/npcs/qm6.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm6.lua
@@ -19,17 +19,12 @@ end
 entity.onTrigger = function(player, npc)
     local mJob   = player:getMainJob()
     local mLvl   = player:getMainLvl()
-    local lotdCS = player:getCharVar("LuckOfTheDraw")
     local efao   = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
     local efaoCS = player:getCharVar("EquippedforAllOccasions")
     local ntus   = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.NAVIGATING_THE_UNFRIENDLY_SEAS)
 
-    -- LUCK OF THE DRAW
-    if lotdCS == 2 then
-        player:startEvent(211)
-
     -- EQUIPPED FOR ALL OCCASIONS
-    elseif efao == QUEST_AVAILABLE and mJob == xi.job.COR and mLvl >= AF1_QUEST_LEVEL then
+    if efao == QUEST_AVAILABLE and mJob == xi.job.COR and mLvl >= AF1_QUEST_LEVEL then
         player:startEvent(228)
     elseif efao == QUEST_ACCEPTED and efaoCS == 3 then
         player:startEvent(231)
@@ -50,12 +45,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- LUCK OF THE DRAW
-    if csid == 211 then
-        player:setCharVar("LuckOfTheDraw", 3)
-
     -- EQUIPPED FOR ALL OCCASIONS
-    elseif csid == 228 then
+    if csid == 228 then
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
         player:setCharVar("EquippedforAllOccasions", 1)
     elseif csid == 231 then

--- a/scripts/zones/Arrapago_Reef/npcs/qm6.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm6.lua
@@ -23,14 +23,8 @@ entity.onTrigger = function(player, npc)
     local efaoCS = player:getCharVar("EquippedforAllOccasions")
     local ntus   = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.NAVIGATING_THE_UNFRIENDLY_SEAS)
 
-    -- EQUIPPED FOR ALL OCCASIONS
-    if efao == QUEST_AVAILABLE and mJob == xi.job.COR and mLvl >= AF1_QUEST_LEVEL then
-        player:startEvent(228)
-    elseif efao == QUEST_ACCEPTED and efaoCS == 3 then
-        player:startEvent(231)
-
     -- NAVIGATING THE UNFRIENDLY SEAS
-    elseif efao == QUEST_COMPLETED and ntus == QUEST_AVAILABLE and mJob == xi.job.COR and mLvl >= AF2_QUEST_LEVEL then
+    if efao == QUEST_COMPLETED and ntus == QUEST_AVAILABLE and mJob == xi.job.COR and mLvl >= AF2_QUEST_LEVEL then
         player:startEvent(232)
     elseif player:getCharVar("NavigatingtheUnfriendlySeas") == 4 then
         player:startEvent(233)
@@ -45,16 +39,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- EQUIPPED FOR ALL OCCASIONS
-    if csid == 228 then
-        player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
-        player:setCharVar("EquippedforAllOccasions", 1)
-    elseif csid == 231 then
-        player:delKeyItem(xi.ki.WHEEL_LOCK_TRIGGER)
-        player:setCharVar("EquippedforAllOccasions", 4)
-
     -- NAVIGATING THE UNFRIENDLY SEAS
-    elseif csid == 232 then
+    if csid == 232 then
         player:addQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.NAVIGATING_THE_UNFRIENDLY_SEAS)
         player:setCharVar("NavigatingtheUnfriendlySeas", 1)
     elseif csid == 233 then

--- a/scripts/zones/Arrapago_Reef/npcs/qm6.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm6.lua
@@ -20,7 +20,6 @@ entity.onTrigger = function(player, npc)
     local mJob   = player:getMainJob()
     local mLvl   = player:getMainLvl()
     local efao   = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
-    local efaoCS = player:getCharVar("EquippedforAllOccasions")
     local ntus   = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.NAVIGATING_THE_UNFRIENDLY_SEAS)
 
     -- NAVIGATING THE UNFRIENDLY SEAS

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Lost_Soul.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Lost_Soul.lua
@@ -5,9 +5,6 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    if player:getCharVar("EquippedforAllOccasions") == 1 then
-        player:setCharVar("EquippedforAllOccasions", 2)
-    end
 end
 
 return entity

--- a/scripts/zones/Maze_of_Shakhrami/npcs/_5i0.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/_5i0.lua
@@ -4,35 +4,18 @@
 --  NPC: Iron Door (Spawn Lost Soul)
 -- !pos 247.735 18.499 -142.267 198
 -----------------------------------
-local ID = require("scripts/zones/Maze_of_Shakhrami/IDs")
-require("scripts/globals/keyitems")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local efao = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.EQUIPPED_FOR_ALL_OCCASIONS)
-    local efaoStat = player:getCharVar("EquippedforAllOccasions")
-
-    if efao == QUEST_ACCEPTED and efaoStat == 1 and npcUtil.popFromQM(player, npc, ID.mob.LOST_SOUL, {hide = 0}) then
-        -- no further action
-    elseif efao == QUEST_ACCEPTED and efaoStat == 2 then
-        player:startEvent(66)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 66 then
-        npcUtil.giveKeyItem(player, xi.ki.WHEEL_LOCK_TRIGGER)
-        player:setCharVar("EquippedforAllOccasions", 3)
-    end
 end
 
 return entity

--- a/scripts/zones/Talacca_Cove/npcs/_1l0.lua
+++ b/scripts/zones/Talacca_Cove/npcs/_1l0.lua
@@ -16,15 +16,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    local LuckOfTheDraw = player:getCharVar("LuckOfTheDraw")
-
-    if (LuckOfTheDraw ==4) then
-        player:startEvent(3)
-    elseif (EventTriggerBCNM(player, npc)) then
+    if EventTriggerBCNM(player, npc) then
         return
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option, extras)
@@ -32,19 +26,7 @@ entity.onEventUpdate = function(player, csid, option, extras)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 3) then -- complete corsair job flag quest
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 5493)
-        else
-            player:setCharVar("LuckOfTheDraw", 5) -- var will remain for af quests
-            player:addItem(5493)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 5493)
-            player:delKeyItem(xi.ki.FORGOTTEN_HEXAGUN)
-            player:unlockJob(xi.job.COR)
-            player:messageSpecial(ID.text.YOU_CAN_NOW_BECOME_A_CORSAIR)
-            player:completeQuest(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.LUCK_OF_THE_DRAW)
-        end
-    elseif (EventFinishBCNM(player, csid, option)) then
+    if EventFinishBCNM(player, csid, option) then
         return
     end
 

--- a/scripts/zones/Talacca_Cove/npcs/qm1.lua
+++ b/scripts/zones/Talacca_Cove/npcs/qm1.lua
@@ -11,26 +11,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    LuckOfTheDraw = player:getCharVar("LuckOfTheDraw")
-
-    if (LuckOfTheDraw ==3) then
-        player:startEvent(2)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 2) then
-        player:setCharVar("LuckOfTheDraw", 4)
-        player:addKeyItem(xi.ki.FORGOTTEN_HEXAGUN)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.FORGOTTEN_HEXAGUN)
-    end
-
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
