### PR TITLE
Fix broken link Windy 2-3 Sandy->Bastok leg

### DIFF
--- a/scripts/zones/Metalworks/npcs/Grohm.lua
+++ b/scripts/zones/Metalworks/npcs/Grohm.lua
@@ -49,6 +49,8 @@ entity.onEventFinish = function(player, csid, option)
             player:setMissionStatus(pNation, 5)
             player:setCharVar("notReceivePickaxe", 0)
         end
+    elseif pNation == xi.nation.WINDURST and csid == 426 then
+        player:setMissionStatus(pNation, 10)
     end
 end
 


### PR DESCRIPTION
Grohm got clipped in the first 2-3 conversion, was missing this onEventFinish preventing Windurstians from getting the status required to trigger the BCNM for the mission. Just restoring that prior to the conversion for Windy 2-3 that will come in the near future.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [o] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
