### PR TITLE
Deprecate CLuaBaseEntity::getOtherRank(), require argument for CLuaBaseEntity::getRank()

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -98,7 +98,7 @@ local function setHomepointFee(player, guardNation)
     local fee = 0
 
     if pNation ~= guardNation and not xi.conquest.areAllies(pNation, guardNation) then
-        local rank = player:getRank()
+        local rank = player:getRank(player:getNation())
         if rank <= 5 then
             fee = 100 * math.pow(2, rank - 1)
         else
@@ -611,7 +611,7 @@ end
 -- bits 5-6 seem to encode the citizenship as below. This part needs more testing and verification.
 
 local function getArg6(player)
-    return player:getRank() + (player:getNation() * 32)
+    return player:getRank(player:getNation()) + (player:getNation() * 32)
 end
 
 -----------------------------------
@@ -937,7 +937,7 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
 
         -- DONATE CRYSTALS FOR RANK OR CONQUEST POINTS
         if guardType <= xi.conquest.guard.FOREIGN and crystals[item] then
-            local pRank = player:getRank()
+            local pRank = player:getRank(player:getNation())
             local pRankPoints = player:getRankPoints()
             local addPoints = 0
 
@@ -953,7 +953,7 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
                         break
                     else
                         trade:confirmItem(crystalId, count)
-                        addPoints = addPoints + count * math.floor(4000 / (player:getRank() * 12 - crystalWorth))
+                        addPoints = addPoints + count * math.floor(4000 / (player:getRank(player:getNation()) * 12 - crystalWorth))
                     end
                 end
             end
@@ -1030,7 +1030,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
     elseif guardType >= xi.conquest.guard.OUTPOST then
         local a1 = getArg1(player, guardNation, guardType)
         if a1 == 1808 then -- non-allied nation
-            player:startEvent(guardEvent, a1, 0, 0, 0, 0, player:getRank(), 0, 0)
+            player:startEvent(guardEvent, a1, 0, 0, 0, 0, player:getRank(player:getNation()), 0, 0)
         else
             player:startEvent(guardEvent, a1, 0, 0x3F0000, 0, 0, getArg6(player), 0, 0)
         end
@@ -1076,7 +1076,7 @@ end
 
 xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, guardType, guardRegion)
     local pNation  = player:getNation()
-    local pRank    = player:getRank()
+    local pRank    = player:getRank(pNation)
     local sRegion  = player:getCharVar("supplyQuest_region")
     local sOutpost = outposts[sRegion]
     local mOffset  = zones[player:getZoneID()].text.CONQUEST

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -760,7 +760,7 @@ function getMissionRankPoints(player, missionID)
     elseif (missionID == 23) then crystals = 228                    -- Additional 8 stacks needed, plus mission reward of 36 (87% rank bar)
     end
 
-    points_needed = 1024 * (crystals-.25) / (3*rankPointMath(player:getRank()))
+    points_needed = 1024 * (crystals-.25) / (3*rankPointMath(player:getRank(player:getNation())))
 
     if (player:getRankPoints() >= points_needed) then
         return 1
@@ -770,8 +770,8 @@ function getMissionRankPoints(player, missionID)
 end
 
 function getMissionMask(player)
-    rank = player:getRank()
     nation = player:getNation()  -- 0 = San d'Oria  1 = Bastok  2 = Windurst
+    rank = player:getRank(nation)
     mission_status =  player:getCurrentMission(nation)
 
     first_mission = 0

--- a/scripts/missions/rotz/01_The_New_Frontier.lua
+++ b/scripts/missions/rotz/01_The_New_Frontier.lua
@@ -25,7 +25,7 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and player:getRank() >= 6
+            return currentMission == mission.missionId and player:getRank(player:getNation()) >= 6
         end,
 
         [xi.zone.NORG] =

