### PR TITLE
Luacheck: Abilities, commands, auto ws, beastmen treasure, and besieged global

### DIFF
--- a/scripts/commands/gotoid.lua
+++ b/scripts/commands/gotoid.lua
@@ -64,8 +64,8 @@ function onTrigger(player, target)
         end
 
         -- half a second later, go.  this delay gives time for previous message to appear
-        player:timer(500, function(player)
-            player:setPos(targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos(), gotoZone)
+        player:timer(500, function(playerArg)
+            playerArg:setPos(targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos(), gotoZone)
         end)
     end
 end

--- a/scripts/globals/abilities/pets/bone_crusher.lua
+++ b/scripts/globals/abilities/pets/bone_crusher.lua
@@ -52,7 +52,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
     end
 
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     if damage > 0 then
         local chance = 0.033 * skill:getTP()

--- a/scripts/globals/abilities/pets/cannibal_blade.lua
+++ b/scripts/globals/abilities/pets/cannibal_blade.lua
@@ -57,7 +57,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         end
     end
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     if damage > 0 then
         if not target:isUndead() then

--- a/scripts/globals/abilities/pets/chimera_ripper.lua
+++ b/scripts/globals/abilities/pets/chimera_ripper.lua
@@ -40,7 +40,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         params.ftp300 = 11.0
     end
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     return damage
 end

--- a/scripts/globals/abilities/pets/knockout.lua
+++ b/scripts/globals/abilities/pets/knockout.lua
@@ -41,7 +41,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         params.ftp300 = 11.0
     end
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     if damage > 0 then
         if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then

--- a/scripts/globals/abilities/pets/magic_mortar.lua
+++ b/scripts/globals/abilities/pets/magic_mortar.lua
@@ -39,7 +39,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
        automaton:addTP(80)
     end
 
-    target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
+    target:takeDamage(damage, automaton, xi.attackType.MAGICAL, xi.damageType.LIGHT)
     return damage
 end
 

--- a/scripts/globals/abilities/pets/perfect_defense.lua
+++ b/scripts/globals/abilities/pets/perfect_defense.lua
@@ -14,8 +14,9 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill, master)
     local power = 100 * (master:getMP() / master:getMaxMP())
-    duration = 60
-    if (master ~= nil) then
+    local duration = 60
+
+    if master ~= nil then
         local summoningSkill = master:getSkillLevel(xi.skill.SUMMONING_MAGIC)
         if (summoningSkill > 600) then
             summoningSkill = 600

--- a/scripts/globals/abilities/pets/poison_nails.lua
+++ b/scripts/globals/abilities/pets/poison_nails.lua
@@ -25,7 +25,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     target:updateEnmityFromDamage(pet, totaldamage)
 
-    if (AvatarPhysicalHit(skill, totalDamage) and target:hasStatusEffect(xi.effect.POISON) == false) then
+    if (AvatarPhysicalHit(skill, totaldamage) and target:hasStatusEffect(xi.effect.POISON) == false) then
         target:addStatusEffect(xi.effect.POISON, 1, 3, 60)
     end
 

--- a/scripts/globals/abilities/pets/slapstick.lua
+++ b/scripts/globals/abilities/pets/slapstick.lua
@@ -40,7 +40,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         params.accBonus = 0.04 * skill:getTP()
     end
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     return damage
 end

--- a/scripts/globals/abilities/pets/string_clipper.lua
+++ b/scripts/globals/abilities/pets/string_clipper.lua
@@ -40,7 +40,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         params.accBonus = 0.05 * skill:getTP()
     end
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     return damage
 end

--- a/scripts/globals/abilities/pets/string_shredder.lua
+++ b/scripts/globals/abilities/pets/string_shredder.lua
@@ -37,7 +37,7 @@ ability_object.onPetAbility = function(target, automaton, skill, master, action)
         chr_wsc = 0.0
     }
 
-    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill, action)
+    local damage = doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)
 
     return damage
 end

