### PR TITLE
Attach crafting global functions to xi.crafting

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -3,12 +3,13 @@
 --  Info from:
 --      http://wiki.ffxiclopedia.org/wiki/Crafts_%26_Hobbies
 -----------------------------------
-
+xi = xi or {}
+xi.crafting = {}
 -----------------------------------
 -- IDs for signupGuild bitmask
 -----------------------------------
 
-guild =
+xi.crafting.guild =
 {
     ["alchemy"]      = 2,
     ["bonecraft"]    = 4,
@@ -76,7 +77,7 @@ local HQCrystals = {
 -- isGuildMember Action
 -----------------------------------
 
-function isGuildMember(player, guild)
+xi.crafting.isGuildMember = function(player, guild)
 
     local guildOK = player:getCharVar("Guild_Member")
     local bit = {}
@@ -99,7 +100,7 @@ end
 -- signupGuild Action
 -----------------------------------
 
-function signupGuild(player, nbr)
+xi.crafting.signupGuild = function(player, nbr)
     player:addCharVar("Guild_Member", nbr)
 end
 
@@ -107,7 +108,7 @@ end
 -- getTestItem Action
 -----------------------------------
 
-function getTestItem(player, npc, craftID)
+xi.crafting.getTestItem = function(player, npc, craftID)
 
     local TItemList = {}
     local NextRank = player:getSkillRank(craftID) + 1
@@ -162,7 +163,7 @@ function tradeTestItem(player, npc, trade, craftID)
 
     local guildID = craftID - 48
     local skillLvL = player:getSkillLevel(craftID)
-    local myTI = getTestItem(player, npc, craftID)
+    local myTI = xi.crafting.getTestItem(player, npc, craftID)
     local newRank = 0
     -- local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
 
@@ -188,7 +189,7 @@ end
 -----------------------------------
 -- getCraftSkillCap
 -----------------------------------
-function getCraftSkillCap(player, craftID)
+xi.crafting.getCraftSkillCap = function(player, craftID)
 
     local Rank = player:getSkillRank(craftID)
     return (Rank+1)*10
@@ -198,14 +199,14 @@ end
 -----------------------------------
 -- getAdvImageSupportCost
 -----------------------------------
-function getAdvImageSupportCost(player, craftID)
+xi.crafting.getAdvImageSupportCost = function(player, craftID)
 
     local Rank = player:getSkillRank(craftID)
     return (Rank+1)*30
 
 end
 
-function unionRepresentativeTrigger(player, guildID, csid, currency, keyitems)
+xi.crafting.unionRepresentativeTrigger = function(player, guildID, csid, currency, keyitems)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildID)
     local rank = player:getSkillRank(guildID + 48)
     local cap = (rank + 1) * 10
@@ -222,7 +223,7 @@ function unionRepresentativeTrigger(player, guildID, csid, currency, keyitems)
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-function unionRepresentativeTriggerFinish(player, option, target, guildID, currency, keyitems, items)
+xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, guildID, currency, keyitems, items)
     local rank = player:getSkillRank(guildID + 48)
     local category = bit.band(bit.rshift(option, 2), 3)
     local text = zones[player:getZoneID()].text
@@ -289,7 +290,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
     end
 end
 
-function unionRepresentativeTrade(player, npc, trade, csid, guildID)
+xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildID)
     local _, remainingPoints = player:getCurrentGPItem(guildID)
     local text = zones[player:getZoneID()].text
 

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -159,7 +159,7 @@ end
 -- tradeTestItem Action
 -----------------------------------
 
-function tradeTestItem(player, npc, trade, craftID)
+xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
 
     local guildID = craftID - 48
     local skillLvL = player:getSkillLevel(craftID)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
     local SkillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
@@ -12,7 +12,7 @@ local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 5)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
 
     if guildMember == 1 then
         if npcUtil.tradeHas(trade, 2184) then
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 5)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
     -- local SkillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
     local SkillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
@@ -12,7 +12,7 @@ local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
 
     if guildMember == 1 then
         if npcUtil.tradeHas(trade, 2184) then
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
     local SkillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 3)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 3)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
     local SkillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Macici.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Macici.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 2)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 2)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
     local SkillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 4)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 4)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
     local SkillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 6)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 6)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
     local SkillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 9)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 9)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
     local SkillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if guildMember == 1 then

--- a/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
@@ -11,7 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = isGuildMember(player, 7)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
@@ -26,7 +26,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 7)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
     local SkillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -87,22 +87,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 341, 3)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 341, 3)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 3, 340, "guild_goldsmithing", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 3, 340, "guild_goldsmithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 340) then
