### PR TITLE
Add basic implementation of `Aqua Blast` mob skill

### DIFF
--- a/scripts/globals/mobskills/aqua_blast.lua
+++ b/scripts/globals/mobskills/aqua_blast.lua
@@ -14,12 +14,12 @@ require("scripts/globals/monstertpmoves")
 local mobskill_object = {}
 
 mobskill_object.onMobSkillCheck = function(target, mob, skill)
-  -- Do not use this weapon skill on targets behind. Sub-Zero Smash
-  -- should trigger in this case.
-  if target:isBehind(mob) then
-    return 1
-  end
-  return 0
+    -- Do not use this weapon skill on targets behind. Sub-Zero Smash
+    -- should trigger in this case.
+    if target:isBehind(mob) then
+        return 1
+    end
+    return 0
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/aqua_blast.lua
+++ b/scripts/globals/mobskills/aqua_blast.lua
@@ -6,8 +6,7 @@
 --  Utsusemi/Blink absorb: Wipes shadows
 --  Range: Fan (cone)
 --  Note: There was not a lot of information about this spell available online, so
---        the initial implementation is relatively basic. It was implemented based
---        heavily off of `aqua_breath.lua`.
+--        the initial implementation is relatively basic.
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/monstertpmoves")
@@ -24,9 +23,10 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local dmgmod = MobBreathMove(mob, target, 0.25, 1.5, xi.magic.ele.WATER, 400)
-    local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, MOBPARAM_WIPE_SHADOWS)
-    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    local dmgmod = 1
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.magic.ele.WATER, dmgmod, TP_NO_EFFECT)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, MOBPARAM_WIPE_SHADOWS)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WATER)
     return dmg
 end
 

--- a/scripts/globals/mobskills/aqua_blast.lua
+++ b/scripts/globals/mobskills/aqua_blast.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+--  Aqua Blast
+--
+--  Description: Fires a blast of Water, dealing damage in a fan-shaped area. Additional effect: knockback
+--  Type: Magical (Water)
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: Fan (cone)
+--  Note: There was not a lot of information about this spell available online, so
+--        the initial implementation is relatively basic. It was implemented based
+--        heavily off of `aqua_breath.lua`.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target, mob, skill)
+  -- Do not use this weapon skill on targets behind. Sub-Zero Smash
+  -- should trigger in this case.
+  if target:isBehind(mob) then
+    return 1
+  end
+  return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local dmgmod = MobBreathMove(mob, target, 0.25, 1.5, xi.magic.ele.WATER, 400)
+    local dmg = MobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.WATER, MOBPARAM_WIPE_SHADOWS)
+    target:takeDamage(dmg, mob, xi.attackType.BREATH, xi.damageType.WATER)
+    return dmg
+end
+
+return mobskill_object

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2245,7 +2245,7 @@ INSERT INTO `mob_skills` VALUES (2433,1711,'calamitous_wind',1,15.0,2000,1000,4,
 -- INSERT INTO `mob_skills` VALUES (2434,2178,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2435,1697,'severing_fang',4,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2436,1698,'sub-zero_smash',4,5.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2437,1699,'aqua_blast',4,10.0,2000,1000,4,0,0,1,0,0,0);  -- TODO: Verify knockback value.
+INSERT INTO `mob_skills` VALUES (2437,1699,'aqua_blast',4,7.0,2000,1000,4,0,0,2,0,0,0);  -- TODO: Verify knockback value.
 INSERT INTO `mob_skills` VALUES (2438,1700,'frozen_mist',1,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2439,1701,'hydro_wave',1,18.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2440,2184,'ice_guillotine',0,7.0,2000,1500,4,0,0,0,0,0,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2245,7 +2245,7 @@ INSERT INTO `mob_skills` VALUES (2433,1711,'calamitous_wind',1,15.0,2000,1000,4,
 -- INSERT INTO `mob_skills` VALUES (2434,2178,'.',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2435,1697,'severing_fang',4,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2436,1698,'sub-zero_smash',4,5.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2437,1699,'aqua_blast',1,18.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2437,1699,'aqua_blast',4,10.0,2000,1000,4,0,0,1,0,0,0);  -- TODO: Verify knockback value.
 INSERT INTO `mob_skills` VALUES (2438,1700,'frozen_mist',1,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2439,1701,'hydro_wave',1,18.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2440,2184,'ice_guillotine',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
There was not a whole lot available about this spell online, so I implemented it to behave largely like `aqua_breath.lua`. Also, for most of the knockback, I just put a placeholder value.

Most knockback spells appear to use `1` for the value in the SQL, so I put that as the placeholder in the SQL for this spell as well.

(This doc also mentioned as a TODO for this spell, as well: https://github.com/LandSandBoat/server/blob/base/documentation/Mobskills_Knockback_Values_TODO.xml#L12)

This change is done as part of https://github.com/LandSandBoat/server/issues/201

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
