### PR TITLE
Convert Windurst Mission 1-1: The Horutoto Ruins Experiment

### DIFF
--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -1,0 +1,376 @@
+-----------------------------------
+-- The Horutoto Ruins Experiment
+-- Windurst M1-1
+-----------------------------------
+-- !addmission 2 0
+--     Gate Guards
+-- Mokyokyo - !pos -55 -8 227 238
+-- Janshura-Rashura - !pos -227 -8 184 240
+-- Rakoh Buuma - !pos 106 -5 -23 241
+-- Zokima-Rokima - !pos 0 -16 124 239
+--
+-- Hakkuru-Rinkuru - !pos -111 -4 101 240
+--
+-- Sama Gohjima - !pos 377 -13 98 116
+--
+-- _5c5 (Gate: Magical Gizmo) - !pos 419 0 -27 192
+--
+--     Gizmos
+-- _5cp (Magical Gizmo) #1 - !pos 464 -3 100 192
+-- _5cq (Magical Gizmo) #2 - !pos 406 -3 59 192
+-- _5cr (Magical Gizmo) #3 - !pos 464 -3 20 192
+-- _5cs (Magical Gizmo) #4 - !pos 295 -3 19 192
+-- _5ct (Magical Gizmo) #5 - !pos 353 -3 60 192
+-- _5cu (Magical Gizmo) #6 - !pos 295 -3 100 192
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/missions')
+require('scripts/globals/npc_util')
+require('scripts/globals/settings')
+require('scripts/globals/keyitems')
+require('scripts/globals/interaction/mission')
+require('scripts/globals/zone')
+-----------------------------------
+local innerHorutotoRuinsID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
+local eastSarutabarutaID = require("scripts/zones/East_Sarutabaruta/IDs")
+-----------------------------------
+
+local mission = Mission:new(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT)
+
+-- A unique title is awarded from accepting the mission at each gate guard
+-- This is handled by zone ID and used in handleAcceptMission below
+local whichTitle =
+{
+    [238] = {titleGiven = xi.title.FRESH_NORTH_WINDS_RECRUIT}, -- Windurst Waters
+    [239] = {titleGiven = xi.title.HEAVENS_TOWER_GATEHOUSE_RECRUIT}, -- Windurst Walls
+    [240] = {titleGiven = xi.title.NEW_BEST_OF_THE_WEST_RECRUIT}, -- Port Windurst
+    [241] = {titleGiven = xi.title.NEW_BUUMAS_BOOMERS_RECRUIT} -- Windurst Woods
+}
+
+mission.reward =
+{
+    rankPoints = 250,
+}
+
+local handleAcceptMission = function(player, csid, option, npc)
+    local zone = player:getZoneID()
+    local which = whichTitle[zone]
+    if option == 1 then
+        mission:begin(player)
+        player:messageSpecial(zones[player:getZoneID()].text.YOU_ACCEPT_THE_MISSION)
+        player:addTitle(which.titleGiven)
+        player:setMissionStatus(mission.areaId, 1)
+    end
+end
+
+local examineGizmo = function(mission, player, gizmoIndex, successCS, failCS)
+    if mission:getVar(player, 'RandomGizmo') == gizmoIndex then
+        return mission:progressEvent(successCS)
+    else
+        if not mission:isVarBitsSet(player, 'GizmoExamined', gizmoIndex) then
+            mission:setVarBit(player, 'GizmoExamined', gizmoIndex)
+            return mission:progressEvent(failCS)
+        else
+            return mission:messageSpecial(innerHorutotoRuinsID.text.EXAMINED_RECEPTACLE)
+        end
+    end
+end
+
+local gizmoSuccess = function(player, csid, option, npc)
+    player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
+    player:messageSpecial(innerHorutotoRuinsID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
+    player:setMissionStatus(mission.areaId, 4)
+    mission:setVar(player, 'GizmoExamined', 0)
+    mission:setVar(player, 'RandomGizmo', 0)
+end
+
+local gizmoFailure = function(player, csid, option, npc)
+    player:messageSpecial(innerHorutotoRuinsID.text.NOT_BROKEN_ORB)
+end
+
+mission.sections =
+{
+    -- Player is offered mission from a gate guard
+    {
+        check = function(player, currentMission)
+            return currentMission == xi.mission.id.nation.NONE and
+                player:getNation() == mission.areaId and
+                not player:hasCompletedMission(mission.areaId, mission.missionId)
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Janshura-Rashura'] =  mission:progressEvent(83),
+
+            onEventFinish = {
+                [83] = handleAcceptMission,
+            },
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Zokima-Rokima'] = mission:progressEvent(96),
+
+            onEventFinish = {
+                [96] = handleAcceptMission,
+            },
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Mokyokyo'] = mission:progressEvent(118),
+
+            onEventFinish = {
+                [118] = handleAcceptMission,
+            },
+        },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Rakoh_Buuma'] = mission:progressEvent(121),
+
+            onEventFinish = {
+                [121] =  handleAcceptMission,
+            },
+        },
+    },
+
+    -- Mission has been accepted, these NPCs dialogue does not change during mission
+    {
+        check = function(player, currentMission)
+            return currentMission == mission.missionId
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Janshura-Rashura'] =  mission:event(89),
+            ['Nine_of_Clubs'] = mission:event(86),
+            ['Puo_Rhen'] = mission:event(88),
+            ['Ten_of_Clubs'] = mission:event(87),
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Keo-Koruo'] = mission:event(100),
+            ['Pakke-Pokke'] = mission:event(101),
+            ['Zokima-Rokima'] = mission:event(99),
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Dagoza-Beruza'] = mission:event(121),
+            ['Mokyokyo'] = mission:event(123),
+            ['Panna-Donna'] = mission:event(122),
+            ['Ten_of_Hearts'] = mission:event(124),
+        },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Miiri-Wohri'] = mission:event(124),
+            ['Rakoh_Buuma'] = mission:event(127),
+            ['Sola_Jaab'] = mission:event(125),
+            ['Tih_Pikeh'] = mission:event(126),
+        },
+    },
+
+    -- Go to the Orastery in Port Windurst (Home Point #1) and talk to Hakkuru-Rinkuru (E-7) for a cutscene.
+    {
+        check = function(player, currentMission, missionStatus)
+            return currentMission == mission.missionId and missionStatus == 1
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Hakkuru-Rinkuru'] = mission:progressEvent(90),
+
+            onEventFinish =
+            {
+                [90] = function(player, csid, option, npc)
+                    player:setMissionStatus(mission.areaId, 2)
+                end,
+            },
+        },
+    },
+
+    -- Head to Inner Horutoto Ruins at (J-7) and examine Gate: Magic Gizmo
+    {
+        check = function(player, currentMission, missionStatus)
+            return currentMission == mission.missionId and missionStatus == 2
+        end,
+
+        [xi.zone.EAST_SARUTABARUTA] = {
+            ['Sama_Gohjima'] = mission:event(53),
+        },
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Hakkuru-Rinkuru'] = mission:event(91),
+        },
+
+        [xi.zone.INNER_HORUTOTO_RUINS] =
+        {
+             -- Gate: Magical Gizmo
+            ['_5c5'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:progressEvent(42)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [42] = function(player, csid, option, npc)
+                    player:setMissionStatus(mission.areaId, 3)
+                    mission:setVar(player, 'RandomGizmo', math.random(1, 6))
+                end,
+            },
+        },
+    },
+
+    -- Find the broken Gizmo
+    {
+        check = function(player, currentMission, missionStatus)
+            return currentMission == mission.missionId and missionStatus == 3
+        end,
+
+        [xi.zone.INNER_HORUTOTO_RUINS] =
+        {
+            ['_5cp'] = { -- Magical Gizmo #1
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 1, 48, 49)
+                end,
+            },
+
+            ['_5cq'] = { -- Magical Gizmo #2
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 2, 50, 51)
+                end,
+            },
+
+            ['_5cr'] = { -- Magical Gizmo #3
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 3, 52, 53)
+                end,
+            },
+
+            ['_5cs'] = { -- Magical Gizmo #4
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 4, 54, 55)
+                end,
+            },
+
+            ['_5ct'] = { -- Magical Gizmo #5
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 5, 56, 57)
+                end,
+            },
+
+            ['_5cu'] = { -- Magical Gizmo #6
+                onTrigger = function(player, npc)
+                    return examineGizmo(mission, player, 6, 58, 59)
+                end,
+            },
+
+            onEventFinish = {
+                -- Magical Gizmo #1
+                [48] = gizmoSuccess,
+                [49] = gizmoFailure,
+
+                -- Magical Gizmo #2
+                [50] = gizmoSuccess,
+                [51] = gizmoFailure,
+
+                -- Magical Gizmo #3
+                [52] = gizmoSuccess,
+                [53] = gizmoFailure,
+
+                -- Magical Gizmo #4
+                [54] = gizmoSuccess,
+                [55] = gizmoFailure,
+
+                -- Magical Gizmo #5
+                [56] = gizmoSuccess,
+                [57] = gizmoFailure,
+
+                -- Magical Gizmo #6
+                [58] = gizmoSuccess,
+                [59] = gizmoFailure,
+            },
+
+        },
+    },
+
+    -- Take the Cracked Mana Orb back to Hakkuru-Rinkuru in the Orastery to complete the mission.
+    {
+        check = function(player, currentMission, missionStatus)
+            return currentMission == mission.missionId and missionStatus == 4
+        end,
+
+        [xi.zone.EAST_SARUTABARUTA] = {
+            ['Sama_Gohjima'] = {
+                onTrigger = function(player, npc)
+                    return mission:messageText(eastSarutabarutaID.text.SAMA_GOHJIMA_POSTDIALOG):setPriority(1000)
+                end,
+            },
+        },
+
+        [xi.zone.PORT_WINDURST] = {
+            ['Hakkuru-Rinkuru'] = {
+                onTrigger = function(player, npc)
+                    return mission:progressEvent(94, 0, xi.ki.CRACKED_MANA_ORBS)
+                end,
+            },
+
+            ['Kuroido-Moido'] = mission:event(98),
+
+            onEventFinish = {
+                [94] = function(player, csid, option, npc)
+                    mission:complete(player)
+                end,
+            },
+        },
+    },
+
+    -- All of the optional, very temporary post-mission dialogue! WOW, SO MUCH!
+    -- TODO: Verify when Hakkuru-Rinkuru and Kuroido-Moido dialogue should change next for
+    -- a Windurst citizen after completing this mission. For now, grouping with other
+    -- gate guard-adjacent NPCs whose dialogue changes on accepting next mission.
+    {
+        check = function(player)
+            return player:getNation() == mission.areaId and
+                player:hasCompletedMission(mission.areaId, mission.missionId) and
+                not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HEART_OF_THE_MATTER)
+        end,
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Hakkuru-Rinkuru'] = mission:event(96),
+            ['Kuroido-Moido'] = mission:event(100):importantOnce(),
+            ['Nine_of_Clubs'] = mission:event(102),
+            ['Puo_Rhen'] = mission:event(101),
+            ['Ten_of_Clubs'] = mission:event(103),
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Keo-Koruo'] = mission:event(105),
+            ['Pakke-Pokke'] = mission:event(104),
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Dagoza-Beruza'] = mission:event(128),
+            ['Panna-Donna'] = mission:event(127),
+            ['Ten_of_Hearts'] = mission:event(129),
+        },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Miiri-Wohri'] = mission:event(115),
+            ['Sola_Jaab'] = mission:event(130),
+            ['Tih_Pikeh'] = mission:event(131),
+        },
+    },
+}
+
+return mission

