### PR TITLE
Hook something up to isWeaponSkillKill for now

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -20,7 +20,8 @@ function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
     if isKiller then
         -- DRK quest - Blade Of Darkness
         if
-            (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == QUEST_ACCEPTED or player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == QUEST_ACCEPTED) and
+            (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == QUEST_ACCEPTED or
+            player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == QUEST_ACCEPTED) and
             player:getEquipID(xi.slot.MAIN) == 16607 and
             player:getCharVar("ChaosbringerKills") < 200 and
             not isWeaponSkillKill

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -894,6 +894,11 @@ function takeWeaponskillDamage(defender, attacker, wsParams, primaryMsg, attack,
 
     xi.magian.checkMagianTrial(attacker, {['mob'] = defender, ['triggerWs'] = true,  ['wSkillId'] = wsResults.wsID})
 
+
+    if finaldmg > 0 then
+        defender:setLocalVar("weaponskillHit", 1)
+    end
+
     return finaldmg
 end
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -564,6 +564,9 @@ int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullp
     else if (PLastAttacker && PLastAttacker->objtype == TYPE_PC)
     {
         roeutils::event(ROE_EVENT::ROE_DMGDEALT, static_cast<CCharEntity*>(attacker), RoeDatagram("dmg", amount));
+
+        // Took dmg from non ws source, so remove ws kill var
+        this->SetLocalVar("weaponskillHit", 0);
     }
 
     return addHP(-amount);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -184,7 +184,6 @@ CCharEntity::CCharEntity()
 
     MeritMode = false;
 
-    m_isWeaponSkillKill = false;
     m_isStyleLocked     = false;
     m_isBlockingAid     = false;
 
@@ -429,16 +428,6 @@ int32 CCharEntity::addMP(int32 mp)
     PLatentEffectContainer->CheckLatentsMP();
 
     return abs(mp);
-}
-
-bool CCharEntity::getWeaponSkillKill() const
-{
-    return m_isWeaponSkillKill;
-}
-
-void CCharEntity::setWeaponSkillKill(bool isWeaponSkillKill)
-{
-    m_isWeaponSkillKill = isWeaponSkillKill;
 }
 
 bool CCharEntity::getStyleLocked() const

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -385,9 +385,6 @@ public:
 
     int8 getShieldSize();
 
-    bool getWeaponSkillKill() const;
-    void setWeaponSkillKill(bool isWeaponSkillKill);
-
     bool getStyleLocked() const;
     void setStyleLocked(bool isStyleLocked);
     bool getBlockingAid() const;
@@ -487,7 +484,6 @@ private:
     std::unique_ptr<CItemContainer> m_Wardrobe3;
     std::unique_ptr<CItemContainer> m_Wardrobe4;
 
-    bool m_isWeaponSkillKill;
     bool m_isStyleLocked;
     bool m_isBlockingAid;
     bool m_reloadParty;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -779,7 +779,6 @@ void CMobEntity::DistributeRewards()
 
     if (PChar != nullptr && PChar->id == m_OwnerID.id)
     {
-        PChar->setWeaponSkillKill(false);
         StatusEffectContainer->KillAllStatusEffect();
         PChar->m_charHistory.enemiesDefeated++;
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -220,7 +220,7 @@ namespace luautils
         set_function("selectDailyItem", &luautils::SelectDailyItem);
         set_function("GetQuestAndMissionFilenamesList", &luautils::GetQuestAndMissionFilenamesList);
         set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
-        
+
 
         // Register Sol Bindings
         CLuaAbility::Register();
@@ -664,7 +664,7 @@ namespace luautils
 
                 ShowInfo("[FileWatcher] INTERACTION %s -> %s\n", requireName, parts[2]);
             }
-            
+
             return;
         }
 
@@ -2999,7 +2999,7 @@ namespace luautils
                     CLuaBaseEntity LuaMobEntity(PMob);
                     CLuaBaseEntity LuaAllyEntity(PMember);
                     bool           isKiller          = PMember == PChar;
-                    bool           isWeaponSkillKill = PChar->getWeaponSkillKill();
+                    bool           isWeaponSkillKill = PMob->GetLocalVar("weaponskillHit") > 0;
 
                     auto result = onMobDeathEx(LuaMobEntity, LuaAllyEntity, isKiller, isWeaponSkillKill);
                     if (!result.valid())


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

… but would like to see this refactored away later.

For more than 6yrs now this has been a dead unused bool. In the far distant past it was being set and some refactor removed the spot the bool was set true in band its been perma false ever since.

Note: dots will still be handled wrong here. Any mob that "falls to the ground" from dot shouldn't be a ws kill. That's a preexisting problem - we have no method of telling death from dots happened right now.


~~testing pending..~~ _tested, working._