### PR TITLE
Add San d'Orian Flag to xi.items

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -9,6 +9,7 @@ xi.items =
     IMPERIAL_STANDARD               = 129,
     TABLEWARE_SET                   = 132,
     TEA_SET                         = 133,
+    SAN_DORIAN_FLAG                 = 181,
     COPY_OF_ANCIENT_BLOOD           = 206,
     PRISHE_STATUE                   = 277,
     NANAA_MIHGO_STATUE              = 286,

--- a/scripts/missions/sandoria/9_2_The_Heir_to_the_Light.lua
+++ b/scripts/missions/sandoria/9_2_The_Heir_to_the_Light.lua
@@ -214,7 +214,7 @@ mission.sections =
                     mission:complete(player)
                     mission:setVar(player, 'Option', 1)
 
-                    if not npcUtil.giveItem(player, 181) then
+                    if not npcUtil.giveItem(player, xi.items.SAN_DORIAN_FLAG) then
                         mission:setVar(player, 'Flag', 1)
                     end
                 end,
@@ -348,7 +348,7 @@ mission.sections =
                 -- with one conditional, but playing it safe.
                 onTrigger = function(player, npc)
                     if mission:getVar(player, 'Flag') == 1 then
-                        if npcUtil.giveItem(player, 181) then
+                        if npcUtil.giveItem(player, xi.items.SAN_DORIAN_FLAG) then
                             mission:setVar(player, 'Flag', 0)
                         end
                     end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds flag to items global, and adjusts San d'Oria M9-2 to use it.