### PR TITLE
Fix bit check for Zilart Mission 17

### DIFF
--- a/scripts/missions/rotz/17_Awakening.lua
+++ b/scripts/missions/rotz/17_Awakening.lua
@@ -49,7 +49,7 @@ mission.sections =
             onRegionEnter =
             {
                 [1] = function(player, csid, option, npc)
-                    if not utils.mask.hasBit(player:getMissionStatus(mission.areaId), 1) then
+                    if not utils.mask.getBit(player:getMissionStatus(mission.areaId), 1) then
                         return mission:event(20)
                     end
                 end,
@@ -69,7 +69,7 @@ mission.sections =
             onZoneIn =
             {
                 function(player, prevZone)
-                    if not utils.mask.hasBit(player:getMissionStatus(mission.areaId), 0) then
+                    if not utils.mask.getBit(player:getMissionStatus(mission.areaId), 0) then
                         return 176
                     end
                 end,


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
