### PR TITLE
Add Logic to Several Trusts

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -20,6 +20,7 @@ ai.target =
     RANGED     = 6,
     CASTER     = 7,
     TOP_ENMITY = 8,
+    PARTY_DEAD = 9,
 }
 ai.t = ai.target
 

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -37,6 +37,7 @@ spell_object.onMobSpawn = function(mob)
     -- TODO: Make Apururu stand back from mob 15' by setting mob_pools behavior to 2
     -- TODO: Setup conditional behaviors for Devotion, Martyr
 
+
     mob:addSimpleGambit(ai.t.SELF, ai.c.MPP_LT, 25, ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT)
 
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -13,12 +13,23 @@ spell_object.onSpellCast = function(caster, target, spell)
     return xi.trust.spawn(caster, spell)
 end
 
+local isWearingHerShirt = function(player)
+    local wearingBody = player:getEquipID(xi.slot.BODY) == 25737 -- Apururu Unity Shirt
+    return wearingBody
+end
+
 spell_object.onMobSpawn = function(mob)
-    xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+    local master = mob:getMaster()
+    if isWearingHerShirt(master) then
+        xi.trust.message(mob, xi.trust.message_offset.TEAMWORK_2)
+    else
+        xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+    end
+    -- Unity ranking high : xi.trust.message(mob, xi.trust.message_offset.TEAMWORK_1)
 
     -- TODO: Nott weaponskill needs implemented and logic added here for Apururu to use at 50% MP at level 50.
     -- TODO: UC trusts are supposed to get bonuses depending on unity ranking. Needs research.
-    -- TODO: Custom spawn messages if Caster wears Apururu Unity Shirt (25737) or if Unity rank is higher.
+    -- TODO: Custom spawn messages if Unity ranking is higher.
     -- TODO: SQL  Change mob pools spell list to 367. Add Curaga V 11 (lvl 91) to spell list.
     -- Remove Slow (56) / Paralyze (58) from list (research needed). Remove Esuna (95). Add Stoneskin (54)
     -- Remove skill_list from mob pools

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -37,7 +37,6 @@ spell_object.onMobSpawn = function(mob)
     -- TODO: Make Apururu stand back from mob 15' by setting mob_pools behavior to 2
     -- TODO: Setup conditional behaviors for Devotion, Martyr
 
-
     mob:addSimpleGambit(ai.t.SELF, ai.c.MPP_LT, 25, ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT)
 
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -22,7 +22,8 @@ spell_object.onMobSpawn = function(mob)
     -- TODO: SQL  Change mob pools spell list to 367. Add Curaga V 11 (lvl 91) to spell list.
     -- Remove Slow (56) / Paralyze (58) from list (research needed). Remove Esuna (95). Add Stoneskin (54)
     -- Remove skill_list from mob pools
-    -- TODO: Make Apururu stand back from mob 15' unless top_enmity.
+    -- TODO: Make Apururu stand back from mob 15' by setting mob_pools behavior to 2
+    -- TODO: Setup conditional behaviors for Devotion, Martyr
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.MPP_LT, 25, ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT)
 

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -15,6 +15,45 @@ end
 
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+
+    -- TODO: Nott weaponskill needs implemented and logic added here for Apururu to use at 50% MP at level 50.
+    -- TODO: UC trusts are supposed to get bonuses depending on unity ranking. Needs research.
+    -- TODO: Custom spawn messages if Caster wears Apururu Unity Shirt (25737) or if Unity rank is higher.
+    -- TODO: SQL  Change mob pools spell list to 367. Add Curaga V 11 (lvl 91) to spell list.
+    -- Remove Slow (56) / Paralyze (58) from list (research needed). Remove Esuna (95). Add Stoneskin (54)
+    -- Remove skill_list from mob pools
+
+    mob:addSimpleGambit(ai.t.SELF, ai.c.MPP_LT, 25, ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURAGA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_II, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURAGA)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.PROTECT, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.PROTECTRA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.SHELL, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.SHELLRA)
+
+    mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.POISON, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.POISONA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.BLINDNESS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.BLINDNA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SILENCE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.SILENA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.PETRIFICATION, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STONA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.DISEASE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.VIRUNA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.CURSE_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+
+    mob:addSimpleGambit(ai.t.SELF, ai.c.STATUS_FLAG, xi.effectFlag.ERASABLE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.ERASE)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS_FLAG, xi.effectFlag.ERASABLE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.ERASE)
+
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.STONESKIN, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STONESKIN)
+
+    -- BGwiki states 75/tick regain.  Only used for Nott WS.
+    mob:addMod(xi.mod.REGAIN, 75)
+
+    mob:SetAutoAttackEnabled(false)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -2,6 +2,7 @@
 -- Trust: Apururu UC
 -----------------------------------
 require("scripts/globals/trust")
