### PR TITLE
Alter language migration script to prevent exception being thrown

### DIFF
--- a/tools/migrations/languages.py
+++ b/tools/migrations/languages.py
@@ -7,9 +7,10 @@ def check_preconditions(cur):
     return
 
 def needs_to_run(cur):
-    cur.execute("SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'chars' AND COLUMN_NAME = 'languages';")
-    row = cur.fetchall()[0][0]
-    return row == "tinyint"
+    cur.execute("SHOW COLUMNS FROM chars LIKE 'languages'")
+    if not cur.fetchone():
+        return True
+    return False
 
 def migrate(cur, db):
     try:


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

NOTE: I'm a db potato, but followed previous migration script logic.