### PR TITLE
[trust] Add Quest and Impl. for Trust: Maat

### DIFF
--- a/scripts/globals/mobskills/bear_killer.lua
+++ b/scripts/globals/mobskills/bear_killer.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Bear Killer
+-- Description: Damage varies with TP.
+-- Type: Physical
+-----------------------------------
+require("scripts/settings/main")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target,mob,skill)
+    return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 3
+    local accmod = 1
+    local dmgmod = 1
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,2.5,2.75,3)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target, xi.attackType.PHYSICAL, xi.damageType.H2H,info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)
+    return dmg
+end
+
+return mobskill_object

--- a/scripts/globals/mobskills/combo.lua
+++ b/scripts/globals/mobskills/combo.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Combo
+-- Description: Damage varies with TP.
+-- Type: Physical
+-----------------------------------
+require("scripts/settings/main")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target,mob,skill)
+    return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 3
+    local accmod = 1
+    local dmgmod = 1
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,2.5,2.75,3)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target, xi.attackType.PHYSICAL, xi.damageType.H2H,info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)
+    return dmg
+end
+
+return mobskill_object

--- a/scripts/globals/mobskills/one-ilm_punch.lua
+++ b/scripts/globals/mobskills/one-ilm_punch.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- One-Ilm Punch
+-- Description: Damage varies with TP.
+-- Type: Physical
+-----------------------------------
+require("scripts/settings/main")
+require("scripts/globals/status")
+require("scripts/globals/monstertpmoves")
+-----------------------------------
+local mobskill_object = {}
+
+mobskill_object.onMobSkillCheck = function(target,mob,skill)
+    return 0
+end
+
+mobskill_object.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 1
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,2.5,2.75,3)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target, xi.attackType.PHYSICAL, xi.damageType.H2H,info.hitslanded)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)
+    return dmg
+end
+
+return mobskill_object

--- a/scripts/globals/spells/trust/maat.lua
+++ b/scripts/globals/spells/trust/maat.lua
@@ -22,6 +22,13 @@ spell_object.onMobSpawn = function(mob)
     -- On cooldown
     mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
                         ai.r.JA, ai.s.SPECIFIC, xi.ja.MANTRA)
+
+    mob:addListener("WEAPONSKILL_USE", "MAAT_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
+        if wsid == 3263 then -- Bear Killer
+            --  Heh heh heh
+            xi.trust.message(mobArg, xi.trust.message_offset.SPECIAL_MOVE_1)
+        end
+    end)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/trust.lua
+++ b/scripts/globals/trust.lua
@@ -177,16 +177,18 @@ local poolIDToMessagePageOffset = {
     [6019] = 112, -- Shantotto II
 }
 
-xi.trust.onTradeCipher = function(player, trade, csid, rovCs, arkAngelCs)
-    local hasPermit = player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT) or
-                      player:hasKeyItem(xi.ki.BASTOK_TRUST_PERMIT) or
-                      player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT)
+xi.trust.hasPermit = function(player)
+    return player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT) or
+           player:hasKeyItem(xi.ki.BASTOK_TRUST_PERMIT) or
+           player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT)
+end
 
+xi.trust.onTradeCipher = function(player, trade, csid, rovCs, arkAngelCs)
     local itemId = trade:getItemId(0)
     local subId = trade:getItemSubId(0)
     local isCipher = itemId >= 10112 and itemId <= 10193
 
-    if hasPermit and trade:getSlotCount() == 1 and subId ~= 0 and isCipher then
+    if xi.trust.hasPermit(player) and trade:getSlotCount() == 1 and subId ~= 0 and isCipher then
         -- subId is a smallInt in the database (16 bits).
         -- The bottom 12 bits of the subId are the spellId taught by the ciper
         -- The top 4 bits of the subId are for the flags to be given to the csid

