### PR TITLE
Interaction - Quest: Lakeside Minuet

### DIFF
--- a/scripts/quests/jeuno/Lakeside_Minuet.lua
+++ b/scripts/quests/jeuno/Lakeside_Minuet.lua
@@ -1,0 +1,171 @@
+-----------------------------------
+-- Lakeside Minuet
+-----------------------------------
+-- !addquest 3 95
+-- Laila           : !pos -54.045 -1 100.996 244
+-- Rhea Myuliah    : !pos -56.220 -1 101.805 244
+-- Valderotaux     : !pos 97 0.1 113 230
+-- Glowing Pebbles : !pos 104.2 4.1 443.6 82
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/settings')
+require('scripts/globals/status')
+require('scripts/globals/titles')
+require('scripts/globals/zone')
+-----------------------------------
+local upperJeunoID = require('scripts/zones/Upper_Jeuno/IDs')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.LAKESIDE_MINUET)
+
+quest.reward =
+{
+    fame = 30,
+    title = xi.title.TROUPE_BRILIOTH_DANCER,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+                player:getMainLvl() >= xi.settings.ADVANCED_JOB_LEVEL and
+                xi.settings.ENABLE_WOTG == 1
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Laila'] = quest:progressEvent(10111),
+
+            onEventFinish =
+            {
+                [10111] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Laila'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.STARDUST_PEBBLE) then
+                        return quest:progressEvent(10118)
+                    else
+                        -- TODO: Verify CS events for Laila for other mission statuses.  Original
+                        -- code had event 10113 for quest progress 3; however, that is incorrect.
+                        return quest:progressEvent(10112)
+                    end
+                end,
+            },
+
+            ['Rhea_Myuliah'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 0 then
+                        return quest:progressEvent(10113)
+                    elseif questProgress == 1 then
+                        return quest:progressEvent(10114)
+                    elseif questProgress == 2 then
+                        return quest:progressEvent(10115)
+                    elseif questProgress >= 3 then
+                        return quest:progressEvent(10116)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10113] = function(player, csid, option, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+
+                [10115] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [10118] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:unlockJob(xi.job.DNC)
+                        player:messageSpecial(upperJeunoID.text.UNLOCK_DANCER)
+                        player:delKeyItem(xi.ki.STARDUST_PEBBLE)
+                        player:needToZone(true)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.SOUTHERN_SAN_DORIA] =
+        {
+            ['Valderotaux'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 1 then
+                        return quest:progressEvent(888)
+                    elseif questProgress >= 2 then
+                        return quest:progressEvent(889)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [888] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+            },
+        },
+
+        [xi.zone.JUGNER_FOREST_S] =
+        {
+            ['Glowing_Pebbles'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        quest:getVar(player, 'Prog') == 3 and
+                        not player:hasKeyItem(xi.ki.STARDUST_PEBBLE)
+                    then
+                        return quest:progressEvent(100)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [100] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.STARDUST_PEBBLE)
+                end,
+            }
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED and player:needToZone()
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Laila'] = quest:progressEvent(10119),
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Jugner_Forest_[S]/npcs/Glowing_Pebbles.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/Glowing_Pebbles.lua
@@ -14,9 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar("Lakeside_Minuet_Progress") == 3 and not player:hasKeyItem(xi.ki.STARDUST_PEBBLE) then
-        player:startEvent(100)
-    elseif player:getCharVar("roadToDivadomCS") == 2 then
+    if player:getCharVar("roadToDivadomCS") == 2 then
         player:startEvent(106)
     end
 end
@@ -25,9 +23,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 100 then
-        npcUtil.giveKeyItem(player, xi.ki.STARDUST_PEBBLE)
-    elseif csid == 106 then
+    if csid == 106 then
         player:setCharVar("roadToDivadomCS", 3)
     elseif csid == 107 then
         player:confirmTrade()

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -1,7 +1,8 @@
 local ID = require("scripts/zones/Southern_San_dOria/IDs")
 
 return {
-    ['Atelloune'] = { event = 884 },
-    ['Rosel']  = { text = ID.text.ROSEL_GREETINGS },
-    ['Sobane'] = { text = ID.text.SOBANE_DIALOG },
+    ['Atelloune']   = { event = 884 },
+    ['Rosel']       = { text = ID.text.ROSEL_GREETINGS },
+    ['Sobane']      = { text = ID.text.SOBANE_DIALOG },
+    ['Valderotaux'] = { event = 58 },
 }

--- a/scripts/zones/Southern_San_dOria/npcs/Valderotaux.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Valderotaux.lua
@@ -4,23 +4,12 @@
 --  General Info NPC
 -- !pos 97 0.1 113 230
 -----------------------------------
-require("scripts/globals/quests")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lakeProg = player:getCharVar("Lakeside_Minuet_Progress")
-    if (lakeProg == 1) then
-        player:startEvent(888) -- Dance for the drunks!
-        player:setCharVar("Lakeside_Minuet_Progress", 2)
-    elseif (lakeProg >= 2) then
-        player:startEvent(889) -- Immediate regret of failure!
-    else
-        player:startEvent(58)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Upper_Jeuno/npcs/Laila.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Laila.lua
@@ -22,19 +22,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lakesideMin = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.LAKESIDE_MINUET)
-    local lakeProg = player:getCharVar("Lakeside_Minuet_Progress")
-    if (lakesideMin == QUEST_AVAILABLE and player:getMainLvl() >= xi.settings.ADVANCED_JOB_LEVEL and xi.settings.ENABLE_WOTG == 1) then
-        player:startEvent(10111) -- Start quest csid, asks for Key Item Stardust Pebble
-    elseif (lakesideMin == QUEST_COMPLETED and player:needToZone()) then
-        player:startEvent(10119)
-    elseif (player:hasKeyItem(xi.ki.STARDUST_PEBBLE)) then
-        player:startEvent(10118) -- Ends Quest
-    elseif (lakeProg == 3) then
-        player:startEvent(10113)
-    elseif (lakesideMin == QUEST_ACCEPTED) then
-        player:startEvent(10112) -- After accepting, reminder
-    elseif ((player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_AVAILABLE
+    if ((player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_AVAILABLE
         or (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_COMPLETED
         and player:hasItem(19203) == false))
         and player:getMainJob() == xi.job.DNC and player:getMainLvl()>=40) then
@@ -86,18 +74,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 10111 and option == 1) then
-        player:addQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.LAKESIDE_MINUET)
-    elseif (csid == 10118) then
-        player:setCharVar("Lakeside_Minuet_Progress", 0)
-        player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.LAKESIDE_MINUET)
-        player:addTitle(xi.title.TROUPE_BRILIOTH_DANCER)
-        player:unlockJob(xi.job.DNC)
-        player:messageSpecial(ID.text.UNLOCK_DANCER)
-        player:addFame(JEUNO, 30)
-        player:delKeyItem(xi.ki.STARDUST_PEBBLE)
-        player:needToZone(true)
-    elseif (csid== 10129) then
+    if (csid== 10129) then
         if (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_COMPLETED) then
             player:delQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ)
             player:delKeyItem(xi.ki.THE_ESSENCE_OF_DANCE)

