### PR TITLE
adding effects to statusres bard songs

### DIFF
--- a/scripts/globals/effects/aubade.lua
+++ b/scripts/globals/effects/aubade.lua
@@ -4,12 +4,16 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.SLEEPRES, effect:getPower())
+    target:addMod(xi.mod.LULLABYRES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.SLEEPRES, effect:getPower())
+    target:delMod(xi.mod.LULLABYRES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/capriccio.lua
+++ b/scripts/globals/effects/capriccio.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.PETRIFYRES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.PETRIFYRES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/fantasia.lua
+++ b/scripts/globals/effects/fantasia.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.BLINDRES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.BLINDRES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/gavotte.lua
+++ b/scripts/globals/effects/gavotte.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.BINDRES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.BINDRES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/operetta.lua
+++ b/scripts/globals/effects/operetta.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.SILENCERES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.SILENCERES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/pastoral.lua
+++ b/scripts/globals/effects/pastoral.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.POISONRES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.POISONRES, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/effects/round.lua
+++ b/scripts/globals/effects/round.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CURSERES, effect:getPower())
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CURSERES, effect:getPower())
 end
 
 return effect_object


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I wanted to pull the bard songs in (thank you snugglesffxi) for our server and noticed that the effect scripts were blank. I may be misunderstanding, but i think that means the songs can cast but just apply an effect that does nothing at the moment. i couldn't spot anywhere where the effects do anything, but if i just missed it, happy to close this out.  i looked and used madrigal as an example, to add mods to the effect scripts. 

note: tangentially related - while trying to look for other examples, it looks like haste samba has this same issue, but has an extra script that confused me. if someone can look at that ability/effect script (there's a haste_samba_haste effect script but it never is referred to by the ability script???) if i'm right, ill be happy to fix haste samba in another pr. 
