### PR TITLE
[cpp] Make initial quest loading more robust

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -371,23 +371,20 @@ namespace luautils
         {
             for (auto const& entry : std::filesystem::recursive_directory_iterator(subFolder))
             {
-                auto path = entry.path();
+                auto path = entry.path().relative_path();
 
                 // TODO(compiler updates):
-                // entry.depth() is not yet available in all of our compilers, so we'll use a hack: counting slashes!
-                // std::filesystem defines '/' as an acceptable path separator
-                auto relPathString = entry.path().relative_path().string();
-                std::size_t numSlashes = std::count_if(relPathString.begin(), relPathString.end(), [](char c){ return c == '/'; });
-                bool isCorrectDepth = numSlashes == 3;
+                // entry.depth() is not yet available in all of our compilers
+                auto depth = std::distance(path.begin(), path.end());
 
                 bool isHelperFile = path.filename() == "helper.lua" || path.filename() == "helpers.lua";
 
                 if (!entry.is_directory() &&
                     path.extension() == ".lua" &&
-                    isCorrectDepth &&
+                    depth == 4 &&
                     !isHelperFile)
                 {
-                    outVec.emplace_back(path.relative_path().replace_extension("").generic_string());
+                    outVec.emplace_back(path.replace_extension("").make_preferred().string());
                 }
             }
         };


### PR DESCRIPTION
Fixes https://github.com/LandSandBoat/server/issues/189

No more messing with strings!

Tested by logging in in Norg with ROTZ01 flagged and Rank 6, getting the CS.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
