### PR TITLE
[build] Silence GCC note/warning:  variable tracking size limit exceeded with ‘-fvar-tracking-assignments’

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -86,6 +86,10 @@ function(set_project_warnings project_name)
       -Wno-extra
       -Wno-restrict
       -Wno-duplicated-branches
+      
+      # Silence GCC note/warning:
+      # note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’
+      --param=max-vartrack-size=60000000
   )
 
   if(MSVC)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -89,7 +89,7 @@ function(set_project_warnings project_name)
       
       # Silence GCC note/warning:
       # note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’
-      --param=max-vartrack-size=60000000
+      -fno-var-tracking-assignments
   )
 
   if(MSVC)


### PR DESCRIPTION
We want a nice clean build
GCC build now quiet:
```
[100%] Building CXX object src/map/CMakeFiles/topaz_game.dir/zone.cpp.o
[100%] Linking CXX executable ../../topaz_game
[100%] Built target topaz_game
```

**NOTE: Please squash on merge**

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
