### PR TITLE
Interaction - Quest: The Road to Divadom

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -297,6 +297,7 @@ xi.items =
     ASPHODEL                        = 2554,
     DANCERS_TESTIMONY               = 2556,
     SCHOLARS_TESTIMONY              = 2557,
+    BLOCK_OF_YAGUDO_GLUE            = 2558,
     BALRAHNS_EYEPATCH               = 2571,
     SQUARE_OF_OIL_SOAKED_CLOTH      = 2704,
     SQUARE_OF_FOULARD               = 2705,

--- a/scripts/quests/jeuno/The_Road_to_Divadom.lua
+++ b/scripts/quests/jeuno/The_Road_to_Divadom.lua
@@ -1,0 +1,137 @@
+-----------------------------------
+-- The Road to Divadom
+-----------------------------------
+-- !addquest 3 97
+-- Laila           : !pos -54.045 -1 100.996 244
+-- Rhea Myuliah    : !pos -56.220 -1 101.805 244
+-- Glowing Pebbles : !pos 104.2 4.1 443.6 82
+-----------------------------------
+require('scripts/settings/main')
+require('scripts/globals/interaction/quest')
+require('scripts/globals/items')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/titles')
+require('scripts/globals/zone')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM)
+
+quest.reward =
+{
+    title = xi.title.STARDUST_DANCER,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) and
+                player:getMainJob() == xi.job.DNC and
+                player:getMainLvl() >= xi.settings.AF2_QUEST_LEVEL
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Laila'] = quest:progressEvent(10136),
+
+            onEventFinish =
+            {
+                [10136] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Laila'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress == 0 then
+                        return quest:progressEvent(10137)
+                    elseif questProgress == 3 then
+                        player:startEvent(10139)
+                        player:startEvent(10214)
+                        player:startEvent(10215)
+                        return quest:progressEvent(10170)
+                    elseif questProgress == 4 then
+                        return quest:progressEvent(10170)
+                    end
+                end,
+            },
+
+            ['Rhea_Myuliah'] = quest:event(10138),
+
+            onEventFinish =
+            {
+                [10170] = function(player, csid, option, npc)
+                    local tightsItemID = 15660 - player:getGender()
+
+                    if npcUtil.giveItem(player, tightsItemID) then
+                        quest:complete(player)
+                    else
+                        quest:setVar(player, 'Prog', 4)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.JUGNER_FOREST_S] =
+        {
+            ['Glowing_Pebbles'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        quest:getVar(player, 'Prog') == 2 and
+                        npcUtil.tradeHasExactly(trade, xi.items.BLOCK_OF_YAGUDO_GLUE)
+                    then
+                        return quest:progressEvent(107)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(106)
+                    end
+                end,
+            },
+
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return 105
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [105] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [106] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+
+                [107] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                    quest:setVar(player, 'Prog', 3)
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Jugner_Forest_[S]/Zone.lua
+++ b/scripts/zones/Jugner_Forest_[S]/Zone.lua
@@ -25,8 +25,6 @@ zone_object.onZoneIn = function(player, prevZone)
 
     if player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.CLAWS_OF_THE_GRIFFON) == QUEST_ACCEPTED and player:getCharVar("ClawsOfGriffonProg") == 0 then
         cs = 200
-    elseif player:getCharVar("roadToDivadomCS") == 1 then
-        cs = 105
     end
 
     return cs
@@ -42,8 +40,6 @@ end
 zone_object.onEventFinish = function(player, csid, option)
     if csid == 200 then
         player:setCharVar("ClawsOfGriffonProg", 1)
-    elseif csid == 105 then
-        player:setCharVar("roadToDivadomCS", 2)
     end
 end
 

--- a/scripts/zones/Jugner_Forest_[S]/npcs/Glowing_Pebbles.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/Glowing_Pebbles.lua
@@ -2,33 +2,18 @@
 -- Area: Jugner Forest (S)
 --  NPC: Glowing Pebbles
 -----------------------------------
-require("scripts/globals/keyitems")
-require("scripts/globals/npc_util")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, 2558) and player:getCharVar("roadToDivadomCS") == 3 then
-        player:startEvent(107)
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getCharVar("roadToDivadomCS") == 2 then
-        player:startEvent(106)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 106 then
-        player:setCharVar("roadToDivadomCS", 3)
-    elseif csid == 107 then
-        player:confirmTrade()
-        player:setCharVar("roadToDivadomCS", 4)
-    end
 end
 
 return entity

