### PR TITLE
Interaction - Quest: Rosel the Armorer

### DIFF
--- a/scripts/quests/sandoria/Rosel_the_Armorer.lua
+++ b/scripts/quests/sandoria/Rosel_the_Armorer.lua
@@ -1,0 +1,139 @@
+-----------------------------------
+-- Rosel the Armorer
+-----------------------------------
+-- Log ID: 0, Quest ID: 2
+-- Rosel    : !pos 69.895 0 41.073 230
+-- Guilerme : !pos -4.5 0 99 231
+-----------------------------------
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
+require("scripts/globals/zone")
+require("scripts/globals/interaction/quest")
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER)
+
+quest.reward =
+{
+    -- Delivered to correct Prince: 200G, Incorrect Prince: 100G
+    title = xi.title.ENTRANCE_DENIED,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.SOUTHERN_SAN_DORIA] = {
+            ['Rosel'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+                    local questStage = quest:getVar(player, 'Stage')
+
+                    -- On triggering this CS, set a value to determine if Pieuje or Trion is the intended
+                    -- recipient.  This will persist until the quest is completed, and is one higher than
+                    -- the parameter value (1 == Pieuje, 2 == Trion)
+
+                    -- Using questStage directly eliminates the need for an additional questProgress state
+                    -- and the subsequent need for an additional db write on that change.
+                    if questStage == 0 then
+                        questStage = math.random(1, 2)
+                        quest:setVar(player, 'Stage', questStage)
+                    end
+
+                    if questProgress == 0 then
+                        return quest:progressEvent(523, 0, 0, 0, 0, questStage - 1)
+                    elseif questProgress == 1 then
+                        return quest:progressEvent(524, 0, 0, 0, 0, questStage - 1)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [523] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.RECEIPT_FOR_THE_PRINCE)
+                    else
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+
+                [524] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                        npcUtil.giveKeyItem(player, xi.ki.RECEIPT_FOR_THE_PRINCE)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.SOUTHERN_SAN_DORIA] =
+        {
+            ['Rosel'] =
+            {
+                onTrigger = function(player, npc)
+                    local questStage = quest:getVar(player, 'Stage')
+                    if player:hasKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE) then
+                        return quest:progressEvent(524, 0, 0, 0, 0, questStage - 1)
+                    else
+                        local questOption = quest:getVar(player, 'Option')
+                        return quest:progressEvent(527, 0, 0, 0, 0, questStage - 1, questOption)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [527] = function(player, csid, option, npc)
+                    local gilReward = 100
+
+                    if option == 0 then
+                        gilReward = 200
+                    end
+
+                    npcUtil.giveCurrency(player, "gil", gilReward)
+                    quest:complete(player)
+                end,
+            },
+        },
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Guilerme'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE) then
+                        local questStage = quest:getVar(player, 'Stage')
+                        return quest:progressEvent(507, 0, 0, 0, 0, 0, 0, questStage - 1)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [507] = function(player, csid, option, npc)
+                    -- The option returned from this event determines whether the player
+                    -- has chosen correctly or not.  Option 0 is correct answer, while
+                    -- option 1 was an incorrect answer.
+                    quest:setVar(player, 'Option', option)
+                    player:delKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Northern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Northern_San_dOria/DefaultActions.lua
@@ -3,6 +3,7 @@ local ID = require("scripts/zones/Northern_San_dOria/IDs")
 return {
     ['Ailbeche']   = { event = 868 },
     ['Gilipese']   = { text = ID.text.GILIPESE_DIALOG },
+    ['Guilerme']   = { text = ID.text.GUILERME_DIALOG },
     ['Maurinne']   = { text = ID.text.MAURINNE_DIALOG },
     ['Miageau']    = { event = 517 },
     ['Nouveil']    = { event = 574 },

--- a/scripts/zones/Northern_San_dOria/npcs/Guilerme.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Guilerme.lua
@@ -4,39 +4,18 @@
 --  Involved in Quest: Rosel the Armorer
 -- !pos -4.500 0.000 99.000 231
 -----------------------------------
-local ID = require("scripts/zones/Northern_San_dOria/IDs")
-require("scripts/globals/keyitems")
-require("scripts/globals/quests")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    -- "Rosel the Armorer" quest status var
-    local RoselTheArmorer = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER)
-
-    -- "Rosel the Armorer" - turn in reciept to prince
-    if (RoselTheArmorer == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE)) then
-        player:startEvent(507)
-    else
-        player:showText(npc, ID.text.GUILERME_DIALOG)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    -- "Rosel the Armorer", give receipt to NPC:Guilerme
-    if (csid == 507) then
-        player:delKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE)
-    end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -1,5 +1,6 @@
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 
 return {
+    ['Rosel']  = { text = ID.text.ROSEL_GREETINGS },
     ['Sobane'] = { text = ID.text.SOBANE_DIALOG },
 }

