### PR TITLE
Fix Vermillion-eared Norberry's elemental pet offset in script

### DIFF
--- a/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
@@ -12,7 +12,7 @@ mixins =
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local elementalId = mob:getID() + 1
+    local elementalId = mob:getID() + 2
     if GetMobByID(elementalId):isSpawned() then
         DespawnMob(elementalId)
     end


### PR DESCRIPTION
This mob's pet offset is 2 in the DB, which links the correct mobid for the Tonberry's Elemental. We were attempting to despawn an invalid mobid.

![image](https://user-images.githubusercontent.com/61239975/123557645-02e00480-d760-11eb-8d42-e4cc99cd904e.png)


<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
