### PR TITLE
[core] Add 5sdelay before zones have their tick timer removed

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -600,12 +600,9 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 {
     m_zoneEntities->DecreaseZoneCounter(PChar);
 
-    if (ZoneTimer && m_zoneEntities->CharListEmpty())
+    if (m_zoneEntities->CharListEmpty())
     {
-        ZoneTimer->m_type = CTaskMgr::TASK_REMOVE;
-        ZoneTimer         = nullptr;
-
-        m_zoneEntities->HealAllMobs();
+        m_timeZoneEmpty = server_clock::now();
     }
     else
     {
@@ -807,6 +804,14 @@ void CZone::ZoneServer(time_point tick, bool check_regions)
     if (m_BattlefieldHandler != nullptr)
     {
         m_BattlefieldHandler->HandleBattlefields(tick);
+    }
+
+    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5min < server_clock::now())
+    {
+        ZoneTimer->m_type = CTaskMgr::TASK_REMOVE;
+        ZoneTimer         = nullptr;
+
+        m_zoneEntities->HealAllMobs();
     }
 }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -806,7 +806,7 @@ void CZone::ZoneServer(time_point tick, bool check_regions)
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
 
-    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5min < server_clock::now())
+    if (ZoneTimer && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < server_clock::now())
     {
         ZoneTimer->m_type = CTaskMgr::TASK_REMOVE;
         ZoneTimer         = nullptr;

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -634,6 +634,8 @@ private:
 
     CTreasurePool* m_TreasurePool; // глобальный TreasuerPool
 
+    time_point m_timeZoneEmpty; // The time_point when the last player left the zone
+
 protected:
     CTaskMgr::CTask* ZoneTimer; // указатель на созданный таймер - ZoneServer. необходим для возможности его остановки
     void createZoneTimer();


### PR DESCRIPTION
Tested with print statements, the empty zone stops ticking after 5s.

Brought down from 5mins due to potential performance problems on low-powered servers.

(Entirely selfishly, this will help me with AMK and confrontation battles 👀. But we can absolutely afford this extra ticking after `sol_refactor`)

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
