### PR TITLE
Additional safety for Crafting and Trading exploit block

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4142,11 +4142,6 @@ void SmallPacket0x085(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    if (!PTarget)
-    {
-        return;
-    }
-
     if (jailutils::InPrison(PChar))
     {
         // Prevent crafting in prison
@@ -4157,6 +4152,10 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     // NOTE: This section is intended to be temporary to ensure that duping shenanigans aren't possible.
     // It should be replaced by something more robust or more stateful as soon as is reasonable
     CCharEntity* PTarget = (CCharEntity*)PChar->GetEntity(PChar->TradePending.targid, TYPE_PC);
+    if (!PTarget)
+    {
+        return;
+    }
 
     // Clear pending trades on synthesis start
     if (PTarget && PChar->TradePending.id == PTarget->id)

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4168,19 +4168,16 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     // trade request.
     if (PChar->UContainer->GetType() != UCONTAINER_EMPTY)
     {
-        if (PTarget)
-        {
-            ShowDebug(CL_CYAN "%s trade request with %s was canceled because %s tried to craft.\n" CL_RESET,
-                  PChar->GetName(), PTarget->GetName(), PChar->GetName());
+        ShowDebug(CL_CYAN "%s trade request with %s was canceled because %s tried to craft.\n" CL_RESET,
+            PChar->GetName(), PTarget->GetName(), PChar->GetName());
 
-            PTarget->TradePending.clean();
-            PTarget->UContainer->Clean();
-            PTarget->pushPacket(new CTradeActionPacket(PChar, 0x01));
-        }
-        PChar->pushPacket(new CMessageStandardPacket(MsgStd::CannotBeProcessed));
+        PTarget->TradePending.clean();
+        PTarget->UContainer->Clean();
+        PTarget->pushPacket(new CTradeActionPacket(PChar, 0x01));
         PChar->TradePending.clean();
         PChar->UContainer->Clean();
         PChar->pushPacket(new CTradeActionPacket(PTarget, 0x01));
+        PChar->pushPacket(new CMessageStandardPacket(MsgStd::CannotBeProcessed));
         return;
     }
     // End temporary additions

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4142,6 +4142,11 @@ void SmallPacket0x085(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
+    if (!PTarget)
+    {
+        return;
+    }
+
     if (jailutils::InPrison(PChar))
     {
         // Prevent crafting in prison

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4158,7 +4158,7 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
     }
 
     // Clear pending trades on synthesis start
-    if (PTarget && PChar->TradePending.id == PTarget->id)
+    if (PChar->TradePending.id == PTarget->id)
     {
         PChar->TradePending.clean();
         PTarget->TradePending.clean();


### PR DESCRIPTION
Let's ensure there's a PTarget well before we end up using it in a message packet later.

Adjustment for exploit prevention first PR'd here: https://github.com/LandSandBoat/server/pull/280

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
