### PR TITLE
Define regions for Bhaflau, Zhayolm Remnants

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -904,7 +904,9 @@ namespace zoneutils
             case ZONE_NYZUL_ISLE:
             case ZONE_ARRAPAGO_REMNANTS:
             case ZONE_ALZADAAL_UNDERSEA_RUINS:
+            case ZONE_BHAFLAU_REMNANTS:
             case ZONE_SILVER_SEA_REMNANTS:
+            case ZONE_ZHAYOLM_REMNANTS:
                 return REGION_TYPE::ALZADAAL;
             case ZONE_SOUTHERN_SAN_DORIA_S:
             case ZONE_EAST_RONFAURE_S:


### PR DESCRIPTION
These zones did not have a defined region, which at least causes the In Assault latent to not function correctly there.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
