### PR TITLE
Remove "Brass Ribbon of Service" from "The Tigress Stirs"

### DIFF
--- a/scripts/zones/Windurst_Waters_[S]/npcs/Door_Acolyte_Hostel_down.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Door_Acolyte_Hostel_down.lua
@@ -43,8 +43,6 @@ entity.onEventFinish = function(player, csid, option)
         player:addItem(4144) -- hi-elixir
         player:messageSpecial(ID.text.ITEM_OBTAINED, 4144)
         player:delKeyItem(xi.ki.SMALL_STARFRUIT)
-        player:addKeyItem(xi.ki.BRASS_RIBBON_OF_SERVICE)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BRASS_RIBBON_OF_SERVICE)
         player:completeQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.THE_TIGRESS_STIRS)
     elseif csid == 151 then
         player:addQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE)


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/The_Tigress_Stirs shows this should not be a reward from that

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [ x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [ x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Sorry, I've not tested and it this is just a drive-by fix. Feel free to push back if you feel the change is non-trivial.