### PR TITLE
Interaction - Quest: The Siren's Tear

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -144,7 +144,7 @@ xi.quest.id =
     -----------------------------------
     [xi.quest.area[xi.quest.log_id.BASTOK]] =
     {
-        THE_SIREN_S_TEAR                = 0,  -- ±
+        THE_SIRENS_TEAR                 = 0,  -- ±
         BEAUTY_AND_THE_GALKA            = 1,  -- ±
         WELCOME_TO_BASTOK               = 2,  -- +
         GUEST_OF_HAUTEUR                = 3,

--- a/scripts/quests/bastok/The_Sirens_Tear.lua
+++ b/scripts/quests/bastok/The_Sirens_Tear.lua
@@ -1,0 +1,135 @@
+-----------------------------------
+-- The Siren's Tear
+-----------------------------------
+-- Log ID: 1, Quest ID: 0
+-- Wahid       : !pos 26.305 -1 -66.403 234
+-- Otto        : !pos -145.929 -7.48 13.701 236
+-- Carmelo     : !pos -146.476 -7.48 -10.889 236
+-- Echo Hawk   : !pos -0.965 5.999 -15.567 234
+-- qm1 (moves) : !pos 309.6 2.6 324 106
+-----------------------------------
+require("scripts/globals/items")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
+require("scripts/globals/zone")
+require("scripts/globals/interaction/quest")
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIRENS_TEAR)
+
+quest.reward =
+{
+    fame = 120,
+    gil = 150,
+    title = xi.title.TEARJERKER,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Wahid']     = quest:progressEvent(81),
+            ['Echo_Hawk'] = quest:event(5),
+
+            onEventFinish =
+            {
+                [81] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Otto'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(5)
+                    end
+                end,
+            },
+
+            ['Carmelo'] = quest:progressEvent(6),
+
+            onEventFinish =
+            {
+                [6] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Carmelo'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        quest:getVar(player, 'Prog') < 2 and
+                        not player:findItem(xi.items.SIRENS_TEAR)
+                    then
+                        return quest:progressEvent(19)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [19] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status ~= QUEST_AVAILABLE
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Wahid'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, xi.items.SIRENS_TEAR) then
+                        return quest:progressEvent(82)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [82] = function(player, csid, option, npc)
+                    -- This is called even after the initial complete to handle quest var cleanup
+                    -- CLuaBaseEntity::completeQuest() will only actually complete the quest the
+                    -- first time the player finishes this.
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Bastok_Mines/DefaultActions.lua
+++ b/scripts/zones/Bastok_Mines/DefaultActions.lua
@@ -3,5 +3,7 @@ local ID = require("scripts/zones/Bastok_Mines/IDs")
 return {
     ['Black_Mud']     = { event = 100 },
     ['Deadly_Spider'] = { event = 17 },
+    ['Echo_Hawk']     = { event = 13 },
     ['Tall_Mountain'] = { event = 55 },
+    ['Wahid']         = { event = 28 },
 }

--- a/scripts/zones/Bastok_Mines/npcs/Echo_Hawk.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Echo_Hawk.lua
@@ -14,17 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-
     local WildcatBastok = player:getCharVar("WildcatBastok")
 
-    if (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatBastok, 17)) then
+    if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatBastok, 17) then
         player:startEvent(505)
-    elseif (SirensTear == QUEST_AVAILABLE) then
-        player:startEvent(5)
-    else
-        player:startEvent(13)
     end
 end
 
@@ -32,11 +25,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 505) then
+    if csid == 505 then
         player:setCharVar("WildcatBastok", utils.mask.setBit(player:getCharVar("WildcatBastok"), 17, true))
     end
-
 end
 
 return entity

--- a/scripts/zones/Bastok_Mines/npcs/Wahid.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Wahid.lua
@@ -4,51 +4,18 @@
 -- Start & Finishes Quest: The Siren's Tear
 -- !pos 26.305 -1 -66.403 234
 -----------------------------------
