### PR TITLE
Add getVE and getCE ability bindings to support existing scripts

### DIFF
--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -83,9 +83,19 @@ void CLuaAbility::setRecast(uint16 recastTime)
     m_PLuaAbility->setRecastTime(recastTime);
 }
 
+uint16 CLuaAbility::getCE()
+{
+    return m_PLuaAbility->getCE();
+}
+
 void CLuaAbility::setCE(uint16 ce)
 {
     m_PLuaAbility->setCE(ce);
+}
+
+uint16 CLuaAbility::getVE()
+{
+    return m_PLuaAbility->getVE();
 }
 
 void CLuaAbility::setVE(uint16 ve)
@@ -112,7 +122,9 @@ void CLuaAbility::Register()
     SOL_REGISTER("setMsg", CLuaAbility::setMsg);
     SOL_REGISTER("setAnimation", CLuaAbility::setAnimation);
     SOL_REGISTER("setRecast", CLuaAbility::setRecast);
+    SOL_REGISTER("getCE", CLuaAbility::getCE);
     SOL_REGISTER("setCE", CLuaAbility::setCE);
+    SOL_REGISTER("getVE", CLuaAbility::getVE);
     SOL_REGISTER("setVE", CLuaAbility::setVE);
     SOL_REGISTER("setRange", CLuaAbility::setRange);
 }

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -46,12 +46,14 @@ public:
     auto   getName() -> const char*;
     uint16 getAnimation();
 
-    void setMsg(uint16 messageID);
-    void setAnimation(uint16 animationID);
-    void setRecast(uint16 recastTime);
-    void setCE(uint16 ce);
-    void setVE(uint16 ve);
-    void setRange(float range);
+    void   setMsg(uint16 messageID);
+    void   setAnimation(uint16 animationID);
+    void   setRecast(uint16 recastTime);
+    uint16 getCE();
+    void   setCE(uint16 ce);
+    uint16 getVE();
+    void   setVE(uint16 ve);
+    void   setRange(float range);
 
     static void Register();
 };


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Invincible ability calls `ability:getVE()` in its calculation.  Adds getVE and getCE bindings for CLuaAbility