### PR TITLE
RoE: Miscellaneous Improvements + Fixes

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -689,6 +689,10 @@ xi.caskets.onTrigger = function(player, npc)
         if npc:getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.SPAWNED_CLOSED then      -- is the chest shut?, then open it.
             npc:setAnimationSub(1)
             npc:setLocalVar("[caskets]SPAWNSTATUS", casketInfo.spawnStatus.SPAWNED_OPEN)
+            -- RoE Timed Record #4019 - Crack Tresure Caskets
+            if player:getEminenceProgress(4019) then
+                xi.roe.onRecordTrigger(player, 4019)
+            end
         end
 
         if itemType == 1 then                -- temp items

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -249,13 +249,12 @@ local function completeRecord(player, record)
         type(rewards["accolades"]) == "number"
     then
         local bonusAccoladeRate = 1.0
-
         if record ~= 5 then -- Do not grant a bonus for All for One
             bonusAccoladeRate = bonusAccoladeRate + ((player:getUnityRank() - 1) * 0.05)
         end
-
-        player:addCurrency("unity_accolades", math.floor(rewards["accolades"] * bonusAccoladeRate), CAP_CURRENCY_ACCOLADES)
-        player:messageBasic(xi.msg.basic.ROE_RECEIVED_ACCOLADES, rewards["accolades"], player:getCurrency("unity_accolades"))
+        local accoladePayout = math.floor(rewards["accolades"] * bonusAccoladeRate)
+        player:addCurrency("unity_accolades", accoladePayout, CAP_CURRENCY_ACCOLADES)
+        player:messageBasic(xi.msg.basic.ROE_RECEIVED_ACCOLADES, accoladePayout, player:getCurrency("unity_accolades"))
     end
 
     if rewards["keyItem"] ~= nil then

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -166,6 +166,8 @@ local defaults = {
                                 --        "weekly" - Weekly record.
                                 --        "unity"  - Weekly reset, but doesn't reset progress, only completion.
                                 --        "retro"  - Can be claimed retroactively. Calls check on taking record.
+                                --        "hidden" - Special internal-use record used only as a client-flag to unlock others.
+                                --                   Does not count towards completed record count.
     reqs = {},                  -- Other requirements. List of function names from above, with required values.
     reward = {},                -- Reward parameters give on completion. (See completeRecord directly below.)
 }

--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -163,6 +163,8 @@ local defaults = {
                                 --        "timed"  - 4-hour record.
                                 --        "repeat" - Repeatable record.
                                 --        "daily"  - Daily record.
+                                --        "weekly" - Weekly record.
+                                --        "unity"  - Weekly reset, but doesn't reset progress, only completion.
                                 --        "retro"  - Can be claimed retroactively. Calls check on taking record.
     reqs = {},                  -- Other requirements. List of function names from above, with required values.
     reward = {},                -- Reward parameters give on completion. (See completeRecord directly below.)
@@ -189,7 +191,9 @@ RoeParseRecords(records)
         item = { {640,2}, 641 },          -- see npcUtil.giveItem for formats (Only given on first completion)
         keyItem = xi.ki.ZERUHN_REPORT,   -- see npcUtil.giveKeyItem for formats
         sparks = 500,
-        xp = 1000
+        xp = 1000,
+        accolades = 300,
+        capacity = 400,
     })
 *************************************************************************** --]]
 local function completeRecord(player, record)

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -7594,6 +7594,7 @@ function getRoeRecords(triggers)
       -----------------------------------
 
         [4085] = { -- 10 RoE Objectives Complete (All for One requirement)
+            flags = set{"hidden"},
         },
     }
 end

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -285,7 +285,15 @@ function getRoeRecords(triggers)
             reward = { sparks = 100, xp = 300 },
         },
 
