### PR TITLE
Fix Mind Blast multiplier and modifier

### DIFF
--- a/scripts/globals/spells/bluemagic/mind_blast.lua
+++ b/scripts/globals/spells/bluemagic/mind_blast.lua
@@ -26,12 +26,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local params = {}
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.LIGHTNING
-    params.diff = caster:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    params.attribute = xi.mod.INT
+    params.diff = caster:getStat(xi.mod.MND) - target:getStat(xi.mod.MND)
+    params.attribute = xi.mod.MND
     params.skillType = xi.skill.BLUE_MAGIC
     params.bonus = 1.0
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
-    params.multiplier = 7.08
+    params.multiplier = 2.08
     params.tMultiplier = 1.5
     params.duppercap = 69
     params.str_wsc = 0.0


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I noticed the damage seemed off the other day. Fixed a couple mistakes, it should now be retail accurate according to [wiki](https://ffxiclopedia.fandom.com/wiki/Calculating_Blue_Magic_Damage#MND_Modified_Magical_Attack).