### PR TITLE
[CI] Re-enable workflow_dispatch on changelog CI job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # At 12:00 on day-of-month 1 and 15.
     - cron:  '0 12 1,15 * *'
+  workflow_dispatch:
 
 jobs:
   Publish_Changelog:


### PR DESCRIPTION
GitHub is giving me sass about generating the changelogs. Re-adding the option for me to tell it "just do it" regardless of schedule.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
