### PR TITLE
Luacheck: Effects and Globals dynamis, equipment, harvest festival, and helm

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -413,11 +413,11 @@ dynamis.zoneOnZoneIn = function(player, prevZone)
 
     if player:getCharVar("Dynamis_Entry") == 1 or player:getGMLevel() > 0 then
         if player:getCharVar("Dynamis_subjob") == 1 then
-            player:timer(5000, function(player) player:messageBasic(xi.msg.basic.UNABLE_TO_ACCESS_SJ) end)
+            player:timer(5000, function(playerArg) playerArg:messageBasic(xi.msg.basic.UNABLE_TO_ACCESS_SJ) end)
             player:addStatusEffect(xi.effect.SJ_RESTRICTION, 0, 0, 0, 7200)
         end
         player:addStatusEffectEx(xi.effect.DYNAMIS, 0, 0, 3, 3600)
-        player:timer(5500, function(player) player:messageSpecial(ID.text.DYNAMIS_TIME_BEGIN, 60, xi.ki.PRISMATIC_HOURGLASS) end)
+        player:timer(5500, function(playerArg) playerArg:messageSpecial(ID.text.DYNAMIS_TIME_BEGIN, 60, xi.ki.PRISMATIC_HOURGLASS) end)
         player:setCharVar("Dynamis_Entry", 0)
         player:setCharVar("Dynamis_subjob", 0)
     end
@@ -541,7 +541,6 @@ dynamis.refillStatueOnSpawn = function(mob)
 
     if RF then
         local found = false
-        local eye = nil
 
         -- set this statue's eye color
         for _, g in pairs(RF) do
@@ -597,16 +596,16 @@ dynamis.refillStatueOnDeath = function(mob, player, isKiller)
                 if eye == dynamis.eye.BLUE or eye == dynamis.eye.GREEN then
                     local zone = mob:getZone()
                     local players = zone:getPlayers()
-                    for name, player in pairs(players) do
-                        if mob:checkDistance(player) < 30 then
+                    for name, playerObj in pairs(players) do
+                        if mob:checkDistance(playerObj) < 30 then
                             if eye == dynamis.eye.BLUE then
-                                local amt = player:getMaxMP() - player:getMP()
-                                player:restoreMP(amt)
-                                player:messageBasic(xi.msg.basic.RECOVERS_MP, 0, amt)
+                                local amt = playerObj:getMaxMP() - playerObj:getMP()
+                                playerObj:restoreMP(amt)
+                                playerObj:messageBasic(xi.msg.basic.RECOVERS_MP, 0, amt)
                             else
-                                local amt = player:getMaxHP() - player:getHP()
-                                player:restoreHP(amt)
-                                player:messageBasic(xi.msg.basic.RECOVERS_HP, 0, amt)
+                                local amt = playerObj:getMaxHP() - playerObj:getHP()
+                                playerObj:restoreHP(amt)
+                                playerObj:messageBasic(xi.msg.basic.RECOVERS_HP, 0, amt)
                             end
                         end
                     end

--- a/scripts/globals/effects/auspice.lua
+++ b/scripts/globals/effects/auspice.lua
@@ -36,7 +36,7 @@ effect_object.onEffectLose = function(target, effect)
         local accuracyBonus = target:getStatusEffect(xi.effect.AFFLATUS_MISERY):getSubPower()
         --printf("AUSPICE: Removing Accuracy Bonus +%d!", accuracyBonus)
         target:delMod(xi.mod.ACC, accuracyBonus)
-        local accuracyBonus = target:getStatusEffect(xi.effect.AFFLATUS_MISERY):setSubPower(0)
+        target:getStatusEffect(xi.effect.AFFLATUS_MISERY):setSubPower(0)
 
         target:setMod(xi.mod.ENSPELL_DMG, 0)
         target:setMod(xi.mod.ENSPELL, 0)

--- a/scripts/globals/effects/battlefield.lua
+++ b/scripts/globals/effects/battlefield.lua
@@ -27,10 +27,4 @@ effect_object.onEffectLose = function(target, effect)
     target:setLocalVar("[battlefield]area", 0)
 end
 
-function onEventUpdate(player, csid, option)
-end
-
-function onEventFinish(player, csid, option)
-end
-
 return effect_object

--- a/scripts/globals/effects/chr_down.lua
+++ b/scripts/globals/effects/chr_down.lua
@@ -22,8 +22,8 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    downCHR_effect_size = effect:getPower()
-    if (downCHR_effect_size > 0) then
+    local downCHR_effect_size = effect:getPower()
+    if downCHR_effect_size > 0 then
         target:delMod(xi.mod.CHR, -downCHR_effect_size)
     end
 end

--- a/scripts/globals/effects/dynamis.lua
+++ b/scripts/globals/effects/dynamis.lua
@@ -63,10 +63,4 @@ effect_object.onEffectLose = function(target, effect)
     end
 end
 
-function onEventUpdate(target, csid, option)
-end
-
-function onEventFinish(target, csid, option)
-end
-
 return effect_object

--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -25,17 +25,17 @@ effect_object.onEffectGain = function(target, effect)
         local minWaitTime = math.min(3 * secondsPerTick, maxWaitTime)
         local waitTimeInSeconds = math.random(minWaitTime, maxWaitTime)
         target:setLocalVar("GEO_DWL_Resting", os.time() + waitTimeInSeconds)
