### PR TITLE
Table Artifact Armor ranges to reduce isArtifactArmor function complexity

### DIFF
--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -122,28 +122,37 @@ xi.equipment.relicIDs =
 -- Place convenience functions
 -- related to equipment here
 -----------------------------------
+-- TODO: Should Adoulin exist here as well?
+local artifactArmorRanges =
+{--     Min,   Max
+    { 12511, 12520 }, -- Original Head
+    { 13855, 13857 },
+    { 13868, 13869 },
+    { 12638, 12650 }, -- Original Body
+    { 13781, 13782 },
+    { 13961, 13975 }, -- Original Hand
+    { 14089, 14103 }, -- Original Feet
+    { 14214, 14228 }, -- Original Legs
+    { 15265, 15267 }, -- ToAU Head
+    { 14521, 14523 }, -- ToAU Body
+    { 14928, 14930 }, -- ToAU Hand
+    { 15684, 15686 }, -- ToAU Feet
+    { 15600, 15602 }, -- ToAU Legs
+    { 16138, 16140 }, -- WotG Head
+    { 14578, 14580 }, -- WotG Body
+    { 15002, 15004 }, -- WotG Hand
+    { 15746, 15748 }, -- WotG Feet
+    { 15659, 15661 }, -- WotG Legs
+}
 
-xi.equipment.isArtifactArmor = function(itemid)
-    local retval = false
-    if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true -- normal head sets
-    elseif ((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true -- normal body sets
-    elseif (itemid >= 13961 and itemid <= 13975) then retval = true -- normal hand sets
-    elseif (itemid >= 14089 and itemid <= 14103) then retval = true -- normal feet sets
-    elseif (itemid >= 14214 and itemid <= 14228) then retval = true -- normal legs sets
-
-    elseif (itemid >= 15265 and itemid <= 15267) then retval = true -- ToAU head sets
-    elseif (itemid >= 14521 and itemid <= 14523) then retval = true -- ToAU body sets
-    elseif (itemid >= 14928 and itemid <= 14930) then retval = true -- ToAU hand sets
-    elseif (itemid >= 15684 and itemid <= 15686) then retval = true -- ToAU feet sets
-    elseif (itemid >= 15600 and itemid <= 15602) then retval = true -- ToAU legs sets
-
-    elseif (itemid >= 16138 and itemid <= 16140) then retval = true -- WotG head sets
-    elseif (itemid >= 14578 and itemid <= 14580) then retval = true -- WotG body sets
-    elseif (itemid >= 15002 and itemid <= 15004) then retval = true -- WotG hand sets
-    elseif (itemid >= 15746 and itemid <= 15748) then retval = true -- WotG feet sets
-    elseif (itemid >= 15659 and itemid <= 15661) then retval = true -- WotG legs sets
+xi.equipment.isArtifactArmor = function(itemId)
+    for _, v in ipairs(artifactArmorRanges) do
+        if itemId >= v[1] and itemId <= v[2] then
+            return true
+        end
     end
-    return retval
+
+    return false
 end
 
 xi.equipment.isBaseNyzulWeapon = function(itemId)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
