### PR TITLE
Fix San d'Oria M9-2 BCNM Phase 2

### DIFF
--- a/scripts/zones/QuBia_Arena/Globals.lua
+++ b/scripts/zones/QuBia_Arena/Globals.lua
@@ -6,21 +6,50 @@ local ID = require("scripts/zones/QuBia_Arena/IDs")
 local global = {}
 
 -----------------------------------
--- Mission 9-2 SANDO
+-- Mission 9-2 San d'Oria
 -- BCNM: Heir to the light
 -----------------------------------
 
-global.phaseChangeReady = function(battlefield)
+local phaseInfo =
+{
+    -- Trion Spawn              -- Player Position
+    { { -403, -201,  413, 58 }, { -400,-201,  419, 61 }, },
+    { {   -3,   -1,    4, 61 }, {    0,  -1,   10, 61 }, },
+    { {  397,  198, -395, 64 }, {  399, 198, -381, 57 }, },
+}
+
+global.tryPhaseChange = function(player)
+    local battlefield = player:getBattlefield()
     local inst = battlefield:getArea()
-    printf("AreaID %i ", inst)
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst - 1))
+    local allMobsDead = true
+
     for i = instOffset + 3, instOffset + 13 do
-        printf("MobID %i isDead => %s ",i, GetMobByID(i):isDead() and 'T' or 'F')
         if not GetMobByID(i):isDead() then
-            return false
+            allMobsDead = false
         end
     end
-    return true
+
+    if allMobsDead and player:getLocalVar('secondPhase') == 0 then
+        player:setLocalVar('secondPhase', 1)
+        player:startEvent(32004, 0, 0, 4)
+    end
+end
+
+global.phaseEventFinish = function(player, csid)
+    if csid == 32004 then
+        local battlefield = player:getBattlefield()
+        local bfArea = battlefield:getArea()
+
+        for i = 1, 3 do
+            SpawnMob(ID.mob.HEIR_TO_THE_LIGHT_OFFSET + 14 * (bfArea - 1) + i)
+        end
+
+        local trion = battlefield:insertEntity(75, true, true)
+        trion:setSpawn(unpack(phaseInfo[bfArea][1]))
+        trion:spawn()
+        player:setPos(unpack(phaseInfo[bfArea][2]))
+    end
 end
 
 return global

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -8,6 +8,10 @@ require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
+entity.onEventFinish = function(player, csid, option)
+    global.phaseEventFinish(player, csid)
+end
+
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.HP_STANDBACK, 60)
 end
@@ -36,11 +40,7 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local battlefield = player:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
-        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004, 0, 0, 4)
-    end
+    global.tryPhaseChange(player)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: QuBia_Arena
 --  Mob: Rallbrog of Clan Death
--- Mission 9-2 SANDO
+-- Mission 9-2 San d'Oria
 -----------------------------------
 local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
@@ -9,11 +9,11 @@ local ID = require("scripts/zones/QuBia_Arena/IDs")
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local battlefield = player:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
-        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004, 0, 0, 4)
-    end
+    global.tryPhaseChange(player)
+end
+
+entity.onEventFinish = function(player, csid, option, target)
+    global.phaseEventFinish(player, csid)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
+    if battlefield then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
+    if battlefield then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: QuBia_Arena
 --  Mob: Vangknok of Clan Death
--- Mission 9-2 SANDO
+-- Mission 9-2 San d'Oria
 -----------------------------------
 local global = require("scripts/zones/QuBia_Arena/Globals")
 local ID = require("scripts/zones/QuBia_Arena/IDs")
@@ -9,11 +9,11 @@ local ID = require("scripts/zones/QuBia_Arena/IDs")
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local battlefield = player:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
-        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004, 0, 0, 4)
-    end
+    global.tryPhaseChange(player)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    global.phaseEventFinish(player, csid)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
@@ -16,7 +16,7 @@ end
 
 entity.onMobSpawn = function(mob)
     local battlefield = mob:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
+    if battlefield then
         battlefield:setLocalVar("phaseChange", 0)
     end
 end

--- a/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
@@ -9,11 +9,11 @@ local ID = require("scripts/zones/QuBia_Arena/IDs")
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local battlefield = player:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
-        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004, 0, 0, 4)
-    end
+    global.tryPhaseChange(player)
+end
+
+entity.onEventFinish = function(player, csid, option, target)
+    global.phaseEventFinish(player, csid)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
@@ -10,11 +10,11 @@ mixins = {require("scripts/mixins/job_special")}
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local battlefield = player:getBattlefield()
-    if battlefield and global.phaseChangeReady(battlefield) then
-        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004, 0, 0, 4)
-    end
+    global.tryPhaseChange(player)
+end
+
+entity.onEventFinish = function(player, csid, option, target)
+    global.phaseEventFinish(player, csid)
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds phase 2 back to the BCNM (after removal in 2017), and adds a bit of safety for event 32004 firing multiple times.  There are some strange behaviors that occur when mass nuking the enemies as GM, and that part still needs to be investigated; however, on multiple runs with a mostly-legitimate setup, all testing has passed.
