### PR TITLE
[util] Make printing from Lua more robust and useful

### DIFF
--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -37,7 +37,7 @@ enum ENTITYTYPE
     TYPE_PET    = 0x08,
     TYPE_SHIP   = 0x10,
     TYPE_TRUST  = 0x20,
-    TYPE_FELLOW = 0x40
+    TYPE_FELLOW = 0x40,
 };
 
 enum class STATUS_TYPE : uint8
@@ -49,7 +49,7 @@ enum class STATUS_TYPE : uint8
     STATUS_4      = 4,
     CUTSCENE_ONLY = 6,
     STATUS_18     = 18,
-    SHUTDOWN      = 20
+    SHUTDOWN      = 20,
 };
 
 enum ANIMATIONTYPE
@@ -150,7 +150,7 @@ enum UPDATETYPE
     UPDATE_NAME     = 0x08,
     UPDATE_LOOK     = 0x10,
     UPDATE_ALL_MOB  = 0x0F,
-    UPDATE_ALL_CHAR = 0x1F
+    UPDATE_ALL_CHAR = 0x1F,
 };
 
 enum ENTITYFLAGS

--- a/src/map/lua/lua_ability.cpp
+++ b/src/map/lua/lua_ability.cpp
@@ -129,4 +129,10 @@ void CLuaAbility::Register()
     SOL_REGISTER("setRange", CLuaAbility::setRange);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaAbility& ability)
+{
+    std::string id = ability.m_PLuaAbility ? std::to_string(ability.m_PLuaAbility->getID()) : "nullptr";
+    return os << "CLuaAbility(" << id << ")";
+}
+
 //==========================================================//

--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -39,6 +39,8 @@ public:
         return m_PLuaAbility;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaAbility& ability);
+
     uint16 getID();
     int16  getMsg();
     uint16 getRecast();

--- a/src/map/lua/lua_action.cpp
+++ b/src/map/lua/lua_action.cpp
@@ -187,4 +187,10 @@ void CLuaAction::Register()
     SOL_REGISTER("addEffectMessage", CLuaAction::addEffectMessage);
 };
 
+std::ostream& operator<<(std::ostream& os, const CLuaAction& action)
+{
+    std::string id = action.m_PLuaAction ? std::to_string(action.m_PLuaAction->id) : "nullptr";
+    return os << "CLuaAction(" << id << ")";
+}
+
 //==========================================================//

--- a/src/map/lua/lua_action.h
+++ b/src/map/lua/lua_action.h
@@ -39,6 +39,8 @@ public:
         return m_PLuaAction;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaAction& action);
+
     void   ID(uint32 actionTargetID, uint16 newActionTargetID);
     void   setRecast(uint16 recast);
     uint16 getRecast();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13665,4 +13665,67 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getHistory", CLuaBaseEntity::getHistory);
 }
 
+
+std::ostream& operator<<(std::ostream& os, const CLuaBaseEntity& entity)
+{
+    if (entity.m_PBaseEntity != nullptr)
+    {
+        std::string id   = std::to_string(entity.m_PBaseEntity->id);
+        std::string name = entity.m_PBaseEntity->name;
+        std::string type = "";
+        switch (entity.m_PBaseEntity->objtype)
+        {
+            case TYPE_NONE:
+            {
+                type = "TYPE_NONE";
+                break;
+            }
+            case TYPE_PC:
+            {
+                type = "TYPE_PC";
+                break;
+            }
+            case TYPE_NPC:
+            {
+                type = "TYPE_NPC";
+                break;
+            }
+            case TYPE_MOB:
+            {
+                type = "TYPE_MOB";
+                break;
+            }
+            case TYPE_PET:
+            {
+                type = "TYPE_PET";
+                break;
+            }
+            case TYPE_SHIP:
+            {
+                type = "TYPE_SHIP";
+                break;
+            }
+            case TYPE_TRUST:
+            {
+                type = "TYPE_TRUST";
+                break;
+            }
+            case TYPE_FELLOW:
+            {
+                type = "TYPE_FELLOW";
+                break;
+            }
+            default:
+            {
+                type = "UNKNOWN";
+                break;
+            }
+        }
+
+        return os << "CLuaBaseEntity(" << type << " | " << id << " | " << name << ")";
+    }
+
+    return os << "CLuaBaseEntity(nullptr)";
+}
+
 //==========================================================//

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -46,6 +46,8 @@ public:
         return m_PBaseEntity;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaBaseEntity& entity);