+require("scripts/globals/items")
 -----------------------------------
 local spell_object = {}
 
@@ -13,14 +14,14 @@ spell_object.onSpellCast = function(caster, target, spell)
     return xi.trust.spawn(caster, spell)
 end
 
-local isWearingHerShirt = function(player)
-    local wearingBody = player:getEquipID(xi.slot.BODY) == 25737 -- Apururu Unity Shirt
+local isWearingApururuShirt = function(player)
+    local wearingBody = player:getEquipID(xi.slot.BODY) == xi.items.APURURU_SHIRT -- Apururu Unity Shirt
     return wearingBody
 end
 
 spell_object.onMobSpawn = function(mob)
     local master = mob:getMaster()
-    if isWearingHerShirt(master) then
+    if isWearingApururuShirt(master) then
         xi.trust.message(mob, xi.trust.message_offset.TEAMWORK_2)
     else
         xi.trust.message(mob, xi.trust.message_offset.SPAWN)

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -15,7 +15,7 @@ spell_object.onSpellCast = function(caster, target, spell)
 end
 
 local isWearingApururuShirt = function(player)
-    local wearingBody = player:getEquipID(xi.slot.BODY) == xi.items.APURURU_SHIRT -- Apururu Unity Shirt
+    local wearingBody = player:getEquipID(xi.slot.BODY) == xi.items.APURURU_UNITY_SHIRT
     return wearingBody
 end
 

--- a/scripts/globals/spells/trust/apururu_uc.lua
+++ b/scripts/globals/spells/trust/apururu_uc.lua
@@ -22,6 +22,7 @@ spell_object.onMobSpawn = function(mob)
     -- TODO: SQL  Change mob pools spell list to 367. Add Curaga V 11 (lvl 91) to spell list.
     -- Remove Slow (56) / Paralyze (58) from list (research needed). Remove Esuna (95). Add Stoneskin (54)
     -- Remove skill_list from mob pools
+    -- TODO: Make Apururu stand back from mob 15' unless top_enmity.
 
     mob:addSimpleGambit(ai.t.SELF, ai.c.MPP_LT, 25, ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT)
 

--- a/scripts/globals/spells/trust/cherukiki.lua
+++ b/scripts/globals/spells/trust/cherukiki.lua
@@ -14,7 +14,41 @@ spell_object.onSpellCast = function(caster, target, spell)
 end
 
 spell_object.onMobSpawn = function(mob)
-    xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+    xi.trust.teamworkMessage(mob, {
+        [xi.magic.spell.MAKKI_CHEBUKKI] = xi.trust.message_offset.TEAMWORK_1,
+        [xi.magic.spell.KUKKI_CHEBUKKI] = xi.trust.message_offset.TEAMWORK_2,
+        [xi.magic.spell.PRISHE] = xi.trust.message_offset.TEAMWORK_3,
+        [xi.magic.spell.TENZEN] = xi.trust.message_offset.TEAMWORK_4,
+    })
+
+    -- TODO: Research numerous emotes
+    -- TODO: Verify amount of Regen potency, Regen effect
+    -- TODO: Is supposed to path erratically during battle
+    -- TODO: Meteor casting with siblings
+    -- TODO: Any intelligence with casting Silence on mobs?
+    -- TODO: Make Apururu stand back from mob by setting mob_pools behavior to 2
+
+    mob:addSimpleGambit(ai.t.MASTER, ai.c.NOT_STATUS, xi.effect.REGEN, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.REGEN)
+    mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.REGEN, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.REGEN)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spellFamily.CURE)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_II, ai.r.MA, ai.s.SPECIFIC, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.PROTECT, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.PROTECTRA)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.SHELL, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.SHELLRA)
+
+    mob:addSimpleGambit(ai.t.MASTER, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
+    mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
+
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.PARALYZE, 60)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, xi.effect.SLOW, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.SLOW, 60)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, xi.effect.SILENCE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.SILENCE, 60)
+
+    mob:SetAutoAttackEnabled(false)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -16,10 +16,9 @@ end
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
 
-    -- TODO: Research and apply correct amounts of Double Attack and Auto-Refresh. Given some lower base
-    -- values for now.
+    -- TODO: Research and apply correct amount Auto-Refresh. Given some lower base value for now.
     -- TODO: Add Randgrith to skill list.
-    -- TODO: Raise family gambit not being respected. Resolve before merge.
+    -- TODO: Raise family gambit needs to target dead party members. Adjustments elsewhere need to be made.
 
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.CURSE_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
@@ -30,7 +29,8 @@ spell_object.onMobSpawn = function(mob)
 
     mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
 
