### PR TITLE
Fix data type in getWeaponSkillLevel binding

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10824,7 +10824,7 @@ void CLuaBaseEntity::removeAmmo()
  *  Notes   : Mainly used to determine String/Wind level, but can be used for others
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getWeaponSkillLevel(uint8 slotID)
+uint16 CLuaBaseEntity::getWeaponSkillLevel(uint8 slotID)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -631,7 +631,7 @@ public:
 
     void removeAmmo();
 
-    uint8  getWeaponSkillLevel(uint8 slotID);                        // Get Skill for equipped weapon
+    uint16 getWeaponSkillLevel(uint8 slotID);                        // Get Skill for equipped weapon
     uint16 getWeaponDamageType(uint8 slotID);                        // gets the type of weapon equipped
     uint8  getWeaponSkillType(uint8 slotID);                         // gets the type of weapon equipped
     uint8  getWeaponSubSkillType(uint8 slotID);                      // gets the subskill of weapon equipped


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Data type is incorrectly set to uint8, causing an overflow.

Closes #501