### PR TITLE
[WIP][core] Stop avatars/elementals wrongly giving cure hate to their master

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9483,23 +9483,25 @@ void CLuaBaseEntity::updateEnmityFromCure(CLuaBaseEntity* PEntity, int32 amount)
 {
     XI_DEBUG_BREAK_IF(amount < 0);
 
-    auto* PCurer = [&]() -> CBattleEntity* {
-        if (m_PBaseEntity->objtype == TYPE_PC || m_PBaseEntity->objtype == TYPE_TRUST)
-        {
-            return static_cast<CBattleEntity*>(m_PBaseEntity);
-        }
-        else if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON)
-        {
-            auto* PMaster = static_cast<CPetEntity*>(m_PBaseEntity)->PMaster;
-            if (PMaster->objtype == TYPE_PC)
-            {
-                return static_cast<CCharEntity*>(PMaster);
-            }
-        }
-        return nullptr;
-    }();
+    CBattleEntity* PCurer = nullptr;
+    if (m_PBaseEntity->objtype == TYPE_PC || m_PBaseEntity->objtype == TYPE_TRUST)
+    {
+        PCurer = static_cast<CBattleEntity*>(m_PBaseEntity);
+    }
+    else if (m_PBaseEntity->objtype == TYPE_PET)
+    {
+        auto* PPet = static_cast<CPetEntity*>(m_PBaseEntity);
+        auto* PMaster = PPet->PMaster;
+        auto  type = PPet->getPetType();
 
-    if (PEntity != nullptr && PCurer)
+        // TODO: Does this also apply to Wyverns, Fellows etc.?
+        if (PMaster->objtype == TYPE_PC && type != PET_TYPE::AUTOMATON && type != PET_TYPE::AVATAR)
+        {
+            PCurer = PMaster;
+        }
+    }
+
+    if (PEntity != nullptr && PCurer != nullptr)
     {
         battleutils::GenerateCureEnmity(PCurer, static_cast<CBattleEntity*>(PEntity->GetBaseEntity()), amount);
     }


### PR DESCRIPTION
Elementals (and presumably Avatars) are wrongly giving cure hate to their masters. This marks the area that is the problem and removes that specific condition - but should be looked into because it generally looks wrong...

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
