### PR TITLE
Luacheck: Fix homepoint, item_utils, and items

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -225,8 +225,8 @@ xi.homepoint.onEventUpdate = function(player, csid, option)
             elseif choice == selection.REM_FAVORITE then
                 for x = 1, 9 do
                     if favs[x] == index then
-                        for x = x, 8 do
-                            favs[x] = favs[x+1]
+                        for y = x, 8 do
+                            favs[y] = favs[y+1]
                         end
                         favs[9] = -1
                         break
@@ -258,7 +258,7 @@ end
 xi.homepoint.onEventFinish = function(player, csid, option, event)
 
     if csid == event then
-        choice = bit.band(option, 0xFF)
+        local choice = bit.band(option, 0xFF)
         if choice == selection.SET_HOMEPOINT then
             player:setHomePoint()
             if zones[player:getZoneID()].text.HOMEPOINT_SET then

--- a/scripts/globals/item_utils.lua
+++ b/scripts/globals/item_utils.lua
@@ -7,18 +7,16 @@ function item_utils.skillBookCheck(target, skillID)
     local skill = skillID
     local mainCap = target:getMaxSkillLevel(target:getMainLvl(), target:getMainJob(), skill) or 0
     local subCap = target:getMaxSkillLevel(target:getSubLvl(), target:getSubJob(), skill) or 0
-    local skillLevel = target:getCharSkillLevel(skill)/10
     local mainDif = (mainCap*10)/10 - (target:getCharSkillLevel(skill)*10)/100
     local subDif = (subCap*10)/10 - (target:getCharSkillLevel(skill)*10)/100
     local noSkill = 0
-    local canUse = 0
 
     if mainCap == 0 then
         noSkill = noSkill + 1
     end
 
     if subCap == 0 then
-        noSkill = noSkill + 1  
+        noSkill = noSkill + 1
     end
 
     if noSkill >= 2 then

--- a/scripts/globals/items/aspir_knife.lua
+++ b/scripts/globals/items/aspir_knife.lua
@@ -16,9 +16,9 @@ item_object.onAdditionalEffect = function(player, target, damage)
         return 0, 0, 0
     else
         local drain = math.random(1, 3)
-        local params = {}
-        params.bonusmab = 0
-        params.includemab = false
+        -- local params = {}
+        -- params.bonusmab = 0
+        -- params.includemab = false
         -- drain = addBonusesAbility(player, xi.magic.ele.DARK, target, drain, params)
         drain = drain * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         drain = adjustForTarget(target, drain, xi.magic.ele.DARK)

--- a/scripts/globals/items/beaming_score.lua
+++ b/scripts/globals/items/beaming_score.lua
@@ -3,7 +3,7 @@
 -- Item: Beaming Score
 -- A musical score composed by Lewenhart.
 -- Its notes symbolize the gently glowing beams of light that filter through the leaves of a deciduous tree in the late afternoon.
--- Adventurers note that reading it increases one's wind instrument skill. 
+-- Adventurers note that reading it increases one's wind instrument skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/bounty_list.lua
+++ b/scripts/globals/items/bounty_list.lua
@@ -3,7 +3,7 @@
 -- Item: Bounty List
 -- A simple list of known criminals who are better off dead.
 -- Every single name is crossed out in Azima's handwriting.
--- Adventurers note that reading it increases one's elemental magic skill. 
+-- Adventurers note that reading it increases one's elemental magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/bunch_of_gysahl_greens.lua
+++ b/scripts/globals/items/bunch_of_gysahl_greens.lua
@@ -22,14 +22,13 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    chocoboShirt = target:getEquipID(xi.slot.BODY) == 10293
+    local chocoboShirt = target:getEquipID(xi.slot.BODY) == 10293
     target:addStatusEffect(xi.effect.FOOD, chocoboShirt, 0, 300, 4545)
 end
 
 item_object.onEffectGain = function(target, effect)
     local power = effect:getPower()
     if (power == 1) then
-        chocoboShirt = 1
         target:addMod(xi.mod.AGI, 13)
         target:addMod(xi.mod.VIT, -5)
     else

