### PR TITLE
Sheltered Ring / Brachyura Earring / Effect Audit

### DIFF
--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -20,7 +20,7 @@ item_object.onItemUse = function(target)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
     if (target:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.SHELL)
     else

--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -5,7 +5,6 @@
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
-require("scripts/globals/utils")
 -----------------------------------
 local item_object = {}
 
@@ -14,13 +13,13 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    local power = 27 -- power/256 handled below to pass final DMGMAGIC value
+    local power = 1055 -- Shell I   (27/256)
     local tier = 1
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = power + (bonus * tier)
     if (target:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.SHELL)
     else

--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
+require("scripts/globals/utils")
 -----------------------------------
 local item_object = {}
 
@@ -13,7 +14,14 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    if (target:addStatusEffect(xi.effect.SHELL, 9, 0, 1800)) then
+    local power = 27 -- power/256 handled below to pass final DMGMAGIC value
+    local tier = 1
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    if (target:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.SHELL)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/protect_earring.lua
+++ b/scripts/globals/items/protect_earring.lua
@@ -13,7 +13,16 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    if (target:addStatusEffect(xi.effect.PROTECT, 15, 0, 1800)) then
+    local power = 20
+    local tier = 1
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
+
+    if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/protect_earring.lua
+++ b/scripts/globals/items/protect_earring.lua
@@ -15,12 +15,12 @@ end
 item_object.onItemUse = function(target)
     local power = 20
     local tier = 1
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)

--- a/scripts/globals/items/protect_earring.lua
+++ b/scripts/globals/items/protect_earring.lua
@@ -20,7 +20,7 @@ item_object.onItemUse = function(target)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)

--- a/scripts/globals/items/protect_ring.lua
+++ b/scripts/globals/items/protect_ring.lua
@@ -15,12 +15,12 @@ end
 item_object.onItemUse = function(target)
     local power = 50
     local tier = 2
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)

--- a/scripts/globals/items/protect_ring.lua
+++ b/scripts/globals/items/protect_ring.lua
@@ -13,7 +13,16 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    if (target:addStatusEffect(xi.effect.PROTECT, 40, 0, 1800)) then
+    local power = 50
+    local tier = 2
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
+
+    if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/protect_ring.lua
+++ b/scripts/globals/items/protect_ring.lua
@@ -20,7 +20,7 @@ item_object.onItemUse = function(target)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     if (target:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)) then
         target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.PROTECT)

--- a/scripts/globals/mobskills/crystal_shield.lua
+++ b/scripts/globals/mobskills/crystal_shield.lua
@@ -13,7 +13,7 @@ mobskill_object.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local power = 40
+    local power = 50
     local duration = 300
 
     local typeEffect = xi.effect.PROTECT

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1199,35 +1199,62 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
         elseif act == "PROTECT" then
             local mLvl = player:getMainLvl()
             local power = 0
+            local tier = 0
 
             if mLvl < 27 then
-                power = 15
+                power = 20
+                tier = 1
             elseif mLvl < 47 then
-                power = 40
+                power = 50
+                tier = 2
             elseif mLvl < 63 then
-                power = 75
+                power = 90
+                tier = 3
+            elseif mLvl < 76 then
+                power = 140
+                tier = 4
             else
-                power = 120
+                power = 220
+                tier = 5
             end
 
+            local buff = 0
+            if player:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+                buff = 2 -- 2x Tier from MOD
+            end
+
+            local power = power + (buff * tier)
             player:delStatusEffectSilent(xi.effect.PROTECT)
-            player:addStatusEffect(xi.effect.PROTECT, power, 0, 1800)
+            player:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)
 
         elseif act == "SHELL" then
             local mLvl = player:getMainLvl()
             local power = 0
+            local tier = 0
 
             if mLvl < 37 then
-                power = 9
+                power = 27 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 1
             elseif mLvl < 57 then
-                power = 14
+                power = 42 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 2
             elseif mLvl < 68 then
-                power = 19
+                power = 56 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 3
+            elseif mLvl < 76 then
+                power = 67 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 4
             else
-                power = 22
+                power = 75 -- power/256 handled below before passing final DMGMAGIC value
+                tier = 5
             end
+            local buff = 0
+            if player:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+                buff = 1 -- Adds the tier as a bonus to power before calculation
+            end
+            local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
             player:delStatusEffectSilent(xi.effect.SHELL)
-            player:addStatusEffect(xi.effect.SHELL, power, 0, 1800)
+            player:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)
 
         elseif act == "HASTE" then
             player:delStatusEffectSilent(xi.effect.HASTE)

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1218,12 +1218,12 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
                 tier = 5
             end
 
