### PR TITLE
Fix Bloodsucker (NM version) respawn point

### DIFF
--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker.lua
@@ -26,7 +26,7 @@ end
 
 entity.onMobDespawn = function(mob)
     if mob:getID() == ID.mob.BLOODSUCKER then
-        UpdateNMSpawnPoint(mob)
+        UpdateNMSpawnPoint(ID.mob.BLOODSUCKER)
         mob:setRespawnTime(3600)
     end
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

The spawn point update command was throwing an error to the console log because it expects the mobID not the entity. This resulted in it always appearing at its first default position.