### PR TITLE
Add config options for ws points and gm command to display current points of equipped weapons.

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -104,6 +104,13 @@ level_sync_enable: 1
 #Disables ability to equip higher level gear when level cap/sync effect is on player.
 disable_gear_scaling: 0
 
+#Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
+ws_points_base: 1
+
+#Weaponskill points per skillchain element - whole numbers only, retail is 1 
+# (tier 3 sc's have 4 elements, plus 1 for the ws itself, giving 5 points to the closer).
+ws_points_skillchain: 1
+
 #Enable/disable jobs other than BST and RNG having widescan
 all_jobs_widescan: 1
 

--- a/scripts/commands/getwspoints.lua
+++ b/scripts/commands/getwspoints.lua
@@ -1,0 +1,53 @@
+---------------------------------------------------------------------------------------------------
+-- func: getwspoints
+-- desc: prints current ws points, optionaly specifying the weapon slot to check (default main)
+---------------------------------------------------------------------------------------------------
+require("scripts/globals/status")
+require("scripts/globals/msg")
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "ss"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!getwspoints {main/sub/ranged} <optional target>")
+end
+
+function onTrigger(player, equipSlot, name)
+    local target = player:getCursorTarget()
+
+    if name then
+        target = GetPlayerByName(name)
+        if not target then
+            error(player, string.format("player named %s not found!", name))
+            return
+        end
+    else
+        if not target then
+            target = player
+        end
+        name = target:getName()
+    end
+
+    if not target:isPC() then
+        error(player, "Invalid target!")
+        return
+    end
+
+    if not equipSlot then
+        equipSlot = "main"
+        player:PrintToPlayer("No equip slot specified, defaulting to mainhand weapon.")
+    end
+
+    local equip = xi.slot[string.upper(equipSlot)]
+    if not equip or equip > xi.slot.RANGED then
+        error(player, "Invalid equip slot specified.")
+        return
+    end
+
+    local points = target:getStorageItem(0,0,equip):getWeaponskillPoints()
+    player:PrintToPlayer(string.format("The weapon in %s's %s slot has %i ws points", name, equipSlot, points))
+end

--- a/scripts/settings/default/main.lua
+++ b/scripts/settings/default/main.lua
@@ -94,7 +94,6 @@ xi.settings =
     DARK_POWER      = 1.000, -- Multiplies amount drained by Dark Magic.
     ITEM_POWER      = 1.000, -- Multiplies the effect of items such as Potions and Ethers.
     WEAPON_SKILL_POWER  = 1.000, -- Multiplies damage dealt by Weapon Skills.
-    WEAPON_SKILL_POINTS = 1.000, -- Multiplies points earned during weapon unlocking. (Not Implemented)
     USE_ADOULIN_WEAPON_SKILL_CHANGES = true, -- true/false. Change to toggle new Adoulin weapon skill damage calculations
 
     -- TRUSTS

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -927,13 +927,14 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
                         actionTarget_t dummy;
                         luautils::OnAdditionalEffect(this, PTarget, static_cast<CItemWeapon*>(getEquip(SLOT_AMMO)), &dummy, damage);
                     }
-                    int wspoints = 1;
+                    int wspoints = map_config.ws_points_base;
                     if (PWeaponSkill->getPrimarySkillchain() != 0)
                     {
                         // NOTE: GetSkillChainEffect is INSIDE this if statement because it
                         //  ALTERS the state of the resonance, which misses and non-elemental skills should NOT do.
                         SUBEFFECT effect = battleutils::GetSkillChainEffect(PBattleTarget, PWeaponSkill->getPrimarySkillchain(),
                                                                             PWeaponSkill->getSecondarySkillchain(), PWeaponSkill->getTertiarySkillchain());
+                        // See SUBEFFECT enum in battleentity.h
                         if (effect != SUBEFFECT_NONE)
                         {
                             actionTarget.addEffectParam = battleutils::TakeSkillchainDamage(this, PBattleTarget, damage, taChar);
@@ -947,18 +948,18 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
                                 actionTarget.addEffectMessage = 287 + effect;
                             }
                             actionTarget.additionalEffect = effect;
-
-                            if (effect >= 7)
+                             // Despite appearances, ws_points_skillchain is not a multiplier it is just an amount "per element"
+                            if (effect >= 7 && effect < 15)
                             {
-                                wspoints += 1;
+                                wspoints += (1 * map_config.ws_points_skillchain); // 1 element
                             }
                             else if (effect >= 3)
                             {
-                                wspoints += 2;
+                                wspoints += (2 * map_config.ws_points_skillchain); // 2 elements
                             }
                             else
                             {
-                                wspoints += 4;
+                                wspoints += (4 * map_config.ws_points_skillchain); // 4 elements
                             }
                         }
                     }
