### PR TITLE
[interaction] QC quest "Waters of the Cheval"

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -56,7 +56,7 @@ xi.quest.id =
     [xi.quest.area[xi.quest.log_id.SANDORIA]] =
     {
         A_SENTRYS_PERIL                 = 0,  -- ±
-        WATER_OF_THE_CHEVAL             = 1,  -- ±
+        WATERS_OF_THE_CHEVAL            = 1,  -- ±
         ROSEL_THE_ARMORER               = 2,  -- ±
         THE_PICKPOCKET                  = 3,  -- ±
         FATHER_AND_SON                  = 4,  -- +

--- a/scripts/zones/East_Ronfaure/DefaultActions.lua
+++ b/scripts/zones/East_Ronfaure/DefaultActions.lua
@@ -1,0 +1,5 @@
+local ID = require("scripts/zones/East_Ronfaure/IDs")
+
+return {
+    ['Cheval_River'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+}

--- a/scripts/zones/East_Ronfaure/npcs/Cheval_River.lua
+++ b/scripts/zones/East_Ronfaure/npcs/Cheval_River.lua
@@ -2,43 +2,20 @@
 -- Area: East Ronfaure
 --  NPC: Cheval_River
 -- !pos 223 -58 426 101
---  Involved in Quest: Waters of Cheval
------------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/quests")
-local ID = require("scripts/zones/East_Ronfaure/IDs")
+-- Involved in Quest: "Waters of the Cheval"
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED and trade:hasItemQty(602, 1)) then
-        if (trade:getItemCount() == 1 and player:getFreeSlotsCount() > 0) then
-            player:tradeComplete()
-            player:addItem(603)
-            player:messageSpecial(ID.text.CHEVAL_RIVER_WATER, 603)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 603)
-        end
-    end
-
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:hasItem(602) == true) then
-        player:messageSpecial(ID.text.BLESSED_WATERSKIN)
-    else
-        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
 end
 
 return entity

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -4,6 +4,8 @@ return {
     ['Ailbeche']   = { event = 868 },
     ['Gilipese']   = { text = ID.text.GILIPESE_DIALOG },
     ['Maurinne']   = { text = ID.text.MAURINNE_DIALOG },
+    ['Miageau']    = { event = 517 },
+    ['Nouveil']    = { event = 574 },
     ['Pepigort']   = { text = ID.text.PEPIGORT_DIALOG },
     ['Rodaillece'] = { text = ID.text.RODAILLECE_DIALOG },
 }

--- a/scripts/zones/Northern_San_dOria/npcs/Miageau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Miageau.lua
@@ -3,59 +3,20 @@
 --  NPC: Miageau
 -- Type: Quest Giver NPC
 -- !pos 115 0 108 231
--- Starts and Finishes: Waters of Cheval
------------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/quests")
-require("scripts/globals/titles")
+-- Starts and Finishes: "Waters of the Cheval"
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED) then
-        if (trade:getItemCount() == 1 and trade:hasItemQty(603, 1)) then
-            player:startEvent(515)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-
-    local watersOfTheCheval = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL)
-    if (watersOfTheCheval == QUEST_ACCEPTED) then
-        if (player:hasItem(602) == true) then
-            player:startEvent(512)
-        else
-            player:startEvent(519)
-        end
-    elseif (watersOfTheCheval == QUEST_AVAILABLE) then
-        player:startEvent(504)
-    else
-        player:startEvent(517)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 515) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13183)
-        else
-            player:tradeComplete()
-            player:addItem(13183)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 13183)
-            player:addFame(SANDORIA, 30)
-            player:addTitle(xi.title.THE_PURE_ONE)
-            player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL)
-        end
-    elseif (csid == 504) then
-        player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL)
-    end
-
 end
 
 return entity

--- a/scripts/zones/Northern_San_dOria/npcs/Nouveil.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Nouveil.lua
@@ -1,53 +1,21 @@
 -----------------------------------
 -- Area: Northern San d'Oria
 --  NPC: Nouveil
--- Type: General
 -- !pos 123 0 106 231
------------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/quests")
+-- Involved in Quest: "Waters of the Cheval"
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED) then
-        if (trade:getGil() >= 10) then
-            player:startEvent(571)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.WATER_OF_THE_CHEVAL) == QUEST_ACCEPTED) then
-        if (player:hasItem(603) == true) then
-            player:startEvent(573)
-        elseif (player:hasItem(602) == true) then
-            player:startEvent(572)
-        else
-            player:startEvent(575)
-        end
-    else
-        player:startEvent(574)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    -- Waters of the Cheval, recieve blessed waterskin
-    if (csid == 571) then
-        if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 602)
-        else
-            player:delGil(10)
-            player:addItem(602)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 602)
-        end
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Fix typo in quest name
* Leverage the new `silent` and `fromTrade` params of npcUtil.giveItem
* Add default actions
* Remove old quest code from NPCs
