### PR TITLE
Fix survival guide require with multiple return values

### DIFF
--- a/scripts/globals/survival_guide.lua
+++ b/scripts/globals/survival_guide.lua
@@ -2,7 +2,7 @@ require("scripts/globals/settings")
 require("scripts/globals/teleports")
 require("scripts/globals/utils")
 
-local survivalGuides, zoneIdToGuideIdMap = require("scripts/globals/survival_guide_map")
+local survival = require("scripts/globals/survival_guide_map")
 
 xi = xi or {}
 xi.survivalGuide = xi.survivalGuide or {}
@@ -99,8 +99,8 @@ end
 
 xi.survivalGuide.onTrigger = function(player)
     local currentZoneId = player:getZoneID()
-    local tableIndex = zoneIdToGuideIdMap[currentZoneId]
-    local guide = survivalGuides[tableIndex]
+    local tableIndex = survival.zoneIdToGuideIdMap[currentZoneId]
+    local guide = survival.survivalGuides[tableIndex]
 
     if guide then
         -- If this survival guide hasn't been registered yet (saved to database) do that now.
@@ -150,7 +150,7 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option)
         local selectedMenuId = bit.rshift(option, 16)
 
         if selectedMenuId <= 97 then
-            local guide = survivalGuides[selectedMenuId]
+            local guide = survival.survivalGuides[selectedMenuId]
             local currentZoneId = player:getZoneID()
 
             if guide and not (guide.zoneId == currentZoneId) then

--- a/scripts/globals/survival_guide_map.lua
+++ b/scripts/globals/survival_guide_map.lua
@@ -1,6 +1,8 @@
 require("scripts/globals/zone")
 
-local survivalGuides =
+local survival = {}
+
+survival.survivalGuides =
 {
     [6] =
     {
@@ -1082,7 +1084,7 @@ local survivalGuides =
     }
 }
 
-local zoneIdToGuideIdMap =
+survival.zoneIdToGuideIdMap =
 {
     [xi.zone.NORTHERN_SAN_DORIA] = 0,
     [xi.zone.BASTOK_MINES] = 1,
@@ -1184,4 +1186,4 @@ local zoneIdToGuideIdMap =
     [xi.zone.EASTERN_ADOULIN] = 97
 }
 
-return survivalGuides, zoneIdToGuideIdMap
+return survival


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #262 

Multiple Lua returns from a require needs a bit of finessing to happen.  Return and expect function from those two files.