--- a/scripts/zones/Bastok_Markets/npcs/Cleades.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Cleades.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
+        elseif (player:getRank(player:getNation()) == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
         elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated

--- a/scripts/zones/Bastok_Mines/npcs/Rashid.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Rashid.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
+        elseif (player:getRank(player:getNation()) == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
         elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated

--- a/scripts/zones/Chateau_dOraguille/npcs/Aramaviont.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Aramaviont.lua
@@ -36,7 +36,7 @@ entity.onTrigger = function(player, npc)
         -- San d'Oria 8-2 "Lightbringer" (optional dialogue)
         elseif
             player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.LIGHTBRINGER) and
-            player:getRank() == 9 and player:getRankPoints() == 0
+            player:getRank(player:getNation()) == 9 and player:getRankPoints() == 0
         then
             player:showText(npc, ID.text.LIGHTBRINGER_EXTRA + 1)
         elseif currentMission == sandyMissions.LIGHTBRINGER and missionStatus == 6 then
@@ -46,7 +46,7 @@ entity.onTrigger = function(player, npc)
         elseif
             -- Directly after winning BCNM and up until next mission
             currentMission == sandyMissions.THE_SHADOW_LORD and missionStatus == 4 or
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank() == 6 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank(player:getNation()) == 6 and
             (currentMission ~= sandyMissions.LEAUTE_S_LAST_WISHES or currentMission ~= sandyMissions.RANPERRE_S_FINAL_REST)
         then
             player:startEvent(12)

--- a/scripts/zones/Chateau_dOraguille/npcs/Curilla.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Curilla.lua
@@ -51,7 +51,7 @@ entity.onTrigger = function(player, npc)
     local theGeneralSecret = player:getQuestStatus(xi.quest.log_id.SANDORIA, sandyQuests.THE_GENERAL_S_SECRET)
     local envelopedInDarkness = player:getQuestStatus(xi.quest.log_id.SANDORIA, sandyQuests.ENVELOPED_IN_DARKNESS)
     local peaceForTheSpirit = player:getQuestStatus(xi.quest.log_id.SANDORIA, sandyQuests.PEACE_FOR_THE_SPIRIT)
-    local Rank3 = player:getRank() >= 3 and 1 or 0
+    local Rank3 = player:getRank(player:getNation()) >= 3 and 1 or 0
 
     -- Trust: San d'Oria (Curilla)
     if
@@ -115,14 +115,14 @@ entity.onTrigger = function(player, npc)
     -- San d'Oria Missions (optional dialogues)
     elseif
         player:getNation() == xi.nation.SANDORIA and
-        (player:getCharVar("SandoEpilogue") == 1 or player:getRank() ~= 10)
+        (player:getCharVar("SandoEpilogue") == 1 or player:getRank(player:getNation()) ~= 10)
     then
         local sandyMissions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
 
         -- San d'Oria Epilogue
-        if player:getRank() == 10 then
+        if player:getRank(player:getNation()) == 10 then
             player:startEvent(20)
 
         -- San d'Oria 9-2 "The Heir to the Light"
@@ -152,14 +152,14 @@ entity.onTrigger = function(player, npc)
         elseif
             -- Directly after winning BCNM and up until next mission
             currentMission == sandyMissions.THE_SHADOW_LORD and missionStatus == 4 or
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank() == 6 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank(player:getNation()) == 6 and
             (currentMission ~= sandyMissions.LEAUTE_S_LAST_WISHES or currentMission ~= sandyMissions.RANPERRE_S_FINAL_REST)
         then
             player:startEvent(56)
 
         -- San d'Oria 5-1 "The Ruins of Fei'Yin" (optional)
         elseif
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank() == 5 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank(player:getNation()) == 5 and
             currentMission ~= sandyMissions.THE_SHADOW_LORD
         then
             player:startEvent(545)

--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(565)
     elseif (pNation == xi.nation.SANDORIA) then
         -- Rank 10 default dialogue
-        if player:getRank() == 10 then
+        if player:getRank(player:getNation()) == 10 then
             player:startEvent(31)
         -- Mission San D'Oria 9-2 The Heir to the Light
         elseif (currentMission == xi.mission.id.sandoria.THE_HEIR_TO_THE_LIGHT and missionStatus == 7) then

--- a/scripts/zones/Chateau_dOraguille/npcs/Milchupain.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Milchupain.lua
@@ -32,7 +32,7 @@ entity.onTrigger = function(player, npc)
         -- San d'Oria 8-2 "Lightbringer" (optional)
         elseif
             player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.LIGHTBRINGER) and
-            player:getRank() == 9 and player:getRankPoints() == 0
+            player:getRank(player:getNation()) == 9 and player:getRankPoints() == 0
         then
             player:showText(npc, ID.text.LIGHTBRINGER_EXTRA + 3)
         elseif currentMission == sandyMissions.LIGHTBRINGER and missionStatus == 6 then