-            local buff = 0
+            local bonus = 0
             if player:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-                buff = 2 -- 2x Tier from MOD
+                bonus = 2 -- 2x Tier from MOD
             end
 
-            power = power + (buff * tier)
+            power = power + (bonus * tier)
             player:delStatusEffectSilent(xi.effect.PROTECT)
             player:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)
 
@@ -1233,26 +1233,26 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
             local tier = 0
 
             if mLvl < 37 then
-                power = 27 -- power/256 handled below before passing final DMGMAGIC value
+                power = 1055 -- Shell I   (27/256)
                 tier = 1
             elseif mLvl < 57 then
-                power = 42 -- power/256 handled below before passing final DMGMAGIC value
+                power = 1641 -- Shell II  (42/256)
                 tier = 2
             elseif mLvl < 68 then
-                power = 56 -- power/256 handled below before passing final DMGMAGIC value
+                power = 2188 -- Shell III (56/256)
                 tier = 3
             elseif mLvl < 76 then
-                power = 67 -- power/256 handled below before passing final DMGMAGIC value
+                power = 2617 -- Shell IV  (67/256)
                 tier = 4
             else
-                power = 75 -- power/256 handled below before passing final DMGMAGIC value
+                power = 2930 -- Shell V   (75/256)
                 tier = 5
             end
-            local buff = 0
+            local bonus = 0
             if player:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-                buff = 1 -- Adds the tier as a bonus to power before calculation
+                bonus = 39   -- (1/256 bonus buff per tier of spell)
             end
-            power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+            power = power + (bonus * tier)
             player:delStatusEffectSilent(xi.effect.SHELL)
             player:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)
 

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1223,7 +1223,7 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
                 buff = 2 -- 2x Tier from MOD
             end
 
-            local power = power + (buff * tier)
+            power = power + (buff * tier)
             player:delStatusEffectSilent(xi.effect.PROTECT)
             player:addStatusEffect(xi.effect.PROTECT, power, 0, 1800, 0, 0, tier)
 
@@ -1252,7 +1252,7 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
             if player:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
                 buff = 1 -- Adds the tier as a bonus to power before calculation
             end
-            local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+            power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
             player:delStatusEffectSilent(xi.effect.SHELL)
             player:addStatusEffect(xi.effect.SHELL, power, 0, 1800, 0, 0, tier)
 

--- a/scripts/globals/spells/protect.lua
+++ b/scripts/globals/spells/protect.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 15
+    local power = 20
+    local tier = 1
+    local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 7, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect.lua
+++ b/scripts/globals/spells/protect.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect.lua
+++ b/scripts/globals/spells/protect.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_ii.lua
+++ b/scripts/globals/spells/protect_ii.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 40
+    local power = 50
+    local tier = 2
+    local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 27, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_ii.lua
+++ b/scripts/globals/spells/protect_ii.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_ii.lua
+++ b/scripts/globals/spells/protect_ii.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_iii.lua
+++ b/scripts/globals/spells/protect_iii.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_iii.lua
+++ b/scripts/globals/spells/protect_iii.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_iii.lua
+++ b/scripts/globals/spells/protect_iii.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 75
+    local power = 90
+    local tier = 3
+    local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 47, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_iv.lua
+++ b/scripts/globals/spells/protect_iv.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_iv.lua
+++ b/scripts/globals/spells/protect_iv.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 120
+    local power = 140
+    local tier = 4
+    local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 63, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_iv.lua
+++ b/scripts/globals/spells/protect_iv.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_v.lua
+++ b/scripts/globals/spells/protect_v.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 76
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protect_v.lua
+++ b/scripts/globals/spells/protect_v.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Spell: Protect IV
+-- Spell: Protect V
 -----------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 175
