### PR TITLE
Fix a bad merge conflict affecting Bastok 7-1

### DIFF
--- a/scripts/zones/Metalworks/npcs/Cid.lua
+++ b/scripts/zones/Metalworks/npcs/Cid.lua
@@ -168,9 +168,9 @@ entity.onTrigger = function(player, npc)
         else
             player:startEvent(505)
         end
-    elseif (currentMission == xi.mission.id.bastok.THE_FINAL_IMAGE and player:getMissionStatus(player:getNation()) == 0) then
+    elseif (bastokMission == xi.mission.id.bastok.THE_FINAL_IMAGE and player:getMissionStatus(player:getNation()) == 0) then
         player:startEvent(763) -- Bastok Mission 7-1
-    elseif (currentMission == xi.mission.id.bastok.THE_FINAL_IMAGE and player:getMissionStatus(player:getNation()) == 2) then
+    elseif (bastokMission == xi.mission.id.bastok.THE_FINAL_IMAGE and player:getMissionStatus(player:getNation()) == 2) then
         player:startEvent(764) -- Bastok Mission 7-1 (with Ki)
     --Begin Cid's Secret
     elseif (player:getFameLevel(BASTOK) >= 4 and CidsSecret == QUEST_AVAILABLE) then


### PR DESCRIPTION
`currentMission` was renamed to with `bastokMission` in https://github.com/LandSandBoat/server/commit/bbb9b9615c3cbd82ae6bfa5d820a9cfb5cb0902f

But later https://github.com/LandSandBoat/server/commit/58003c45743854fa2110c6696c47f12f1612acb0 was submitted with a bad merge, which brought back the old `currentMission` references accidentally.

This pull request just renames these variables back to `bastokMission`.

Fixes https://github.com/LandSandBoat/server/issues/152

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
