### PR TITLE
get and set mob roamflags via scripting

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2661,6 +2661,26 @@ xi.behavior =
 }
 
 -----------------------------------
+-- Roam flags
+-----------------------------------
+
+xi.roamFlag =
+{
+    NONE    = 0x000,
+    NONE0   = 0x001,
+    NONE1   = 0x002,
+    NONE2   = 0x004,
+    NONE3   = 0x008,
+    NONE4   = 0x010,
+    NONE5   = 0x020,
+    WORM    = 0x040, -- pop up and down when moving
+    AMBUSH  = 0x080, -- stays hidden until someone comes close (antlion)
+    EVENT   = 0x100, -- calls lua method for roaming logic
+    IGNORE  = 0x200, -- ignore all hate, except linking hate
+    STEALTH = 0x400, -- stays name hidden and untargetable until someone comes close (chigoe)
+}
+
+-----------------------------------
 -- Elevator IDs
 -----------------------------------
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12271,6 +12271,33 @@ void CLuaBaseEntity::setBehaviour(uint16 behavior)
     static_cast<CMobEntity*>(m_PBaseEntity)->m_Behaviour = behavior;
 }
 
+
+/************************************************************************
+ *  Function: getRoamFlags()
+ *  Purpose : Returns the current mob roam flags
+ *  Example : mob:getRoamFlags()
+ ************************************************************************/
+
+uint16 CLuaBaseEntity::getRoamFlags()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+    return static_cast<CMobEntity*>(m_PBaseEntity)->m_roamFlags;
+}
+
+/************************************************************************
+ *  Function: setRoamFlags()
+ *  Purpose : Sets roam flags for a mob
+ *  Example : mob:setRoamFlags(bit.bor(mob:getRoamFlags(), xi.roamFlag.STEALTH))
+ ************************************************************************/
+
+void CLuaBaseEntity::setRoamFlags(uint16 newRoamFlags)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+    static_cast<CMobEntity*>(m_PBaseEntity)->m_roamFlags = newRoamFlags;
+}
+
 /************************************************************************
  *  Function: getTarget()
  *  Purpose : Return available targets as a Lua table to the Mob
@@ -13469,6 +13496,8 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getBehaviour", CLuaBaseEntity::getBehaviour);
     SOL_REGISTER("setBehaviour", CLuaBaseEntity::setBehaviour);
+    SOL_REGISTER("getRoamFlags", CLuaBaseEntity::getRoamFlags);
+    SOL_REGISTER("setRoamFlags", CLuaBaseEntity::setRoamFlags);
 
     SOL_REGISTER("getTarget", CLuaBaseEntity::getTarget);
     SOL_REGISTER("updateTarget", CLuaBaseEntity::updateTarget);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -733,6 +733,8 @@ public:
 
     uint16 getBehaviour();
     void   setBehaviour(uint16 behavior);
+    uint16 getRoamFlags();
+    void   setRoamFlags(uint16 newRoamFlags);
 
     auto getTarget() -> std::optional<CLuaBaseEntity>;
     void updateTarget(); // Force mob to update target from enmity container (ie after updateEnmity)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

For #139 

Adds bindings to get and set mob roamFlags via scripting.

Note that I don't fully know potential ramifications of changing every roamflag on the fly via scripting.  Unexpected behavior may result.

For example in my testing if you set ROAMFLAG_STEALTH via mob:setRoamFlag(), the mob hides name and becomes untargetable on roam tick ...

https://github.com/LandSandBoat/server/blob/094ec9f022916bc86b8d0efee166b626ec560c2c/src/map/ai/controllers/mob_controller.cpp#L845-L852

... but if you then remove ROAMFLAG_STEALTH via mob:setRoamFlag(), while it does update the roamflags, it does not automatically unhide name/make targetable, because nothing in the core expects this.  So you'd have to unhide name/make targetable manually.

I'm guessing #139 wants this functionality so that it can set/unset ROAMFLAG_EVENT and toggle use of OnMobRoamAction; this PR should serve this purpose.