### PR TITLE
Switch UpdateItem to RemoveAmmo for blanksoulplate

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3676,11 +3676,8 @@ auto CLuaBaseEntity::addSoulPlate(std::string const& name, uint16 mobFamily, uin
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
         // Deduct Blank Plate
-        if (charutils::UpdateItem(PChar, PChar->equipLoc[SLOT_AMMO], PChar->equip[SLOT_AMMO], -1) == 0)
-        {
-            // Couldn't remove a blank plate
-            return std::nullopt;
-        }
+        battleutils::RemoveAmmo(PChar);
+        
         PChar->pushPacket(new CInventoryFinishPacket());
 
         // Used Soul Plate


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
In addSoulPlate using UpdateItem on the last item in a stack on the ammo slot then adding a new item will cause the new item to be equipped in the ammo slot even if it is not a equipment Item
[link](https://imgur.com/a/SoYzCQD)
Removeammo is more robust in how it handles edge cases