+    local power = 220
+    local tier = 5
+    local spelllevel = 76
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 76, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protect_v.lua
+++ b/scripts/globals/spells/protect_v.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra.lua
+++ b/scripts/globals/spells/protectra.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 15
+    local power = 20
+    local tier = 1
+    local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 7, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra.lua
+++ b/scripts/globals/spells/protectra.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra.lua
+++ b/scripts/globals/spells/protectra.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 7
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_ii.lua
+++ b/scripts/globals/spells/protectra_ii.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 40
+    local power = 50
+    local tier = 2
+    local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 27, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_ii.lua
+++ b/scripts/globals/spells/protectra_ii.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 27
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_ii.lua
+++ b/scripts/globals/spells/protectra_ii.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_iii.lua
+++ b/scripts/globals/spells/protectra_iii.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_iii.lua
+++ b/scripts/globals/spells/protectra_iii.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_iii.lua
+++ b/scripts/globals/spells/protectra_iii.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 75
+    local power = 90
+    local tier = 3
+    local spelllevel = 47
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 47, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_iv.lua
+++ b/scripts/globals/spells/protectra_iv.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_iv.lua
+++ b/scripts/globals/spells/protectra_iv.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 120
+    local power = 140
+    local tier = 4
+    local spelllevel = 63
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 63, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_iv.lua
+++ b/scripts/globals/spells/protectra_iv.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -12,12 +12,20 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
+    local power = 220
+    local tier = 5
+    local spelllevel = 75
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 75, target:getMainLvl())
-    local power = 220 -- bg-wiki
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 2 -- 2x Tier from MOD
+    end
+
+    local power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -22,7 +22,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         buff = 2 -- 2x Tier from MOD
     end
 
-    local power = power + (buff * tier)
+    power = power + (buff * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -17,12 +17,12 @@ spell_object.onSpellCast = function(caster, target, spell)
     local spelllevel = 75
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-    local buff = 0
+    local bonus = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 2 -- 2x Tier from MOD
+        bonus = 2 -- 2x Tier from MOD
     end
 
-    power = power + (buff * tier)
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.PROTECT
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shell.lua
+++ b/scripts/globals/spells/shell.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 1055 -- Shell I   (27/256)
     local tier = 1
     local spelllevel = 18
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shell.lua
+++ b/scripts/globals/spells/shell.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,12 +13,22 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 9
+    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 1
+    local spelllevel = 18
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 18, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect

--- a/scripts/globals/spells/shell.lua
+++ b/scripts/globals/spells/shell.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shell_ii.lua
+++ b/scripts/globals/spells/shell_ii.lua
@@ -14,7 +14,7 @@ end
 
 spell_object.onSpellCast = function(caster, target, spell)
     local power = 42 -- power/256 handled below before passing final DMGMAGIC value
-    local tier =2 
+    local tier = 2
     local spelllevel = 37
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shell_ii.lua
+++ b/scripts/globals/spells/shell_ii.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 1641 -- Shell II  (42/256)
     local tier = 2
     local spelllevel = 37
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shell_ii.lua
+++ b/scripts/globals/spells/shell_ii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 14
+    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local tier =2 
+    local spelllevel = 37
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 37, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shell_iii.lua
+++ b/scripts/globals/spells/shell_iii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,17 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 19
+    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 3
+    local spelllevel = 57
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
 
-    duration = calculateDurationForLvl(duration, 57, target:getMainLvl())
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shell_iii.lua
+++ b/scripts/globals/spells/shell_iii.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shell_iii.lua
+++ b/scripts/globals/spells/shell_iii.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2188 -- Shell III (56/256)
     local tier = 3
     local spelllevel = 57
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shell_iv.lua
+++ b/scripts/globals/spells/shell_iv.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2617 -- Shell IV  (67/256)
     local tier = 4
     local spelllevel = 68
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shell_iv.lua
+++ b/scripts/globals/spells/shell_iv.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shell_iv.lua
+++ b/scripts/globals/spells/shell_iv.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 22
+    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 4
+    local spelllevel = 68
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 68, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shell_v.lua
+++ b/scripts/globals/spells/shell_v.lua
@@ -1,9 +1,10 @@
 -----------------------------------
--- Spell: Shell IV
+-- Spell: Shell V
 -----------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 24
+    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 5
+    local spelllevel = 76
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 76, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shell_v.lua
+++ b/scripts/globals/spells/shell_v.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shell_v.lua
+++ b/scripts/globals/spells/shell_v.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2930 -- Shell V   (75/256)
     local tier = 5
     local spelllevel = 76
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra.lua
+++ b/scripts/globals/spells/shellra.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 9
+    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 1
+    local spelllevel = 18
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 18, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shellra.lua
+++ b/scripts/globals/spells/shellra.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shellra.lua
+++ b/scripts/globals/spells/shellra.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 27 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 1055 -- Shellra I   (27/256)
     local tier = 1
     local spelllevel = 18
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra_ii.lua
+++ b/scripts/globals/spells/shellra_ii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 14
+    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 2
+    local spelllevel = 37
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 37, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shellra_ii.lua
+++ b/scripts/globals/spells/shellra_ii.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 42 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 1641 -- Shellra II  (42/256)
     local tier = 2
     local spelllevel = 37
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra_ii.lua
+++ b/scripts/globals/spells/shellra_ii.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shellra_iii.lua
+++ b/scripts/globals/spells/shellra_iii.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2188 -- Shellra III (56/256)
     local tier = 3
     local spelllevel = 57
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra_iii.lua
+++ b/scripts/globals/spells/shellra_iii.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 19
+    local power = 56 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 3
+    local spelllevel = 57
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 57, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shellra_iii.lua
+++ b/scripts/globals/spells/shellra_iii.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shellra_iv.lua
+++ b/scripts/globals/spells/shellra_iv.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/spells/shellra_iv.lua
+++ b/scripts/globals/spells/shellra_iv.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
-require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2617 -- Shellra IV  (67/256)
     local tier = 4
     local spelllevel = 68
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra_iv.lua
+++ b/scripts/globals/spells/shellra_iv.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,16 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 22
+    local power = 67 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 4
+    local spelllevel = 68
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 68, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if target:addStatusEffect(typeEffect, power, 0, duration) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -1,9 +1,10 @@
 -----------------------------------
--- Spell: Shellra
+-- Spell: Shellra V
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
+require("scripts/globals/utils")
 -----------------------------------
 local spell_object = {}
 
@@ -12,17 +13,27 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 29 -- according to bg-wiki
-
+    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local tier = 5
+    local spelllevel = 75
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
-    duration = calculateDurationForLvl(duration, 75, target:getMainLvl())
+    duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
+
+    local buff = 0
+    if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
+        buff = 1 -- Adds the tier as a bonus to power before calculation
+    end
+    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+
+
 
     local typeEffect = xi.effect.SHELL
-    if (target:addStatusEffect(typeEffect, power, 0, duration)) then
+    if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- no effect
     end
+
     return typeEffect
 end
 

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -1,10 +1,9 @@
 -----------------------------------
 -- Spell: Shellra V
 -----------------------------------
-require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/msg")
-require("scripts/globals/utils")
+require("scripts/globals/status")
 -----------------------------------
 local spell_object = {}
 
@@ -13,19 +12,16 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 75 -- power/256 handled below before passing final DMGMAGIC value
+    local power = 2930 -- Shellra V   (75/256)
     local tier = 5
     local spelllevel = 75
+    local bonus = 0
     local duration = calculateDuration(1800, spell:getSkillType(), spell:getSpellGroup(), caster, target, false)
     duration = calculateDurationForLvl(duration, spelllevel, target:getMainLvl())
-
-    local buff = 0
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
-        buff = 1 -- Adds the tier as a bonus to power before calculation
+        bonus = 39 -- (1/256 bonus buff per tier of spell)
     end
-    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
-
-
+    power = power + (bonus * tier)
 
     local typeEffect = xi.effect.SHELL
     if target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, tier) then

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -23,7 +23,7 @@ spell_object.onSpellCast = function(caster, target, spell)
     if target:getMod(xi.mod.ENHANCES_PROT_SHELL_RCVD) > 0 then
         buff = 1 -- Adds the tier as a bonus to power before calculation
     end
