### PR TITLE
Implement basic support for Item Level display and helper functions

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -137,26 +137,10 @@ function getRoeRecords(triggers)
 
         [1049] = { -- Always Stand on 117 (gives Cipher: Koru-Moru)
             check = function(self, player, params)
-                local count = 0
-                for _, slot in pairs( {
-                    xi.slot.MAIN,
-                    xi.slot.SUB,
-                    xi.slot.RANGED,
-                    xi.slot.HEAD,
-                    xi.slot.BODY,
-                    xi.slot.HANDS,
-                    xi.slot.LEGS,
-                    xi.slot.FEET,
-                } ) do
-                    local item = player:getEquippedItem(slot)
-                    if item and item:getILvl() and item:getILvl() == self.reqs.hasEquip.ilevel then
-                        count = count + 1
-                    end
-                end
-                return count >= self.reqs.hasEquip.count and true or false
+                return player:getAverageItemLevel() >= self.reqs.hasItemLevel and true or false
             end,
             trigger = triggers.talkToRoeNpc,
-            reqs = { hasEquip = { ilevel = 117, count = 3 } },
+            reqs = { hasItemLevel = 117 },
             reward =  {
                 sparks = 200,
                 xp = 300,

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7555,6 +7555,21 @@ void CLuaBaseEntity::updateHealth()
 }
 
 /************************************************************************
+ *  Function: getAverageItemLevel()
+ *  Purpose : Returns the weighted item level value displayed in stats
+ *  Example : target:getAverageItemLevel()
+ ************************************************************************/
+uint8 CLuaBaseEntity::getAverageItemLevel()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return 0;
+    }
+
+    return charutils::getItemLevelDifference(static_cast<CCharEntity*>(m_PBaseEntity)) + 99;
+}
+
+/************************************************************************
  *  Function: capSkill()
  *  Purpose : Caps a particular skill for a PC
  *  Example : player:capSkill(xi.skill.DAGGER)
@@ -13368,6 +13383,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("delTP", CLuaBaseEntity::delTP);
 
     SOL_REGISTER("updateHealth", CLuaBaseEntity::updateHealth);
+    SOL_REGISTER("getAverageItemLevel", CLuaBaseEntity::getAverageItemLevel);
 
     // Skills and Abilities
     SOL_REGISTER("capSkill", CLuaBaseEntity::capSkill);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -84,10 +84,10 @@ public:
     void updateEvent(sol::variadic_args va);                      // Updates event
     void updateEventString(sol::variadic_args va);                // (string, string, string, string, uint32, ...)
     auto getEventTarget() -> std::optional<CLuaBaseEntity>;
-    bool isInEvent(); // Returns true if the player is in an event
-    void release(); // Stops event
-    bool startSequence(); // Flags the player as being in a sequence
-    bool didGetMessage(); // Used by interaction framework to determine if player triggered something else
+    bool isInEvent();       // Returns true if the player is in an event
+    void release();         // Stops event
+    bool startSequence();   // Flags the player as being in a sequence
+    bool didGetMessage();   // Used by interaction framework to determine if player triggered something else
     void resetGotMessage(); // Used by interaction framework to reset if player triggered something else
 
     void  setFlag(uint32 flags);
@@ -169,13 +169,13 @@ public:
     uint32 getPlayerRegionInZone();                                                           // Returns the player's current region in the zone. (regions made with registerRegion)
     void   updateToEntireZone(uint8 statusID, uint8 animation, sol::object const& matchTime); // Forces an update packet to update the NPC entity zone-wide
 
-    auto  getPos() -> sol::table; // Get Entity position (x,y,z)
-    void  showPosition();         // Display current position of character
-    float getXPos();              // Get Entity X position
-    float getYPos();              // Get Entity Y position
-    float getZPos();              // Get Entity Z position
-    uint8 getRotPos();            // Get Entity Rot position
-    void setRotation(uint8 rotation); // Set Entity rotation
+    auto  getPos() -> sol::table;      // Get Entity position (x,y,z)
+    void  showPosition();              // Display current position of character
+    float getXPos();                   // Get Entity X position
+    float getYPos();                   // Get Entity Y position
+    float getZPos();                   // Get Entity Z position
+    uint8 getRotPos();                 // Get Entity Rot position
+    void  setRotation(uint8 rotation); // Set Entity rotation
 
     void setPos(sol::variadic_args va);                                       // Set Entity position (x,y,z,rot) or (x,y,z,rot,zone)
     void warp();                                                              // Returns Character to home point
@@ -427,7 +427,8 @@ public:
     void  setTP(int16 value);  // Set tp of Entity to value
     void  delTP(int16 amount); // Subtract tp of Entity
 
-    void updateHealth();
+    void  updateHealth();
+    uint8 getAverageItemLevel();
 
     // Skills and Abilities
     void capSkill(uint8 skill); // Caps the given skill id for the job you're on (GM COMMAND)

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -76,9 +76,10 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
 
     // 0x51 = 0x01 on fresh player, 0x03 with 99
     ref<uint8>(0x52) = PChar->getMod(Mod::SUPERIOR_LEVEL);
-    // 0x54 = maximum item level
-    // 0x55 = itemlevel over 99
-    // 0x56 = main weapon item level
+    ref<uint8>(0x54) = charutils::getMaxItemLevel(PChar);        // Maximum Item Level
+    ref<uint8>(0x55) = charutils::getItemLevelDifference(PChar); // itemlevel over 99
+    ref<uint8>(0x56) = charutils::getMainhandItemLevel(PChar);   // Item level of Main Hand weapon
+    ref<uint8>(0x57) = charutils::getRangedItemLevel(PChar);     // Item level of Ranged (Ranged priority, ammo if only)
 
     ref<uint32>(0x58) = (charutils::GetPoints(PChar, "unity_accolades") << 10) | (0x00 << 5 | PChar->profile.unity_leader);
     ref<uint16>(0x5C) = charutils::GetPoints(PChar, "current_accolades") / 1000; // Partial Personal Eval

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -5923,5 +5923,85 @@ namespace charutils
         {
             ShowError("Error writing char history for: '%s'", PChar->name.c_str());
         }
+    }
+
+    uint8 getMaxItemLevel(CCharEntity* PChar)
+    {
+        uint8 maxItemLevel = 0;
+
+        for (uint8 slotID = 0; slotID < 16; ++slotID)
+        {
+            CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)slotID);
+
+            if (PItem && PItem->getILvl() > maxItemLevel)
+            {
+                maxItemLevel = PItem->getILvl();
+            }
+        }
+
+        return maxItemLevel;
+    }
+
+    uint8 getItemLevelDifference(CCharEntity* PChar)
+    {
+        float itemLevelDiff = 0;
+        uint8 highestItem   = 0;
+
+        // Find the highest iLevel in weapons, this is 50% of the iLvl diff value
+        for (uint8 slotID = 0; slotID < 4; ++slotID)
+        {
+            CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)slotID);
+
+            if (PItem && PItem->getILvl() > highestItem)
+            {
+                highestItem = PItem->getILvl();
+            }
+        }
+
+        if (highestItem > 99)
+        {
+            itemLevelDiff += (highestItem - 99) / 2;
+        }
+
+        for (uint8 slotID = 4; slotID < 9; ++slotID)
+        {
+            CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)slotID);
+
+            if (PItem && PItem->getILvl() > 99)
+            {
+                itemLevelDiff += (PItem->getILvl() - 99) / 10;
+            }
+        }
+
+        return floor(itemLevelDiff);
+    }
+
+    uint8 getMainhandItemLevel(CCharEntity* PChar)
+    {
+        CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)SLOTTYPE::SLOT_MAIN);
+
+        if (PItem)
+        {
+            return PItem->getILvl();
+        }
+
+        return 0;
+    }
+
+    // Return Ranged Weapon Item Level; If ranged slot exists use that, else use Ammo
+    uint8 getRangedItemLevel(CCharEntity* PChar)
+    {
+        CItemEquipment* PItem = nullptr;
+
+        if (PItem = PChar->getEquip((SLOTTYPE)SLOTTYPE::SLOT_RANGED))
+        {
+            return PItem->getILvl();
+        }
+        else if (PItem = PChar->getEquip((SLOTTYPE)SLOTTYPE::SLOT_AMMO))
+        {
+            return PItem->getILvl();
+        }
+
+        return 0;
     }
 }; // namespace charutils

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -222,6 +222,11 @@ namespace charutils
 
     void ReadHistory(CCharEntity* PChar);
     void WriteHistory(CCharEntity* PChar);
+
+    uint8 getMaxItemLevel(CCharEntity* PChar);
+    uint8 getItemLevelDifference(CCharEntity* PChar);
+    uint8 getMainhandItemLevel(CCharEntity* PChar);
+    uint8 getRangedItemLevel(CCharEntity* PChar);
 }; // namespace charutils
 
 #endif // _CHARUTILS_H


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds functions to calculate values and populate 4 bytes in char stats packet:
* Max Ilvl
* Average Ilvl (weighted value for levels over 99)
* Main Weapon ILvl
* Ranged ILvl (Default: Ranged slot, Ammo if no ranged equipped)