### PR TITLE
Implement a basic `Severing Fang` mob TP skill

### DIFF
--- a/scripts/globals/mobskills/severing_fang.lua
+++ b/scripts/globals/mobskills/severing_fang.lua
@@ -28,8 +28,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
     local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, MOBPARAM_WIPE_SHADOWS)
 
-    local typeEffect = xi.effect.DEFENSE_DOWN
-    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 30, 0, 60)
+    MobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 30, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/globals/mobskills/severing_fang.lua
+++ b/scripts/globals/mobskills/severing_fang.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+--  Severing Fang
+--
+--  Description: Bites at all targets in front. Additional effect: Defense Down
+--  Type: Physical
+--  Utsusemi/Blink absorb: 2 shadows
+--  Range: Front arc (cone)
+-----------------------------------
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target, mob, skill)
+  -- Do not use this weapon skill on targets behind. Sub-Zero Smash
+  -- should trigger in this case.
+  if target:isBehind(mob) then
+    return 1
+  end
+  return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 2
+    local accmod = 1
+    local dmgmod = 1.5
+    local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, MOBPARAM_WIPE_SHADOWS)
+
+    local typeEffect = xi.effect.DEFENSE_DOWN
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 30, 0, 60)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+    return dmg
+end
+
+return mobskill_object

--- a/scripts/globals/mobskills/severing_fang.lua
+++ b/scripts/globals/mobskills/severing_fang.lua
@@ -26,7 +26,7 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local accmod = 1
     local dmgmod = 1.5
     local info = MobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, TP_NO_EFFECT)
-    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, MOBPARAM_WIPE_SHADOWS)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
     MobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 30, 0, 60)
 

--- a/scripts/globals/mobskills/severing_fang.lua
+++ b/scripts/globals/mobskills/severing_fang.lua
@@ -13,12 +13,12 @@ require("scripts/globals/monstertpmoves")
 local mobskill_object = {}
 
 mobskill_object.onMobSkillCheck = function(target, mob, skill)
-  -- Do not use this weapon skill on targets behind. Sub-Zero Smash
-  -- should trigger in this case.
-  if target:isBehind(mob) then
-    return 1
-  end
-  return 0
+    -- Do not use this weapon skill on targets behind. Sub-Zero Smash
+    -- should trigger in this case.
+    if target:isBehind(mob) then
+        return 1
+    end
+    return 0
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2244,7 +2244,7 @@ INSERT INTO `mob_skills` VALUES (2431,1709,'reaving_wind',1,15.0,2000,1000,4,0,0
 INSERT INTO `mob_skills` VALUES (2432,1710,'storm_wing',1,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2433,1711,'calamitous_wind',1,15.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2434,2178,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2435,1697,'severing_fang',1,18.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2435,1697,'severing_fang',4,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2436,1698,'sub-zero_smash',1,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2437,1699,'aqua_blast',1,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2438,1700,'frozen_mist',1,18.0,2000,1000,4,0,0,0,0,0,0);


### PR DESCRIPTION
This implementation is largely based off of `razor_fang.lua`.

The skill is set to not trigger for targets behind the mob, since sub-zero smash should always be triggered in that case.

I also adjusted the shape and range in the .sql file. The range value was chosen based off of the one from `razor_fang`. And the shape was updated to be a cone since the shape is a "front arc".

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
