### PR TITLE
Luacheck: Globals Blue Magic through Crafting

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -64,7 +64,7 @@ local function getPrice(zoneId, info)
     return price
 end
 
-function updatePrice(zoneId, info, price)
+local function updatePrice(zoneId, info, price)
     SetServerVariable("[CHOCOBO][" .. zoneId .. "]price", price + info.addedPrice)
     SetServerVariable("[CHOCOBO][" .. zoneId .. "]time", os.time())
 end

--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -810,7 +810,7 @@ local function updatePlayerDigCount(player, increment)
     player:setLocalVar('[DIG]LastDigTime', os.time())
 end
 
-
+--[[ Not Implemented
 local function updateZoneDigCount(zoneId, increment)
     local serverVar = '[DIG]ZONE' .. zoneId .. '_ITEMS'
 
@@ -821,6 +821,7 @@ local function updateZoneDigCount(zoneId, increment)
         SetServerVariable(serverVar, GetServerVariable(serverVar) + increment)
     end
 end
+]]--
 
 local function canDig(player)
     local digCount = player:getCharVar('[DIG]DigCount')

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -28,7 +28,7 @@ local CONQUEST_UPDATE      = 2
 -- (LOCAL) expeditionary forces
 -- TODO: implement this menu
 -----------------------------------
-
+--[[
 local exForceMenuData =
 {
     0x20006, ZULK_EF, 103, 0x000040, 20, xi.ki.ZULKHEIM_EF_INSIGNIA,
@@ -45,7 +45,7 @@ local exForceMenuData =
     0x20013, ELLO_EF, 123, 0x080000, 35, xi.ki.ELSHIMO_LOWLANDS_EF_INSIGNIA,
     0x20014, ELUP_EF, 124, 0x100000, 45, xi.ki.ELSHIMO_UPLANDS_EF_INSIGNIA
 }
-
+]]--
 local function getExForceAvailable(player, guardNation)
     return 0
 end
@@ -1047,11 +1047,13 @@ xi.conquest.overseerOnEventUpdate = function(player, csid, option, guardNation)
         local u2 = 0 -- default: player has enough CP for item
         local u3 = stock.item -- default: the item ID we're purchasing
 
+        --[[
         if false then -- TODO: if player is a job that cannot equip selected item, set u1 to 0 here
             u1 = 0
         elseif stock.lvl > player:getMainLvl() then
             u1 = 1
         end
+        ]]--
 
         if stock.cp > player:getCP() then
             u2 = 1
@@ -1214,11 +1216,11 @@ xi.conquest.vendorOnEventFinish = function(player, option, vendorRegion)
         xi.shop.outpost(player)
     elseif option == 2 then
         if player:delGil(fee) then
-            player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 1, 0, region)
+            player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 1, 0, vendorRegion)
         end
     elseif option == 6 then
         player:delCP(fee)
-        player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 1, 0, region)
+        player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 1, 0, vendorRegion)
     end
 end
 

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -35,7 +35,7 @@ local TI_Goldsmithing = {12496, 12497, 12495, 13082, 13446, 13084, 12545, 13125,
 local TI_Leathercraft = {13594, 16386, 13588, 13195, 12571, 12572, 12980, 12702, 12447, 10577}
 local TI_Smithing =     {16530, 12299, 16512, 16650, 16651, 16559, 12427, 16577, 12428, 19788}
 local TI_Woodworking =  {   22,    23, 17354, 17348, 17053, 17156, 17054,    56, 17101, 18884}
-local TI_Synergy =      {}
+-- local TI_Synergy =      {}
 
 local HQCrystals = {
     [1] = {
@@ -82,7 +82,7 @@ function isGuildMember(player, guild)
     local bit = {}
 
     for i = 12, 1, -1 do
-        twop = 2^i
+        local twop = 2^i
 
         if (guildOK >= twop) then
             bit[i]=1 guildOK = guildOK - twop
@@ -133,8 +133,7 @@ end
 -- canGetNewRank Action
 -----------------------------------
 
-function canGetNewRank(player, skillLvL, craftID)
-
+local function canGetNewRank(player, skillLvL, craftID)
     local Rank = player:getSkillRank(craftID) + 1
     local canGet = 0
 
@@ -152,7 +151,6 @@ function canGetNewRank(player, skillLvL, craftID)
     end
 
     return canGet
-
 end
 
 
@@ -166,7 +164,7 @@ function tradeTestItem(player, npc, trade, craftID)
     local skillLvL = player:getSkillLevel(craftID)
     local myTI = getTestItem(player, npc, craftID)
     local newRank = 0
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    -- local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
 
     if (canGetNewRank(player, skillLvL, craftID) == 1 and
         trade:hasItemQty(myTI, 1) and
@@ -292,7 +290,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
 end
 
 function unionRepresentativeTrade(player, npc, trade, csid, guildID)
-    local gpItem, remainingPoints = player:getCurrentGPItem(guildID)
+    local _, remainingPoints = player:getCurrentGPItem(guildID)
     local text = zones[player:getZoneID()].text
 
     if (player:getCharVar('[GUILD]currentGuild') - 1 == guildID) then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Converted local bluemagic.lua functions to local
* Fix castkets.lua locals, unused
* chocobo.lua local function
* chocobo_digging.lua: commented out unused function
* conquest.lua: commented out unused function, dead code, and fixed variable reference
* crafting.lua: Fixed locals, remove unused variables
