### PR TITLE
Luacheck: Pso'Xja Zone Globals

### DIFF
--- a/scripts/zones/PsoXja/globals.lua
+++ b/scripts/zones/PsoXja/globals.lua
@@ -4,19 +4,20 @@
 local ID = require("scripts/zones/PsoXja/IDs")
 -----------------------------------
 
+local psoXjaGlobal = {}
 --[[..............................................................................................
     thief attempting to pick a lock on stone gate NPC during 5-3T1: Spiral
     correctSideOfDoor (boolean) true if player is trading from the near(gargoyle)-side of the gate
     ..............................................................................................]]
-function attemptPickLock(player, npc, correctSideOfDoor)
-    if (npc:getAnimation() == xi.anim.CLOSE_DOOR and correctSideOfDoor) then
+psoXjaGlobal.attemptPickLock = function(player, npc, correctSideOfDoor)
+    if npc:getAnimation() == xi.anim.CLOSE_DOOR and correctSideOfDoor then
         local offset = npc:getID() - ID.npc.STONE_DOOR_OFFSET
         local gargoyle = ID.mob.GARGOYLE_OFFSET + offset
 
-        if (GetMobByID(gargoyle):isSpawned()) then
+        if GetMobByID(gargoyle):isSpawned() then
             player:messageSpecial(ID.text.DOOR_LOCKED)
         else
-            if (math.random(1, 2) == 1) then
+            if math.random(1, 2) == 1 then
                 npc:messageName(ID.text.DISCOVER_DISARM_FAIL, player)
                 SpawnMob(gargoyle):updateClaim(player)
             else
@@ -32,16 +33,16 @@ end
     player clicking on stone gate NPC during 5-3T1: Spiral
     correctSideOfDoor (boolean) true if player is clicking from the near(gargoyle)-side of gate
     ..............................................................................................]]
-function attemptOpenDoor(player, npc, correctSideOfDoor)
-    if (npc:getAnimation() == xi.anim.CLOSE_DOOR) then
-        if (correctSideOfDoor) then
+psoXjaGlobal.attemptOpenDoor = function(player, npc, correctSideOfDoor)
+    if npc:getAnimation() == xi.anim.CLOSE_DOOR then
+        if correctSideOfDoor then
             local offset = npc:getID() - ID.npc.STONE_DOOR_OFFSET
             local gargoyle = ID.mob.GARGOYLE_OFFSET + offset
 
-            if (GetMobByID(gargoyle):isSpawned()) then
+            if GetMobByID(gargoyle):isSpawned() then
                 player:messageSpecial(ID.text.DOOR_LOCKED)
             else
-                if (math.random(1, 10) <= 9) then -- Spawn Gargoyle
+                if math.random(1, 10) <= 9 then -- Spawn Gargoyle
                     npc:messageName(ID.text.TRAP_ACTIVATED, player)
                     SpawnMob(gargoyle):updateClaim(player)
                 else
@@ -54,3 +55,5 @@ function attemptOpenDoor(player, npc, correctSideOfDoor)
         end
     end
 end
+
+return psoXjaGlobal

--- a/scripts/zones/PsoXja/npcs/_090.lua
+++ b/scripts/zones/PsoXja/npcs/_090.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 341.600 -1.925 -50.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() <= 341)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() <= 341)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() <= 341)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() <= 341)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_091.lua
+++ b/scripts/zones/PsoXja/npcs/_091.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 350.000 -1.925 -61.600 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() >= -61)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() >= -61)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() >= -61)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() >= -61)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_092.lua
+++ b/scripts/zones/PsoXja/npcs/_092.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 338.399 -1.925 -70.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() >= 339)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() >= 339)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() >= 339)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() >= 339)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_093.lua
+++ b/scripts/zones/PsoXja/npcs/_093.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 321.600 -1.925 -70.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() >= 322)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() >= 322)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() >= 322)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() >= 322)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_094.lua
+++ b/scripts/zones/PsoXja/npcs/_094.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 310.000 -1.925 -101.600 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() >= -101)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() >= -101)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() >= -101)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() >= -101)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_095.lua
+++ b/scripts/zones/PsoXja/npcs/_095.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 298.399 -1.925 -110.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() >= 299)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() >= 299)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() >= 299)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() >= 299)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_096.lua
+++ b/scripts/zones/PsoXja/npcs/_096.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 290.000 -1.925 -98.399 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() <= -99)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() <= -99)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() <= -99)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() <= -99)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_097.lua
+++ b/scripts/zones/PsoXja/npcs/_097.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 290.000 -1.925 -81.600 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() <= -82)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() <= -82)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() <= -82)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() <= -82)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_098.lua
+++ b/scripts/zones/PsoXja/npcs/_098.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 258.399 -1.925 -70.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() >= 259)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() >= 259)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() >= 259)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() >= 259)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_099.lua
+++ b/scripts/zones/PsoXja/npcs/_099.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 250.000 -1.925 -58.399 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() <= -59)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() <= -59)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() <= -59)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() <= -59)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09a.lua
+++ b/scripts/zones/PsoXja/npcs/_09a.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 261.600 -1.925 -50.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() <= 261)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() <= 261)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() <= 261)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() <= 261)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09b.lua
+++ b/scripts/zones/PsoXja/npcs/_09b.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 278.399 -1.925 -50.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() <= 278)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() <= 278)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() <= 278)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() <= 278)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09c.lua
+++ b/scripts/zones/PsoXja/npcs/_09c.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 290.000 -1.925 -18.400 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() <= -19)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() <= -19)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() <= -19)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() <= -19)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09d.lua
+++ b/scripts/zones/PsoXja/npcs/_09d.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 301.600 -1.925 -10.000 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getXPos() <= 301)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getXPos() <= 301)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getXPos() <= 301)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getXPos() <= 301)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09e.lua
+++ b/scripts/zones/PsoXja/npcs/_09e.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 310.000 -1.925 -21.599 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() >= -21)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() >= -21)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() >= -21)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() >= -21)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end

--- a/scripts/zones/PsoXja/npcs/_09f.lua
+++ b/scripts/zones/PsoXja/npcs/_09f.lua
@@ -4,26 +4,30 @@
 -- Notes: Spawns Gargoyle when triggered
 -- !pos 310.000 -1.925 -38.400 9
 -----------------------------------
-require("scripts/zones/PsoXja/globals")
+local psoXjaGlobal = require("scripts/zones/PsoXja/globals")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if ( player:getMainJob() == xi.job.THF and trade:getItemCount() == 1 and (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1)) ) then
-        attemptPickLock(player, npc, player:getZPos() >= -38)
+    if
+        player:getMainJob() == xi.job.THF and
+        trade:getItemCount() == 1 and
+        (trade:hasItemQty(1115, 1) or trade:hasItemQty(1023, 1) or trade:hasItemQty(1022, 1))
+    then
+        psoXjaGlobal.attemptPickLock(player, npc, player:getZPos() >= -38)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    attemptOpenDoor(player, npc, player:getZPos() >= -38)
+    psoXjaGlobal.attemptOpenDoor(player, npc, player:getZPos() >= -38)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 26 and option == 1) then
+    if csid == 26 and option == 1 then
         player:setPos(260, -0.25, -20, 254, 111)
     end
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
