### PR TITLE
Remove `nil` check that was skipping death logic.

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -12,13 +12,10 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    if player == nil then
-        local players = mob:getZone():getPlayers()
-
-        for i, person in pairs(players) do -- can't use the variable name "player" because it's already being used
-            if person:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) == QUEST_ACCEPTED and person:checkDistance(mob) < 32 then
-                person:setCharVar("TheFangedOneCS", 2)
-            end
+    local players = mob:getZone():getPlayers()
+    for i, person in pairs(players) do -- can't use the variable name "player" because it's already being used
+        if person:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_FANGED_ONE) == QUEST_ACCEPTED and person:checkDistance(mob) < 32 then
+            person:setCharVar("TheFangedOneCS", 2)
         end
     end
 end


### PR DESCRIPTION
I'm not sure the history of why this nil check was being used, but now the `player` is non-nil when you kill it so that the entire `onMobDeath` is essentially skipped.

Tested the mission flow with the change on a new character.

Fixes https://github.com/LandSandBoat/server/issues/217

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