--- a/scripts/globals/abilities/pets/super_climb.lua
+++ b/scripts/globals/abilities/pets/super_climb.lua
@@ -15,8 +15,8 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(pet, target, ability)
-    pet:queue(0, function(pet)
-        pet:stun(5000)
+    pet:queue(0, function(petArg)
+        petArg:stun(5000)
     end)
 end
 

--- a/scripts/globals/abilities/pets/zantetsuken.lua
+++ b/scripts/globals/abilities/pets/zantetsuken.lua
@@ -25,7 +25,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
         dmg = MobMagicalMove(pet, target, skill, dmg, xi.magic.ele.DARK, 1, TP_NO_EFFECT, 0)
         dmg = mobAddBonuses(pet, nil, target, dmg.dmg, xi.magic.ele.DARK)
         dmg = AvatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
-        target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
+        target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
         target:updateEnmityFromDamage(pet, dmg)
         return dmg
     else

--- a/scripts/globals/abilities/reward.lua
+++ b/scripts/globals/abilities/reward.lua
@@ -131,7 +131,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
             pet:delStatusEffect(xi.effect.SLOW)
             pet:delStatusEffect(xi.effect.SILENCE)
             end,
-        [14481] = function (x) -- monster jackcoat +1
+        [14508] = function (x) -- monster jackcoat +1
             -- This will remove Paralyze, Poison, Blind, Weight, Slow and Silence from the pet.
             -- printf("Monster jackcoat +1 detected.")
             pet:delStatusEffect(xi.effect.PARALYSIS)

--- a/scripts/globals/abilities/steal.lua
+++ b/scripts/globals/abilities/steal.lua
@@ -17,7 +17,7 @@ local ability_object = {}
 -- garnet quadav groupid = 7960
 -- silver quadav groupid = 7977
 -- zircorn quadav groupid = 7985
-validThfQuestMobs =
+local validThfQuestMobs =
 {
     17379367, 17379368, 17379459, 17379470, 17379477, 17379489, 17379493, 17379495, 17379501, 17379505, 17379509,
     17379513, 17379517, 17379521, 17379525, 17379529, 17379533, 17379538, 17379543, 17379547, 17379552, 17379556,
@@ -32,7 +32,18 @@ validThfQuestMobs =
     17379554, 17379558, 17379562, 17379567, 17379571, 17379575, 17379579, 17379583, 17379587, 17379599
 }
 
+local function checkThfAfQuest(player, target)
+    local targid = target:getID()
 
+    if (player:getCharVar("theTenshodoShowdownCS") == 3) then
+        for key, value in pairs(validThfQuestMobs) do
+            if value == targid then
+                return true
+            end
+        end
+    return false
+    end
+end
 
 ability_object.onAbilityCheck = function(player, target, ability)
     if (player:getFreeSlotsCount() == 0) then
@@ -69,16 +80,18 @@ ability_object.onUseAbility = function(player, target, ability, action)
         target:itemStolen()
         ability:setMsg(xi.msg.basic.STEAL_SUCCESS) -- Item stolen successfully
         target:triggerListener("ITEM_STOLEN", target, player, stolen)
+        -- Aura Steal does not trigger on successful item steal
+        return
     else
         ability:setMsg(xi.msg.basic.STEAL_FAIL) -- Failed to steal
         action:setAnimation(target:getID(), 182)
     end
 
     -- Attempt Aura steal
-    local effect = xi.effect.NONE
+    -- local effect = xi.effect.NONE
     if (stolen == 0 and player:hasTrait(75)) then
         local resist = applyResistanceAbility(player, target, xi.magic.ele.NONE, 0, 0)
-        local effectStealSuccess = false
+        -- local effectStealSuccess = false
         if (resist > 0.0625) then
             local auraStealChance = math.min(player:getMerit(xi.merit.AURA_STEAL), 95)
             if (math.random(100) < auraStealChance) then
@@ -91,6 +104,10 @@ ability_object.onUseAbility = function(player, target, ability, action)
             end
 
             -- Try for a second effect if we have the augment
+            --[[
+            TODO: This implementation is currently broken and inaccurate.  20% chance of a second aura being
+            stolen per merit.
+
             if ((effect ~= xi.effect.NONE or stolen ~= 0) and player:getMod(xi.mod.AUGMENTS_AURA_STEAL) > 0) then
                 if (math.random(100) < auraStealChance) then
                     if (stolenEffect2 ~= nil and math.random(100) < auraStealChance) then
@@ -100,24 +117,11 @@ ability_object.onUseAbility = function(player, target, ability, action)
                     end
                 end
             end
+            ]]--
         end
     end
 
     return stolen
-end
-
-
-function checkThfAfQuest(player, target)
-    local targid = target:getID()
-
-    if (player:getCharVar("theTenshodoShowdownCS") == 3) then
-        for key, value in pairs(validThfQuestMobs) do
-            if value == targid then
-                return true
-            end
-        end
-    return false
-    end
 end
 
 return ability_object

--- a/scripts/globals/abilities/violent_flourish.lua
+++ b/scripts/globals/abilities/violent_flourish.lua
@@ -45,7 +45,6 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability, action)
-    local hit = 4
     --get fstr
     local fstr = fSTR(player:getStat(xi.mod.STR), target:getStat(xi.mod.VIT), player:getWeaponDmgRank())
 