--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -344,7 +344,7 @@ mission.sections =
 
         [xi.zone.PORT_WINDURST] =
         {
-            ['Hakkuru-Rinkuru'] = mission:event(96),
+            ['Hakkuru-Rinkuru'] = mission:event(96):importantOnce(),
             ['Kuroido-Moido'] = mission:event(100):importantOnce(),
             ['Nine_of_Clubs'] = mission:event(102),
             ['Puo_Rhen'] = mission:event(101),

--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -63,7 +63,7 @@ local handleAcceptMission = function(player, csid, option, npc)
     end
 end
 
-local examineGizmo = function(mission, player, gizmoIndex, successCS, failCS)
+local examineGizmo = function(player, gizmoIndex, successCS, failCS)
     if mission:getVar(player, 'RandomGizmo') == gizmoIndex then
         return mission:progressEvent(successCS)
     else
@@ -77,8 +77,7 @@ local examineGizmo = function(mission, player, gizmoIndex, successCS, failCS)
 end
 
 local gizmoSuccess = function(player, csid, option, npc)
-    player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-    player:messageSpecial(innerHorutotoRuinsID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
+    player:npcUtil.giveKeyItem(player, xi.ki.CRACKED_MANA_ORBS)
     player:setMissionStatus(mission.areaId, 4)
     mission:setVar(player, 'GizmoExamined', 0)
     mission:setVar(player, 'RandomGizmo', 0)
@@ -215,12 +214,7 @@ mission.sections =
         [xi.zone.INNER_HORUTOTO_RUINS] =
         {
              -- Gate: Magical Gizmo
-            ['_5c5'] =
-            {
-                onTrigger = function(player, npc)
-                    return mission:progressEvent(42)
-                end,
-            },
+            ['_5c5'] = mission:progressEvent(42),
 
             onEventFinish =
             {
@@ -243,42 +237,42 @@ mission.sections =
             ['_5cp'] = -- Magical Gizmo #1
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 1, 48, 49)
+                    return examineGizmo(player, 1, 48, 49)
                 end,
             },
 
             ['_5cq'] = -- Magical Gizmo #2
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 2, 50, 51)
+                    return examineGizmo(player, 2, 50, 51)
                 end,
             },
 
             ['_5cr'] = -- Magical Gizmo #3
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 3, 52, 53)
+                    return examineGizmo(player, 3, 52, 53)
                 end,
             },
 
             ['_5cs'] = -- Magical Gizmo #4
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 4, 54, 55)
+                    return examineGizmo(player, 4, 54, 55)
                 end,
             },
 
             ['_5ct'] = -- Magical Gizmo #5
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 5, 56, 57)
+                    return examineGizmo(player, 5, 56, 57)
                 end,
             },
 
             ['_5cu'] = -- Magical Gizmo #6
             {
                 onTrigger = function(player, npc)
-                    return examineGizmo(mission, player, 6, 58, 59)
+                    return examineGizmo(player, 6, 58, 59)
                 end,
             },
 