@@ -42,7 +42,7 @@ entity.onTrigger = function(player, npc)
         elseif
             -- Directly after winning BCNM and up until next mission
             currentMission == sandyMissions.THE_SHADOW_LORD and missionStatus == 4 or
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank() == 6 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank(player:getNation()) == 6 and
             (currentMission ~= sandyMissions.LEAUTE_S_LAST_WISHES or currentMission ~= sandyMissions.RANPERRE_S_FINAL_REST)
         then
             player:startEvent(33)

--- a/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Perfaumand.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(560)
 
     -- San d'Oria Missions
-    elseif player:getNation() == xi.nation.SANDORIA and player:getRank() ~= 10 then
+    elseif player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) ~= 10 then
         local sandyMissions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())

--- a/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
@@ -64,7 +64,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(41)
 
     -- San d'Oria Missions
-    elseif player:getNation() == xi.nation.SANDORIA and player:getRank() ~= 10 then
+    elseif player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) ~= 10 then
         local sandyMissions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
@@ -87,7 +87,7 @@ entity.onTrigger = function(player, npc)
         -- San d'Oria 8-2 "Lightbringer"
         elseif
             player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.LIGHTBRINGER) and
-            player:getRank() == 9 and player:getRankPoints() == 0
+            player:getRank(player:getNation()) == 9 and player:getRankPoints() == 0
         then
             player:startEvent(42) -- (optional)
         elseif currentMission == sandyMissions.LIGHTBRINGER then
@@ -103,14 +103,14 @@ entity.onTrigger = function(player, npc)
         elseif
             -- Directly after winning BCNM and up until next mission
             currentMission == sandyMissions.THE_SHADOW_LORD and missionStatus == 4 or
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank() == 6 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_SHADOW_LORD) and player:getRank(player:getNation()) == 6 and
             (currentMission ~= sandyMissions.LEAUTE_S_LAST_WISHES or currentMission ~= sandyMissions.RANPERRE_S_FINAL_REST)
         then
             player:startEvent(77)
 
         -- San d'Oria 5-1 "The Ruins of Fei'Yin" (optional)
         elseif
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank() == 5 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank(player:getNation()) == 5 and
             currentMission ~= sandyMissions.THE_SHADOW_LORD
         then
             player:startEvent(544)

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -59,7 +59,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(90) -- Start
 
     -- Trust: San d'Oria (Trion)
-    elseif player:getRank() >= 6 and player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) and not player:hasSpell(905) then
+    elseif player:getRank(player:getNation()) >= 6 and player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) and not player:hasSpell(905) then
         player:startEvent(574, 0, 0, 0, TrustMemory(player))
 
     -- "A Boy's Dream" (PLD AF Feet)
@@ -67,11 +67,11 @@ entity.onTrigger = function(player, npc)
         player:startEvent(88)
 
     -- San d'Oria Rank 10 (different default)
-    elseif player:getNation() == xi.nation.SANDORIA and player:getRank() == 10 then
+    elseif player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) == 10 then
         player:startEvent(62)
 
     -- San d'Oria Missions
-    elseif player:getNation() == xi.nation.SANDORIA and player:getRank() ~= 10 then
+    elseif player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) ~= 10 then
         local sandyMissions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
@@ -82,7 +82,7 @@ entity.onTrigger = function(player, npc)
 
         -- San d'Oria 8-2 "Lightbringer" (optional)
         elseif
-            player:getRank() == 9 and player:getRankPoints() == 0 and
+            player:getRank(player:getNation()) == 9 and player:getRankPoints() == 0 and
             player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.LIGHTBRINGER) and
             (player:getCharVar("Cutscenes_8-2") == 0 or player:getCharVar("Cutscenes_8-2") == 2)
         then
@@ -104,7 +104,7 @@ entity.onTrigger = function(player, npc)
 
         -- San d'Oria 5-1 "The Ruins of Fei'Yin" (optional)
         elseif
-            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank() == 5 and
+            player:hasCompletedMission(xi.mission.log_id.SANDORIA, sandyMissions.THE_RUINS_OF_FEI_YIN) and player:getRank(player:getNation()) == 5 and
             currentMission ~= sandyMissions.THE_SHADOW_LORD
         then
             player:startEvent(115)

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h1.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h1.lua
@@ -29,7 +29,7 @@ entity.onTrigger = function(player, npc)
         end
 
     -- San d'Oria Rank 10 (new default)