@@ -63,7 +62,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
     end
 
     local base = weaponDamage + fstr
-    local cratio, ccritratio = cMeleeRatio(player, target, params, 0, 0)
+    local cratio, _ = cMeleeRatio(player, target, params, 0, 0)
     local isSneakValid = player:hasStatusEffect(xi.effect.SNEAK_ATTACK)
     if (isSneakValid and not player:isBehind(target)) then
         isSneakValid = false
@@ -72,11 +71,10 @@ ability_object.onUseAbility = function(player, target, ability, action)
     local hitrate = getHitRate(player, target, true)
 
     if (math.random() <= hitrate or isSneakValid) then
-        hit = 3
-        dmg = base * pdif
+        local hit = 3
+        local dmg = base * pdif
 
         local spell = GetSpell(252)
-        local params = {}
         params.diff = 0
         params.skillType = player:getWeaponSkillType(xi.slot.MAIN)
         params.bonus = 50 - target:getMod(xi.mod.STUNRES) + player:getMod(xi.mod.VFLOURISH_MACC) + player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT)

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -6,9 +6,151 @@ require("scripts/globals/utils")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 
+local function getAutoHitRate(attacker, defender, capHitRate, bonus, melee)
+    local acc = (melee and attacker:getACC() or attacker:getRACC()) + (bonus or 0)
+    local eva = defender:getEVA()
+
+    local levelbonus = 0
+    if (attacker:getMainLvl() > defender:getMainLvl()) then
+        levelbonus = 2 * (attacker:getMainLvl() - defender:getMainLvl())
+    end
+
+    local hitrate = acc - eva + levelbonus + 75
+    hitrate = hitrate/100
+
+    -- Applying hitrate caps
+    if (capHitRate) then -- this isn't capped for when acc varies with tp, as more penalties are due
+        hitrate = utils.clamp(hitrate, 0.2, 0.95)
+    end
+    return hitrate
+end
+
+-- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
+local function getAutocRatio(attacker, defender, params, ignoredDef, melee)
+    local cratio = (melee and attacker:getStat(xi.mod.ATT) or attacker:getRATT()) * params.atkmulti / (defender:getStat(xi.mod.DEF) - ignoredDef)
+
+    local levelbonus = 0
+    if attacker:getMainLvl() > defender:getMainLvl() then
+        levelbonus = 0.05 * (attacker:getMainLvl() - defender:getMainLvl())
+    end
+
+    cratio = cratio + levelbonus
+    cratio = utils.clamp(cratio, 0, melee and 4.0 or 3.0)
+
+    local pdif = {}
+    local pdifcrit = {}
+
+    if melee then
+        local pdifmin = 0
+        local pdifmax = 1
+
+        if cratio < 0.5 then
+            pdifmax = cratio + 0.5
+        elseif 0.5 <= cratio and cratio <= 0.7 then
+            pdifmax = 1
+        elseif 0.7 < cratio and cratio <= 1.2 then
+            pdifmax = cratio + 0.3
+        elseif 1.2 < cratio and cratio <= 1.5 then
+            pdifmax = (cratio * 0.25) + cratio
+        elseif 1.5 < cratio and cratio <= 2.625 then
+            pdifmax = cratio + 0.375
+        elseif 2.625 < cratio and cratio <= 3.25 then
+            pdifmax = 3
+        else
+            pdifmax = cratio
+        end
+
+        if cratio < 0.38 then
+            pdifmin =  0
+        elseif 0.38 <= cratio and cratio <= 1.25 then
+            pdifmin = cratio * 1176 / 1024 - 448 / 1024
+        elseif 1.25 < cratio and cratio <= 1.51 then
+            pdifmin = 1
+        elseif 1.51 < cratio and cratio <= 2.44 then
+            pdifmin = cratio * 1176 / 1024 - 775 / 1024
+        else
+            pdifmin = cratio - 0.375
+        end
+
+        pdif[1] = pdifmin
+        pdif[2] = pdifmax
+
+        cratio = cratio + 1
+        cratio = utils.clamp(cratio, 0, 4.0)
+
+        -- printf("ratio: %f min: %f max %f\n", cratio, pdifmin, pdifmax)
+
+        if cratio < 0.5 then
+            pdifmax = cratio + 0.5
+        elseif 0.5 <= cratio and cratio <= 0.7 then
+            pdifmax = 1
+        elseif 0.7 < cratio and cratio <= 1.2 then
+            pdifmax = cratio + 0.3
+        elseif 1.2 < cratio and cratio <= 1.5 then
+            pdifmax = cratio * 0.25 + cratio
+        elseif 1.5 < cratio and cratio <= 2.625 then
+            pdifmax = cratio + 0.375
+        elseif 2.625 < cratio and cratio <= 3.25 then
+            pdifmax = 3
+        else
+            pdifmax = cratio
+        end
+
+        if cratio < 0.38 then
+            pdifmin =  0
+        elseif 0.38 <= cratio and cratio <= 1.25 then
+            pdifmin = cratio * 1176 / 1024 - 448 / 1024
+        elseif 1.25 < cratio and cratio <= 1.51 then
+            pdifmin = 1
+        elseif 1.51 < cratio and cratio <= 2.44 then
+            pdifmin = cratio * 1176 / 1024 - 775 / 1024
+        else
+            pdifmin = cratio - 0.375
+        end
+
+        local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)
+        critbonus = utils.clamp(critbonus, 0, 100)
+        pdifcrit[1] = pdifmin * (100 + critbonus) / 100
+        pdifcrit[2] = pdifmax * (100 + critbonus) / 100
+    else
+        -- max
+        local pdifmax = 0
+        if cratio < 0.9 then
+            pdifmax = cratio * 10 / 9
+        elseif cratio < 1.1 then
+            pdifmax = 1
+        else
+            pdifmax = cratio
+        end
+
+        -- min
+        local pdifmin = 0
+        if cratio < 0.9 then
+            pdifmin = cratio
+        elseif cratio < 1.1 then
+            pdifmin = 1
+        else
+            pdifmin = cratio * 20 / 19 - 3 / 19
+        end
+
+        pdif[1] = pdifmin
+        pdif[2] = pdifmax
+        -- printf("ratio: %f min: %f max %f\n", cratio, pdifmin, pdifmax)
+
+        pdifmin = pdifmin * 1.25
+        pdifmax = pdifmax * 1.25
+
+        local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)
+        critbonus = utils.clamp(critbonus, 0, 100)
+        pdifcrit[1] = pdifmin * (100 + critbonus) / 100
+        pdifcrit[2] = pdifmax * (100 + critbonus) / 100
+    end
+
+    return pdif, pdifcrit
+end
 
 -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
