### PR TITLE
Make Fisherman's Belt usable

### DIFF
--- a/scripts/globals/items/fishermans_belt.lua
+++ b/scripts/globals/items/fishermans_belt.lua
@@ -14,8 +14,8 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.FISHING_IMAGERY) == true) then
-        result = 242
+    if target:hasStatusEffect(xi.effect.FISHING_IMAGERY) == true then
+        result = 235
     end
     return result
 end

--- a/scripts/globals/items/fishermans_belt.lua
+++ b/scripts/globals/items/fishermans_belt.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- ID: 15452
+-- Item: Fisherman's belt
+-- Enchantment: Fishing image support
+-- 2 hours, All Races
+-----------------------------------
+-- Enchantment: Fishing image support
+-- Duration: 2 hours
+-- Fishing Skill +2
+-----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+local item_object = {}
+
+item_object.onItemCheck = function(target)
+    local result = 0
+    if (target:hasStatusEffect(xi.effect.FISHING_IMAGERY) == true) then
+        result = 242
+    end
+    return result
+end
+
+item_object.onItemUse = function(target)
+    target:addStatusEffect(xi.effect.FISHING_IMAGERY, 2, 0, 7200)
+end
+
+item_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.FISH, 1)
+end
+
+item_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.FISH, 1)
+end
+
+return item_object

--- a/scripts/globals/items/fishermans_belt.lua
+++ b/scripts/globals/items/fishermans_belt.lua
@@ -15,7 +15,7 @@ local item_object = {}
 item_object.onItemCheck = function(target)
     local result = 0
     if target:hasStatusEffect(xi.effect.FISHING_IMAGERY) == true then
-        result = 235
+        result = xi.effect.FISHING_IMAGERY
     end
     return result
 end


### PR DESCRIPTION
Item script for Fisherman's Belt, which is usable once in place. Adds Fishing Imagery support with +2 skill for 2 hours, per wiki entry below.

https://ffxiclopedia.fandom.com/wiki/Fisherman's_Belt

Similar craft support belt can be found here already implemented: https://github.com/LandSandBoat/server/blob/base/scripts/globals/items/alchemists_belt.lua

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