@@ -320,23 +314,12 @@ mission.sections =
 
         [xi.zone.EAST_SARUTABARUTA] =
         {
-            ['Sama_Gohjima'] =
-            {
-                onTrigger = function(player, npc)
-                    return mission:messageText(eastSarutabarutaID.text.SAMA_GOHJIMA_POSTDIALOG):setPriority(1000)
-                end,
-            },
+            ['Sama_Gohjima'] = mission:messageText(eastSarutabarutaID.text.SAMA_GOHJIMA_POSTDIALOG):setPriority(1000),
         },
 
         [xi.zone.PORT_WINDURST] =
         {
-            ['Hakkuru-Rinkuru'] =
-            {
-                onTrigger = function(player, npc)
-                    return mission:progressEvent(94, 0, xi.ki.CRACKED_MANA_ORBS)
-                end,
-            },
-
+            ['Hakkuru-Rinkuru'] = mission:progressEvent(94, 0, xi.ki.CRACKED_MANA_ORBS),
             ['Kuroido-Moido'] = mission:event(98),
 
             onEventFinish =

--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -102,7 +102,8 @@ mission.sections =
         {
             ['Janshura-Rashura'] =  mission:progressEvent(83),
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 [83] = handleAcceptMission,
             },
         },
@@ -111,7 +112,8 @@ mission.sections =
         {
             ['Zokima-Rokima'] = mission:progressEvent(96),
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 [96] = handleAcceptMission,
             },
         },
