### PR TITLE
Add option check to The Dismayed Customer

### DIFF
--- a/scripts/quests/sandoria/The_Dismayed_Customer.lua
+++ b/scripts/quests/sandoria/The_Dismayed_Customer.lua
@@ -51,8 +51,10 @@ quest.sections =
             onEventFinish =
             {
                 [605] = function(player, csid, option, npc)
-                    quest:begin(player)
-                    quest:setVar(player, 'Stage', math.random(1, 3))
+                    if option == 0 then
+                        quest:begin(player)
+                        quest:setVar(player, 'Stage', math.random(1, 3))
+                    end
                 end,
             },
         },


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Only begin quest and progress if the player chooses to accept it (option 0)