-        unionRepresentativeTriggerFinish(player, option, target, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 3, "guild_goldsmithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 340) then
-        unionRepresentativeTriggerFinish(player, option, target, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 3, "guild_goldsmithing", keyitems, items)
     elseif (csid == 341) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 6)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
     local SkillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then
         if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
 
     if csid == 302 and option == 1 then
         if player:getGil() >= Cost then

--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.GOLDSMITHING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.GOLDSMITHING)
 
     if
         newRank > 9 and
@@ -37,9 +37,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.GOLDSMITHING)
-    local testItem = getTestItem(player, npc, xi.skill.GOLDSMITHING)
-    local guildMember = isGuildMember(player, 6)
-    local rankCap = getCraftSkillCap(player, xi.skill.GOLDSMITHING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.GOLDSMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.GOLDSMITHING)
     local realSkill = (craftSkill - Rank) / 32
@@ -72,7 +72,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 6)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
 
     if (csid == 300 and option == 2) then
         if guildMember == 1 then
@@ -85,7 +85,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.goldsmithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.goldsmithing)
         end
     else
         if player:getLocalVar("GoldsmithingTraded") == 1 then

--- a/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 6)
-    local SkillCap = getCraftSkillCap(player, xi.skill.GOLDSMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 6)
-    local SkillCap = getCraftSkillCap(player, xi.skill.GOLDSMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 6)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.ALCHEMY)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.ALCHEMY)
 
     if
         newRank > 9 and
@@ -38,9 +38,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.ALCHEMY)
-    local testItem = getTestItem(player, npc, xi.skill.ALCHEMY)
-    local guildMember = isGuildMember(player, 1)
-    local rankCap = getCraftSkillCap(player, xi.skill.ALCHEMY)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.ALCHEMY)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.ALCHEMY)
     local realSkill = (craftSkill - Rank) / 32
@@ -86,7 +86,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
 
     if (csid == 120 and option == 2) then
         if guildMember == 1 then
@@ -100,7 +100,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.alchemy)
+            xi.crafting.signupGuild(player, xi.crafting.guild.alchemy)
         end
     else
         if player:getLocalVar("AlchemyTraded") == 1 then

--- a/scripts/zones/Bastok_Mines/npcs/Azima.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Azima.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
     local SkillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
-    local Cost = getAdvImageSupportCost(player, xi.skill.ALCHEMY)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.ALCHEMY)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.ALCHEMY)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.ALCHEMY)
 
     if (csid == 122 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
@@ -92,22 +92,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 207, 7)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 207, 7)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 7, 206, "guild_alchemy", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 7, 206, "guild_alchemy", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 206) then
-        unionRepresentativeTriggerFinish(player, option, target, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 7, "guild_alchemy", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 206) then
-        unionRepresentativeTriggerFinish(player, option, target, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 7, "guild_alchemy", keyitems, items)
     elseif (csid == 207) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
@@ -13,8 +13,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
-    local SkillCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Bastok_Mines/npcs/Titus.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Titus.lua
@@ -13,8 +13,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 1)
-    local SkillCap = getCraftSkillCap(player, xi.skill.ALCHEMY)
+    local guildMember = xi.crafting.isGuildMember(player, 1)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
     local SkillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if (guildMember == 1) then

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.SMITHING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.SMITHING)
 
     if
         newRank > 9 and
@@ -37,9 +37,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.SMITHING)
-    local testItem = getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember = isGuildMember(player, 8)
-    local rankCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.SMITHING)
     local realSkill = (craftSkill - Rank) / 32
@@ -73,7 +73,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
 
     if (csid == 101 and option == 2) then
         if guildMember == 1 then
@@ -85,7 +85,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4096)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4096) -- Fire Crystal
-            signupGuild(player, guild.smithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.smithing)
         end
     else
         if player:getLocalVar("SmithingTraded") == 1 then

--- a/scripts/zones/Metalworks/npcs/Hugues.lua
+++ b/scripts/zones/Metalworks/npcs/Hugues.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
-    local SkillCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -83,22 +83,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 801, 2)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 801, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 2, 800, "guild_smithing", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 2, 800, "guild_smithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 800) then
-        unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 800) then
-        unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     elseif (csid == 801) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Metalworks/npcs/Romero.lua
+++ b/scripts/zones/Metalworks/npcs/Romero.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
-    local SkillCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then

