### PR TITLE
prevent dia/bio dots from stacking

### DIFF
--- a/scripts/globals/spells/dia.lua
+++ b/scripts/globals/spells/dia.lua
@@ -43,22 +43,16 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() == 1 then
+    if  bio == nil then -- if no bio, add dia dot
+        target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
+    elseif  bio:getSubPower() == 10 and BIO_OVERWRITE == 1 then -- Try to kill same tier Bio (non-default behavior)
             target:delStatusEffect(xi.effect.BIO)
-        end
-    else
-        -- Do it!
-        if bio ~= nil then -- if mob has bio effect
-            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-        else -- otherwise hit for initial damage and add dot
             target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
-            spell:setMsg(xi.msg.basic.MAGIC_DMG)
-        end
     end
 
     return final

--- a/scripts/globals/spells/dia.lua
+++ b/scripts/globals/spells/dia.lua
@@ -46,14 +46,18 @@ spell_object.onSpellCast = function(caster, target, spell)
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() == 1 then
             target:delStatusEffect(xi.effect.BIO)
+        end
+    else
+        -- Do it!
+        if bio ~= nil then -- if mob has bio effect
+            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+        else -- otherwise hit for initial damage and add dot
+            target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
+            spell:setMsg(xi.msg.basic.MAGIC_DMG)
         end
     end
 

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage  
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -43,22 +43,19 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+    
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() <= 2 then
-            target:delStatusEffect(xi.effect.BIO)
-        end
-    else 
-        -- Do it!
-        if bio ~= nil and bio:getPower() <= 2 then -- if mob has bio up through level 2
-            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-        else -- otherwise hit for initial damage and add dia dot, remove bio dot
-            target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-            spell:setMsg(xi.msg.basic.MAGIC_DMG)
-            target:delStatusEffect(xi.effect.BIO)
-        end
+
+    if  bio == nil then -- if no bio, add dia dot
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
+    elseif  
+        bio:getSubPower() == 10 or 
+        (BIO_OVERWRITE == 1 and bio:getSubPower() <= 15) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
+    then -- erase lower tier bio and add dia dot
+        target:delStatusEffect(xi.effect.BIO)
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
     end
 
     return final

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -45,14 +45,18 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() <= 2 then
+            target:delStatusEffect(xi.effect.BIO)
+        end
+    else 
+        -- Do it!
+        if bio ~= nil and bio:getPower() <= 2 then -- if mob has bio up through level 2
+            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+        else -- otherwise hit for initial damage and add dia dot, remove bio dot
+            target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
+            spell:setMsg(xi.msg.basic.MAGIC_DMG)
             target:delStatusEffect(xi.effect.BIO)
         end
     end

--- a/scripts/globals/spells/dia_ii.lua
+++ b/scripts/globals/spells/dia_ii.lua
@@ -43,15 +43,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
-    
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage  
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
     if  bio == nil then -- if no bio, add dia dot
         target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-    elseif  
-        bio:getSubPower() == 10 or 
+    elseif
+        bio:getSubPower() == 10 or
         (BIO_OVERWRITE == 1 and bio:getSubPower() <= 15) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
     then -- erase lower tier bio and add dia dot
         target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -43,22 +43,19 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+    
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() <= 3 then
-            target:delStatusEffect(xi.effect.BIO)
-        else
-            -- Do it!
-            if bio ~= nil and bio:getPower() <= 3 then -- if mob has bio up through level 3
-                spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-            else -- otherwise hit for initial damage and add dia dot, remove bio dot
-                target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-                spell:setMsg(xi.msg.basic.MAGIC_DMG)
-                target:delStatusEffect(xi.effect.BIO)
-            end
-        end
+
+    if  bio == nil then -- if no bio, just add dia dot
+        target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
+    elseif  
+        bio:getSubPower() <= 15 or 
+        (BIO_OVERWRITE == 1 and bio:getSubPower() <= 20) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
+    then -- erase lower tier bio and add dia dot
+        target:delStatusEffect(xi.effect.BIO)
+        target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
     end
 
     return final

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -43,15 +43,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
-    
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
     if  bio == nil then -- if no bio, just add dia dot
         target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-    elseif  
-        bio:getSubPower() <= 15 or 
+    elseif
+        bio:getSubPower() <= 15 or
         (BIO_OVERWRITE == 1 and bio:getSubPower() <= 20) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
     then -- erase lower tier bio and add dia dot
         target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/dia_iii.lua
+++ b/scripts/globals/spells/dia_iii.lua
@@ -45,15 +45,19 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() <= 3 then
             target:delStatusEffect(xi.effect.BIO)
+        else
+            -- Do it!
+            if bio ~= nil and bio:getPower() <= 3 then -- if mob has bio up through level 3
+                spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+            else -- otherwise hit for initial damage and add dia dot, remove bio dot
+                target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
+                spell:setMsg(xi.msg.basic.MAGIC_DMG)
+                target:delStatusEffect(xi.effect.BIO)
+            end
         end
     end
 

--- a/scripts/globals/spells/diaga.lua
+++ b/scripts/globals/spells/diaga.lua
@@ -43,22 +43,16 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() == 1 then
+    if  bio == nil then -- if no bio, add dia dot
+        target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
+    elseif  bio:getSubPower() == 10 and BIO_OVERWRITE == 1 then -- Try to kill same tier Bio (non-default behavior)
             target:delStatusEffect(xi.effect.BIO)
-        end
-    else
-        -- Do it!
-        if bio ~= nil then -- if mob has bio effect
-            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-        else -- otherwise hit for initial damage and add dot
             target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
-            spell:setMsg(xi.msg.basic.MAGIC_DMG)
-        end
     end
 
     return final