-    elseif player:getNation() == xi.nation.SANDORIA and player:getRank() == 10 then
+    elseif player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) == 10 then
         player:startEvent(73)
 
     -- San d'Oria 9-2 "The Heir to the Light" (optional)
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
 
     -- San d'Oria 8-2 "Lightbringer" (optional)
     elseif
-        player:getRank() == 9 and player:getRankPoints() == 0 and
+        player:getRank(player:getNation()) == 9 and player:getRankPoints() == 0 and
         player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.LIGHTBRINGER) and
         (player:getCharVar("Cutscenes_8-2") == 0 or player:getCharVar("Cutscenes_8-2") == 2)
     then

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
@@ -16,7 +16,7 @@ end
 entity.onTrigger = function(player, npc)
 
     -- This NPC is relevant only to San d'Orians on missions
-    if player:getNation() == xi.nation.SANDORIA and player:getRank() ~= 10 then
+    if player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) ~= 10 then
         local sandyMissions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())

--- a/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
@@ -43,7 +43,7 @@ entity.onTrade = function(player, npc, trade)
         trade:hasItemQty(4365, 1) and -- Rolanberry
         trade:getItemCount() == 1 and
         player:getNation() == xi.nation.WINDURST and
-        player:getRank() >= 2 and
+        player:getRank(player:getNation()) >= 2 and
         not player:hasKeyItem(xi.ki.PORTAL_CHARM)
     then
         if player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.WRITTEN_IN_THE_STARS) then
@@ -64,7 +64,7 @@ entity.onTrigger = function(player, npc)
     local TrustWindurst = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TRUST_WINDURST)
     local WindurstFirstTrust = player:getCharVar("WindurstFirstTrust")
     local KupipiTrustChatFlag = player:getLocalVar("KupipiTrustChatFlag")
-    local Rank3 = player:getRank() >= 3 and 1 or 0
+    local Rank3 = player:getRank(player:getNation()) >= 3 and 1 or 0
 
     if TrustWindurst == QUEST_ACCEPTED and (TrustSandoria == QUEST_COMPLETED or TrustBastok == QUEST_COMPLETED) then
         player:startEvent(439, 0, 0, 0, TrustMemory(player), 0, 0, 0, Rank3)
@@ -143,7 +143,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(293) -- Kupipi repays your favor
         elseif player:getCurrentMission(WINDURST) == xi.mission.id.windurst.MOON_READING and missionStatus >= 3 then
             player:startEvent(400) -- Kupipi in disbelief over player becoming Rank 10
-        elseif pNation == xi.nation.WINDURST and player:getRank() == 10 then
+        elseif pNation == xi.nation.WINDURST and player:getRank(player:getNation()) == 10 then
             player:startEvent(408) -- After achieving Windurst Rank 10, Kupipi has more to say
         else
             player:startEvent(251)

--- a/scripts/zones/Heavens_Tower/npcs/_6q2.lua
+++ b/scripts/zones/Heavens_Tower/npcs/_6q2.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     elseif player:hasKeyItem(xi.ki.MESSAGE_TO_JEUNO_WINDURST) then
         player:startEvent(166)
     elseif
-        player:getRank() == 5 and
+        player:getRank(player:getNation()) == 5 and
         currentMission == xi.mission.id.windurst.NONE and
         not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_FINAL_SEAL)
     then

--- a/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Shattered_Telepoint.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local copMission = player:getCurrentMission(COP)
 
     -- RoV Missions
-    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank(player:getNation()) >= 3 then
         player:startEvent(3)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, xi.items.CIPHER_OF_LIONS_ALTER_EGO_II) then -- Cipher: Lion II

--- a/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Shattered_Telepoint.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local copMission = player:getCurrentMission(COP)
 
     -- RoV Missions
-    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank(player:getNation()) >= 3 then
         player:startEvent(14)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, xi.items.CIPHER_OF_LIONS_ALTER_EGO_II) then -- Cipher: Lion II

--- a/scripts/zones/Lower_Jeuno/npcs/Aldo.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Aldo.lua
@@ -21,7 +21,7 @@ entity.onTrigger = function(player, npc)
         player:getMissionStatus(player:getNation()) == 3) then
         player:startEvent(183)
     elseif player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-        player:getCharVar('ApocalypseNigh') == 5 and player:getRank() >= 5 then
