### PR TITLE
Post-Soultrapper fixes

### DIFF
--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -138,6 +138,7 @@ void CItemState::UpdateTarget(CBaseEntity* target)
 {
     if (target != nullptr)
     {
+        CState::UpdateTarget(target);
         CState::SetTarget(target->targid);
     }
 

--- a/tools/migrations/extend_valid_targets.py
+++ b/tools/migrations/extend_valid_targets.py
@@ -9,10 +9,13 @@ def check_preconditions(cur):
 
 def needs_to_run(cur):
     cur.execute("SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'item_usable' AND COLUMN_NAME = 'validTargets';")
-    row = cur.fetchone()[0]
+    row = cur.fetchall()[0][0]
     return row == "tinyint"
 
 def migrate(cur, db):
-    cur.execute("ALTER TABLE item_usable MODIFY COLUMN validTargets SMALLINT(3) UNSIGNED NOT NULL DEFAULT '0';")
-    cur.execute("ALTER TABLE spell_list MODIFY COLUMN validTargets SMALLINT(3) UNSIGNED NOT NULL DEFAULT '0';")
-    db.commit()
+    try:
+        cur.execute("ALTER TABLE item_usable MODIFY COLUMN validTargets SMALLINT(3) UNSIGNED NOT NULL DEFAULT '0';")
+        cur.execute("ALTER TABLE spell_list  MODIFY COLUMN validTargets SMALLINT(3) UNSIGNED NOT NULL DEFAULT '0';")
+        db.commit()
+    except mysql.connector.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
I did some whoopsies with my soultrapper work:
- Migration errors out: now fixed and tested 🤞 -> https://github.com/LandSandBoat/server/issues/340 -> https://github.com/LandSandBoat/server/commit/86b4b99bcc5ac7f1d2258693af6788752d9e3c88
- Self-targetting charged items stopped working: I forgot to call the super... oof -> https://github.com/LandSandBoat/server/issues/343 -> https://github.com/LandSandBoat/server/commit/f71fb15c4250e7c5fa6f545525b85c23eedbd598
    - Tested with `Potion` and `Warp Ring`, re-tested soul-trapping other people's mobs etc. All _seems_ fine...



<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
