### PR TITLE
Refactor xi.teleport.escape to use tabled values

### DIFF
--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -2,6 +2,7 @@
 -- A collection of frequently needed teleport shortcuts.
 -----------------------------------
 require("scripts/globals/settings")
+require("scripts/globals/utils")
 require("scripts/globals/zone")
 
 xi = xi or {}
@@ -338,171 +339,129 @@ end
 -- CAST ESCAPE SPELL
 -----------------------------------
 
+-- TODO: Use Zone Table for FromZone and perhaps ToZone, heck, maybe just move this to one beefy zone table?
+-- TODO: Arrapago Remnants I/II, Zhaylohm Remnants I/II, Everbloom Hollow?, Ruhoyz Silvermines?, The Ashu Talif?
+-- TODO: Abyssea / SOA Areas
+-- MISC Flag in zone_settings will also need +1 or -1 depending on escape possibility.
+local escapeDestinations =
+{
+--  FromZone        X      Y         Z  Rot  ToZone
+    [  9] = {    -427,   -41,     -422,   0, 111 }, -- Pso'Xja to Beaucedine Glacier (E-11)
+    [ 10] = {    -427,   -41,     -422,   0, 111 }, -- The Shrouded Maw to Beaucedine Glacier (E-11)
+    [ 11] = {     448,    -4,      730,  96, 106 }, -- Oldton Movalpolos to North Gustaberg (K-6)
+    [ 12] = {     448,    -4,      730,  96, 106 }, -- Newton Movalpolos to North Gustaberg (K-6)
+    [ 13] = {     448,    -4,      730,  96, 106 }, -- Mine Shaft 2716 to North Gustaberg (K-6)
+    [ 16] = {     332,    24,     -148,  96, 102 }, -- Promyvion-Holla to La Theine Plateau (J-9)
+    [ 17] = {     332,    24,     -148,  96, 102 }, -- Spire of Holla to La Theine Plateau (J-9)
+    [ 18] = {     134,    24,      134,  96, 108 }, -- Promyvion-Dem to Konschtat Highlands (I-7)
+    [ 19] = {     134,    24,      134,  96, 108 }, -- Spire of Dem to Konschtat Highlands (I-7)
+    [ 20] = {     266,    40,      254,  32, 117 }, -- Promyvion-Mea to Tahrongi Canyon (J-6)
+    [ 21] = {     266,    40,      254,  32, 117 }, -- Spire of Mea to Tahrongi Canyon (J-6)
+    [ 22] = {    -331,  -100,      128,  32, 111 }, -- Promyvion-Vahzl to Beaucedine Glacier (F-7)
+    [ 23] = {    -331,  -100,      128,  32, 111 }, -- Spire of Vahzl to Beaucedine Glacier (F-7)
+    [ 27] = {     540,   -16,      265, 160,  25 }, -- Phomiuna Aqueducts to Misareaux Coast (K-7)
+    [ 28] = {      39,   -24,      743,  64,  25 }, -- Sacrarium to Misareaux Coast (H-4)
+    [ 29] = {    -483,   -31,      403, 116,  25 }, -- Riverne - Site #B01 to Misareaux Coast (D-6)
+    [ 30] = {    -483,   -31,      403, 116,  25 }, -- Riverne - Site #A01 to Misareaux Coast (D-6)
+    [ 31] = {    -483,   -31,      403, 116,  25 }, -- Monarch Linn to Misareaux Coast (D-6)
+    [ 34] = {     -23,     0,     -465,  64,  33 }, -- Grand Palace of HuXzoi to Al'Taieu (H-11)
+    [ 35] = {     -23,     0,     -465,  64,  33 }, -- The Garden of RuHmet to Al'Taieu (H-11)
+    [ 36] = {     -23,     0,     -465,  64,  33 }, -- Empyreal Paradox to Al'Taieu (H-11)
+    [ 54] = {  227.36, -17.3,  -60.718,  95,  79 }, -- Arrapago Reef to Caedarva Mire Azouph Isle (I-6)
+    [ 55] = {   9.304,  -7.4,  620.133,   0,  54 }, -- Ilrusi Atoll to Arrapago Reef (G-4)
+    [ 56] = { -252.72,  -7.7,   -30.64, 128,  79 }, -- Periqia to Caedarva Mire (?-??)
+    [ 57] = { -467.08,  7.89, -538.603,   0,  79 }, -- Talacca Cove to Caedarva Mire Azouph Isle (E-9)
+    [ 62] = { 860.994, -15.7,  223.567, 192,  61 }, -- Halvung to Mount Zhayolm (L-7)
+    [ 63] = { 681.950,   -24,  369.936,  64,  61 }, -- Lebros Cavernto Mount Zhayolm (?-??)
+    [ 64] = { -630.15, -17.6,  223.012,   0,  61 }, -- Navukgo Execution Chamber to Mount Zhayolm (C-7)
+    [ 65] = { -459.96, -4.36,  -513.19, 192,  51 }, -- Mamook to Wajaom Woodlands (E-12)
+    [ 66] = { -172.86, -12.3,  -801.02, 128,  52 }, -- Mamool Ja Training Grounds to Bhaflau Thickets (?-??)
+    [ 67] = { -125.76, -12.2,  -499.69, 124,  52 }, -- Jade Sepulcher to Bhaflau Thickets (I-9)
+    [ 68] = {  95.251,   -16,  428.910,  64,  51 }, -- Aydeewa Subterrane to Wajaom Woodlands (I-6)
+    [ 69] = {  495.45, -28.3,  -478.43,  32,  79 }, -- Leujaoam Sanctum to Caedarva Mire (?-??)
+    [ 72] = {  14.186, -29.8,  590.427,   0,  52 }, -- Alzadaal Undersea Ruins to Bhaflau Thickets (F-6)
+    [ 75] = {     620,     0,     -260,  64,  72 }, -- Bhaflau Remnants I/II to Alzadaal Undersea Ruins BR (H-8)
+    [ 76] = {     580,     0,      500, 192,  72 }, -- Silver Sea Remnants I/II to Alzadaal Undersea Ruins SSR (H-8)
+    [ 77] = {     180,     0,       20,   0,  72 }, -- Nyzul Isle Investigation/Uncharted Region to Alzadaal Undersea Ruins (?-??)
+    [ 78] = { -467.08,  7.89, -538.603,   0,  79 }, -- Hazhalm Testing Grounds to Caedarva Mire Azouph Isle (E-9)
+    [ 85] = { -203.58, -7.35,  -494.53,   0,  82 }, -- La Vaule (S) to Jugner Forest (S) (G-12)
+    [ 92] = { 548.199,    25, -341.959, 128,  90 }, -- Beadeaux (S) to Pashhow Marshlands (S) (K-11)
+    [ 99] = { 720.589,   -32,  -81.495, 162,  97 }, -- Castle Oztroja (S) to Meriphataud Mountains (S) (L-8)
+    [138] = {    -414,   -44,       19,   0, 137 }, -- Castle Zvahl Baileys (S) to Xarcabard (S) (G-7)
+    [139] = {    -720,   -61,      600,  64, 100 }, -- Ghelsba Outpost to West Ronfaure (E-4)
+    [140] = {    -720,   -61,      600,  64, 100 }, -- Fort Ghelsba to West Ronfaure (E-4)
+    [141] = {    -720,   -61,      600,  64, 100 }, -- Yughott Grotto to West Ronfaure (E-4)
+    [142] = {    -720,   -61,      600,  64, 100 }, -- Horlais Peak to West Ronfaure (E-4)
+    [143] = {     483,   -31,     1159, 128, 106 }, -- Palborough Mines to North Gustaberg (K-3)
+    [144] = {     483,   -31,     1159, 128, 106 }, -- Waughroon Shrine to North Gustaberg (K-3)
+    [145] = {    -360,   -20,       78, 192, 115 }, -- Giddeus to West Sarutabaruta (F-8)
+    [146] = {    -360,   -20,       78, 192, 115 }, -- Balgas Dais to West Sarutabaruta (F-8)
+    [147] = {     557,    24,     -385, 192, 109 }, -- Beadeaux to Pashhow Marshlands (K-11)
+    [148] = {     557,    24,     -385, 192, 109 }, -- Qulun Dome to Pashhow Marshlands (K-11)
+    [149] = {    -232,    -8,     -562,   0, 104 }, -- Davoi to Jugner Forest (G-12)
+    [150] = {    -232,    -8,     -562,   0, 104 }, -- Monastic Cavern to Jugner Forest (G-12)
+    [151] = {     718,   -31,      -63, 128, 119 }, -- Castle Oztroja to Meriphataud Mountains (L-8)
+    [152] = {     718,   -31,      -63, 128, 119 }, -- Altar Room to Meriphataud Mountains (L-8)
+    [153] = {   509.5,     1,     -575, 128, 121 }, -- The Boyahda Tree to The Sanctuary of Zi'Tah (K-12)
+    [154] = {   509.5,     1,     -575, 128, 121 }, -- Dragon's Aery to The Sanctuary of Zi'Tah (K-12)
+    [155] = {    -414,   -44,       19,   0, 137 }, -- Castle Zvahl Keep (S) to Xarcabard (S) (G-7)
+    [157] = {    -267,   -20,      320,   0, 126 }, -- Middle Delkfutt's Tower to Qufim Island (F-6)
+    [158] = {    -267,   -20,      320,   0, 126 }, -- Upper Delkfutt's Tower to Qufim Island (F-6)
+    [159] = {     298,    -2,     -445, 192, 124 }, -- Temple of Uggalepih to Yhoator Jungle (J-11)
+    [160] = {     298,    -2,     -445, 192, 124 }, -- Den of Rancor to Yhoator Jungle (J-11)
+    [161] = {    -414,   -44,       19,   0, 112 }, -- Castle Zvahl Baileys to Xarcabard (G-7)
+    [162] = {    -414,   -44,       19,   0, 112 }, -- Castle Zvahl Keep to Xarcabard (G-7)
+    [163] = {     298,    -2,     -445, 192, 124 }, -- Sacrificial Chamber to Yhoator Jungle (J-11)
+    [164] = {    -112,   -24,     -403, 192,  98 }, -- Garlaige Citadel (S) to Sauromugue Champaign (S) (H-11)
+    [165] = {    -414,   -44,       19,   0, 112 }, -- Throne Room to Xarcabard (G-7)
+    [166] = {     803,   -61,      635, 128, 101 }, -- Ranguemont Pass to East Ronfaure (K-4)
+    [167] = {    -685,   -30,       18,   0, 100 }, -- Bostaunieux Oubliette to West Ronfaure (F-8)
+    [168] = {     454,   -11,      -35, 128, 114 }, -- Chamber of Oracles to Eastern Altepa Desert (J-8)
+    [169] = {     366,   -13,       92, 128, 116 }, -- Toraimarai Canal to East Sarutabaruta (J-7)
+    [170] = {     366,   -13,       92, 128, 116 }, -- Full Moon Fountain to East Sarutabaruta (J-7)
+    [171] = {    -356,   -24,     -763, 192,  91 }, -- Crawlers' Nest (S) to Rolanberry Field (S) (G-13)
+    [173] = {     -75,    -1,       20,   0, 172 }, -- Korroloka Tunnel to Zeruhn Mines (H-7)
+    [174] = {     -46,     6,      418, 192, 125 }, -- Kuftal Tunnel to Western Altepa Desert (I-5)
+    [175] = { 283.593, 7.999, -403.207, 145,  84 }, -- The Eldieme Necropolis (S) to Batallia Downs (S) (J-10)
+    [176] = {    -627,    16,     -427, 192, 123 }, -- Sea Serpent Grotto to Yuhtunga Jungle (E-11)
+    [177] = {       0,   -35,     -472, 192, 130 }, -- Ve'Lugannon Palace to Ru'Aun Gardens (H-11)
+    [178] = {       0,   -35,     -472, 192, 130 }, -- Shrine of Ru'Avitau to Ru'Aun Gardens (H-11)
+    [179] = {    -267,   -20,      320,   0, 126 }, -- Stellar Fulcrum to Qufim Island (F-6)
+    [180] = {       0,   -35,     -472, 192, 130 }, -- LaLoff Amphitheater to Ru'Aun Gardens (H-11)
+    [181] = {       0,   -35,     -472, 192, 130 }, -- The Celestial Nexus to Ru'Aun Gardens (H-11)
+    [184] = {    -267,   -20,      320,   0, 126 }, -- Lower Delkfutt's Tower to Qufim Island (F-6)
+    [190] = {     203,    -1,     -521, 192, 101 }, -- King Ranperre's Tomb to East Ronfaure (H-11)
+    [191] = {    -564,    38,     -541,   0, 107 }, -- Dangruf Wadi to South Gustaberg (E-9)
+    [192] = {     366,   -13,       92, 128, 116 }, -- Inner Horutoto Ruins to East Sarutabaruta (J-7)
+    [193] = {    -261,    23,      123, 192, 102 }, -- Ordelle's Caves to La Theine Plateau (F-7)
+    [194] = {     366,   -13,       92, 128, 116 }, -- Outer Horutoto Ruins to East Sarutabaruta (J-7)
+    [195] = { 382.398, 7.314, -106.298, 160, 105 }, -- The Eldieme Necropolis to Batallia Downs (F-8)
+    [196] = {     680,    21,      204,  64, 108 }, -- Gusgen Mines to Konschtat Highlands (L-7)
+    [197] = {    -356,   -24,     -763, 192, 110 }, -- Crawlers' Nest to Rolanberry Fields (F-13)
+    [198] = {     446,    46,      481, 128, 117 }, -- Maze of Shakhrami to Tahrongi Canyon (K-5)
+    [200] = {    -112,   -24,     -403, 192, 120 }, -- Garlaige Citadel to Sauromugue Champaign (H-10)
+    [201] = {    -291,    -3,      494,  32, 113 }, -- Cloister of Gales to Cape Teriggan (F-5)
+    [202] = {   509.5,     1,     -575, 128, 121 }, -- Cloister of Storms to The Sanctuary of Zi'Tah (K-12)
+    [203] = {     279,    19,      536,  64, 111 }, -- Cloister of Frost to Beaucedine Glacier (J-5)
+    [204] = {     279,    19,      536,  64, 111 }, -- Fei'Yin to Beaucedine Glacier (J-5)
+    [205] = {      91,    -1,      336,  96, 124 }, -- Ifrit's Cauldron to Yhoator Jungle (I-6)
+    [206] = {     279,    19,      536,  64, 111 }, -- Qu'Bia Arena to Beaucedine Glacier (J-5)
+    [207] = {      91,    -1,      336,  96, 124 }, -- Cloister of Flames to Yhoator Jungle (I-6)
+    [208] = {     454,   -11,      -35, 128, 114 }, -- Quicksand Caves to Eastern Altepa Desert (J-8)
+    [209] = {     454,   -11,      -35, 128, 114 }, -- Cloister of Tremors to Eastern Altepa Desert (J-8)
+    [211] = {     298,    -2,     -445, 192, 124 }, -- Cloister of Tides to Yhoator Jungle (J-11)
+    [212] = {    -791,    -6,       57, 192, 103 }, -- Gustav Tunnel to Valkurm Dunes (B-8)
+    [213] = {     447,    18,      191,  32, 118 }, -- Labyrinth of Onzozo to Buburimu Peninsula (K-6)
+}
+
 xi.teleport.escape = function(player)
     local zone = player:getZoneID()
 