-function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, action, taChar, wsParams, skill, action)
+function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, action, taChar, wsParams, skill)
 
     -- Determine cratio and ccritratio
     local ignoredDef = 0
@@ -156,147 +298,4 @@ function doAutoRangedWeaponskill(attacker, target, wsID, wsParams, tp, primaryMs
     end
 
     return finaldmg, calcParams.criticalHit, calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.shadowsAbsorbed
-end
-
-function getAutoHitRate(attacker, defender, capHitRate, bonus, melee)
-    local acc = (melee and attacker:getACC() or attacker:getRACC()) + (bonus or 0)
-    local eva = defender:getEVA()
-
-    local levelbonus = 0
-    if (attacker:getMainLvl() > defender:getMainLvl()) then
-        levelbonus = 2 * (attacker:getMainLvl() - defender:getMainLvl())
-    end
-
-    local hitrate = acc - eva + levelbonus + 75
-    hitrate = hitrate/100
-
-    -- Applying hitrate caps
-    if (capHitRate) then -- this isn't capped for when acc varies with tp, as more penalties are due
-        hitrate = utils.clamp(hitrate, 0.2, 0.95)
-    end
-    return hitrate
-end
-
--- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
-function getAutocRatio(attacker, defender, params, ignoredDef, melee)
-    local cratio = (melee and attacker:getStat(xi.mod.ATT) or attacker:getRATT()) * params.atkmulti / (defender:getStat(xi.mod.DEF) - ignoredDef)
-
-    local levelbonus = 0
-    if attacker:getMainLvl() > defender:getMainLvl() then
-        levelbonus = 0.05 * (attacker:getMainLvl() - defender:getMainLvl())
-    end
-
-    cratio = cratio + levelbonus
-    cratio = utils.clamp(cratio, 0, melee and 4.0 or 3.0)
-
-    local pdif = {}
-    local pdifcrit = {}
-
-    if melee then
-        local pdifmin = 0
-        local pdifmax = 1
-
-        if cratio < 0.5 then
-            pdifmax = cratio + 0.5
-        elseif 0.5 <= cratio and cratio <= 0.7 then
-            pdifmax = 1
-        elseif 0.7 < cratio and cratio <= 1.2 then
-            pdifmax = cratio + 0.3
-        elseif 1.2 < cratio and cratio <= 1.5 then
-            pdifmax = (cratio * 0.25) + cratio
-        elseif 1.5 < cratio and cratio <= 2.625 then
-            pdifmax = cratio + 0.375
-        elseif 2.625 < cratio and cratio <= 3.25 then
-            pdifmax = 3
-        else
-            pdifmax = cratio
-        end
-
-        if cratio < 0.38 then
-            pdifmin =  0
-        elseif 0.38 <= cratio and cratio <= 1.25 then
-            pdifmin = cratio * 1176 / 1024 - 448 / 1024
-        elseif 1.25 < cratio and cratio <= 1.51 then
-            pdifmin = 1
-        elseif 1.51 < cratio and cratio <= 2.44 then
-            pdifmin = cratio * 1176 / 1024 - 775 / 1024
-        else
-            pdifmin = cratio - 0.375
-        end
-
-        pdif[1] = pdifmin
-        pdif[2] = pdifmax
-
-        cratio = cratio + 1
-        cratio = utils.clamp(cratio, 0, 4.0)
-
-        -- printf("ratio: %f min: %f max %f\n", cratio, pdifmin, pdifmax)
-
-        if cratio < 0.5 then
-            pdifmax = cratio + 0.5
-        elseif 0.5 <= cratio and cratio <= 0.7 then
-            pdifmax = 1
-        elseif 0.7 < cratio and cratio <= 1.2 then
-            pdifmax = cratio + 0.3
-        elseif 1.2 < cratio and cratio <= 1.5 then
-            pdifmax = cratio * 0.25 + cratio
-        elseif 1.5 < cratio and cratio <= 2.625 then
-            pdifmax = cratio + 0.375
-        elseif 2.625 < cratio and cratio <= 3.25 then
-            pdifmax = 3
-        else
-            pdifmax = cratio
-        end
-
-        if cratio < 0.38 then
-            pdifmin =  0
-        elseif 0.38 <= cratio and cratio <= 1.25 then
-            pdifmin = cratio * 1176 / 1024 - 448 / 1024
-        elseif 1.25 < cratio and cratio <= 1.51 then
-            pdifmin = 1
-        elseif 1.51 < cratio and cratio <= 2.44 then
-            pdifmin = cratio * 1176 / 1024 - 775 / 1024
-        else
-            pdifmin = cratio - 0.375
-        end
-
-        local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)
-        critbonus = utils.clamp(critbonus, 0, 100)
-        pdifcrit[1] = pdifmin * (100 + critbonus) / 100
-        pdifcrit[2] = pdifmax * (100 + critbonus) / 100
-    else
-        -- max
-        local pdifmax = 0
-        if cratio < 0.9 then
-            pdifmax = cratio * 10 / 9
-        elseif cratio < 1.1 then
-            pdifmax = 1
-        else
-            pdifmax = cratio
-        end
-
-        -- min
-        local pdifmin = 0
-        if cratio < 0.9 then
-            pdifmin = cratio
-        elseif cratio < 1.1 then
-            pdifmin = 1
-        else
-            pdifmin = cratio * 20 / 19 - 3 / 19
-        end
-
-        pdif[1] = pdifmin
-        pdif[2] = pdifmax
-        -- printf("ratio: %f min: %f max %f\n", cratio, pdifmin, pdifmax)
-
-        pdifmin = pdifmin * 1.25
-        pdifmax = pdifmax * 1.25
-
-        local critbonus = attacker:getMod(xi.mod.CRIT_DMG_INCREASE) - defender:getMod(xi.mod.CRIT_DEF_BONUS)
-        critbonus = utils.clamp(critbonus, 0, 100)
-        pdifcrit[1] = pdifmin * (100 + critbonus) / 100
-        pdifcrit[2] = pdifmax * (100 + critbonus) / 100
-    end
-
-    return pdif, pdifcrit
 end