-    local power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
+    power = utils.roundup((power + (buff * tier)) / 2.56) -- takes the result and converts it back to a usable DMGMAGIC value
 
 
 

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1434,6 +1434,7 @@ xi.mod =
     ENHANCES_CURSNA_RCVD            = 67,  -- Potency of "Cursna" effects received
     ENHANCES_CURSNA                 = 310, -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove
     ENHANCES_HOLYWATER              = 495, -- Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute
+    ENHANCES_PROT_SHELL_RCVD        = 977, -- Enhances Protect and Shell Effects Received (Binary MOD)
 
     RETALIATION                     = 414, -- Increases damage of Retaliation hits
     THIRD_EYE_COUNTER_RATE          = 508, -- Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -41,6 +41,11 @@ function utils.permgen(max_val, min_val)
     return utils.shuffle(indices)
 end
 
+function utils.roundup(num)
+    local mult = 10^(0)
+    return math.floor(num * mult + 0.5) / mult
+end
+
 function utils.clamp(input, min_val, max_val)
     if input < min_val then
         input = min_val

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -41,11 +41,6 @@ function utils.permgen(max_val, min_val)
     return utils.shuffle(indices)
 end
 
-function utils.roundup(num)
-    local mult = 10^(0)
-    return math.floor(num * mult + 0.5) / mult
-end
-
 function utils.clamp(input, min_val, max_val)
     if input < min_val then
         input = min_val

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -2286,7 +2286,8 @@ INSERT INTO `item_mods` VALUES (10762,30,4);
 INSERT INTO `item_mods` VALUES (10762,71,2);
 INSERT INTO `item_mods` VALUES (10763,24,8);
 INSERT INTO `item_mods` VALUES (10763,73,-4);