--- a/scripts/zones/Metalworks/npcs/Wise_Owl.lua
+++ b/scripts/zones/Metalworks/npcs/Wise_Owl.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.SMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if guildMember == 1 then
         if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.SMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if csid == 103 and option == 1 then
         if player:getGil() >= Cost then

--- a/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 9)
-    local SkillCap = getCraftSkillCap(player, xi.skill.WOODWORKING)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local SkillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -82,22 +82,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 732, 1)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 732, 1)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 1, 731, "guild_woodworking", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 1, 731, "guild_woodworking", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 731) then
-        unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 731) then
-        unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
     elseif (csid == 732) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
-    local SkillCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.WOODWORKING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.WOODWORKING)
 
     if
         newRank > 9 and
@@ -38,9 +38,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.WOODWORKING)
-    local testItem = getTestItem(player, npc, xi.skill.WOODWORKING)
-    local guildMember = isGuildMember(player, 9)
-    local rankCap = getCraftSkillCap(player, xi.skill.WOODWORKING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.WOODWORKING)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.WOODWORKING)
     local realSkill = (craftSkill - Rank) / 32
@@ -73,7 +73,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 9)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
 
     if (csid == 621 and option == 2) then
         if guildMember == 1 then
@@ -85,7 +85,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4098)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4098) -- Wind Crystal
-            signupGuild(player, guild.woodworking)
+            xi.crafting.signupGuild(player, xi.crafting.guild.woodworking)
         end
     else
         if player:getLocalVar("WoodworkingTraded") == 1 then

--- a/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.SMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.SMITHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if (csid == 628 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -82,22 +82,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 730, 2)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 730, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 2, 729, "guild_smithing", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 2, 729, "guild_smithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 729) then
-        unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 729) then
-        unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     elseif (csid == 730) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.SMITHING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.SMITHING)
 
     if
         newRank > 9 and
@@ -37,9 +37,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.SMITHING)
-    local testItem = getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember = isGuildMember(player, 8)
-    local rankCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.SMITHING)
     local realSkill = (craftSkill - Rank) / 32
@@ -73,7 +73,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
 
     if (csid == 626 and option == 2) then
         if guildMember == 1 then
@@ -85,7 +85,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4096)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4096) -- Fire Crystal
-            signupGuild(player, guild.smithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.smithing)
         end
     else
         if player:getLocalVar("SmithingTraded") == 1 then

--- a/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
-    local SkillCap = getCraftSkillCap(player, xi.skill.SMITHING)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local SkillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 9)
-    local SkillCap = getCraftSkillCap(player, xi.skill.WOODWORKING)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local SkillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 9)
+    local guildMember = xi.crafting.isGuildMember(player, 9)
     local SkillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.WOODWORKING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.WOODWORKING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
     if (csid == 623 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Port_Windurst/npcs/Degong.lua
+++ b/scripts/zones/Port_Windurst/npcs/Degong.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 5)
-    local SkillCap = getCraftSkillCap(player, xi.skill.FISHING)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local SkillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
+++ b/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 5)
-    local SkillCap = getCraftSkillCap(player, xi.skill.FISHING)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local SkillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Port_Windurst/npcs/Fennella.lua
+++ b/scripts/zones/Port_Windurst/npcs/Fennella.lua
@@ -77,22 +77,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 10021, 0)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10021, 0)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 0, 10020, "guild_fishing", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 0, 10020, "guild_fishing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 10020) then
-        unionRepresentativeTriggerFinish(player, option, target, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 0, "guild_Fishing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 10020) then
-        unionRepresentativeTriggerFinish(player, option, target, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 0, "guild_Fishing", keyitems, items)
     elseif (csid == 10021) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
+++ b/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 8)
+    local guildMember = xi.crafting.isGuildMember(player, 8)
     local SkillLevel = player:getSkillLevel(xi.skill.FISHING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.FISHING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.FISHING)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, 256)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.FISHING)
 
     if (csid == 10011 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
+++ b/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
@@ -11,7 +11,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.FISHING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.FISHING)
 
     if
         newRank > 9 and
@@ -31,9 +31,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.FISHING)
-    local testItem = getTestItem(player, npc, xi.skill.FISHING)
-    local guildMember = isGuildMember(player, 5)
-    local rankCap = getCraftSkillCap(player, xi.skill.FISHING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.FISHING)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.FISHING)
     local realSkill = (craftSkill - Rank) / 32