+
     // Messaging System
     void showText(CLuaBaseEntity* mob, uint16 messageID, sol::object const& p0, sol::object const& p1, sol::object const& p2, sol::object const& p3); // Displays Dialog for npc
     void messageText(CLuaBaseEntity* PLuaBaseEntity, uint16 messageID, sol::object const& arg2, sol::object const& arg3);

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -278,4 +278,10 @@ void CLuaBattlefield::Register()
     SOL_REGISTER("lose", CLuaBattlefield::lose);
 };
 
+std::ostream& operator<<(std::ostream& os, const CLuaBattlefield& battlefield)
+{
+    std::string id = battlefield.m_PLuaBattlefield ? std::to_string(battlefield.m_PLuaBattlefield->GetID()) : "nullptr";
+    return os << "CLuaBattlefield(" << id << ")";
+}
+
 //==========================================================//

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -40,6 +40,8 @@ public:
         return m_PLuaBattlefield;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaBattlefield& battlefield);
+
     uint16   getID();
     uint8    getArea();
     uint32   getTimeLimit();

--- a/src/map/lua/lua_instance.cpp
+++ b/src/map/lua/lua_instance.cpp
@@ -269,4 +269,10 @@ void CLuaInstance::Register()
     SOL_REGISTER("setLocalVar", CLuaInstance::setLocalVar);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaInstance& instance)
+{
+    std::string id = instance.m_PLuaInstance ? std::to_string(instance.m_PLuaInstance->GetID()) : "nullptr";
+    return os << "CLuaInstance(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_instance.h
+++ b/src/map/lua/lua_instance.h
@@ -41,6 +41,8 @@ public:
         return m_PLuaInstance;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaInstance& instance);
+
     uint8  getID();
     auto   getName() -> std::string;
     auto   getZone() -> CLuaZone;

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -345,4 +345,10 @@ void CLuaItem::Register()
     SOL_REGISTER("getSoulPlateData", CLuaItem::getSoulPlateData);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaItem& item)
+{
+    std::string id = item.m_PLuaItem ? std::to_string(item.m_PLuaItem->getID()) : "nullptr";
+    return os << "CLuaItem(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -38,6 +38,8 @@ public:
         return m_PLuaItem;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaItem& item);
+
     uint16 getID();    // get the item's id
     uint16 getSubID(); // get the item's subid
 

--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -125,4 +125,10 @@ void CLuaMobSkill::Register()
     SOL_REGISTER("getMobHPP", CLuaMobSkill::getMobHPP);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaMobSkill& mobskill)
+{
+    std::string id = mobskill.m_PLuaMobSkill ? std::to_string(mobskill.m_PLuaMobSkill->getID()) : "nullptr";
+    return os << "CLuaMobSkill(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -38,6 +38,9 @@ public:
     {
         return m_PLuaMobSkill;
     }
+
+    friend std::ostream& operator<<(std::ostream& out, const CLuaMobSkill& mobskill);
+
     float  getTP();
     uint8  getMobHPP();
     uint16 getID();

--- a/src/map/lua/lua_region.cpp
+++ b/src/map/lua/lua_region.cpp
@@ -91,4 +91,10 @@ void CLuaRegion::Register()
     SOL_REGISTER("DelCount", CLuaRegion::DelCount);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaRegion& region)
+{
+    std::string id = region.m_PLuaRegion ? std::to_string(region.m_PLuaRegion->GetRegionID()) : "nullptr";
+    return os << "CLuaRegion(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_region.h
+++ b/src/map/lua/lua_region.h
@@ -38,6 +38,8 @@ public:
         return m_PLuaRegion;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaRegion& region);
+
     uint32 GetRegionID();
     int16  GetCount();
     int16  AddCount(int16 count);

--- a/src/map/lua/lua_spell.cpp
+++ b/src/map/lua/lua_spell.cpp
@@ -166,4 +166,10 @@ void CLuaSpell::Register()
     SOL_REGISTER("getCastTime", CLuaSpell::getCastTime);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaSpell& spell)
