### PR TITLE
Add PChar Nullptr Checks to Get/Set CharVar

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5680,6 +5680,11 @@ namespace charutils
 
     int32 GetCharVar(CCharEntity* PChar, const char* var)
     {
+        if (PChar == nullptr)
+        {
+            return 0;
+        }
+
         const char* fmtQuery = "SELECT value FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, PChar->id, var);
@@ -5693,6 +5698,11 @@ namespace charutils
 
     void SetCharVar(CCharEntity* PChar, const char* var, int32 value)
     {
+        if (PChar == nullptr)
+        {
+            return;
+        }
+
         if (value == 0)
         {
             Sql_Query(SqlHandle, "DELETE FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;", PChar->id, var);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5682,6 +5682,7 @@ namespace charutils
     {
         if (PChar == nullptr)
         {
+            ShowError("GetCharVar was requested for a nullptr PChar\n");
             return 0;
         }
 
@@ -5700,6 +5701,7 @@ namespace charutils
     {
         if (PChar == nullptr)
         {
+            ShowError("SetCharVar was requested for a nullptr PChar\n");
             return;
         }
 


### PR DESCRIPTION
Apparently a fairly rare crash is possible here. So let's not let it occur.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
