### PR TITLE
Add DefaultActions to Castle Zvahl Keep (S) NPCs

### DIFF
--- a/scripts/zones/Castle_Zvahl_Keep_[S]/DefaultActions.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/DefaultActions.lua
@@ -1,0 +1,7 @@
+local ID = require("scripts/zones/Castle_Zvahl_Keep_[S]/IDs")
+
+return {
+    ['Rakke'] = { event = 29 },
+    ['Rikke'] = { event = 28 },
+    ['Rokke'] = { event = 30 },
+}


### PR DESCRIPTION
There's not many unique NPCs I've found here, but their dialogue is amusing and might be missed when someone captures their only usage, the Bastok quest The Truth Lies Hid.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [o] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
