### PR TITLE
Allow table with params for startEvent and updateEvent

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -831,20 +831,38 @@ void CLuaBaseEntity::startEvent(uint32 EventID, sol::variadic_args va)
         }
     }
 
-    uint32 param0 = va.get_type(0) == sol::type::number ? va.get<uint32>(0) : 0;
-    uint32 param1 = va.get_type(1) == sol::type::number ? va.get<uint32>(1) : 0;
-    uint32 param2 = va.get_type(2) == sol::type::number ? va.get<uint32>(2) : 0;
-    uint32 param3 = va.get_type(3) == sol::type::number ? va.get<uint32>(3) : 0;
-    uint32 param4 = va.get_type(4) == sol::type::number ? va.get<uint32>(4) : 0;
-    uint32 param5 = va.get_type(5) == sol::type::number ? va.get<uint32>(5) : 0;
-    uint32 param6 = va.get_type(6) == sol::type::number ? va.get<uint32>(6) : 0;
-    uint32 param7 = va.get_type(7) == sol::type::number ? va.get<uint32>(7) : 0;
+    std::vector<std::pair<uint8, uint32>> params;
 
-    int16 textTable = va.get_type(8) == sol::type::number ? va.get<int16>(8) : -1;
+    int16 textTable = -1;
+    if (va.get_type(0) == sol::type::table)
+    {
+        auto table = va.get<sol::table>(0);
+        for (int i = 0; i < 8; i++)
+        {
+            uint32 param = table.get_or<uint32>(i, 0);
+            if (param != 0)
+            {
+                params.emplace_back(i, param);
+            }
+        }
 
-    PChar->pushPacket(new CEventPacket(PChar, EventID, va.size(),
-                                       param0, param1, param2, param3, param4, param5, param6, param7,
-                                       textTable));
+        textTable = table.get_or<int16>("text_table", -1);
+    }
+    else
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            if (va.get_type(i) == sol::type::number)
+            {
+                params.emplace_back(i, va.get<uint32>(i));
+            }
+        }
+
+        textTable = va.get_type(8) == sol::type::number ? va.get<int16>(8) : -1;
+    }
+
+
+    PChar->pushPacket(new CEventPacket(PChar, EventID, params, textTable));
 
     // if you want to return a dummy result, then do it
     if (textTable != -1)
@@ -912,16 +930,32 @@ void CLuaBaseEntity::updateEvent(sol::variadic_args va)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    uint32 param0 = va.get_type(0) == sol::type::number ? va.get<uint32>(0) : 0;
-    uint32 param1 = va.get_type(1) == sol::type::number ? va.get<uint32>(1) : 0;
-    uint32 param2 = va.get_type(2) == sol::type::number ? va.get<uint32>(2) : 0;
-    uint32 param3 = va.get_type(3) == sol::type::number ? va.get<uint32>(3) : 0;
-    uint32 param4 = va.get_type(4) == sol::type::number ? va.get<uint32>(4) : 0;
-    uint32 param5 = va.get_type(5) == sol::type::number ? va.get<uint32>(5) : 0;
-    uint32 param6 = va.get_type(6) == sol::type::number ? va.get<uint32>(6) : 0;
-    uint32 param7 = va.get_type(7) == sol::type::number ? va.get<uint32>(7) : 0;
+    std::vector<std::pair<uint8, uint32>> params;
 
