### PR TITLE
Fix San 6-1 Mission Status after Great Hall Dialogue

### DIFF
--- a/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h4.lua
@@ -83,7 +83,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 61 then
         finishMissionTimeline(player, 3, csid, option)
     elseif csid == 87 then
-        player:setCharVar('missionStatus', 2)
+        player:setMissionStatus(player:getNation(), 2)
     elseif csid == 100 then
         player:setCharVar("Mission8-1Completed", 0) -- dont need this var anymore. JP midnight is done and prev mission completed.
         player:setMissionStatus(player:getNation(), 1)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