-    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.KO, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
+    -- Adjust target to appropriate type when he can target the dead.
+    -- mob:addSimpleGambit(ai.t.ISEEDEADPEOPLE, ai.c.STATUS, xi.effect.KO, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
 
     mob:addListener("WEAPONSKILL_USE", "FERREOUS_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
         if wsid == 1198 then -- Randgrith
@@ -39,7 +39,6 @@ spell_object.onMobSpawn = function(mob)
         end
     end)
 
-    mob:addMod(xi.mod.DOUBLE_ATTACK, 5)
     mob:addMod(xi.mod.REFRESH, 1)
 end
 

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -16,9 +16,11 @@ end
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
 
-    -- TODO: Research and apply correct amount Auto-Refresh. Given some lower base value for now.
+    -- TODO: Research and apply correct amounts of Double Attack and Auto-Refresh. Given some lower base
+    -- values for now.
     -- TODO: Add Randgrith to skill list.
-    -- TODO: Raise family gambit needs to target dead party members. Adjustments elsewhere need to be made.
+    -- TODO: Raise family gambit not being respected. Resolve before merge.
+
 
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.CURSE_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -30,7 +30,7 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
 
     -- Adjust target to appropriate type when he can target the dead.
-    -- mob:addSimpleGambit(ai.t.ISEEDEADPEOPLE, ai.c.STATUS, xi.effect.KO, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
+    mob:addSimpleGambit(ai.t.PARTY_DEAD, ai.c.STATUS, xi.effect.KO, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
 
     mob:addListener("WEAPONSKILL_USE", "FERREOUS_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
         if wsid == 1198 then -- Randgrith

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -15,6 +15,32 @@ end
 
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+
+    -- TODO: Research and apply correct amounts of Double Attack and Auto-Refresh. Given some lower base
+    -- values for now.
+    -- TODO: Add Randgrith to skill list.
+    -- TODO: Raise family gambit not being respected. Resolve before merge.
+
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.CURSE_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS_FLAG, xi.effectFlag.ERASABLE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.ERASE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 25, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.MELEE, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.HASTE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.KO, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
+
+    mob:addListener("WEAPONSKILL_USE", "FERREOUS_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
+        if wsid == 1198 then -- Randgrith
+            --  Return to the dust whence you came! Randgrith!!!
+            xi.trust.message(mobArg, xi.trust.message_offset.SPECIAL_MOVE_1)
+        end
+    end)
+
+    mob:addMod(xi.mod.DOUBLE_ATTACK, 5)
+    mob:addMod(xi.mod.REFRESH, 1)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -16,10 +16,9 @@ end
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
 
-    -- TODO: Research and apply correct amounts of Double Attack and Auto-Refresh. Given some lower base
-    -- values for now.
+    -- TODO: Research and apply correct amount Auto-Refresh. Given some lower base value for now.
     -- TODO: Add Randgrith to skill list.
-    -- TODO: Raise family gambit not being respected. Resolve before merge.
+    -- TODO: Raise family gambit needs to target dead party members. Adjustments elsewhere need to be made.
 
 
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)

--- a/scripts/globals/spells/trust/koru-moru.lua
+++ b/scripts/globals/spells/trust/koru-moru.lua
@@ -14,6 +14,8 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
     return xi.trust.canCast(caster, spell)
 end
 
+-- TODO: remove Phalanx 1 from spell list
+
 spell_object.onSpellCast = function(caster, target, spell)
     return xi.trust.spawn(caster, spell)
 end

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -159,6 +159,20 @@ namespace gambits
                 }
                 return result;
             }
+            else if (gambit.predicates[0].target == G_TARGET::PARTY_DEAD)
+            {
+                // Is in combat
+                if (auto* PMob = dynamic_cast<CMobEntity*>(POwner->GetBattleTarget()))
+                {
+                   static_cast<CCharEntity*>(POwner->PMaster)->ForParty([&](CBattleEntity* PMember) {
+                        if (isValidMember(PMember) && CheckTrigger(PMember, predicate) && (PMember->isDead()))
+                            /* Do regular checking, but invert the logic to select dead party members */
+                        {
+                            result = true;
+                        }
+                    });
+                }
+            }
 
             // Fallthrough
             return false;

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -25,6 +25,7 @@ namespace gambits
         RANGED     = 6,
         CASTER     = 7,
         TOP_ENMITY = 8,
+        PARTY_DEAD = 9,
     };
 
     enum class G_CONDITION : uint16

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -91,6 +91,11 @@ void CMobSpellContainer::AddSpell(SpellID spellId)
         // buff
         m_buffList.push_back(spellId);
     }
