### PR TITLE
Add Kilusha Events and Shop

### DIFF
--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -128,6 +128,7 @@ local function CharCreate(player)
     player:setCharVar("spokeKindlix", 1) -- Kindlix introduction
     player:setCharVar("spokePyropox", 1) -- Pyropox introduction
     player:setCharVar("TutorialProgress", 1) -- Has not started tutorial
+    player:setCharVar("EinherjarIntro", 1) -- Has not seen Einherjar intro
     player:setNewPlayer(true) -- apply new player flag
 end
 

--- a/scripts/zones/Nashmau/npcs/Kilusha.lua
+++ b/scripts/zones/Nashmau/npcs/Kilusha.lua
@@ -53,7 +53,7 @@ entity.onTrigger = function(player, npc)
     else
         player:startEvent(24, lampCost, 856, 3, reentryTime, 10, 135, allowValkyrieBuying, ichor)
         player:setLocalVar("reentryTime", reentryTime)
-	end
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
@@ -65,7 +65,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if csid == 23 then
         player:setCharVar("EinherjarIntro", 0) -- deletes CharVar set at character creation
-	elseif csid == 24 and option ~= 1073741824 and option ~= 0 then
+    elseif csid == 24 and option ~= 1073741824 and option ~= 0 then
         local kilushaItems = {
             [1] = {item = xi.items.ANIMATOR_P1, cost = 15000},
             [2] = {item = xi.items.ASLAN_CAPE, cost = 15000},
@@ -91,17 +91,17 @@ entity.onEventFinish = function(player, csid, option)
             [22] = {item = xi.items.VALKYRIES_TEAR, cost = 1000},
             [23] = {item = xi.items.VALKYRIES_WING, cost = 2000},
             [24] = {item = xi.items.VALKYRIES_SOUL, cost = 3000},
-            }
+        }
 
         local row = kilushaItems[option]
 
         if player:getFreeSlotsCount() ~= 0 and player:getCurrency("therion_ichor") >= row.cost then
             npcUtil.giveItem(player, row.item)
-			player:delCurrency("therion_ichor", row.cost)
-		else
-			player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, row.item)
-		end
-	end
+            player:delCurrency("therion_ichor", row.cost)
+        else
+            player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, row.item)
+        end
+    end
 end
 
 return entity

--- a/scripts/zones/Nashmau/npcs/Kilusha.lua
+++ b/scripts/zones/Nashmau/npcs/Kilusha.lua
@@ -1,21 +1,107 @@
 -----------------------------------
 -- Area: Nashmau
 --  NPC: Kilusha
--- Standard Info NPC
+-- Einherjar-related NPC, Smoldering Glass, Therion Ichor items
+-- !pos 0.373 -6.667 14.712 53
 -----------------------------------
