### PR TITLE
Refactor East Ronfaure, East Sarutabaruta Signposts and Misc Cleanup

### DIFF
--- a/scripts/missions/sandoria/4_1_Magicite.lua
+++ b/scripts/missions/sandoria/4_1_Magicite.lua
@@ -124,7 +124,7 @@ mission.sections =
                     player:delKeyItem(xi.ki.MAGICITE_ORASTONE)
 
                     if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                        npcUtil.giveCurrency(player, "gil", GIL_RATE * 20000)
+                        npcUtil.giveCurrency(player, "gil", 20000)
                     else
                         npcUtil.giveKeyItem(player, xi.ki.AIRSHIP_PASS)
                     end

--- a/scripts/missions/windurst/4_1_Magicite.lua
+++ b/scripts/missions/windurst/4_1_Magicite.lua
@@ -124,7 +124,7 @@ mission.sections =
                     player:delKeyItem(xi.ki.MAGICITE_ORASTONE)
 
                     if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                        npcUtil.giveCurrency(player, "gil", GIL_RATE * 20000)
+                        npcUtil.giveCurrency(player, "gil", 20000)
                     else
                         npcUtil.giveKeyItem(player, xi.ki.AIRSHIP_PASS)
                     end

--- a/scripts/quests/tutorial.lua
+++ b/scripts/quests/tutorial.lua
@@ -114,7 +114,7 @@ xi.tutorial.onEventFinish = function(player, csid, option, npc_event_offset, nat
         player:addExp(800 * EXP_RATE)
         player:setCharVar("TutorialProgress", 10)
     elseif csid == (npc_event_offset + 14) then
-        npcUtil.giveCurrency(player, 'gil', 1000 * GIL_RATE)
+        npcUtil.giveCurrency(player, 'gil', 1000)
         player:setCharVar("TutorialProgress", 11)
     elseif csid == (npc_event_offset + 16) then
         if npcUtil.giveItem(player, {{xi.items.FREE_CHOCOPASS, 3}}) then

--- a/scripts/zones/East_Ronfaure/npcs/Signpost.lua
+++ b/scripts/zones/East_Ronfaure/npcs/Signpost.lua
@@ -6,49 +6,68 @@
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 local ID = require("scripts/zones/East_Ronfaure/IDs")
 -----------------------------------
 local entity = {}
+
+-- TODO: These really should be split out into unique NPCs, as this handles all
+-- signposts in East Ronfaure.
+local signPostPositions =
+{
+-- Event      xMin,  xMax,   zMin,   zMax
+    [ 3] = { 434.9, 446.9,  136.4,  148.4 },
+    [ 5] = { 251.6, 263.6,  207.7,  219.7 },
+    [ 7] = { 652.2, 664.2,  299.5,  311.5 },
+    [ 9] = { 459.2, 471.2, -179.4, -167.4 },
+    [11] = {   532,   544, -390.2, -378.2 },
+    [13] = { 273.1, 285.1, -263.6, -251.6 },
+    [15] = { 290.5, 302.5, -463.1, -451.1 },
+    [17] = { 225.1, 237.1,   56.6,   68.6 },
+}
+
+-- This same function is used in other signposts as well, though making this
+-- a global would encourage more things like this instead of splitting NPCs.
+local function isNpcInBounds(npcXpos, npcZpos, signPostTable)
+    if
+        npcXpos > signPostTable[1] and
+        npcXpos < signPostTable[2] and
+        npcZpos > signPostTable[3] and
+        npcZpos < signPostTable[4]
+    then
+        return true
+    end
+
+    return false
+end
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local xPos = npc:getXPos()
+    local zPos = npc:getZPos()
 
-    local X = player:getXPos()
-    local Z = player:getZPos()
-
-    if ((X > 251.6 and X < 263.6) and (Z < 219.7 and Z > 207.7)) then
-        if (player:hasKeyItem(xi.ki.SCROLL_OF_TREASURE) == true) then
-            player:startEvent(20)
-            player:delKeyItem(xi.ki.SCROLL_OF_TREASURE)
-            player:addGil(GIL_RATE*3000)
-            player:messageSpecial(ID.text.GIL_OBTAINED, GIL_RATE*3000)
-        else
-            player:startEvent(5)
+    for eventID, signPost in pairs(signPostPositions) do
+        if isNpcInBounds(xPos, zPos, signPost) then
+            if eventID == 5 and player:hasKeyItem(xi.ki.SCROLL_OF_TREASURE) then
+                -- Event for 'To Cure a Cough' reward
+                player:startEvent(20)
+            else
+                player:startEvent(eventID)
+            end
         end
-    elseif ((X > 434.9 and X < 446.9) and (Z < 148.4 and Z > 136.4)) then
-        player:startEvent(3)
-    elseif ((X > 652.2 and X < 664.2) and (Z < 311.5 and Z > 299.5)) then
-        player:startEvent(7)
-    elseif ((X > 459.2 and X < 471.2) and (Z < -167.4 and Z > -179.4)) then
-        player:startEvent(9)
-    elseif ((X > 532 and X < 544) and (Z < -378.2 and Z > -390.2)) then
-        player:startEvent(11)
-    elseif ((X > 273.1 and X < 285.1) and (Z < -251.6 and Z > -263.6)) then
-        player:startEvent(13)
-    elseif ((X > 290.5 and X < 302.5) and (Z < -451.1 and Z > -463.1)) then
-        player:startEvent(15)
-    elseif ((X > 225.1 and X < 237.1) and (Z < 68.6 and Z > 56.6)) then
-        player:startEvent(17)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 20 then
+        player:delKeyItem(xi.ki.SCROLL_OF_TREASURE)
+        npcUtil.giveCurrency(player, "gil", 3000)
+    end
 end
 
 return entity

--- a/scripts/zones/East_Sarutabaruta/npcs/Signpost.lua
+++ b/scripts/zones/East_Sarutabaruta/npcs/Signpost.lua
@@ -6,34 +6,50 @@ local ID = require("scripts/zones/East_Sarutabaruta/IDs")
 -----------------------------------
 local entity = {}
 
+-- TODO: These really should be split out into unique NPCs, as this handles all
+-- signposts in East Sarutabaruta.
+local signPostPositions =
+{
+-- Offset     xMin,   xMax,    zMin,    zMax
+    [0] = {   83.9,   96.7,  -352.6,  -339.8 },
+    [1] = {  191.5,  204.3, -277.13, -265.03 },
+    [2] = {  212.9,    225,   -37.7,   -24.8 },
+    [3] = {   -0.4,   12.6,   -54.9,   -42.9 },
+    [4] = { -135.3, -122.3,  -67.14,  -55.04 },
+    [5] = {  -80.5,  -67.4,   442.7,   454.8 },
+    [6] = {  144.1,  157.1,   374.6,   386.7 },
+    [7] = {  -94.9,  -82.9,  -292.4,  -279.5 },
+    [8] = {  -55.8,  -43.8,  -133.5,  -120.5 },
+}
+
+-- This same function is used in other signposts as well, though making this
+-- a global would encourage more things like this instead of splitting NPCs.
+local function isNpcInBounds(npcXpos, npcZpos, signPostTable)
+    if
+        npcXpos > signPostTable[1] and
+        npcXpos < signPostTable[2] and
+        npcZpos > signPostTable[3] and
+        npcZpos < signPostTable[4]
+    then
+        return true
+    end
+
+    return false
+end
+
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local xPos = npc:getXPos()
+    local zPos = npc:getZPos()
 
-    local X = player:getXPos()
-    local Z = player:getZPos()
 
-    if ((X > 83.9 and X < 96.7) and (Z < -339.8 and Z > -352.6)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET)
-    elseif ((X > 191.5 and X < 204.3) and (Z < -265.03 and Z > -277.13)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+1)
-    elseif ((X > 212.9 and X < 225) and (Z < -24.8 and Z > -37.7)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+2)
-    elseif ((X > -0.4 and X < 12.6) and (Z < -42.9 and Z > -54.9)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+3)
-    elseif ((X > -135.3 and X < -122.3) and (Z < -55.04 and Z > -67.14)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+4)
-    elseif ((X > -80.5 and X < -67.4) and (Z < 454.8 and Z > 442.7)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+5)
-    elseif ((X > 144.1 and X < 157.1) and (Z < 386.7 and Z > 374.6)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+6)
-    elseif ((X > -94.9 and X < -82.9) and (Z < -279.5 and Z > -292.4)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+7)
-    elseif ((X > -55.8 and X < -43.8) and (Z < -120.5 and Z > -133.5)) then
-        player:messageSpecial(ID.text.SIGNPOST_OFFSET+8)
+    for offsetValue, signPost in pairs(signPostPositions) do
+        if isNpcInBounds(xPos, zPos, signPost) then
+            player:messageSpecial(ID.text.SIGNPOST_OFFSET + offsetValue)
+        end
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -2,7 +2,7 @@
 -- Area: Port Jeuno
 --  NPC: Shami
 -- Orb Seller (BCNM)
--- !pos -14 8 44 246
+-- !pos -53.9 0 10.8 246
 -----------------------------------
 local ID = require("scripts/zones/Port_Jeuno/IDs")
 require("scripts/globals/settings")


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Refactors Signposts to use tabled data to verify position.  This is a stopgap measure, as one day these should be separated into individual NPCs (Comments added to the scripts)
* Updates Shami's !pos in comments
* Removes a few cases where GIL_RATE was being applied twice (at parameter, since npcUtil.giveCurrency() applies that rate for gil already.