--- a/scripts/globals/items/cavernous_score.lua
+++ b/scripts/globals/items/cavernous_score.lua
@@ -3,7 +3,7 @@
 -- Item: Cavernous Score
 -- A musical score composed by Lewenhart.
 -- Its notes symbolize the damp and musty air that stagnates within an underground cave.
--- Adventurers note that reading it increases one's string instrument skill.  
+-- Adventurers note that reading it increases one's string instrument skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/chunk_of_smelling_salts.lua
+++ b/scripts/globals/items/chunk_of_smelling_salts.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg")
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    pet = target:getPet()
+    local pet = target:getPet()
     if (pet == nil) then
         return xi.msg.basic.REQUIRES_A_PET
     elseif (pet:hasStatusEffect(xi.effect.MEDICINE)) then
@@ -21,7 +21,9 @@ end
 
 item_object.onItemUse = function(target)
     if (target:addStatusEffect(xi.effect.MEDICINE, 0, 0, 180, 5320)) then
-        target:messageBasic(GAINS_EFFECT_OF_STATUS, xi.effect.MEDICINE)
+        local pet = target:getPet()
+        -- TODO: Verify targeting and messages are correct
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.MEDICINE)
         pet:delStatusEffect(xi.effect.SLEEP_I)
         pet:delStatusEffect(xi.effect.SLEEP_II)
         pet:delStatusEffect(xi.effect.LULLABY)

--- a/scripts/globals/items/copy_of_aid_for_all.lua
+++ b/scripts/globals/items/copy_of_aid_for_all.lua
@@ -3,7 +3,7 @@
 -- Item: Aid for All
 -- A guide to the finer points of heightening the potential of one's compatriots, written by Rainemard.
 -- It also includes some tips on how to swing special swords.
--- Adventurers note that reading it increases one's enhancing magic skill. 
+-- Adventurers note that reading it increases one's enhancing magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_astral_homeland.lua
+++ b/scripts/globals/items/copy_of_astral_homeland.lua
@@ -3,7 +3,7 @@
 -- Item: Astral Homeland
 -- A specious work written by an unknown individual that both reads and feels like an illusion from the ancient past.
 -- It discusses the world avatars inhabit, but seems too absurd to be true.
--- Adventurers note that reading it increases one's summoning magic skill. 
+-- Adventurers note that reading it increases one's summoning magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_barrels_of_fun.lua
+++ b/scripts/globals/items/copy_of_barrels_of_fun.lua
@@ -1,9 +1,9 @@
 -----------------------------------------
 -- ID: 6160
 -- Item: Barrels of Fun
--- An educational text authored by Elivira Gogol. 
--- It discusses how to dismantle, clean, and reconstruct firearms in careful detail. 
--- Adventurers note that reading it increases one's marksmanship skill. 
+-- An educational text authored by Elivira Gogol.
+-- It discusses how to dismantle, clean, and reconstruct firearms in careful detail.
+-- Adventurers note that reading it increases one's marksmanship skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_breezy_libretto.lua
+++ b/scripts/globals/items/copy_of_breezy_libretto.lua
@@ -3,7 +3,7 @@
 -- Item: Breezy Libretto
 -- A musical score composed by Lewenhart.
 -- Its notes symbolize a fragrant, early morning summer breeze.
--- Adventurers note that reading it increases one's singing skill. 
+-- Adventurers note that reading it increases one's singing skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_clash_of_titans.lua
+++ b/scripts/globals/items/copy_of_clash_of_titans.lua
@@ -3,7 +3,7 @@
 -- Item: Clash of Titans
 -- An article detailing the duel between Yrvaulair S Cousseraux
 -- and Alphonimile M Aurchiat that became all the rage in San d'Oria after appearing in a popular newspaper.
--- Adventurers note that reading it increases one's polearm skill.  
+-- Adventurers note that reading it increases one's polearm skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_dark_deeds.lua
+++ b/scripts/globals/items/copy_of_dark_deeds.lua
@@ -3,7 +3,7 @@
 -- Item: Dark Deeds
 -- A guide to the finer points of insidious dark magic, as compiled by Azima.
 -- Proceeds from this tome have gone to fund her various purchases dealing with alchemical research.
