### PR TITLE
Naming and wording adjustments to avoid worrying new server owners

### DIFF
--- a/conf/default/packet_tcp.conf
+++ b/conf/default/packet_tcp.conf
@@ -35,21 +35,21 @@ order: deny,allow
 // deny: 127.0.0.1
 
 
-//---- DDoS Protection Settings ----
-// If ddos_count connection request are made within ddos_interval msec, it assumes it's a DDoS attack
+//---- Connection Limit Settings ----
+// If connect_count connection request are made within connect_interval msec, it blocks it
 
 // Consecutive attempts interval (msec)
 // (default is 3000 msecs, 3 seconds)
-ddos_interval: 3000
+connect_interval: 3000
 
 // Consecutive attempts trigger
-// (default is 5 attemps)
-ddos_count: 5
+// (default is 10 attempts)
+connect_count: 10
 
-// The time interval after which the threat of DDoS is assumed to be gone. (msec)
-// After this amount of time, the DDoS restrictions are lifted.
+// The time interval after which the connection lockout is lifted. (msec)
+// After this amount of time, the connection restrictions are lifted.
 // (default is 600000 msecs, 10 minutes)
-ddos_autoreset: 600000
+connect_lockout: 600000
 
 
 //import: conf/import/packet_conf.txt


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I've never seen any of this tripped by an _actual_ DDoS or even a regular DoS. But every once in a while some person logs in a bunch of accounts from the same IP to fast and trips it, then there is that scary message about a DDoS in their log.

No functionality is altered this is just a name change for the settings and the phrasing involved - the settings do what they say they do, and triggering the warning may or may not be a sign of a DDoS but its more likely just user error.