### PR TITLE
Cleanup Leftover Old Mods After SDT Changes

### DIFF
--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -212,13 +212,13 @@ function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, actio
     if not wsParams.formless then
         --finaldmg = target:physicalDmgTaken(finaldmg, attack.damageType)
         if (attack.weaponType == xi.skill.HAND_TO_HAND) then
-            finaldmg = finaldmg * target:getMod(xi.mod.HTHRES) / 1000
+            finaldmg = finaldmg * target:getMod(xi.mod.HTH_SDT) / 1000
         elseif (attack.weaponType == xi.skill.DAGGER or attack.weaponType == xi.skill.POLEARM) then
-            finaldmg = finaldmg * target:getMod(xi.mod.PIERCERES) / 1000
+            finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
         elseif (attack.weaponType == xi.skill.CLUB or attack.weaponType == xi.skill.STAFF) then
-            finaldmg = finaldmg * target:getMod(xi.mod.IMPACTRES) / 1000
+            finaldmg = finaldmg * target:getMod(xi.mod.IMPACT_SDT) / 1000
         else
-            finaldmg = finaldmg * target:getMod(xi.mod.SLASHRES) / 1000
+            finaldmg = finaldmg * target:getMod(xi.mod.SLASH_SDT) / 1000
         end
     end
 
@@ -286,7 +286,7 @@ function doAutoRangedWeaponskill(attacker, target, wsID, wsParams, tp, primaryMs
 
     -- Calculate reductions
     finaldmg = target:rangedDmgTaken(finaldmg)
-    finaldmg = finaldmg * target:getMod(xi.mod.PIERCERES) / 1000
+    finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
 
     finaldmg = finaldmg * WEAPON_SKILL_POWER -- Add server bonus
     calcParams.finalDmg = finaldmg

--- a/scripts/globals/items/excalibur.lua
+++ b/scripts/globals/items/excalibur.lua
@@ -16,7 +16,7 @@ item_object.onAdditionalEffect = function(player, target, damage)
         local finalDMG = math.floor(player.getHP(player) / 4)
         if finalDMG > 0 then
             local damageType = player:getWeaponDamageType(xi.slot.MAIN)
-            local physicalResist = target:getMod(xi.mod.SLASHRES) / 1000
+            local physicalResist = target:getMod(xi.mod.SLASH_SDT) / 1000
             finalDMG = finalDMG * physicalResist
             finalDMG = target:physicalDmgTaken(finalDMG, damageType)
             finalDMG = finalDMG - target:getMod(xi.mod.PHALANX)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -380,13 +380,13 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
         adjustedDamage = target:physicalDmgTaken(adjustedDamage, attackTbl.damageType)
 
         if attackTbl.weaponType == xi.skill.HAND_TO_HAND then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.HTHRES) / 1000
+            adjustedDamage = adjustedDamage * target:getMod(xi.mod.HTH_SDT) / 1000
         elseif attackTbl.weaponType == xi.skill.DAGGER or attackTbl.weaponType == xi.skill.POLEARM then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.PIERCERES) / 1000
+            adjustedDamage = adjustedDamage * target:getMod(xi.mod.PIERCE_SDT) / 1000
         elseif attackTbl.weaponType == xi.skill.CLUB or attackTbl.weaponType == xi.skill.STAFF then
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACTRES) / 1000
+            adjustedDamage = adjustedDamage * target:getMod(xi.mod.IMPACT_SDT) / 1000
         else
-            adjustedDamage = adjustedDamage * target:getMod(xi.mod.SLASHRES) / 1000
+            adjustedDamage = adjustedDamage * target:getMod(xi.mod.SLASH_SDT) / 1000
         end
     end
 
@@ -727,7 +727,7 @@ end
 
     -- Calculate reductions
     finaldmg = target:rangedDmgTaken(finaldmg)
-    finaldmg = finaldmg * target:getMod(xi.mod.PIERCERES) / 1000
+    finaldmg = finaldmg * target:getMod(xi.mod.PIERCE_SDT) / 1000
 
     finaldmg = finaldmg * WEAPON_SKILL_POWER -- Add server bonus
     calcParams.finalDmg = finaldmg

--- a/scripts/zones/Apollyon/mobs/Adamantshell.lua
+++ b/scripts/zones/Apollyon/mobs/Adamantshell.lua
@@ -68,8 +68,8 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.SLASHRES, 0)
-    mob:setMod(xi.mod.PIERCERES, 1500)
+    mob:setMod(xi.mod.SLASH_SDT, 0)
+    mob:setMod(xi.mod.PIERCE_SDT, 1500)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)

