### PR TITLE
[WIP][SQL] query_builder helper

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     md52.cpp
     md52.h
     mmo.h
+    query_builder.h
     socket.cpp
     socket.h
     sql.cpp

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -39,6 +39,8 @@ using uint16 = std::uint16_t;
 using uint32 = std::uint32_t;
 using uint64 = std::uint64_t;
 
+using blob = int8*;
+
 // string case comparison for *nix portability
 #if !defined(_MSC_VER)
 #define strcmpi strcasecmp

--- a/src/common/query_builder.h
+++ b/src/common/query_builder.h
@@ -247,6 +247,12 @@ namespace query
             return *this;
         }
 
+        builder& join(std::string const& str)
+        {
+            joinsVec.emplace_back(str);
+            return *this;
+        }
+
         template <typename... Args>
         builder& where(Args&&... args)
         {
@@ -280,6 +286,11 @@ namespace query
             }
 
             query += fmt::format("FROM {} ", fromTable);
+
+            for (auto& joinStr : joinsVec)
+            {
+                query += fmt::format("JOIN {} ", joinStr);
+            }
 
             if (!whereCondition.empty())
             {
@@ -389,6 +400,7 @@ namespace query
 
         std::string queryType;
         std::string fromTable;
+        std::vector<std::string> joinsVec;
         std::string whereCondition;
         std::string limitStr;
     };

--- a/src/common/query_builder.h
+++ b/src/common/query_builder.h
@@ -1,0 +1,245 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2021 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _QUERY_BUILDER_H
+#define _QUERY_BUILDER_H
+
+/*
+This helper is designed to abstract away the manual field and index tracking of our SQL query building.
+One day, we will rewrite all of our database access to not build queries on the fly, but that
+is a problem for future us!
+
+THIS IS NOT A SILVER BULLET FOR OUR DATABASE ACCESS PATTERNS/PROBLEMS.
+It's just to make our lives a little easier until we do a rewrite.
+*/
+
+#include "cbasetypes.h"
+#include "logging.h"
+#include "sql.h"
+
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace query
+{
+    using field_t = std::pair<std::string, SqlDataType>;
+    using data_t = std::variant<uint32, int32, float, int8*>;
+
+    struct row_t
+    {
+        template <typename T>
+        T& get(std::string const& key)
+        {
+            return std::get<T>(dataMap[key]);
+        }
+
+        std::map<std::string, data_t> dataMap;
+    };
+
+    struct results
+    {
+        // Query information
+        std::string m_query;
+
+        // Result information
+        std::vector<row_t> m_rows;
+
+        // Error information
+        bool m_error = false;
+        std::string m_errorStr = "";
+    };
+
+    class builder
+    {
+    public:
+        builder(Sql_t* handle)
+        : SqlHandle(handle)
+        {
+        }
+
+        builder& select()
+        {
+            if (!queryType.empty())
+            {
+                // You shouldn't be here!
+                throw;
+            }
+            queryType = "SELECT";
+            return *this;
+        }
+
+        template <typename T>
+        builder& field(std::string const& str)
+        {
+            if constexpr (std::is_same_v<float, T>)
+            {
+                // Sql_GetFloatData
+                fields.emplace_back(str, SqlDataType::SQLDT_FLOAT);
+            }
+            else if constexpr (std::is_same_v<unsigned int, T>)
+            {
+                // Sql_GetUIntData
+                fields.emplace_back(str, SqlDataType::SQLDT_UINT32);
+            }
+            else if constexpr (std::is_same_v<int, T>)
+            {
+                // Sql_GetIntData
+                fields.emplace_back(str, SqlDataType::SQLDT_INT32);
+            }
+            else if constexpr (std::is_same_v<std::string, T>)
+            {
+                // Sql_GetData
+                fields.emplace_back(str, SqlDataType::SQLDT_STRING);
+            }
+            // TODO: blob
+            // TODO: datetime (uint32?)
+            else
+            {
+                // You shouldn't be here!
+                throw;
+            }
+            return *this;
+        }
+
+        builder& from(std::string const& str)
+        {
+            if (!fromTable.empty())
+            {
+                // You shouldn't be here!
+                throw;
+            }
+            fromTable = str;
+            return *this;
+        }
+
+        template <typename... Args>
+        builder& where(Args&&... args)
+        {
+            if (!whereCondition.empty())
+            {
+                // You shouldn't be here!
+                throw;
+            }
+            whereCondition = fmt::format(std::forward<Args>(args)...);
+            return *this;
+        }
+
+        builder& limit(std::size_t sz)
+        {
+            limitStr = fmt::format("LIMIT {}", sz);
+            return *this;
+        }
+
+        results execute()
+        {
+            std::string query;
+
+            query += fmt::format("{} ", queryType);
+
+            // Build comma-delimited list of fields
+            // TODO: Do this better
+            for (int i = 0; i < fields.size(); ++i)
+            {
+                query += fields[i].first;
+                query += (i == fields.size() - 1) ? " " : ", ";
+            }
+
+            query += fmt::format("FROM {} ", fromTable);
+
+            if (!whereCondition.empty())
+            {
+                query += fmt::format("WHERE {}", whereCondition);
+            }
+
+            if (!limitStr.empty())
+            {
+                query += fmt::format(" {}", limitStr);
+            }
+
+            query += ";";
+
+            results res;
+            res.m_query = query;
+            int32 ret = Sql_Query(SqlHandle, query.c_str());
+            if (ret == SQL_ERROR)
+            {
+                ShowSQL("Query failed");
+                res.m_error = true;
+                res.m_errorStr = "Query failed";
+                return res;
+            }
+
+            if (Sql_NumRows(SqlHandle) == 0)
+            {
+                return res;
+            }
+
+            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+            {
+                row_t row;
+                for (int i = 0; i < fields.size(); ++i)
+                {
+                    auto name = fields[i].first;
+                    auto type = fields[i].second;
+                    switch (type)
+                    {
+                        case SqlDataType::SQLDT_FLOAT:
+                        {
+                            row.dataMap[name] = static_cast<float>(Sql_GetFloatData(SqlHandle, i));
+                            break;
+                        }
+                        case SqlDataType::SQLDT_UINT32:
+                        {
+                            row.dataMap[name] = static_cast<uint32>(Sql_GetUIntData(SqlHandle, i));
+                            break;
+                        }
+                        case SqlDataType::SQLDT_INT32:
+                        {
+                            row.dataMap[name] = static_cast<int32>(Sql_GetIntData(SqlHandle, i));
+                            break;
+                        }
+                        default:
+                        {
+                            row.dataMap[name] = Sql_GetData(SqlHandle, i);
+                            break;
+                        }
+                    }
+                }
+                res.m_rows.emplace_back(row);
+            }
+            return res;
+        }
+
+    private:
+        Sql_t* SqlHandle;
+
+        std::vector<field_t> fields;
+
+        std::string queryType;
+        std::string fromTable;
+        std::string whereCondition;
+        std::string limitStr;
+    };
+} // namespace query
+
+#endif // _QUERY_BUILDER_H

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -22,6 +22,7 @@
 #include "../common/logging.h"
 #include "../common/taskmgr.h"
 #include "../common/timer.h"