+        player:getCharVar('ApocalypseNigh') == 5 and player:getRank(player:getNation()) >= 5 then
         player:startEvent(10057)
     elseif player:getCharVar('ApocalypseNigh') == 6 then
         player:startEvent(10058)

--- a/scripts/zones/Metalworks/npcs/Ayame.lua
+++ b/scripts/zones/Metalworks/npcs/Ayame.lua
@@ -62,7 +62,7 @@ entity.onTrigger = function(player, npc)
     local trueStrength = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TRUE_STRENGTH)
     local WildcatBastok = player:getCharVar("WildcatBastok")
     local FadedPromises = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.FADED_PROMISES)
-    local Rank3 = player:getRank() >= 3 and 1 or 0
+    local Rank3 = player:getRank(player:getNation()) >= 3 and 1 or 0
 
     if (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatBastok, 9)) then
         player:startEvent(935)

--- a/scripts/zones/Metalworks/npcs/Lucius.lua
+++ b/scripts/zones/Metalworks/npcs/Lucius.lua
@@ -49,7 +49,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local Rank6 = player:getRank() >= 6 and 1 or 0
+    local Rank6 = player:getRank(player:getNation()) >= 6 and 1 or 0
 
     if (player:getCurrentMission(BASTOK) == xi.mission.id.bastok.JEUNO and player:getMissionStatus(player:getNation()) == 0) then
         player:startEvent(322);

--- a/scripts/zones/Metalworks/npcs/Malduc.lua
+++ b/scripts/zones/Metalworks/npcs/Malduc.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
+        elseif (player:getRank(player:getNation()) == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
         elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated

--- a/scripts/zones/Metalworks/npcs/Naji.lua
+++ b/scripts/zones/Metalworks/npcs/Naji.lua
@@ -51,7 +51,7 @@ entity.onTrigger = function(player, npc)
     local TrustWindurst = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TRUST_WINDURST)
     local BastokFirstTrust = player:getCharVar("BastokFirstTrust")
     local NajiTrustChatFlag = player:getLocalVar("NajiTrustChatFlag")
-    local Rank3 = player:getRank() >= 3 and 1 or 0
+    local Rank3 = player:getRank(player:getNation()) >= 3 and 1 or 0
 
     if TrustBastok == QUEST_ACCEPTED and (TrustSandoria == QUEST_COMPLETED or TrustWindurst == QUEST_COMPLETED) then
         player:startEvent(984, 0, 0, 0, TrustMemory(player), 0, 0, 0, Rank3)

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -88,7 +88,7 @@ zone_object.onRegionEnter = function(player, region)
         [1] = function (x)  -- Chateau d'Oraguille access
         pNation = player:getNation()
         currentMission = player:getCurrentMission(pNation)
-            if (pNation == 0 and player:getRank() >= 2) or (pNation > 0 and player:hasCompletedMission(pNation, 5) == 1) or (currentMission >= 5 and currentMission <= 9) or (player:getRank() >= 3) then
+            if (pNation == 0 and player:getRank(player:getNation()) >= 2) or (pNation > 0 and player:hasCompletedMission(pNation, 5) == 1) or (currentMission >= 5 and currentMission <= 9) or (player:getRank(player:getNation()) >= 3) then
                 player:startEvent(569)
             else
                 player:startEvent(568)

--- a/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
@@ -38,7 +38,7 @@ entity.onTrigger = function(player, npc)
     local TrustWindurst = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TRUST_WINDURST)
     local SandoriaFirstTrust = player:getCharVar("SandoriaFirstTrust")
     local ExcenmilleTrustChatFlag = player:getLocalVar("ExcenmilleTrustChatFlag")
-    local Rank3 = player:getRank() >= 3 and 1 or 0
+    local Rank3 = player:getRank(player:getNation()) >= 3 and 1 or 0
 
     if TrustSandoria == QUEST_ACCEPTED and (TrustWindurst == QUEST_COMPLETED or TrustBastok == QUEST_COMPLETED) then
         player:startEvent(897, 0, 0, 0, TrustMemory(player), 0, 0, 0, Rank3)

--- a/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
@@ -50,7 +50,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
         if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then

