### PR TITLE
Fix Bluemagic spell blitzstrahl

### DIFF
--- a/scripts/globals/spells/bluemagic/blitzstrahl.lua
+++ b/scripts/globals/spells/bluemagic/blitzstrahl.lua
@@ -25,7 +25,7 @@ end
 spell_object.onSpellCast = function(caster, target, spell)
     local params = {}
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
-    params.attackType = xi.damagaType.MAGICAL
+    params.attackType = xi.damageType.MAGICAL
     params.damageType = xi.damageType.LIGHTNING
     params.multiplier = 1.5625
     params.tMultiplier = 1.0


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fix Typo damagaType -> damageType in blitzstrahl.lua