+#include "../common/tracy.h"
 
 #include "sql.h"
 
@@ -255,6 +256,9 @@ size_t Sql_EscapeString(Sql_t* self, char* out_to, const char* from)
 
 int32 Sql_QueryStr(Sql_t* self, const char* query)
 {
+    TracyZoneScoped;
+    TracyZoneCString(query);
+
     if (self == nullptr)
     {
         return SQL_ERROR;

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -429,34 +429,12 @@ int8* Sql_GetData(Sql_t* self, size_t col)
 
 int32 Sql_GetIntData(Sql_t* self, size_t col)
 {
-    if (self && self->row)
-    {
-        if (col < Sql_NumColumns(self))
-        {
-            return (self->row[col] ? (int32)atoi(self->row[col]) : 0);
-        }
-    }
-    ShowFatalError("Sql_GetIntData: SQL_ERROR");
-    return 0;
+    return Sql_GetIntData<int32>(self, col);
 }
-
-/************************************************************************
- *																		*
- *				  														*
- *																		*
- ************************************************************************/
 
 uint32 Sql_GetUIntData(Sql_t* self, size_t col)
 {
-    if (self && self->row)
-    {
-        if (col < Sql_NumColumns(self))
-        {
-            return (self->row[col] ? (uint32)strtoul(self->row[col], nullptr, 10) : 0);
-        }
-    }
-    ShowFatalError("Sql_GetUIntData: SQL_ERROR");
-    return 0;
+    return Sql_GetUIntData<uint32>(self, col);
 }
 
 /************************************************************************
@@ -471,12 +449,34 @@ float Sql_GetFloatData(Sql_t* self, size_t col)
     {
         if (col < Sql_NumColumns(self))
         {
+            // NOTE: atof returns a double (64-bit)
             return (self->row[col] ? (float)atof(self->row[col]) : 0.f);
         }
     }
     ShowFatalError("Sql_GetFloatData: SQL_ERROR");
     return 0;
 }
+
+/************************************************************************
+ *																		*
+ *				  														*
+ *																		*
+ ************************************************************************/
+
+double Sql_GetDoubleData(Sql_t* self, size_t col)
+{
+    if (self && self->row)
+    {
+        if (col < Sql_NumColumns(self))
+        {
+            // NOTE: atof returns a double (64-bit)
+            return (self->row[col] ? atof(self->row[col]) : 0.f);
+        }
+    }
+    ShowFatalError("Sql_GetFloatData: SQL_ERROR");
+    return 0;
+}
+
 
 /************************************************************************
  *																		*

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -164,11 +164,54 @@ int32 Sql_Keepalive(Sql_t* self);
 ///
 /// @return SQL_SUCCESS or SQL_ERROR
 int32 Sql_GetData(Sql_t* self, size_t col, char** out_buf, size_t* out_len);
+int8* Sql_GetData(Sql_t* self, size_t col);
 
-int8*  Sql_GetData(Sql_t* self, size_t col);
+template <typename T>
+T Sql_GetIntData(Sql_t* self, size_t col)
+{
+    if (self && self->row)
+    {
+        if (col < Sql_NumColumns(self))
+        {
+            if constexpr (sizeof(T) >= 8)
+            {
+                return (self->row[col] ? (T)atoll(self->row[col]) : T());
+            }
+            else
+            {
+                return (self->row[col] ? (T)atol(self->row[col]) : T());
+            }
+        }
+    }
+    ShowFatalError("Sql_GetIntData: SQL_ERROR");
+    return T();
+}
+
+template <typename T>
+T Sql_GetUIntData(Sql_t* self, size_t col)
+{
+    if (self && self->row)
+    {
+        if (col < Sql_NumColumns(self))
+        {
+            if constexpr (sizeof(T) >= 8)
+            {
+                return (self->row[col] ? (T)strtoull(self->row[col], nullptr, 10) : T());
+            }
+            else
+            {
+                return (self->row[col] ? (T)strtoul(self->row[col], nullptr, 10) : T());
+            }
+        }
+    }
+    ShowFatalError("Sql_GetUIntData: SQL_ERROR");
+    return T();
+}
+
 int32  Sql_GetIntData(Sql_t* self, size_t col);
 uint32 Sql_GetUIntData(Sql_t* self, size_t col);
 float  Sql_GetFloatData(Sql_t* self, size_t col);
+double Sql_GetDoubleData(Sql_t* self, size_t col);
 
 /// Frees the result of the query.
 void Sql_FreeResult(Sql_t* self);

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -427,6 +427,8 @@ namespace roeutils
 
     void onCharLoad(CCharEntity* PChar)
     {
+        TracyZoneScoped;
+
         if (!RoeSystem.RoeEnabled)
         {
             return;

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -428,7 +428,6 @@ namespace roeutils
     void onCharLoad(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         if (!RoeSystem.RoeEnabled)
         {
             return;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -332,14 +332,10 @@ namespace charutils
     void LoadChar(CCharEntity* PChar)
     {
         TracyZoneScoped;
-        uint8  meritPoints = 0;
-        uint16 limitPoints = 0;
-        int32  HP          = 0;
-        int32  MP          = 0;
 
-        // Legacy
-        int32 ret = 0;
-        const char* fmtQuery = "";
+        bool zoning = false;
+        int32 HP    = 0;
+        int32 MP    = 0;
 
         LoadBaseData(PChar);
         LoadSpells(PChar);
@@ -347,247 +343,15 @@ namespace charutils
         roeutils::onCharLoad(PChar);
         LoadStorageBuffs(PChar);
         LoadLook(PChar);
-
-        fmtQuery = "SELECT head, body, hands, legs, feet, main, sub, ranged FROM char_style WHERE charid = %u;";
-        ret      = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->styleItems[SLOT_HEAD]   = (uint16)Sql_GetIntData(SqlHandle, 0);
-            PChar->styleItems[SLOT_BODY]   = (uint16)Sql_GetIntData(SqlHandle, 1);
-            PChar->styleItems[SLOT_HANDS]  = (uint16)Sql_GetIntData(SqlHandle, 2);
-            PChar->styleItems[SLOT_LEGS]   = (uint16)Sql_GetIntData(SqlHandle, 3);
-            PChar->styleItems[SLOT_FEET]   = (uint16)Sql_GetIntData(SqlHandle, 4);
-            PChar->styleItems[SLOT_MAIN]   = (uint16)Sql_GetIntData(SqlHandle, 5);
-            PChar->styleItems[SLOT_SUB]    = (uint16)Sql_GetIntData(SqlHandle, 6);
-            PChar->styleItems[SLOT_RANGED] = (uint16)Sql_GetIntData(SqlHandle, 7);
-        }
-
-        fmtQuery = "SELECT unlocked, genkai, war, mnk, whm, blm, rdm, thf, pld, drk, bst, brd, rng, sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run "
-                   "FROM char_jobs "
-                   "WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->jobs.unlocked = (uint32)Sql_GetUIntData(SqlHandle, 0);
-            PChar->jobs.genkai   = (uint8)Sql_GetUIntData(SqlHandle, 1);
-
-            PChar->jobs.job[JOB_WAR] = (uint8)Sql_GetIntData(SqlHandle, 2);
-            PChar->jobs.job[JOB_MNK] = (uint8)Sql_GetIntData(SqlHandle, 3);
-            PChar->jobs.job[JOB_WHM] = (uint8)Sql_GetIntData(SqlHandle, 4);
-            PChar->jobs.job[JOB_BLM] = (uint8)Sql_GetIntData(SqlHandle, 5);
-            PChar->jobs.job[JOB_RDM] = (uint8)Sql_GetIntData(SqlHandle, 6);
-            PChar->jobs.job[JOB_THF] = (uint8)Sql_GetIntData(SqlHandle, 7);
-            PChar->jobs.job[JOB_PLD] = (uint8)Sql_GetIntData(SqlHandle, 8);
-            PChar->jobs.job[JOB_DRK] = (uint8)Sql_GetIntData(SqlHandle, 9);
-            PChar->jobs.job[JOB_BST] = (uint8)Sql_GetIntData(SqlHandle, 10);
-            PChar->jobs.job[JOB_BRD] = (uint8)Sql_GetIntData(SqlHandle, 11);
-            PChar->jobs.job[JOB_RNG] = (uint8)Sql_GetIntData(SqlHandle, 12);
-            PChar->jobs.job[JOB_SAM] = (uint8)Sql_GetIntData(SqlHandle, 13);
-            PChar->jobs.job[JOB_NIN] = (uint8)Sql_GetIntData(SqlHandle, 14);
-            PChar->jobs.job[JOB_DRG] = (uint8)Sql_GetIntData(SqlHandle, 15);
-            PChar->jobs.job[JOB_SMN] = (uint8)Sql_GetIntData(SqlHandle, 16);
-            PChar->jobs.job[JOB_BLU] = (uint8)Sql_GetIntData(SqlHandle, 17);
-            PChar->jobs.job[JOB_COR] = (uint8)Sql_GetIntData(SqlHandle, 18);
-            PChar->jobs.job[JOB_PUP] = (uint8)Sql_GetIntData(SqlHandle, 19);
-            PChar->jobs.job[JOB_DNC] = (uint8)Sql_GetIntData(SqlHandle, 20);
-            PChar->jobs.job[JOB_SCH] = (uint8)Sql_GetIntData(SqlHandle, 21);
-            PChar->jobs.job[JOB_GEO] = (uint8)Sql_GetIntData(SqlHandle, 22);
-            PChar->jobs.job[JOB_RUN] = (uint8)Sql_GetIntData(SqlHandle, 23);
-        }
-
-        fmtQuery = "SELECT mode, war, mnk, whm, blm, rdm, thf, pld, drk, bst, brd, rng, sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run, merits, limits "
-                   "FROM char_exp "
-                   "WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->MeritMode         = (uint8)Sql_GetIntData(SqlHandle, 0);
-            PChar->jobs.exp[JOB_WAR] = (uint16)Sql_GetIntData(SqlHandle, 1);
-            PChar->jobs.exp[JOB_MNK] = (uint16)Sql_GetIntData(SqlHandle, 2);
-            PChar->jobs.exp[JOB_WHM] = (uint16)Sql_GetIntData(SqlHandle, 3);
-            PChar->jobs.exp[JOB_BLM] = (uint16)Sql_GetIntData(SqlHandle, 4);
-            PChar->jobs.exp[JOB_RDM] = (uint16)Sql_GetIntData(SqlHandle, 5);
-            PChar->jobs.exp[JOB_THF] = (uint16)Sql_GetIntData(SqlHandle, 6);
-            PChar->jobs.exp[JOB_PLD] = (uint16)Sql_GetIntData(SqlHandle, 7);
-            PChar->jobs.exp[JOB_DRK] = (uint16)Sql_GetIntData(SqlHandle, 8);
-            PChar->jobs.exp[JOB_BST] = (uint16)Sql_GetIntData(SqlHandle, 9);
-            PChar->jobs.exp[JOB_BRD] = (uint16)Sql_GetIntData(SqlHandle, 10);
-            PChar->jobs.exp[JOB_RNG] = (uint16)Sql_GetIntData(SqlHandle, 11);
-            PChar->jobs.exp[JOB_SAM] = (uint16)Sql_GetIntData(SqlHandle, 12);
-            PChar->jobs.exp[JOB_NIN] = (uint16)Sql_GetIntData(SqlHandle, 13);
-            PChar->jobs.exp[JOB_DRG] = (uint16)Sql_GetIntData(SqlHandle, 14);
-            PChar->jobs.exp[JOB_SMN] = (uint16)Sql_GetIntData(SqlHandle, 15);
-            PChar->jobs.exp[JOB_BLU] = (uint16)Sql_GetIntData(SqlHandle, 16);
-            PChar->jobs.exp[JOB_COR] = (uint16)Sql_GetIntData(SqlHandle, 17);
-            PChar->jobs.exp[JOB_PUP] = (uint16)Sql_GetIntData(SqlHandle, 18);
-            PChar->jobs.exp[JOB_DNC] = (uint16)Sql_GetIntData(SqlHandle, 19);
-            PChar->jobs.exp[JOB_SCH] = (uint16)Sql_GetIntData(SqlHandle, 20);
-            PChar->jobs.exp[JOB_GEO] = (uint16)Sql_GetIntData(SqlHandle, 21);
-            PChar->jobs.exp[JOB_RUN] = (uint16)Sql_GetIntData(SqlHandle, 22);
-            meritPoints              = (uint8)Sql_GetIntData(SqlHandle, 23);
-            limitPoints              = (uint16)Sql_GetIntData(SqlHandle, 24);
-        }
-
-        fmtQuery = "SELECT nameflags, mjob, sjob, hp, mp, mhflag, title, bazaar_message, zoning, "
-                   "pet_id, pet_type, pet_hp, pet_mp "
-                   "FROM char_stats WHERE charid = %u;";
-
-        ret          = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-        uint8 zoning = 0;
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->nameflags.flags = (uint32)Sql_GetUIntData(SqlHandle, 0);
-
-            PChar->SetMJob(Sql_GetUIntData(SqlHandle, 1));
-            PChar->SetSJob(Sql_GetUIntData(SqlHandle, 2));
-
-            HP = Sql_GetIntData(SqlHandle, 3);
-            MP = Sql_GetIntData(SqlHandle, 4);
-
-            PChar->profile.mhflag = (uint8)Sql_GetIntData(SqlHandle, 5);
-            PChar->profile.title  = (uint16)Sql_GetIntData(SqlHandle, 6);
-
-            int8* bazaarMessage = Sql_GetData(SqlHandle, 7);
-            if (bazaarMessage != nullptr)
-            {
-                PChar->bazaar.message.insert(0, (char*)Sql_GetData(SqlHandle, 7));
-            }
-            else
-            {
-                PChar->bazaar.message = '\0';
-            }
-
-            zoning = Sql_GetUIntData(SqlHandle, 8);
-
-            // Determine if the pet should be respawned.
-            int16 petHP = Sql_GetUIntData(SqlHandle, 11);
-            if (petHP)
-            {
-                PChar->petZoningInfo.petHP      = petHP;
-                PChar->petZoningInfo.petID      = Sql_GetUIntData(SqlHandle, 9);
-                PChar->petZoningInfo.petMP      = Sql_GetIntData(SqlHandle, 12);
-                PChar->petZoningInfo.petType    = static_cast<PET_TYPE>(Sql_GetUIntData(SqlHandle, 10));
-                PChar->petZoningInfo.respawnPet = true;
-            }
-        }
-
-        Sql_Query(SqlHandle, "UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
-
-        if (zoning == 2)
-        {
-            ShowDebug("Player <%s> logging in to zone <%u>", PChar->name.c_str(), PChar->getZone());
-        }
-
-        PChar->SetMLevel(PChar->jobs.job[PChar->GetMJob()]);
-        PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
-
-        fmtQuery = "SELECT id, time, recast FROM char_recast WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
-        {
-            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-            {
-                uint32    cast_time  = Sql_GetUIntData(SqlHandle, 1);
-                uint32    recast     = Sql_GetUIntData(SqlHandle, 2);
-                time_t    now        = time(nullptr);
-                uint32    chargeTime = 0;
-                uint8     maxCharges = 0;
-                Charge_t* charge     = ability::GetCharge(PChar, Sql_GetUIntData(SqlHandle, 0));
-                if (charge != nullptr)
-                {
-                    chargeTime = charge->chargeTime;
-                    maxCharges = charge->maxCharges;
-                }
-                if (now < cast_time + recast)
-                {
-                    PChar->PRecastContainer->Load(RECAST_ABILITY, Sql_GetUIntData(SqlHandle, 0), (cast_time + recast - (uint32)now), chargeTime, maxCharges);
-                }
-            }
-        }
-
-        fmtQuery = "SELECT skillid, value, rank "
-                   "FROM char_skills "
-                   "WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
-        {
-            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-            {
-                uint8 SkillID = (uint8)Sql_GetUIntData(SqlHandle, 0);
-
-                if (SkillID < MAX_SKILLTYPE)
-                {
-                    PChar->RealSkills.skill[SkillID] = (uint16)Sql_GetUIntData(SqlHandle, 1);
-                    if (SkillID >= SKILL_FISHING)
-                    {
-                        PChar->RealSkills.rank[SkillID] = (uint8)Sql_GetUIntData(SqlHandle, 2);
-                    }
-                }
-            }
-        }
-
-        fmtQuery = "SELECT outpost_sandy, outpost_bastok, outpost_windy, runic_portal, maw, "
-                   "campaign_sandy, campaign_bastok, campaign_windy, homepoints, survivals "
-                   "FROM char_unlocks "
-                   "WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->teleport.outpostSandy   = Sql_GetUIntData(SqlHandle, 0);
-            PChar->teleport.outpostBastok  = Sql_GetUIntData(SqlHandle, 1);
-            PChar->teleport.outpostWindy   = Sql_GetUIntData(SqlHandle, 2);
-            PChar->teleport.runicPortal    = Sql_GetUIntData(SqlHandle, 3);
-            PChar->teleport.pastMaw        = Sql_GetUIntData(SqlHandle, 4);
-            PChar->teleport.campaignSandy  = Sql_GetUIntData(SqlHandle, 5);
-            PChar->teleport.campaignBastok = Sql_GetUIntData(SqlHandle, 6);
-            PChar->teleport.campaignWindy  = Sql_GetUIntData(SqlHandle, 7);
-
-            size_t length = 0;
-            char*  buf    = nullptr;
-            Sql_GetData(SqlHandle, 8, &buf, &length);
-            memcpy(&PChar->teleport.homepoint, buf, (length > sizeof(PChar->teleport.homepoint) ? sizeof(PChar->teleport.homepoint) : length));
-
-            length = 0;
-            buf    = nullptr;
-            Sql_GetData(SqlHandle, 9, &buf, &length);
-            memcpy(&PChar->teleport.survival, buf, (length > sizeof(PChar->teleport.survival) ? sizeof(PChar->teleport.survival) : length));
-        }
-
-        PChar->PMeritPoints = new CMeritPoints(PChar);
-        PChar->PMeritPoints->SetMeritPoints(meritPoints);
-        PChar->PMeritPoints->SetLimitPoints(limitPoints);
-        PChar->PJobPoints = new CJobPoints(PChar);
-
-        fmtQuery = "SELECT "
-                   "gmlevel, "    // 0
-                   "mentor, "     // 1
-                   "job_master, " // 2
-                   "nnameflags "  // 3
-                   "FROM chars "
-                   "WHERE charid = %u;";
-
-        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
-
-        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            PChar->m_GMlevel             = (uint8)Sql_GetUIntData(SqlHandle, 0);
-            PChar->m_mentorUnlocked      = Sql_GetUIntData(SqlHandle, 1) > 0;
-            PChar->m_jobMasterDisplay    = Sql_GetUIntData(SqlHandle, 2) > 0;
-            PChar->menuConfigFlags.flags = (uint32)Sql_GetUIntData(SqlHandle, 3);
-        }
-
-        charutils::LoadInventory(PChar);
+        LoadStyle(PChar);
+        LoadJobs(PChar);
+        LoadExp(PChar);
+        LoadStats(PChar, zoning, HP, MP);
+        LoadRecast(PChar);
+        LoadSkills(PChar);
+        LoadUnlocks(PChar);
+        LoadFlags(PChar);
+        LoadInventory(PChar);
 
         CalculateStats(PChar);
         blueutils::LoadSetSpells(PChar);
@@ -605,7 +369,9 @@ namespace charutils
         PChar->health.hp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxHP() : HP;
         PChar->health.mp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxMP() : MP;
         PChar->UpdateHealth();
+
         PChar->m_event.EventID = luautils::OnZoneIn(PChar);
+
         luautils::OnGameIn(PChar, zoning == 1);
     }
 
@@ -912,8 +678,372 @@ namespace charutils
         }
     }
 
+    void LoadStyle(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        // clang-format off
+        auto styleQuery = query::builder()
+        .select()
+            .field<uint16>("head")
+            .field<uint16>("body")
+            .field<uint16>("hands")
+            .field<uint16>("legs")
+            .field<uint16>("feet")
+            .field<uint16>("main")
+            .field<uint16>("sub")
+            .field<uint16>("ranged")
+        .from("char_style")
+        .where("charid = {}", PChar->id);
+        // clang-format on
+
+        auto styleResults = styleQuery.execute(SqlHandle);
+        if (styleResults.size() != 1)
+        {
+            // Either no results or multiple results. Both are bad!
+            // TODO: Uh oh!
+            throw;
+        }
+
+        for (auto& row : styleResults)
+        {
+            PChar->styleItems[SLOT_HEAD]   = row.get<uint16>("head");
+            PChar->styleItems[SLOT_BODY]   = row.get<uint16>("body");
+            PChar->styleItems[SLOT_HANDS]  = row.get<uint16>("hands");
+            PChar->styleItems[SLOT_LEGS]   = row.get<uint16>("legs");
+            PChar->styleItems[SLOT_FEET]   = row.get<uint16>("feet");
+            PChar->styleItems[SLOT_MAIN]   = row.get<uint16>("main");
+            PChar->styleItems[SLOT_SUB]    = row.get<uint16>("sub");
+            PChar->styleItems[SLOT_RANGED] = row.get<uint16>("ranged");
+        }
+    }
+
+    void LoadJobs(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        // clang-format off
+        auto jobQuery = query::builder()
+        .select()
+            .field<uint32>("unlocked")
+            .field<uint8>("genkai")
+
+            .field<uint8>("war")
+            .field<uint8>("mnk")
+            .field<uint8>("whm")
+            .field<uint8>("blm")
+            .field<uint8>("rdm")
+            .field<uint8>("thf")
+            .field<uint8>("pld")
+            .field<uint8>("drk")
+            .field<uint8>("bst")
+            .field<uint8>("brd")
+            .field<uint8>("rng")
+            .field<uint8>("sam")
+            .field<uint8>("nin")
+            .field<uint8>("drg")
+            .field<uint8>("smn")
+            .field<uint8>("blu")
+            .field<uint8>("cor")
+            .field<uint8>("pup")
+            .field<uint8>("dnc")
+            .field<uint8>("sch")
+            .field<uint8>("geo")
+            .field<uint8>("run")
+        .from("char_jobs")
+        .where("charid = {}", PChar->id);
+        // clang-format on
+
+        auto jobResults = jobQuery.execute(SqlHandle);
+        if (jobResults.size() != 1)
+        {
+            // Either no results or multiple results. Both are bad!
+            // TODO: Uh oh!
+            throw;
+        }
+
+        for (auto& row : jobResults)
+        {
+            PChar->jobs.unlocked = row.get<uint32>("unlocked");
+            PChar->jobs.genkai   = row.get<uint8>("genkai");
+
+            PChar->jobs.job[JOB_WAR] = row.get<uint8>("war");
+            PChar->jobs.job[JOB_MNK] = row.get<uint8>("mnk");
+            PChar->jobs.job[JOB_WHM] = row.get<uint8>("whm");
+            PChar->jobs.job[JOB_BLM] = row.get<uint8>("blm");
+            PChar->jobs.job[JOB_RDM] = row.get<uint8>("rdm");
+            PChar->jobs.job[JOB_THF] = row.get<uint8>("thf");
+            PChar->jobs.job[JOB_PLD] = row.get<uint8>("pld");
+            PChar->jobs.job[JOB_DRK] = row.get<uint8>("drk");
+            PChar->jobs.job[JOB_BST] = row.get<uint8>("bst");
+            PChar->jobs.job[JOB_BRD] = row.get<uint8>("brd");
+            PChar->jobs.job[JOB_RNG] = row.get<uint8>("rng");
+            PChar->jobs.job[JOB_SAM] = row.get<uint8>("sam");
+            PChar->jobs.job[JOB_NIN] = row.get<uint8>("nin");
+            PChar->jobs.job[JOB_DRG] = row.get<uint8>("drg");
+            PChar->jobs.job[JOB_SMN] = row.get<uint8>("smn");
+            PChar->jobs.job[JOB_BLU] = row.get<uint8>("blu");
+            PChar->jobs.job[JOB_COR] = row.get<uint8>("cor");
+            PChar->jobs.job[JOB_PUP] = row.get<uint8>("pup");
+            PChar->jobs.job[JOB_DNC] = row.get<uint8>("dnc");
+            PChar->jobs.job[JOB_SCH] = row.get<uint8>("sch");
+            PChar->jobs.job[JOB_GEO] = row.get<uint8>("geo");
+            PChar->jobs.job[JOB_RUN] = row.get<uint8>("run");
+        }
+    }
+
+    void LoadExp(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+
+        // clang-format off
+        auto expQuery = query::builder()
+        .select()
+            .field<uint8>("mode")
+
+            .field<uint16>("war")
+            .field<uint16>("mnk")
+            .field<uint16>("whm")
+            .field<uint16>("blm")
+            .field<uint16>("rdm")
+            .field<uint16>("thf")
+            .field<uint16>("pld")
+            .field<uint16>("drk")
+            .field<uint16>("bst")
+            .field<uint16>("brd")
+            .field<uint16>("rng")
+            .field<uint16>("sam")
+            .field<uint16>("nin")
+            .field<uint16>("drg")
+            .field<uint16>("smn")
+            .field<uint16>("blu")
+            .field<uint16>("cor")
+            .field<uint16>("pup")
+            .field<uint16>("dnc")
+            .field<uint16>("sch")
+            .field<uint16>("geo")
+            .field<uint16>("run")
+
+            .field<uint8>("merits")
+            .field<uint16>("limits")
+        .from("char_exp")
+        .where("charid = {}", PChar->id);
+        // clang-format on
+
+        auto expResults = expQuery.execute(SqlHandle);
+        if (expResults.size() != 1)
+        {
+            // Either no results or multiple results. Both are bad!
+            // TODO: Uh oh!
+            throw;
+        }
+
+        for (auto& row : expResults)
+        {
+            PChar->MeritMode = row.get<uint8>("mode");
+
+            PChar->jobs.exp[JOB_WAR] = row.get<uint16>("war");
+            PChar->jobs.exp[JOB_MNK] = row.get<uint16>("mnk");
+            PChar->jobs.exp[JOB_WHM] = row.get<uint16>("whm");
+            PChar->jobs.exp[JOB_BLM] = row.get<uint16>("blm");
+            PChar->jobs.exp[JOB_RDM] = row.get<uint16>("rdm");
+            PChar->jobs.exp[JOB_THF] = row.get<uint16>("thf");
+            PChar->jobs.exp[JOB_PLD] = row.get<uint16>("pld");
+            PChar->jobs.exp[JOB_DRK] = row.get<uint16>("drk");
+            PChar->jobs.exp[JOB_BST] = row.get<uint16>("bst");
+            PChar->jobs.exp[JOB_BRD] = row.get<uint16>("brd");
+            PChar->jobs.exp[JOB_RNG] = row.get<uint16>("rng");
+            PChar->jobs.exp[JOB_SAM] = row.get<uint16>("sam");
+            PChar->jobs.exp[JOB_NIN] = row.get<uint16>("nin");
+            PChar->jobs.exp[JOB_DRG] = row.get<uint16>("drg");
+            PChar->jobs.exp[JOB_SMN] = row.get<uint16>("smn");
+            PChar->jobs.exp[JOB_BLU] = row.get<uint16>("blu");
+            PChar->jobs.exp[JOB_COR] = row.get<uint16>("cor");
+            PChar->jobs.exp[JOB_PUP] = row.get<uint16>("pup");
+            PChar->jobs.exp[JOB_DNC] = row.get<uint16>("dnc");
+            PChar->jobs.exp[JOB_SCH] = row.get<uint16>("sch");
+            PChar->jobs.exp[JOB_GEO] = row.get<uint16>("geo");
+            PChar->jobs.exp[JOB_RUN] = row.get<uint16>("run");
+
+            auto meritPoints = row.get<uint8>("merits");
+            auto limitPoints    = row.get<uint16>("limits");
+            PChar->PMeritPoints = new CMeritPoints(PChar);
+            PChar->PMeritPoints->SetMeritPoints(meritPoints);
+            PChar->PMeritPoints->SetLimitPoints(limitPoints);
+            PChar->PJobPoints = new CJobPoints(PChar);
+        }
+    }
+
+    void LoadStats(CCharEntity* PChar, bool& zoning, int32& HP, int32& MP)
+    {
+        TracyZoneScoped;
+        fmtQuery = "SELECT nameflags, mjob, sjob, hp, mp, mhflag, title, bazaar_message, zoning, "
+                   "pet_id, pet_type, pet_hp, pet_mp "
+                   "FROM char_stats WHERE charid = %u;";
+
+        ret          = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+        uint8 zoning = 0;
+
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            PChar->nameflags.flags = (uint32)Sql_GetUIntData(SqlHandle, 0);
+
+            PChar->SetMJob(Sql_GetUIntData(SqlHandle, 1));
+            PChar->SetSJob(Sql_GetUIntData(SqlHandle, 2));
+
+            HP = Sql_GetIntData(SqlHandle, 3);
+            MP = Sql_GetIntData(SqlHandle, 4);
+
+            PChar->profile.mhflag = (uint8)Sql_GetIntData(SqlHandle, 5);
+            PChar->profile.title  = (uint16)Sql_GetIntData(SqlHandle, 6);
+
+            int8* bazaarMessage = Sql_GetData(SqlHandle, 7);
+            if (bazaarMessage != nullptr)
+            {
+                PChar->bazaar.message.insert(0, (char*)Sql_GetData(SqlHandle, 7));
+            }
+            else
+            {
+                PChar->bazaar.message = '\0';
+            }
+
+            zoning = Sql_GetUIntData(SqlHandle, 8);
+
+            // Determine if the pet should be respawned.
+            int16 petHP = Sql_GetUIntData(SqlHandle, 11);
+            if (petHP)
+            {
+                PChar->petZoningInfo.petHP      = petHP;
+                PChar->petZoningInfo.petID      = Sql_GetUIntData(SqlHandle, 9);
+                PChar->petZoningInfo.petMP      = Sql_GetIntData(SqlHandle, 12);
+                PChar->petZoningInfo.petType    = static_cast<PET_TYPE>(Sql_GetUIntData(SqlHandle, 10));
+                PChar->petZoningInfo.respawnPet = true;
+            }
+        }
+
+        Sql_Query(SqlHandle, "UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
+
+        if (zoning == 2)
+        {
+            ShowDebug("Player <%s> logging in to zone <%u>", PChar->name.c_str(), PChar->getZone());
+        }
+
+        PChar->SetMLevel(PChar->jobs.job[PChar->GetMJob()]);
+        PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
+    }
+
+    void LoadRecast(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        fmtQuery = "SELECT id, time, recast FROM char_recast WHERE charid = %u;";
+
+        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+        {
+            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+            {
+                uint32    cast_time  = Sql_GetUIntData(SqlHandle, 1);
+                uint32    recast     = Sql_GetUIntData(SqlHandle, 2);
+                time_t    now        = time(nullptr);
+                uint32    chargeTime = 0;
+                uint8     maxCharges = 0;
+                Charge_t* charge     = ability::GetCharge(PChar, Sql_GetUIntData(SqlHandle, 0));
+                if (charge != nullptr)
+                {
+                    chargeTime = charge->chargeTime;
+                    maxCharges = charge->maxCharges;
+                }
+                if (now < cast_time + recast)
+                {
+                    PChar->PRecastContainer->Load(RECAST_ABILITY, Sql_GetUIntData(SqlHandle, 0), (cast_time + recast - (uint32)now), chargeTime, maxCharges);
+                }
+            }
+        }
+    }
+
+    void LoadSkills(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        fmtQuery = "SELECT skillid, value, rank "
+                   "FROM char_skills "
+                   "WHERE charid = %u;";
+
+        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+        {
+            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+            {
+                uint8 SkillID = (uint8)Sql_GetUIntData(SqlHandle, 0);
+
+                if (SkillID < MAX_SKILLTYPE)
+                {
+                    PChar->RealSkills.skill[SkillID] = (uint16)Sql_GetUIntData(SqlHandle, 1);
+                    if (SkillID >= SKILL_FISHING)
+                    {
+                        PChar->RealSkills.rank[SkillID] = (uint8)Sql_GetUIntData(SqlHandle, 2);
+                    }
+                }
+            }
+        }
+    }
+
+    void LoadUnlocks(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        fmtQuery = "SELECT outpost_sandy, outpost_bastok, outpost_windy, runic_portal, maw, "
+                   "campaign_sandy, campaign_bastok, campaign_windy, homepoints, survivals "
+                   "FROM char_unlocks "
+                   "WHERE charid = %u;";
+
+        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            PChar->teleport.outpostSandy   = Sql_GetUIntData(SqlHandle, 0);
+            PChar->teleport.outpostBastok  = Sql_GetUIntData(SqlHandle, 1);
+            PChar->teleport.outpostWindy   = Sql_GetUIntData(SqlHandle, 2);
+            PChar->teleport.runicPortal    = Sql_GetUIntData(SqlHandle, 3);
+            PChar->teleport.pastMaw        = Sql_GetUIntData(SqlHandle, 4);
+            PChar->teleport.campaignSandy  = Sql_GetUIntData(SqlHandle, 5);
+            PChar->teleport.campaignBastok = Sql_GetUIntData(SqlHandle, 6);
+            PChar->teleport.campaignWindy  = Sql_GetUIntData(SqlHandle, 7);
+
+            size_t length = 0;
+            char*  buf    = nullptr;
+            Sql_GetData(SqlHandle, 8, &buf, &length);
+            memcpy(&PChar->teleport.homepoint, buf, (length > sizeof(PChar->teleport.homepoint) ? sizeof(PChar->teleport.homepoint) : length));
+
+            length = 0;
+            buf    = nullptr;
+            Sql_GetData(SqlHandle, 9, &buf, &length);
+            memcpy(&PChar->teleport.survival, buf, (length > sizeof(PChar->teleport.survival) ? sizeof(PChar->teleport.survival) : length));
+        }
+    }
+
+    void LoadFlags(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+        fmtQuery = "SELECT "
+                   "gmlevel, "    // 0
+                   "mentor, "     // 1
+                   "job_master, " // 2
+                   "nnameflags "  // 3
+                   "FROM chars "
+                   "WHERE charid = %u;";
+
+        ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+
+        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            PChar->m_GMlevel             = (uint8)Sql_GetUIntData(SqlHandle, 0);
+            PChar->m_mentorUnlocked      = Sql_GetUIntData(SqlHandle, 1) > 0;
+            PChar->m_jobMasterDisplay    = Sql_GetUIntData(SqlHandle, 2) > 0;
+            PChar->menuConfigFlags.flags = (uint32)Sql_GetUIntData(SqlHandle, 3);
+        }
+    }
+
     void LoadInventory(CCharEntity* PChar)
     {
+        TracyZoneScoped;
         const char* Query = "SELECT "
                             "itemid,"     // 0
                             "location,"   // 1
@@ -1013,6 +1143,7 @@ namespace charutils
 
     void LoadEquip(CCharEntity* PChar)
     {
+        TracyZoneScoped;
         const char* Query = "SELECT "
                             "slotid,"
                             "equipslotid,"

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -130,6 +130,7 @@ namespace charutils
 
     void CalculateStats(CCharEntity* PChar)
     {
+        TracyZoneScoped;
         // Объявление переменных, нужных для рассчета.
 
         float raceStat  = 0; // конечное число HP для уровня на основе расы.
@@ -331,7 +332,6 @@ namespace charutils
     void LoadChar(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         uint8  meritPoints = 0;
         uint16 limitPoints = 0;
         int32  HP          = 0;
@@ -711,7 +711,6 @@ namespace charutils
     void LoadSpells(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         // disable all spells
         PChar->m_SpellList.reset();
 
@@ -750,7 +749,6 @@ namespace charutils
     void LoadRankAndFame(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         // clang-format off
         auto charProfileDataQuery = query::builder()
         .select()
@@ -823,7 +821,6 @@ namespace charutils
     void LoadStorageBuffs(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         // clang-format off
         auto storageBuffsQuery = query::builder()
         .select()
@@ -869,7 +866,6 @@ namespace charutils
     void LoadLook(CCharEntity* PChar)
     {
         TracyZoneScoped;
-
         // clang-format off
         auto lookQuery = query::builder()
         .select()
@@ -3288,6 +3284,7 @@ namespace charutils
 
     void LoadExpTable()
     {
+        TracyZoneScoped;
         const char* fmtQuery = "SELECT r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15,r16,r17,r18,r19,r20 "
                                "FROM exp_table "
                                "ORDER BY level ASC "

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -59,6 +59,14 @@ namespace charutils
     void LoadRankAndFame(CCharEntity* PChar);
     void LoadStorageBuffs(CCharEntity* PChar);
     void LoadLook(CCharEntity* PChar);
+    void LoadStyle(CCharEntity* PChar);
+    void LoadJobs(CCharEntity* PChar);
+    void LoadExp(CCharEntity* PChar);
+    bool LoadStats(CCharEntity* PChar, bool& zoning, uint32& HP, uint32& MP);
+    void LoadRecast(CCharEntity* PChar);
+    void LoadSkills(CCharEntity* PChar);
+    void LoadUnlocks(CCharEntity* PChar);
+    void LoadFlags(CCharEntity* PChar);
     void LoadInventory(CCharEntity* PChar);
     void LoadEquip(CCharEntity* PChar);
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -54,7 +54,11 @@ namespace charutils
 {
     void LoadExpTable();
     void LoadChar(CCharEntity* PChar);
+    void LoadBaseData(CCharEntity* PChar);
     void LoadSpells(CCharEntity* PChar);
+    void LoadRankAndFame(CCharEntity* PChar);
+    void LoadStorageBuffs(CCharEntity* PChar);
+    void LoadLook(CCharEntity* PChar);
     void LoadInventory(CCharEntity* PChar);
     void LoadEquip(CCharEntity* PChar);
 

--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -56,38 +56,35 @@ namespace gardenutils
 {
     void LoadResultList()
     {
-        auto qb = query::builder(SqlHandle);
+        auto qb = query::builder();
         qb.select()
             .field<uint32>("resultId")
-            .field<uint32>("seed")
-            .field<uint32>("element1")
-            .field<uint32>("element2")
-            .field<uint32>("result")
-            .field<uint32>("min_quantity")
-            .field<uint32>("max_quantity")
-            .field<uint32>("weight")
+            .field<uint8>("seed")
+            .field<uint8>("element1")
+            .field<uint8>("element2")
+            .field<uint16>("result")
+            .field<uint8>("min_quantity")
+            .field<uint8>("max_quantity")
+            .field<uint8>("weight")
             .from("gardening_results");
 
-        auto results = qb.execute();
-        if (!results.m_rows.empty())
+        auto results = qb.execute(SqlHandle);
+        for (auto& entry : results)
         {
-            for (auto& entry : results.m_rows)
-            {
-                uint8 SeedID   = entry.get<uint32>("seed");
-                uint8 Element1 = entry.get<uint32>("element1");
-                uint8 Element2 = entry.get<uint32>("element1");
+            auto SeedID   = entry.get<uint8>("seed");
+            auto Element1 = entry.get<uint8>("element1");
+            auto Element2 = entry.get<uint8>("element2");
 
-                uint32 uid = (SeedID << 8) + (Element1 << 4) + Element2;
+            uint32 uid = (SeedID << 8) + (Element1 << 4) + Element2;
                 
-                GardenResultList_t& resultList = g_pGardenResultMap[uid];
+            GardenResultList_t& resultList = g_pGardenResultMap[uid];
                 
-                uint16 ItemID      = entry.get<uint32>("result");
-                uint8  MinQuantity = entry.get<uint32>("min_quantity");
-                uint8  MaxQuantity = entry.get<uint32>("max_quantity");
-                uint8  Weight      = entry.get<uint32>("weight");
+            auto ItemID      = entry.get<uint16>("result");
+            auto MinQuantity = entry.get<uint8>("min_quantity");
+            auto MaxQuantity = entry.get<uint8>("max_quantity");
+            auto Weight      = entry.get<uint8>("weight");
                 
-                resultList.emplace_back(ItemID, MinQuantity, MaxQuantity, Weight);
-            }
+            resultList.emplace_back(ItemID, MinQuantity, MaxQuantity, Weight);
         }
     }
 


### PR DESCRIPTION
Behold, some of the worst code I've written in many years!

Until someone (me) gets the gall to tear apart everything to do with how we use the db, a little helper to make adding/removing/changing fields in our raw queries is probably welcome. **The main goal here is to stop us from having to track the raw indexes into SQL results.**

**TODO**
- More and better type checking
- Storing type (and blob/string/container) length at field declaration time

Turns:
```cpp
        int32 ret = Sql_Query(SqlHandle, "SELECT resultId, seed, element1, element2, result, min_quantity, max_quantity, weight FROM gardening_results");

        if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
        {
            while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
            {
                uint8 SeedID   = (uint8)Sql_GetUIntData(SqlHandle, 1);
                uint8 Element1 = (uint8)Sql_GetUIntData(SqlHandle, 2);
                uint8 Element2 = (uint8)Sql_GetUIntData(SqlHandle, 3);

                uint32 uid = (SeedID << 8) + (Element1 << 4) + Element2;

                GardenResultList_t& resultList = g_pGardenResultMap[uid];

                uint16 ItemID      = (uint16)Sql_GetIntData(SqlHandle, 4);
                uint8  MinQuantity = (uint8)Sql_GetIntData(SqlHandle, 5);
                uint8  MaxQuantity = (uint8)Sql_GetIntData(SqlHandle, 6);
                uint8  Weight      = (uint8)Sql_GetIntData(SqlHandle, 7);
                resultList.emplace_back(ItemID, MinQuantity, MaxQuantity, Weight);
            }
        }
```
into:
```cpp
        auto qb = query::builder(SqlHandle);
        qb.select()
            .field<uint32>("resultId")
            .field<uint32>("seed")
            .field<uint32>("element1")
            .field<uint32>("element2")
            .field<uint32>("result")
            .field<uint32>("min_quantity")
            .field<uint32>("max_quantity")
            .field<uint32>("weight")
            .from("gardening_results");

        auto results = qb.execute();
        if (!results.m_rows.empty())
        {
            for (auto& entry : results.m_rows)
            {
                uint8 SeedID   = entry.get<uint32>("seed");
                uint8 Element1 = entry.get<uint32>("element1");
                uint8 Element2 = entry.get<uint32>("element1");

                uint32 uid = (SeedID << 8) + (Element1 << 4) + Element2;
                
                GardenResultList_t& resultList = g_pGardenResultMap[uid];
                
                uint16 ItemID      = entry.get<uint32>("result");
                uint8  MinQuantity = entry.get<uint32>("min_quantity");
                uint8  MaxQuantity = entry.get<uint32>("max_quantity");
                uint8  Weight      = entry.get<uint32>("weight");
                
                resultList.emplace_back(ItemID, MinQuantity, MaxQuantity, Weight);
            }
        }
```


<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