-    -- Ronfaure {R}
-    if zone == 139 or zone == 140 or zone == 141 or zone == 142 then         -- From Ghelsba Outpost, Fort Ghelsba, Yughott Grotto, Horlais Peak
-        player:setPos(-720, -61, 600, 64, 100)                                 -- To West Ronfaure at E-4
-    elseif zone == 167 then                                                 -- From Bostaunieux Oubliette
-        player:setPos(-685, -30, 18, 0, 100)                                     -- To West Ronfaure at F-8
-    elseif zone == 190 then                                                 -- From King Ranperre's Tomb
-        player:setPos(203, -1, -521, 192, 101)                                 -- To East Ronfaure at H-11
-    -- Valdeaunia {R}
-    elseif zone == 162 or zone == 161 or zone == 165 then                     -- From Castle Zvahl Keep, Castle Zvahl Baileys, Throne Room
-        player:setPos(-414, -44, 19, 0, 112)                                     -- To Xarcabard at G-7
-    -- Norvallen {R}
-    elseif zone == 195 then                                                 -- From The Eldieme Necropolis
-        player:setPos(382.398, 7.314, -106.298, 160, 105)                         -- To Batallia Downs at F-8
-    elseif zone == 149 or zone == 150 then                                 -- From Davoi or Monastic Cavern
-        player:setPos(-232, -8, -562, 0, 104)                                     -- To Jugner Forest at G-12
-    -- Fauregandi {R}
-    elseif zone == 166 then                                                 -- From Ranguemont Pass
-        player:setPos(803, -61, 635, 128, 101)                                 -- To East Ronfaure at K-4
-    elseif zone == 9 or zone == 10 then                                    -- From Pso'Xja, The Shrouded Maw
-        player:setPos(-427, -41, -422, 0, 111)                                 -- To Beaucedine Glacier at E-11
-    elseif zone == 204 or zone == 206 or zone == 203 then                     -- From Fei'Yin, Qu'Bia Arena, Cloister of Frost
-        player:setPos(279, 19, 536, 64, 111)                                     -- To Beaucedine Glacier at J-5
-    -- Derfland {R}
-    elseif zone == 197 then                                                 -- From Crawlers' Nest
-        player:setPos(-356, -24, -763, 192, 110)                                 -- To Rolanberry Fields at F-13
-    elseif zone == 148 or zone == 147 then                                 -- From Qulun Dome, Beadeaux
-        player:setPos(557, 24, -385, 192, 109)                                 -- To Pashhow Marshlands at K-11
-    -- Emptiness {R}
-    elseif zone == 16 or zone == 17 then                                    -- From Promyvion-Holla, Spire of Holla
-        player:setPos(332, 24, -148, 96, 102)                                     -- To La Theine Plateau at J-9
-    elseif zone == 18 or zone == 19 then                                    -- From Promyvion-Dem, Spire of Dem
-        player:setPos(134, 24, 134, 96, 108)                                     -- To Konschtat Highlands at I-7
-    elseif zone == 20 or zone == 21 then                                    -- From Promyvion-Mea, Spire of Mea
-        player:setPos(266, 40, 254, 32, 117)                                     -- To Tahrongi Canyon at J-6
-    elseif zone == 22 or zone == 23 then                                    -- From Promyvion-Vahzl, Spire of Vahzl
-        player:setPos(-331, -100, 128, 32, 111)                                 -- To Beaucedine Glacier at F-7
-    -- Qufim Island {R}
-    elseif zone == 157 or zone == 158 or zone == 184 or zone == 179 then     -- From Delkfutt's Tower: Middle, Upper, Lower, Stellar Fulcrum
-        player:setPos(-267, -20, 320, 0, 126)                                     -- To Qufim Island at F-6
-    -- Tu'Lia {R}
-    elseif zone == 177 or zone == 178 or zone == 180 or zone == 181 then    -- From Ve'Lugannon Palace, Shrine of Ru'Avitau, LaLoff Amphitheater, The Celestial Nexus
-        player:setPos(0, -35, -472, 192, 130)                                     -- To Ru'Aun Gardens at H-11
-    -- Li'Telor {R}
-    elseif zone == 153 or zone == 154 or zone == 202 then                     -- From The Boyahda Tree, Dragon's Aery, Cloister of Storms
-        player:setPos(509.5, 1, -575, 128, 121)                                 -- To The Sanctuary of Zi'Tah at K-12
-    -- Aragonau {R}
-    elseif zone == 200 then                                                 -- From Garlaige Citadel
-        player:setPos(-112, -24, -403, 192, 120)                                 -- To Sauromugue Champaign at H-10
-    elseif zone == 152 or zone == 151 then                                 -- From Altar Room, Castle Oztroja
-        player:setPos(718, -31, -63, 128, 119)                                 -- To Meriphataud Mountains at L-8
-    -- Kolshushu {R}
-    elseif zone == 213 then                                                 -- From Labyrinth of Onzozo
-        player:setPos(447, 18, 191, 32, 118)                                     -- To Buburimu Peninsula at K-6
-    elseif zone == 198 then                                                 -- From Maze of Shakhrami
-        player:setPos(446, 46, 481, 128, 117)                                     -- To Tahrongi Canyon at K-5
-    -- Sarutabaruta {R}
-    elseif zone == 169 or zone == 192 or zone == 194 or zone == 170 then     -- From Toraimarai Canal, Inner Horutoto Ruins, Outer Horutoto Ruins, Full Moon Fountain
-        player:setPos(366, -13, 92, 128, 116)                                     -- To East Sarutabaruta at J-7
-    elseif zone == 145 or zone == 146 then                                 -- From Giddeus, Balgas Dais
-        player:setPos(-360, -20, 78, 192, 115)                                 -- To West Sarutabaruta at F-8
-    -- Elshimo Uplands {R}
-    elseif zone == 159 or zone == 160 or zone == 163 or zone == 211 then     -- From Temple of Uggalepih, Den of Rancor, Sacrificial Chamber, Cloister of Tides
-        player:setPos(298, -2, -445, 192, 124)                                 -- To Yhoator Jungle at J-11
-    elseif zone == 205 or zone == 207 then                                                 -- From Ifrit's Cauldron, Cloister of Flames
-        player:setPos(91, -1, 336, 96, 124)                                     -- To Yhoator Jungle at I-6
-    -- Elshimo Lowlands {R}
-    elseif zone == 176 then                                                 -- From Sea Serpent Grotto
-        player:setPos(-627, 16, -427, 192, 123)                                -- To Yuhtunga Jungle at E-11
-    -- Gustaberg {R}
-    elseif zone == 173 then                                                 -- From Korroloka Tunnel
-        player:setPos(-75, -1, 20, 0, 172)                                     -- To Zeruhn Mines at H-7
-    elseif zone == 191 then                                                 -- From Dangruf Wadi
-        player:setPos(-564, 38, -541, 0, 107)                                     -- To South Gustaberg at E-9
-    elseif zone == 143 or zone == 144 then                                    -- From Palborough Mines, Waughroon Shrine
-        player:setPos(483, -31, 1159, 128, 106)                                 -- To North Gustaberg at K-3
-    -- Movalpolos {R}
-    elseif zone == 13 or zone == 12 or zone == 11 then                     -- From Mine Shaft 2716, Newton Movalpolos, Oldton Movalpolos
-        player:setPos(448, -4, 730, 96, 106)                                     -- To North Gustaberg at K-6
-    -- Kuzotz {R}
-    elseif zone == 208 or zone == 168 or zone == 209 then                     -- From Quicksand Caves, Chamber of Oracles, Cloister of Tremors
-        player:setPos(454, -11, -35, 128, 114)                                 -- To Eastern Altepa Desert at J-8
-    -- Vollbow {R}
-    elseif zone == 174 then                                                 -- From Kuftal Tunnel
-        player:setPos(-46, 6, 418, 192, 125)                                     -- To Western Altepa Desert at I-5
-    elseif zone == 212 then                                                 -- From Gustav Tunnel
-        player:setPos(-791, -6, 57, 192, 103)                                     -- To Valkurm Dunes at B-8
-    elseif zone == 201 then                                                -- From Cloister of Gales
-        player:setPos(-291, -3, 494, 32, 113)                                     -- To Cape Teriggan F-5
-    -- Zulkheim {R}
-    elseif zone == 196 then                                                 -- From Gusgen Mines
-        player:setPos(680, 21, 204, 64, 108)                                     -- To Konschtat Highlands at L-7
-    elseif zone == 193 then                                                 -- From Ordelle's Caves
-        player:setPos(-261, 23, 123, 192, 102)                                 -- To La Theine Plateau at F-7
-    -- Tavnazian Archipelago {R}
-    elseif zone == 27 then                                                 -- From Phomiuna Aqueducts
-        player:setPos(540, -16, 265, 160, 25)                                     -- To Misareaux Coast at K-7
-    elseif zone == 28 then                                                 -- From Sacrarium
-        player:setPos(39, -24, 743, 64, 25)                                     -- To Misareaux Coast at H-4
-    elseif zone == 29 or zone == 30 or zone == 31 then                        -- From Riverne - Site B01, Riverne - Site A01, Monarch Linn
-        player:setPos(-483, -31, 403, 116, 25)                                 -- To Misareaux Coast at D-6
-    -- Mamool Ja Savagelands {R}
-    elseif zone == 65 then                                                 -- From Mamook
-        player:setPos(-459.961, -4.357, -513.191, 192, 51)                     -- To Wajaom Woodlands at E-12
-    elseif zone == 66 then                                                    -- From Mamool Ja Training Grounds
-        player:setPos(-172.863, -12.25, -801.021, 128, 52)                 -- Bhaflau Thickets
-    elseif zone == 67 then                                                 -- From Jade Sepulcher
-        player:setPos(-125.762, -12.226, -499.689, 124, 52)                     -- To Bhaflau Thickets at I-9
-    elseif zone == 68 then                                                 -- From Aydeewa Subterrane
-        player:setPos(95.251, -16.04, 428.910, 64, 51)                         -- To Wajaom Woodlands at I-6
-    -- Halvung Territory {R}
-    elseif zone == 62 then                                                 -- From Halvung
-        player:setPos(860.994, -15.675, 223.567, 192, 61)                         -- To Mount Zhayolm at L-7
-    elseif zone == 63 then                                                    -- From Lebros Cavern
-        player:setPos(681.950, -24, 369.936, 64, 61)                        -- To Mount Zhayolm
-    elseif zone == 64 then                                                 -- From Navukgo Execution Chamber
-        player:setPos(-630.146, -17.643, 223.012, 0, 61)                         -- To Mount Zhayolm at C-7
-    -- Arrapago Islands {R}
-    elseif zone == 54 then                                                 -- From Arrapago Reef
-        player:setPos(227.36, -17.276, -60.718, 95, 79)                         -- To Caedarva Mire Azouph Isle at I-6
-    elseif zone == 55 then                                                 -- From Ilrusi Atoll
-        player:setPos(9.304, -7.376, 620.133, 0, 54)                             -- To Arrapago Reef G-4
-    elseif zone == 56 then                                                    -- From Periqia
-        player:setPos(-252.715, -7.666, -30.64, 128, 79)                    -- To Caedarva Mire
-    elseif zone == 57 or zone == 78 then                                     -- From Talacca Cove, Hazhalm Testing Grounds
-        player:setPos(-467.077, 7.89, -538.603, 0, 79)                         -- To Caedarva Mire Azouph Isle at E-9
-    elseif zone == 69 then                                                    -- From Leujaoam Sanctum
-        player:setPos(495.450, -28.25, -478.430, 32, 79)                    -- To Caedarva Mire
-    -- Ruins of Alzadaal {R}
-    elseif zone == 72 then                                                 -- From Alzadaal Undersea Ruins
-        player:setPos(14.186, -29.789, 590.427, 0, 52)                         -- To Bhaflau Thickets at F-6
-    elseif zone == 75 then                                                    -- From Bhaflau Remnants I/II
-        player:setPos(620, 0, -260, 64, 72)                                     -- To Alzadaal Undersea Ruins BR H-8
-    elseif zone == 76 then                                                 -- From Silver Sea Remnants I/II
-        player:setPos(580, 0, 500, 192, 72)                                     -- To Alzadaal Undersea Ruins SSR H-8
-    elseif zone == 77 then                                                    -- From Nyzul Isle Investigation/Uncharted Region
-        player:setPos(180, 0, 20, 0, 72)                                         -- To Alzadaal Undersea Ruins
-    -- Lumoria {R}
-    elseif zone == 34 or zone == 35 or zone == 36 then                        -- From Grand Palace of HuXzoi or The Garden of RuHmet or Empyreal Paradox
-        player:setPos(-23, 0, -465, 64, 33)                                    -- To Al'Taieu (H-11)
-    -- The Aragoneu Front {R}
-    elseif zone == 99 then                                                 -- From Castle Oztroja (S)
-        player:setPos(720.589, -31.999, -81.495, 162, 97)                         -- To Meriphataud Mountains (S) at L-8
-    elseif zone == 164 then                                                 -- From Garlaige Citadel (S)
-        player:setPos(-112, -24, -403, 192, 98)                                 -- To Sauromugue Champaign (S) at H-11
-    -- The Derfland Front {R}
-    elseif zone == 92 then                                                 -- From Beadeaux (S)
-        player:setPos(548.199, 24.999, -341.959, 128, 90)                         -- To Pashhow Marshlands (S) at K-11
-    elseif zone == 171 then                                                 -- From Crawlers' Nest (S)
-        player:setPos(-356, -24, -763, 192, 91)                                 -- To Rolanberry Field (S) G-13
-    -- The Valdeaunia Front {R}
-    elseif zone == 155 or zone == 138 then                                 -- Fromn Castle Zvahl Keep (S), Castle Zvahl Baileys (S)
-        player:setPos(-414, -44, 19, 0, 137)                                     -- To Xarcabard (S) at G-7
-    -- The Norvallen Front {R}
-    elseif zone == 85 then                                                 -- From La Vaule (S)
-        player:setPos(-203.576, -7.351, -494.53, 0, 82)                         -- To Jugner Forest (S) at G-12
-    elseif zone == 175 then                                                 -- From The Eldieme Necropolis (S)
-        player:setPos(283.593, 7.999, -403.207, 145, 84)                         -- To Batallia Downs (S) J-10
+    if utils.hasKey(zone, escapeDestinations) then
+        player:setPos(unpack(escapeDestinations[zone]))
+    else
+        printf("WARNING: xi.teleport.escape received undefined escapeDestinations zone (%d)", zone)
     end