@@ -120,7 +122,8 @@ mission.sections =
         {
             ['Mokyokyo'] = mission:progressEvent(118),
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 [118] = handleAcceptMission,
             },
         },
@@ -129,7 +132,8 @@ mission.sections =
         {
             ['Rakoh_Buuma'] = mission:progressEvent(121),
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 [121] =  handleAcceptMission,
             },
         },
@@ -198,7 +202,8 @@ mission.sections =
             return currentMission == mission.missionId and missionStatus == 2
         end,
 
-        [xi.zone.EAST_SARUTABARUTA] = {
+        [xi.zone.EAST_SARUTABARUTA] =
+        {
             ['Sama_Gohjima'] = mission:event(53),
         },
 
@@ -235,43 +240,50 @@ mission.sections =
 
         [xi.zone.INNER_HORUTOTO_RUINS] =
         {
-            ['_5cp'] = { -- Magical Gizmo #1
+            ['_5cp'] = -- Magical Gizmo #1
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 1, 48, 49)
                 end,
             },
 
-            ['_5cq'] = { -- Magical Gizmo #2
+            ['_5cq'] = -- Magical Gizmo #2
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 2, 50, 51)
                 end,
             },
 
-            ['_5cr'] = { -- Magical Gizmo #3
+            ['_5cr'] = -- Magical Gizmo #3
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 3, 52, 53)
                 end,
             },
 
-            ['_5cs'] = { -- Magical Gizmo #4
+            ['_5cs'] = -- Magical Gizmo #4
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 4, 54, 55)
                 end,
             },
 
-            ['_5ct'] = { -- Magical Gizmo #5
+            ['_5ct'] = -- Magical Gizmo #5
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 5, 56, 57)
                 end,
             },
 
