### PR TITLE
fix some mobs that had incorrect pools

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -5148,8 +5148,8 @@ INSERT INTO `mob_groups` VALUES (11,2085,87,'Invincible_Shield',0,128,0,0,0,1,1,
 INSERT INTO `mob_groups` VALUES (12,10,87,'3rd_Legionnaire',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (13,50,87,'Adelheid',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (14,3098,87,'Paralyzing_Tube',0,128,0,0,0,1,1,0);
-INSERT INTO `mob_groups` VALUES (15,420,87,'Binding_Tube',0,128,0,0,0,1,1,0);
-INSERT INTO `mob_groups` VALUES (16,3624,87,'Silencing_Tube',0,128,0,0,0,1,1,0);
+INSERT INTO `mob_groups` VALUES (15,3624,87,'Silencing_Tube',0,128,0,0,0,1,1,0);
+INSERT INTO `mob_groups` VALUES (16,420,87,'Binding_Tube',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (17,9,87,'2nd_Legion_Scout',0,128,0,0,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (18,3700,87,'Sonia',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (19,1331,87,'Field_Musician_Guard',0,128,0,0,0,0,0,0);
@@ -6287,8 +6287,8 @@ INSERT INTO `mob_groups` VALUES (52,6999,95,'Yilbegan',86400,0,3185,90000,5000,9
 INSERT INTO `mob_groups` VALUES (53,7010,95,'Orcus',7200,0,3182,39000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (54,7009,95,'Farruca_Fly',3600,0,3173,18200,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (55,7008,95,'Jyeshtha',3600,0,3172,11917,0,82,82,0);
-INSERT INTO `mob_groups` VALUES (56,7006,95,'Raker_Bee',300,0,0,5150,0,80,80,0);
-INSERT INTO `mob_groups` VALUES (57,7007,95,'Rummager_Beetle',300,0,0,4900,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (56,7007,95,'Rummager_Beetle',300,0,0,5150,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (57,7006,95,'Raker_Bee',300,0,0,4900,0,80,80,0);
 
 INSERT INTO `mob_groups` VALUES (58,2197,95,'Kayeel-Payeel',0,128,0,0,0,70,70,0);
 INSERT INTO `mob_groups` VALUES (59,2044,95,'Ice_Fiend',0,128,0,0,0,70,70,0);
@@ -6602,8 +6602,8 @@ INSERT INTO `mob_groups` VALUES (50,6999,97,'Yilbegan',86400,0,3185,90000,5000,9
 INSERT INTO `mob_groups` VALUES (51,7010,97,'Orcus',7200,0,3182,39000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (52,7009,97,'Farruca_Fly',3600,0,3173,18200,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (53,7008,97,'Jyeshtha',3600,0,3172,11917,0,82,82,0);
-INSERT INTO `mob_groups` VALUES (54,7006,97,'Raker_Bee',300,0,0,5150,0,80,80,0);
-INSERT INTO `mob_groups` VALUES (55,7007,97,'Rummager_Beetle',300,0,0,4900,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (54,7007,97,'Rummager_Beetle',300,0,0,5150,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (55,7006,97,'Raker_Bee',300,0,0,4900,0,80,80,0);
 
 INSERT INTO `mob_groups` VALUES (56,2197,97,'Kayeel-Payeel',0,128,0,0,0,70,70,0);
 INSERT INTO `mob_groups` VALUES (57,2044,97,'Ice_Fiend',0,128,0,0,0,70,70,0);
@@ -6817,10 +6817,10 @@ INSERT INTO `mob_groups` VALUES (97,4298,98,'War_Lynx',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (98,1333,98,'Fiendish_Leechkeeper',0,128,0,0,0,75,80,0);
 INSERT INTO `mob_groups` VALUES (99,3569,98,'Shadowhorn',0,128,2222,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (100,3570,98,'Shadowhorn_Stormer',0,128,0,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (101,3563,98,'Shadowfang',0,128,2213,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (102,3564,98,'Shadowfang_Void',0,128,0,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (103,3565,98,'Shadowhand',0,128,2219,0,0,60,60,0);
-INSERT INTO `mob_groups` VALUES (104,3566,98,'Shadowhand_Cuirassier',0,128,0,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (101,3565,98,'Shadowhand',0,128,2219,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (102,3566,98,'Shadowhand_Cuirassier',0,128,0,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (103,3563,98,'Shadowfang',0,128,2213,0,0,60,60,0);
+INSERT INTO `mob_groups` VALUES (104,3564,98,'Shadowfang_Void',0,128,0,0,0,60,60,0);
 INSERT INTO `mob_groups` VALUES (105,6608,98,'Shadoweye',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (106,3562,98,'Shadoweye_Gnat',0,128,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (107,1408,98,'Fortification',0,128,463,0,0,1,1,0);
@@ -8212,8 +8212,8 @@ INSERT INTO `mob_groups` VALUES (36,6999,115,'Yilbegan',86400,0,3185,90000,5000,
 INSERT INTO `mob_groups` VALUES (37,7010,115,'Orcus',7200,0,3182,39000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (38,7009,115,'Farruca_Fly',3600,0,3173,18200,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (39,7008,115,'Jyeshtha',3600,0,3172,11917,0,82,82,0);
-INSERT INTO `mob_groups` VALUES (40,7006,115,'Raker_Bee',300,0,0,5150,0,80,80,0);
-INSERT INTO `mob_groups` VALUES (41,7007,115,'Rummager_Beetle',300,0,0,4900,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (40,7007,115,'Rummager_Beetle',300,0,0,5150,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (41,7006,115,'Raker_Bee',300,0,0,4900,0,80,80,0);
 
 INSERT INTO `mob_groups` VALUES (42,5148,115,'Virvatuli',0,128,0,0,9999,89,90,0);
 INSERT INTO `mob_groups` VALUES (43,0,115,'Tatenashi_Armor',0,128,0,0,0,0,0,0);
@@ -8512,8 +8512,8 @@ INSERT INTO `mob_groups` VALUES (64,6999,119,'Yilbegan',86400,0,3185,90000,5000,
 INSERT INTO `mob_groups` VALUES (65,7010,119,'Orcus',7200,0,3182,39000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (66,7009,119,'Farruca_Fly',3600,0,3173,18200,0,82,82,0);
 INSERT INTO `mob_groups` VALUES (67,7008,119,'Jyeshtha',3600,0,3172,11917,0,82,82,0);
-INSERT INTO `mob_groups` VALUES (68,7006,119,'Raker_Bee',300,0,0,5150,0,80,80,0);
-INSERT INTO `mob_groups` VALUES (69,7007,119,'Rummager_Beetle',300,0,0,4900,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (68,7007,119,'Rummager_Beetle',300,0,0,5150,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (69,7006,119,'Raker_Bee',300,0,0,4900,0,80,80,0);
 
 INSERT INTO `mob_groups` VALUES (70,5189,119,'Lord_Asag',0,128,0,0,25000,94,95,0);
 INSERT INTO `mob_groups` VALUES (71,6839,119,'Warblade_Beak',0,128,0,0,0,99,99,0);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