-
-    -- TODO: Arrapago Remnants I/II, Zhaylohm Remnants I/II, Everbloom Hollow?, Ruhoyz Silvermines?, The Ashu Talif?
-    -- TODO: Abyssea / SOA Areas
-    -- MISC Flag in zone_settings will also need +1 or -1 depending on escape possibility.
 end
 
 -----------------------------------

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -401,6 +401,16 @@ function utils.contains(value, collection)
     return false
 end
 
+function utils.hasKey(keyVal, collection)
+    for k, _ in pairs(collection) do
+        if k == keyVal then
+            return true
+        end
+    end
+
+    return false
+end
+
 -- Selects a random entry from a table, returns the index and the entry
 -- https://gist.github.com/jdev6/1e7ff30671edf88d03d4
 function utils.randomEntry(t)

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -391,6 +391,9 @@ function utils.prequire(...)
     end
 end
 
+-- Checks to see if a specific value is contained in a table.  This is often
+-- used for tables that do not define specific indices.
+-- See: Sigil NPCs
 function utils.contains(value, collection)
     for _, v in collection do
         if value == v then
@@ -401,6 +404,9 @@ function utils.contains(value, collection)
     return false
 end
 
+-- Checks to see if a specific key is contained in the table.  This is used by
+-- tables that contain specific indices that may be non-sequential.
+-- See: xi.teleport.escape
 function utils.hasKey(keyVal, collection)
     for k, _ in pairs(collection) do
         if k == keyVal then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Complexity 107 to 7 lines of code in the function :)