### PR TITLE
Add distance check to Phomiuna ladders and use tabled position data

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/IDs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/IDs.lua
@@ -19,6 +19,7 @@ zones[xi.zone.PHOMIUNA_AQUEDUCTS] =
         LOGIN_CAMPAIGN_UNDERWAY = 7001, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!<space>
         LOGIN_NUMBER            = 7002, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         CONQUEST_BASE           = 7050, -- Tallying conquest results...
+        CANNOT_REACH_LADDER     = 7211, -- You cannot reach the ladder from here.
         DOOR_SEALED_SHUT        = 7212, -- The door above you is sealed shut.
         DOOR_LOCKED             = 7214, -- The door is locked.  You might be able to open it with <item>.
         LAMP_OFFSET             = 7220, -- A symbol for fire is engraved on the base of the lamp...

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
@@ -67,7 +67,7 @@ entity.onTrigger = function(player, npc)
 
     for eventID, ladder in pairs(ladderPositions) do
         if isNpcInBounds(xPos, yPos, zPos, ladder) then
-            if distanceToLadder >= 1.8 then
+            if distanceToLadder >= 1.95 then
                 player:messageSpecial(ID.text.CANNOT_REACH_LADDER)
             elseif
                 eventID == 28 and

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
@@ -19,52 +19,78 @@ local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
 -----------------------------------
 local entity = {}
 
+-- Ladder positions which have events associated with them.  There is one
+-- ladder that only displays a message, which is marked as 99.  This is
+-- a placeholder to detect that.
+local ladderPositions =
+{
+-- Event        xMin,    xMax,  yMin, yMax,   zMin,  zMax
+    [21] = {    95.9,   107.9,    -1,    1, -108.9,   -98 },
+    [22] = {    95.9,   107.9,    -1,    1,    -24,   -12 },
+    [23] = { -67.888, -55.888,    -1,    1,    -24,   -12 },
+    [24] = {  -224.1,  -212.1,    -1,    1,     12,    24 },
+    [25] = {   -67.9,   -55.9,    -1,    1,    132,   144 },
+    [26] = {    15.9,    27.9,    -1,    1,    132,   144 },
+    [27] = {    95.9,   107.9,    -1,    1,  175.9, 187.9 },
+    [28] = {  -168.3,  -153.3,    -2,    0,     54,    66 },
+    [29] = {  -168.3,  -153.3,   -24,  -22,     54,    66 },
+    [30] = {   193.3,   205.3,    -2,    0,     54,    66 },
+    [31] = {   193.3,   205.3,   -24,  -22,     54,    66 },
+    [99] = {  -206.6,  -194.6,    -8,   -6,     54,    66 },
+}
+
+-- This same function is used in other signposts as well, though making this
+-- a global would encourage more things like this instead of splitting NPCs.
+local function isNpcInBounds(npcXpos, npcYpos, npcZpos, ladderTable)
+    if
+        npcXpos >= ladderTable[1] and
+        npcXpos <= ladderTable[2] and
+        npcYpos >= ladderTable[3] and
+        npcYpos <= ladderTable[4] and
+        npcZpos >= ladderTable[5] and
+        npcZpos <= ladderTable[6]
+    then
+        return true
+    end
+
+    return false
+end
+
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local xPos = player:getXPos()
+    local yPos = player:getYPos()
+    local zPos = player:getZPos()
+    local distanceToLadder = player:checkDistance(npc)
 
-    local X = player:getXPos()
-    local Y = player:getYPos()
-    local Z = player:getZPos()
-
-    if ((X <= 107.9 and X >= 95.9) and (Y >= -1 and Y <= 1) and (Z >= -108.9 and Z <= -98)) then
-        player:startEvent(21)
-    elseif ((X <= 107.9 and X >= 95.9) and (Y >= -1 and Y <= 1) and (Z >= -24 and Z <= -12)) then
-        player:startEvent(22)
-    elseif ((X <= -55.888 and X >= -67.888) and (Y >= -1 and Y <= 1) and (Z >= -24 and Z <= -12)) then
-        player:startEvent(23)
-    elseif ((X <= -212.1 and X >= -224.1) and (Y >= -1 and Y <= 1) and (Z >= 12 and Z <= 24)) then
-        player:startEvent(24)
-    elseif ((X <= -55.9 and X >= -67.9) and (Y >= -1 and Y <= 1) and (Z >= 132 and Z <= 144)) then
-        player:startEvent(25)
-    elseif ((X <= 27.9 and X >= 15.9) and (Y >= -1 and Y <= 1) and (Z >= 132 and Z <= 144)) then
-        player:startEvent(26)
-    elseif ((X <= 107.9 and X >= 95.9) and (Y >= -1 and Y <= 1) and (Z >= 175.9 and Z <= 187.9)) then
-        player:startEvent(27)
-    elseif ((X <= -153.3 and X >= -168.3) and (Y >= -2 and Y <= 0) and (Z >= 54 and Z <= 66)) then
-        if (player:getCurrentMission(COP) == xi.mission.id.cop.DISTANT_BELIEFS and player:getCharVar("PromathiaStatus") == 1) then
-            player:setCharVar("PromathiaStatus", 2)
-            player:startEvent(35)
-        else
-            player:startEvent(28)
+    for eventID, ladder in pairs(ladderPositions) do
+        if isNpcInBounds(xPos, yPos, zPos, ladder) then
+            if distanceToLadder >= 1.8 then
+                player:messageSpecial(ID.text.CANNOT_REACH_LADDER)
+            elseif
+                eventID == 28 and
+                player:getCurrentMission(COP) == xi.mission.id.cop.DISTANT_BELIEFS and
+                player:getCharVar("PromathiaStatus") == 1
+            then
+                player:startEvent(35)
+            elseif eventID == 99 then
+                player:messageSpecial(ID.text.DOOR_SEALED_SHUT)
+            else
+                player:startEvent(eventID)
+            end
         end
-    elseif ((X <= -153.3 and X >= -168.3) and (Y >= -24 and Y <= -22) and (Z >= 54 and Z <= 66)) then
-        player:startEvent(29)
-    elseif ((X <= 205.3 and X >= 193.3) and (Y >= -2 and Y <= 0) and (Z >= 54 and Z <= 66)) then
-        player:startEvent(30)
-    elseif ((X <= 205.3 and X >= 193.3) and (Y >= -24 and Y <= -22) and (Z >= 54 and Z <= 66)) then
-        player:startEvent(31)
-    elseif ((X <= -194.6 and X >= -206.6) and (Y >= -8 and Y <= -6) and (Z >= 54 and Z <= 66)) then
-        player:messageSpecial(ID.text.DOOR_SEALED_SHUT)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    if csid == 35 then
+        player:setCharVar("PromathiaStatus", 2)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Tested maximum distance of 1.8 against all race types (just to be sure)