--- a/scripts/zones/Northern_San_dOria/npcs/_6fc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/_6fc.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
 
     -- This NPC is relevant only to San d'Orians on missions and has no default
-    if player:getNation() == xi.nation.SANDORIA and player:getRank() ~= 10 then
+    if player:getNation() == xi.nation.SANDORIA and player:getRank(player:getNation()) ~= 10 then
         local missions = xi.mission.id.sandoria
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())

--- a/scripts/zones/Port_Bastok/npcs/Argus.lua
+++ b/scripts/zones/Port_Bastok/npcs/Argus.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(cs, p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
             end
-        elseif (player:getRank() == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
+        elseif (player:getRank(player:getNation()) == 1 and player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_ZERUHN_REPORT) == false) then
             player:startEvent(1000) -- Start First Mission "The Zeruhn Report"
         elseif (currentMission ~= xi.mission.id.bastok.NONE) then
             player:startEvent(1002) -- Have mission already activated

--- a/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
+++ b/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 3, currentMission, missionStatus)
 
         if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then

--- a/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(66)
         elseif currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 3 then
             player:startEvent(139)
-        elseif player:getRank() == 4 and missionStatus == 0 then
+        elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(3)
             else

--- a/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(67)
         elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 5 then
             player:startEvent(140)
-        elseif player:getRank() == 4 and missionStatus == 0 then
+        elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(45)
             else

--- a/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(68)
         elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 3 then
             player:startEvent(141)
-        elseif player:getRank() == 4 and missionStatus == 0 then
+        elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
             if getMissionRankPoints(player, 13) == 1 then
                 player:startEvent(50)
             else

--- a/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
@@ -21,7 +21,7 @@ entity.onTrigger = function(player, npc)
 
         if currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 4 then
             player:startEvent(38)
-        elseif player:getRank() == 4 and
+        elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.bastok.NONE and
             getMissionRankPoints(player, 13) == 1
         then
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(129)
             end
-        elseif player:getRank() >= 4 then
+        elseif player:getRank(player:getNation()) >= 4 then
             player:messageSpecial(ID.text.RESTRICTED)
         else
             player:messageSpecial(ID.text.RESTRICTED+1) -- you have no letter of introduction

--- a/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
@@ -21,7 +21,7 @@ entity.onTrigger = function(player, npc)
 
         if currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 6 then
             player:startEvent(39)
-        elseif player:getRank() == 4 and
+        elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.sandoria.NONE and
             getMissionRankPoints(player, 13) == 1 and
             missionStatus == 0
@@ -31,7 +31,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(130)
             end
-        elseif player:getRank() >= 4 then
+        elseif player:getRank(player:getNation()) >= 4 then
             player:messageSpecial(ID.text.RESTRICTED)
         else
             player:messageSpecial(ID.text.RESTRICTED + 1) -- you have no letter of introduction

--- a/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
 
         if currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 4 then
             player:startEvent(40)
-        elseif player:getRank() == 4 and
+        elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.windurst.NONE and
             getMissionRankPoints(player, 13) == 1
         then
@@ -31,7 +31,7 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(131)
             end
-        elseif player:getRank() >= 4 then
+        elseif player:getRank(player:getNation()) >= 4 then
             player:messageSpecial(ID.text.RESTRICTED)
         else
             player:messageSpecial(ID.text.RESTRICTED+1) -- you have no letter of introduction

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -50,7 +50,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 2, currentMission, missionStatus)
 
         if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -49,7 +49,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(SANDORIA)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
         if currentMission <= xi.mission.id.sandoria.THE_SHADOW_LORD and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.sandoria.SMASH_THE_ORCISH_SCOUTS and offset == 0)) then

--- a/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Shattered_Telepoint.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local copMission = player:getCurrentMission(COP)
 
     -- RoV Missions
-    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank() >= 3 then
+    if rovMission == xi.mission.id.rov.THE_PATH_UNTRAVELED and player:getRank(player:getNation()) >= 3 then
         player:startEvent(41)
     elseif player:getCharVar("LionIICipher") == 1 then
         if npcUtil.giveItem(player, xi.items.CIPHER_OF_LIONS_ALTER_EGO_II) then -- Cipher: Lion II

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 4, currentMission, missionStatus)
 
         if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -191,7 +191,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
         end
 
