### PR TITLE
Fix numeric checks against getMissionRankPoints

### DIFF
--- a/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
         elseif currentMission == xi.mission.id.bastok.JEUNO and missionStatus == 3 then
             player:startEvent(139)
         elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
-            if getMissionRankPoints(player, 13) == 1 then
+            if getMissionRankPoints(player, 13) then
                 player:startEvent(3)
             else
                 player:startEvent(4)

--- a/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
         elseif currentMission == xi.mission.id.sandoria.APPOINTMENT_TO_JEUNO and missionStatus == 5 then
             player:startEvent(140)
         elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
-            if getMissionRankPoints(player, 13) == 1 then
+            if getMissionRankPoints(player, 13) then
                 player:startEvent(45)
             else
                 player:startEvent(49)

--- a/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
         elseif currentMission == xi.mission.id.windurst.A_NEW_JOURNEY and missionStatus == 3 then
             player:startEvent(141)
         elseif player:getRank(player:getNation()) == 4 and missionStatus == 0 then
-            if getMissionRankPoints(player, 13) == 1 then
+            if getMissionRankPoints(player, 13) then
                 player:startEvent(50)
             else
                 player:startEvent(54)

--- a/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r2.lua
@@ -23,7 +23,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(38)
         elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.bastok.NONE and
-            getMissionRankPoints(player, 13) == 1
+            getMissionRankPoints(player, 13)
         then
             if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
                 player:startEvent(129, 1)

--- a/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r5.lua
@@ -23,7 +23,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(39)
         elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.sandoria.NONE and
-            getMissionRankPoints(player, 13) == 1 and
+            getMissionRankPoints(player, 13) and
             missionStatus == 0
         then
             if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then

--- a/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/_6r8.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(40)
         elseif player:getRank(player:getNation()) == 4 and
             currentMission == xi.mission.id.windurst.NONE and
-            getMissionRankPoints(player, 13) == 1
+            getMissionRankPoints(player, 13)
         then
             if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
                 player:startEvent(131, 1)

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -58,7 +58,7 @@ entity.onTrigger = function(player, npc)
             end
         elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
             player:startEvent(1034)
-        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
+        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) and player:getCharVar("SecretWeaponStatus") < 2 then
             player:startEvent(1042)
         elseif currentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
             player:startEvent(1044)

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -57,7 +57,7 @@ entity.onTrigger = function(player, npc)
             end
         elseif currentMission == xi.mission.id.sandoria.RANPERRE_S_FINAL_REST and player:getMissionStatus(player:getNation()) == 7 then
             player:startEvent(1033)
-        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) == 1 and player:getCharVar("SecretWeaponStatus") < 2 then
+        elseif currentMission ~= xi.mission.id.sandoria.THE_SECRET_WEAPON and pRank == 7 and PresOfPapsqueCompleted == true and getMissionRankPoints(player, 19) and player:getCharVar("SecretWeaponStatus") < 2 then
             player:startEvent(1041)
         elseif currentMission == xi.mission.id.sandoria.THE_SECRET_WEAPON and player:getCharVar("SecretWeaponStatus") == 3 then
             player:startEvent(1043)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

getMissionRankPoints needs an eventual refactor for naming and to become accurate with required crystals.  This just fixes failed checks from Lua's truthiness.