### PR TITLE
Update Curio Moogle Shops

### DIFF
--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -425,7 +425,6 @@ xi.shop =
                 4112,     300,      xi.ki.RHAPSODY_IN_WHITE,   -- Potion
                 4116,     600,      xi.ki.RHAPSODY_IN_UMBER,   -- Hi-Potion
                 4120,    1200,    xi.ki.RHAPSODY_IN_CRIMSON,   -- X-Potion
-                4128,     650,      xi.ki.RHAPSODY_IN_WHITE,   -- Ether
                 4132,    1300,      xi.ki.RHAPSODY_IN_UMBER,   -- Hi-Ether
                 4136,    3000,    xi.ki.RHAPSODY_IN_CRIMSON,   -- Super Ether
                 4145,   15000,      xi.ki.RHAPSODY_IN_AZURE,   -- Elixir
@@ -508,7 +507,6 @@ xi.shop =
                 4376,     120,      xi.ki.RHAPSODY_IN_WHITE,   -- Meat Jerky
                 4371,     184,      xi.ki.RHAPSODY_IN_WHITE,   -- Grilled Hare
                 4381,     720,      xi.ki.RHAPSODY_IN_UMBER,   -- Meat Mithkabob
-                4456,     550,      xi.ki.RHAPSODY_IN_WHITE,   -- Boiled Crab
                 4398,    1080,      xi.ki.RHAPSODY_IN_UMBER,   -- Fish Mithkabob
                 5166,    1500,      xi.ki.RHAPSODY_IN_WHITE,   -- Coeurl Sub
                 4538,     900,      xi.ki.RHAPSODY_IN_WHITE,   -- Roast Pipira

--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -425,6 +425,7 @@ xi.shop =
                 4112,     300,      xi.ki.RHAPSODY_IN_WHITE,   -- Potion
                 4116,     600,      xi.ki.RHAPSODY_IN_UMBER,   -- Hi-Potion
                 4120,    1200,    xi.ki.RHAPSODY_IN_CRIMSON,   -- X-Potion
+                -- 4128,     650,      xi.ki.RHAPSODY_IN_WHITE,   -- Ether / Temporarily(?) removed by SE June 2021
                 4132,    1300,      xi.ki.RHAPSODY_IN_UMBER,   -- Hi-Ether
                 4136,    3000,    xi.ki.RHAPSODY_IN_CRIMSON,   -- Super Ether
                 4145,   15000,      xi.ki.RHAPSODY_IN_AZURE,   -- Elixir
@@ -507,6 +508,7 @@ xi.shop =
                 4376,     120,      xi.ki.RHAPSODY_IN_WHITE,   -- Meat Jerky
                 4371,     184,      xi.ki.RHAPSODY_IN_WHITE,   -- Grilled Hare
                 4381,     720,      xi.ki.RHAPSODY_IN_UMBER,   -- Meat Mithkabob
+                -- 4456,     550,      xi.ki.RHAPSODY_IN_WHITE,   -- Boiled Crab / Temporarily(?) removed by SE June 2021
                 4398,    1080,      xi.ki.RHAPSODY_IN_UMBER,   -- Fish Mithkabob
                 5166,    1500,      xi.ki.RHAPSODY_IN_WHITE,   -- Coeurl Sub
                 4538,     900,      xi.ki.RHAPSODY_IN_WHITE,   -- Roast Pipira


### PR DESCRIPTION
SE recently removed some items due to an issue with players printing gil. We have two of them implemented with RoV progress so far. They may address the issue later and put these back up on Curio Moogles, they may not. For now, it's probably better to adjust this while someone remembers it.

http://www.playonline.com/ff11us/polnews/news26469.shtml

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [o] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
