### PR TITLE
Backtrace dumping support for Windows

### DIFF
--- a/scripts/commands/crash.lua
+++ b/scripts/commands/crash.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- func: crash
+-- desc: force the server process to crash
+-----------------------------------
+
+cmdprops =
+{
+    permission = 5,
+    parameters = ""
+}
+
+function onTrigger(player)
+    ForceCrash()
+end

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -251,6 +251,10 @@ LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
             break;
     }
 
+    // A fatal event has occured, from this point on all code executed comes from our error handling.
+    // We no longer need to trace where each log comes from, so change to a cleaner pattern.
+    spdlog::set_pattern(fmt::format("[%D %T:%e][{}]%^[%l][%n]%$ %v", SERVER_NAME));
+
     ShowFatalError("Exception %s occured!", SystemErrorToString(pExceptionInfo->ExceptionRecord->ExceptionCode));
 
     CONTEXT* ctx = pExceptionInfo->ContextRecord;

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -32,6 +32,11 @@
 #include <cstdlib>
 #include <cstring>
 
+#ifdef WIN32 // For stack trace tools
+#include <DbgHelp.h>
+#include <Windows.h>
+#endif
+
 #ifndef _WIN32
 #include <unistd.h>
 #endif
@@ -86,7 +91,7 @@ sigfunc* compat_signal(int signo, sigfunc* func)
 
 /************************************************************************
  *                                                                       *
- *  CORE : Magical backtrace dump procedure                              *
+ *  CORE : Magical backtrace dump procedure (Linux + gdb)                *
  *                                                                       *
  ************************************************************************/
 
@@ -142,6 +147,208 @@ static void dump_backtrace()
     }
 #endif
 }
