### PR TITLE
Boost doesn't even have any tick code in its effect script

### DIFF
--- a/scripts/globals/abilities/boost.lua
+++ b/scripts/globals/abilities/boost.lua
@@ -16,7 +16,7 @@ end
 ability_object.onUseAbility = function(player, target, ability)
     local power = 12.5 + (0.10 * player:getMod(xi.mod.BOOST_EFFECT))
 
-    if (player:hasStatusEffect(xi.effect.BOOST) == true) then
+    if player:hasStatusEffect(xi.effect.BOOST) then
         local effect = player:getStatusEffect(xi.effect.BOOST)
         effect:setPower(effect:getPower() + power)
         player:addMod(xi.mod.ATTP, power)

--- a/scripts/globals/abilities/boost.lua
+++ b/scripts/globals/abilities/boost.lua
@@ -21,7 +21,7 @@ ability_object.onUseAbility = function(player, target, ability)
         effect:setPower(effect:getPower() + power)
         player:addMod(xi.mod.ATTP, power)
     else
-        player:addStatusEffect(xi.effect.BOOST, power, 1, 180)
+        player:addStatusEffect(xi.effect.BOOST, power, 0, 180)
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [:crossed_fingers: ] that I've _**tested my code honest sir and things my code changed what can possibly go wrong anyway**_ since the last commit in the PR, and will test after any later commits
