### PR TITLE
[ci] Fix remaining cppcheck errors

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -163,7 +163,7 @@ int32 do_init(int32 argc, char** argv)
                             auto temp             = (++version_info.ver_lock) % 3;
                             version_info.ver_lock = temp;
 
-                            const auto* value = "";
+                            const char* value = "";
                             switch (version_info.ver_lock)
                             {
                                 case 0:

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -32,12 +32,12 @@
  *																		*
  ************************************************************************/
 CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
+: m_subWeaponType(DAMAGE_TYPE::NONE)
 {
     m_attacker          = attacker;
     m_defender          = defender;
     m_kickAttackOccured = false;
     m_sataOccured       = false;
-    m_subWeaponType     = DAMAGE_TYPE::NONE;
 
     if (auto* weapon = dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_SUB]))
     {

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -28,11 +28,11 @@
 #include "baseentity.h"
 
 CBaseEntity::CBaseEntity()
+: status(STATUS_TYPE::DISAPPEAR)
 {
     id       = 0;
     targid   = 0;
     objtype  = ENTITYTYPE::TYPE_NONE;
-    status   = STATUS_TYPE::DISAPPEAR;
     m_TargID = 0;
     memset(&look, 0, sizeof(look));
     memset(&mainlook, 0, sizeof(mainlook));

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1843,9 +1843,6 @@ void CCharEntity::UpdateMoghancement()
     bool   hasTiedElements = false;
     for (uint8 elementID = 1; elementID < 9; ++elementID)
     {
-        // False positive: elements size is always 8
-        // error: Out of bounds access in 'elements[elementID-1]', if 'elements' size is 1 and 'elementID-1' is 7 [containerOutOfBounds]
-        // cppcheck-suppress containerOutOfBounds
         uint16 aura = elements[elementID - 1];
         if (aura > dominantAura)
         {

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -38,9 +38,9 @@
 #include "petentity.h"
 
 CPetEntity::CPetEntity(PET_TYPE petType)
+: m_PetType(petType)
 {
     objtype          = TYPE_PET;
-    m_PetType        = petType;
     m_EcoSystem      = ECOSYSTEM::UNCLASSIFIED;
     allegiance       = ALLEGIANCE_TYPE::PLAYER;
     m_MobSkillList   = 0;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5722,10 +5722,6 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
         for (int32 i = 0; i < MAX_CONTAINER_SIZE * 2; ++i)
         {
             // We can stop updating the order numbers once we hit an empty order number
-
-            // False positive: we're checking to make sure we don't over-run
-            // error: Out of bounds access in 'placedItems[i]', if 'placedItems' size is 1 and 'i' is 239 [containerOutOfBounds]
-            // cppcheck-suppress containerOutOfBounds
             if (placedItems[i] == nullptr)
             {
                 break;

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -32,8 +32,8 @@
 #include "utils/blueutils.h"
 
 CSpell::CSpell(SpellID id)
+: m_ID(id)
 {
-    m_ID = id;
 }
 
 std::unique_ptr<CSpell> CSpell::clone()

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -133,14 +133,14 @@ int32 zone_update_weather(time_point tick, CTaskMgr::CTask* PTask)
  ************************************************************************/
 
 CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID)
+: m_zoneID(ZoneID)
+, m_zoneType(ZONE_TYPE::NONE)
+, m_regionID(RegionID)
+, m_continentID(ContinentID)
 {
     std::ignore = m_useNavMesh;
     ZoneTimer   = nullptr;
 
-    m_zoneID             = ZoneID;
-    m_zoneType           = ZONE_TYPE::NONE;
-    m_regionID           = RegionID;
-    m_continentID        = ContinentID;
     m_TreasurePool       = nullptr;
     m_BattlefieldHandler = nullptr;
     m_Weather            = WEATHER_NONE;


### PR DESCRIPTION
The recurring errors in cpp ci were coming from the fact that Ubuntu 20.04 has quite an old version of cppcheck, so the modern things I was using weren't being recognised. I've checked this on my WSL2 Ubuntu install so we should be all good now.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
