### PR TITLE
[navmesh] Reduce values for findNearestPoly search area

### DIFF
--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -28,7 +28,8 @@
 #include <fstream>
 #include <iostream>
 
-const int8 CNavMesh::ERROR_NEARESTPOLY;
+constexpr int8 CNavMesh::ERROR_NEARESTPOLY;
+constexpr float polyPickExt[3] = { 5.0f, 10.0f, 5.0f };
 
 void CNavMesh::ToFFXIPos(const position_t* pos, float* out)
 {
@@ -216,11 +217,6 @@ std::vector<position_t> CNavMesh::findPath(const position_t& start, const positi
     filter.setIncludeFlags(0xffff);
     filter.setExcludeFlags(0);
 
-    float polyPickExt[3];
-    polyPickExt[0] = 5;
-    polyPickExt[1] = 10;
-    polyPickExt[2] = 5;
-
     dtPolyRef startRef;
     dtPolyRef endRef;
 
@@ -307,11 +303,6 @@ std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& star
     float spos[3];
     CNavMesh::ToDetourPos(&start, spos);
 
-    float polyPickExt[3];
-    polyPickExt[0] = 5;
-    polyPickExt[1] = 10;
-    polyPickExt[2] = 5;
-
     float randomPt[3];
     float snearest[3];
 
@@ -364,11 +355,6 @@ bool CNavMesh::validPosition(const position_t& position)
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
-    float polyPickExt[3];
-    polyPickExt[0] = 5;
-    polyPickExt[1] = 10;
-    polyPickExt[2] = 5;
-
     float snearest[3];
 
     dtQueryFilter filter;
@@ -403,11 +389,6 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end, bool look
 
     float epos[3];
     CNavMesh::ToDetourPos(&end, epos);
-
-    float polyPickExt[3];
-    polyPickExt[0] = 5;
-    polyPickExt[1] = 10;
-    polyPickExt[2] = 5;
 
     dtQueryFilter filter;
     filter.setIncludeFlags(0xffff);

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -217,9 +217,9 @@ std::vector<position_t> CNavMesh::findPath(const position_t& start, const positi
     filter.setExcludeFlags(0);
 
     float polyPickExt[3];
-    polyPickExt[0] = 10;
-    polyPickExt[1] = 20;
-    polyPickExt[2] = 10;
+    polyPickExt[0] = 5;
+    polyPickExt[1] = 10;
+    polyPickExt[2] = 5;
 
     dtPolyRef startRef;
     dtPolyRef endRef;
@@ -308,9 +308,9 @@ std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& star
     CNavMesh::ToDetourPos(&start, spos);
 
     float polyPickExt[3];
-    polyPickExt[0] = 30;
-    polyPickExt[1] = 60;
-    polyPickExt[2] = 30;
+    polyPickExt[0] = 5;
+    polyPickExt[1] = 10;
+    polyPickExt[2] = 5;
 
     float randomPt[3];
     float snearest[3];
@@ -365,9 +365,9 @@ bool CNavMesh::validPosition(const position_t& position)
     CNavMesh::ToDetourPos(&position, spos);
 
     float polyPickExt[3];
-    polyPickExt[0] = 30;
-    polyPickExt[1] = 60;
-    polyPickExt[2] = 30;
+    polyPickExt[0] = 5;
+    polyPickExt[1] = 10;
+    polyPickExt[2] = 5;
 
     float snearest[3];
 
@@ -405,9 +405,9 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end, bool look
     CNavMesh::ToDetourPos(&end, epos);
 
     float polyPickExt[3];
-    polyPickExt[0] = 30;
-    polyPickExt[1] = 60;
-    polyPickExt[2] = 30;
+    polyPickExt[0] = 5;
+    polyPickExt[1] = 10;
+    polyPickExt[2] = 5;
 
     dtQueryFilter filter;
     filter.setIncludeFlags(0xffff);


### PR DESCRIPTION
I did a live stream, I profiled some things. All the navmesh calls have gone from 200us to 50us (or less). 
Probably warrants some testing, but looks like a pretty easy win.

The extants passed to findNearestPoly appear to just be defining a box in which to search. We generate the vast majority of points that we're searching around, and later validating, by lerping between points given to us from detour's findPath, so they're very likely to be valid, or extremely close to a valid point 


So it seems to be safe to reduce this search area. 

There is a tiny chance this might affect wyrm's draw in. If they can search a massive area, they won't be able to validate a broken-add point to warp you to, so they'll work better. This is just untested conjecture though, could be worth a look. 

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
