### PR TITLE
[tooling] Update tooling docs, build in option to run valgrind suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,9 @@ ip.txt
 
 # Tracy download
 ext/tracy/
+
+# Valgrind
+*.memcheck.log
+*.callgrind.log
+callgrind.out.*
+memcheck.out.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CompilerWarnings)
 include(Sanitizers)
 include(ClangFormat)
 include(Tracy)
+include(Valgrind)
 
 # CMake adds "/W3" by default on MSVC, remove it.
 # Fixed with CMake 3.15

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,4 +1,4 @@
-# Enable on command-line with 'cmake -DENABLE_CLANG_TIDY=ON ..'
+# Enable these jobs on command-line with 'cmake -DENABLE_CLANG_TIDY=ON ..'
 
 option(ENABLE_CLANG_TIDY "Run clang-tidy with the compiler." OFF)
 option(ENABLE_CLANG_TIDY_AUTO_FIX "Allow clang-tidy to automatically apply fixes to problems." OFF)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,3 +1,5 @@
+# Set your build to use these sanitizers by configuring with 'cmake -DCMAKE_BUILD_TYPE=UBSAN ..' etc.
+
 # Build Types
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
         CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel TSAN ASAN LSAN MSAN UBSAN"

--- a/cmake/Valgrind.cmake
+++ b/cmake/Valgrind.cmake
@@ -1,0 +1,34 @@
+# Enable these jobs on command-line with 'cmake -DENABLE_VALGRIND=ON ..'
+
+option(ENABLE_VALGRIND "Run the server with Valgrind." OFF)
+message(STATUS "ENABLE_VALGRIND: ${ENABLE_VALGRIND}")
+
+if(ENABLE_VALGRIND)
+  find_program(VALGRIND_COMMAND NAMES valgrind)
+  message(STATUS "VALGRIND_COMMAND: ${VALGRIND_COMMAND}")
+  if(NOT VALGRIND_COMMAND)
+    message(FATAL_ERROR "ENABLE_VALGRIND is ON but valgrind is not found!")
+  endif()
+
+  add_custom_target(
+    valgrind_memcheck_topaz_game
+    COMMAND ${VALGRIND_COMMAND} --tool=memcheck --leak-check=full --show-reachable=yes
+          --undef-value-errors=yes --track-origins=no --child-silent-after-fork=no
+          --trace-children=no
+          --log-file=${CMAKE_SOURCE_DIR}/topaz_game.memcheck.log
+          ./topaz_game
+    COMMENT "Writing memcheck log to: ${CMAKE_SOURCE_DIR}/topaz_game.memcheck.log"
+    DEPENDS topaz_game
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+
+  add_custom_target(
+          valgrind_callgrind_topaz_game
+          COMMAND ${VALGRIND_COMMAND} --tool=callgrind
+          --log-file=${CMAKE_SOURCE_DIR}/topaz_game.callgrind.log
+          ./topaz_game
+          COMMENT "Writing callgrind log to: ${CMAKE_SOURCE_DIR}/topaz_game.callgrind.log"
+          DEPENDS topaz_game
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+endif(ENABLE_VALGRIND)


### PR DESCRIPTION
Not super needed, but a nice option for anyone who cares

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
