### PR TITLE
[dbtool] Fix Windows specific preflight check

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -14,16 +14,16 @@ def preflight_exit():
         input('Press ENTER to continue...')
     exit(-1)
 
-# - git should available
+# - git should installed and available
 try:
     subprocess.call(["git"], stdout=subprocess.PIPE)
 except:
-    print("ERROR: Make sure a git executable is available in your system's PATH environment variable.")
+    print("ERROR: Make sure git is installed and available on your system's PATH environment variable.")
     preflight_exit()
 
 # - dbtool.py is designed to be run from <root>/tools folder, not <root>
 if not os.path.isfile("./dbtool.py"):
-    print("ERROR: dbtool.py is designed to be run from <root>/tools folder, not <root>. Please run from the tools folder.")
+    print("ERROR: dbtool.py is designed to be run from the <root>/tools folder, not <root>. Please run from the tools folder.")
     preflight_exit()
 
 # - Repo should be checked out as a git repo, not as plain files

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -14,9 +14,11 @@ def preflight_exit():
         input('Press ENTER to continue...')
     exit(-1)
 
-# - git should be on the user's PATH
-if not 'git' in os.environ['PATH'].lower():
-    print("ERROR: Make sure git.exe is available in your system's PATH environment variable.")
+# - git should available
+try:
+    subprocess.call(["git"], stdout=subprocess.PIPE)
+except:
+    print("ERROR: Make sure a git executable is available in your system's PATH environment variable.")
     preflight_exit()
 
 # - dbtool.py is designed to be run from <root>/tools folder, not <root>


### PR DESCRIPTION
Quickly swinging by with the web editor again, works on OSX, should work on Linux

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