--- a/scripts/zones/Apollyon/mobs/Ghost_Clot.lua
+++ b/scripts/zones/Apollyon/mobs/Ghost_Clot.lua
@@ -8,9 +8,9 @@ local ID = require("scripts/zones/Apollyon/IDs")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.SLASHRES, 1500)
-    mob:setMod(xi.mod.HTHRES, 0)
-    mob:setMod(xi.mod.IMPACTRES, 0)
+    mob:setMod(xi.mod.SLASH_SDT, 1500)
+    mob:setMod(xi.mod.HTH_SDT, 0)
+    mob:setMod(xi.mod.IMPACT_SDT, 0)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)

--- a/scripts/zones/Apollyon/mobs/Grave_Digger.lua
+++ b/scripts/zones/Apollyon/mobs/Grave_Digger.lua
@@ -8,9 +8,9 @@ local ID = require("scripts/zones/Apollyon/IDs")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.HTHRES, 1500)
-    mob:setMod(xi.mod.IMPACTRES, 1500)
-    mob:setMod(xi.mod.PIERCERES, 0)
+    mob:setMod(xi.mod.HTH_SDT, 1500)
+    mob:setMod(xi.mod.IMPACT_SDT, 1500)
+    mob:setMod(xi.mod.PIERCE_SDT, 0)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)

--- a/scripts/zones/Apollyon/mobs/Inhumer.lua
+++ b/scripts/zones/Apollyon/mobs/Inhumer.lua
@@ -65,9 +65,9 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.HTHRES, 1500)
-    mob:setMod(xi.mod.IMPACTRES, 1500)
-    mob:setMod(xi.mod.PIERCERES, 0)
+    mob:setMod(xi.mod.HTH_SDT, 1500)
+    mob:setMod(xi.mod.IMPACT_SDT, 1500)
+    mob:setMod(xi.mod.PIERCE_SDT, 0)
 end
 
 entity.onMobEngaged = function(mob, target)

--- a/scripts/zones/Apollyon/mobs/Metalloid_Amoeba.lua
+++ b/scripts/zones/Apollyon/mobs/Metalloid_Amoeba.lua
@@ -7,9 +7,9 @@ local ID = require("scripts/zones/Apollyon/IDs")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.SLASHRES, 1500)
-    mob:setMod(xi.mod.HTHRES, 0)
-    mob:setMod(xi.mod.IMPACTRES, 0)
+    mob:setMod(xi.mod.SLASH_SDT, 1500)
+    mob:setMod(xi.mod.HTH_SDT, 0)
+    mob:setMod(xi.mod.IMPACT_SDT, 0)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)

--- a/scripts/zones/Apollyon/mobs/Tieholtsodi.lua
+++ b/scripts/zones/Apollyon/mobs/Tieholtsodi.lua
@@ -27,8 +27,8 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.SLASHRES, 0)
-    mob:setMod(xi.mod.PIERCERES, 1500)
+    mob:setMod(xi.mod.SLASH_SDT, 0)
+    mob:setMod(xi.mod.PIERCE_SDT, 1500)
     xi.mix.jobSpecial.config(mob, {
         specials =
         {

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
@@ -8,10 +8,10 @@ require("scripts/globals/missions")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if (mob:getMod(xi.mod.SLASHRES)) then mob:setMod(xi.mod.SLASHRES, 1000); end
-    if (mob:getMod(xi.mod.PIERCERES)) then mob:setMod(xi.mod.PIERCERES, 1000); end
-    if (mob:getMod(xi.mod.IMPACTRES)) then mob:setMod(xi.mod.IMPACTRES, 1000); end
-    if (mob:getMod(xi.mod.HTHRES)) then mob:setMod(xi.mod.HTHRES, 1000); end
+    if (mob:getMod(xi.mod.SLASH_SDT)) then mob:setMod(xi.mod.SLASH_SDT, 1000); end
+    if (mob:getMod(xi.mod.PIERCE_SDT)) then mob:setMod(xi.mod.PIERCE_SDT, 1000); end
+    if (mob:getMod(xi.mod.IMPACT_SDT)) then mob:setMod(xi.mod.IMPACT_SDT, 1000); end
+    if (mob:getMod(xi.mod.HTH_SDT)) then mob:setMod(xi.mod.HTH_SDT, 1000); end
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -16,10 +16,10 @@ entity.onMobSpawn = function(mob)
     -- Change animation to pot
     mob:setAnimationSub(0)
     -- Set the damage resists
-    mob:setMod(xi.mod.HTHRES, 1000)
-    mob:setMod(xi.mod.SLASHRES, 0)
-    mob:setMod(xi.mod.PIERCERES, 0)
-    mob:setMod(xi.mod.IMPACTRES, 1000)
+    mob:setMod(xi.mod.HTH_SDT, 1000)
+    mob:setMod(xi.mod.SLASH_SDT, 0)
+    mob:setMod(xi.mod.PIERCE_SDT, 0)
+    mob:setMod(xi.mod.IMPACT_SDT, 1000)
     -- Set the magic resists. It always takes no damage from direct magic
     for n =1, #xi.magic.resistMod, 1 do
         mob:setMod(xi.magic.resistMod[n], 0)
@@ -41,16 +41,16 @@ entity.onMobFight = function(mob)
 
         -- We changed to Poles. Make it only take piercing.
         if (aniChange == 2) then
-            mob:setMod(xi.mod.HTHRES, 0)
-            mob:setMod(xi.mod.SLASHRES, 0)
-            mob:setMod(xi.mod.PIERCERES, 1000)
-            mob:setMod(xi.mod.IMPACTRES, 0)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 1000)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         else -- We changed to Rings. Make it only take slashing.
-            mob:setMod(xi.mod.HTHRES, 0)
-            mob:setMod(xi.mod.SLASHRES, 1000)
-            mob:setMod(xi.mod.PIERCERES, 0)
-            mob:setMod(xi.mod.IMPACTRES, 0)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 1000)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         end
     -- We're in poles, but changing
@@ -60,17 +60,17 @@ entity.onMobFight = function(mob)
         -- Changing to Pot, only take Blunt damage
         if (aniChange == 0) then
             mob:setAnimationSub(0)
-            mob:setMod(xi.mod.HTHRES, 1000)
-            mob:setMod(xi.mod.SLASHRES, 0)
-            mob:setMod(xi.mod.PIERCERES, 0)
-            mob:setMod(xi.mod.IMPACTRES, 1000)
+            mob:setMod(xi.mod.HTH_SDT, 1000)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 1000)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         else -- Going to Rings, only take slashing
             mob:setAnimationSub(3)
