### PR TITLE
[ci] Disable version checking for headless client run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,13 +220,13 @@ jobs:
           mysql xidb -h 127.0.0.1 -uroot -proot < $f
         done
         mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
-    - name: Disable version mismatch warnings
-      run: |
-        # DO NOT USE VER_LOCK: 0 IN PRODUCTION, VERY BAD!
-        sed -i 's/VER_LOCK: 2/VER_LOCK: 0/' conf/default/version.conf
     - name: Copy confs
       run: |
         cp conf/default/* conf/
+    - name: Disable version mismatch warnings
+      run: |
+        # DO NOT USE VER_LOCK: 0 IN PRODUCTION, VERY BAD!
+        sed -i 's/VER_LOCK: 2/VER_LOCK: 0/g' conf/version.conf
     - name: Startup and character login checks
       uses: nick-invision/retry@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,10 @@ jobs:
           mysql xidb -h 127.0.0.1 -uroot -proot < $f
         done
         mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
+    - name: Disable version mismatch warnings
+      run: |
+        # DO NOT USE VER_LOCK: 0 IN PRODUCTION, VERY BAD!
+        sed -i 's/VER_LOCK: 2/VER_LOCK: 0/' conf/default/version.conf
     - name: Copy confs
       run: |
         cp conf/default/* conf/


### PR DESCRIPTION
Tested the sed command locally, works as expected

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
