### PR TITLE
[Fix] ToAU mission 1 CS getting hanged and re-define CS trigger region

### DIFF
--- a/scripts/missions/toau/01_Land_of_Sacred_Serpents.lua
+++ b/scripts/missions/toau/01_Land_of_Sacred_Serpents.lua
@@ -35,6 +35,8 @@ mission.sections =
             onRegionEnter =
             {
                 [3] = function (player, csid, option, npc)
+                    -- Naja Salaheem interactions require the 9th argument set to 0.
+                    -- This is because Aht Uhrgan Whitegate uses 2 different dats.
                     return mission:progressEvent(3000, 0, 0, 0, 0, 0, 0, 0, 0, 0)
                 end,
             },

--- a/scripts/missions/toau/01_Land_of_Sacred_Serpents.lua
+++ b/scripts/missions/toau/01_Land_of_Sacred_Serpents.lua
@@ -32,13 +32,10 @@ mission.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-
-            -- TODO: Edit region defined in Aht Urghan Whitegate, becouse as of now, it is incorrect.
-            -- CS should trigger in the ramp inside Naja Salaheem building.
             onRegionEnter =
             {
                 [3] = function (player, csid, option, npc)
-                    return mission:progressEvent(3000)
+                    return mission:progressEvent(3000, 0, 0, 0, 0, 0, 0, 0, 0, 0)
                 end,
             },
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -17,7 +17,7 @@ local zone_object = {}
 zone_object.onInitialize = function(zone)
     zone:registerRegion(1,  57, -1,  -70,  62,  1,  -65) -- Sets Mark for "Got It All" Quest cutscene.
     zone:registerRegion(2, -96, -7,  121, -64, -5,  137) -- Sets Mark for "Vanishing Act" Quest cutscene.
-    zone:registerRegion(3,  14, -7,  -65,  37, -2,  -41) -- TOAU Mission 1 CS area
+    zone:registerRegion(3,  20, -8,  -51,  39, -6,  -40) -- TOAU Mission 1 CS area
     zone:registerRegion(4,  75, -3,   25,  90,  1,   59)
     zone:registerRegion(5,  73, -7, -137,  95, -3, -115) -- entering Shaharat Teahouse
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Naja_Salaheem.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Naja_Salaheem.lua
@@ -4,6 +4,11 @@
 -- Type: Standard NPC
 -- !pos 22.700 -8.804 -45.591 50
 -----------------------------------
+-- NOTE
+
+-- Naja Salaheem interactions require the 9th argument in events set to 0.
+-- This is because Aht Uhrgan Whitegate uses 2 different dats.
+-----------------------------------
 require("scripts/zones/Aht_Urhgan_Whitegate/Shared")
 local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 require("scripts/globals/missions")


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

As title suggests. closes #553

Reminder: The last parameter needs to be set to 0. Aht uhrgan whitegate events seemingly need them to not hang.

The CS doesnt trigger as fast as desired, wich should be in the middle of the ramp, but it will not trigger outside the building anymore, at least.