### PR TITLE
Fix unused and shadowing variables for Corsair Shots

### DIFF
--- a/scripts/globals/abilities/dark_shot.lua
+++ b/scripts/globals/abilities/dark_shot.lua
@@ -49,7 +49,8 @@ ability_object.onUseAbility = function(player, target, ability)
 
     if #effects > 0 then
         local effect = effects[math.random(#effects)]
-        local duration = effect:getDuration()
+        -- TODO: duration here overwrites all previous values, this logic needs to be verified
+        duration = effect:getDuration()
         local startTime = effect:getStartTime()
         local tick = effect:getTick()
         local power = effect:getPower()
@@ -72,7 +73,7 @@ ability_object.onUseAbility = function(player, target, ability)
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
     end
 
-    local del = player:delItem(2183, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2183, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return dispelledEffect
 end

--- a/scripts/globals/abilities/earth_shot.lua
+++ b/scripts/globals/abilities/earth_shot.lua
@@ -71,7 +71,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2179, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2179, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return dmg
 end

--- a/scripts/globals/abilities/fire_shot.lua
+++ b/scripts/globals/abilities/fire_shot.lua
@@ -66,7 +66,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2176, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2176, 1) or player:delItem(2974, 1)
 
     target:updateClaim(player)
     return dmg

--- a/scripts/globals/abilities/ice_shot.lua
+++ b/scripts/globals/abilities/ice_shot.lua
@@ -71,7 +71,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2177, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2177, 1) or player:delItem(2974, 1)
 
     target:updateClaim(player)
     return dmg

--- a/scripts/globals/abilities/light_shot.lua
+++ b/scripts/globals/abilities/light_shot.lua
@@ -45,7 +45,8 @@ ability_object.onUseAbility = function(player, target, ability)
 
     if #effects > 0 then
         local effect = effects[math.random(#effects)]
-        local duration = effect:getDuration()
+        -- TODO: duration here overwrites all previous values, this logic needs to be verified
+        duration = effect:getDuration()
         local startTime = effect:getStartTime()
         local tick = effect:getTick()
         local power = effect:getPower()
@@ -67,7 +68,7 @@ ability_object.onUseAbility = function(player, target, ability)
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
     end
 
-    local del = player:delItem(2182, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2182, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return xi.effect.SLEEP_I
 end

--- a/scripts/globals/abilities/thunder_shot.lua
+++ b/scripts/globals/abilities/thunder_shot.lua
@@ -66,7 +66,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2180, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2180, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return dmg
 end

--- a/scripts/globals/abilities/water_shot.lua
+++ b/scripts/globals/abilities/water_shot.lua
@@ -71,7 +71,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2181, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2181, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return dmg
 end

--- a/scripts/globals/abilities/wind_shot.lua
+++ b/scripts/globals/abilities/wind_shot.lua
@@ -72,7 +72,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         end
     end
 
-    local del = player:delItem(2178, 1) or player:delItem(2974, 1)
+    local _ = player:delItem(2178, 1) or player:delItem(2974, 1)
     target:updateClaim(player)
     return dmg
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Replaces unused variable with _ (uses or short circuit to determine which card to remove)
* Removes shadowing definition of duration, adds comment to verify (previous calculations were being overwritten)