--- a/scripts/zones/Upper_Jeuno/npcs/Rhea_Myuliah.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Rhea_Myuliah.lua
@@ -13,21 +13,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    local lakesideMin = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.LAKESIDE_MINUET)
-    local lakeProg = player:getCharVar("Lakeside_Minuet_Progress")
-    if (lakeProg >= 3) then
-        player:startEvent(10116)
-    elseif (lakeProg == 2) then
-        player:startEvent(10115) -- You danced! Here's your hint
-        player:setCharVar("Lakeside_Minuet_Progress", 3)
-    elseif (lakeProg == 1) then
-        player:startEvent(10114) -- After the CS
-    elseif (lakesideMin == QUEST_ACCEPTED and lakeProg < 1) then
-        player:startEvent(10113) -- intial CS
-        player:setCharVar("Lakeside_Minuet_Progress", 1)
-    elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_ACCEPTED and player:getCharVar("QuestStatus_DNC_AF1")==1) then
-    player:startEvent(10131)
+    if (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_ACCEPTED and player:getCharVar("QuestStatus_DNC_AF1")==1) then
+        player:startEvent(10131)
     --Dancer AF: Road to Divadom
     elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM) == QUEST_ACCEPTED)  then
         player:startEvent (10138)


### PR DESCRIPTION
Minor cleanup and bugfixes

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Left a couple of TODOs based on previous implementation to verify in the future, and added option check for the initial quest dialogue.
* `UNLOCK_DANCER` text ID shifted, though is correct in the update PR (11834)