### PR TITLE
add missing bard song scripts

### DIFF
--- a/scripts/globals/spells/fowl_aubade.lua
+++ b/scripts/globals/spells/fowl_aubade.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Fowl Aubade
+-- Enhances resistance against sleep for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.AUBADE, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.AUBADE
+end
+
+return spell_object

--- a/scripts/globals/spells/fowl_aubade.lua
+++ b/scripts/globals/spells/fowl_aubade.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/goblin_gavotte.lua
+++ b/scripts/globals/spells/goblin_gavotte.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Goblin Gavotte
+-- Enhances resistance against bind for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.GAVOTTE, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.GAVOTTE
+end
+
+return spell_object

--- a/scripts/globals/spells/goblin_gavotte.lua
+++ b/scripts/globals/spells/goblin_gavotte.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/gold_capriccio.lua
+++ b/scripts/globals/spells/gold_capriccio.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Gold Capriccio
+-- Enhances resistance against petrification for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.CAPRICCIO, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.CAPRICCIO
+end
+
+return spell_object

--- a/scripts/globals/spells/gold_capriccio.lua
+++ b/scripts/globals/spells/gold_capriccio.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/herb_pastoral.lua
+++ b/scripts/globals/spells/herb_pastoral.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Herb Pastoral
+-- Enhances resistance against poison for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.PASTORAL, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.PASTORAL
+end
+
+return spell_object

--- a/scripts/globals/spells/herb_pastoral.lua
+++ b/scripts/globals/spells/herb_pastoral.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/puppets_operetta.lua
+++ b/scripts/globals/spells/puppets_operetta.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 120
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/puppets_operetta.lua
+++ b/scripts/globals/spells/puppets_operetta.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Puppet's Operetta
+-- Enhances resistance against silence for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 40 -- needs verification
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 120) then -- needs verification
+        power = 120
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.OPERETTA
+end
+
+return spell_object

--- a/scripts/globals/spells/scops_operetta.lua
+++ b/scripts/globals/spells/scops_operetta.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 120
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/scops_operetta.lua
+++ b/scripts/globals/spells/scops_operetta.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Puppet's Operetta
+-- Enhances resistance against silence for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 40
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 120) then
+        power = 120
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.OPERETTA
+end
+
+return spell_object

--- a/scripts/globals/spells/shining_fantasia.lua
+++ b/scripts/globals/spells/shining_fantasia.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then

--- a/scripts/globals/spells/shining_fantasia.lua
+++ b/scripts/globals/spells/shining_fantasia.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Shining Fantasia
+-- Enhances resistance against blind for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.FANTASIA, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.FANTASIA
+end
+
+return spell_object

--- a/scripts/globals/spells/warding_round.lua
+++ b/scripts/globals/spells/warding_round.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Spell: Warding Round
+-- Enhances resistance against curse for party members within the area of effect.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
+    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    local power = 20
+
+    if (sLvl+iLvl > 200) then
+        power = power + math.floor((sLvl+iLvl-200) / 10)
+    end
+
+    if (power >= 80) then
+        power = 80
+    end
+
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    power = power + iBoost*8
+
+    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
+        power = power * 2
+    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
+        power = power * 1.5
+    end
+    caster:delStatusEffect(xi.effect.MARCATO)
+
+    local duration = 120
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
+
+    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
+        duration = duration * 2
+    end
+
+    if not (target:addBardSong(caster, xi.effect.ROUND, power, 0, duration, caster:getID(), 0, 1)) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return xi.effect.ROUND
+end
+
+return spell_object

--- a/scripts/globals/spells/warding_round.lua
+++ b/scripts/globals/spells/warding_round.lua
@@ -26,7 +26,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         power = 80
     end
 
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT) 
+    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
     power = power + iBoost*8
 
     if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

we had the effects in place for these spells but lacked the scripts for song execution. I slightly boosted puppets operetta since it's a higher level version of scop's, and left needs verification comments, though it is difficult to test these types of spells. the animations for these are really cool, it's a shame these aren't really worth using. 

closes #456 


