### PR TITLE
Remove old references from Windurst M1-1

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -966,13 +966,11 @@ function finishMissionTimeline(player, guard, csid, option)
         end
     elseif (nation == xi.nation.WINDURST) then
         local guardlist = {114, 111, 78, 93}
-        if (csid == guardlist[guard] and option ~= 1073741824 and option ~= 31) then
+        if (csid == guardlist[guard] and option ~= 1073741824 and option ~= 31 and option > 0) then -- last part of conditional is for converted missions, increment for each converted
             timeline = {option, {guardlist[guard], option}, {guardlist[guard], option}, {guardlist[guard], option}, {guardlist[guard], option}, {{1}, {2}}}
         else
             timeline =
             { -- ID    Guard 1      Guard 2      Guard 3     Guard 4        Function List
-                 0,    {121, 1},    {118, 1},    {83, 1},    {96, 1},       {{1}, {2}},                                                 -- MISSION 1-1 (First Mission [START])
-                 0,     {94, 0},      {0, 0},     {0, 0},     {0, 0},       {{14, 0}, {5, 150}, {9, 28}, {12}},                         -- MISSION 1-1 (Finish (Hakkuru-Rinkuru))
                  1,    {132, 1},    {130, 1},   {104, 1},   {106, 1},       {{1}, {2}},                                                 -- MISSION 1-2 [START]
                  1,    {143, 0},      {0, 0},     {0, 0},     {0, 0},       {{14, 0}, {5, 200}, {12}},                                  -- MISSION 1-2 (Finish (Apururu)) [WITHOUT ORB]
                  1,    {145, 0},      {0, 0},     {0, 0},     {0, 0},       {{14, 0}, {5, 250}, {12}},                                  -- MISSION 1-2 (Finish (Apururu)) [WITH ORB]

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -905,7 +905,6 @@ function getMissionOffset(player, guard, pMission, missionStatus)
         end
 
         switch (pMission) : caseof {
-            [0] = function (x) cs = GuardCS[1] end,
             [1] = function (x) cs = GuardCS[2] end,
             [2] = function (x) if (missionStatus <= 2) then cs = GuardCS[3] else cs = GuardCS[4] end end,
             [3] = function (x) cs = GuardCS[5] end,


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞 ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Removes missions.lua references for Windurst M1-1