@@ -1005,10 +1006,10 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             // Blood pact MP costs are stored under animation ID
             float mpCost = PAbility->getAnimationID();
             if (StatusEffectContainer->HasStatusEffect(EFFECT_APOGEE))
-            { 
+            {
                 mpCost *= 1.5f;
             }
-            
+
             if (this->health.mp < mpCost)
             {
                 pushPacket(new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_UNABLE_TO_USE_JA));

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1029,14 +1029,16 @@ int32 map_config_default()
     map_config.capacity_rate               = 1.0f;
     map_config.level_sync_enable           = false;
     map_config.disable_gear_scaling        = false;
+    map_config.ws_points_base              = 1;
+    map_config.ws_points_skillchain        = 1;
     map_config.all_jobs_widescan           = true;
     map_config.speed_mod                   = 0;
     map_config.mount_speed_mod             = 0;
     map_config.mob_speed_mod               = 0;
     map_config.skillup_chance_multiplier   = 1.0f;
     map_config.craft_chance_multiplier     = 1.0f;
-    map_config.skillup_amount_multiplier   = 1;
-    map_config.craft_amount_multiplier     = 1;
+    map_config.skillup_amount_multiplier   = 1.0f;
+    map_config.craft_amount_multiplier     = 1.0f;
     map_config.garden_day_matters          = false;
     map_config.garden_moonphase_matters    = false;
     map_config.garden_pot_matters          = false;
@@ -1348,6 +1350,14 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "disable_gear_scaling") == 0)
         {
             map_config.disable_gear_scaling = atoi(w2);
+        }
+        else if (strcmp(w1, "ws_points_base") == 0)
+        {
+            map_config.ws_points_base = atoi(w2);
+        }
+        else if (strcmp(w1, "ws_points_skillchain") == 0)
+        {
+            map_config.ws_points_skillchain = atoi(w2);
         }
         else if (strcmp(w1, "all_jobs_widescan") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -89,6 +89,8 @@ struct map_config_t
     float       capacity_rate;               // Capacity Point rate increase per kill
     bool        level_sync_enable;           // Enable/disable Level Sync
     bool        disable_gear_scaling;        // Disables ability to equip higher level gear when level cap/sync effect is on player.
+    uint8       ws_points_base;              // Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
+    uint8       ws_points_skillchain;        // eaponskill points per skillchain element/tier - whole numbers only, retail is 1.
     bool        all_jobs_widescan;           // Enable/disable jobs other than BST and RNG having widescan.
     int8        speed_mod;                   // Modifier to add to player speed
     int8        mount_speed_mod;             // Modifier to add to mount speed


### PR DESCRIPTION


<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [:crossed_fingers: ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This removes unused lua setting for ws points as ws points are 100% core side..

See https://ffxiclopedia.fandom.com/wiki/Weapon_Skill_Points for details on how ws points stack up on skillchains

I've lightly tested this. Enough to see that I:
* got points on both a non skillchain ws as is retail accurate
* got MORE points for ***closing*** a skillchain, as is retail accurate
* the gm command I made works in every circumstance I intended and errors when things I didn't intend are attempted

While more thorough testing would be welcome, but the code is pretty simplistic so I'm pretty confident I can't have screwed anything up too badly.

Note these are not multipliers, and it doesn't make sense to do so. A float here would be useless as you can't have partial ws points they get stored right into the items EX data blob. Instead I went with overriding the basic values for per ws and per element, the latter of which looks like a multiplier in core because the core isn't really counting elements..subeffects be funky things.