### PR TITLE
Ashtu Talif missing onInstanceLoadFailed

### DIFF
--- a/scripts/zones/The_Ashu_Talif/Zone.lua
+++ b/scripts/zones/The_Ashu_Talif/Zone.lua
@@ -25,4 +25,8 @@ end
 zone_object.onEventFinish = function(player, csid, option)
 end
 
+zone_object.onInstanceLoadFailed = function()
+    return 54
+end
+
 return zone_object


### PR DESCRIPTION
Any zone used for instances like this should have this in place to direct the server where to spit you out at in the case of a failed instance load. See: https://github.com/LandSandBoat/server/blob/base/scripts/zones/Nyzul_Isle/Zone.lua

This is a for sure map crash pre-SOL, not sure of the results post-SOL. But an easy fix!

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