--- Adventurers note that reading it increases one's dark magic skill. 
+-- Adventurers note that reading it increases one's dark magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_death_for_dimwits.lua
+++ b/scripts/globals/items/copy_of_death_for_dimwits.lua
@@ -2,7 +2,7 @@
 -- ID: 6152
 -- Item: Death for Dimwits
 -- A guide to the finer points of hacking everything in one's way to pieces with a two-handed axe,
--- written by an anonymous individual. 
+-- written by an anonymous individual.
 -- Adventurers note that reading it increases one's great axe skill.
 -----------------------------------------
 require("scripts/globals/item_utils")

--- a/scripts/globals/items/copy_of_ferreouss_diary.lua
+++ b/scripts/globals/items/copy_of_ferreouss_diary.lua
@@ -2,7 +2,7 @@
 -- ID: 6157
 -- Item: Ferreous's Diary
 -- A diary written by Ferreous Coffin that describes his encounters with Orcs in the north.
--- So many were there that his war hammer became coated with a thick layer of blood after all was said and done. 
+-- So many were there that his war hammer became coated with a thick layer of blood after all was said and done.
 -- Adventurers note that reading it increases one's club skill.
 -----------------------------------------
 require("scripts/globals/item_utils")

--- a/scripts/globals/items/copy_of_hrohjs_record.lua
+++ b/scripts/globals/items/copy_of_hrohjs_record.lua
@@ -3,7 +3,7 @@
 -- Item: Hrohj's Record
 -- A record of what happened on the fateful day the lifestream overflowed,
 -- as kept by Hrohj Wagrehsa.
--- Adventurers note that reading it increases one's geomancy skill. 
+-- Adventurers note that reading it increases one's geomancy skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_kayeel-payeels_memoirs.lua
+++ b/scripts/globals/items/copy_of_kayeel-payeels_memoirs.lua
@@ -1,8 +1,8 @@
 -----------------------------------------
 -- ID: 6158
 -- Item: K-P's Memoirs
--- Memoirs penned by Kayeel-Payeel. 
--- They describe in particular detail the time he received Claustrum from the Warlock Warlord Robel-Akbel. 
+-- Memoirs penned by Kayeel-Payeel.
+-- They describe in particular detail the time he received Claustrum from the Warlock Warlord Robel-Akbel.
 -- Adventurers note that reading them increases one's staff skill.
 -----------------------------------------
 require("scripts/globals/item_utils")

--- a/scripts/globals/items/copy_of_life-form_study.lua
+++ b/scripts/globals/items/copy_of_life-form_study.lua
@@ -3,7 +3,7 @@
 -- Item: Life-form Study
 -- A report written and filed by an anonymous individual.
 -- It covers the behavioral patterns and diets of almost every known family of beasts in existence.
--- Adventurers note that reading it increases one's blue magic skill. 
+-- Adventurers note that reading it increases one's blue magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_ludwigs_report.lua
+++ b/scripts/globals/items/copy_of_ludwigs_report.lua
@@ -3,7 +3,7 @@
 -- Item: Ludwig's Report
 -- A report made by Ludwig Eichberg regarding the Battle of Grauberg.
 -- It details the constant changes in the position of the front line and the withdrawal of Republic troops.
--- Adventurers note that reading it increases one's scythe skill. 
+-- Adventurers note that reading it increases one's scythe skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_mikhes_memo.lua
+++ b/scripts/globals/items/copy_of_mikhes_memo.lua
@@ -1,9 +1,9 @@
 -----------------------------------------
 -- ID: 6147
 -- Item: Mikhe's Memo
--- A memo scrawled by Mikhe Aryohcha that matter-of-factly states, 
+-- A memo scrawled by Mikhe Aryohcha that matter-of-factly states,
 -- "Just throw your fist at your opponent and it'll all work out."
--- Adventurers say that their hand-to-hand skill increases after reading this note. 
+-- Adventurers say that their hand-to-hand skill increases after reading this note.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_mikhes_note.lua
+++ b/scripts/globals/items/copy_of_mikhes_note.lua
@@ -3,7 +3,7 @@
 -- Item: Mikhe's Note
 -- A memo scrawled by Mikhe Aryohcha that matter-of-factly states,
 -- "Just throw your guard up and it'll all work out."
