### PR TITLE
Fix getRequiredRank for M3+

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -789,12 +789,15 @@ local function getRequiredRank(missionId)
     local requiredRank = 0
 
     if
-        missionId <= 2 or
-        (missionId >= 10 and missionId <= 12)
+        missionId <= 2
     then
         requiredRank = math.floor(missionId / 3) + 1
-    elseif missionId >= 13 then
-        requiredRank = math.floor((missionId - 12) / 2) + 4
+    elseif missionId >= 10 and missionId <= 12 then
+        requiredRank = 3
+    elseif missionId == 13 then
+        requiredRank = 4
+    elseif missionId >= 14 then
+        requiredRank = math.floor((missionId - 13) / 2) + 5
     else
         requiredRank = 2
     end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Thanks to Juggalo on Discord for reporting this issue.  `getRequiredRank()` had some wonky math associated with it for missions rank 3 and greater.  Fixed, though I'd still like a cleaner solution in the future.