### PR TITLE
Fix incorrect "What Works" URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Welcome to LandSandBoat, an open source server emulator for FFXI.
 
 ## Getting Started
-A [quick start guide](https://github.com/LandSandBoat/server/wiki/Quick-Start-Guide), [frequently asked questions](https://github.com/LandSandBoat/server/-/wikis/Frequently-Asked-Questions), and a table of "[what works](https://github.com/LandSandBoat/server/-/wikis/What-Works)" are all available on [our wiki](https://github.com/LandSandBoat/server/wiki).
+A [quick start guide](https://github.com/LandSandBoat/server/wiki/Quick-Start-Guide), [frequently asked questions](https://github.com/LandSandBoat/server/-/wikis/Frequently-Asked-Questions), and a table of "[what works](https://github.com/LandSandBoat/server/wikis/What-Works)" are all available on [our wiki](https://github.com/LandSandBoat/server/wiki).
 
 ## LICENSE
 LandSandBoat is licensed under [GNU GPL v3](https://github.com/LandSandBoat/server/blob/topaz/LICENSE)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
