### PR TITLE
[dbtool] Move protected player_data list into the script, away from configs

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -100,7 +100,7 @@ migrations = [
     languages
 ]
 
-# These are the default 'protected' files
+# These are the 'protected' files
 player_data = [
     'accounts.sql',
     'accounts_banned.sql',
@@ -227,7 +227,7 @@ def fetch_versions():
         fetch_files()
 
 def fetch_configs():
-    global player_data, mysql_bin, auto_backup, auto_update_client
+    global mysql_bin, auto_backup, auto_update_client
     try:
         with open(r'config.yaml') as file:
             configs = yaml.full_load(file)
@@ -240,14 +240,12 @@ def fetch_configs():
                         auto_backup = int(value)
                     if key == 'auto_update_client':
                         auto_update_client = bool(value)
-                    if key == 'player_data':
-                        player_data = value
     except:
         write_configs()
 
 def write_configs():
     with open(r'config.yaml', 'w') as file:
-        dump = [{'mysql_bin' : mysql_bin}, {'auto_backup' : auto_backup}, {'auto_update_client' : auto_update_client},{'player_data' : player_data}]
+        dump = [{'mysql_bin' : mysql_bin}, {'auto_backup' : auto_backup}, {'auto_update_client' : auto_update_client}]
         yaml.dump(dump, file)
 
 def fetch_files(express=False):


### PR DESCRIPTION
Fixes #485

Even though `char_history.sql` was added to the list of protected tables, `dbtool` reads that list _out of the cached config, rather than the script itself_. I removed caching for this list. 

Now works as expected:
```
Would you like to backup your database? [y/N] n
The following files will be imported:
abilities.sql
abilities_charges.sql
account_ip_record.sql
accounts_parties.sql
accounts_sessions.sql
audit_chat.sql
audit_gm.sql
augments.sql
automaton_spells.sql
bcnm_battlefield.sql
bcnm_info.sql
bcnm_treasure_chests.sql
blue_spell_list.sql
blue_spell_mods.sql
blue_traits.sql
char_recast.sql
cheat_incidents.sql
cheat_types.sql
despoil_effects.sql
exp_base.sql
exp_table.sql
fishing_fish.sql
fishing_lure.sql
fishing_rod.sql
fishing_zone.sql
gardening_results.sql
guild_item_points.sql
guild_shops.sql
guilds.sql
instance_entities.sql
instance_list.sql
item_basic.sql
item_equipment.sql
item_furnishing.sql
item_latents.sql
item_mods.sql
item_mods_pet.sql
item_puppet.sql
item_usable.sql
item_weapon.sql
job_point_gifts.sql
job_points.sql
magian.sql
merits.sql
mob_droplist.sql
mob_family_mods.sql
mob_family_system.sql
mob_groups.sql
mob_pets.sql
mob_pool_mods.sql
mob_pools.sql
mob_resistances.sql
mob_skill_lists.sql
mob_skills.sql
mob_spawn_mods.sql
mob_spawn_points.sql
mob_spell_lists.sql
nm_spawn_points.sql
npc_list.sql
pet_list.sql
pet_name.sql
skill_caps.sql
skill_ranks.sql
skillchain_damage_modifiers.sql
spell_list.sql
status_effects.sql
synth_recipes.sql
traits.sql
transport.sql
water_points.sql
weapon_skills.sql
zone_settings.sql
zone_weather.sql
zonelines.sql
triggers.sql
Proceed with update? [y/N] y
Importing abilities.sql...
Importing abilities_charges.sql...
Importing account_ip_record.sql...
Importing accounts_parties.sql...
Importing accounts_sessions.sql...
Importing audit_chat.sql...
Importing audit_gm.sql...
Importing augments.sql...
Importing automaton_spells.sql...
Importing bcnm_battlefield.sql...
Importing bcnm_info.sql...
Importing bcnm_treasure_chests.sql...
Importing blue_spell_list.sql...
Importing blue_spell_mods.sql...
Importing blue_traits.sql...
Importing char_recast.sql...
Importing cheat_incidents.sql...
Importing cheat_types.sql...
Importing despoil_effects.sql...
Importing exp_base.sql...
Importing exp_table.sql...
Importing fishing_fish.sql...
Importing fishing_lure.sql...
Importing fishing_rod.sql...
Importing fishing_zone.sql...
Importing gardening_results.sql...
Importing guild_item_points.sql...
Importing guild_shops.sql...
Importing guilds.sql...
Importing instance_entities.sql...
Importing instance_list.sql...
Importing item_basic.sql...
Importing item_equipment.sql...
Importing item_furnishing.sql...
Importing item_latents.sql...
Importing item_mods.sql...
Importing item_mods_pet.sql...
Importing item_puppet.sql...
Importing item_usable.sql...
Importing item_weapon.sql...
Importing job_point_gifts.sql...
Importing job_points.sql...
Importing magian.sql...
Importing merits.sql...
Importing mob_droplist.sql...
Importing mob_family_mods.sql...
Importing mob_family_system.sql...
Importing mob_groups.sql...
Importing mob_pets.sql...
Importing mob_pool_mods.sql...
Importing mob_pools.sql...
Importing mob_resistances.sql...
Importing mob_skill_lists.sql...
Importing mob_skills.sql...
Importing mob_spawn_mods.sql...
Importing mob_spawn_points.sql...
Importing mob_spell_lists.sql...
Importing nm_spawn_points.sql...
Importing npc_list.sql...
Importing pet_list.sql...
Importing pet_name.sql...
Importing skill_caps.sql...
Importing skill_ranks.sql...
Importing skillchain_damage_modifiers.sql...
Importing spell_list.sql...
Importing status_effects.sql...
Importing synth_recipes.sql...
Importing traits.sql...
Importing transport.sql...
Importing water_points.sql...
Importing weapon_skills.sql...
Importing zone_settings.sql...
Importing zone_weather.sql...
Importing zonelines.sql...
Importing triggers.sql...
Finished importing!
Checking migrations...
[*] Display Head and New Player
[*] Spell blobs to spell table
[*] Changing Char Unlock Table Columns
[*] HP Masks to BLOB Data
[*] Adding crystal storage columns to char_points table
[*] Adding broken column to linkshells table
[*] Adding family column to spell_list table
[*] Pad mission log
[*] Adding extra data to mission blob
[*] Converting CoP mission IDs
[*] Adding daily_tally column to char_points table
[*] Adding timecreated column to chars table
[*] Adding eminence column for chars
[*] Adding timestamp column for chars
[*] Adding currency columns to char_points table
[*] Adding instance_zone column to instance_list table
[*] Converting DB engine for all tables from MyISAM to InnoDB
[*] Adding unity columns to char_points table
[*] Adding unity_leader column to char_profile table
[*] Converting mission status
[*] Converting zilart status
[*] Adding job_master column to chars table
[*] Adding currency2 columns to char_points table
[*] Extend validTargets from tinyint to smallint
[*] Search comment and language columns
No migrations required.
```
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
