### PR TITLE
Luacheck: Simplify Bahamut Megaflare triggers

### DIFF
--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
@@ -19,6 +19,11 @@ entity.onMobSpawn = function(mob)
     mob:addStatusEffect(xi.effect.SHELL, 24, 0, 1800)
 end
 
+local megaflareHPP =
+{
+    90, 80, 70, 60, 50, 40, 30, 20,
+}
+
 entity.onMobFight = function(mob, target)
     local MegaFlareQueue = mob:getLocalVar("MegaFlareQueue")
     local MegaFlareTrigger = mob:getLocalVar("MegaFlareTrigger")
@@ -34,59 +39,43 @@ entity.onMobFight = function(mob, target)
         isBusy = true -- is set to true if Bahamut is in any stage of using a mobskill or casting a spell
     end
 
-    if (mobHPP < 90 and MegaFlareTrigger < 1) then -- if Megaflare hasn't been set to be used this many times, increase the queue of Megaflares. This will allow it to use multiple Megaflares in a row if the HP is decreased quickly enough.
-        mob:setLocalVar("MegaFlareTrigger", 1)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 80 and MegaFlareTrigger < 2) then
-        mob:setLocalVar("MegaFlareTrigger", 2)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 70 and MegaFlareTrigger < 3) then
-        mob:setLocalVar("MegaFlareTrigger", 3)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 60 and MegaFlareTrigger < 4) then
-        mob:setLocalVar("MegaFlareTrigger", 4)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 50 and MegaFlareTrigger < 5) then
-        mob:setLocalVar("MegaFlareTrigger", 5)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 40 and MegaFlareTrigger < 6) then
-        mob:setLocalVar("MegaFlareTrigger", 6)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 30 and MegaFlareTrigger < 7) then
-        mob:setLocalVar("MegaFlareTrigger", 7)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
-    elseif (mobHPP < 20 and MegaFlareTrigger < 8) then
-        mob:setLocalVar("MegaFlareTrigger", 8)
-        mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
+    -- if Megaflare hasn't been set to be used this many times, increase the queue of Megaflares. This will allow it to use multiple Megaflares in a row if the HP is decreased quickly enough.
+    for trigger, hpp in ipairs(megaflareHPP) do
+        if mobHPP < hpp and MegaFlareTrigger < trigger then
+            mob:setLocalVar("MegaFlareTrigger", trigger)
+            mob:setLocalVar("MegaFlareQueue", MegaFlareQueue + 1)
+            break
+        end
     end
 
-    if (mob:actionQueueEmpty() == true and isBusy == false) then -- the last check prevents multiple Mega/Gigaflares from being called at the same time.
-        if (MegaFlareQueue > 0) then
+    if mob:actionQueueEmpty() == true and not isBusy then -- the last check prevents multiple Mega/Gigaflares from being called at the same time.
+        if MegaFlareQueue > 0 then
             mob:SetMobAbilityEnabled(false) -- disable all other actions until Megaflare is used successfully
             mob:SetMagicCastingEnabled(false)
             mob:SetAutoAttackEnabled(false)
-            if (FlareWait == 0 and tauntShown == 0) then -- if there is a queued Megaflare and the last Megaflare has been used successfully or if the first one hasn't been used yet.
+
+            if FlareWait == 0 and tauntShown == 0 then -- if there is a queued Megaflare and the last Megaflare has been used successfully or if the first one hasn't been used yet.
                 target:showText(mob, ID.text.BAHAMUT_TAUNT)
                 mob:setLocalVar("FlareWait", mob:getBattleTime() + 2) -- second taunt happens two seconds after the first.
                 mob:setLocalVar("tauntShown", 1)
-            elseif (FlareWait < mob:getBattleTime() and FlareWait ~= 0 and tauntShown >= 0) then -- the wait time between the first and second taunt as passed. Checks for wait to be not 0 because it's set to 0 on successful use.
-                if (tauntShown == 1) then
+            elseif FlareWait < mob:getBattleTime() and FlareWait ~= 0 and tauntShown >= 0 then -- the wait time between the first and second taunt as passed. Checks for wait to be not 0 because it's set to 0 on successful use.
+                if tauntShown == 1 then
                     mob:setLocalVar("tauntShown", 2) -- if Megaflare gets stunned it won't show the text again, until successful use.
                     target:showText(mob, ID.text.BAHAMUT_TAUNT + 1)
                 end
-                if (mob:checkDistance(target) <= 15) then -- without this check if the target is out of range it will keep attemping and failing to use Megaflare. Both Megaflare and Gigaflare have range 15.
+                if mob:checkDistance(target) <= 15 then -- without this check if the target is out of range it will keep attemping and failing to use Megaflare. Both Megaflare and Gigaflare have range 15.
                     if (bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0) then -- default behaviour
                         mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
                     end
                     mob:useMobAbility(1551)
                 end
             end
-        elseif (MegaFlareQueue == 0 and mobHPP < 10 and GigaFlare < 1 and mob:checkDistance(target) <= 15) then  -- All of the scripted Megaflares are to happen before Gigaflare.
-            if (tauntShown == 0) then
+        elseif MegaFlareQueue == 0 and mobHPP < 10 and GigaFlare < 1 and mob:checkDistance(target) <= 15 then  -- All of the scripted Megaflares are to happen before Gigaflare.
+            if tauntShown == 0 then
                 target:showText(mob, ID.text.BAHAMUT_TAUNT + 2)
                 mob:setLocalVar("tauntShown", 3) -- again, taunt won't show again until the move is successfully used.
             end
-            if (bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0) then -- default behaviour
+            if bit.band(mob:getBehaviour(), xi.behavior.NO_TURN) > 0 then -- default behaviour
                 mob:setBehaviour(bit.band(mob:getBehaviour(), bit.bnot(xi.behavior.NO_TURN)))
             end
             mob:useMobAbility(1552)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Tables MobHPP values, and loops over them in onMobFight to remove large conditional.