### PR TITLE
Return itemid for steal message

### DIFF
--- a/scripts/globals/abilities/steal.lua
+++ b/scripts/globals/abilities/steal.lua
@@ -81,7 +81,7 @@ ability_object.onUseAbility = function(player, target, ability, action)
         ability:setMsg(xi.msg.basic.STEAL_SUCCESS) -- Item stolen successfully
         target:triggerListener("ITEM_STOLEN", target, player, stolen)
         -- Aura Steal does not trigger on successful item steal
-        return
+        return stolen
     else
         ability:setMsg(xi.msg.basic.STEAL_FAIL) -- Failed to steal
         action:setAnimation(target:getID(), 182)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
Missing return value on successful steals