@@ -68,7 +68,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 5)
+    local guildMember = xi.crafting.isGuildMember(player, 5)
 
     if (csid == 10009 and option == 2) then
         if guildMember == 1 then
@@ -82,7 +82,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.fishing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.fishing)
         end
     else
         if player:getLocalVar("FishingTraded") == 1 then

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -77,22 +77,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 691, 5)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 691, 5)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 5, 690, "guild_leathercraft", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 5, 690, "guild_leathercraft", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 690) then
-        unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 690) then
-        unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
     elseif (csid == 691) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.LEATHERCRAFT)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.LEATHERCRAFT)
 
     if
         newRank > 9 and
@@ -38,9 +38,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.LEATHERCRAFT)
-    local testItem = getTestItem(player, npc, xi.skill.LEATHERCRAFT)
-    local guildMember = isGuildMember(player, 7)
-    local rankCap = getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.LEATHERCRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.LEATHERCRAFT)
     local realSkill = (craftSkill - Rank) / 32
@@ -88,7 +88,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 7)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
 
     if (csid == 648 and option == 2) then
         if guildMember == 1 then
@@ -101,7 +101,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.leathercraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.leathercraft)
         end
     else
         if player:getLocalVar("LeathercraftTraded") == 1 then

--- a/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
@@ -24,7 +24,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local sayItWithAHandbagCS = player:getCharVar("sayItWithAHandbagCS")
-    local SkillCap = getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
     if
@@ -44,7 +44,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(909)
     elseif player:hasKeyItem(xi.ki.TORN_PATCHES_OF_LEATHER) and sayItWithAHandbagCS == 1 then
         player:startEvent(908)
-    elseif isGuildMember(player, 7) == 1 then
+    elseif xi.crafting.isGuildMember(player, 7) == 1 then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(651, SkillCap, SkillLevel, 1, 239, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
@@ -13,9 +13,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 7)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
     local SkillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
-    local Cost = getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false) then
@@ -32,7 +32,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
     if (csid == 650 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 7)
-    local SkillCap = getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 7)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
     if (guildMember == 1) then

--- a/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 4)
-    local SkillCap = getCraftSkillCap(player, xi.skill.COOKING)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local SkillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 4)
-    local SkillCap = getCraftSkillCap(player, xi.skill.COOKING)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local SkillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if (guildMember == 1) then

--- a/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 4)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
     local SkillLevel = player:getSkillLevel(xi.skill.COOKING)
-    local Cost = getAdvImageSupportCost(player, xi.skill.COOKING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.COOKING)
 
     if (guildMember == 1) then
         if (player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, xi.skill.COOKING)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.COOKING)
 
     if (csid == 10015 and option == 1) then
         player:delGil(Cost)

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.COOKING)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.COOKING)
 
     if
         newRank > 9 and
@@ -37,9 +37,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.COOKING)
-    local testItem = getTestItem(player, npc, xi.skill.COOKING)
-    local guildMember = isGuildMember(player, 4)
-    local rankCap = getCraftSkillCap(player, xi.skill.COOKING)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.COOKING)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.COOKING)
     local realSkill = (craftSkill - Rank) / 32
@@ -72,7 +72,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 4)
+    local guildMember = xi.crafting.isGuildMember(player, 4)
 
     if (csid == 10013 and option == 2) then
         if guildMember == 1 then
@@ -85,7 +85,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.cooking)
+            xi.crafting.signupGuild(player, xi.crafting.guild.cooking)
         end
     else
         if player:getLocalVar("CookingTraded") == 1 then

--- a/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
@@ -82,22 +82,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 10025, 8)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10025, 8)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 8, 10024, "guild_cooking", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 8, 10024, "guild_cooking", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if (csid == 10024) then
-        unionRepresentativeTriggerFinish(player, option, target, 8, "guild_cooking", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 8, "guild_cooking", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if (csid == 10024) then
-        unionRepresentativeTriggerFinish(player, option, target, 8, "guild_cooking", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 8, "guild_cooking", keyitems, items)
     elseif (csid == 10025) then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Anillah.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Anillah.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 3)
-    local SkillCap = getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
@@ -82,22 +82,22 @@ local items = {
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 10025, 4)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10025, 4)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 4, 10024, "guild_weaving", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 4, 10024, "guild_weaving", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if csid == 10024 then
-        unionRepresentativeTriggerFinish(player, option, target, 4, "guild_weaving", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 4, "guild_weaving", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if csid == 10024 then
-        unionRepresentativeTriggerFinish(player, option, target, 4, "guild_weaving", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 4, "guild_weaving", keyitems, items)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 2)
-    local SkillCap = getCraftSkillCap(player, xi.skill.BONECRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
@@ -30,9 +30,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 2)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
     local SkillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