+local ID = require("scripts/zones/Nashmau/IDs")
+require("scripts/globals/items")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/npc_util")
+-----------------------------------
+
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
+    local lampCost = 60000 -- base cost without RHAPSODY_IN_AZURE key item
+
+    if player:hasKeyItem(xi.ki.RHAPSODY_IN_AZURE) then
+        lampCost = 1000
+    end
+
+    if npcUtil.tradeHasExactly(trade, {{"gil", lampCost}}) and player:getCharVar("EinherjarIntro") ~= 1 then
+        if npcUtil.giveItem(player, xi.items.SMOLDERING_LAMP) then
+            player:tradeComplete()
+            player:startEvent(25)
+        else
+            player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, xi.items.SMOLDERING_LAMP)
+        end
+    end
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(22)
+    local ichor = player:getCurrency("therion_ichor")
+    local allowValkyrieBuying = 29360128 -- set this to 0 if you wish to allow players to buy feather key items without KI
+    local lampCost = 60000 -- base cost without RHAPSODY_IN_AZURE key item
+    local reentryTime = 20 -- in hours
+    local toau = player:hasCompletedMission(xi.mission.log_id.TOAU, xi.mission.id.toau.IMMORTAL_SENTRIES)
+
+    if player:hasKeyItem(xi.ki.RHAPSODY_IN_AZURE) then
+        lampCost = 1000
+        reentryTime = 1
+    end
+
+    if player:hasKeyItem(xi.ki.MARK_OF_THE_EINHERJAR) then -- June 2012 update added Valkyrie items
+        allowValkyrieBuying = 0
+    end
+
+    if player:getMainLvl() <= 59 or not toau then
+        player:startEvent(22) -- worthless CS
+    elseif (player:getMainLvl() >= 60 or toau) and player:getCharVar("EinherjarIntro") == 1 then
+        player:startEvent(23, lampCost, 856, 3, 616, 10, 172, 172, 0) -- Einherjar introduction
+    else
+        player:startEvent(24, lampCost, 856, 3, reentryTime, 10, 135, allowValkyrieBuying, ichor)
+        player:setLocalVar("reentryTime", reentryTime)
+	end
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    if csid == 24 and option == 6 then -- about Entry Conditions
+        player:updateEvent(53,10,3,player:getLocalVar("reentryTime"),10,231,xi.items.SMOLDERING_LAMP,xi.items.GLOWING_LAMP)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 23 then
+        player:setCharVar("EinherjarIntro", 0) -- deletes CharVar set at character creation
+	elseif csid == 24 and option ~= 1073741824 and option ~= 0 then
+        local kilushaItems = {
+            [1] = {item = xi.items.ANIMATOR_P1, cost = 15000},
+            [2] = {item = xi.items.ASLAN_CAPE, cost = 15000},
+            [3] = {item = xi.items.GLEEMANS_CAPE, cost = 15000},
+            [4] = {item = xi.items.RITTER_GORGET, cost = 15000},
+            [5] = {item = xi.items.KUBIRA_BEAD_NECKLACE, cost = 15000},
+            [6] = {item = xi.items.MORGANAS_CHOKER, cost = 15000},
+            [7] = {item = xi.items.BUCANEERS_BELT, cost = 15000},
+            [8] = {item = xi.items.IOTA_RING, cost = 15000},
+            [9] = {item = xi.items.OMEGA_RING, cost = 15000},
+            [10] = {item = xi.items.DELT_RING, cost = 15000},
+            [11] = {item = xi.items.RUBBER_CAP, cost = 5000},
+            [12] = {item = xi.items.RUBBER_HARNESS, cost = 5000},
+            [13] = {item = xi.items.RUBBER_GLOVES, cost = 5000},
+            [14] = {item = xi.items.RUBBER_CHAUSSES, cost = 5000},
+            [15] = {item = xi.items.RUBBER_SOLES, cost = 5000},
+            [16] = {item = xi.items.NETHEREYE_CHAIN, cost = 5000},
+            [17] = {item = xi.items.NETHERFIELD_CHAIN, cost = 5000},
+            [18] = {item = xi.items.NETHERSPIRIT_CHAIN, cost = 5000},
+            [19] = {item = xi.items.NETHERCANT_CHAIN, cost = 5000},
+            [20] = {item = xi.items.NETHERPACT_CHAIN, cost = 5000},
+            [21] = {item = xi.items.BALRAHNS_EYEPATCH, cost = 100000},
+            [22] = {item = xi.items.VALKYRIES_TEAR, cost = 1000},
+            [23] = {item = xi.items.VALKYRIES_WING, cost = 2000},
+            [24] = {item = xi.items.VALKYRIES_SOUL, cost = 3000},
+            }
+
+        local row = kilushaItems[option]
+
+        if player:getFreeSlotsCount() ~= 0 and player:getCurrency("therion_ichor") >= row.cost then
+            npcUtil.giveItem(player, row.item)
+			player:delCurrency("therion_ichor", row.cost)
+		else
+			player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, row.item)
+		end
+	end
 end
 
 return entity


### PR DESCRIPTION
Kilusha is the Einherjar introductory NPC as well as your dealer in Smoldering Glasses and Therion Ichor items. NPC is all setup for later RoV KI adjustments once players have access to it. Requirements for the introduction CS has been personally verified on retail using multiple characters. Included comments that may help enable a module or era servers to make appropriate adjustments.

https://www.bg-wiki.com/ffxi/Kilusha
https://ffxiclopedia.fandom.com/wiki/Kilusha

Had discussed with @TeoTwawki how to handle the introduction CS and it was decided setting a CharVar on character creation was the best way. Current server operators will either need to add that CharVar to characters or it will have to be handled with dbtool somehow for them.

This requires items global update from PR #435 , currently pending merger.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
