### PR TITLE
Fix typo for Mijin Gakure in JP table

### DIFF
--- a/scripts/globals/jobpoints.lua
+++ b/scripts/globals/jobpoints.lua
@@ -176,7 +176,7 @@ xi.jp = {
     ZANSHIN_EFFECT           = JPCATEGORY_SAM + 0x09, --X zanshin follow-ups p.atk +2
 
     --NIN
-    MIJIN_GAUKURE_EFFECT     = JPCATEGORY_NIN + 0x00, --+ dmg +3%
+    MIJIN_GAKURE_EFFECT      = JPCATEGORY_NIN + 0x00, --+ dmg +3%
     MIKAGE_EFFECT            = JPCATEGORY_NIN + 0x02, --+ p.atk +3
     YONIN_EFFECT             = JPCATEGORY_NIN + 0x01, --+ p.eva +2
     INNIN_EFFECT             = JPCATEGORY_NIN + 0x03, --+ p.acc +1


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #418 