### PR TITLE
Fix Some ToAU Instance Blackscreens

### DIFF
--- a/scripts/zones/Ilrusi_Atoll/Zone.lua
+++ b/scripts/zones/Ilrusi_Atoll/Zone.lua
@@ -31,7 +31,7 @@ end
 
 zone_object.onEventFinish = function(player, csid, option)
     if csid == 102 then
-        v:setPos(0, 0, 0, 0, 54)
+        player:setPos(0, 0, 0, 0, 54)
     end
 end
 

--- a/scripts/zones/Ilrusi_Atoll/Zone.lua
+++ b/scripts/zones/Ilrusi_Atoll/Zone.lua
@@ -30,12 +30,8 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    local instance = player:getInstance()
-    local chars = instance:getChars()
     if csid == 102 then
-        for i, v in pairs(chars) do
-            v:setPos(0, 0, 0, 0, 54)
-        end
+        v:setPos(0, 0, 0, 0, 54)
     end
 end
 

--- a/scripts/zones/Lebros_Cavern/Zone.lua
+++ b/scripts/zones/Lebros_Cavern/Zone.lua
@@ -30,7 +30,7 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if (csid == 102) then
+    if csid == 102 then
         player:setPos(0, 0, 0, 0, 61)
     end
 end

--- a/scripts/zones/Leujaoam_Sanctum/Zone.lua
+++ b/scripts/zones/Leujaoam_Sanctum/Zone.lua
@@ -29,7 +29,7 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if (csid == 102) then
+    if csid == 102 then
         player:setPos(0, 0, 0, 0, 79)
     end
 end

--- a/scripts/zones/Periqia/Zone.lua
+++ b/scripts/zones/Periqia/Zone.lua
@@ -32,11 +32,8 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    local chars = instance:getChars()
     if csid == 102 then
-        for i, v in pairs(chars) do
-            v:setPos(0, 0, 0, 0, 79)
-        end
+        v:setPos(0, 0, 0, 0, 79)
     end
 end
 

--- a/scripts/zones/Periqia/Zone.lua
+++ b/scripts/zones/Periqia/Zone.lua
@@ -33,7 +33,7 @@ end
 
 zone_object.onEventFinish = function(player, csid, option)
     if csid == 102 then
-        v:setPos(0, 0, 0, 0, 79)
+        player:setPos(0, 0, 0, 0, 79)
     end
 end
 


### PR DESCRIPTION
Players completing ToAU 31 Shades of Vengeance battlefield and possibly players completing Assaults in Periqia (the later untested) were met with a black screen on CS 102 firing on instance completion. On local server, this was due to instance returning nil by this point in the process (instance complete-> play CS -> check for instance -- what instance?).

Simply removing these checks for the instance status on the victory animation removes the possibility of any of these issues. A user receiving that CS will be completing their instance anyway or will be a GM firing it intentionally.

Upon examination of Ilrusi Atol, I saw similar checks and feel it's best to remove them as well. Again, I don't believe it's necessary due to what has to happen for that event to fire.

Following the CS (a simple warping animation), the player is sent to the destination zone that interprets where they land from their prior zone in onZoneIn.

Also removed a few unnecessary parenthesis per style guide.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
