### PR TITLE
[ci] Rollback to g++10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           topaz_game
           topaz_search
   
-  Linux_2004_GCC11_64bit:
+  Linux_2004_GCC10_64bit:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
@@ -51,8 +51,8 @@ jobs:
         sudo apt-get install -y software-properties-common cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev
     - name: Configure CMake
       run: |
-        export CC=/usr/bin/gcc-11
-        export CXX=/usr/bin/g++-11
+        export CC=/usr/bin/gcc-10
+        export CXX=/usr/bin/g++-10
         CFLAGS=-m64 CXXFLAGS=-m64 LDFLAGS=-m64 cmake .
     - name: Build
       run: |


### PR DESCRIPTION
GitHub, stop removing our compilers!
https://github.com/actions/virtual-environments/issues/3467

Breaking changes
GCC and Gfortran 11 will be removed from Ubuntu images on May, 31 in the scope of #3436

Target date
Image deployment will start on May, 31 and will take 3-4 days.

The motivation for the changes
GCC 11 contains an experimental toolchain that is not compatible with older GCC versions, so it breaks existing workflows. More details can be found in the discussion #3464

Possible impact
Projects that depends on GCC-11 features will be broken

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