--- a/scripts/quests/hiddenQuests/Trust_Maat.lua
+++ b/scripts/quests/hiddenQuests/Trust_Maat.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+-- Trust: Maat
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/magic')
+require('scripts/globals/trust')
+require('scripts/globals/quests')
+require('scripts/globals/npc_util')
+require('scripts/globals/interaction/hidden_quest')
+local ID = require('scripts/zones/RuLude_Gardens/IDs')
+-----------------------------------
+
+local quest = HiddenQuest:new("TrustMaat")
+
+quest.sections =
+{
+    {
+        check = function(player, questVars, vars)
+            return xi.trust.hasPermit(player) and
+                   utils.mask.countBits(player:getCharVar("maatsCap"), 16) >= 6 and
+                   not player:hasSpell(xi.magic.spell.MAAT)
+        end,
+
+        [xi.zone.RULUDE_GARDENS] =
+        {
+            ['Maat'] = quest:progressEvent(10241),
+
+            onEventFinish =
+            {
+                [10241] = function(player, csid, option, npc)
+                    if option == 2 and quest:complete(player) then
+                        player:addSpell(xi.magic.spell.MAAT, true, true)
+                        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.MAAT)
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/RuLude_Gardens/IDs.lua
+++ b/scripts/zones/RuLude_Gardens/IDs.lua
@@ -25,6 +25,7 @@ zones[xi.zone.RULUDE_GARDENS] =
         LOGIN_CAMPAIGN_UNDERWAY          = 6569,  -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!<space>
         LOGIN_NUMBER                     = 6570,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         YOUR_MAXIMUM_LEVEL               = 6585,  -- Your maximum level has been raised to [50/55/60/65/70/75/80/85/90/95/99]!
+        YOU_LEARNED_TRUST                = 6592, -- You learned Trust: <name>!
         MOG_LOCKER_OFFSET                = 6701,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
         REGIME_CANCELED                  = 6860,  -- Current training regime canceled.
         HUNT_ACCEPTED                    = 6878,  -- Hunt accepted!

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3524,16 +3524,12 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lehko_Habhoka',1037,3233); -- Lunar
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Aldo',1045,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Moogle',1046,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Fablinix',1047,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Combo (Maat)
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1028); -- Shoulder Tackle (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- One Inch Punch (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Backhand Blow (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Raging Fists (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Spinning Attack (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- Howling Fist (Maat)
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1033); -- Dragon Kick (Maat)
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,1034); -- Asuran Fists (Maat)
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,0); -- TODO: Bear Killer
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3263); -- Bear Killer
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3413); -- Combo (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3414); -- One Inch Punch (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3415); -- Howling Fist (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3416); -- Dragon Kick (Maat)
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Maat',1048,3417); -- Asuran Fists (Maat)
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_D_Shantotto',1049,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Star_Sibyl',1050,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Karaha-Baruha',1051,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -3071,7 +3071,7 @@ INSERT INTO `mob_skills` VALUES (3259,364,'happobarai',0,7.0,2000,1500,4,0,0,0,0
 INSERT INTO `mob_skills` VALUES (3260,354,'rinpyotosha',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3261,335,'bomb_toss',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3262,334,'goblin_rush',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (3263,3007,'bear_killer',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3263,1625,'bear_killer',4,7.0,2000,1500,4,0,0,0,0,0,0); -- TODO: Skillchain properties
 INSERT INTO `mob_skills` VALUES (3264,259,'salvation_scythe',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3265,3009,'elemental_sforzo',0,7.0,2000,0,1,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3266,3010,'liement',0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -3221,11 +3221,11 @@ INSERT INTO `mob_skills` VALUES (3409,2419,'crippling_agony',1,18.0,2000,1000,4,
 INSERT INTO `mob_skills` VALUES (3410,2420,'bane_of_tartarus',1,18.0,2000,1000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3411,434,'',0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3412,683,'freezebite',0,7.0,2000,0,1,2,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3413,728,'combo',1,20.0,2000,0,1,2,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3414,730,'one-ilm_punch',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3415,397,'chaotic_eye',4,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3416,291,'charged_whisker',1,12.5,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (3417,3161,'asuran_fists',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3413,728,'combo',0,7.0,2000,1500,4,0,0,0,8,0,0);
+INSERT INTO `mob_skills` VALUES (3414,730,'one-ilm_punch',0,7.0,2000,1500,4,0,0,0,2,0,0);
+INSERT INTO `mob_skills` VALUES (3415,733,'howling_fist',0,7.0,2000,1500,4,0,0,0,1,8,0);
+INSERT INTO `mob_skills` VALUES (3416,734,'dragon_kick',0,7.0,2000,1500,4,0,0,0,12,0,0);
+INSERT INTO `mob_skills` VALUES (3417,735,'asuran_fists',0,7.0,2000,1500,4,0,0,0,9,3,0);
 INSERT INTO `mob_skills` VALUES (3418,1037,'amatsu_torimai',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3419,1038,'amatsu_kazakiri',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3420,1039,'amatsu_yukiarashi',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
As it turns out, I've already set up Trust: Maat. I just left out some of his moves pending captures. MrSent sent me the captures I need... so... here's Maat!

![image](https://user-images.githubusercontent.com/1389729/133564117-c9666131-ac3e-43ac-ba2d-fd55e4211e8e.png)

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
