### PR TITLE
[WOTG] Clean out leftover mission logic in maws.lua

### DIFF
--- a/scripts/globals/maws.lua
+++ b/scripts/globals/maws.lua
@@ -18,24 +18,24 @@ local MAW = xi.teleport.type.PAST_MAW
 
 local pastMaws =
 { --[ZONE ID]                    = {Bit Slot in Array, Cutscenes{new to WoTg or add new, mission, warp}, Destination {Coordinates}}
-    [ZN.BATALLIA_DOWNS]          = {bit = 0, cs = {new = 500, msn = 501, warp = 910}, dest = { -51.486,   0.371,  436.972, 128,  84}},
-    [ZN.ROLANBERRY_FIELDS]       = {bit = 1, cs = {new = 500, msn = 501, warp = 904}, dest = {-196.500,   7.999,  361.192, 225,  91}},
-    [ZN.SAUROMUGUE_CHAMPAIGN]    = {bit = 2, cs = {new = 500, msn = 501, warp = 904}, dest = { 366.858,   8.545, -228.861,  95,  98}},
-    [ZN.JUGNER_FOREST]           = {bit = 3, cs = {add = nil, msn = nil, warp = 905}, dest = {-116.093,  -8.005, -520.041,   0,  82}},
-    [ZN.PASHHOW_MARSHLANDS]      = {bit = 4, cs = {add = nil, msn = nil, warp = 905}, dest = { 415.945,  24.659,   25.611, 101,  90}},
-    [ZN.MERIPHATAUD_MOUNTAINS]   = {bit = 5, cs = {add = nil, msn = nil, warp = 905}, dest = { 595.000, -32.000,  279.300,  93,  97}},
-    [ZN.EAST_RONFAURE]           = {bit = 6, cs = {add = nil, msn = nil, warp = 904}, dest = { 322.057, -60.059,  503.712,  64,  81}},
-    [ZN.NORTH_GUSTABERG]         = {bit = 7, cs = {add = nil, msn = nil, warp = 903}, dest = { 469.697,  -0.050,  478.949,   0,  88}},
-    [ZN.WEST_SARUTABARUTA]       = {bit = 8, cs = {add = nil, msn = nil, warp = 904}, dest = {   2.628,  -0.150, -166.562,  32,  95}},
-    [ZN.BATALLIA_DOWNS_S]        = {bit = 0, cs = {add = 100, msn = 701, warp = 101}, dest = { -51.486,   0.371,  436.972, 128, 105}},
-    [ZN.ROLANBERRY_FIELDS_S]     = {bit = 1, cs = {add = 101, msn = 701, warp = 102}, dest = {-196.500,   7.999,  361.192, 225, 110}},
-    [ZN.SAUROMUGUE_CHAMPAIGN_S]  = {bit = 2, cs = {add = 101, msn = 701, warp = 102}, dest = { 366.858,   8.545, -228.861,  95, 120}},
-    [ZN.JUGNER_FOREST_S]         = {bit = 3, cs = {add = 101, msn = nil, warp = 102}, dest = {-116.093,  -8.005, -520.041,   0, 104}},
-    [ZN.PASHHOW_MARSHLANDS_S]    = {bit = 4, cs = {add = 100, msn = nil, warp = 101}, dest = { 415.945,  24.659,   25.611, 101, 109}},
-    [ZN.MERIPHATAUD_MOUNTAINS_S] = {bit = 5, cs = {add = 102, msn = nil, warp = 103}, dest = { 595.000, -32.000,  279.300,  93, 119}},
-    [ZN.EAST_RONFAURE_S]         = {bit = 6, cs = {add = 100, msn = nil, warp = 101}, dest = { 322.057, -60.059,  503.712,  64, 101}},
-    [ZN.NORTH_GUSTABERG_S]       = {bit = 7, cs = {add = 100, msn = nil, warp = 101}, dest = { 469.697,  -0.050,  478.949,   0, 106}},
-    [ZN.WEST_SARUTABARUTA_S]     = {bit = 8, cs = {add = 100, msn = nil, warp = 101}, dest = {   2.628,  -0.150, -166.562,  32, 115}},
+    [ZN.BATALLIA_DOWNS]          = {bit = 0, cs = {new = 500, warp = 910}, dest = { -51.486,   0.371,  436.972, 128,  84}},
+    [ZN.ROLANBERRY_FIELDS]       = {bit = 1, cs = {new = 500, warp = 904}, dest = {-196.500,   7.999,  361.192, 225,  91}},
+    [ZN.SAUROMUGUE_CHAMPAIGN]    = {bit = 2, cs = {new = 500, warp = 904}, dest = { 366.858,   8.545, -228.861,  95,  98}},
+    [ZN.JUGNER_FOREST]           = {bit = 3, cs = {add = nil, warp = 905}, dest = {-116.093,  -8.005, -520.041,   0,  82}},
+    [ZN.PASHHOW_MARSHLANDS]      = {bit = 4, cs = {add = nil, warp = 905}, dest = { 415.945,  24.659,   25.611, 101,  90}},
+    [ZN.MERIPHATAUD_MOUNTAINS]   = {bit = 5, cs = {add = nil, warp = 905}, dest = { 595.000, -32.000,  279.300,  93,  97}},
+    [ZN.EAST_RONFAURE]           = {bit = 6, cs = {add = nil, warp = 904}, dest = { 322.057, -60.059,  503.712,  64,  81}},
+    [ZN.NORTH_GUSTABERG]         = {bit = 7, cs = {add = nil, warp = 903}, dest = { 469.697,  -0.050,  478.949,   0,  88}},
+    [ZN.WEST_SARUTABARUTA]       = {bit = 8, cs = {add = nil, warp = 904}, dest = {   2.628,  -0.150, -166.562,  32,  95}},
+    [ZN.BATALLIA_DOWNS_S]        = {bit = 0, cs = {add = 100, warp = 101}, dest = { -51.486,   0.371,  436.972, 128, 105}},
+    [ZN.ROLANBERRY_FIELDS_S]     = {bit = 1, cs = {add = 101, warp = 102}, dest = {-196.500,   7.999,  361.192, 225, 110}},
+    [ZN.SAUROMUGUE_CHAMPAIGN_S]  = {bit = 2, cs = {add = 101, warp = 102}, dest = { 366.858,   8.545, -228.861,  95, 120}},
+    [ZN.JUGNER_FOREST_S]         = {bit = 3, cs = {add = 101, warp = 102}, dest = {-116.093,  -8.005, -520.041,   0, 104}},
+    [ZN.PASHHOW_MARSHLANDS_S]    = {bit = 4, cs = {add = 100, warp = 101}, dest = { 415.945,  24.659,   25.611, 101, 109}},
+    [ZN.MERIPHATAUD_MOUNTAINS_S] = {bit = 5, cs = {add = 102, warp = 103}, dest = { 595.000, -32.000,  279.300,  93, 119}},
+    [ZN.EAST_RONFAURE_S]         = {bit = 6, cs = {add = 100, warp = 101}, dest = { 322.057, -60.059,  503.712,  64, 101}},
+    [ZN.NORTH_GUSTABERG_S]       = {bit = 7, cs = {add = 100, warp = 101}, dest = { 469.697,  -0.050,  478.949,   0, 106}},
+    [ZN.WEST_SARUTABARUTA_S]     = {bit = 8, cs = {add = 100, warp = 101}, dest = {   2.628,  -0.150, -166.562,  32, 115}},
 }
 xi.maws.pastMaws = pastMaws
 
