### PR TITLE
Add KI ID: BUNDLE_OF_HALF_INSCRIBED_SCROLLS

### DIFF
--- a/scripts/globals/keyitems.lua
+++ b/scripts/globals/keyitems.lua
@@ -2439,6 +2439,7 @@ xi.keyItem =
     UNBLEMISHED_PIONEERS_BADGE               = 2507,
     SILVERY_PLATE                            = 2508,
     SOUL_SIPHON                              = 2509,
+    BUNDLE_OF_HALF_INSCRIBED_SCROLLS         = 2510,
     TAPESTRY_OF_BAGUA_POETRY                 = 2511,
     FUTHARKIC_CONCEPTS_IN_FLUX               = 2512,
     CRYSTALLIZED_LIFESTREAM_ESSENCE          = 2513,


### PR DESCRIPTION
Closes https://github.com/LandSandBoat/server/issues/655

Unfortunately for us, unlike titles, effects etc. the POLUtils output for key items isn't in line with what we use to assign key items in-game.

The POLUtils output for this KI:
```
<thing type="DMSGStringBlock">
    <field name="index">1876</field>
    <field name="string-1">
    </field>
    <field name="string-2">
    </field>
    <field name="string-3">
    </field>
    <field name="string-4">
    </field>
    <field name="string-5">bundle of half-inscribed scrolls</field>
    <field name="string-6">bundles of half-inscribed scrolls</field>
    <field name="string-7">
These scrolls, supplied to you by
Jamal of the Jeuno Institute of
Magical Studies, are magical
tableaus referred to as "ciphers,"
and call upon the bonds of a third
party to summon another being into
this world.</field>
    <field name="string-count">7</field>
  </thing>
```

But ID: 1876 is already taken in-game by: `    MAP_OF_ARRAPAGO_REMNANTS                 = 1876,`

There doesn't appear to be a way to reliably automate the extraction of this information.

If I was to look at my cleaned output from parsing the POLUtils output:
```
    CONCORDOLL                            = 1872,
    WINDURST_TRUST_PERMIT                 = 1873,
    BASTOK_TRUST_PERMIT                   = 1874,
    SAN_DORIA_TRUST_PERMIT                = 1875,
    BUNDLE_OF_HALF_INSCRIBED_SCROLLS      = 1876,
    SILVERY_PLATE                         = 1877,
    CARD_JAILER_TEODOR                    = 1878,
    GRUNT_HEARD_ROUND_THE_WORLD           = 1879,
    YGNASS_INSIGNIA                       = 1880,
```

I would see that the _actual_ KI IDs for all of these are scattered. I only found the in-game ID for `BUNDLE_OF_HALF_INSCRIBED_SCROLLS` by looking at what other KIs were nearby in the output and testing them by hand in game.

⭐ THERE ARE MANY CASES OF THIS, AND THIS WOULD BE A GOOD TASK FOR SOMEONE WHO'S BORED -> JUST SIT AND MAP OUT THE GAPS IN OUR KI TABLE BY USING `!addkeyitem <id>` IN GAME. 

* there are blanks, which will show you repeats of the last item you successfully added, so you have to be careful doing this. 

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