-            ['_5cu'] = { -- Magical Gizmo #6
+            ['_5cu'] = -- Magical Gizmo #6
+            {
                 onTrigger = function(player, npc)
                     return examineGizmo(mission, player, 6, 58, 59)
                 end,
             },
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 -- Magical Gizmo #1
                 [48] = gizmoSuccess,
                 [49] = gizmoFailure,
@@ -306,16 +318,20 @@ mission.sections =
             return currentMission == mission.missionId and missionStatus == 4
         end,
 
-        [xi.zone.EAST_SARUTABARUTA] = {
-            ['Sama_Gohjima'] = {
+        [xi.zone.EAST_SARUTABARUTA] =
+        {
+            ['Sama_Gohjima'] =
+            {
                 onTrigger = function(player, npc)
                     return mission:messageText(eastSarutabarutaID.text.SAMA_GOHJIMA_POSTDIALOG):setPriority(1000)
                 end,
             },
         },
 
-        [xi.zone.PORT_WINDURST] = {
-            ['Hakkuru-Rinkuru'] = {
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Hakkuru-Rinkuru'] =
+            {
                 onTrigger = function(player, npc)
                     return mission:progressEvent(94, 0, xi.ki.CRACKED_MANA_ORBS)
                 end,
@@ -323,7 +339,8 @@ mission.sections =
 
             ['Kuroido-Moido'] = mission:event(98),
 
-            onEventFinish = {
+            onEventFinish =
+            {
                 [94] = function(player, csid, option, npc)
                     mission:complete(player)
                 end,

--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -77,7 +77,7 @@ local examineGizmo = function(player, gizmoIndex, successCS, failCS)
 end
 
 local gizmoSuccess = function(player, csid, option, npc)
-    player:npcUtil.giveKeyItem(player, xi.ki.CRACKED_MANA_ORBS)
+    npcUtil.giveKeyItem(player, xi.ki.CRACKED_MANA_ORBS)
     player:setMissionStatus(mission.areaId, 4)
     mission:setVar(player, 'GizmoExamined', 0)
     mission:setVar(player, 'RandomGizmo', 0)
@@ -325,6 +325,7 @@ mission.sections =
             onEventFinish =
             {
                 [94] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.CRACKED_MANA_ORBS)
                     mission:complete(player)
                 end,
             },

--- a/scripts/zones/East_Sarutabaruta/DefaultActions.lua
+++ b/scripts/zones/East_Sarutabaruta/DefaultActions.lua
@@ -1,0 +1,5 @@
+local ID = require("scripts/zones/East_Sarutabaruta/IDs")
+
+return {
+    ['Sama_Gohjima'] = { event = 43 },
+}

--- a/scripts/zones/East_Sarutabaruta/IDs.lua
+++ b/scripts/zones/East_Sarutabaruta/IDs.lua
@@ -25,7 +25,6 @@ zones[xi.zone.EAST_SARUTABARUTA] =
         SIGNPOST_OFFSET          = 7382, -- Southeast: South Tower, Horutoto Ruins Southwest: Windurst Woods
         TABY_CANATAHEY_DIALOG    = 7392, -- This is the entrrrance to Windurst. Please maintain orderrrly conduct while you'rrre in town.
         HEIH_PORHIAAP_DIALOG     = 7393, -- These grrrasslands make up East Sarutabaruta. Lately the number of monsters has drrramatically increased, causing us all sorts of trrrouble.
-        SAMA_GOHJIMA_PREDIALOG   = 7395, -- The ministerrr of the Orastery is in the laborrratory beneath here. To get there, you should check the walls verrry carrrefully.
         SAMA_GOHJIMA_POSTDIALOG  = 7396, -- Were you able to find the laborrratory? There are many such hidden passages in the Horutoto Ruins.
         PLAYER_OBTAINS_ITEM      = 7573, -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM    = 7574, -- You were unable to obtain the item.

--- a/scripts/zones/East_Sarutabaruta/npcs/Sama_Gohjima.lua
+++ b/scripts/zones/East_Sarutabaruta/npcs/Sama_Gohjima.lua
@@ -4,24 +4,12 @@
 --  Involved in Mission: The Horutoto Ruins Experiment (optional)
 -- !pos 377 -13 98 116
 -----------------------------------
-require("scripts/globals/missions")
-local ID = require("scripts/zones/East_Sarutabaruta/IDs")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and player:getMissionStatus(player:getNation()) == 1) then
-        player:showText(npc, ID.text.SAMA_GOHJIMA_PREDIALOG)
-    elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and player:getMissionStatus(player:getNation()) ~= 1) then
-        player:messageSpecial(ID.text.SAMA_GOHJIMA_POSTDIALOG)
-    else
-        player:startEvent(43)
-    end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/DefaultActions.lua
@@ -1,0 +1,5 @@
+local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
+
+return {
+    ['_5c5'] = { messageSpecial = ID.text.DOOR_FIRMLY_CLOSED },
+}

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5c5.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5c5.lua
@@ -4,46 +4,18 @@
 -- Involved In Mission: The Horutoto Ruins Experiment
 -- !pos 419 0 -27 192
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 1
-    then
-        player:startEvent(42)
-    else
-        player:showText(npc, ID.text.DOOR_FIRMLY_CLOSED)
-    end
-
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 42 then
-        player:setMissionStatus(player:getNation(), 2)
-
-        -- Generate a random value to use for the next part of the mission
-        -- where you have to examine 6 Magical Gizmo's, each of them having
-        -- a number from 1 to 6 (Remember, setting 0 deletes the var)
-        local random_value = math.random(1, 6)
-        player:setCharVar("MissionStatus_rv", random_value) -- 'rv' = random value
-        player:setCharVar("MissionStatus_op1", 1)
-        player:setCharVar("MissionStatus_op2", 1)
-        player:setCharVar("MissionStatus_op3", 1)
-        player:setCharVar("MissionStatus_op4", 1)
-        player:setCharVar("MissionStatus_op5", 1)
-        player:setCharVar("MissionStatus_op6", 1)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cp.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cp.lua
@@ -3,57 +3,19 @@
 --  NPC: _5cp (Magical Gizmo) #1
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 1 -- of the 6
-
-    -- Check if we are on Windurst Mission 1-1
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(48)
-        else
-            if player:getCharVar("MissionStatus_op1") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(49) -- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 48 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 49 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op1", 2)
-        -- Give the message that thsi orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cq.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cq.lua
@@ -3,57 +3,19 @@
 --  NPC: _5cq (Magical Gizmo) #2
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 2 -- of the 6
-
-    -- Check if we are on Windurst Mission 1-1
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(50)
-        else
-            if player:getCharVar("MissionStatus_op2") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(51) -- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 50 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 51 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op2", 2)
-        -- Give the message that thsi orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cr.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cr.lua
@@ -3,57 +3,19 @@
 --  NPC: _5cr (Magical Gizmo) #3
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 3 -- of the 6
-
-    -- Check if we are on Windurst Mission 1-1
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(52)
-        else
-            if player:getCharVar("MissionStatus_op3") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(53) -- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 52 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 53 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op3", 2)
-        -- Give the message that thsi orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cs.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cs.lua
@@ -3,57 +3,19 @@
 --  NPC: _5cs (Magical Gizmo) #4
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 4 -- of the 6
-
-    -- Check if we are on Windurst Mission 1-1
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(54)
-        else
-            if player:getCharVar("MissionStatus_op4") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(55) -- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 54 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 55 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op4", 2)
-        -- Give the message that thsi orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ct.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5ct.lua
@@ -3,57 +3,19 @@
 --  NPC: _5ct (Magical Gizmo) #5
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 5 -- of the 6
-
-    -- Check if we are on Windurst Mission 1-1
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(56)
-        else
-            if player:getCharVar("MissionStatus_op5") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(57) -- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 56 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 57 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op5", 2)
-        -- Give the message that thsi orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cu.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/npcs/_5cu.lua
@@ -3,57 +3,19 @@
 --  NPC: _5cu (Magical Gizmo) #6
 -- Involved In Mission: The Horutoto Ruins Experiment
 -----------------------------------
-local ID = require("scripts/zones/Inner_Horutoto_Ruins/IDs")
-require("scripts/globals/missions")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- The Magical Gizmo Number, this number will be compared to the random
-    -- value created by the mission The Horutoto Ruins Experiment, when you
-    -- reach the Gizmo Door and have the cutscene
-    local magical_gizmo_no = 6 -- of the 6
-
-    if
-        player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and
-        player:getMissionStatus(player:getNation()) == 2
-    then
-        -- Check if we found the correct Magical Gizmo or not
-        if player:getCharVar("MissionStatus_rv") == magical_gizmo_no then
-            player:startEvent(58)
-        else
-            if player:getCharVar("MissionStatus_op6") == 2 then
-                player:messageSpecial(ID.text.EXAMINED_RECEPTACLE) -- We've already examined this
-            else
-                player:startEvent(59)-- Opened the wrong one
-            end
-        end
-    end
-
-    return 1
-
+    -- Outside of Windurst Mission 1-1, these Gizmos give no responde or text.
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- If we just finished the cutscene for Windurst Mission 1-1
-    -- The cutscene that we opened the correct Magical Gizmo
-    if csid == 58 then
-        player:setMissionStatus(player:getNation(), 3)
-        player:setCharVar("MissionStatus_rv", 0)
-        player:addKeyItem(xi.ki.CRACKED_MANA_ORBS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.CRACKED_MANA_ORBS)
-    elseif csid == 59 then
-        -- Opened the wrong one
-        player:setCharVar("MissionStatus_op6", 2)
-        -- Give the message that this orb is not broken
-        player:messageSpecial(ID.text.NOT_BROKEN_ORB)
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Windurst/DefaultActions.lua
+++ b/scripts/zones/Port_Windurst/DefaultActions.lua
@@ -1,0 +1,5 @@
+local ID = require("scripts/zones/Port_Windurst/IDs")
+
+return {
+    ['Hakkuru-Rinkuru'] = { event = 224 },
+}

--- a/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
@@ -29,8 +29,6 @@ entity.onTrade = function(player, npc, trade)
         else
             player:startEvent(260, 0, 17091, 17061, 17053) --Remind player which items are needed ifquest is accepted and items are not traded
         end
-    else
-        player:startEvent(224)
     end
 
 end
@@ -48,16 +46,6 @@ entity.onTrigger = function(player, npc)
         player:startEvent(456, 0, 248)
     elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.FULL_MOON_FOUNTAIN and player:getMissionStatus(player:getNation()) == 3) then
         player:startEvent(457)
-    -- Check if we are on Windurst Mission 1-1
-    elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
-        local missionStatus = player:getMissionStatus(player:getNation())
-        if (missionStatus == 0) then
-            player:startEvent(90)
-        elseif (missionStatus == 1) then
-            player:startEvent(91)
-        elseif (missionStatus == 3) then
-            player:startEvent(94, 0, xi.ki.CRACKED_MANA_ORBS) -- Finish Mission 1-1
-        end
     elseif (player:getCurrentMission(WINDURST) == xi.mission.id.windurst.TO_EACH_HIS_OWN_RIGHT and player:getMissionStatus(player:getNation()) == 2) then
         player:startEvent(147)
 -- Begin Making Amends Section
@@ -75,11 +63,7 @@ entity.onTrigger = function(player, npc)
     elseif (WonderWands == QUEST_COMPLETED) then
         if (player:getCharVar("SecondRewardVar") == 1) then
             player:startEvent(267) --Initiates second reward ifWonder Wands has been completed.
-        else
-            player:startEvent(224) --Plays default conversation once all quests in the series have been completed.
         end
-    else
-        player:startEvent(224) --Standard Conversation
     end
 -- End Wonder Wands Section
 end
@@ -89,23 +73,8 @@ end
 
 entity.onEventFinish = function(player, csid, option)
 
-    if (csid == 90) then
-        player:setMissionStatus(player:getNation(), 1)
-    elseif (csid == 147) then
+    if (csid == 147) then
         player:setMissionStatus(player:getNation(), 3)
-    elseif (csid == 94) then
-
-        -- Delete the variable(s) that was created for this mission
-        player:setCharVar("Mission_started_from", 0)
-        player:setCharVar("MissionStatus_op1", 0)
-        player:setCharVar("MissionStatus_op2", 0)
-        player:setCharVar("MissionStatus_op3", 0)
-        player:setCharVar("MissionStatus_op4", 0)
-        player:setCharVar("MissionStatus_op5", 0)
-        player:setCharVar("MissionStatus_op6", 0)
-
-        finishMissionTimeline(player, 1, csid, option)
-
     elseif (csid == 274 and option == 1) then
             player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.MAKING_AMENDS)
     elseif (csid == 277) then

--- a/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
+++ b/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
@@ -14,14 +14,14 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
 
-    if (player:getNation() ~= xi.nation.WINDURST) then
+    if player:getNation() ~= xi.nation.WINDURST then
         player:startEvent(71) -- for other nation
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
         local cs, p, offset = getMissionOffset(player, 3, currentMission, missionStatus)
 
-        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or currentMission ~= xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -29,8 +29,6 @@ entity.onTrigger = function(player, npc)
             end
         elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(76)
-        elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
-            player:startEvent(83)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false) then
             player:startEvent(104)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_PRICE_OF_PEACE) == false) then
