### PR TITLE
Improper ordering of events for Shantotto

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -89,6 +89,9 @@ entity.onTrigger = function(player, npc)
     if (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_JESTER_WHO_D_BE_KING and
         player:getMissionStatus(player:getNation()) == 7) then
         player:startEvent(397, 0, 0, 0, 282)
+    elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_JESTER_WHO_D_BE_KING) and
+        player:getCharVar("ShantottoCS") == 1) then
+        player:startEvent(399, 0, 0, 282)
     elseif (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(WildcatWindurst, 6)) then
         player:startEvent(498)
     elseif (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and
@@ -156,9 +159,6 @@ entity.onTrigger = function(player, npc)
 
     elseif (CFA2 == QUEST_COMPLETED) then
         player:startEvent(184) -- New standard dialog after CFA2
-    elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_JESTER_WHO_D_BE_KING) and
-        player:getCharVar("ShantottoCS") == 1) then
-        player:startEvent(399, 0, 0, 282)
     else
         player:startEvent(164)
     end


### PR DESCRIPTION
We set a CharVar for Windy mission The Jester Whod Be King for a post-mission event. If a player had finished some other content related to Shantotto, this event never fired and the CharVar remained forever. Simply bumping it towards the top so that it can fire.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