-        if (player:getNation() == xi.nation.WINDURST and player:getRank() == 10 and player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_PROMISE) == QUEST_COMPLETED) then
+        if (player:getNation() == xi.nation.WINDURST and player:getRank(player:getNation()) == 10 and player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_PROMISE) == QUEST_COMPLETED) then
             player:addKeyItem(xi.ki.DARK_MANA_ORB)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.DARK_MANA_ORB)
         end
@@ -227,7 +227,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
         end
 
-        if (player:getNation() == xi.nation.WINDURST and player:getRank() == 10 and player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_PROMISE) == QUEST_COMPLETED) then
+        if (player:getNation() == xi.nation.WINDURST and player:getRank(player:getNation()) == 10 and player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_PROMISE) == QUEST_COMPLETED) then
             player:addKeyItem(xi.ki.DARK_MANA_ORB)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.DARK_MANA_ORB)
         end

--- a/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 2, currentMission, missionStatus)
 
         if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -61,7 +61,7 @@ entity.onTrigger = function(player, npc)
     local kindCardianCS = player:getCharVar("theKindCardianVar")
     local allNewC3000 = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_ALL_NEW_C_3000)
     local canCardiansCry = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY)
-    local Rank6 = player:getRank() >= 6 and 1 or 0
+    local Rank6 = player:getRank(player:getNation()) >= 6 and 1 or 0
 
     -- WINDURST 1-2: THE HEART OF THE MATTER
     if player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HEART_OF_THE_MATTER then

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -96,7 +96,7 @@ entity.onTrigger = function(player, npc)
         not player:hasSpell(xi.magic.spell.NANAA_MIHGO) and
         player:getLocalVar("TrustDialogue") == 0
     then
-        local trustFlag = (player:getRank() >=3 and 1 or 0) + (mihgosAmigo == QUEST_COMPLETED and 2 or 0)
+        local trustFlag = (player:getRank(player:getNation()) >=3 and 1 or 0) + (mihgosAmigo == QUEST_COMPLETED and 2 or 0)
 
         player:setLocalVar("TrustDialogue", 1)
 

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
-        local pRank = player:getRank()
+        local pRank = player:getRank(player:getNation())
         local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
         if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -33,7 +33,7 @@ zone_object.onZoneIn = function(player, prevZone)
 
     if
         not player:hasKeyItem(xi.ki.VIAL_OF_SHROUDED_SAND) and
-        player:getRank() >= 6 and
+        player:getRank(player:getNation()) >= 6 and
         player:getMainLvl() >= 65 and
         not utils.mask.getBit(dynamisMask, 0)
     then

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5501,25 +5501,10 @@ uint8 CLuaBaseEntity::getFameLevel(sol::object const& areaObj)
 /************************************************************************
  *  Function: getRank()
  *  Purpose : Returns the rank of a player's current nation
- *  Example : player:getRank()
+ *  Example : player:getRank(xi.nation.WINDURST)
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getRank()
-{
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    return PChar->profile.rank[PChar->profile.nation];
-}
-
-/************************************************************************
- *  Function: getOtherRank()
- *  Purpose : Returns the rank of <nation> for the player
- *  Example : player:getOtherRank(xi.nation.WINDURST)
- ************************************************************************/
-
-uint8 CLuaBaseEntity::getOtherRank(uint8 nation)
+uint8 CLuaBaseEntity::getRank(uint8 nation)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -316,8 +316,7 @@ public:
     void   setFame(sol::object const& areaObj, uint16 fame); // Sets Fame
     uint8  getFameLevel(sol::object const& areaObj);         // Gets Fame Level for specified nation
 
-    uint8  getRank();                        // Get Rank for current active nation
-    uint8  getOtherRank(uint8 nation);       // Get Rank for a specific nation, getNationRank is used in utils, and this may be unneeded
+    uint8  getRank(uint8 nation);            // Get Rank for current active nation
     void   setRank(uint8 rank);              // Set Rank
     uint32 getRankPoints();                  // Get Current Rank points
     void   addRankPoints(uint32 rankpoints); // Add rank points to existing rank point total


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

`CLuaBaseEntity::getRank()` does not accept an argument post sol refactor (at least).  This PR changes references to `player:getRank(player:getNation())` and replaces with `player:getRank()`

In addition, Immigration NPCs reference a non-current rank value; replaced `getRank(newNation)` with `getOtherRank(newNation)` (binding pre-existing).