### PR TITLE
[core, packets] Fix mob and player update packet accumulation problems (dynamis etc.)

### DIFF
--- a/src/common/tracy.h
+++ b/src/common/tracy.h
@@ -37,6 +37,18 @@ inline std::string Hex16ToString(uint16 hex)
     TracyPlotConfig("Lua Memory Usage", tracy::PlotFormatType::Memory);                                                                                        \
     TracyPlot("Lua Memory Usage", static_cast<double>(lua_gc(L, LUA_GCCOUNT, 0)) * 1024.0);
 
+#define TracyReportGraphNumber(name, num)                 \
+    TracyPlotConfig(name, tracy::PlotFormatType::Number); \
+    TracyPlot(name, num);
+
+#define TracyReportGraphBytes(name, num)                  \
+    TracyPlotConfig(name, tracy::PlotFormatType::Memory); \
+    TracyPlot(name, num);
+
+#define TracyReportGraphPercent(name, num)                    \
+    TracyPlotConfig(name, tracy::PlotFormatType::Percentage); \
+    TracyPlot(name, num);
+
 #else // Empty stubs for regular builds
 #define TracyFrameMark
 #define TracyZoneScoped
@@ -49,6 +61,9 @@ inline std::string Hex16ToString(uint16 hex)
 #define TracyZoneHex8(num)
 #define TracyZoneHex16(num)
 #define TracyReportLuaMemory(L)
+#define TracyReportGraphNumber(name, num)
+#define TracyReportGraphBytes(name, num)
+#define TracyReportGraphPercent(name, num)
 #endif
 
 #endif // _TRACY_H

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -265,6 +265,35 @@ void CCharEntity::pushPacket(CBasicPacket* packet)
     TracyZoneHex16(packet->id());
 
     std::lock_guard<std::mutex> lk(m_PacketListMutex);
+
+    // TODO: Iterating the entire queue like this isn't very efficient, but the server
+    // can still _easily_ handle it
+    // This could easily be accelerated by creating a lookup, building a key out of:
+    // - packetId + mainId + targId + updateMask
+    // and storing the position in the queue of that entry
+    for (auto&& entry : PacketList)
+    {
+        if (packet->id() == 0x0E && entry->id() == 0x0E || // Entity Update (CEntityUpdatePacket)
+            packet->id() == 0x0D && entry->id() == 0x0D)   // Char Packet (CCharPacket)
+        {
+            bool sameMainId     = packet->ref<uint32>(0x04) == entry->ref<uint32>(0x04);
+            bool sameTargId     = packet->ref<uint16>(0x08) == entry->ref<uint16>(0x08);
+            bool sameUpdateMask = packet->ref<uint8>(0x0A)  == entry->ref<uint8>(0x0A);
+            if (sameMainId && sameTargId && sameUpdateMask)
+            {
+                // Put the newer packet in the place of the one already in the queue
+                std::swap(entry, packet);
+
+                // Get rid of the original packet
+                delete packet;
+
+                // Bail out and don't add anything new to the queue
+                return;
+            }
+        }
+    }
+
+    // Nothing to dedupe? Just put the packet in the queue
     PacketList.push_back(packet);
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -708,6 +708,10 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     auto       PacketCount = PChar->getPacketCount();
     uint8      packets     = 0;
 
+#ifdef LOG_OUTGOING_PACKETS
+    PacketGuard::PrintPacketList(PChar);
+#endif
+
     do
     {
         do

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -688,24 +688,25 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
 int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t* map_session_data)
 {
     TracyZoneScoped;
-    // Модификация заголовка исходящего пакета
-    // Суть преобразований:
-    //  - отправить клиенту номер последнего полученного от него пакета
-    //  - присвоить исходящему пакету номер последнего отправленного клиенту пакета +1
-    //  - записать текущее время отправки пакета
+    // Modify the header of the outgoing packet
+    // The essence of the transformations:
+    // - send the client the number of the last packet received from him
+    // - assign the outgoing packet the number of the last packet sent to the client +1
+    // - write down the current time of sending the packet
 
     ref<uint16>(buff, 0) = map_session_data->server_packet_id;
     ref<uint16>(buff, 2) = map_session_data->client_packet_id;
 
-    // сохранение текущего времени (32 BIT!)
+    // save the current time (32 BIT!)
     ref<uint32>(buff, 8) = (uint32)time(nullptr);
 
-    // собираем большой пакет, состоящий из нескольких маленьких
+    // build a large package, consisting of several small packets
     CCharEntity*  PChar = map_session_data->PChar;
     CBasicPacket* PSmallPacket;
-    uint32        PacketSize  = UINT32_MAX;
-    auto          PacketCount = PChar->getPacketCount();
-    uint8         packets     = 0;
+
+    uint32     PacketSize  = UINT32_MAX;
+    auto       PacketCount = PChar->getPacketCount();
+    uint8      packets     = 0;
 
     do
     {
@@ -729,13 +730,14 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
             PacketCount /= 2;
 
-            //Сжимаем данные без учета заголовка
-            //Возвращаемый размер в 8 раз больше реальных данных
+            // Compress the data without regard to the header
+            // The returned size is 8 times the real data
             PacketSize = zlib_compress(buff + FFXI_HEADER_SIZE, (uint32)(*buffsize - FFXI_HEADER_SIZE), PTempBuff, map_config.buffer_size);
 
             // handle compression error
             if (PacketSize == static_cast<uint32>(-1))
             {
+                ShowError("zlib compression error");
                 continue;
             }
 
@@ -761,7 +763,7 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     } while (PacketSize == static_cast<uint32>(-1));
     PChar->erasePackets(packets);
 
-    //Запись размера данных без учета заголовка
+    // Record data size excluding header
     uint8 hash[16];
     md5((uint8*)PTempBuff, hash, PacketSize);
     memcpy(PTempBuff + PacketSize, hash, 16);
@@ -769,10 +771,10 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
     if (PacketSize > map_config.buffer_size + 20)
     {
-        ShowFatalError("%Memory manager: PTempBuff is overflowed (%u)", PacketSize);
+        ShowFatalError("Memory manager: PTempBuff is overflowed (%u)", PacketSize);
     }
 
-    // making total packet
+    // Making total packet
     memcpy(buff + FFXI_HEADER_SIZE, PTempBuff, PacketSize);
 
     uint32 CypherSize = (PacketSize / 4) & -2;
@@ -784,12 +786,12 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
         blowfish_encipher((uint32*)(buff) + j + 7, (uint32*)(buff) + j + 8, pbfkey->P, pbfkey->S[0]);
     }
 
