### PR TITLE
Fix 2 Conquest Flags.

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -222,7 +222,7 @@ local overseerOffsets =
         {offset =  1, nation = xi.nation.BASTOK},   -- Yoshihiro, I.M.
         {offset =  8, nation = xi.nation.BASTOK},   -- Molting Moth, I.M.
         {offset =  4, nation = xi.nation.BASTOK},   -- Flag
-        {offset = 13, nation = xi.nation.BASTOK},   -- Flag
+        {offset = 12, nation = xi.nation.BASTOK},   -- Flag
         {offset =  2, nation = xi.nation.WINDURST}, -- Kyanta-Pakyanta, W.W.
         {offset =  9, nation = xi.nation.WINDURST}, -- Tottoto, W.W.
         {offset =  5, nation = xi.nation.WINDURST}, -- Flag
@@ -236,7 +236,7 @@ local overseerOffsets =
         {offset =  0, nation = xi.nation.SANDORIA}, -- Quanteilleron, R.K.
         {offset =  7, nation = xi.nation.SANDORIA}, -- Prunilla, R.K.
         {offset =  3, nation = xi.nation.SANDORIA}, -- flag
-        {offset = 12, nation = xi.nation.SANDORIA}, -- flag
+        {offset = 11, nation = xi.nation.SANDORIA}, -- flag
         {offset =  1, nation = xi.nation.BASTOK},   -- Tsunashige, I.M.
         {offset =  8, nation = xi.nation.BASTOK},   -- Fighting Ant, I.M.
         {offset =  4, nation = xi.nation.BASTOK},   -- flag

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -24,14 +24,13 @@ end
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(60.989, -4.898, -151.001, 198)
     end
 
     if quests.rainbow.onZoneIn(player) then
         cs = 3;
-    elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.VAIN and player:getMissionStatus(player:getNation()) ==
-        1) then
+    elseif player:getCurrentMission(WINDURST) == xi.mission.id.windurst.VAIN and player:getMissionStatus(player:getNation()) == 1 then
         cs = 5
     end
 
@@ -51,11 +50,11 @@ zone_object.onRegionEnter = function(player, region)
 end
 
 zone_object.onEventUpdate = function(player, csid, option)
-    if (csid == 3) then
+    if csid == 3 then
         quests.rainbow.onEventUpdate(player)
-    elseif (csid == 5) then
-        if (player:getZPos() > 45) then
-            if (player:getZPos() > -301) then
+    elseif csid == 5 then
+        if player:getZPos() > 45 then
+            if player:getZPos() > -301 then
                 player:updateEvent(0, 0, 0, 0, 0, 1)
             else
                 player:updateEvent(0, 0, 0, 0, 0, 3)
@@ -69,7 +68,7 @@ end
 
 zone_object.onZoneWeatherChange = function(weather)
     local qm1 = GetNPCByID(ID.npc.SUNSAND_QM) -- Quest: An Empty Vessel
-    if (weather == xi.weather.DUST_STORM) then
+    if weather == xi.weather.DUST_STORM then
         qm1:setStatus(xi.status.NORMAL)
     else
         qm1:setStatus(xi.status.DISAPPEAR)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Stuff done:
- Fixes San'dorian Flag always being up in Valkrum Dunes (Konchtat entrance), no matter who controls the region.
- Fixes Bastok and Windurst missing their flag in West Ronfaure south exit.
- Clean Valkrum dunes zone script.

Time to end those sneaky elvaan shenanigans!
![Apururu_2021 07 11_120428](https://user-images.githubusercontent.com/60053999/125290836-0313fe80-e321-11eb-8f8f-cffd0375ce6a.png)