-require("scripts/globals/quests")
-require("scripts/globals/titles")
-require("scripts/globals/settings")
-local ID = require("scripts/zones/Bastok_Mines/IDs")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-
-    if (SirensTear ~= QUEST_AVAILABLE) then
-        if (trade:hasItemQty(576, 1) and trade:getItemCount() == 1) then
-            player:startEvent(82)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-
-    if (SirensTear == QUEST_AVAILABLE) then
-        player:startEvent(81)
-    else
-        player:startEvent(28)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    -- printf("CSID2: %u", csid)
-    -- printf("RESULT2: %u", option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 81) then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-    elseif (csid == 82) then
-        player:tradeComplete()
-        player:completeQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-        player:addFame(BASTOK, 120)
-        player:addGil(150*GIL_RATE)
-        player:messageSpecial(ID.text.GIL_OBTAINED, 150*GIL_RATE)
-        player:addTitle(xi.title.TEARJERKER)
-        player:setCharVar("SirensTear", 0)
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Bastok/DefaultActions.lua
+++ b/scripts/zones/Port_Bastok/DefaultActions.lua
@@ -1,6 +1,8 @@
 local ID = require("scripts/zones/Port_Bastok/IDs")
 
 return {
+    ['Carmelo'] = { event = 182 },
     ['Ehrhard'] = { event = 47 },
     ['Latifah'] = { event = 13 },
+    ['Otto']    = { event = 20 },
 }

--- a/scripts/zones/Port_Bastok/npcs/Carmelo.lua
+++ b/scripts/zones/Port_Bastok/npcs/Carmelo.lua
@@ -12,24 +12,18 @@ require("scripts/globals/quests")
 -----------------------------------
 local entity = {}
 
-
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-    local SirensTearProgress = player:getCharVar("SirensTear")
+    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIRENS_TEAR)
     local LoveAndIce = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LOVE_AND_ICE)
     local LoveAndIceProgress = player:getCharVar("LoveAndIceProgress")
     local ATestOfTrueLove = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.A_TEST_OF_TRUE_LOVE)
     local ATestOfTrueLoveProgress = player:getCharVar("ATestOfTrueLoveProgress")
     local LoversInTheDusk = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LOVERS_IN_THE_DUSK)
 
-    if (SirensTear == QUEST_ACCEPTED) then
-        player:startEvent(6)
-    elseif (SirensTear == QUEST_COMPLETED and player:hasItem(576) == false and SirensTearProgress < 2) then
-        player:startEvent(19)
-    elseif (LoveAndIce == QUEST_AVAILABLE and SirensTear == QUEST_COMPLETED and SirensTear == QUEST_COMPLETED) then
+    if (LoveAndIce == QUEST_AVAILABLE and SirensTear == QUEST_COMPLETED) then
         if (player:getFameLevel(BASTOK) >= 5 and player:seenKeyItem(xi.ki.CARRIER_PIGEON_LETTER) == true) then
             player:startEvent(185)
         else
@@ -53,8 +47,6 @@ entity.onTrigger = function(player, npc)
         player:startEvent(276)
     elseif (LoversInTheDusk == QUEST_COMPLETED) then
         player:startEvent(277)
-    else
-        player:startEvent(182)
     end
 end
 
@@ -62,12 +54,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 6) then
-        player:setCharVar("SirensTear", 1)
-    elseif (csid == 19) then
-        player:setCharVar("SirensTear", 2)
-    elseif (csid == 185) then
+    if (csid == 185) then
         player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LOVE_AND_ICE)
         player:addKeyItem(xi.ki.CARMELOS_SONG_SHEET)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CARMELOS_SONG_SHEET)

--- a/scripts/zones/Port_Bastok/npcs/Otto.lua
+++ b/scripts/zones/Port_Bastok/npcs/Otto.lua
@@ -3,9 +3,7 @@
 --  NPC: Otto
 -- Standard Info NPC
 -- Involved in Quest: The Siren's Tear
--- !pos -145.929 -7.48 -13.701 236
------------------------------------
-require("scripts/globals/quests")
+-- !pos -145.929 -7.48 13.701 236
 -----------------------------------
 local entity = {}
 
@@ -13,13 +11,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local SirensTear = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_SIREN_S_TEAR)
-
-    if (SirensTear == QUEST_ACCEPTED and player:getCharVar("SirensTear") == 0) then
-        player:startEvent(5)
-    else
-        player:startEvent(20)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Converts Bastok quest 'The Siren's Tear' to Interaction Framework.  Does not modify the qm that handles giving the item, as this is not specific to the quest itself.