--- a/scripts/zones/Upper_Jeuno/npcs/Laila.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Laila.lua
@@ -33,19 +33,6 @@ entity.onTrigger = function(player, npc)
     elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_ACCEPTED) then
         player:startEvent(10134)
 
-    -- Dancer AF: The Road to Divadom
-    elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_COMPLETED
-        and player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM) == QUEST_AVAILABLE
-        and player:getMainJob() == xi.job.DNC) then
-
-        player:startEvent(10136) -- CSID 10136
-    elseif (player:getCharVar("roadToDivadomCS") == 1) then
-        player:startEvent(10137) --  quest chat line after the quest has been accepted
-    elseif (player:getCharVar("roadToDivadomCS") == 4) then
-        player:startEvent(10139) --CSID 10139
-    elseif (player:getCharVar("roadToDivadomCS") == 5) then
-        player:startEvent(10170) --CSID 10170. This should only occur if the player's inventory was full during the chain of events that start in the elseif above.
-
     -- Dancer AF: Comeback Queen
     elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM) == QUEST_COMPLETED
         and player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.COMEBACK_QUEEN) == QUEST_AVAILABLE
@@ -92,33 +79,6 @@ entity.onEventFinish = function(player, csid, option)
             player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ)
         end
 
-    -- Dancer AF: The Road to Divadom
-    elseif (csid == 10136) then -- Road To Divadom pt 1
-        player:setCharVar("roadToDivadomCS", 1)
-        player:addQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM)
-    elseif (csid == 10139) then -- string of events
-        player:startEvent(10214)
-    elseif (csid == 10214) then
-        player:startEvent(10215)
-    elseif (csid == 10215) then
-        player:setCharVar("roadToDivadomCS", 5)
-        player:startEvent(10170)
-    elseif (csid == 10170) then
-        if (player:getFreeSlotsCount() == 0) then
-            -- do nothing. player doesn't have room to receive the reward item.
-            player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, 15660) -- the names of the gender specific items are the same
-        else
-            player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM)
-            player:setCharVar("roadToDivadomCS", 0)
-            player:setCharVar("dancerTailorCS", 1) -- allows player to start dancer version of Coffer AF. check Olgald and Matthias(@Bastok Markets) for the rest of the quest line
-            -- determine what gender the player is so we can give the correct item
-            local playerGender = player:getGender()
-            local dancersTights = 15660 - playerGender
-
-            player:addItem(dancersTights)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, dancersTights)
-            player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM)
-            end
     -- Dancer AF: Comeback Queen
     elseif (csid == 10143) then
         player:setCharVar("comebackQueenCS", 1)

--- a/scripts/zones/Upper_Jeuno/npcs/Olgald.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Olgald.lua
@@ -4,6 +4,8 @@
 -- Type: Standard NPC
 -- !pos -53.072 -1 103.380 244
 -----------------------------------
+require('scripts/globals/quests')
+-----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
@@ -11,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    if (player:getCharVar("dancerTailorCS") == 1) then
+    if player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM) then
         player:startEvent(10167)
     elseif (player:getCharVar("comebackQueenCS") == 1) then
         player:startEvent(10146)

--- a/scripts/zones/Upper_Jeuno/npcs/Rhea_Myuliah.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Rhea_Myuliah.lua
@@ -15,9 +15,6 @@ end
 entity.onTrigger = function(player, npc)
     if (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_UNFINISHED_WALTZ) == QUEST_ACCEPTED and player:getCharVar("QuestStatus_DNC_AF1")==1) then
         player:startEvent(10131)
-    --Dancer AF: Road to Divadom
-    elseif (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_ROAD_TO_DIVADOM) == QUEST_ACCEPTED)  then
-        player:startEvent (10138)
     --Dancer AF: Comeback Queen
     elseif (player:getCharVar("comebackQueenCS") == 1) then
         player:startEvent(10145)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Converts 'The Road to Divadom' to interaction framework, and also utilizes Ino's event changes to queue the final cs's.