--- a/scripts/zones/Southern_San_dOria/IDs.lua
+++ b/scripts/zones/Southern_San_dOria/IDs.lua
@@ -49,6 +49,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA] =
         DYNA_NPC_DEFAULT_MESSAGE       = 7432, -- There is an unusual arrangement of branches here.
         VARCHET_BET_LOST               = 7763, -- You lose your bet of 5 gil.
         VARCHET_KEEP_PROMISE           = 7772, -- As promised, I shall go and see about those woodchippers. Maybe we can play another game later.
+        ROSEL_GREETINGS                = 7773, -- Greetings!
         FFR_ROSEL                      = 7792, -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
         LUSIANE_SHOP_DIALOG            = 7966, -- Hello! Let Taumila's handle all your sundry needs!
         OSTALIE_SHOP_DIALOG            = 7967, -- Welcome, customer. Please have a look.

--- a/scripts/zones/Southern_San_dOria/npcs/Rosel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rosel.lua
@@ -4,12 +4,7 @@
 -- Starts and Finishes Quest: Rosel the Armorer
 -- !zone 230
 -----------------------------------
-local ID = require("scripts/zones/Southern_San_dOria/IDs")
 require("scripts/quests/flyers_for_regine")
-require("scripts/globals/keyitems")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
-require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
@@ -18,42 +13,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    local RoselTheArmorer = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER)
-    local receiprForThePrince = player:hasKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE)
-
-    if (player:getCharVar("RefuseRoselTheArmorerQuest") == 1 and RoselTheArmorer == QUEST_AVAILABLE) then
-        player:startEvent(524)
-    elseif (RoselTheArmorer == QUEST_AVAILABLE) then
-        player:startEvent(523)
-        player:setCharVar("RefuseRoselTheArmorerQuest", 1)
-    elseif (RoselTheArmorer == QUEST_ACCEPTED and receiprForThePrince) then
-        player:startEvent(524)
-    elseif (RoselTheArmorer == QUEST_ACCEPTED and receiprForThePrince == false) then
-        player:startEvent(527)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    -- Rosel the Armorer, get quest and receipt for prince
-    if ((csid == 523 or csid == 524) and option == 0) then
-        player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER)
-        player:setCharVar("RefuseRoselTheArmorerQuest", 0)
-        player:addKeyItem(xi.ki.RECEIPT_FOR_THE_PRINCE)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RECEIPT_FOR_THE_PRINCE)
-    -- Rosel the Armorer, finished quest, recieve 200gil
-    elseif (csid == 527) then
-        npcUtil.completeQuest(player, SANDORIA, xi.quest.id.sandoria.ROSEL_THE_ARMORER, {
-            title= xi.title.ENTRANCE_DENIED,
-            gil= 200
-            })
-    end
-
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Converts 'Rosel the Armorer' to Interaction Framework and aligns with retail:
* Added random selection of Trion or Pieuje for quest objective
* Added failure messages for Rosel and Guilerme when incorrect choice was selected
* Added default actions for Rosel and Guilerme