@@ -80,9 +80,7 @@ xi.maws.onTrigger = function(player, npc)
     local event = nil
     local event_params = nil
 
-    if maw.cs.msn and xi.maws.meetsMission2Reqs(player) then
-        event = maw.cs.msn
-    elseif hasMaw then
+    if hasMaw then
         event = maw.cs.warp
     else
         local hasFeather = player:hasKeyItem(xi.ki.PURE_WHITE_FEATHER)
@@ -103,22 +101,14 @@ xi.maws.onTrigger = function(player, npc)
     else
         player:messageSpecial(ID.text.NOTHING_HAPPENS)
     end
-
 end
 
 xi.maws.onEventFinish = function(player, csid, option)
-
     local maw = xi.maws.pastMaws[player:getZoneID()]
 
     if csid == maw.cs.warp and option == 1 then
         xi.maws.goToMaw(player, maw) -- Known to have maw, no need to check
     elseif maw.cs.add and csid == maw.cs.add and option == 1 then
         xi.maws.addMaw(player, maw)
-    elseif maw.cs.msn and csid == maw.cs.msn then
-        player:completeMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING)
-        player:addMission(xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH)
-        player:addTitle(xi.title.CAIT_SITHS_ASSISTANT)
-        xi.maws.addMaw(player, maw) -- May not have yet, check
     end
-
 end


### PR DESCRIPTION
`meetsMission2Reqs` wasn't in this file anymore, so was nil, which made maws unhappy.

The rest of this logic is now in the interaction missions

Tested on fresh character, jumping between different maws after first CS, unlocking them etc.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
