### PR TITLE
Add NPC position check to San d'Oria M2-2

### DIFF
--- a/scripts/missions/sandoria/2_2_The_Davoi_Report.lua
+++ b/scripts/missions/sandoria/2_2_The_Davoi_Report.lua
@@ -7,7 +7,7 @@
 -- Grilau         : !pos -241.987 6.999 57.887 231
 -- Endracion      : !pos -110 1 -34 230
 -- Zantaviat      : !pos 215 0.1 -10 149
--- "!"            : !pos 164 0.1 -21 149
+-- "!"            : !pos 211 2 -104 149
 -- Papal Chambers : !pos 131 -11 122 231
 -----------------------------------
 require('scripts/globals/keyitems')
@@ -79,11 +79,16 @@ mission.sections =
                 end,
             },
 
-            -- TODO: Rename this NPC to be a non-special character
+            -- TODO: Rename this NPC to be a non-special character, and make this NPC unique!
             ['!'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.LOST_DOCUMENT) then
+                    local xPos = npc:getXPos()
+
+                    if
+                        not player:hasKeyItem(xi.ki.LOST_DOCUMENT) and
+                        xPos > 210 and xPos < 212
+                    then
                         player:setMissionStatus(player:getNation(), 2)
                         player:addKeyItem(xi.ki.LOST_DOCUMENT)
                         return mission:messageSpecial(davoiID.text.KEYITEM_OBTAINED, xi.ki.LOST_DOCUMENT)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

There are four '!' NPCs in Davoi for San d'Oria missions, and in the past they shared the same script.  While these should be broken out in the future, this ensures that the correct '!' is selected for M2-2