### PR TITLE
npcUtil.giveItem messages, options

### DIFF
--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -32,5 +32,9 @@ function onTrigger(player, itemId, quantity, aug0, aug0val, aug1, aug1val, aug2,
 
     -- Give the GM the item...
     player:addItem( itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId )
-    player:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+    if quantity and quantity > 1 then
+        player:messageSpecial( ID.text.ITEM_OBTAINED + 9, itemId , quantity )
+    else
+        player:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+    end
 end

--- a/scripts/commands/giveitem.lua
+++ b/scripts/commands/giveitem.lua
@@ -30,7 +30,11 @@ function onTrigger(player, target, itemId, amount, aug0, aug0val, aug1, aug1val,
         player:PrintToPlayer( string.format( "Player '%s' does not have free space for that item!", target ) )
     else
         targ:addItem( itemId, amount, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val )
-        targ:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+        if amount and amount > 1 then
+            targ:messageSpecial( ID.text.ITEM_OBTAINED + 9, itemId, amount )
+        else
+            targ:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+        end
         player:PrintToPlayer( string.format( "Gave player '%s' Item with ID of '%u' ", target, itemId ) )
     end
 end


### PR DESCRIPTION
Fixes #131

add additional optional params to npcUtil.giveItem

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

### npcUtil.giveItem
* when giving 4 of item FOO, display message "You obtain 4 FOOs!" instead of "Obtained: FOO"
* add `params`, with optional
    * `silent` (default false): if true, display no messages
    * `fromTrade` (default false): if true, when player has no room, display `"Try trading again after sorting your inventory"` instead of `"Come back again after sorting your inventory"`
    
example:
```
npcUtil.giveItem(player, {{2184, 3}}, {silent = true}) -- attempt to give 3 coins. display no messages.
npcUtil.giveItem(player, {{2184, 3}}, {fromTrade = true}) -- attempt to give 3 coins. if no room, display "trade again" message
```

### npcUtil.completeQuest and npcUtil.completeMission
* add itemParams, which passes through to npcUtil.giveItem

example:

```
        npcUtil.completeQuest(player, SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER, {
            item = {{2184, 3}},   -- attempt to give 3 coins
            itemParams = {        -- pass these options along to npcUtil.giveItem
                fromTrade = true,
            },
        })
```