### PR TITLE
Fix Typo in Windy 5-1

### DIFF
--- a/scripts/missions/windurst/5_1_The_Final_Seal.lua
+++ b/scripts/missions/windurst/5_1_The_Final_Seal.lua
@@ -121,7 +121,7 @@ mission.sections =
             return currentMission == mission.missionId
         end,
 
-        [xi.zone.CHATEAU_DORAGUILLE] =
+        [xi.zone.HEAVENS_TOWER] =
         {
             ['_6q2'] =
             {


### PR DESCRIPTION
Fixed zone typo. fixes #448 

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