--- Adventurers note that reading it increases one's guarding skill. 
+-- Adventurers note that reading it increases one's guarding skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_perihs_primer.lua
+++ b/scripts/globals/items/copy_of_perihs_primer.lua
@@ -1,9 +1,9 @@
 -----------------------------------------
 -- ID: 6159
 -- Item: Perih's Primer
--- A guidebook Perih Vashai jotted down for the edification of new recruits. 
--- It discusses everything from the various ways of holding a bow to methods of judging distance. 
--- Adventurers note that reading it increases one's archery skill. 
+-- A guidebook Perih Vashai jotted down for the edification of new recruits.
+-- It discusses everything from the various ways of holding a bow to methods of judging distance.
+-- Adventurers note that reading it increases one's archery skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_striking_bulls_diary.lua
+++ b/scripts/globals/items/copy_of_striking_bulls_diary.lua
@@ -3,7 +3,7 @@
 -- Item: Bull's Diary
 -- An account penned by Striking Bull during the Second Battle of Konschtat.
 -- It details the Republic's victory over King Raigegue the Lupine's San d'Orian army.
--- Adventurers note that reading it increases one's axe skill. 
+-- Adventurers note that reading it increases one's axe skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_swing_and_stab.lua
+++ b/scripts/globals/items/copy_of_swing_and_stab.lua
@@ -3,8 +3,8 @@
 -- Item: Swing and Stab
 -- Ulla wrote this guide on sword wielding
 -- from how to grip the hilt to tips on footwork
--- so others could follow in her footsteps. 
--- Adventurers note that reading it increases one's sword skill. 
+-- so others could follow in her footsteps.
+-- Adventurers note that reading it increases one's sword skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/copy_of_yomis_diagram.lua
+++ b/scripts/globals/items/copy_of_yomis_diagram.lua
@@ -2,7 +2,7 @@
 -- ID: 6175
 -- Item: Yomi's Diagram
 -- A meticulously drawn diagram Yomi made for Kagetora explaining how to construct certain ninja tools.
--- Adventurers note that reading it increases one's ninjutsu skill. 
+-- Adventurers note that reading it increases one's ninjutsu skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/cup_of_caravan_tea.lua
+++ b/scripts/globals/items/cup_of_caravan_tea.lua
@@ -14,7 +14,7 @@ require("scripts/globals/msg")
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    result = 0
+    local result = 0
     if target:hasStatusEffect(xi.effect.FOOD) or target:hasStatusEffect(xi.effect.FIELD_SUPPORT_FOOD) then
         result = xi.msg.basic.IS_FULL
     end

--- a/scripts/globals/items/custodes.lua
+++ b/scripts/globals/items/custodes.lua
@@ -16,7 +16,7 @@ item_object.onAdditionalEffect = function(player, target, damage)
         chance = chance+6
     end
 
-    if (player:getWeather() == WEATHER_ICE) then
+    if (player:getWeather() == xi.weather.SNOW) then
         chance = chance+4
     elseif (player:getWeather() == xi.weather.BLIZZARDS) then
         chance = chance+6

--- a/scripts/globals/items/dagger_enchiridion.lua
+++ b/scripts/globals/items/dagger_enchiridion.lua
@@ -2,7 +2,7 @@
 -- ID: 6148
 -- Item: Dagger enchiridion
 -- A guide to the finer points of wielding a dagger,
--- written by an anonymous individual. 
+-- written by an anonymous individual.
 -- Adventurers note that reading it increases one's dagger skill.
 -----------------------------------------
 require("scripts/globals/item_utils")

--- a/scripts/globals/items/investigative_report.lua
+++ b/scripts/globals/items/investigative_report.lua
@@ -3,7 +3,7 @@
 -- Item: Inv. Report
 -- A collection of observations made by Rainemard on a particular exploration.
 -- It goes into such detail on so much minutiae that many admit to never finishing it.