-        target:timer(waitTimeInSeconds * 1000, function(target)
-            local finishTime = target:getLocalVar("GEO_DWL_Resting")
+        target:timer(waitTimeInSeconds * 1000, function(targetArg)
+            local finishTime = targetArg:getLocalVar("GEO_DWL_Resting")
             if finishTime > 0 and os.time() >= finishTime then
-                local ID = zones[target:getZoneID()]
-                target:messageSpecial(ID.text.MYSTICAL_WARMTH)  -- You feel a mystical warmth welling up inside you!
-                target:setLocalVar("GEO_DWL_Resting", 0)
-                target:setCharVar("GEO_DWL_Luopan", 1)
+                local ID = zones[targetArg:getZoneID()]
+                targetArg:messageSpecial(ID.text.MYSTICAL_WARMTH)  -- You feel a mystical warmth welling up inside you!
+                targetArg:setLocalVar("GEO_DWL_Resting", 0)
+                targetArg:setCharVar("GEO_DWL_Luopan", 1)
             end
         end)
     end
-    
+
     xi.voidwalker.onHealing(target)
 end
 

--- a/scripts/globals/effects/mark_of_seed.lua
+++ b/scripts/globals/effects/mark_of_seed.lua
@@ -28,7 +28,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    if (target:hasKeyItem(xi.ki.MARK_OF_SEED) == false and player:hasKeyItem(xi.ki.AZURE_KEY) == false) then
+    if (target:hasKeyItem(xi.ki.MARK_OF_SEED) == false and target:hasKeyItem(xi.ki.AZURE_KEY) == false) then
         target:messageSpecial(ID.text.MARK_OF_SEED_HAS_VANISHED)
     end
     target:setCharVar("SEED_AFTERGLOW_TIMER", 0)

--- a/scripts/globals/effects/pianissimo.lua
+++ b/scripts/globals/effects/pianissimo.lua
@@ -7,7 +7,7 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    local jpValue = caster:getJobPointLevel(xi.jp.PIANISSIMO_EFFECT)
+    local jpValue = target:getJobPointLevel(xi.jp.PIANISSIMO_EFFECT)
 
     target:addMod(xi.mod.SONG_SPELLCASTING_TIME, jpValue * 2)
 end
@@ -16,7 +16,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    local jpValue = caster:getJobPointLevel(xi.jp.PIANISSIMO_EFFECT)
+    local jpValue = target:getJobPointLevel(xi.jp.PIANISSIMO_EFFECT)
 
     target:delMod(xi.mod.SONG_SPELLCASTING_TIME, jpValue * 2)
 end

--- a/scripts/globals/effects/sigil.lua
+++ b/scripts/globals/effects/sigil.lua
@@ -36,7 +36,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     local power = effect:getPower() -- Tracks which bonus effects are in use.
-    local subPower = effect:getSubPower() -- subPower sets % required to trigger regen/refresh.
+    -- local subPower = effect:getSubPower() -- subPower sets % required to trigger regen/refresh.
 
     if (power == 1 or power == 3 or power == 5 or power == 7 or power == 9 or power == 11 or power == 13 or power == 15) then
         local percentage = 70 -- TODO: This should be based off of controlled areas in Campaign

--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -124,7 +124,7 @@ xi.equipment.relicIDs =
 -----------------------------------
 
 xi.equipment.isArtifactArmor = function(itemid)
-    retval = false
+    local retval = false
     if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true -- normal head sets
     elseif ((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true -- normal body sets
     elseif (itemid >= 13961 and itemid <= 13975) then retval = true -- normal hand sets

--- a/scripts/globals/events/harvest_festivals.lua
+++ b/scripts/globals/events/harvest_festivals.lua
@@ -25,7 +25,7 @@ function isHalloweenEnabled()
 end
 
 
-function halloweenItemsCheck(player)
+local function halloweenItemsCheck(player)
     local headSlot = player:getEquipID(xi.slot.HEAD)
     local mainHand = player:getEquipID(xi.slot.MAIN)
     local reward = 0
@@ -36,7 +36,7 @@ function halloweenItemsCheck(player)
     local trickStaff = 17565
     local trickStaff2 = 17587
 
-    reward_list = {pumpkinHead, pumpkinHead2, trickStaff, trickStaff2}
+    local reward_list = {pumpkinHead, pumpkinHead2, trickStaff, trickStaff2}
 
     -- Checks for HQ Upgrade
     for ri = 1, #reward_list do
@@ -153,7 +153,7 @@ function onHalloweenTrade(player, trade, npc)
                     player:addItem(itemReward)
                     player:messageSpecial(ID.text.ITEM_OBTAINED, itemReward)
 
-                elseif target:canUseMisc(xi.zoneMisc.COSTUME) and not AlreadyTradedChk then
+                elseif player:canUseMisc(xi.zoneMisc.COSTUME) and not AlreadyTradedChk then
                 -- Other neat looking halloween type costumes
                 -- two dragon skins: @420/421
                 -- @422 dancing weapon

--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1330,7 +1330,7 @@ local function doesToolBreak(player, info)
     return false
 end
 
-function pickItem(player, info)
+local function pickItem(player, info)
     local zoneId = player:getZoneID()
 
     -- found nothing

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -226,6 +226,9 @@ global_objects=(
     applyHalloweenNpcCostumes
     isHalloweenEnabled
     onHalloweenTrade
+    HALLOWEEN_2008
+    HALLOWEEN_2009
+    HALLOWEEN_2010
 
     salvageUtil
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Globals
* dynamis.lua: Fix shadowing, unused variable
* equipment.lua: Global->Local Var
* harvest_festival.lua: Add globals to CI script, fix object reference, local vars
* helm.lua: Global->Local function

Effects:
* auspice.lua: Fix unneeded var assignment
* battlefield.lua: Remove unused global functions
* chr_down.lua: Global->Local Var
* dynamis.lua: Remove unused global functions
* healing.lua: Fix shadowing upvalue, whitespace
* mark_of_seed.lua: Fix object reference
* pianissimo.lua: Fix object reference
* sigil.lua: Comment unused variable