--- a/scripts/globals/beastmentreasure.lua
+++ b/scripts/globals/beastmentreasure.lua
@@ -127,8 +127,8 @@ end
 local function addLoot(t1, t2)
     -- Used for non-destructively combining a table containing a single weighted item (`t2`)
     -- and an existing loot table containing one or more weighted items (`t1`).
-    newTable = {}
-    newItem = table.maxn(t2)
+    local newTable = {}
+    local newItem = table.maxn(t2)
 
     -- Copy the contents of the first table so that we don't modify the global version
     for item, weight in pairs(t1) do
@@ -232,12 +232,12 @@ xi.beastmentreasure.handleNpcOnEventFinish = function(player, csid)
     end
 end
 
-xi.beastmentreasure.updatePeddlestox = function(zone, peddlestox)
+xi.beastmentreasure.updatePeddlestox = function(zone, peddlestoxID)
     --[[ Allows Peddlestox to appear on the appropriate day and disappear when the day is over.
     This function is called by each of the three zones where Peddlestox can appear: once on init,
     and once at the start of each new game day. Since Peddlestox is disabled in the db by default, we
     only need to enable her on the appropriate day and disable her on the following day. ]]--
-    local peddlestox = GetNPCByID(peddlestox)
+    local peddlestox = GetNPCByID(peddlestoxID)
 
     if zoneData[zone].day == VanadielDayOfTheWeek() then
         peddlestox:setStatus(xi.status.NORMAL)

