### PR TITLE
[debug] Add additional error code exceptions for LuaJIT runtime

### DIFF
--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -243,10 +243,23 @@ LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
     // https://love2d.org/forums/viewtopic.php?t=84336
     switch (pExceptionInfo->ExceptionRecord->ExceptionCode)
     {
-        // exceptions NOT documented by Microsoft
-        case 0xE24C4A02 : // Magic exception number from LuaJIT: Ignore!
+       // LuaJIT throws and handles exceptions as part of its regular runtime.
+       // We should ignore these. By using Sol, there is no scenario where we want a Lua error to be fatal.
+       // The LuaJIT exception codes are all built by OR-ing 0xE24C4A00 with the relevant Lua error codes:
+       // https://github.com/LuaJIT/LuaJIT/blob/4deb5a1588ed53c0c578a343519b5ede59f3d928/src/lj_err.c#L250-L256
+       // https://github.com/LuaJIT/LuaJIT/blob/20f556e53190ab9a735b932f5d868d45ec536a70/src/lua.h#L42-L48
+        case 0xE24C4A00: // LUA_OK (0)
+            [[fallthrough]];
+        case 0xE24C4A01: // LUA_YIELD (1)
+            [[fallthrough]];
+        case 0xE24C4A02: // LUA_ERRRUN (2)
+            [[fallthrough]];
+        case 0xE24C4A03: // LUA_ERRSYNTAX (3)
+            [[fallthrough]];
+        case 0xE24C4A04: // LUA_ERRMEM (4)
+            [[fallthrough]];
+        case 0xE24C4A05: // LUA_ERRERR (5)
             return EXCEPTION_CONTINUE_SEARCH;
-
         default:
             break;
     }


### PR DESCRIPTION
Clay reported a LuaJIT crash relating to bogus syntax, looks like LuaJIT throws lots of different codes depending on whats going on.

Very well documented code supplied to fix

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞 ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
