### PR TITLE
Adding --append-date command line option to append date to log file

### DIFF
--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -47,11 +47,13 @@ namespace logging
         std::vector<spdlog::sink_ptr> sinks{ stdout_sink };
 
         // Daily Sink, creating new files at midnight
-	if (appendDate) {
+        if (appendDate)
+        {
             sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_mt>(logFile, 0, 00, false, 0));
-	}
-	// Basic sink, use OS tools to rotate logs
-	else {
+        }
+        // Basic sink, use OS tools to rotate logs
+        else
+        {
             sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile));
         }
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -51,7 +51,7 @@ namespace logging
         {
             sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_mt>(logFile, 0, 00, false, 0));
         }
-        // Basic sink, use OS tools to rotate logs
+        // Basic sink, sink to file with name specified in main routine
         else
         {
             sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile));

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -64,10 +64,10 @@ namespace logging
 
         auto createLogger = [&](std::string const& name)
         {
-                auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
-                logger->set_pattern(defaultPattern);
-                spdlog::register_logger(logger);
-                return logger;
+            auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
+            logger->set_pattern(defaultPattern);
+            spdlog::register_logger(logger);
+            return logger;
         };
 
         // Create a series of loggers with different names, all sinking to the file and console sinks

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -35,7 +35,7 @@ uint32 filterMask = 0;
 
 namespace logging
 {
-    void InitializeLog(std::string serverName, std::string logFile, bool appendData)
+    void InitializeLog(std::string serverName, std::string logFile, bool appendDate)
     {
         TracyZoneScoped;
 
@@ -47,7 +47,7 @@ namespace logging
         std::vector<spdlog::sink_ptr> sinks{ stdout_sink };
 
         // Daily Sink, creating new files at midnight
-	if (appendData) {
+	if (appendDate) {
             sinks.push_back(std::make_shared<spdlog::sinks::daily_file_sink_mt>(logFile, 0, 00, false, 0));
 	}
 	// Basic sink, use OS tools to rotate logs
@@ -63,9 +63,7 @@ namespace logging
         auto createLogger = [&](std::string const& name)
         {
 		auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
-		if (appendData) {
-                    logger->set_pattern(defaultPattern);
-		}
+                logger->set_pattern(defaultPattern);
                 spdlog::register_logger(logger);
                 return logger;
         };

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -64,7 +64,7 @@ namespace logging
 
         auto createLogger = [&](std::string const& name)
         {
-		auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
+                auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
                 logger->set_pattern(defaultPattern);
                 spdlog::register_logger(logger);
                 return logger;

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -61,7 +61,7 @@ extern uint32 filterMask;
 
 namespace logging
 {
-    void InitializeLog(std::string serverName, std::string logFile);
+    void InitializeLog(std::string serverName, std::string logFile, bool appendDate);
     void ShutDown();
 
     void SetFilters(uint32 _filterMask);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -719,11 +719,10 @@ void log_init(int argc, char** argv)
         {
             logFile = argv[i + 1];
         }
-
-	if (strcmp(argv[i], "--append-date") == 0)
-	{
-	    appendDate = true;
-	}
+        else if (strcmp(argv[i], "--append-date") == 0)
+        {
+            appendDate = true;
+        }
     }
     logging::InitializeLog("login", logFile, appendDate);
 }

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -706,6 +706,7 @@ void login_helpscreen(int32 flag)
 void log_init(int argc, char** argv)
 {
     std::string logFile;
+    bool appendDate {};
 
 #ifdef WIN32
     logFile = "log\\login-server.log";
@@ -718,8 +719,12 @@ void log_init(int argc, char** argv)
         {
             logFile = argv[i + 1];
         }
+	if (strcmp(argv[i], "--append-date") == 0)
+	{
+	    appendDate = true;
+	}
     }
-    logging::InitializeLog("login", logFile);
+    logging::InitializeLog("login", logFile, appendDate);
 }
 
 ///////////////////////////////////////////////////////

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -719,6 +719,7 @@ void log_init(int argc, char** argv)
         {
             logFile = argv[i + 1];
         }
+
 	if (strcmp(argv[i], "--append-date") == 0)
 	{
 	    appendDate = true;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1560,6 +1560,7 @@ void log_init(int argc, char** argv)
 #endif
 #endif
     bool defaultname = true;
+    bool appendDate {};
     for (int i = 1; i < argc; i++)
     {
         if (strcmp(argv[i], "--ip") == 0 && defaultname)
@@ -1575,6 +1576,10 @@ void log_init(int argc, char** argv)
             defaultname = false;
             logFile     = argv[i + 1];
         }
+        if (strcmp(argv[i], "--append-date") == 0)
+        {
+            appendDate = true;
+        }
     }
-    logging::InitializeLog("map", logFile);
+    logging::InitializeLog("map", logFile, appendDate);
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1576,6 +1576,7 @@ void log_init(int argc, char** argv)
             defaultname = false;
             logFile     = argv[i + 1];
         }
+
         if (strcmp(argv[i], "--append-date") == 0)
         {
             appendDate = true;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -159,6 +159,7 @@ int32 main(int32 argc, char** argv)
         {
             logFile = argv[i + 1];
         }
+
         if (strcmp(argv[i], "--append-date") == 0)
         {
             appendDate = true;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -140,6 +140,7 @@ void PrintPacket(char* data, int size)
 
 int32 main(int32 argc, char** argv)
 {
+    bool appendDate {};
 #ifdef WIN32
     WSADATA wsaData;
 #endif
@@ -158,9 +159,13 @@ int32 main(int32 argc, char** argv)
         {
             logFile = argv[i + 1];
         }
+        if (strcmp(argv[i], "--append-date") == 0)
+        {
+            appendDate = true;
+        }
     }
 
-    logging::InitializeLog("search", logFile);
+    logging::InitializeLog("search", logFile, appendDate);
 
     int iResult;
 


### PR DESCRIPTION
Adding --append-date command line option to append date to log file names and use daily_file_sink_mt instead of basic_file_sink_mt

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