+    else if (spell->isRaise())
+    {
+        // raise spells from Trust, pixies
+        m_raiseList.push_back(spellId);
+    }
     else
     {
         ShowDebug("Where does this spell go? %d\n", static_cast<uint16>(spellId));
@@ -107,6 +112,7 @@ void CMobSpellContainer::RemoveSpell(SpellID spellId)
     findAndRemove(m_debuffList, spellId);
     findAndRemove(m_healList, spellId);
     findAndRemove(m_naList, spellId);
+    findAndRemove(m_raiseList, spellId);
 
     m_hasSpells = !(m_gaList.empty() && m_damageList.empty() && m_buffList.empty() && m_debuffList.empty() && m_healList.empty() && m_naList.empty());
 }
@@ -150,6 +156,7 @@ std::optional<SpellID> CMobSpellContainer::GetBestAvailable(SPELLFAMILY family)
         searchInList(m_debuffList);
         searchInList(m_healList);
         searchInList(m_naList);
+        searchInList(m_raiseList);
     }
 
     // Assume the highest ID is the best (back of the vector)
@@ -327,6 +334,11 @@ std::optional<SpellID> CMobSpellContainer::GetSpell()
         return GetHealSpell();
     }
 
+    if (HasRaiseSpells())
+    {
+        return GetRaiseSpell();
+    }
+
     // Got no spells to use
     return {};
 }
@@ -374,6 +386,16 @@ std::optional<SpellID> CMobSpellContainer::GetDebuffSpell()
 std::optional<SpellID> CMobSpellContainer::GetHealSpell()
 {
     if (m_PMob->m_EcoSystem == ECOSYSTEM::UNDEAD || m_healList.empty())
+    {
+        return {};
+    }
+
+    return m_healList[xirand::GetRandomNumber(m_healList.size())];
+}
+
+std::optional<SpellID> CMobSpellContainer::GetRaiseSpell()
+{
+    if (m_raiseList.empty())
     {
         return {};
     }
@@ -458,6 +480,11 @@ bool CMobSpellContainer::HasHealSpells() const
 bool CMobSpellContainer::HasNaSpells() const
 {
     return !m_naList.empty();
+}
+
+bool CMobSpellContainer::HasRaiseSpells() const
+{
+    return !m_raiseList.empty();
 }
 
 bool CMobSpellContainer::HasDebuffSpells() const

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -44,6 +44,7 @@ public:
     std::optional<SpellID> GetDebuffSpell();
     std::optional<SpellID> GetHealSpell();   // cures, regen, armys paeon
     std::optional<SpellID> GetNaSpell();     // silena, blindna etc
+    std::optional<SpellID> GetRaiseSpell();  // Raise spells (trusts, pixies)
     std::optional<SpellID> GetSevereSpell(); // select spells like death, impact, meteor
     std::optional<SpellID> GetSpell();       // return a random spell
 
@@ -55,6 +56,7 @@ public:
     bool HasBuffSpells() const;
     bool HasHealSpells() const;
     bool HasNaSpells() const;
+    bool HasRaiseSpells() const;
     bool HasDebuffSpells() const;
     bool HasSevereSpells() const;
 
@@ -72,6 +74,7 @@ public:
     std::vector<SpellID> m_debuffList;
     std::vector<SpellID> m_healList;
     std::vector<SpellID> m_naList;
+    std::vector<SpellID> m_raiseList;
     std::vector<SpellID> m_severeList;
 
 private:

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -176,6 +176,11 @@ bool CSpell::isSevere()
     return m_ID == SpellID::Death || m_ID == SpellID::Impact || m_ID == SpellID::Meteor || m_ID == SpellID::Meteor_II || m_ID == SpellID::Comet;
 }
 
+bool CSpell::isRaise()
+{
+    return m_ID == SpellID::Raise || m_ID == SpellID::Raise_II || m_ID == SpellID::Raise_III;
+}
+
 bool CSpell::canHitShadow()
 {
     return m_ID != SpellID::Meteor_II && canTargetEnemy();

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -1020,6 +1020,7 @@ public:
     bool        isCure();           // is a Cure spell
     bool        isDebuff();         // is a debuff spell
     bool        isNa();             // is a -na spell
+    bool        isRaise();          // is a Raise spell (trusts, pixies)
     bool        canHitShadow();     // check if spell ignores shadows
 
     void setRadius(float radius);


### PR DESCRIPTION
By popular demand from Canaria players, here's an initial pass at Apururu (UC). A few TODOs left at this point, and SQL work can't be submitted until mob tables are greenlit for changes.

EDIT: Expanded to a few more trusts because I was on a roll.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