--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -12,6 +12,124 @@ require("scripts/globals/teleports")
 xi = xi or {}
 xi.besieged = xi.besieged or {}
 
+local function getMapBitmask(player)
+    local mamook = player:hasKeyItem(xi.ki.MAP_OF_MAMOOK) and 1 or 0 -- Map of Mammok
+    local halvung = player:hasKeyItem(xi.ki.MAP_OF_HALVUNG) and 2 or 0 -- Map of Halvung
+    local arrapago = player:hasKeyItem(xi.ki.MAP_OF_ARRAPAGO_REEF) and 4 or 0 -- Map of Arrapago Reef
+    local astral = bit.lshift(xi.besieged.getAstralCandescence(), 31) -- Include astral candescence in the top byte
+
+    return bit.bor(mamook, halvung, arrapago, astral)
+end
+
+-----------------------------------
+-- function getImperialDefenseStats() returns:
+-- *how many successive times Al Zahbi has been defended
+-- *Imperial Defense Value
+-- *Total number of imperial victories
+-- *Total number of beastmen victories.
+-- hardcoded constants for now until we have a Besieged system.
+-----------------------------------
+local function getImperialDefenseStats()
+    local successiveWins = 0
+    local defenseBonus = 0
+    local imperialWins = 0
+    local beastmanWins = 0
+    return { successiveWins, defenseBonus, imperialWins, beastmanWins }
+end
+
+-----------------------------------
+-- function getISPItem(i) returns the item ID and cost of the imperial standing
+-- points item indexed by i (the same value  as that used by the vendor event.)
+-----------------------------------
+local function getISPItem(i)
+    local IS_item =
+    {
+        -- Common Items
+        [1] = {id = 4182, price = 7}, -- scroll of Instant Reraise
+        [4097] = {id = 4181, price = 10}, -- scroll of Instant Warp
+        [8193] = {id = 2230, price = 100}, -- lambent fire cell
+        [12289] = {id = 2231, price = 100}, -- lambent water cell
+        [16385] = {id = 2232, price = 100}, -- lambent earth cell
+        [20481] = {id = 2233, price = 100}, -- lambent wind cell
+        [24577] = {id = 19021, price = 20000}, -- katana strap
+        [28673] = {id = 19022, price = 20000}, -- axe grip
+        [32769] = {id = 19023, price = 20000}, -- staff strap
+        [36865] = {id = 3307, price = 5000}, -- heat capacitor
+        [40961] = {id = 3308, price = 5000}, -- power cooler
+        [45057] = {id = 3309, price = 5000}, -- barrage turbine
+        [53249] = {id = 3311, price = 5000}, -- galvanizer
+        [57345] = {id = 6409, price = 50000},
+        -- Private Second Class
+        -- Map Key Items (handled separately)
+        -- Private First Class
+        [33] = {id = 18689, price = 2000}, -- volunteer's dart
+        [289] = {id = 18690, price = 2000}, -- mercenary's dart
+        [545] = {id = 18691, price = 2000}, -- Imperial dart
+        -- Superior Private
+        [49] = {id = 18692, price = 4000}, -- Mamoolbane
+        [305] = {id = 18693, price = 4000}, -- Lamiabane
+        [561] = {id = 18694, price = 4000}, -- Trollbane
+        [817] = {id = 15810, price = 4000}, -- Luzaf's ring
+        -- Lance Corporal
+        [65] = {id = 15698, price = 8000}, -- sneaking boots
+        [321] = {id = 15560, price = 8000}, -- trooper's ring
+        [577] = {id = 16168, price = 8000}, -- sentinel shield
+        -- Corporal
+        [81] = {id = 18703, price = 16000}, -- shark gun
+        [337] = {id = 18742, price = 16000}, -- puppet claws
+        [593] = {id = 17723, price = 16000}, -- singh kilij
+        -- Sergeant
+        [97] = {id = 15622, price = 24000}, -- mercenary's trousers
+        [353] = {id = 15790, price = 24000}, -- multiple ring
+        [609] = {id = 15981, price = 24000}, -- haten earring
+        -- Sergeant Major
+        [113] = {id = 15623, price = 32000}, -- volunteer's brais
+        [369] = {id = 15982, price = 32000}, -- priest's earring
+        [625] = {id = 15983, price = 32000}, -- chaotic earring
+        -- Chief Sergeant
+        [129] = {id = 17741, price = 40000}, -- perdu hanger
+        [385] = {id = 18943, price = 40000}, -- perdu sickle
+        [641] = {id = 18850, price = 40000}, -- perdu wand
+        [897] = {id = 18717, price = 40000}, -- perdu bow
+        -- Second Lieutenant
+        [145] = {id = 16602, price = 48000}, -- perdu sword
+        [401] = {id = 18425, price = 48000}, -- perdu blade
+        [657] = {id = 18491, price = 48000}, -- perdu voulge
+        [913] = {id = 18588, price = 48000}, -- perdu staff
+        [1169] = {id = 18718, price = 48000}, -- perdu crossbow
+        -- First Lieutenant
+        [161] = {id = 16271, price = 56000}, -- lieutenant's gorget
+        [417] = {id = 15912, price = 56000}, -- lieutenant's sash
+        [673] = {id = 16230, price = 56000} -- lieutenant's cape
+    }
+    local item = IS_item[i]
+    if item then
+        return item.id, item.price
+    end
+
+    return nil
+end
+
+-----------------------------------
+-- function getSanctionDuration(player) returns the duration of the sanction effect
+-- in seconds. Duration is known to go up with mercenary rank but data published on
+-- ffxi wiki (http://wiki.ffxiclopedia.org/wiki/Sanction) is unclear and even
+-- contradictory (the page on the AC http://wiki.ffxiclopedia.org/wiki/Astral_Candescence
+-- says that duration is 3-8 hours with the AC, 1-3 hours without the AC while the Sanction
+-- page says it's 3-6 hours with th AC.)
+--
+-- I decided to use the formula duration (with AC) = 3 hours + (mercenary rank - 1) * 20 minutes.
+-----------------------------------
+local function getSanctionDuration(player)
+    local duration = 10800 + 1200 * (xi.besieged.getMercenaryRank(player) - 1)
+
+    if xi.besieged.getAstralCandescence() == 0 then
+        duration = duration / 2
+    end
+
+    return duration
+end
+
 xi.besieged.onTrigger = function(player, npc, eventBase)
     local mercRank = xi.besieged.getMercenaryRank(player)
     if mercRank == 0 then
@@ -124,122 +242,4 @@ local assaultLevels =
 
 function getRecommendedAssaultLevel(assaultid)
     return assaultLevels[assaultid]
-end
-
-function getMapBitmask(player)
-    local mamook = player:hasKeyItem(xi.ki.MAP_OF_MAMOOK) and 1 or 0 -- Map of Mammok
-    local halvung = player:hasKeyItem(xi.ki.MAP_OF_HALVUNG) and 2 or 0 -- Map of Halvung
-    local arrapago = player:hasKeyItem(xi.ki.MAP_OF_ARRAPAGO_REEF) and 4 or 0 -- Map of Arrapago Reef
-    local astral = bit.lshift(xi.besieged.getAstralCandescence(), 31) -- Include astral candescence in the top byte
-
-    return bit.bor(mamook, halvung, arrapago, astral)
-end
-
------------------------------------
--- function getSanctionDuration(player) returns the duration of the sanction effect
--- in seconds. Duration is known to go up with mercenary rank but data published on
--- ffxi wiki (http://wiki.ffxiclopedia.org/wiki/Sanction) is unclear and even
--- contradictory (the page on the AC http://wiki.ffxiclopedia.org/wiki/Astral_Candescence
--- says that duration is 3-8 hours with the AC, 1-3 hours without the AC while the Sanction
--- page says it's 3-6 hours with th AC.)
---
--- I decided to use the formula duration (with AC) = 3 hours + (mercenary rank - 1) * 20 minutes.
------------------------------------
-function getSanctionDuration(player)
-    local duration = 10800 + 1200 * (xi.besieged.getMercenaryRank(player) - 1)
-
-    if xi.besieged.getAstralCandescence() == 0 then
-        duration = duration / 2
-    end
-
-    return duration
-end
-
------------------------------------
--- function getImperialDefenseStats() returns:
--- *how many successive times Al Zahbi has been defended
--- *Imperial Defense Value
--- *Total number of imperial victories
--- *Total number of beastmen victories.
--- hardcoded constants for now until we have a Besieged system.
------------------------------------
-function getImperialDefenseStats()
-    local successiveWins = 0
-    local defenseBonus = 0
-    local imperialWins = 0
-    local beastmanWins = 0
-    return { successiveWins, defenseBonus, imperialWins, beastmanWins }
-end
-
------------------------------------
--- function getISPItem(i) returns the item ID and cost of the imperial standing
--- points item indexed by i (the same value  as that used by the vendor event.)
------------------------------------
-function getISPItem(i)
-    local IS_item =
-    {
-        -- Common Items
-        [1] = {id = 4182, price = 7}, -- scroll of Instant Reraise
-        [4097] = {id = 4181, price = 10}, -- scroll of Instant Warp
-        [8193] = {id = 2230, price = 100}, -- lambent fire cell
-        [12289] = {id = 2231, price = 100}, -- lambent water cell
-        [16385] = {id = 2232, price = 100}, -- lambent earth cell
-        [20481] = {id = 2233, price = 100}, -- lambent wind cell
-        [24577] = {id = 19021, price = 20000}, -- katana strap
-        [28673] = {id = 19022, price = 20000}, -- axe grip
-        [32769] = {id = 19023, price = 20000}, -- staff strap
-        [36865] = {id = 3307, price = 5000}, -- heat capacitor
-        [40961] = {id = 3308, price = 5000}, -- power cooler
-        [45057] = {id = 3309, price = 5000}, -- barrage turbine
-        [53249] = {id = 3311, price = 5000}, -- galvanizer
-        [57345] = {id = 6409, price = 50000},
-        -- Private Second Class
-        -- Map Key Items (handled separately)
-        -- Private First Class
-        [33] = {id = 18689, price = 2000}, -- volunteer's dart
-        [289] = {id = 18690, price = 2000}, -- mercenary's dart
-        [545] = {id = 18691, price = 2000}, -- Imperial dart
-        -- Superior Private
-        [49] = {id = 18692, price = 4000}, -- Mamoolbane
-        [305] = {id = 18693, price = 4000}, -- Lamiabane
-        [561] = {id = 18694, price = 4000}, -- Trollbane
-        [817] = {id = 15810, price = 4000}, -- Luzaf's ring
-        -- Lance Corporal
-        [65] = {id = 15698, price = 8000}, -- sneaking boots
-        [321] = {id = 15560, price = 8000}, -- trooper's ring
-        [577] = {id = 16168, price = 8000}, -- sentinel shield
-        -- Corporal
-        [81] = {id = 18703, price = 16000}, -- shark gun
-        [337] = {id = 18742, price = 16000}, -- puppet claws
-        [593] = {id = 17723, price = 16000}, -- singh kilij
-        -- Sergeant
-        [97] = {id = 15622, price = 24000}, -- mercenary's trousers
-        [353] = {id = 15790, price = 24000}, -- multiple ring
-        [609] = {id = 15981, price = 24000}, -- haten earring
-        -- Sergeant Major
-        [113] = {id = 15623, price = 32000}, -- volunteer's brais
-        [369] = {id = 15982, price = 32000}, -- priest's earring
-        [625] = {id = 15983, price = 32000}, -- chaotic earring
-        -- Chief Sergeant
-        [129] = {id = 17741, price = 40000}, -- perdu hanger
-        [385] = {id = 18943, price = 40000}, -- perdu sickle
-        [641] = {id = 18850, price = 40000}, -- perdu wand
-        [897] = {id = 18717, price = 40000}, -- perdu bow
-        -- Second Lieutenant
-        [145] = {id = 16602, price = 48000}, -- perdu sword
-        [401] = {id = 18425, price = 48000}, -- perdu blade
-        [657] = {id = 18491, price = 48000}, -- perdu voulge
-        [913] = {id = 18588, price = 48000}, -- perdu staff
-        [1169] = {id = 18718, price = 48000}, -- perdu crossbow
-        -- First Lieutenant
-        [161] = {id = 16271, price = 56000}, -- lieutenant's gorget
-        [417] = {id = 15912, price = 56000}, -- lieutenant's sash
-        [673] = {id = 16230, price = 56000} -- lieutenant's cape
-    }
-    local item = IS_item[i]
-    if item then
-        return item.id, item.price
-    end
-
-    return nil
 end

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -185,6 +185,14 @@ global_objects=(
     updateModPerformance
 
     fTP
+    fSTR
+    calculateRawWSDmg
+    calculatedIgnoredDef
+    cMeleeRatio
+    generatePdif
+    getMeleeDmg
+
+    getRecommendedAssaultLevel
 
     PATHFLAG_WALLHACK
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Automaton Weaponskill functions localized, removed additional duplicate argument from Physical WS scripts
* Fixed Monster Jackcoat +1 entry in reward.lua
* Fixed locals in steal.lua, disabled second aura steal (broken, incorrect implementation)
* Local functions in beastmen treasure
* Local functions in besieged, added assault level to globals in CI
* Added additional weaponskill.lua items to CI script