-        -- TODO: [505] Obtain a Support Job (Has two potential quest completes for objective)
+        [ 505] = { -- Obtain a Support Job
+            trigger = triggers.questComplete,
+            flags = set{"retro"},
+            check = function(self, player, params)
+                        return player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.ELDER_MEMORIES) == QUEST_COMPLETED or
+                                player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.THE_OLD_LADY) == QUEST_COMPLETED
+                    end,
+            reward = { sparks = 100, xp = 500 },
+        },
 
         [ 506] = { -- Obtain an Alter Ego: San d'Oria
             trigger = triggers.questComplete,

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -6,6 +6,7 @@ require("scripts/globals/missions")
 require("scripts/globals/common")
 require("scripts/globals/quests")
 require("scripts/globals/status")
+require("scripts/globals/zone")
 -----------------------------------
 
 
@@ -7475,7 +7476,7 @@ function getRoeRecords(triggers)
         [4008] = {   -- Vanquish Aquans
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.AQUAN} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.AQUAN} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7483,7 +7484,7 @@ function getRoeRecords(triggers)
         [4009] = {   -- Vanquish Beasts
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.BEAST} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.BEAST} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7491,7 +7492,7 @@ function getRoeRecords(triggers)
         [4010] = {   -- Vanquish Plantoids
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.PLANTOID} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.PLANTOID} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7499,7 +7500,7 @@ function getRoeRecords(triggers)
         [4011] = {   -- Vanquish Lizards
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.LIZARD} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.LIZARD} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7507,7 +7508,7 @@ function getRoeRecords(triggers)
         [4012] = {   -- Vanquish Vermin
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.VERMIN} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.VERMIN} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7535,10 +7536,10 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
 
-        [4015] = {   -- Vanquish Birds (TODO: No abyssea zone kills for vanquishes when exists)
+        [4015] = {   -- Vanquish Birds
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.BIRD} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.BIRD} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7546,7 +7547,7 @@ function getRoeRecords(triggers)
         [4016] = {   -- Vanquish Amorphs
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.AMORPH} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.AMORPH} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7554,7 +7555,7 @@ function getRoeRecords(triggers)
         [4017] = {   -- Vanquish Undead
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.UNDEAD} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.UNDEAD} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },
@@ -7562,7 +7563,7 @@ function getRoeRecords(triggers)
         [4018] = {   -- Vanquish Arcana
             trigger = triggers.mobKill,
             goal = 20,
-            reqs = { mobXP = true, mobSystem = set{xi.eco.ARCANA} },
+            reqs = { mobXP = true, zoneNot = xi.expansionRegion.ABYSSEA, mobSystem = set{xi.eco.ARCANA} },
             flags = set{"timed", "repeat"},
             reward = { sparks = 300, xp = 1500, accolades = 300, item = { 8711 } },
         },

--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -420,6 +420,19 @@ xi.expansionRegion.ORIGINAL_ROTZ = set{
     xi.region.DYNAMIS,
 }
 
+xi.expansionRegion.ABYSSEA = set{
+    xi.region.ABYSSEA_KONSCHTAT,
+    xi.region.ABYSSEA_TAHRONGI,
+    xi.region.ABYSSEA_LA_THEINE,
+    xi.region.ABYSSEA_ATTOHWA,
+    xi.region.ABYSSEA_MISAREAUX,
+    xi.region.ABYSSEA_VUNKERL,
+    xi.region.ABYSSEA_ALTEPA,
+    xi.region.ABYSSEA_ULEGUERAND,
+    xi.region.ABYSSEA_GRAUBERG,
+    xi.region.ABYSSEA_EMPYREAL_PARADOX,
+}
+
 -----------------------------------
 -- SetExplorerMoogles
 -----------------------------------

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -108,6 +108,7 @@ namespace roeutils
         roeutils::RoeSystem.ImplementedRecords.reset();
         roeutils::RoeSystem.RepeatableRecords.reset();
         roeutils::RoeSystem.RetroactiveRecords.reset();
+        roeutils::RoeSystem.HiddenRecords.reset();
         roeutils::RoeSystem.DailyRecords.reset();
         roeutils::RoeSystem.DailyRecordIDs.clear();
         roeutils::RoeSystem.NotifyThresholds.fill(1);