+{
+    std::string id = spell.m_PLuaSpell ? std::to_string(static_cast<uint16>(spell.m_PLuaSpell->getID())) : "nullptr";
+    return os << "CLuaSpell(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_spell.h
+++ b/src/map/lua/lua_spell.h
@@ -38,6 +38,8 @@ public:
         return m_PLuaSpell;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaSpell& spell);
+
     void   setMsg(uint16 messageID);
     void   setAoE(uint8 aoe);
     void   setFlag(uint8 flags);

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -241,4 +241,10 @@ void CLuaStatusEffect::Register()
     SOL_REGISTER("unsetFlag", CLuaStatusEffect::unsetFlag);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaStatusEffect& effect)
+{
+    std::string id = effect.GetStatusEffect() ? std::to_string(effect.GetStatusEffect()->GetStatusID()) : "nullptr";
+    return os << "CLuaStatusEffect(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -38,6 +38,8 @@ public:
         return m_PLuaStatusEffect;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CStatusEffect& effect);
+
     uint32 getType();
     uint32 getSubType();
     uint16 getPower();

--- a/src/map/lua/lua_trade_container.cpp
+++ b/src/map/lua/lua_trade_container.cpp
@@ -188,4 +188,10 @@ void CLuaTradeContainer::Register()
     SOL_REGISTER("confirmSlot", CLuaTradeContainer::confirmSlot);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaTradeContainer& trade)
+{
+    // TODO: Print out contents of container
+    return os << "CLuaTradeContainer";
+}
+
 //======================================================//

--- a/src/map/lua/lua_trade_container.h
+++ b/src/map/lua/lua_trade_container.h
@@ -38,6 +38,8 @@ public:
         return m_pMyTradeContainer;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CTradeContainer& trade);
+
     uint32 getGil();
     auto   getItem(sol::object const& SlotIDObj) -> std::optional<CLuaItem>;
     uint16 getItemId(sol::object const& SlotIDObj);

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -143,4 +143,10 @@ void CLuaZone::Register()
     SOL_REGISTER("reloadNavmesh", CLuaZone::reloadNavmesh);
 }
 
+std::ostream& operator<<(std::ostream& os, const CLuaZone& zone)
+{
+    std::string id = zone.m_pLuaZone ? std::to_string(zone.m_pLuaZone->GetID()) : "nullptr";
+    return os << "CLuaZone(" << id << ")";
+}
+
 //======================================================//

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -38,6 +38,8 @@ public:
         return m_pLuaZone;
     }
 
+    friend std::ostream& operator<<(std::ostream& out, const CLuaZone& zone);
+
     void        registerRegion(uint32 RegionID, float x1, float y1, float z1, float x2, float y2, float z2);
     sol::object levelRestriction();
     auto        getPlayers() -> sol::table;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -121,8 +121,7 @@ namespace luautils
 
     std::vector<std::string> GetQuestAndMissionFilenamesList();
 
-    template <typename T>
-    void print(T const& item);
+    void print(sol::variadic_args va);
 
     // Cache helpers
     auto getEntityCachedFunction(CBaseEntity* PEntity, std::string funcName) -> sol::function;


### PR DESCRIPTION
NOTE: Sol skips over nil entries in tables. So `print({ 1, 2, nil, 4 })` will print: `table{ 1, 2, 4}`. Can't find away around this 🤷‍♂️ 

```
print(player)
print(target)
print(target)
print("A raw string?")
print({"A string in a table?"})
print(1, 2, 3, 4)
print(nil)
...
[LUA Script] CLuaBaseEntity(TYPE_PC | 2 | Testo)
[LUA Script] CLuaBaseEntity(TYPE_NPC | 17490328 | Grounds_Tome)
[LUA Script] CLuaBaseEntity(TYPE_MOB | 17490085 | Robber_Crab)
...
[LUA Script] A raw string?
[LUA Script] table{ "A string in a table?" }
[LUA Script] 1 2 3 4
[LUA Script] nil
[LUA Script] table{ "nested tables?", table{ 1, 2, 3, table{ CLuaBaseEntity(TYPE_PC | 2 | Testo) } } }
[LUA Script] table{ "nested tables?", table{ 1, 2, 3, table{ CLuaBaseEntity(TYPE_PC | 2 | Testo), CLuaBaseEntity(TYPE_MOB | 17490083 | Robber_Crab) } } }
```

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