-    // контролируем размер отправляемого пакета. в случае,
-    // если его размер превышает 1400 байт (размер данных + 42 байта IP заголовок),
-    // то клиент игнорирует пакет и возвращает сообщение о его потере
+    // Control the size of the sent packet.
+    // if its size exceeds 1400 bytes (data size + 42 bytes IP header),
+    // then the client ignores the packet and returns a message about its loss
 
-    // в случае возникновения подобной ситуации выводим предупреждующее сообщение и
-    // уменьшаем размер BuffMaxSize с шагом в 4 байта до ее устранения (вручную)
+    // in case of a similar situation, display a warning message and
+    // decrease the size of BuffMaxSize in 4 byte increments until it is removed (manually)
 
     *buffsize = PacketSize + FFXI_HEADER_SIZE;
 

--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -98,4 +98,33 @@ namespace PacketGuard
         return timeNowSeconds - lastPacketRecievedTime < ratelimitList[SmallPD_Type];
     }
 
+    void PrintPacketList(CCharEntity* PChar)
+    {
+        // Count packets in queue
+        std::map<std::string, uint32> packetCounterMap;
+        for (auto& entry : PChar->getPacketList())
+        {
+            auto packetStr = fmt::format("0x{:4X}", entry->id());
+            packetCounterMap[packetStr]++;
+        }
+
+        // Sort
+        using pair_t = std::pair<std::string, uint32>;
+        std::vector<pair_t> sortedVec;
+        for (auto& entry : packetCounterMap)
+        {
+            sortedVec.emplace_back(entry);
+        }
+        std::sort(sortedVec.begin(), sortedVec.end(), [](pair_t& a, pair_t& b) { return a.second < b.second; });
+
+        // Print
+        std::string output;
+        output += "\n=======================================\n";
+        for (auto& entry : packetCounterMap)
+        {
+            output += fmt::format("{} : {}\n", entry.first, entry.second);
+        }
+        output += "=======================================\n";
+        ShowInfo(output);
+    }
 } // namespace PacketGuard

--- a/src/map/packet_guard.h
+++ b/src/map/packet_guard.h
@@ -12,6 +12,7 @@ namespace PacketGuard
     void Init();
     bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type);
     bool IsRateLimitedPacket(CCharEntity* PChar, uint16 SmallPD_Type);
+    void PrintPacketList(CCharEntity* PChar);
 } // namespace PacketGuard
 
 #endif // _PACKETGUARD_H


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1389729/129020328-8340aa58-f50f-4364-a801-753d06f1ae12.png)

Closes: https://github.com/LandSandBoat/server/issues/584

I'm going to talk about this on stream, but we have some behaviour that needs fixing. 

**EDIT1:**
I worked on this on stream and demonstrated that de-duplicating Char/Entity update packets going into the queue would be enough to stop "runaway mode" for packets. I struggled to get it to work without mobs meleeing the air 20' away from the player though. 

**EDIT2:**
As predicted, sitting down first thing in the morning with a fresh coffee has revealed that I was being a smooth brain and casting my pointers incorrectly. Got rid of the pointer manipulation and used the information that's available in the packet buffers. Everything appears to be working nicely. An entire zone pull won't push the packet queue into "runaway mode". There are still a _lot_ of packets if you're fighting a million mobs, but it's never out of control.

![image](https://user-images.githubusercontent.com/1389729/128978821-48d4a076-67f8-43cc-9e74-1d98c8fce5c8.png)
![image](https://user-images.githubusercontent.com/1389729/128978839-204061ef-fd98-4a35-8ec9-dbbf929a27a8.png)
**Bar 1: Total packets in the player's send queue | Bar 2: The number of entity update packets in the send queue (lots)** 

**EDIT3:**
No CPU spikes, no memory leaks etc.
![image](https://user-images.githubusercontent.com/1389729/128981667-5d953082-6e2f-409f-8ebb-18e83f60f34b.png)

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
