### PR TITLE
Quick fix Kf'ghrah

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_BLM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_BLM.lua
@@ -12,6 +12,10 @@ entity.onMobSpawn = function(mob)
     mob:setAnimationSub(0)
     mob:setLocalVar("roamTime", os.time())
     mob:setModelId(1168) -- Dark
+
+    -- Todo: confirm this is legit and move to mob_reistances table if so
+    mob:addmob(xi.mod.LIGHT_RES, -100)
+    mob:addmob(xi.mod.DARK_RES, 100)
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_WHM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Kfghrah_WHM.lua
@@ -12,6 +12,10 @@ entity.onMobSpawn = function(mob)
     mob:setAnimationSub(0)
     mob:setLocalVar("roamTime", os.time())
     mob:setModelId(1167) -- light
+
+    -- Todo: confirm this is legit and move to mob_reistances table if so
+    mob:addmob(xi.mod.LIGHT_RES, 100)
+    mob:addmob(xi.mod.DARK_RES, -100)
 end
 
 entity.onMobRoam = function(mob)

--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -164,10 +164,6 @@ INSERT INTO `mob_spawn_mods` VALUES (16814432,168,2,0);
 INSERT INTO `mob_spawn_mods` VALUES (16814432,29,33,0);
 INSERT INTO `mob_spawn_mods` VALUES (16921015,387,-95,0); -- Jailer of Fortitude -95% phys damage mods
 INSERT INTO `mob_spawn_mods` VALUES (16921015,390,-95,0);
-INSERT INTO `mob_spawn_mods` VALUES (16921016,60,100,0); -- Kf'ghrah res mods
-INSERT INTO `mob_spawn_mods` VALUES (16921016,61,-100,0);
-INSERT INTO `mob_spawn_mods` VALUES (16921017,60,-100,0);
-INSERT INTO `mob_spawn_mods` VALUES (16921017,61,100,0);
 INSERT INTO `mob_spawn_mods` VALUES (16912838,407,150,0); -- Jailer of Hope fastcast, -ga chance, 2hr/2hr multi
 INSERT INTO `mob_spawn_mods` VALUES (16912838,7,60,1);
 INSERT INTO `mob_spawn_mods` VALUES (16916815,55,300,1);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits


Seems to be the only monsters that had their resist modifiers set in `mob_spawn_mods`. I also checked `mob_family_mods` and `mob_pool_mods` tables. Wiki's don't even mention resist, but presumably the Ghrahs "orb" in it determines its element resistances, and these 2 don't qualify for a mixin because they are static?