-    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEventUpdatePacket(param0, param1, param2, param3, param4, param5, param6, param7));
+    if (va.get_type(0) == sol::type::table)
+    {
+        auto table = va.get<sol::table>(0);
+        for (int i = 0; i < 8; i++)
+        {
+            uint32 param = table.get_or<uint32>(i, 0);
+            if (param != 0)
+            {
+                params.emplace_back(i, param);
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            if (va.get_type(i) == sol::type::number)
+            {
+                params.emplace_back(i, va.get<uint32>(i));
+            }
+        }
+    }
+
+    static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEventUpdatePacket(params));
 }
 
 /************************************************************************

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -26,8 +26,7 @@
 #include "../entities/charentity.h"
 #include "event.h"
 
-CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, uint8 numOfParams, uint32 param0, uint32 param1, uint32 param2, uint32 param3, uint32 param4,
-                           uint32 param5, uint32 param6, uint32 param7, int16 textTable)
+CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::pair<uint8, uint32>> params, int16 textTable)
 {
     this->type = 0x32;
     this->size = 0x0A;
@@ -46,19 +45,19 @@ CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, uint8 numOfParams
     }
     ref<uint32>(0x04) = npcID;
 
-    if (numOfParams > 0)
+    if (params.size() > 0)
     {
         this->type = 0x34;
         this->size = 0x1A;
 
-        ref<uint32>(0x08) = param0;
-        ref<uint32>(0x0C) = param1;
-        ref<uint32>(0x10) = param2;
-        ref<uint32>(0x14) = param3;
-        ref<uint32>(0x18) = param4;
-        ref<uint32>(0x1C) = param5;
-        ref<uint32>(0x20) = param6;
-        ref<uint32>(0x24) = param7;
+        for (auto paramPair : params)
+        {
+            // Only params 0 through 7 are valid
+            if (paramPair.first >= 0 && paramPair.first <= 7)
+            {
+                ref<uint32>(0x0008 + paramPair.first * 4) = paramPair.second;
+            }
+        }
 
         ref<uint16>(0x28) = PChar->m_TargID;
 

--- a/src/map/packets/event.h
+++ b/src/map/packets/event.h
@@ -39,8 +39,7 @@ class CCharEntity;
 class CEventPacket : public CBasicPacket
 {
 public:
-    CEventPacket(CCharEntity* PChar, uint16 EventID, uint8 numOfParams = 0, uint32 param0 = 0, uint32 param1 = 0, uint32 param2 = 0, uint32 param3 = 0,
-                 uint32 param4 = 0, uint32 param5 = 0, uint32 param6 = 0, uint32 param7 = 0, int16 textTable = -1);
+    CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::pair<uint8, uint32>> params, int16 textTable = -1);
 };
 
 #endif

--- a/src/map/packets/event_update.cpp
+++ b/src/map/packets/event_update.cpp
@@ -24,17 +24,17 @@
 #include "../entities/charentity.h"
 #include "event_update.h"
 
-CEventUpdatePacket::CEventUpdatePacket(uint32 param0, uint32 param1, uint32 param2, uint32 param3, uint32 param4, uint32 param5, uint32 param6, uint32 param7)
+CEventUpdatePacket::CEventUpdatePacket(std::vector<std::pair<uint8, uint32>> params)
 {
     this->type = 0x5C;
     this->size = 0x12;
 
-    ref<uint32>(0x04) = param0;
-    ref<uint32>(0x08) = param1;
-    ref<uint32>(0x0C) = param2;
-    ref<uint32>(0x10) = param3;
-    ref<uint32>(0x14) = param4;
-    ref<uint32>(0x18) = param5;
-    ref<uint32>(0x1C) = param6;
-    ref<uint32>(0x20) = param7;
+    for (auto paramPair : params)
+    {
+        // Only params 0 through 7 are valid
+        if (paramPair.first >= 0 && paramPair.first <= 7)
+        {
+            ref<uint32>(0x0004 + paramPair.first * 4) = paramPair.second;
+        }
+    }
 }

--- a/src/map/packets/event_update.h
+++ b/src/map/packets/event_update.h
@@ -35,8 +35,7 @@
 class CEventUpdatePacket : public CBasicPacket
 {
 public:
-    CEventUpdatePacket(uint32 param0 = 0, uint32 param1 = 0, uint32 param2 = 0, uint32 param3 = 0, uint32 param4 = 0, uint32 param5 = 0, uint32 param6 = 0,
-                       uint32 param7 = 0);
+    CEventUpdatePacket(std::vector<std::pair<uint8, uint32>> params);
 };
 
 #endif


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Makes it possible to pass a table of params to `startEvent` and `updateEvent`, which is utilized by the interaction framework. Note that the index of the parameters given in the table is 0-indexed.

It also allows for cleaner code in places where only some specific params of an event matters, i.e.:

```lua
player:startEvent(123, 0, 0, 0, 0, 0, 0, 0, 999)
```

Can now be done as:

```lua
player:startEvent(123, { [7] = 999 })
```