### PR TITLE
[core] Stop event listeners from swallowing errors in their attached Lua funcs

### DIFF
--- a/src/map/ai/helpers/event_handler.h
+++ b/src/map/ai/helpers/event_handler.h
@@ -55,7 +55,12 @@ public:
         {
             for (auto&& event : eventListener->second)
             {
-                event.lua_func(std::forward<Args&&>(args)...);
+                auto result = event.lua_func(std::forward<Args&&>(args)...);
+                if (!result.valid())
+                {
+                    sol::error err = result;
+                    ShowScript("Error in listener event %s: %s", eventname, err.what());
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
