### PR TITLE
Fix onZoneIn and onRegionEnter checks for ZM17

### DIFF
--- a/scripts/missions/rotz/17_Awakening.lua
+++ b/scripts/missions/rotz/17_Awakening.lua
@@ -8,9 +8,10 @@
 -- Norg        : !zone 252
 -----------------------------------
 require('scripts/globals/interaction/mission')
-require("scripts/globals/keyitems")
+require('scripts/globals/keyitems')
 require('scripts/globals/missions')
-require("scripts/globals/titles")
+require('scripts/globals/titles')
+require('scripts/globals/utils')
 require('scripts/globals/zone')
 -----------------------------------
 
@@ -34,6 +35,10 @@ mission.sections =
         }
     },
 
+    -- Optional cutscenes that should be displayed only once onZone.  In this
+    -- case, missionStatus is handled as a bitfield, and missionStatus < 3 isn't
+    -- really required.
+    -- TODO: Remove this and refactor.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and missionStatus < 3
@@ -44,13 +49,16 @@ mission.sections =
             onRegionEnter =
             {
                 [1] = function(player, csid, option, npc)
-                    return mission:event(20)
+                    if not utils.mask.hasBit(player:getMissionStatus(mission.areaId), 1) then
+                        return mission:event(20)
+                    end
                 end,
             },
 
             onEventFinish =
             {
                 [20] = function(player, csid, option, npc)
+                    -- Set bit 1 of missionStatus
                     player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 2)
                 end,
             },
@@ -61,13 +69,16 @@ mission.sections =
             onZoneIn =
             {
                 function(player, prevZone)
-                    return 176
+                    if not utils.mask.hasBit(player:getMissionStatus(mission.areaId), 0) then
+                        return 176
+                    end
                 end,
             },
 
             onEventFinish =
             {
                 [176] = function(player, csid, option, npc)
+                    -- Set bit 0 of missionStatus
                     player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                 end,
             },


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