@@ -59,11 +57,10 @@ end
 
 entity.onEventFinish = function(player, csid, option)
 
-    finishMissionTimeline(player, 3, csid, option)
-
-    if (csid == 118 and option == 1) then
-        player:addTitle(xi.title.NEW_BEST_OF_THE_WEST_RECRUIT)
-    elseif (csid == 78 and (option == 12 or option == 15)) then
+    if csid ~= 83 then
+        finishMissionTimeline(player, 3, csid, option)
+    end
+    if (csid == 78 and (option == 12 or option == 15)) then
         player:addKeyItem(xi.ki.STAR_CRESTED_SUMMONS_1)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.STAR_CRESTED_SUMMONS_1)
     end

--- a/scripts/zones/Windurst_Walls/DefaultActions.lua
+++ b/scripts/zones/Windurst_Walls/DefaultActions.lua
@@ -1,0 +1,4 @@
+local ID = require("scripts/zones/Windurst_Walls/IDs")
+
+return {
+}

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -14,14 +14,14 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
 
-    if (player:getNation() ~= xi.nation.WINDURST) then
+    if player:getNation() ~= xi.nation.WINDURST then
         player:startEvent(87) -- for other nation
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
         local cs, p, offset = getMissionOffset(player, 4, currentMission, missionStatus)
 
