### PR TITLE
Implement a basic `Bloody Caress` mob TP skill

### DIFF
--- a/scripts/globals/mobskills/bloody_caress.lua
+++ b/scripts/globals/mobskills/bloody_caress.lua
@@ -4,7 +4,9 @@
 --  Delivers a threefold attack. Additional effect: Drain
 --  Type: Physical
 --  100% TP: ??? / 250% TP: ??? / 300% TP: ???
---
+--  Note: There is not a whole lot of info about this spell available online,
+--        so the initial implemention is just a basic version similar to
+--        Goblin Rush, which is also a physical 3-hit spell.
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")

--- a/scripts/globals/mobskills/bloody_caress.lua
+++ b/scripts/globals/mobskills/bloody_caress.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+--  Bloody Caress
+--
+--  Delivers a threefold attack. Additional effect: Drain
+--  Type: Physical
+--  100% TP: ??? / 250% TP: ??? / 300% TP: ???
+--
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 3
+    local accmod = 1
+    local dmgmod = 1
+
+    -- TODO: Once `Floral Bouquet` TP move is implemented, this skill is eligible to target
+    -- the charmed monsters.
+
+    local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_ACC_VARIES, 1, 2, 3)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    skill:setMsg(MobPhysicalDrainMove(mob, target, skill, MOBDRAIN_HP, dmg))
+
+    return dmg
+end
+
+return mobskill_object

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -928,7 +928,7 @@ INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2163); -- Seedspray
 INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2164); -- Viscid Emission
 INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2165); -- Rotten Stench
 INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2166); -- Floral Bouquet
--- INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2167); -- Bloody Caress
+INSERT INTO `mob_skill_lists` VALUES ('Rafflesia',207,2167); -- Bloody Caress
 INSERT INTO `mob_skill_lists` VALUES ('Ram',208,265);
 INSERT INTO `mob_skill_lists` VALUES ('Ram',208,266);
 INSERT INTO `mob_skill_lists` VALUES ('Ram',208,267);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1977,8 +1977,7 @@ INSERT INTO `mob_skills` VALUES (2162,1571,'emetic_discharge',0,7.0,2000,1000,4,
 -- INSERT INTO `mob_skills` VALUES (2164,1550,'viscid_emission',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2165,1909,'rotten_stench',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2166,1910,'floral_bouquet',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2167,1553,'bloody_caress',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2168,1912,'bloody_caress',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2167,1553,'bloody_caress',0,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2169,1913,'soothing_aroma',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2170,1589,'fevered_pitch',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2171,1590,'call_of_the_moon_up',1,25.0,2000,1500,4,0,0,0,0,0,0); -- standing up


### PR DESCRIPTION
There is not a whole lot of info about this spell available online, so I implemented a basic version similar to `Goblin Rush`, which is also a physical 3-hit spell.

I confirmed the animation matches retail videos from youtube.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
