### PR TITLE
Interaction - Quest: Fix Fear of the Dark 2 currency reward

### DIFF
--- a/scripts/quests/ahtUrhgan/Fear_of_the_Dark_2.lua
+++ b/scripts/quests/ahtUrhgan/Fear_of_the_Dark_2.lua
@@ -86,7 +86,7 @@ quest.sections = {
             onEventFinish = {
                 [18] = function(player, csid, option, npc)
                     player:confirmTrade()
-                    npcUtil.giveGil(player, 200)
+                    npcUtil.giveCurrency(player, "gil", 200)
                 end,
             },
         },


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

npcUtil.giveGil() does not exist in the current repo, converted to npcUtil.giveCurrency()