### PR TITLE
Improved event handling logic (CS black screen fix)

### DIFF
--- a/scripts/zones/RuAun_Gardens/Zone.lua
+++ b/scripts/zones/RuAun_Gardens/Zone.lua
@@ -53,15 +53,15 @@ zone_object.onRegionEnter = function(player, region)
 
     elseif (p["portal"] ~= nil) then -- blue portal
         if (GetNPCByID(p["portal"]):getAnimation() == xi.anim.OPEN_DOOR) then
-            player:startEvent(p["event"])
+            player:startOptionalCutscene(p["event"])
         end
 
     elseif (type(p["event"]) == "table") then -- portal with random destination
         local events = p["event"]
-        player:startEvent(events[math.random(#events)])
+        player:startOptionalCutscene(events[math.random(#events)])
 
     else -- portal with static destination
-        player:startEvent(p["event"])
+        player:startOptionalCutscene(p["event"])
     end
 end
 

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     daily_system.h
     enmity_container.cpp
     enmity_container.h
+    event_info.h
     grades.cpp
     grades.h
     guild.cpp

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -24,6 +24,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "../../common/cbasetypes.h"
 #include "../../common/mmo.h"
+#include "../event_info.h"
 
 #include <bitset>
 #include <deque>
@@ -48,25 +49,6 @@ struct jobs_t
     uint8  job[MAX_JOBTYPE]; // the current levels of each of the jobs from above
     uint16 exp[MAX_JOBTYPE]; // the experience points for each of the jobs above
     uint8  genkai;           // the maximum genkai level achieved
-};
-
-struct event_t
-{
-    int32 EventID;
-    int32 Option; // dummy return result
-
-    CBaseEntity* Target; // event initiator
-
-    // TODO: Change this to something more descriptive
-    string_t Script; // path to the file responsible for handling the event
-
-    void reset()
-    {
-        EventID = -1;
-        Option  = 0;
-        Target  = 0;
-        Script.clear();
-    }
 };
 
 struct profile_t
@@ -221,9 +203,13 @@ class CCharEntity : public CBattleEntity
 public:
     jobs_t     jobs;       // доступрые профессии персонажа
     keyitems_t keys;       // таблица ключевых предметов
-    event_t    m_event;    // структура для запуска событый
-    bool       inSequence; // True if the player is locked in a NPC sequence
-    bool       gotMessage; // Used to let the interaction framework know that a message outside of it was triggered.
+
+    EventPrep* eventPreparation;      // Information about a potential upcoming event
+    EventInfo* currentEvent;          // The currently ongoing event playing for the player
+    std::list<EventInfo*> eventQueue; // The queued events to play for the player
+    bool       inSequence;            // True if the player is locked in a NPC sequence
+    bool       gotMessage;            // Used to let the interaction framework know that a message outside of it was triggered.
+
     skills_t   RealSkills; // структура всех реальных умений персонажа, с точностью до 0.1 и не ограниченных уровнем
 
     nameflags_t nameflags;           // флаги перед именем персонажа
@@ -440,6 +426,11 @@ public:
 
     bool isInEvent();
     bool isNpcLocked();
+    void queueEvent(EventInfo* eventToQueue);
+    void endCurrentEvent();
+    void tryStartNextEvent();
+    void skipEvent();
+    void setLocked(bool locked);
 
     void SetMoghancement(uint16 moghancementID);
     bool hasMoghancement(uint16 moghancementID) const;
@@ -484,6 +475,7 @@ private:
     std::unique_ptr<CItemContainer> m_Wardrobe3;
     std::unique_ptr<CItemContainer> m_Wardrobe4;
 
+    bool m_Locked; // Is the player locked in a cutscene
     bool m_isStyleLocked;
     bool m_isBlockingAid;
     bool m_reloadParty;

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -1,0 +1,84 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2020-2021 Eden Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _EVENT_INFO_H
+#define _EVENT_INFO_H
+
+#include "../common/cbasetypes.h"
+#include "../common/mmo.h"
+
+#include <bitset>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <vector>
+
+class CBaseEntity;
+
+struct EventPrep
+{
+    CBaseEntity* targetEntity;
+    string_t     scriptFile;
+
+    void reset()
+    {
+        targetEntity = 0;
+        scriptFile.clear();
+    }
+};
+
+enum EVENT_TYPE : uint8
+{
+    NORMAL,
+    CUTSCENE,
+    OPTIONAL_CUTSCENE,
+};
+
+struct EventInfo : EventPrep
+{
+    int32                        eventId = -1;
+    int32                        option  = 0;
+    std::map<uint8, uint32>      params;
+    std::map<uint8, std::string> strings;
+    int16                        textTable = -1;
+
+    EVENT_TYPE         type = NORMAL;
+    std::vector<int32> cutsceneOptions;
+    uint16             interruptText = 0;
+
+    bool hasCutsceneOption(int32 option)
+    {
+        return std::find(cutsceneOptions.begin(), cutsceneOptions.end(), option) != cutsceneOptions.end();
+    }
+
+    void reset()
+    {
+        EventPrep::reset();
+        eventId = -1;
+        option  = 0;
+        cutsceneOptions.clear();
+        params.clear();
+        strings.clear();
+        textTable = -1;
+    }
+};
+
+#endif

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -79,8 +79,13 @@ public:
     void entityVisualPacket(std::string const& command, sol::object const& entity);
     void entityAnimationPacket(const char* command);
 
-    void startEvent(uint32 EventID, sol::variadic_args va);
-    void startEventString(uint16 EventID, sol::variadic_args va); // Begins Event with string param (0x33 packet)
+    void       StartEventHelper(int32 EventID, sol::variadic_args va, EVENT_TYPE eventType);
+    EventInfo* ParseEvent(int32 EventID, sol::variadic_args va, EventPrep* eventPreparation, EVENT_TYPE eventType);
+    void       startEvent(int32 EventID, sol::variadic_args va);
+    void       startEventString(int32 EventID, sol::variadic_args va); // Begins Event with string param (0x33 packet)
+    void       startCutscene(int32 EventID, sol::variadic_args va); // Begins cutscene which locks the character
+    void       startOptionalCutscene(int32 EventID, sol::variadic_args va); // Begins an event that can turn into a cutscene
+
     void updateEvent(sol::variadic_args va);                      // Updates event
     void updateEventString(sol::variadic_args va);                // (string, string, string, string, uint32, ...)
     auto getEventTarget() -> std::optional<CLuaBaseEntity>;

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -69,7 +69,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // + model sizing : 0x02 - 0; 0x08 - 1; 0x10 - 2;
     ref<uint8>(0x2C) = PChar->GetSpeed();
     ref<uint16>(0x2E) |= PChar->speedsub << 1; // Not sure about this, it was a work around when we set speedsub incorrectly..
-    ref<uint8>(0x30) = PChar->m_event.EventID != -1 ? ANIMATION_EVENT : PChar->animation;
+    ref<uint8>(0x30) = PChar->isInEvent() ? ANIMATION_EVENT : PChar->animation;
 
     CItemLinkshell* linkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
 

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -26,13 +26,13 @@
 #include "../entities/charentity.h"
 #include "event.h"
 
-CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::pair<uint8, uint32>> params, int16 textTable)
+CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
 {
     this->type = 0x32;
     this->size = 0x0A;
 
     uint32 npcID = 0;
-    auto*  PNpc  = PChar->m_event.Target;
+    auto*  PNpc  = eventInfo->targetEntity;
     if (PNpc)
     {
         npcID = PNpc->id;
@@ -45,12 +45,12 @@ CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::
     }
     ref<uint32>(0x04) = npcID;
 
-    if (params.size() > 0)
+    if (eventInfo->params.size() > 0)
     {
         this->type = 0x34;
         this->size = 0x1A;
 
-        for (auto paramPair : params)
+        for (auto paramPair : eventInfo->params)
         {
             // Only params 0 through 7 are valid
             if (paramPair.first >= 0 && paramPair.first <= 7)
@@ -62,25 +62,24 @@ CEventPacket::CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::
         ref<uint16>(0x28) = PChar->m_TargID;
 
         ref<uint16>(0x2A) = PChar->getZone();
-        if (textTable != -1)
+        if (eventInfo->textTable != -1)
         {
-            ref<uint16>(0x30) = textTable;
+            ref<uint16>(0x30) = eventInfo->textTable;
         }
         else
         {
             ref<uint16>(0x30) = PChar->getZone();
         }
 
-        ref<uint16>(0x2C) = EventID;
+        ref<uint16>(0x2C) = eventInfo->eventId;
         ref<uint8>(0x2E)  = 8; // если патаметров меньше, чем 8, то после завершения события камера "прыгнет" за спину персонажу
     }
     else
     {
         ref<uint16>(0x08) = PChar->targid;
-        ref<uint16>(0x0C) = EventID;
+        ref<uint16>(0x0C) = eventInfo->eventId;
 
         ref<uint16>(0x0A) = PChar->getZone();
         ref<uint16>(0x10) = PChar->getZone();
     }
-    PChar->m_event.EventID = EventID;
 }

--- a/src/map/packets/event.h
+++ b/src/map/packets/event.h
@@ -23,6 +23,7 @@
 #define _CEVENTPACKET_H
 
 #include "../../common/cbasetypes.h"
+#include "../event_info.h"
 
 #include <string>
 
@@ -39,7 +40,7 @@ class CCharEntity;
 class CEventPacket : public CBasicPacket
 {
 public:
-    CEventPacket(CCharEntity* PChar, uint16 EventID, std::vector<std::pair<uint8, uint32>> params, int16 textTable = -1);
+    CEventPacket(CCharEntity* PChar, EventInfo* eventInfo);
 };
 
 #endif

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -26,9 +26,7 @@
 #include "../entities/charentity.h"
 #include "event_string.h"
 
-CEventStringPacket::CEventStringPacket(CCharEntity* PChar, uint16 EventID, const std::string& string0, const std::string& string1, const std::string& string2,
-                                       const std::string& string3, uint32 param0, uint32 param1, uint32 param2, uint32 param3, uint32 param4, uint32 param5,
-                                       uint32 param6, uint32 param7)
+CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
 {
     this->type = 0x33;
     this->size = 0x38;
@@ -36,22 +34,20 @@ CEventStringPacket::CEventStringPacket(CCharEntity* PChar, uint16 EventID, const
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->m_TargID;
     ref<uint16>(0x0A) = PChar->getZone();
-    ref<uint16>(0x0C) = EventID;
+    ref<uint16>(0x0C) = eventInfo->eventId;
     ref<uint8>(0x0E)  = 8; // camera "jumps" behind the character if < 8 params
 
-    memcpy(data + (0x10), string0.c_str(), string0.size());
-    memcpy(data + (0x20), string1.c_str(), string1.size());
-    memcpy(data + (0x30), string2.c_str(), string2.size());
-    memcpy(data + (0x40), string3.c_str(), string3.size());
+    for (auto stringPair : eventInfo->strings)
+    {
+        memcpy(data + 0x10 + 0x10 * stringPair.first, stringPair.second.c_str(), stringPair.second.size());
+    }
 
-    ref<uint32>(0x50) = param0;
-    ref<uint32>(0x54) = param1;
-    ref<uint32>(0x58) = param2;
-    ref<uint32>(0x5C) = param3;
-    ref<uint32>(0x60) = param4;
-    ref<uint32>(0x64) = param5;
-    ref<uint32>(0x68) = param6;
-    ref<uint32>(0x6C) = param7;
-
-    PChar->m_event.EventID = EventID;
+    for (auto paramPair : eventInfo->params)
+    {
+        // Only params 0 through 7 are valid
+        if (paramPair.first >= 0 && paramPair.first <= 7)
+        {
+            ref<uint32>(0x50 + paramPair.first * 4) = paramPair.second;
+        }
+    }
 }

--- a/src/map/packets/event_string.h
+++ b/src/map/packets/event_string.h
@@ -24,6 +24,7 @@
 
 #include "../../common/cbasetypes.h"
 #include "../../common/mmo.h"
+#include "../event_info.h"
 
 #include <string>
 
@@ -40,9 +41,7 @@ class CCharEntity;
 class CEventStringPacket : public CBasicPacket
 {
 public:
-    CEventStringPacket(CCharEntity* PChar, uint16 EventID, const std::string& string0 = "", const std::string& string1 = "", const std::string& string2 = "",
-                       const std::string& string3 = "", uint32 param0 = 0, uint32 param1 = 0, uint32 param2 = 0, uint32 param3 = 0, uint32 param4 = 0,
-                       uint32 param5 = 0, uint32 param6 = 0, uint32 param7 = 0);
+    CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo);
 };
 
 #endif

--- a/src/map/packets/release.cpp
+++ b/src/map/packets/release.cpp
@@ -33,7 +33,7 @@ CReleasePacket::CReleasePacket(CCharEntity* PChar, RELEASE_TYPE releaseType)
 
     if (releaseType == RELEASE_TYPE::SKIPPING)
     {
-        ref<uint16>(0x05) = PChar->m_event.EventID;
+        ref<uint16>(0x05) = PChar->currentEvent->eventId;
     }
 
     PChar->m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -822,7 +822,7 @@ namespace charutils
         PChar->health.hp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxHP() : HP;
         PChar->health.mp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxMP() : MP;
         PChar->UpdateHealth();
-        PChar->m_event.EventID = luautils::OnZoneIn(PChar);
+        PChar->currentEvent->eventId = luautils::OnZoneIn(PChar);
         luautils::OnGameIn(PChar, zoning == 1);
     }
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -266,20 +266,20 @@ void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
 
         if (PCurrentChar->loc.boundary == boundary)
         {
-            if (PCurrentChar->m_event.Target != nullptr)
+            if (PCurrentChar->eventPreparation->targetEntity != nullptr)
             {
                 // The player talked to one of the guys on the boat, and the event target is wrong.
                 // This leads to the wrong script being loaded and you get stuck on a black screen
                 // instead of loading into the port.
 
                 // Attempt to load the proper script
-                PCurrentChar->m_event.Target = nullptr;
-                size_t deleteStart           = PCurrentChar->m_event.Script.find("npcs/");
-                size_t deleteEnd             = PCurrentChar->m_event.Script.find(".lua");
+                PCurrentChar->eventPreparation->targetEntity = nullptr;
+                size_t deleteStart                           = PCurrentChar->eventPreparation->scriptFile.find("npcs/");
+                size_t deleteEnd                             = PCurrentChar->eventPreparation->scriptFile.find(".lua");
 
                 if (deleteStart != std::string::npos && deleteEnd != std::string::npos)
                 {
-                    PCurrentChar->m_event.Script.replace(deleteStart, deleteEnd - deleteStart, "Zone");
+                    PCurrentChar->eventPreparation->scriptFile.replace(deleteStart, deleteEnd - deleteStart, "Zone");
                 }
             }
             luautils::OnTransportEvent(PCurrentChar, zone);


### PR DESCRIPTION
Improves the event handling logic to prevent corrupting ongoing events (i.e. black screens and `onEventFinish` not being called when it should have been).
This PR also makes it possible for events to be queued up for a player, if more are started while a player is already in an event. The queued event(s) will then automatically be started when the current event ends for the player.

Additionally, the support for starting cutscenes and optional cutscenes has been added. A cutscene puts a lock on the player that should prevent it from being targeted by anything, taking damage, or being aggroed. The actual prevention of all of this is not a part of this PR and should be implemented separately, but this implementation can now rely on the `m_Locked` variable on the player entity to check if the player can be targeted or not.

Another follow-up is to clear all enmity on the player when it becomes locked by a cutscene, since the monsters otherwise will attack the player after the cutscene ends.

Additionally, if an event is meant to be a cutscene or an optional cutscene, it can now be specified in lua when starting it with either `:startCutscene(...)` or `startOptionalCutscene(...)`. An example of optional cutscenes has been added to this PR, namely the teleporters in sky, since they have a prompt before the actual teleportation cutscene starts, wherein the player can be interrupted if they don't accept it before being attacked.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