--- Adventurers note that reading it increases one's enfeebling magic skill. 
+-- Adventurers note that reading it increases one's enfeebling magic skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/jar_of_remedy_ointment.lua
+++ b/scripts/globals/items/jar_of_remedy_ointment.lua
@@ -16,7 +16,7 @@ item_object.onItemUse = function(target)
     if (target:hasStatusEffect(xi.effect.SILENCE) or target:hasStatusEffect(xi.effect.BLINDNESS) or target:hasStatusEffect(xi.effect.POISON) or target:hasStatusEffect(xi.effect.PARALYSIS) or target:hasStatusEffect(xi.effect.PLAGUE)) then
         local effectRemoved = 0
         while effectRemoved == 0 do
-            num = math.random(1, 5)
+            local num = math.random(1, 5)
             if (num == 1 and target:hasStatusEffect(xi.effect.SILENCE)) then
                 effectRemoved = effectRemoved + 1
                 target:delStatusEffect(xi.effect.SILENCE)

--- a/scripts/globals/items/messhikimaru.lua
+++ b/scripts/globals/items/messhikimaru.lua
@@ -10,7 +10,7 @@ require("scripts/globals/status")
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    result = 0
+    return 0
 end
 
 item_object.onItemUse = function(target)

--- a/scripts/globals/items/noble_himantes.lua
+++ b/scripts/globals/items/noble_himantes.lua
@@ -7,8 +7,7 @@
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    result = 0
-    return result
+    return 0
 end
 
 item_object.onItemUse = function(target)

--- a/scripts/globals/items/pestle.lua
+++ b/scripts/globals/items/pestle.lua
@@ -16,9 +16,9 @@ item_object.onAdditionalEffect = function(player, target, damage)
         return 0, 0, 0
     else
         local drain = math.random(2, 8)
-        local params = {}
-        params.bonusmab = 0
-        params.includemab = false
+        -- local params = {}
+        -- params.bonusmab = 0
+        -- params.includemab = false
         -- drain = addBonusesAbility(player, xi.magic.ele.DARK, target, drain, params)
         drain = drain * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         drain = adjustForTarget(target, drain, xi.magic.ele.DARK)

--- a/scripts/globals/items/regiment_kheten.lua
+++ b/scripts/globals/items/regiment_kheten.lua
@@ -7,8 +7,7 @@
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    result = 0
-    return result
+    return 0
 end
 
 item_object.onItemUse = function(target)

--- a/scripts/globals/items/throwing_weapon_enchiridion.lua
+++ b/scripts/globals/items/throwing_weapon_enchiridion.lua
@@ -3,7 +3,7 @@
 -- Item: T.W. Enchiridion
 -- A guide to the finer points of hurling projectile objects at opponents,
 -- written by an anonymous individual.
--- Adventurers note that reading it increases one's throwing skill. 
+-- Adventurers note that reading it increases one's throwing skill.
 -----------------------------------------
 require("scripts/globals/item_utils")
 -----------------------------------------

--- a/scripts/globals/items/vampiric_claws.lua
+++ b/scripts/globals/items/vampiric_claws.lua
@@ -16,9 +16,9 @@ item_object.onAdditionalEffect = function(player, target, damage)
         return 0, 0, 0
     else
         local drain = math.random(3, 15)
-        local params = {}
-        params.bonusmab = 0
-        params.includemab = false
+        -- local params = {}
+        -- params.bonusmab = 0
+        -- params.includemab = false
         -- drain = addBonusesAbility(player, xi.magic.ele.DARK, target, drain, params)
         drain = drain * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         drain = adjustForTarget(target, drain, xi.magic.ele.DARK)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Globals
* homepoint.lua: Global->Local, fix shadowing loop var
* item_utils.lua: Remove unused variables, fix whitespace

Items
* Fix whitespace in comments for various items
* aspir_knife.lua: comment out dead code
* bunch_of_gysahl_greens.lua: Global->Local var, remove unused var
* chunk_of_smelling_salts.lua: Global->Local var, object ref, 
* cup_of_caravan_tea.lua: Global->Local var
* custodes.lua: Fix weather reference
* jar_of_remedy_ointment.lua: Global->Local var
* messhikimaru.lua: Fix onItemCheck return
* noble_himantes: Fix onItemCheck return
* pestle.lua: comment out dead code
* regiment_kheten.lua: Fix onItemCheck return
* vampiric_claws.lua: comment out dead code