-            mob:setMod(xi.mod.HTHRES, 0)
-            mob:setMod(xi.mod.SLASHRES, 1000)
-            mob:setMod(xi.mod.PIERCERES, 0)
-            mob:setMod(xi.mod.IMPACTRES, 0)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 1000)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         end
     -- We're in rings, but going to change to pot or poles
@@ -80,16 +80,16 @@ entity.onMobFight = function(mob)
 
         -- We're changing to pot form, only take blunt damage.
         if (aniChange == 0 or aniChange == 1) then
-            mob:setMod(xi.mod.HTHRES, 1000)
-            mob:setMod(xi.mod.SLASHRES, 0)
-            mob:setMod(xi.mod.PIERCERES, 0)
-            mob:setMod(xi.mod.IMPACTRES, 1000)
+            mob:setMod(xi.mod.HTH_SDT, 1000)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 0)
+            mob:setMod(xi.mod.IMPACT_SDT, 1000)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         else -- Changing to poles, only take piercing
-            mob:setMod(xi.mod.HTHRES, 0)
-            mob:setMod(xi.mod.SLASHRES, 0)
-            mob:setMod(xi.mod.PIERCERES, 1000)
-            mob:setMod(xi.mod.IMPACTRES, 0)
+            mob:setMod(xi.mod.HTH_SDT, 0)
+            mob:setMod(xi.mod.SLASH_SDT, 0)
+            mob:setMod(xi.mod.PIERCE_SDT, 1000)
+            mob:setMod(xi.mod.IMPACT_SDT, 0)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         end
     end

--- a/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
+++ b/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
@@ -12,15 +12,15 @@ entity.onMobEngaged = function(mob, target)
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+7):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+8):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+9):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+10):isDead()
     then
-        mob:setMod(xi.mod.SLASHRES, 1400)
-        mob:setMod(xi.mod.PIERCERES, 1400)
-        mob:setMod(xi.mod.IMPACTRES, 1400)
-        mob:setMod(xi.mod.HTHRES, 1400)
+        mob:setMod(xi.mod.SLASH_SDT, 1400)
+        mob:setMod(xi.mod.PIERCE_SDT, 1400)
+        mob:setMod(xi.mod.IMPACT_SDT, 1400)
+        mob:setMod(xi.mod.HTH_SDT, 1400)
     else
-        mob:setMod(xi.mod.SLASHRES, 300)
-        mob:setMod(xi.mod.PIERCERES, 300)
-        mob:setMod(xi.mod.IMPACTRES, 300)
-        mob:setMod(xi.mod.HTHRES, 300)
+        mob:setMod(xi.mod.SLASH_SDT, 300)
+        mob:setMod(xi.mod.PIERCE_SDT, 300)
+        mob:setMod(xi.mod.IMPACT_SDT, 300)
+        mob:setMod(xi.mod.HTH_SDT, 300)
     end
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]+1):updateEnmity(target)
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]+2):updateEnmity(target)