--- a/scripts/globals/spells/diaga.lua
+++ b/scripts/globals/spells/diaga.lua
@@ -46,14 +46,18 @@ spell_object.onSpellCast = function(caster, target, spell)
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() == 1 then
             target:delStatusEffect(xi.effect.BIO)
+        end
+    else
+        -- Do it!
+        if bio ~= nil then -- if mob has bio effect
+            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+        else -- otherwise hit for initial damage and add dot
+            target:addStatusEffect(xi.effect.DIA, 1 + dotBonus, 3, duration, 0, 10, 1)
+            spell:setMsg(xi.msg.basic.MAGIC_DMG)
         end
     end
 

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -43,22 +43,19 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+    
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() <= 2 then
-            target:delStatusEffect(xi.effect.BIO)
-        end
-    else 
-        -- Do it!
-        if bio ~= nil and bio:getPower() <= 2 then -- if mob has bio up through level 2
-            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-        else -- otherwise hit for initial damage and add dia dot, remove bio dot
-            target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-            spell:setMsg(xi.msg.basic.MAGIC_DMG)
-            target:delStatusEffect(xi.effect.BIO)
-        end
+
+    if  bio == nil then -- if no bio, add dia dot
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
+    elseif  
+        bio:getSubPower() == 10 or 
+        (BIO_OVERWRITE == 1 and bio:getSubPower() <= 15) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
+    then -- erase lower tier bio and add dia dot
+        target:delStatusEffect(xi.effect.BIO)
+        target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
     end
 
     return final

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage   
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -43,15 +43,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
-    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
-    
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage   
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
     if  bio == nil then -- if no bio, add dia dot
         target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-    elseif  
-        bio:getSubPower() == 10 or 
+    elseif
+        bio:getSubPower() == 10 or
         (BIO_OVERWRITE == 1 and bio:getSubPower() <= 15) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
     then -- erase lower tier bio and add dia dot
         target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/diaga_ii.lua
+++ b/scripts/globals/spells/diaga_ii.lua
@@ -45,14 +45,18 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() <= 2 then
+            target:delStatusEffect(xi.effect.BIO)
+        end
+    else 
+        -- Do it!
+        if bio ~= nil and bio:getPower() <= 2 then -- if mob has bio up through level 2
+            spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+        else -- otherwise hit for initial damage and add dia dot, remove bio dot
+            target:addStatusEffect(xi.effect.DIA, 2 + dotBonus, 3, duration, 0, 15, 2)
+            spell:setMsg(xi.msg.basic.MAGIC_DMG)
             target:delStatusEffect(xi.effect.BIO)
         end
     end

--- a/scripts/globals/spells/diaga_iii.lua
+++ b/scripts/globals/spells/diaga_iii.lua
@@ -44,14 +44,13 @@ spell_object.onSpellCast = function(caster, target, spell)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
     spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
-    
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
 
     if  bio == nil then -- if no bio, just add dia dot
         target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-    elseif  
-        bio:getSubPower() <= 15 or 
+    elseif
+        bio:getSubPower() <= 15 or
         (BIO_OVERWRITE == 1 and bio:getSubPower() <= 20) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
     then -- erase lower tier bio and add dia dot
         target:delStatusEffect(xi.effect.BIO)

--- a/scripts/globals/spells/diaga_iii.lua
+++ b/scripts/globals/spells/diaga_iii.lua
@@ -43,22 +43,19 @@ spell_object.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local dotBonus = caster:getMod(xi.mod.DIA_DOT) -- Dia Wand
 
+    spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage
+    
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-    -- Try to kill same tier Bio (non-default behavior)
-    if BIO_OVERWRITE == 1 and bio ~= nil then
-        if bio:getPower() <= 3 then
-            target:delStatusEffect(xi.effect.BIO)
-        else
-            -- Do it!
-            if bio ~= nil and bio:getPower() <= 3 then -- if mob has bio up through level 3
-                spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
-            else -- otherwise hit for initial damage and add dia dot, remove bio dot
-                target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-                spell:setMsg(xi.msg.basic.MAGIC_DMG)
-                target:delStatusEffect(xi.effect.BIO)
-            end
-        end
+
+    if  bio == nil then -- if no bio, just add dia dot
+        target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
+    elseif  
+        bio:getSubPower() <= 15 or 
+        (BIO_OVERWRITE == 1 and bio:getSubPower() <= 20) -- also erase same tier bio if BIO_OVERWRITE option is on (non-default)
+    then -- erase lower tier bio and add dia dot
+        target:delStatusEffect(xi.effect.BIO)
+        target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
     end
 
     return final

--- a/scripts/globals/spells/diaga_iii.lua
+++ b/scripts/globals/spells/diaga_iii.lua
@@ -45,15 +45,19 @@ spell_object.onSpellCast = function(caster, target, spell)
 
     -- Check for Bio
     local bio = target:getStatusEffect(xi.effect.BIO)
-
-    -- Do it!
-    target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
-    spell:setMsg(xi.msg.basic.MAGIC_DMG)
-
     -- Try to kill same tier Bio (non-default behavior)
     if BIO_OVERWRITE == 1 and bio ~= nil then
         if bio:getPower() <= 3 then
             target:delStatusEffect(xi.effect.BIO)
+        else
+            -- Do it!
+            if bio ~= nil and bio:getPower() <= 3 then -- if mob has bio up through level 3
+                spell:setMsg(xi.msg.basic.MAGIC_DMG) -- hit for initial damage, but no dot effects
+            else -- otherwise hit for initial damage and add dia dot, remove bio dot
+                target:addStatusEffect(xi.effect.DIA, 3 + dotBonus, 3, duration, 0, 20, 3)
+                spell:setMsg(xi.msg.basic.MAGIC_DMG)
+                target:delStatusEffect(xi.effect.BIO)
+            end
         end
     end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