-INSERT INTO `item_mods` VALUES (10764,370,1);
+INSERT INTO `item_mods` VALUES (10764,370,1); -- Sheltered Ring  Regen +1
+INSERT INTO `item_mods` VALUES (10764,977,1); -- Enhances Prot/Shell Received
 INSERT INTO `item_mods` VALUES (10765,11,4);
 INSERT INTO `item_mods` VALUES (10765,30,2);
 INSERT INTO `item_mods` VALUES (10765,105,3);
@@ -3129,7 +3130,8 @@ INSERT INTO `item_mods` VALUES (11036,30,2);
 INSERT INTO `item_mods` VALUES (11037,18,10);     -- Earthcry Earring: Earth resistance +10
 INSERT INTO `item_mods` VALUES (11037,539,10);    -- Enhances Stoneskin effect +10
 INSERT INTO `item_mods` VALUES (11038,23,7);
-INSERT INTO `item_mods` VALUES (11039,5,20);
+INSERT INTO `item_mods` VALUES (11039,5,20);      -- brachyura earring MP+20
+INSERT INTO `item_mods` VALUES (11039,977,1);     -- Enhances Prot/Shell Received
 INSERT INTO `item_mods` VALUES (11040,2,10);      -- terminus_earring HP+10
 INSERT INTO `item_mods` VALUES (11040,64,1);      -- combat skill +1
 INSERT INTO `item_mods` VALUES (11041,5,10);      -- liminus_earring MP+10

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -722,6 +722,7 @@ enum class Mod
     ENHANCES_CURSNA_RCVD = 67,  // Potency of "Cursna" effects received
     ENHANCES_CURSNA      = 310, // Used by gear with the "Enhances Cursna" or "Cursna+" attribute
     ENHANCES_HOLYWATER   = 495, // Used by gear with the "Enhances Holy Water" or "Holy Water+" attribute
+    ENHANCES_PROT_SHELL_RCVD  = 977, // Enhances Protect and Shell Effects Received (Binary MOD)
 
     RETALIATION = 414, // Increases damage of Retaliation hits
 


### PR DESCRIPTION
Adds MOD ENHANCES_PROT_SHELL_RCVD (977) to the following:
Sheltered Ring 10764
Brachyura Earring 11039

These items add the following bonus when receiving spell/effect:
Add (Tier of Spell x 2) DEF to Protect Spells/Effects
Add (Tier of Spell / 256) to Shell Spells/Effects

Effect Detail and confirmation items do not stack:

https://www.ffxiah.com/item/10764/sheltered-ring
https://www.ffxiah.com/item/11039/brachyura-earring

Updates Spells/Items to use the current BG Values:

https://www.bg-wiki.com/bg/Protect (and _II -> _V)
https://www.bg-wiki.com/bg/Protectra (and _II -> _V)
https://www.bg-wiki.com/bg/Shell (and _II -> _V)
https://www.bg-wiki.com/bg/Shellra (and _II -> _V)
```
Protect/ra  DEF            DEF
                           With MOD
       I -   20             22
      II -   50             54
     III -   90             96
      IV -  140            148
       V -  220            230

Shell/ra    MDT  as /256   MDT  as /256
                           With MOD
       I -  -11 (-27/256)  -11 (-28/256)
      II -  -16 (-42/256)  -17 (-44/256)
     III -  -22 (-56/256)  -23 (-59/256)
      IV -  -26 (-67/256)  -28 (-71/256)
       V -  -29 (-75/256)  -31 (-80/256)

Shell/ra    BG MDT-        Value as Decimal     Rounded Value /10000
I           27/256         .10546875            1055
II          42/256         .1640625             1641
III         56/256         .21875               2188
IV          67/256         .26171875            2617
V           75/256         .29296875            2930

Bonus        1/256         .00390625            0039
```

Script Adjustments:

Added checks on individual Spells/Item Scripts.
Adjusts power value for Shell/ra spells/items to reflect /10000 scale.
Check for MOD Value > 0 (prevents stacking).
Updated Protect Values in scripts to match BG Values.
Added tier values for spells/effects.
Updated regimes to include Tier V and apply bonus with MOD present.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits