### PR TITLE
[meta] Archive website changelogs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,15 +35,19 @@ jobs:
     - name: Git stash pop changes
       run: |
           git stash pop
-    - name: Move changelog
+    - name: Copy changelog in changelogs folder
       run: |
-          mv changelog-* changelogs/
+          cp changelog-* changelogs/
+    - name: Copy changelog in docs folder
+      run: |
+          cp changelog-* docs/changelog.md
     - name: Git stage changes
       run: |
-          git stage changelogs/changelog-*
-    - name: Git commit
+          git stage changelogs/changelog*
+          git stage docs/changelog*
+    - name: Git commit changes
       run: |
-          git commit -m "[changelog] Add changelog-${{ steps.date.outputs.date }}.md"
+          git commit -m "[changelog] Add changelog-${{ steps.date.outputs.date }}.md, update website changelog"
     - name: Git push changes
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
Tested on my fork

`website` branch
`docs/changelog.md` is overwritten every 2 weeks
`changelogs/changelog-<date>.md` is archived every 2 weeks

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
