### PR TITLE
Reorder waking dreams so whisper/reward CS can run

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -69,6 +69,14 @@ entity.onTrigger = function(player, npc)
         player:startEvent(876)
 
     -- WAKING DREAMS
+    elseif player:hasKeyItem(xi.ki.WHISPER_OF_DREAMS) then
+        local availRewards = 0
+            + (player:hasItem(17599) and 1 or 0) -- Diabolos's Pole
+            + (player:hasItem(14814) and 2 or 0) -- Diabolos's Earring
+            + (player:hasItem(15557) and 4 or 0) -- Diabolos's Ring
+            + (player:hasItem(15516) and 8 or 0) -- Diabolos's Torque
+            + (player:hasSpell(304) and 32 or 16) -- Pact or gil
+        player:startEvent(920, 17599, 14814, 15557, 15516, 0, 0, 0, availRewards)
     elseif
         not player:hasKeyItem(xi.ki.VIAL_OF_DREAM_INCENSE) and
         (
@@ -81,14 +89,6 @@ entity.onTrigger = function(player, npc)
         )
     then
         player:startEvent(918)
-    elseif player:hasKeyItem(xi.ki.WHISPER_OF_DREAMS) then
-        local availRewards = 0
-            + (player:hasItem(17599) and 1 or 0) -- Diabolos's Pole
-            + (player:hasItem(14814) and 2 or 0) -- Diabolos's Earring
-            + (player:hasItem(15557) and 4 or 0) -- Diabolos's Ring
-            + (player:hasItem(15516) and 8 or 0) -- Diabolos's Torque
-            + (player:hasSpell(304) and 32 or 16) -- Pact or gil
-        player:startEvent(920, 17599, 14814, 15557, 15516, 0, 0, 0, availRewards)
 
     -- BLUE RIBBON BLUES
     elseif blueRibbonBlues == QUEST_COMPLETED and needZone then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
