### PR TITLE
Add zoning helpers to interaction container

### DIFF
--- a/scripts/globals/interaction/container.lua
+++ b/scripts/globals/interaction/container.lua
@@ -125,3 +125,14 @@ function Container:unsetVarBit(player, name, bitNum)
         return player:setVar(self.varPrefix .. name, currentValue - bitValue)
     end
 end
+
+-- These helper functions will set or get a localVar using varPrefix to determine
+-- if zoning/logout is required.  There is no clearing support at this time, outside
+-- of legitimate methods.
+function Container:getMustZone(player)
+    return player:getLocalVar(self.varPrefix .. "mustZone") == 1 and true or false
+end
+
+function Container:setMustZone(player)
+    player:setLocalVar(self.varPrefix .. "mustZone", 1)
+end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

From previous discussions, there were very valid points for the `needToZone` function being too generic for the task at hand, since it would trigger for all quests, and not its intended purpose.  The suggestion was to move this logic to localVars, and after seeing the light, I agree with this assessment until there's a future reason for not doing so.

This PR adds wrappers for this functionality into the interaction container to support all scripts created using that framework.  Should a time come where we need to change this logic, it should (hopefully) be a drop in replacement to these functions.

PS: I'm open to a different naming convention for these functions, but would prefer to have separate ones for get/set