### PR TITLE
[kernel] Custom exception handler should also ignore internal application exceptions

### DIFF
--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -226,9 +226,6 @@ std::string SystemErrorToString(DWORD errorCode)
         case 0xC0000718: errorString = "STATUS_ALREADY_REGISTERED"; break;
         case 0xC015000F: errorString = "STATUS_SXS_EARLY_DEACTIVATION"; break;
         case 0xC0150010: errorString = "STATUS_SXS_INVALID_DEACTIVATION"; break;
-
-        // Other
-        case 0xE06D7363: errorString = "UNKNOWN_APPLICATION_ERROR"; break; // TODO: What is the name for 0XE06D7363?
     }
     // clang-format on
 
@@ -260,6 +257,11 @@ LONG WINAPI TopLevelExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
             [[fallthrough]];
         case 0xE24C4A05: // LUA_ERRERR (5)
             return EXCEPTION_CONTINUE_SEARCH;
+
+        // Exceptions thrown internally (like is possible in AI state transitions) should also be ignored
+        case 0xE06D7363: // Internal application exception code
+            return EXCEPTION_CONTINUE_SEARCH;
+
         default:
             break;
     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞 ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
