### PR TITLE
Restrict setting spells while in level sync

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6237,7 +6237,8 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                     {
                         if (PChar->m_SetBlueSpells[spellIndex] == 0x00)
                         {
-                            ShowExploit(CL_RED "SmallPacket0x102: Player %s trying to unset BLU spell they don't have set! \n" CL_RESET, PChar->GetName());
+                            ShowExploit(CL_RED "SmallPacket0x102: Player %s trying to unset BLU spell they don't have set!\n" CL_RESET, PChar->GetName());
+                            return;
                         }
                         else
                         {
@@ -6247,6 +6248,7 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                     else
                     {
                         ShowDebug("SmallPacket0x102: Cannot resolve spell id %u \n", spellInQuestion);
+                        return;
                     }
                 }
             }
@@ -6277,6 +6279,15 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (spell != nullptr)
                 {
+                    uint8 mLevel = PChar->m_LevelRestriction != 0 && PChar->m_LevelRestriction < PChar->GetMLevel() ? PChar->m_LevelRestriction : PChar->GetMLevel();
+                    uint8 sLevel = floor(mLevel / 2);
+
+                    if (mLevel < spell->getJob(PChar->GetMJob()) && sLevel < spell->getJob(PChar->GetSJob()))
+                    {
+                        ShowExploit(CL_RED "SmallPacket0x102: Player %s trying to set BLU spell at invalid level!\n" CL_RESET, PChar->GetName());
+                        return;
+                    }
+
                     blueutils::SetBlueSpell(PChar, spell, spellIndex, (spellToAdd > 0));
                     charutils::BuildingCharTraitsTable(PChar);
                     PChar->pushPacket(new CCharAbilitiesPacket(PChar));


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds additional checks for BLU spell setting under level sync conditions.