### PR TITLE
Fix Weapon break mixins

### DIFF
--- a/scripts/mixins/families/qutrub.lua
+++ b/scripts/mixins/families/qutrub.lua
@@ -8,7 +8,7 @@ g_mixins.families = g_mixins.families or {}
 -- 1 = main weapon broken, sub weapon sheathed
 -- 2 = main weapon broken, sub weapon out
 -- 3 = both weapons broken
-
+-- 4 = main weapon out, sub weapon sheathed
 g_mixins.families.qutrub = function(qutrubMob)
 
     -- set default 10% chance to break weapon on critical hit taken
@@ -44,7 +44,7 @@ g_mixins.families.qutrub = function(qutrubMob)
             local animationSub = mob:getAnimationSub()
 
             -- break first weapon
-            if animationSub == 0 then
+            if animationSub == 0 or animationSub == 4 then
                 mob:setAnimationSub(1)
                 mob:setLocalVar("swapTime", os.time() + 60)
 

--- a/scripts/mixins/weapon_break.lua
+++ b/scripts/mixins/weapon_break.lua
@@ -23,7 +23,7 @@ g_mixins.weapon_break = function(weaponBreakMob)
             local animationSub = mob:getAnimationSub()
 
             -- break weapon
-            if animationSub == 0 then
+            if animationSub ~= 1 then
                 mob:setAnimationSub(1)
             end
         end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Qutrub are set to start on animationSub of four not sure if that is what retail uses as a base instead of zero some confirmation from retail would be required, It seems for their model they all have the same appearance so not sure it matters so I left the db alone and just added a check on four as well as zero so if retail tests show one way or the other it is easier to adjust later.