### PR TITLE
Fix Stone Gate behavior for entry to Promyvion Vahzl after entering Spire but before completing PM5-2

### DIFF
--- a/scripts/zones/PsoXja/npcs/_i99.lua
+++ b/scripts/zones/PsoXja/npcs/_i99.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(106) -- Start Floor 1, 3
     elseif (player:getCurrentMission(COP) == xi.mission.id.cop.DESIRES_OF_EMPTINESS and player:getCharVar("PromathiaStatus")==5) then
         player:startEvent(109) -- Start Floor 1, 3 or 4
-    elseif (player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DESIRES_OF_EMPTINESS) or (player:getCurrentMission(COP) == xi.mission.id.cop.DESIRES_OF_EMPTINESS and player:getCharVar("PromathiaStatus")==7)) then
+    elseif (player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.DESIRES_OF_EMPTINESS) or (player:getCurrentMission(COP) == xi.mission.id.cop.DESIRES_OF_EMPTINESS and player:getCharVar("PromathiaStatus")>=7)) then
         player:startEvent(112) -- Start Floor 1, 3, 4, or 5
     elseif (player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR) or player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE)) then
         player:startEvent(50) -- Start Floor 1


### PR DESCRIPTION
When you enter the Spire of Vahzl, PromathiaStatus updates from 7 to 8. If you had PromathiaStatus 8, this Stone Gate would not prompt you for which floor you would like to start on, which is incorrect behavior. If you did not enter the spire or have completed the mission, it would prompt. Adjusting the logic for == 7 to >= 7 so the Stone Gate still works if you have entered the Spire but have not cleared the battlefield yet. This is the correct behavior.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
