### PR TITLE
Fix Tyrannic Tunnok spawn conditions

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/mobs/Sulfur_Scorpion.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Sulfur_Scorpion.lua
@@ -14,7 +14,7 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.TYRANNIC_TURROK_PH, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, ID.mob.TYRANNIC_TUNNOK_PH, 5, 3600) -- 1 hour
 end
 
 return entity


### PR DESCRIPTION
Was informed by someone this NM has issues, another piece of low-hanging fruit secured for the basket. PH mobs are referring to an incorrectly spelled version of the NMs name, which did not match the IDs.lua for the zone.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