+
+/************************************************************************
+ *                                                                       *
+ *  CORE : Magical backtrace dump procedure (Windows)                    *
+ *                                                                       *
+ ************************************************************************/
+
+#ifdef WIN32
+std::string SystemErrorToString(DWORD errorCode)
+{
+    std::string errorString = "UNKNOWN";
+    // clang-format off
+    switch (errorCode)
+    {
+        // WinDbg
+        case 0x00000000: errorString = "STATUS_WAIT_0"; break;
+        case 0x00000080: errorString = "STATUS_ABANDONED_WAIT_0"; break;
+        case 0x000000C0: errorString = "STATUS_USER_APC"; break;
+        case 0x00000102: errorString = "STATUS_TIMEOUT"; break;
+        case 0x00000103: errorString = "STATUS_PENDING"; break;
+        case 0x00010001: errorString = "DBG_EXCEPTION_HANDLED"; break;
+        case 0x00010002: errorString = "DBG_CONTINUE"; break;
+        case 0x40000005: errorString = "STATUS_SEGMENT_NOTIFICATION"; break;
+        case 0x40000015: errorString = "STATUS_FATAL_APP_EXIT"; break;
+        case 0x40010001: errorString = "DBG_REPLY_LATER"; break;
+        case 0x40010003: errorString = "DBG_TERMINATE_THREAD"; break;
+        case 0x40010004: errorString = "DBG_TERMINATE_PROCESS"; break;
+        case 0x40010005: errorString = "DBG_CONTROL_C"; break;
+        case 0x40010006: errorString = "DBG_PRINTEXCEPTION_C"; break;
+        case 0x40010007: errorString = "DBG_RIPEXCEPTION"; break;
+        case 0x40010008: errorString = "DBG_CONTROL_BREAK"; break;
+        case 0x40010009: errorString = "DBG_COMMAND_EXCEPTION"; break;
+        case 0x4001000A: errorString = "DBG_PRINTEXCEPTION_WIDE_C"; break;
+        case 0x80000001: errorString = "STATUS_GUARD_PAGE_VIOLATION"; break;
+        case 0x80000002: errorString = "STATUS_DATATYPE_MISALIGNMENT"; break;
+        case 0x80000003: errorString = "STATUS_BREAKPOINT"; break;
+        case 0x80000004: errorString = "STATUS_SINGLE_STEP"; break;
+        case 0x80000026: errorString = "STATUS_LONGJUMP"; break;
+        case 0x80000029: errorString = "STATUS_UNWIND_CONSOLIDATE"; break;
+        case 0x80010001: errorString = "DBG_EXCEPTION_NOT_HANDLED"; break;
+        case 0xC0000005: errorString = "STATUS_ACCESS_VIOLATION"; break;
+        case 0xC0000006: errorString = "STATUS_IN_PAGE_ERROR"; break;
+        case 0xC0000008: errorString = "STATUS_INVALID_HANDLE"; break;
+        case 0xC000000D: errorString = "STATUS_INVALID_PARAMETER"; break;
+        case 0xC0000017: errorString = "STATUS_NO_MEMORY"; break;
+        case 0xC000001D: errorString = "STATUS_ILLEGAL_INSTRUCTION"; break;
+        case 0xC0000025: errorString = "STATUS_NONCONTINUABLE_EXCEPTION"; break;
+        case 0xC0000026: errorString = "STATUS_INVALID_DISPOSITION"; break;
+        case 0xC000008C: errorString = "STATUS_ARRAY_BOUNDS_EXCEEDED"; break;
+        case 0xC000008D: errorString = "STATUS_FLOAT_DENORMAL_OPERAND"; break;
+        case 0xC000008E: errorString = "STATUS_FLOAT_DIVIDE_BY_ZERO"; break;
+        case 0xC000008F: errorString = "STATUS_FLOAT_INEXACT_RESULT"; break;
+        case 0xC0000090: errorString = "STATUS_FLOAT_INVALID_OPERATION"; break;
+        case 0xC0000091: errorString = "STATUS_FLOAT_OVERFLOW"; break;
+        case 0xC0000092: errorString = "STATUS_FLOAT_STACK_CHECK"; break;
+        case 0xC0000093: errorString = "STATUS_FLOAT_UNDERFLOW"; break;
+        case 0xC0000094: errorString = "STATUS_INTEGER_DIVIDE_BY_ZERO"; break;
+        case 0xC0000095: errorString = "STATUS_INTEGER_OVERFLOW"; break;
+        case 0xC0000096: errorString = "STATUS_PRIVILEGED_INSTRUCTION"; break;
+        case 0xC00000FD: errorString = "STATUS_STACK_OVERFLOW"; break;
+        case 0xC0000135: errorString = "STATUS_DLL_NOT_FOUND"; break;
+        case 0xC0000138: errorString = "STATUS_ORDINAL_NOT_FOUND"; break;
+        case 0xC0000139: errorString = "STATUS_ENTRYPOINT_NOT_FOUND"; break;
+        case 0xC000013A: errorString = "STATUS_CONTROL_C_EXIT"; break;
+        case 0xC0000142: errorString = "STATUS_DLL_INIT_FAILED"; break;
+        case 0xC00001B2: errorString = "STATUS_CONTROL_STACK_VIOLATION"; break;
+        case 0xC00002B4: errorString = "STATUS_FLOAT_MULTIPLE_FAULTS"; break;
+        case 0xC00002B5: errorString = "STATUS_FLOAT_MULTIPLE_TRAPS"; break;
+        case 0xC00002C9: errorString = "STATUS_REG_NAT_CONSUMPTION"; break;
+        case 0xC0000374: errorString = "STATUS_HEAP_CORRUPTION"; break;
+        case 0xC0000409: errorString = "STATUS_STACK_BUFFER_OVERRUN"; break;
+        case 0xC0000417: errorString = "STATUS_INVALID_CRUNTIME_PARAMETER"; break;
+        case 0xC0000420: errorString = "STATUS_ASSERTION_FAILURE"; break;
+        case 0xC00004A2: errorString = "STATUS_ENCLAVE_VIOLATION"; break;
+        case 0xC0000515: errorString = "STATUS_INTERRUPTED"; break;
+        case 0xC0000516: errorString = "STATUS_THREAD_NOT_RUNNING"; break;
+        case 0xC0000718: errorString = "STATUS_ALREADY_REGISTERED"; break;
+        case 0xC015000F: errorString = "STATUS_SXS_EARLY_DEACTIVATION"; break;
+        case 0xC0150010: errorString = "STATUS_SXS_INVALID_DEACTIVATION"; break;
+
+        // Other
+        case 0xE06D7363: errorString = "UNKNOWN_APPLICATION_ERROR"; break; // TODO: What is the name for 0XE06D7363?
+    }
+    // clang-format on
+
+    return fmt::format("{} ({:#08X})", errorString, errorCode);
+}
+
+// https://stackoverflow.com/a/50208684
+// From MSDN.WhiteKnight
+LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
+{
+    // https://www.freelists.org/post/luajit/FirstChance-Exception-in-luajit,1
+    // https://love2d.org/forums/viewtopic.php?t=84336
+    switch (pExceptionInfo->ExceptionRecord->ExceptionCode)
+    {
+        // exceptions NOT documented by Microsoft
+        case 0xE24C4A02 : // Magic exception number from LuaJIT: Ignore!
+            return EXCEPTION_CONTINUE_SEARCH;
+
+        default:
+            break;
+    }
+
+    ShowFatalError("Exception %s occured!", SystemErrorToString(pExceptionInfo->ExceptionRecord->ExceptionCode));
+
+    CONTEXT* ctx = pExceptionInfo->ContextRecord;
+
+    BOOL    result;
+    HANDLE  process;
+    HANDLE  thread;
+    HMODULE hModule;
+
+    STACKFRAME64 stack;
+    ULONG        frame;
+    DWORD64      displacement;
+
+    DWORD            disp;
+    IMAGEHLP_LINE64* line;
+
+    char         buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+    char         name[256];
+    char         module[256];
+    PSYMBOL_INFO pSymbol = (PSYMBOL_INFO)buffer;
+
+    memset(&stack, 0, sizeof(STACKFRAME64));
+
+    process      = GetCurrentProcess();
+    thread       = GetCurrentThread();
+    displacement = 0;
+#if !defined(_M_AMD64)
+    stack.AddrPC.Offset    = (*ctx).Eip;
+    stack.AddrPC.Mode      = AddrModeFlat;
+    stack.AddrStack.Offset = (*ctx).Esp;
+    stack.AddrStack.Mode   = AddrModeFlat;
+    stack.AddrFrame.Offset = (*ctx).Ebp;
+    stack.AddrFrame.Mode   = AddrModeFlat;
+#endif
+
+    SymInitialize(process, NULL, TRUE); // load symbols
+
+    for (frame = 0;; frame++)
+    {
+        // get next call from stack
+        result = StackWalk64(
+#if defined(_M_AMD64)
+            IMAGE_FILE_MACHINE_AMD64
+#else
+            IMAGE_FILE_MACHINE_I386
+#endif
+            ,
+            process,
+            thread,
+            &stack,
+            ctx,
+            NULL,
+            SymFunctionTableAccess64,
+            SymGetModuleBase64,
+            NULL);
+
+        if (!result)
+        {
+            break;
+        }
+
+        // get symbol name for address
+        pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        pSymbol->MaxNameLen   = MAX_SYM_NAME;
+        SymFromAddr(process, (ULONG64)stack.AddrPC.Offset, &displacement, pSymbol);
+
+        line               = (IMAGEHLP_LINE64*)malloc(sizeof(IMAGEHLP_LINE64));
+        line->SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+
+        // try to get line
+        if (SymGetLineFromAddr64(process, stack.AddrPC.Offset, &disp, line))
+        {
+            ShowStacktrace("\tat %s in %s: line: %lu: address: 0x%0X", pSymbol->Name, line->FileName, line->LineNumber, pSymbol->Address);
+        }
+        else
+        {
+            // failed to get line
+            ShowStacktrace("\tat %s, address 0x%0X.", pSymbol->Name, pSymbol->Address);
+            hModule = NULL;
+            lstrcpyA(module, "");
+            GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              (LPCTSTR)(stack.AddrPC.Offset), &hModule);
+
+            // at least print module name
+            if (hModule != NULL)
+            {
+                GetModuleFileNameA(hModule, module, 256);
+            }
+
+            ShowStacktrace("in %s", module);
+        }
+
+        free(line);
+        line = NULL;
+    }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif // WIN32
 
 /************************************************************************
  *																		*
@@ -235,6 +442,10 @@ void usercheck()
 #ifndef DEFINE_OWN_MAIN
 int main(int argc, char** argv)
 {
+#ifdef WIN32
+    AddVectoredExceptionHandler(1, TopLevelExceptionHandler);
+#endif
+
     { // initialize program arguments
         char* p1 = SERVER_NAME = argv[0];
         char* p2               = p1;

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -55,10 +55,10 @@ namespace logging
         //                            ^---  level colour  ---^
         auto defaultPattern = fmt::format("[%D %T:%e][{}]%^[%l][%n]%$ %v (%!:%#)", serverName);
 
-        auto createLogger = [&](std::string const& name, std::string const& pattern)
+        auto createLogger = [&](std::string const& name)
         {
             auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
-            logger->set_pattern(pattern);
+            logger->set_pattern(defaultPattern);
             spdlog::register_logger(logger);
             return logger;
         };
@@ -68,48 +68,48 @@ namespace logging
         // TODO: There is duplication here between the tag and the severity, FIXME
 
         // direct printf replacement
-        auto standardLogger   = createLogger("standard", defaultPattern);
-        auto messageLogger    = createLogger("message", defaultPattern);
+        auto standardLogger   = createLogger("standard");
+        auto messageLogger    = createLogger("message");
 
         // To inform about good things
-        auto statusLogger     = createLogger("status", defaultPattern);
+        auto statusLogger     = createLogger("status");
 
         // Variable information
-        auto infoLogger       = createLogger("info", defaultPattern);
+        auto infoLogger       = createLogger("info");
 
         // Less than a warning
-        auto noticeLogger     = createLogger("notice", defaultPattern);
+        auto noticeLogger     = createLogger("notice");
 
         // Warnings
-        auto warningLogger    = createLogger("warning", defaultPattern);
+        auto warningLogger    = createLogger("warning");
 
         // Important stuff
-        auto debugLogger      = createLogger("debug", defaultPattern);
+        auto debugLogger      = createLogger("debug");
 
         // Regular errors
-        auto errorLogger      = createLogger("error", defaultPattern);
+        auto errorLogger      = createLogger("error");
 
         // Fatal errors, abort(); if possible
-        auto fatalErrorLogger = createLogger("fatalerror", defaultPattern);
+        auto fatalErrorLogger = createLogger("fatalerror");
 
         // For dumping out anything related with SQL) <- Actually, this is mostly used for SQL errors with the database, as
         // successes can as well just be anything else...
-        auto sqlLogger        = createLogger("sql", defaultPattern);
+        auto sqlLogger        = createLogger("sql");
 
         // Lua related logging and errors
-        auto luaLogger        = createLogger("lua", defaultPattern);
+        auto luaLogger        = createLogger("lua");
 
         // Navmesh related errors
-        auto navmeshLogger    = createLogger("navmesh", defaultPattern);
+        auto navmeshLogger    = createLogger("navmesh");
 
         // Mostly useless "player did this" info
-        auto actionLogger     = createLogger("action", defaultPattern);
+        auto actionLogger     = createLogger("action");
 
         // Detected a likely exploit
-        auto exploitLogger    = createLogger("exploit", defaultPattern);
+        auto exploitLogger    = createLogger("exploit");
 
-        // Special format pattern for dumping stack traces
-        auto stacktraceLogger = createLogger("stacktrace", fmt::format("[%D %T:%e][{}]%^[%l][%n]%$ %v", serverName));
+        // Dumping stacktraces
+        auto stacktraceLogger = createLogger("stacktrace");
 
         spdlog::set_default_logger(standardLogger);
         spdlog::flush_on(spdlog::level::warn);

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -108,6 +108,9 @@ namespace logging
         // Detected a likely exploit
         auto exploitLogger    = createLogger("exploit", defaultPattern);
 
+        // Special format pattern for dumping stack traces
+        auto stacktraceLogger = createLogger("stacktrace", fmt::format("[%D %T:%e][{}]%^[%l][%n]%$ %v", serverName));
+
         spdlog::set_default_logger(standardLogger);
         spdlog::flush_on(spdlog::level::warn);
         spdlog::flush_every(std::chrono::seconds(30));

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -90,5 +90,6 @@ namespace logging
 #define ShowAction(...)     SPDLOG_LOGGER_INFO(spdlog::get("action"), fmt::sprintf(__VA_ARGS__))
 #define ShowExploit(...)    SPDLOG_LOGGER_WARN(spdlog::get("exploit"), fmt::sprintf(__VA_ARGS__))
 #define ShowNavError(...)   SPDLOG_LOGGER_ERROR(spdlog::get("navmesh"), fmt::sprintf(__VA_ARGS__))
+#define ShowStacktrace(...) SPDLOG_LOGGER_CRITICAL(spdlog::get("stacktrace"), fmt::sprintf(__VA_ARGS__))
 
 #endif // _LOGGING_H

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -246,6 +246,8 @@ void do_final(int code)
     timer_final();
     socket_final();
 
+    logging::ShutDown();
+
     exit(code);
 }
 
@@ -253,6 +255,7 @@ void do_abort()
 {
     do_final(EXIT_FAILURE);
 }
+
 void set_server_type()
 {
     SERVER_TYPE = XI_SERVER_LOGIN;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -220,7 +220,7 @@ namespace luautils
         set_function("selectDailyItem", &luautils::SelectDailyItem);
         set_function("GetQuestAndMissionFilenamesList", &luautils::GetQuestAndMissionFilenamesList);
         set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
-
+        set_function("ForceCrash", [](){ *((unsigned int*)0) = 0xDEAD; });
 
         // Register Sol Bindings
         CLuaAbility::Register();

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -277,10 +277,10 @@ int32 do_init(int32 argc, char** argv)
  *  do_final                                                             *
  *                                                                       *
  ************************************************************************/
-
 void do_final(int code)
 {
     TracyZoneScoped;
+
     delete[] g_PBuff;
     g_PBuff = nullptr;
     delete[] PTempBuff;
@@ -307,6 +307,8 @@ void do_final(int code)
 
     timer_final();
     socket_final();
+
+    logging::ShutDown();
 
     exit(code);
 }

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -304,6 +304,8 @@ int32 main(int32 argc, char** argv)
         return 1;
     }
 
+    logging::ShutDown();
+
     // cleanup
 #ifdef WIN32
     closesocket(ClientSocket);


### PR DESCRIPTION
Spent a while trying to remember how to be a Windows developer to give us backtrace logging for Win platforms. Eventually tripped over the exact snippet we needed, and put in additional logging support :D

**DUMPS TO LOGS**

![image](https://user-images.githubusercontent.com/1389729/126798594-ef90a655-ba61-4565-abfa-b99c1beff454.png)

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