--- a/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
+++ b/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
@@ -12,15 +12,15 @@ entity.onMobEngaged = function(mob, target)
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+14):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+15):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+16):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+17):isDead()
     then
-        mob:setMod(xi.mod.SLASHRES, 1400)
-        mob:setMod(xi.mod.PIERCERES, 1400)
-        mob:setMod(xi.mod.IMPACTRES, 1400)
-        mob:setMod(xi.mod.HTHRES, 1400)
+        mob:setMod(xi.mod.SLASH_SDT, 1400)
+        mob:setMod(xi.mod.PIERCE_SDT, 1400)
+        mob:setMod(xi.mod.IMPACT_SDT, 1400)
+        mob:setMod(xi.mod.HTH_SDT, 1400)
     else
-        mob:setMod(xi.mod.SLASHRES, 300)
-        mob:setMod(xi.mod.PIERCERES, 300)
-        mob:setMod(xi.mod.IMPACTRES, 300)
-        mob:setMod(xi.mod.HTHRES, 300)
+        mob:setMod(xi.mod.SLASH_SDT, 300)
+        mob:setMod(xi.mod.PIERCE_SDT, 300)
+        mob:setMod(xi.mod.IMPACT_SDT, 300)
+        mob:setMod(xi.mod.HTH_SDT, 300)
     end
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]):updateEnmity(target)
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]+2):updateEnmity(target)

--- a/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
+++ b/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
@@ -12,15 +12,15 @@ entity.onMobEngaged = function(mob, target)
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+20):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+21):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3]+22):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3]+23):isDead()
     then
-        mob:setMod(xi.mod.SLASHRES, 1400)
-        mob:setMod(xi.mod.PIERCERES, 1400)
-        mob:setMod(xi.mod.IMPACTRES, 1400)
-        mob:setMod(xi.mod.HTHRES, 1400)
+        mob:setMod(xi.mod.SLASH_SDT, 1400)
+        mob:setMod(xi.mod.PIERCE_SDT, 1400)
+        mob:setMod(xi.mod.IMPACT_SDT, 1400)
+        mob:setMod(xi.mod.HTH_SDT, 1400)
     else
-        mob:setMod(xi.mod.SLASHRES, 300)
-        mob:setMod(xi.mod.PIERCERES, 300)
-        mob:setMod(xi.mod.IMPACTRES, 300)
-        mob:setMod(xi.mod.HTHRES, 300)
+        mob:setMod(xi.mod.SLASH_SDT, 300)
+        mob:setMod(xi.mod.PIERCE_SDT, 300)
+        mob:setMod(xi.mod.IMPACT_SDT, 300)
+        mob:setMod(xi.mod.HTH_SDT, 300)
     end
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]):updateEnmity(target)
     GetMobByID(ID.mob.TEMENOS_C_MOB[3]+1):updateEnmity(target)

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
@@ -31,10 +31,10 @@ entity.onMobFight = function(mob)
         -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
         -- Make everything do double
         if (mob:getAnimationSub() == 2) then
-            mob:setMod(xi.mod.HTHRES, 2000)
-            mob:setMod(xi.mod.SLASHRES, 2000)
-            mob:setMod(xi.mod.PIERCERES, 2000)
-            mob:setMod(xi.mod.IMPACTRES, 2000)
+            mob:setMod(xi.mod.HTH_SDT, 2000)
+            mob:setMod(xi.mod.SLASH_SDT, 2000)
+            mob:setMod(xi.mod.PIERCE_SDT, 2000)
+            mob:setMod(xi.mod.IMPACT_SDT, 2000)
             for n =1, #xi.magic.resistMod, 1 do
                 mob:setMod(xi.magic.resistMod[n], 2000)
             end
@@ -42,10 +42,10 @@ entity.onMobFight = function(mob)
                 mob:setMod(xi.magic.specificDmgTakenMod[n], -1000)
             end
         else -- Reset all damage types
-            mob:setMod(xi.mod.HTHRES, 1000)
-            mob:setMod(xi.mod.SLASHRES, 1000)
-            mob:setMod(xi.mod.PIERCERES, 1000)
-            mob:setMod(xi.mod.IMPACTRES, 1000)
+            mob:setMod(xi.mod.HTH_SDT, 1000)
+            mob:setMod(xi.mod.SLASH_SDT, 1000)
+            mob:setMod(xi.mod.PIERCE_SDT, 1000)
+            mob:setMod(xi.mod.IMPACT_SDT, 1000)
             for n =1, #xi.magic.resistMod, 1 do
                 mob:setMod(xi.magic.resistMod[n], 1000)
             end


### PR DESCRIPTION
A handful of leftover old RES mods didn't make the conversion in the big SDT change in PR #428  . A quick Replace in Files to clean up what was found.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [o] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
