### PR TITLE
Fix blocking events from San d'Oria M5-2

### DIFF
--- a/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
+++ b/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
@@ -217,16 +217,17 @@ mission.sections =
             return (currentMission == mission.missionId and player:getMissionStatus(mission.areaId) >= 4) or
                 (
                     player:getCurrentMission(mission.areaId) == xi.mission.id.sandoria.NONE and
+                    player:hasCompletedMission(mission.areaId, mission.missionId) and
                     not player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.LEAUTES_LAST_WISHES)
                 )
         end,
 
         [xi.zone.CHATEAU_DORAGUILLE] =
         {
-            ['Aramaviont'] = mission:progressEvent(12),
-            ['Curilla']    = mission:progressEvent(56),
-            ['Milchupain'] = mission:progressEvent(33),
-            ['Rahal']      = mission:progressEvent(77),
+            ['Aramaviont'] = mission:event(12),
+            ['Curilla']    = mission:event(56),
+            ['Milchupain'] = mission:event(33),
+            ['Rahal']      = mission:event(77),
         },
     },
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Add additional condition to completed check to ensure this block isn't hit before intended.