@@ -147,6 +148,8 @@ namespace roeutils
             {
                 for (auto& flag_entry : flags)
                 {
+                    // TODO: This only runs once on load, so it's okay for now, but it is
+                    //       getting kind of ugly and could probably be improved later.
                     std::string flag = flag_entry.first.as<std::string>();
                     if (flag == "daily")
                     {
@@ -174,6 +177,10 @@ namespace roeutils
                     else if (flag == "retro")
                     {
                         roeutils::RoeSystem.RetroactiveRecords.set(recordID);
+                    }
+                    else if (flag == "hidden")
+                    {
+                        roeutils::RoeSystem.HiddenRecords.set(recordID);
                     }
                     else
                     {

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -273,22 +273,24 @@ namespace roeutils
         return PChar->m_eminenceLog.complete[page] & (1 << bit);
     }
 
-    uint16 GetNumEminenceCompleted(CCharEntity* PChar)
-    {
-        uint16 completedCount = 0;
+    uint16 GetNumEminenceCompleted(CCharEntity* PChar){
+        uint16 completedCount {0};
 
-        for (int page = 0; page < 512; page++)
+        for (uint16 page = 0; page < 512; page++)
         {
-            int pageVal = PChar->m_eminenceLog.complete[page];
-
-            while (pageVal)
+            unsigned long bitIndex {0};
+            uint8 pageVal = PChar->m_eminenceLog.complete[page];
+            // Strip off and check only the set bits - Hidden records are not counted.
+            for ( ; pageVal; completedCount += !RoeSystem.HiddenRecords.test(page * 8 + bitIndex))
             {
-                completedCount += pageVal & 1;
-                pageVal >>= 1;
+                #ifdef _MSC_VER
+                    _BitScanForward(&bitIndex, pageVal);
+                #else
+                    bitIndex = __builtin_ctz(pageVal);
+                #endif
+                pageVal &= (pageVal - 1);
             }
         }
-
-        // TODO: Verify count is accurate.  We don't want to count hidden objectives
 
         return completedCount;
     }

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -281,13 +281,14 @@ namespace roeutils
             unsigned long bitIndex {0};
             uint8 pageVal = PChar->m_eminenceLog.complete[page];
             // Strip off and check only the set bits - Hidden records are not counted.
-            for ( ; pageVal; completedCount += !RoeSystem.HiddenRecords.test(page * 8 + bitIndex))
+            while(pageVal)
             {
                 #ifdef _MSC_VER
                     _BitScanForward(&bitIndex, pageVal);
                 #else
                     bitIndex = __builtin_ctz(pageVal);
                 #endif
+                completedCount += !RoeSystem.HiddenRecords.test(page * 8 + bitIndex);
                 pageVal &= (pageVal - 1);
             }
         }

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -273,7 +273,8 @@ namespace roeutils
         return PChar->m_eminenceLog.complete[page] & (1 << bit);
     }
 
-    uint16 GetNumEminenceCompleted(CCharEntity* PChar){
+    uint16 GetNumEminenceCompleted(CCharEntity* PChar)
+    {
         uint16 completedCount {0};
 
         for (uint16 page = 0; page < 512; page++)

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -86,6 +86,7 @@ struct RoeSystemData
     std::bitset<4096>        ImplementedRecords;
     std::bitset<4096>        RepeatableRecords;
     std::bitset<4096>        RetroactiveRecords;
+    std::bitset<4096>        HiddenRecords;
     std::bitset<4096>        DailyRecords;
     std::vector<uint16>      DailyRecordIDs;
     std::bitset<4096>        WeeklyRecords;


### PR DESCRIPTION
Just some simple fixes.

-Adds missing comments and improves commenting
-Adds one record which was marked TODO
-Performance Optimizes GetNumEminenceCompleted & corrects it to not count hidden record IDs
-Removes old workaround for All For One
-Fixes blue caskets not counting towards Crack Caskets record
-Timed vanquish records now exclude Abyssea areas 

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