-        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or currentMission ~= xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -29,8 +29,6 @@ entity.onTrigger = function(player, npc)
             end
         elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(91)
-        elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
-            player:startEvent(96)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false) then
             player:startEvent(106)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_PRICE_OF_PEACE) == false) then
@@ -57,10 +55,8 @@ end
 
 entity.onEventFinish = function(player, csid, option)
 
-    finishMissionTimeline(player, 4, csid, option)
-
-    if (csid == 96 and option == 1) then
-        player:addTitle(xi.title.HEAVENS_TOWER_GATEHOUSE_RECRUIT)
+    if csid ~= 96 then
+        finishMissionTimeline(player, 4, csid, option)
     elseif (csid == 93 and (option == 12 or option == 15)) then
         player:addKeyItem(xi.ki.STAR_CRESTED_SUMMONS_1)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.STAR_CRESTED_SUMMONS_1)

--- a/scripts/zones/Windurst_Waters/DefaultActions.lua
+++ b/scripts/zones/Windurst_Waters/DefaultActions.lua
@@ -1,0 +1,4 @@
+local ID = require("scripts/zones/Windurst_Waters/IDs")
+
+return {
+}

--- a/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
@@ -14,14 +14,15 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
 
-    if (player:getNation() ~= xi.nation.WINDURST) then
+    if player:getNation() ~= xi.nation.WINDURST then
         player:startEvent(103) -- for other nation
     else
         local currentMission = player:getCurrentMission(WINDURST)
         local missionStatus = player:getMissionStatus(player:getNation())
         local cs, p, offset = getMissionOffset(player, 2, currentMission, missionStatus)
 
