### PR TITLE
[fix] Pet healing crash: only allow PCs to use Voidwalker healing logic

### DIFF
--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -36,7 +36,9 @@ effect_object.onEffectGain = function(target, effect)
         end)
     end
 
-    xi.voidwalker.onHealing(target)
+    if target:getObjType() == xi.objType.PC then
+        xi.voidwalker.onHealing(target)
+    end
 end
 
 effect_object.onEffectTick = function(target, effect)


### PR DESCRIPTION
Morning coffee browser driveby

Fixes: https://github.com/LandSandBoat/server/issues/612

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
