### PR TITLE
Refactor getMissionMask

### DIFF
--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -6,6 +6,7 @@ utils = {}
 -- Max uint32 constant, replaces negative values in event parameters
 -- Note: If correcting a negative value, this is *already* -1, adjust accordingly!
 utils.MAX_UINT32 = 4294967295
+utils.MAX_INT32  = 2147483647
 
 -- Shuffles a table and returns a copy of it, not the original.
 function utils.shuffle(tab)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [In Progress] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Refactors getMissionMask to follow a similar pattern across nations.