-    local Cost = getAdvImageSupportCost(player, xi.skill.BONECRAFT)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.BONECRAFT)
 
     if guildMember == 1 then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
@@ -49,7 +49,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, 4)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.BONECRAFT)
 
     if csid == 10018 and option == 1 then
         player:delGil(Cost)

--- a/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 3)
-    local SkillCap = getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.BONECRAFT)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.BONECRAFT)
 
         if
         newRank > 9 and
@@ -37,9 +37,9 @@ end
 
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.BONECRAFT)
-    local testItem = getTestItem(player, npc, xi.skill.BONECRAFT)
-    local guildMember = isGuildMember(player, 2)
-    local rankCap = getCraftSkillCap(player, xi.skill.BONECRAFT)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.BONECRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.BONECRAFT)
     local realSkill = (craftSkill - Rank) / 32
@@ -74,7 +74,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 2)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
 
     if (csid == 10016 and option == 2) then
         if guildMember == 1 then
@@ -87,7 +87,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            signupGuild(player, guild.bonecraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.bonecraft)
         end
     else
         if player:getLocalVar("BonecraftTraded") == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -17,7 +17,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = tradeTestItem(player, npc, trade, xi.skill.CLOTHCRAFT)
+    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.CLOTHCRAFT)
     local moralManifest = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST)
 
     if
@@ -51,9 +51,9 @@ entity.onTrigger = function(player, npc)
     local moralManifest = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST)
 
     local craftSkill = player:getSkillLevel(xi.skill.CLOTHCRAFT)
-    local testItem = getTestItem(player, npc, xi.skill.CLOTHCRAFT)
-    local guildMember = isGuildMember(player, 3)
-    local rankCap = getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
+    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.CLOTHCRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
+    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local expertQuestStatus = 0
     local Rank = player:getSkillRank(xi.skill.CLOTHCRAFT)
     local realSkill = (craftSkill - Rank) / 32
@@ -95,7 +95,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = isGuildMember(player, 3)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
 
     if csid == 700 then
         player:setCharVar("moral", 2)
@@ -113,7 +113,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4099) -- earth crystal
             player:messageSpecial(ID.text.ITEM_OBTAINED, xi.items.EARTH_CRYSTAL)
-            signupGuild(player, guild.clothcraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.clothcraft)
         end
     else
         if player:getLocalVar("ClothcraftTraded") == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Ronana.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ronana.lua
@@ -14,8 +14,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 2)
-    local SkillCap = getCraftSkillCap(player, xi.skill.BONECRAFT)
+    local guildMember = xi.crafting.isGuildMember(player, 2)
+    local SkillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local SkillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
     if guildMember == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
@@ -91,22 +91,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    unionRepresentativeTrade(player, npc, trade, 10023, 6)
+    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10023, 6)
 end
 
 entity.onTrigger = function(player, npc)
-    unionRepresentativeTrigger(player, 6, 10022, "guild_bonecraft", keyitems)
+    xi.crafting.unionRepresentativeTrigger(player, 6, 10022, "guild_bonecraft", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
     if csid == 10022 then
-        unionRepresentativeTriggerFinish(player, option, target, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 6, "guild_bonecraft", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
     if csid == 10022 then
-        unionRepresentativeTriggerFinish(player, option, target, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 6, "guild_bonecraft", keyitems, items)
     elseif csid == 10023 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
@@ -14,9 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = isGuildMember(player, 3)
+    local guildMember = xi.crafting.isGuildMember(player, 3)
     local SkillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
-    local Cost = getAdvImageSupportCost(player, xi.skill.CLOTHCRAFT)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Cost = getAdvImageSupportCost(player, 8)
+    local Cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.CLOTHCRAFT)
     if csid == 10013 and option == 1 then
         player:delGil(Cost)
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 4, 0)

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -198,18 +198,6 @@ global_objects=(
     error
     onTrigger
 
-    unionRepresentativeTrade
-    unionRepresentativeTrigger
-    unionRepresentativeTriggerFinish
-
-    tradeTestItem
-    getTestItem
-    isGuildMember
-    getAdvImageSupportCost
-    getCraftSkillCap
-    signupGuild
-    guild
-
     CheckMaps
     CheckMapsUpdate
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
