### PR TITLE
Add utility to reload navmesh at runtime

### DIFF
--- a/scripts/commands/reloadnavmesh.lua
+++ b/scripts/commands/reloadnavmesh.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- func: reloadnavmesh
+-- desc: Reload the navmesh for the current zone
+-- note: This is for reloading the underlying navmesh object, is not intended
+--       to do anything to runtime pathing
+-----------------------------------
+
+function onTrigger(player)
+    player:getZone():reloadNavmesh()
+end

--- a/scripts/commands/reloadnavmesh.lua
+++ b/scripts/commands/reloadnavmesh.lua
@@ -5,6 +5,14 @@
 --       to do anything to runtime pathing
 -----------------------------------
 
+cmdprops =
+{
+    permission = 5,
+    parameters = ""
+}
+
 function onTrigger(player)
-    player:getZone():reloadNavmesh()
+    local zone = player:getZone()
+    player:PrintToPlayer("Reloading Navmesh for " .. zone:getName())
+    zone:reloadNavmesh()
 end

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -120,6 +120,11 @@ WEATHER CLuaZone::getWeather()
     return m_pLuaZone->GetWeather();
 }
 
+void CLuaZone::reloadNavmesh()
+{
+    m_pLuaZone->m_navMesh->reload();
+}
+
 //======================================================//
 
 void CLuaZone::Register()
@@ -135,6 +140,7 @@ void CLuaZone::Register()
     SOL_REGISTER("getBattlefieldByInitiator", CLuaZone::getBattlefieldByInitiator);
     SOL_REGISTER("battlefieldsFull", CLuaZone::battlefieldsFull);
     SOL_REGISTER("getWeather", CLuaZone::getWeather);
+    SOL_REGISTER("reloadNavmesh", CLuaZone::reloadNavmesh);
 }
 
 //======================================================//

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -48,6 +48,7 @@ public:
     auto        getBattlefieldByInitiator(uint32 charID) -> std::optional<CLuaBattlefield>;
     bool        battlefieldsFull(int battlefieldId);
     WEATHER     getWeather();
+    void        reloadNavmesh();
 
     static void Register();
 };

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -99,6 +99,8 @@ CNavMesh::~CNavMesh() = default;
 
 bool CNavMesh::load(const std::string& filename)
 {
+    this->filename = filename;
+
     std::ifstream file(filename.c_str(), std::ios_base::in | std::ios_base::binary);
 
     if (!file.good())
@@ -166,6 +168,17 @@ bool CNavMesh::load(const std::string& filename)
     return true;
 }
 
+void CNavMesh::reload()
+{
+    this->unload();
+    this->load(this->filename);
+}
+
+void CNavMesh::unload()
+{
+    m_navMesh.reset();
+}
+
 void CNavMesh::outputError(uint32 status)
 {
     if (status & DT_WRONG_MAGIC)
@@ -192,11 +205,6 @@ void CNavMesh::outputError(uint32 status)
     {
         ShowNavError("Detour partial result\n");
     }
-}
-
-void CNavMesh::unload()
-{
-    m_navMesh.reset();
 }
 
 std::vector<position_t> CNavMesh::findPath(const position_t& start, const position_t& end)

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -69,6 +69,7 @@ public:
     ~CNavMesh();
 
     bool load(const std::string& path);
+    void reload();
     void unload();
 
     std::vector<position_t>      findPath(const position_t& start, const position_t& end);
@@ -89,6 +90,7 @@ public:
 private:
     void outputError(uint32 status);
 
+    std::string                filename;
     uint16                     m_zoneID;
     dtRaycastHit               m_hit;
     dtPolyRef                  m_hitPath[20];


### PR DESCRIPTION
Simple, unintrusive, comes with a warning label. I'm about to reboot my PC to test it

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