-        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        -- TODO: This will keep getting uglier as I move forward in the rewrite until I'm done with Mokyokyo
+        if currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or currentMission ~= xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) then
             if (cs == 0) then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -29,8 +30,6 @@ entity.onTrigger = function(player, npc)
             end
         elseif (currentMission ~= xi.mission.id.windurst.NONE) then
             player:startEvent(109)
-        elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
-            player:startEvent(118)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HEART_OF_THE_MATTER) == false) then
             player:startEvent(130)
         elseif (player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_PRICE_OF_PEACE) == false) then
@@ -59,15 +58,14 @@ end
 
 entity.onEventFinish = function(player, csid, option)
 
-    finishMissionTimeline(player, 2, csid, option)
-
-    if (csid == 118 and option == 1) then
-        player:addTitle(xi.title.FRESH_NORTH_WINDS_RECRUIT)
-    elseif (csid == 111 and (option == 12 or option == 15)) then
+    if csid ~= 118 then
+        finishMissionTimeline(player, 2, csid, option)
+    end
+    if csid == 111 and (option == 12 or option == 15) then
         player:addKeyItem(xi.ki.STAR_CRESTED_SUMMONS_1)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.STAR_CRESTED_SUMMONS_1)
     end
-    if (csid == 837) then
+    if csid == 837 then
         player:setCharVar("WWatersRTenText", 1)
     end
 

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
         local missionStatus = player:getMissionStatus(player:getNation())
         local cs, p, offset = getMissionOffset(player, 1, currentMission, missionStatus)
 
-        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or (currentMission == xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0))) then
+        if (currentMission <= xi.mission.id.windurst.THE_SHADOW_AWAITS and (cs ~= 0 or offset ~= 0 or currentMission ~= xi.mission.id.windurst.THE_HORUTOTO_RUINS_EXPERIMENT and offset == 0)) then
             if cs == 0 then
                 player:showText(npc, ORIGINAL_MISSION_OFFSET + offset) -- dialog after accepting mission
             else
@@ -56,11 +56,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    finishMissionTimeline(player, 1, csid, option)
 
-    if csid == 121 and option == 1 then
-        player:addTitle(xi.title.NEW_BUUMAS_BOOMERS_RECRUIT)
-    elseif csid == 114 and (option == 12 or option == 15) then
+    if csid ~= 121 then
+        finishMissionTimeline(player, 1, csid, option)
+    end
+    if csid == 114 and (option == 12 or option == 15) then
         player:addKeyItem(xi.ki.STAR_CRESTED_SUMMONS_1)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.STAR_CRESTED_SUMMONS_1)
     elseif csid == 632 then

--- a/scripts/zones/Windurst_Woods/npcs/Tih_Pikeh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Tih_Pikeh.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: Windurst Woods
 --  NPC: Tih Pikeh
--- Working 100%
+-- !pos 107 -5 -22 241
 -----------------------------------
 local entity = {}
 


### PR DESCRIPTION
What a fun mission to script as the first one in the Windy line -- NOT!

I fell into a rabbit hole of dead NPCs, stayed there too long, and had to hold my hands over my eyes and save that work for another day, which is really hard. They've made it this far and gods only know how long it will take for them to be brought to life! The goal is to just convert these Windurst missions to the new framework, though, so dialed back some of that endeavor and focused on the plan.

I am submitting this one for approval first by itself, as I will likely be re-using the same methods for handling the gate guard-adjacent NPCs and such things in future Windurst missions, where they all comment when you have one flagged.

Help from Zach and Clay, who provided some research on the various NPCs involved. Swiped some Gizmo script from an early draft of Zach's version of this mission. Thanks to their assistance, this mission and its NPCs are in the most fleshed out state it's ever been in!

Reference links:
https://ffxiclopedia.fandom.com/wiki/The_Horutoto_Ruins_Experiment
https://www.bg-wiki.com/ffxi/Windurst_Mission_1-1

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
