### PR TITLE
Require GM flag to be on also before just giving GM characters the full list of BCNM battlefields - it is not desirable to always see them.

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -982,7 +982,7 @@ function EventTriggerBCNM(player, npc)
         local mask = findBattlefields(player, npc, 0)
 
         -- GMs get access to all BCNMs
-        if player:getGMLevel() > 0 then
+        if player:getGMLevel() > 0 and player:checkNameFlags(0x04000000) then
             mask = 268435455
         end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I had to test some BCNM things on my server this evening and found this behavior to be troublesome I had missed/forgotten that blocks existence and wasn't sure if something on my server had gone horribly wrong for a good minute there before commenting it out. With this change, toggling my GM flag will also toggle this so I can choose to see the list like a normal player would.

And yes I know magic number bad but this is just a quickie fix - I promise I will enum the GM flagging properly later and update this.