### PR TITLE
[ci] Add continue-on-error to flakey changed-files step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
     - id: changed-files
       name: Get Changed Files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
     - name: List Changed Files
       if: always()
       run: |


### PR DESCRIPTION
Driveby CI dance

Will hopefully make warning/errors where the head is behind the base (but the file list is still sane) fail silently 🤷 :
```
Run jitterbit/get-changed-files@v1
Base commit: 732ccbf1243057b81529adc2295c66d6ad1ee4f9
Head commit: 787db5a9a350891c46a466806168a3ba48f3a377
Error: The head commit for this pull_request event is not ahead of the base commit. Please submit an issue on this action's GitHub repo.
All: sql/mob_droplist.sql sql/mob_groups.sql
Added: 
Modified: sql/mob_droplist.sql sql/mob_groups.sql
Removed: 
Renamed: 
Added or modified: sql/mob_droplist.sql sql/mob_groups.sql
```




<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
