### PR TITLE
[meta] Add utility to generate changelogs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,28 @@
+name: changelog
+
+on:
+  schedule:
+    # At 12:00 on day-of-month 1 and 15.
+    - cron:  '0 12 1,15 * *'
+  workflow_dispatch:
+
+jobs:
+  Publish_Changelog:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3.7
+        pip3 install requests
+    - name: Generate Changelog
+      run: |
+          python3 tools/generate_changelog.py ci
+          cat changelog-$(date +'%Y-%m-%d').md
+    - name: Capture date for next step
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    # TODO: Publish the changelog somewhere

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -1,0 +1,35 @@
+# pip3 install requests
+
+import sys
+from datetime import date
+from datetime import timedelta
+import requests as reqs
+import json
+import urllib.parse
+
+length_days = 14
+if len(sys.argv) >= 2:
+    length_days = int(sys.argv[1])
+
+print(f"Calculating changes for {length_days} days...")
+
+today = date.today()
+last_week = today - timedelta(days = length_days)
+
+params = {"q" : f"user:LandSandBoat repo:server state:closed is:pr merged:>={str(last_week)}"}
+query_string = urllib.parse.urlencode(params)
+request = f"https://api.github.com/search/issues?page=1&per_page=100&{query_string}"
+response = reqs.get(request)
+data = json.loads(response.text)
+
+print(f"Writing to: changelog-{today}.md...")
+with open(f'changelog-{today}.md', 'w') as file:
+    file.write(f"## LandSandBoat Changelog ({today})\n")
+    for raw_entry in enumerate(data["items"]):
+        entry = raw_entry[1]
+        title = entry['title']
+        number = entry['number']
+        html_url = entry['html_url']
+        patch_url = entry["pull_request"]['patch_url']
+        username = entry['user']['login']
+        file.write(f"- {title.capitalize()} [[#{number}]({html_url}), [patch]({patch_url})] ({username})\n")

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -7,9 +7,24 @@ import requests as reqs
 import json
 import urllib.parse
 
+# At 12:00 on day-of-month 1 and 15.
+# Cron: '0 12 1,15 * *'
+def days_since_last_run():
+    # Count back from today's date, until you encounter either the 1st or the 15th
+    today = date.today()
+    days = 1
+    last_date_day = (today - timedelta(days = days)).day
+    while last_date_day != 1 and last_date_day != 15:
+        days = days + 1
+        last_date_day = (today - timedelta(days = days)).day
+    return days
+
 length_days = 14
 if len(sys.argv) >= 2:
-    length_days = int(sys.argv[1])
+    if "ci" in sys.argv[1]:
+        length_days = days_since_last_run()
+    else:
+        length_days = int(sys.argv[1])
 
 print(f"Calculating changes for {length_days} days...")
 


### PR DESCRIPTION
Slapped this together on my lunchbreak, once this is in we can set up a github action/job for it to run and publish every 2 weeks

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
