### PR TITLE
Refactor and expand gear_sets

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -246,6 +246,13 @@ function BluePhysicalSpell(caster, target, spell, params)
 
     local multiplier = params.multiplier
 
+    -- Caculate for Bonus WSC Chance from Empyrean Set
+
+    local bonusWSC = 0
+    if caster:getMod(xi.mod.AUGMENT_BLU_MAGIC) > math.random(0,99) then
+       bonusWSC = 2 -- BLU Empyrean set triples the base WSC when it procs.
+    end
+
     -- If under CA, replace multiplier with fTP(multiplier, tp150, tp300)
     local chainAffinity = caster:getStatusEffect(xi.effect.CHAIN_AFFINITY)
     if chainAffinity ~= nil then
@@ -256,7 +263,15 @@ function BluePhysicalSpell(caster, target, spell, params)
         end
 
         multiplier = BluefTP(tp, multiplier, params.tp150, params.tp300)
+        bonusWSC = bonusWSC + 1 -- Chain Affinity Doubles the Base WSC.
     end
+
+    -- Calculate final WSC bonuses
+
+    WSC = WSC + (WSC * bonusWSC)
+
+    -- See BG Wiki for reference. Chain Affinity is Double WSC. BLU Empyrean is Triple WSC
+    -- when the set procs, and stacks with Chain Affinity for a maximum 4x WSC total.
 
     -- TODO: Modify multiplier to account for family bonus/penalty
     local finalD = math.floor(D + fStr + WSC) * multiplier

--- a/scripts/globals/effects/aubade.lua
+++ b/scripts/globals/effects/aubade.lua
@@ -4,6 +4,8 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.SLEEPRES, effect:getPower())
+    target:addMod(xi.mod.LULLABYRES, effect:getPower())
     target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +13,8 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.SLEEPRES, effect:getPower())
+    target:delMod(xi.mod.LULLABYRES, effect:getPower())
     target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/aubade.lua
+++ b/scripts/globals/effects/aubade.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/ballad.lua
+++ b/scripts/globals/effects/ballad.lua
@@ -10,6 +10,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.REFRESH, effect:getPower())
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -17,6 +18,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.REFRESH, effect:getPower())
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/capriccio.lua
+++ b/scripts/globals/effects/capriccio.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.AGI, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.AGI, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/capriccio.lua
+++ b/scripts/globals/effects/capriccio.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.PETRIFYRES, effect:getPower())
     target:addMod(xi.mod.AGI, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.PETRIFYRES, effect:getPower())
     target:delMod(xi.mod.AGI, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/carol.lua
+++ b/scripts/globals/effects/carol.lua
@@ -7,14 +7,90 @@ require("scripts/globals/magic")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    target:addMod(xi.magic.resistMod[effect:getSubPower()], effect:getPower())
+    local spower = effect:getSubPower()
+    local buff = 0
+    if spower > 8 then -- unpack and apply stat buff if present
+        if spower > 399 then
+            buff = 4
+            spower = spower - 400
+        elseif spower > 299 then
+            buff = 3
+            spower = spower - 300
+        elseif spower > 199 then
+            buff = 2
+            spower = spower - 200
+        else
+            buff = 1
+            spower = spower - 100
+        end
+    end
+
+    target:addMod(xi.magic.resistMod[spower], effect:getPower())
+
+    if buff > 0 then -- xi.magic.element ids and MODS ids unfortnately don't match
+        if spower == 1 then -- fire add STR
+            target:addMod(xi.mod.STR, buff)
+        elseif spower == 2 then -- ice add INT
+            target:addMod(xi.mod.INT, buff)
+        elseif spower == 3 then -- wind add AGI
+            target:addMod(xi.mod.AGI, buff)
+        elseif spower == 4 then -- earth add VIT
+            target:addMod(xi.mod.VIT, buff)
+        elseif spower == 5 then -- thunder add DEX
+            target:addMod(xi.mod.DEX, buff)
+        elseif spower == 6 then -- water add MND
+            target:addMod(xi.mod.MND, buff)
+        elseif spower == 7 then -- light add CHR
+            target:addMod(xi.mod.CHR, buff)
+        elseif spower == 8 then -- dark add MP
+            target:addMod(xi.mod.MP, buff * 10)
+        end
+    end
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:delMod(xi.magic.resistMod[effect:getSubPower()], effect:getPower())
+    local spower = effect:getSubPower()
+    local buff = 0
+    if spower > 8 then -- unpack and apply stat buff if present
+        if spower > 399 then
+            buff = 4
+            spower = spower - 400
+        elseif spower > 299 then
+            buff = 3
+            spower = spower - 300
+        elseif spower > 199 then
+            buff = 2
+            spower = spower - 200
+        else
+            buff = 1
+            spower = spower - 100
+        end
+    end
+
+    target:delMod(xi.magic.resistMod[spower], effect:getPower())
+
+    if buff > 0 then -- xi.magic.element and MODS unfortnately don't match
+        if spower == 1 then -- fire add STR
+            target:delMod(xi.mod.STR, buff)
+        elseif spower == 2 then -- ice add INT
+            target:delMod(xi.mod.INT, buff)
+        elseif spower == 3 then -- wind add AGI
+            target:delMod(xi.mod.AGI, buff)
+        elseif spower == 4 then -- earth add VIT
+            target:delMod(xi.mod.VIT, buff)
+        elseif spower == 5 then -- thunder add DEX
+            target:delMod(xi.mod.DEX, buff)
+        elseif spower == 6 then -- water add MND
+            target:delMod(xi.mod.MND, buff)
+        elseif spower == 7 then -- light add CHR
+            target:delMod(xi.mod.CHR, buff)
+        elseif spower == 8 then -- dark add MP
+            target:delMod(xi.mod.MP, buff * 10)
+        end
+    end
 end
 
 return effect_object

--- a/scripts/globals/effects/dirge.lua
+++ b/scripts/globals/effects/dirge.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/fantasia.lua
+++ b/scripts/globals/effects/fantasia.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.BLINDRES, effect:getPower())
     target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.BLINDRES, effect:getPower())
     target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/fantasia.lua
+++ b/scripts/globals/effects/fantasia.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/gavotte.lua
+++ b/scripts/globals/effects/gavotte.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.STR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.STR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/gavotte.lua
+++ b/scripts/globals/effects/gavotte.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.BINDRES, effect:getPower())
     target:addMod(xi.mod.STR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.BINDRES, effect:getPower())
     target:delMod(xi.mod.STR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/hymnus.lua
+++ b/scripts/globals/effects/hymnus.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -13,6 +14,7 @@ effect_object.onEffectLose = function(target, effect)
     if (target:getHP() <= 0) then
         target:sendReraise(effect:getPower())
     end
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/madrigal.lua
+++ b/scripts/globals/effects/madrigal.lua
@@ -8,6 +8,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ACC, effect:getPower())
+    target:addMod(xi.mod.DEX, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -15,6 +16,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ACC, effect:getPower())
+    target:delMod(xi.mod.DEX, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/mambo.lua
+++ b/scripts/globals/effects/mambo.lua
@@ -7,6 +7,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.EVA, effect:getPower())
+    target:addMod(xi.mod.AGI, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -14,6 +15,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.EVA, effect:getPower())
+    target:delMod(xi.mod.AGI, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/march.lua
+++ b/scripts/globals/effects/march.lua
@@ -10,6 +10,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.HASTE_MAGIC, effect:getPower())
+    target:addMod(xi.mod.DEX, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -17,6 +18,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.HASTE_MAGIC, effect:getPower())
+    target:delMod(xi.mod.DEX, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/mazurka.lua
+++ b/scripts/globals/effects/mazurka.lua
@@ -7,6 +7,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.MOVE, effect:getPower())
+    target:addMod(xi.mod.AGI, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -14,6 +15,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.MOVE, effect:getPower())
+    target:delMod(xi.mod.AGI, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/minne.lua
+++ b/scripts/globals/effects/minne.lua
@@ -7,6 +7,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.DEF, effect:getPower())
+    target:addMod(xi.mod.VIT, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -14,6 +15,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.DEF, effect:getPower())
+    target:delMod(xi.mod.VIT, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/minuet.lua
+++ b/scripts/globals/effects/minuet.lua
@@ -8,6 +8,7 @@ local effect_object = {}
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ATT, effect:getPower())
     target:addMod(xi.mod.RATT, effect:getPower())
+    target:addMod(xi.mod.STR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -16,6 +17,7 @@ end
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ATT, effect:getPower())
     target:delMod(xi.mod.RATT, effect:getPower())
+    target:delMod(xi.mod.STR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/operetta.lua
+++ b/scripts/globals/effects/operetta.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.SILENCERES, effect:getPower())
     target:addMod(xi.mod.INT, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.SILENCERES, effect:getPower())
     target:delMod(xi.mod.INT, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/operetta.lua
+++ b/scripts/globals/effects/operetta.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.INT, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.INT, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/paeon.lua
+++ b/scripts/globals/effects/paeon.lua
@@ -7,6 +7,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.REGEN, effect:getPower())
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -14,6 +15,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.REGEN, effect:getPower())
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/pastoral.lua
+++ b/scripts/globals/effects/pastoral.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.POISONRES, effect:getPower())
     target:addMod(xi.mod.DEX, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.POISONRES, effect:getPower())
     target:delMod(xi.mod.DEX, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/pastoral.lua
+++ b/scripts/globals/effects/pastoral.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.DEX, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.DEX, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/prelude.lua
+++ b/scripts/globals/effects/prelude.lua
@@ -8,6 +8,7 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.RACC, effect:getPower())
+    target:addMod(xi.mod.DEX, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -15,6 +16,7 @@ end
 
 effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.RACC, effect:getPower())
+    target:delMod(xi.mod.DEX, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/round.lua
+++ b/scripts/globals/effects/round.lua
@@ -4,6 +4,7 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CURSERES, effect:getPower())
     target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
@@ -11,6 +12,7 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CURSERES, effect:getPower())
     target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 

--- a/scripts/globals/effects/round.lua
+++ b/scripts/globals/effects/round.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/scherzo.lua
+++ b/scripts/globals/effects/scherzo.lua
@@ -5,12 +5,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.VIT, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.VIT, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/effects/sirvente.lua
+++ b/scripts/globals/effects/sirvente.lua
@@ -4,12 +4,14 @@
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
+    target:addMod(xi.mod.CHR, effect:getSubPower()) -- Apply Stat Buff from AUGMENT_SONG_STAT
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
+    target:delMod(xi.mod.CHR, effect:getSubPower()) -- Remove Stat Buff from AUGMENT_SONG_STAT
 end
 
 return effect_object

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -15,200 +15,222 @@ local matchtype = {
 -- placeholder for unknown mod types
 -- local MOD_UNKNOWN = 0
 
--- AF3 +2/109/119 set values are based on BGWiki notes.
--- Each set has a 2 piece minimum, with each additional piece adding xxxPieceBonus to the MOD.
-local extraDamageBaseRate = 2
-local extraDamagePieceBonus = 1
-local extraDWAttackBaseRate = 4
-local extraDWAttackPieceBonus = 2
-local extraKickAttackBaseRate = 2
-local extraKickAttackPieceBonus = 1
-local nullDamageBaseRate = 4
-local nullDamagePieceBonus = 2
-local absorbDamageBaseRate = 2
-local absorbDamagePieceBonus = 1
-local instantCastBaseRate = 2
-local instantCastPieceBonus = 1
+-- AF3 (Empyrean) +2/109/119 set values are based on BGWiki notes.
+-- Each set has a bonus with 2 pieces equipped, with each additional piece adding pieceBonus to the MOD.
+-- Exceptions to this rule are manually defined.
+local baseRate = 2
+local pieceBonus = 1
 
 
 --              {id, {item, ids, in, no, particular, order}, minimum matches required, match type, mods{id, value, modvalue for each additional match, additional whole set bonus}
 local GearSets =  {
-             {id = 1, items = {16092, 14554, 14969, 15633, 15719},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 500, 0, 0}} },    --  Usukane's set (5% Haste)
-             {id = 2, items = {16088, 14550, 14965, 15629, 15715},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 5, 0, 0}} },    --  Skadi's set (5% critrate is guess)
-             {id = 3, items = {16084, 14546, 14961, 15625, 15711},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 5, 0, 0}} },  --  Ares's set (5% DA)
-             {id = 4, items = {16107, 14569, 14984, 15648, 15734},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.ACC, 20, 0, 0}} },           --  Denali Jacket Set (Increases Accuracy +20)
-             {id = 5, items = {16106, 14568, 14983, 15647, 15733},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.HPP, 10, 0, 0}} },           --  Askar Korazin Set (Max HP Boost %10)
-             {id = 6, items = {16069, 14530, 14940, 15609, 15695},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.SUBTLE_BLOW, 8, 0, 0}} },    --  Pahluwan Khazagand Set (8% is guess)
-             {id = 7, items = {16100, 14562, 14977, 15641, 15727},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.MATT, 5, 0, 0}} },           --  Morrigan's Robe Set (+5 Magic. Atk Bonus)
-             {id = 8, items = {16096, 14558, 14973, 15637, 15723},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 5, 0, 0}} },       --  Marduk's Jubbah Set (5% fastcast)
-             {id = 9, items = {16108, 14570, 14985, 15649, 15735},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.MDEF, 10, 0, 0}} },          --  Goliard Saio Set - Total Set Bonus +10% Magic Def. Bonus
+            {id =   1, items = {15042, 11402}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 5, 0, 0}, {xi.mod.RATT, 5, 0, 0}} },                        -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
+            {id =   3, items = { 6141, 14581, 15005, 16312, 15749}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 1, 1, 0}, {xi.mod.ATT, 1, 1, 0}} },    -- Iron Ram Chainmail Set. Double mod here! It is why it has 2 IDs.
+            {id =   5, items = {16142, 14582, 15006, 16313, 15750}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 10, 10, 0}} },                          -- Fourth Division Cuirass Set
+            {id =   6, items = {16143, 14583, 15007, 16314, 15751}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MP, 10, 10, 0}} },                          -- Cobra Unit Coat Set
+            {id =   7, items = {15850, 15851}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 6, 0, 0}, {xi.mod.ACC, 12, 0, 0}, {xi.mod.DEF, 6, 0, 0}} }, -- Lava's/Kusha's earring set: Atk+6/Acc+12
+            {id =  10, items = {15852, 15853}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 50, 0, 0}, {xi.mod.MP, 50, 0, 0}} },                         -- Dasra's/Nasatya's Ring set gives HP/MP +50
+            {id =  12, items = {16035, 16036}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AGI, 8, 0, 0}} },                                                -- Altdorf's/Wilhelm's earring: AGI+8
+            {id =  13, items = {16037, 16038}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 5, 0, 0}, {xi.mod.MACC, 5, 0, 0}} },                       -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
+            {id =  15, items = {16146, 14588, 15009, 16315, 15755},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FIRE_RES, 5, 5, 10}, {xi.mod.ICE_RES, 5, 5, 10}, {xi.mod.WIND_RES, 5, 5, 10}, {xi.mod.EARTH_RES, 5, 5, 10}, {xi.mod.THUNDER_RES, 5, 5, 10}, {xi.mod.WATER_RES, 5, 5, 10}, {xi.mod.LIGHT_RES, 5, 5, 10}, {xi.mod.DARK_RES, 5, 5, 10}} },    -- Iron Ram Haubert Set (8 ids)
+            {id =  23, items = {16147, 14589, 15010, 16316, 15756}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 1, 4.7, 0}} },                         -- Fourth Division Brune Set
+            {id =  24, items = {16148, 14590, 15011, 16317, 15757}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.COUNTER, 1, 1, 0}} },                       -- Cobra Unit Harness Set
+            {id =  25, items = {16149, 14591, 15012, 16318, 15758}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 1, 1, 0}} },                          -- Cobra Unit Robe Set
+            {id =  26, items = {18761, 18597, 17757, 19218, 18128, 18500, 16004, 18951}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STR, 6, 0, 0}, {xi.mod.ATT, 4, 0, 0}, {xi.mod.RATT, 4, 0, 0}, {xi.mod.MATT, 2, 0, 0}} }, --  Supremacy Earring Sets. Set Bonus: STR+6, Attack+4, Ranged Attack+4, "Magic Atk. Bonus"+2. Active with any 2 items(Earring+Weapon)
+            {id =  30, items = {16005, 17756, 17962, 18596, 18760, 19112, 19215, 19271, 19156}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 30, 0, 0}, {xi.mod.VIT, 6, 0, 0}, {xi.mod.ACC, 6, 0, 0}, {xi.mod.RACC, 6, 0, 0}} }, --  Paramount Earring Sets. Set Bonus: HP+30, VIT+6, Accuracy+6, Ranged Accuracy+6. Set Bonus is active with any 2 items(Earring+Weapon or Weapon+Weapon)
+            {id =  34, items = {16006, 18450, 18499, 18861, 18862, 18952, 19111, 19217, 19272}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EVA, 10, 0, 0}, {xi.mod.HPHEAL, 10, 0, 0}, {xi.mod.ENMITY, -5, 0, 0}} }, --  Brilliant Earring Set. Set Bonus: Evasion, HP Recovered while healing, Reduces Emnity. Active with any 2 items(Earring+Weapon)
+            {id =  37, items = {14999, 15745}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ENH_DRAIN_ASPIR, 5, 0, 0}} },                                     -- Vampric Mitts/Boots: Enhances Drain/Aspir +5
+            {id =  38, items = {15000, 16169}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.VIT, 10, 0, 0}} },                                                -- Caballero Gauntlets / Shield: VIT +10
+            {id =  39, items = {15001, 16125}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DEF, 10, 0, 0}, {xi.mod.ENMITY, 5, 0, 0}} },                      -- Breeder Mufflers / Mask: Pet: DEF +10 / Enmity +5
+            {id =  41, items = {16126, 15744}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RATT, 15, 0, 0}} },                                              -- Bowman's set: Ranged Attack +15
+            {id =  42, items = {18947, 15818}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 5, 0, 0}, {xi.mod.SOULEATER_EFFECT, 2, 0, 0}} },            -- Moliones's Sickle/Ring: Souleater +2
+            {id =  44, items = {15995, 16127}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CHR, 15, 0, 0}} },                                                -- Carline Ribbon/Ring: CHR +15
+            {id =  45, items = {16062, 14525, 14933, 15604, 15688}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.UDMGBREATH, -800, 0, 0}, {xi.mod.UDMGMAGIC, -800, 0, 0}} },       --  Amir Korazin Set - Double mod here! It is why it has 2 IDs.
+            {id =  47, items = {16064, 14527, 14935, 15606, 15690}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 1, 0, 0}} },                       -- Yigit Set: Adds "Refresh" effect +1
+            {id =  48, items = {16069, 14530, 14940, 15609, 15695}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.SUBTLE_BLOW, 8, 0, 0}} },                   -- Pahluwan Set: Subtle Blow +8 (guess)
+            {id =  49, items = {11281, 15015, 16337, 11364}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STORETP, 5, 5, 5}} },                              -- Hachiryu Set: Store TP 5/10/20
+            {id =  50, items = {16084, 14546, 14961, 15625, 15711}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 5, 0, 0}} },                 -- Ares's Set: DA +5
+            {id =  51, items = {16088, 14550, 14965, 15629, 15715}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 5, 0, 0}} },                   -- Skadi's Set: Crit Hit Rate + 5 (guess)
+            {id =  52, items = {16092, 14554, 14969, 15633, 15719}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 500, 0, 0}} },                  -- Usukane's Set: Haste +5% (Gear)
+            {id =  53, items = {16096, 14558, 14973, 15637, 15723}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 5, 0, 0}} },                      -- Marduk's Set: Fast Cast +5%
+            {id =  54, items = {16100, 14562, 14977, 15641, 15727}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.MATT, 5, 0, 0}} },                          -- Morrigan's Set: +5 Magic. Atk Bonus
+            {id =  55, items = {16106, 14568, 14983, 15647, 15733}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.HPP, 10, 0, 0}} },                          -- Askar Set: Max HP Boost %10
+            {id =  56, items = {16107, 14569, 14984, 15648, 15734}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.ACC, 20, 0, 0}} },                          -- Denali Set: ACC 20
+            {id =  57, items = {16108, 14570, 14985, 15649, 15735}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.MDEF, 10, 0, 0}} },                         -- Goliard Set: +10% Magic Def. Bonus
+            {id =  58, items = {12999, 14041}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 90, 0, 0}} },                                                -- Surrus Sabatons / Gauntlets: HP +90
+            {id =  59, items = {13146, 13619}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 6000, 0, 0}} },                                      -- Tern Necklace / Cape: Haste +6% (Gear)
+            {id =  60, items = {13000, 14042}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STORETP, 5, 0, 0}} },                                            -- Praeda Sabatons / Gauntlets: Store TP +5
+            {id =  61, items = {11503, 13759, 12745, 14210, 11413}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 500, 0, 0}} },                  -- Perle Set: Haste +5% (Gear)
+            {id =  62, items = {11504, 13760, 12746, 14257, 11414}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.STORETP, 8, 0, 0}} },                       -- Aurore Set: Store TP +8
+            {id =  63, items = {11505, 13778, 12747, 14258, 11415}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 4, 2, 0}} },                      -- Teal Set: Fast Cast +4-10%
+            {id =  64, items = {14085, 15019}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CURE_POTENCY, 5, 0, 0}} },                                       -- Serpentes Sabots / Cuffs: Cure Potency +5%
+            {id =  65, items = {11064, 11084, 11104, 11124, 11144}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DA_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },          -- Ravager +2 Set: Double attack double damage chance
+            {id =  66, items = {11065, 11085, 11105, 11125, 11145}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_KICK_ATTACK, baseRate, pieceBonus, 0}} },         -- Tantra +2 Set: Augments "Kick Attacks". Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
+            {id =  67, items = {11066, 11086, 11106, 11126, 11146}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0}} },                   -- Orison +2 Set: Augments elemental resistance spells. Bar Elemental spells will occasionally nullify damage of the same element.
+            {id =  68, items = {11067, 11087, 11107, 11127, 11147}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_CONSERVE_MP, baseRate, pieceBonus, 0}} },      -- Goetia +2 Set: Augments Conserve MP to occasionally increase damage proportional to % of MP Conserved.
+            {id =  69, items = {11068, 11088, 11108, 11128, 11148}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_COMPOSURE, 50, 0, 0}} },                       -- Estoqueur +2 Set: Enhances duration of Enhancing Magic cast on OTHERS while under the effect of Composure 10/15/35/50.
+            {id =  70, items = {11069, 11089, 11109, 11129, 11149}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.TA_TRIPLE_DAMAGE, baseRate, pieceBonus, 0}} },          -- Raider +2 Set: Augments "Triple Attack". Occasionally causes the second and third hits of a Triple Attack to deal triple damage.Verification Needed Requires a minimum of two pieces.
+            {id =  71, items = {11070, 11090, 11110, 11130, 11150}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ABSORB_DMG_CHANCE, baseRate, pieceBonus, 0}} },         -- Creed +2 Set: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
+            {id =  72, items = {11071, 11091, 11111, 11131, 11151}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_HP, baseRate, pieceBonus, 0}} },         -- Bale +2 Set: Occasionally increases damage in direct proportion to the percentage of current HP.
+            {id =  73, items = {11072, 11092, 11112, 11132, 11152}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },     -- Ferine +2 Set: Occasionally increases damage in direct proportion to the percentage of the pets current HP.
+            {id =  74, items = {11073, 11093, 11113, 11133, 11153}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_SONG_STAT, 1, 1, 0}} },                         -- Aoidos +2 Set: Enhancing Songs add +1/2/3/4 to stat related to element (Fire = STR, Thunder = DEX, etc). Adds +10/20/30/40 MP for Dark based Songs.
+            {id =  75, items = {11074, 11094, 11114, 11134, 11154}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },  -- Sylvan +2 Set: Augments "Rapid Shot". Rapid Shots occasionally deal double damage.
+            {id =  76, items = {11075, 11095, 11115, 11135, 11155}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ZANSHIN_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },     -- Unkai +2 Set: Augments "Zanshin". Zanshin attacks will occasionally deal double damage.
+            {id =  77, items = {11076, 11096, 11116, 11136, 11156}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0}} },                   -- Iga +2 Set: Augments "Dual Wield". Attacks made while dual wielding occasionally add an extra attack
+            {id =  78, items = {11077, 11097, 11117, 11137, 11157}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },     -- Lancer +2 Set: Occasionally increases damage in direct proportion to the percentage of the wyverns current HP.
+            {id =  79, items = {11078, 11098, 11118, 11138, 11158}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLOOD_BOON, baseRate, pieceBonus, 0}} },        -- Caller +2 Set: Occasionally increases damage of Blood Pacts when Blood Boon is triggered. Increased amount is proportional to the ratio of MP conserved.
+            {id =  80, items = {11079, 11099, 11119, 11139, 11159}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0}} },        -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+            {id =  81, items = {11080, 11100, 11120, 11140, 11160}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, baseRate, pieceBonus, 0}} },  -- Navarch +2 Set: Augments "Quick Draw". Quick Draw will occasionally deal triple damage.
+            {id =  82, items = {11081, 11101, 11121, 11141, 11161}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },     -- Cirque +2 Set: Occasionally increases damage in direct proportion to the percentage of the automaton's current HP.
+            {id =  83, items = {11082, 11102, 11122, 11142, 11162}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.SAMBA_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },       -- Charis +2 Set: Augments "Samba". Occasionally doubles damage with Samba up.
+            {id =  84, items = {11083, 11103, 11123, 11143, 11163}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.GRIMOIRE_INSTANT_CAST, baseRate, pieceBonus, 0}} },     -- Savant +2 Set: Augments Grimoire. Spells that match your current Arts will occasionally cast instantly, without recast.
+            {id =  85, items = {11798, 11362}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RERAISE_III, 1, 0, 0}} },                                        -- Twilight Set: Auto-Reraise III
+            {id =  86, items = {11808, 11824, 11850, 11857, 11858}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 5, 0, 0}} },                 -- Fazheluo Set: "Double Attack"+5%.
+            {id =  87, items = {11809, 11825, 11851, 11855, 11859}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 800, 0, 0}} },                  -- Cuauhtli Set: Haste+8%.
+            {id =  88, items = {11810, 11826, 11852, 11856, 11860}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 5, 0, 0}} },                          -- Hyskos Set: Magic Accuracy+5.
+            {id =  89, items = {26711, 27851, 27997, 28138, 28277}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 200, 100, 0}} },                -- Perle +1 Set: Haste +2-5%
+            {id =  90, items = {26712, 27852, 27998, 28139, 28278}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STORETP, 2, 2, 0}} },                       -- Aurore +1 Set: Store TP +2-8%
+            {id =  91, items = {26713, 27853, 27999, 28140, 28279}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 4, 2, 0}} },                      -- Teal +1 Set: Fast Cast +4-10%
+            {id =  92, items = {10864, 10867, 11863, 11866, 11869}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.TRIPLE_ATTACK, 3, 0, 0}} },                 -- Ocelo/Toci Set: Triple Attack +3
+            {id =  93, items = {10865, 10868, 11864, 11867, 11870}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 2, 0, 0}} },                       -- Nefer/Heka Set: Refresh +2 (EX HQ Body Carries it's own Refresh)
+            {id =  94, items = {10866, 10869, 11865, 11868, 11871}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 800, 0, 0}} },                  -- Mekira Set: Haste +8% (Gear)
+            {id =  95, items = {10890, 10462, 10512, 11980, 10610}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 600, 0, 0}} },                  -- Calma Set: Haste +6% (Gear)
+            {id =  96, items = {10891, 10463, 10513, 11981, 10611}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 5, 0, 0}} },                   -- Mustela Set: Crit Hit Rate +5
+            {id =  97, items = {10892, 10464, 10514, 11982, 10612}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.MACC, 5, 0, 0}} },                          -- Magavan Set: Magic Accuracy +5
+            {id =  98, items = {10876, 10450, 10500, 11969, 10600}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 1, 0, 0}} },                       -- Ogier Set: Refresh - 2-3 Pieces 1/tick, 4-5 Pieces 2/tick.
+            {id =  99, items = {10877, 10451, 10501, 11970, 10601}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 3, 1, 0}} },                   -- Athos Set: Increases rate of critical hits. Gives +3/4/5/6.
+            {id = 100, items = {10878, 10452, 10502, 11971, 10602}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 10, 0, 0}} },                     -- Rubeus Set: Fast Cast - 2-3 pieces +4, 4-5 pieces +10
+            {id = 101, items = {10315, 10598},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.DMGMAGIC, -500, 0, 0}} },                                       -- Alcedo Cuisses/Gauntlets: Magic damage taken -5%
+            {id = 102, items = {10474, 10523, 10554, 10620, 10901}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STR, 15, 0, 0}, {xi.mod.VIT, 15, 0, 0}, {xi.mod.INT, 15, 0, 0}, {xi.mod.MND, 15, 0, 0}} },      -- Phorcys Set: STR/VIT/INT/MND +2/5/10/15
+            {id = 106, items = {10479, 10528, 10559, 10625, 10906}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STR, 15, 0, 0}, {xi.mod.DEX, 15, 0, 0}, {xi.mod.AGI, 15, 0, 0}, {xi.mod.MND, 15, 0, 0}} },      -- Thaumas Set: STR/DEX/AGI/MND +2/5/10/15
+            {id = 110, items = {10484, 10533, 10564, 10630, 10911}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STR, 15, 0, 0}, {xi.mod.INT, 15, 0, 0}, {xi.mod.MND, 15, 0, 0}, {xi.mod.CHR, 15, 0, 0}} },      -- Nares Set: STR/INT/MND/CHR +2/5/10/15
+            {id = 114, items = {26191, 23308, 23643, 23241, 23576, 23174, 23509, 23107, 23442, 23040, 23375}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 WAR
+            {id = 118, items = {26191, 23309, 23644, 23242, 23577, 23175, 23510, 23108, 23443, 23041, 23376}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 MNK
+            {id = 121, items = {26085, 23310, 23645, 23243, 23578, 23176, 23511, 23109, 23444, 23042, 23377}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 WHM
+            {id = 124, items = {26085, 23311, 23646, 23244, 23579, 23177, 23512, 23110, 23445, 23043, 23378}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BLM
+            {id = 127, items = {26085, 23312, 23647, 23245, 23580, 23178, 23513, 23111, 23446, 23044, 23379}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RDM
+            {id = 130, items = {26191, 23313, 23648, 23246, 23581, 23179, 23514, 23112, 23447, 23045, 23380}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 THF
+            {id = 133, items = {26191, 23314, 23649, 23247, 23582, 23180, 23515, 23113, 23448, 23046, 23381}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 PLD
+            {id = 136, items = {26191, 23315, 23650, 23248, 23583, 23181, 23516, 23114, 23449, 23047, 23382}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DRK
+            {id = 139, items = {26191, 23316, 23651, 23249, 23584, 23182, 23517, 23115, 23450, 23048, 23383}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BST
+            {id = 142, items = {26085, 23317, 23652, 23250, 23585, 23183, 23518, 23116, 23451, 23049, 23384}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BRD
+            {id = 145, items = {26191, 23318, 23653, 23251, 23586, 23184, 23519, 23117, 23452, 23050, 23385}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RNG
+            {id = 148, items = {26191, 23319, 23654, 23252, 23587, 23185, 23520, 23118, 23453, 23051, 23386}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SAM
+            {id = 151, items = {26191, 23320, 23655, 23253, 23588, 23186, 23521, 23119, 23454, 23052, 23387}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 NIN
+            {id = 154, items = {26191, 23321, 23656, 23254, 23589, 23187, 23522, 23120, 23455, 23053, 23388}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DRG
+            {id = 157, items = {26342, 23322, 23657, 23255, 23590, 23188, 23523, 23121, 23456, 23054, 23389}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SMN
+            {id = 160, items = {26085, 23323, 23658, 23256, 23591, 23189, 23524, 23122, 23457, 23055, 23390}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BLU
+            {id = 163, items = {26191, 23324, 23659, 23257, 23592, 23190, 23525, 23123, 23458, 23056, 23391}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 COR
+            {id = 166, items = {26191, 23325, 23660, 23258, 23593, 23191, 23526, 23124, 23459, 23057, 23392}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 PUP
+            {id = 169, items = {26191, 23326, 23661, 23259, 23594, 23192, 23527, 23125, 23460, 23058, 23393}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DNC (M)
+            {id = 172, items = {26191, 23327, 23662, 23260, 23595, 23193, 23528, 23126, 23461, 23059, 23394}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DNC (F)
+            {id = 175, items = {26085, 23328, 23663, 23261, 23596, 23194, 23529, 23127, 23462, 23060, 23395}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SCH
+            {id = 178, items = {26085, 23329, 23664, 23262, 23597, 23195, 23530, 23128, 23463, 23061, 23396}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 GEO
+            {id = 181, items = {26191, 23330, 23665, 23263, 23598, 23196, 23531, 23129, 23464, 23062, 23397}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RUN
+            {id = 184, items = {26204, 25574, 25790, 25828, 25879, 25946}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.SUBTLE_BLOW, 5, 5, 0}} },                                         -- Sulevia +2 Set: Subtle Blow +5-20 (Requires Sulevia's Ring to activate set effect)
+            {id = 185, items = {26205, 25575, 25791, 25829, 25880, 25947}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.REGEN, 3, 3, 0}} },                                               -- Meghanada +2 Set: Regen +3-12 (Requires Megahanada Ring to activate set effect)
+            {id = 186, items = {26206, 25576, 25792, 25830, 25881, 25948}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.COUNTER, 4, 4, 0}} },                                             -- Hizamaru +2 Set: Counter +4-16% (Requires Hizamaru Ring to activate set effect)
+            {id = 187, items = {26207, 25577, 25793, 25831, 25882, 25949}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.REFRESH, 1, 1, 0}} },                                             -- Inyanga +2 Set: Refresh +1-4 (Requires Inyanga Ring to activate set effect)
+            {id = 188, items = {26208, 25578, 25794, 25832, 25883, 25950}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.FAST_CAST, 1, 1, 0}} },                                           -- Jhakri +2 Set: Fast Cast +1-4% (Requires Jhakri Ring to activate set effect)
+            {id = 189, items = {26209, 25572, 25795, 25833, 25884, 25951}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.STR, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}, {xi.mod.MND, 8, 8, 0}} },   -- Ayanmo +2 Set: STR/VIT/MND +8-32 (Requires Ayanmo Ring to activate set effect)
+            {id = 192, items = {26210, 25573, 25796, 25834, 25885, 25952}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.DEX, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}, {xi.mod.CHR, 8, 8, 0}} },   -- Tali'ah +2 Set: DEX/VIT/CHR +8-32 (Requires Tali'ah Ring to activate set effect}
+            {id = 195, items = {26211, 25569, 25797, 25385, 25886, 25953}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.STR, 8, 8, 0}, {xi.mod.DEX, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}} },   -- Flamma +2 Set: STR/DEX/VIT +8-32 (Requires Flamma Ring to activate set effect)
+            {id = 198, items = {26212, 25570, 25798, 25836, 25887, 25954}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.DEX, 8, 8, 0}, {xi.mod.AGI, 8, 8, 0}, {xi.mod.CHR, 8, 8, 0}} },   -- Mummu +2 Set: DEX/AGI/CHR +8-32 (Requires Mummu Ring to activate set effect)
+            {id = 201, items = {26213, 25571, 25799, 25837, 25888, 25955}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.VIT, 8, 8, 0}, {xi.mod.INT, 8, 8, 0}, {xi.mod.MND, 8, 8, 0}} },   -- Mallquis +2 Set: VIT/INT/MND +8-32 (Requires Mallquis Ring to activate set effect)
+            {id = 204, items = {25610, 25683, 27114, 27299, 27470}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 4, 2, 0}} },                                                     -- Emicho +1 Set: Double Attack +4-10
+            {id = 205, items = {25612, 25685, 27116, 27301, 27472}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 20, 10, 0}} },                                                             -- Ryuo +1 Set: Attack +20-50
+            {id = 206, items = {25614, 25687, 27118, 27303, 27474}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 4, 2, 0}} },                                                       -- Adhemar +1 Set: Crit Hit Rate +4-10
+            {id = 207, items = {25616, 25689, 27120, 27305, 27476}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 20, 10, 0}} },                                                            -- Amalric +1 Set: Magic Attack Bonus +20-50
+            {id = 208, items = {25618, 25691, 27122, 27307, 27478}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CURE_POTENCY_II, 4, 2, 0}} },                                                   -- Kaykaus +1 Set: Cure Potency II + 4-10%
+            {id = 209, items = {26669, 26845, 27021, 27197, 27373}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0}} },                                               -- Lustratio +1 Set: Weapon Skill Damage +4-10%
+            {id = 210, items = {26671, 26847, 27023, 27199, 27375}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DMG, -4, -2, 0}} },                                                             -- Souveran +1 Set: Damage Taken - 4-> -10
+            {id = 211, items = {26673, 26849, 27025, 27201, 27377}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 4, 2, 0}} },                                                     -- Argosy +1 Set: Double Attack +4-10
+            {id = 212, items = {26675, 26851, 27027, 27203, 27379}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MARTIAL_ARTS, 8, 4, 0}} },                                                      -- Rao +1 Set: Martial Arts +8-20
+            {id = 213, items = {26677, 26853, 27029, 27205, 27381}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BP_DAMAGE, 4, 2, 0}} },                                                         -- Apogee +1 Set: Blood Pact Damage +4-10
+            {id = 214, items = {26679, 26855, 27031, 27207, 27383}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 20, 10, 0}} },                                                             -- Carmine +1 Set: Accuracy +20-50
+            {id = 215, items = {26740, 26741, 26898, 26899, 27052, 27053, 27237, 27238, 27411, 27412}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DA_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },           -- AF3 WAR 109/119 Set: Double attack double damage chance
+            {id = 216, items = {26742, 26743, 26900, 26901, 27054, 27055, 27239, 27240, 27413, 27414}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_KICK_ATTACK, baseRate, pieceBonus, 0}} },          -- AF3 MNK 109/119 Set: Augments "Kick Attacks". Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
+            {id = 217, items = {26744, 26745, 26902, 26903, 27056, 27057, 27241, 27242, 27415, 27416}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0}} },                    -- AF3 WHM 109/119 Set: Augments elemental resistance spells. Bar Elemental spells will occasionally nullify damage of the same element.
+            {id = 218, items = {26746, 26747, 26904, 26905, 27058, 27059, 27243, 27244, 27417, 27418}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_CONSERVE_MP, baseRate, pieceBonus, 0}} },       -- AF3 BLM 109/119 Set: Augments Conserve MP to occasionally increase damage proportional to % of MP Conserved.
+            {id = 219, items = {26748, 26749, 26906, 26907, 27060, 27061, 27245, 27246, 27419, 27420}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_COMPOSURE, 50, 0, 0}} },                        -- AF3 RDM 109/119 Set: Enhances duration of Enhancing Magic cast on OTHERS while under the effect of Composure 10/15/35/50.
+            {id = 220, items = {26750, 26751, 26908, 26909, 27062, 27063, 27247, 27248, 27421, 27422}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.TA_TRIPLE_DAMAGE, baseRate, pieceBonus, 0}} },           -- AF3 THF 109/119 Set: Augments "Triple Attack". Occasionally causes the second and third hits of a Triple Attack to deal triple damage.Verification Needed Requires a minimum of two pieces.
+            {id = 221, items = {26752, 26753, 26910, 26911, 27064, 27065, 27249, 27250, 27423, 27424}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ABSORB_DMG_CHANCE, baseRate, pieceBonus, 0}} },          -- AF3 PLD 109/119 Set: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
+            {id = 222, items = {26754, 26755, 26912, 26913, 27066, 27067, 27251, 27252, 27425, 27426}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_HP, baseRate, pieceBonus, 0}} },          -- AF3 DRK 109/119 Set: Occasionally increases damage in direct proportion to the percentage of current HP.
+            {id = 223, items = {26756, 26757, 26914, 26915, 27068, 27069, 27253, 27254, 27427, 27428}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },      -- AF3 BST 109/119 Set: Occasionally increases damage in direct proportion to the percentage of the pets current HP.
+            {id = 224, items = {26758, 26759, 26916, 26917, 27070, 27071, 27255, 27256, 27429, 27430}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_SONG_STAT, 1, 1, 0}} },                          -- AF3 BRD 109/119 Set: Enhancing Songs add +1/2/3/4 to stat related to element (Fire = STR, Thunder = DEX, etc). Adds +10/20/30/40 MP for Dark based Songs.
+            {id = 225, items = {26760, 26761, 26918, 26919, 27072, 27073, 27257, 27258, 27431, 27432}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },   -- AF3 RNG 109/119 Set: Augments "Rapid Shot". Rapid Shots occasionally deal double damage.
+            {id = 226, items = {26762, 26763, 26920, 26921, 27074, 27075, 27259, 27260, 27433, 27434}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ZANSHIN_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },      -- AF3 SAM 109/119 Set: Augments "Zanshin". Zanshin attacks will occasionally deal double damage.
+            {id = 227, items = {26764, 26765, 26922, 26923, 27076, 27077, 27261, 27262, 27435, 27436}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0}} },                    -- AF3 NIN 109/119 Set: Augments "Dual Wield". Attacks made while dual wielding occasionally add an extra attack
+            {id = 228, items = {26766, 26767, 26924, 26925, 27078, 27079, 27263, 27264, 27437, 27438}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },      -- AF3 DRG 109/119 Set: Occasionally increases damage in direct proportion to the percentage of the wyverns current HP.
+            {id = 229, items = {26768, 26769, 26926, 26927, 27080, 27081, 27265, 27266, 27439, 27440}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLOOD_BOON, baseRate, pieceBonus, 0}} },         -- AF3 SMN 109/119 Set: Occasionally increases damage of Blood Pacts when Blood Boon is triggered. Increased amount is proportional to the ratio of MP conserved.
+            {id = 230, items = {26770, 26771, 26928, 26929, 27082, 27083, 27267, 27268, 27441, 27442}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0}} },         -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+            {id = 231, items = {26772, 26773, 26930, 26931, 27084, 27085, 27269, 27270, 27443, 27444}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, baseRate, pieceBonus, 0}} },   -- AF3 COR 109/119 Set: Augments "Quick Draw". Quick Draw will occasionally deal triple damage.
+            {id = 232, items = {26774, 26775, 26932, 26933, 27086, 27087, 27271, 27272, 27445, 27446}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_DAMAGE_PET_HP, baseRate, pieceBonus, 0}} },      -- AF3 PUP 109/119 Set: Occasionally increases damage in direct proportion to the percentage of the automaton's current HP.
+            {id = 233, items = {26776, 26777, 26934, 26935, 27088, 27089, 27273, 27274, 27447, 27448}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.SAMBA_DOUBLE_DAMAGE, baseRate, pieceBonus, 0}} },        -- AF3 DNC 109/119 Set: Augments "Samba". Occasionally doubles damage with Samba up.
+            {id = 234, items = {26778, 26779, 26936, 26937, 27090, 27091, 27275, 27276, 27449, 27450}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.GRIMOIRE_INSTANT_CAST, baseRate, pieceBonus, 0}} },      -- AF3 SCH 109/119 Set: Augments Grimoire. Spells that match your current Arts will occasionally cast instantly, without recast.
+            {id = 235, items = {26780, 26781, 26938, 26939, 27092, 27093, 27277, 27278, 27451, 27452}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.GEOMANCY_MP_NO_DEPLETE, baseRate, pieceBonus, 0}} },     -- AF3 GEO 109/119 Set: Occasionally reduces the casting cost of Geomancy to 0.
+            {id = 236, items = {26782, 26783, 26940, 26941, 27094, 27095, 27279, 27280, 27453, 27454}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ABSORB_DMG_CHANCE, baseRate, pieceBonus, 0}} },          -- AF3 RUN 109/119 Set: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
+            {id = 237, items = {27648, 27788, 27928, 28071, 28208},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 3, 2, 0}} },                    -- Ares +1 Set: Double Attack +3-9%
+            {id = 238, items = {27649, 27789, 27929, 28072, 28209},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 3, 2, 0}} },                      -- Skadi +1 Set: Critical hit rate +3-9%
+            {id = 239, items = {27650, 27790, 27930, 28073, 28210},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 300, 200, 0}} },                   -- Usukane +1 Set: Haste +3-9%
+            {id = 240, items = {27651, 27791, 27931, 28074, 28211},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 3, 2, 0}} },                         -- Marduk +1 Set: Fast Cast +3-9%
+            {id = 241, items = {27652, 27792, 27932, 28075, 28212},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 3, 2, 0}} },                             -- Morrigan +1 Set: Magic Atk. Bonus +3-9%
+            {id = 242, items = {27740, 27881, 28029, 28168, 28306}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.DMGPHYS, -1000, 0, 0}} },                       -- Outrider Set: Phys damage taken -10%
+            {id = 243, items = {27741, 27882, 28030, 28169, 28307}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRIT_DMG_INCREASE, 10, 0, 0}} },                -- Espial Set: Crit damage +10%
+            {id = 244, items = {27742, 27883, 28031, 28170, 28308}, matches = 5, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 3, 0, 0}} },                           -- Wayfarer Set: Refresh+3
+            {id = 245, items = {28520, 28521}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 7, 0, 0}} },                                          -- Bladeborn/Steelflash Earrings
+            {id = 246, items = {28522, 28523}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DUAL_WIELD, 7, 0, 0}} },                                             -- Dudgeon/Heartseeker Earrings
+            {id = 247, items = {28524, 28525}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 12, 0, 0}} },                                                  -- Psystorm/Lifestorm Earrings
+            {id = 248, items = {18244, 17595}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },        -- Begin Jailer weapons: Set is weapon + Virtue stone, bonus 50% extra melee swing.
+            {id = 249, items = {18244, 17710}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
+            {id = 250, items = {18244, 17948}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
+            {id = 251, items = {18244, 18100}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
+            {id = 252, items = {18244, 18222}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
+            {id = 253, items = {18244, 18360}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
+            {id = 254, items = {18244, 18397}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },        -- End Jailer weapons
 
-             {id = 10, items = {16064, 14527, 14935, 15606, 15690},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 1, 0, 0}} },      --  Yigit Gomlek Set (1mp per tick) Adds "Refresh" effect
-             {id = 11, items = {11503, 13759, 12745, 14210, 11413},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 500, 0, 0}} },   --  Perle Hauberk Set 5% haste
-             {id = 12, items = {11504, 13760, 12746, 14257, 11414},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.STORETP, 8, 0, 0}} },      --  Aurore Doublet Set  store tp +8
-             {id = 13, items = {11505, 13778, 12747, 14258, 11415},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 4, 2, 0}} },    -- Teal Set: Fast Cast +4-10%
-             {id = 14, items = {10890, 10462, 10512, 11980, 10610},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 600, 0, 0}} },   --  Calma Armor Set haste%6
-             {id = 15, items = {10892, 10464, 10514, 11982, 10612},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.MACC, 5, 0, 0}} },        --  Magavan Armor Set  magic accuracy +5
-             {id = 16, items = {10891, 10463, 10513, 11981, 10611},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 5, 0, 0}} },  --  Mustela Harness Set  crit rate 5%
-             {id = 17, items = {16126, 15744}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RATT, 15, 0, 0}} }, -- Bowman's set: Ranged atk +15
-             {id = 18, items = {16147, 14589, 15010, 16316, 15756},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 1, 4.7, 0}} },        --  Fourth Division Brune Set
-             {id = 19, items = {16148, 14590, 15011, 16317, 15757},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.COUNTER, 1, 1, 0}} },      --  Cobra Unit Harness Set
-             {id = 20, items = {16149, 14591, 15012, 16318, 15758},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 1, 1, 0}} },        --  Cobra Unit Robe Set
-             {id = 21, items = { 6141, 14581, 15005, 16312, 15749},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 1, 1, 0}, {xi.mod.ATT, 1, 1, 0}} },       --  Iron Ram Chainmail Set. Double mod here! It is why it has 2 IDs.
-             {id = 23, items = {16142, 14582, 15006, 16313, 15750} , matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 10, 10, 0}} },        --  Fourth Division Cuirass Set
-             {id = 24, items = {16143, 14583, 15007, 16314, 15751} , matches = 2, matchType = matchtype.any, mods = {{xi.mod.MP, 10, 10, 0}} },        --  Cobra Unit Coat Set
-             {id = 25, items = {16062, 14525, 14933, 15604, 15688} , matches = 5, matchType = matchtype.any, mods = {{xi.mod.UDMGBREATH, -800, 0, 0}, {xi.mod.UDMGMAGIC, -800, 0, 0}} },       --  Amir Korazin Set - Double mod here! It is why it has 2 IDs.
-
-             {id = 27, items = {11281, 15015, 16337, 11364}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.STORETP, 5, 5, 5}} },             --  Hachiryu Haramaki Set - Store tp
-             {id = 28, items = {11064, 11084, 11104, 11124, 11144}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DA_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, --  Ravager's Armor +2 Set - Double attack double damage chance
-
-             {id = 29, items = {11808, 11824, 11850, 11857, 11858}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 5, 0, 0}} },   --  Fazheluo Mail Set. Set Bonus: "Double Attack"+5%. Active with any 2 pieces.
-
-             {id = 30, items = {11809, 11825, 11851, 11855, 11859}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 800, 0, 0}} }, --  Cuauhtli Harness Set. Set Bonus: Haste+8%. Active with any 2 pieces.
-
-             {id = 31, items = {11810, 11826, 11852, 11856, 11860}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 5, 0, 0}} },    --  Hyskos Robe Set. Set Bonus: Magic Accuracy+5. Active with any 2 pieces.
-             {id = 32, items = {10876, 10450, 10500, 11969, 10600}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 1, 0.4, 0}} },     --  Ogier's Armor Set. Set Bonus: Adds "Refresh" xi.effect. Provides 1 mp/tick for 2-3 pieces worn, 2 mp/tick for 4-5 pieces worn.
-             {id = 33, items = {10877, 10451, 10501, 11970, 10601}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 1, 1, 0}} },   --  Athos's Armor Set. Set Bonus: Increases rate of critical hits. Gives +3% for the first 2 pieces and +1% for every additional piece.
-
-             -- Capped Tier set, stick it in cappedTierSets below so we can handle it separately (still need to check if it's a set, though)
-             {id = 34, items = {10878, 10452, 10502, 11971, 10602}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 10, 0, 0}} },        --  Rubeus Armor Set. Set Bonus: Enhances "Fast Cast" effect. 2 or 3 pieces equipped: Fast Cast +4, 4 or 5 pieces equipped: Fast Cast +10
-             {id = 35, items = {11080, 11100, 11120, 11140, 11160}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} },        --  Navarch's Attire +2 Set. Set Bonus: Augments "Quick Draw". Quick Draw will occasionally deal triple damage.
-             {id = 36, items = {11082, 11102, 11122, 11142, 11162}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.SAMBA_DOUBLE_DAMAGE, 1, 1.8, 0}} },                         --  Charis Attire +2 Set. Set Bonus: Augments "Samba". Occasionally doubles damage with Samba up. Adds approximately 1-2% per piece past the first.
-             {id = 37, items = {11076, 11096, 11116, 11136, 11156}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_DUAL_WIELD_ATTACK, extraDWAttackBaseRate, extraDWAttackPieceBonus, 0}} },         --  Iga Garb +2 Set. Set Bonus: Augments "Dual Wield". Attacks made while dual wielding occasionally add an extra attack
-             {id = 38, items = {11074, 11094, 11114, 11134, 11154}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} },        --  Sylvan Attire +2 Set. Set Bonus: Augments "Rapid Shot". Rapid Shots occasionally deal double damage.
-             {id = 39, items = {11070, 11090, 11110, 11130, 11150}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ABSORB_DMG_CHANCE, absorbDamageBaseRate, absorbDamagePieceBonus, 0}} },                          --  Creed Armor +2 Set. Set Bonus: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
-             {id = 40, items = {11075, 11095, 11115, 11135, 11155}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ZANSHIN_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} },          --  Unkai Domaru +2 Set. Set Bonus: Augments "Zanshin". Zanshin attacks will occasionally deal double damage.
-             {id = 41, items = {11065, 11085, 11105, 11125, 11145}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_KICK_ATTACK, extraKickAttackBaseRate, extraKickAttackPieceBonus, 0}} },             --  Tantra Attire +2 Set. Set Bonus: Augments "Kick Attacks". Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
-             {id = 42, items = {11069, 11089, 11109, 11129, 11149}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.TA_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} },              --  Raider's Attire +2 Set. Set Bonus: Augments "Triple Attack". Occasionally causes the second and third hits of a Triple Attack to deal triple damage.Verification Needed Requires a minimum of two pieces.
-             {id = 43, items = {11066, 11086, 11106, 11126, 11146}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BAR_ELEMENT_NULL_CHANCE, nullDamageBaseRate, nullDamagePieceBonus, 0}} },        --  Orison Attire +2 Set. Set Bonus: Augments elemental resistance spells. Bar Elemental spells will occasionally nullify damage of the same element.
-             {id = 44, items = {11083, 11103, 11123, 11143, 11163}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.GRIMOIRE_INSTANT_CAST, instantCastBaseRate, instantCastPieceBonus, 0}} },          --  Savant's Attire +2 Set. Set Bonus: Augments Grimoire. Spells that match your current Arts will occasionally cast instantly, without recast.
-             {id = 45, items = {16005, 17756, 17962, 18596, 18760, 19112, 19215, 19271, 19156}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 30, 0, 0}, {xi.mod.VIT, 6, 0, 0}, {xi.mod.ACC, 6, 0, 0}, {xi.mod.RACC, 6, 0, 0}} }, --  Paramount Earring Sets. Set Bonus: HP+30, VIT+6, Accuracy+6, Ranged Accuracy+6. Set Bonus is active with any 2 items(Earring+Weapon or Weapon+Weapon)
-             {id = 49, items = {18761, 18597, 17757, 19218, 18128, 18500, 16004, 18951}, matches = 2, matchType = matchtype.earring_weapon, mods = {{xi.mod.STR, 6, 0, 0}, {xi.mod.ATT, 4, 0, 0}, {xi.mod.RATT, 4, 0, 0}, {xi.mod.MATT, 2, 0, 0}} }, --  Supremacy Earring Sets. Set Bonus: STR+6, Attack+4, Ranged Attack+4, "Magic Atk. Bonus"+2. Active with any 2 items(Earring+Weapon)
-
-             {id = 53, items = {16006, 18450, 18499, 18861, 18862, 18952, 19111, 19217, 19272}, matches = 2, matchType = matchtype.earring_weapon, mods = {{xi.mod.EVA, 10, 0, 0}, {xi.mod.HPHEAL, 10, 0, 0}, {xi.mod.ENMITY, -5, 0, 0}} }, --  Brilliant Earring Set. Set Bonus: Evasion, HP Recovered while healing, Reduces Emnity. Active with any 2 items(Earring+Weapon)
-             {id = 56, items = {11798, 11362}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RERAISE_III, 1, 0, 0}} },        -- Twilight Mail Set. Set Bonus: Auto-Reraise
-             {id = 57, items = {18244, 17595}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },        -- Begin Jailer weapons: Set is weapon + Virtue stone, bonus 50% extra melee swing.
-             {id = 58, items = {18244, 17710}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
-             {id = 59, items = {18244, 17948}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
-             {id = 60, items = {18244, 18100}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
-             {id = 61, items = {18244, 18222}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
-             {id = 62, items = {18244, 18360}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },
-             {id = 63, items = {18244, 18397}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AMMO_SWING, 50, 0, 0}} },        -- End Jailer weapons
-             {id = 71, items = {28520, 28521}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 7, 0, 0}} }, -- Bladeborn/Steelflash Earrings
-             {id = 72, items = {28522, 28523}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DUAL_WIELD, 7, 0, 0}} }, -- Dudgeon/Heartseeker Earrings
-             {id = 73, items = {28524, 28525}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MACC, 12, 0, 0}} }, -- Psystorm/Lifestorm Earrings
-             {id = 74, items = {26920, 26921, 27434, 27259, 27260, 26762, 26763, 27074, 27075, 27433}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ZANSHIN_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, -- Samurai 109/119 af3
-             {id = 75, items = {27414, 27413, 27240, 27239, 27055, 27054, 26901, 26900, 26743, 26742}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_KICK_ATTACK, extraKickAttackBaseRate, extraKickAttackPieceBonus, 0}} }, -- MNK 109/119 af3
-             {id = 76, items = {26740, 26741, 27411, 27412, 27238, 27237, 27053, 27054, 26899, 26900}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DA_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, -- 109/119 WAR AF3
-             {id = 77, items = {26750, 26751, 27421, 27422, 27247, 27248, 27063, 27062, 26908, 26909}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.TA_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, -- 109/119 THF AF3
-             {id = 78, items = {26918, 26919, 26761, 26762, 27431, 27432, 27257, 27258, 27072, 27073}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, -- 109/119 RNG AF3
-             {id = 79, items = {26910, 26911, 26752, 26753, 27424, 27423, 27064, 27065, 27249, 27250}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ABSORB_DMG_CHANCE, absorbDamageBaseRate, absorbDamagePieceBonus, 0}} }, -- 109/119 PLD AF3
-             {id = 80, items = {26922, 26923, 26764, 26765, 27076, 27077, 27261, 27262, 27435, 27436}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.EXTRA_DUAL_WIELD_ATTACK, extraDWAttackBaseRate, extraDWAttackPieceBonus, 0}} }, -- 109/119 NIN AF3
-             {id = 81, items = {27443, 27444, 26772, 26773, 26930, 26931, 27084, 27085, 27269, 27270}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0}} }, -- 109/119 COR AF3
-             {id = 82, items = {27275, 27276, 27449, 27450, 26778, 26779, 26936, 26937, 27090, 27091}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.GRIMOIRE_INSTANT_CAST, instantCastBaseRate, instantCastPieceBonus, 0}} }, -- 109/119 SCH AF3
-             {id = 83, items = {27241, 27242, 27415, 27416, 26744, 26745, 26902, 26903, 27056, 27057}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BAR_ELEMENT_NULL_CHANCE, nullDamageBaseRate, nullDamagePieceBonus, 0}} }, -- 109/119 WHM AF3
-             {id = 84, items = {11867, 10868, 10865}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 3, 0, 0}} }, -- Heka's body + NQ or HQ Khat = 3 tick refresh
-             {id = 85, items = {10868, 11870, 11864, 10865}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 2, 0, 0}} }, -- Nefer body/head NQ/HQ combo gives Refresh +2
-             {id = 86, items = {15852, 15853}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.HP, 50, 0, 0}, {xi.mod.MP, 50, 0, 0}} }, -- Dasra's/Nasatya's Ring set gives HP/MP +50
-             {id = 88, items = {16037, 16038}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 5, 0, 0}, {xi.mod.MACC, 5, 0, 0}} }, -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
-             {id = 90, items = {15850, 15851}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 6, 0, 0}, {xi.mod.ACC, 12, 0, 0}, {xi.mod.DEF, 6, 0, 0}} }, -- Lava's/Kusha's earring set: Atk+6/Acc+12
-             {id = 93, items = {16146, 14588, 15009, 16315, 15755},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FIRE_RES, 5, 5, 10}, {xi.mod.ICE_RES, 5, 5, 10}, {xi.mod.WIND_RES, 5, 5, 10}, {xi.mod.EARTH_RES, 5, 5, 10}, {xi.mod.THUNDER_RES, 5, 5, 10}, {xi.mod.WATER_RES, 5, 5, 10}, {xi.mod.LIGHT_RES, 5, 5, 10}, {xi.mod.DARK_RES, 5, 5, 10}} }, --  Iron Ram Haubert Set
-             {id = 101, items = {16035, 16036}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AGI, 8, 0, 0}} }, -- Altdorf's/Wilhelm's earring: AGI+8
-             {id = 102, items = {15042, 11402}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 5, 0, 0}, {xi.mod.RATT, 5, 0, 0}} }, -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
-             {id = 104, items = {26713, 27853, 27999, 28140, 28279},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 4, 2, 0}} }, -- Teal Set +1: Fast Cast +4-10%
-             {id = 105, items = {26712, 27852, 27998, 28139, 28278},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.STORETP, 2, 2, 0}} }, -- Aurore Set +1: Sore TP +2-8%
-             {id = 106, items = {26711, 27851, 27997, 28138, 28277},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 200, 100, 0}} }, -- Perle Set +1: Haste +2-5%
-             {id = 107, items = {27652, 27792, 27932, 28075, 28212},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 3, 2, 0}} }, -- Morrigan's Attire Set +1: Magic Atk. Bonus +3-9%
-             {id = 108, items = {27651, 27791, 27931, 28074, 28211},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.FASTCAST, 3, 2, 0}} }, -- Marduk's Attire Set +1: Fast Cast +3-9%
-             {id = 109, items = {27650, 27790, 27930, 28073, 28210},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.HASTE_GEAR, 300, 200, 0}} }, -- Usukane Armor Set +1: Haste +3-9%
-             {id = 110, items = {27649, 27789, 27929, 28072, 28209},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 3, 2, 0}} }, -- Skadi's Attire Set +1: Critical hit rate +3-9%
-             {id = 111, items = {27648, 27788, 27928, 28071, 28208},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 3, 2, 0}} }, -- Ares' Armor Set +1: Double Attack +3-9%
-             {id = 112, items = {10315, 10598},  matches = 2, matchType = matchtype.any, mods = {{xi.mod.DMGMAGIC, -500, 0, 0}} }, -- Alcedo Cuisses and Gauntlets: Magic damage taken -5%
-             {id = 113, items = {26204, 25574, 25790, 25828, 25879, 25946}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.SUBTLE_BLOW, 5, 5, 0}} }, -- Sulevia's Armor Set +2: Subtle Blow +5-20 (Requires Sulevia's Ring to activate set effect)
-             {id = 114, items = {26206, 25576, 25792, 25830, 25881, 25948}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.COUNTER, 4, 4, 0}} }, -- Hizamaru Armor Set +2: Counter +4-16% (Requires Hizamaru Ring to activate set effect)
-             {id = 115, items = {26207, 25577, 25793, 25831, 25882, 25949}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.REFRESH, 1, 1, 0}} }, -- Inyanga Armor Set +2: Refresh +1-4 (Requires Inyanga Ring to activate set effect)
-             {id = 116, items = {26205, 25575, 25791, 25829, 25880, 25947}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.REGEN, 3, 3, 0}} }, -- Meghanada Armor Set +2: Regen +3-12 (Requires Megahanada Ring to activate set effect)
-             {id = 117, items = {26208, 25578, 25794, 25832, 25883, 25950}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.FAST_CAST, 1, 1, 0}} }, -- Jhakri Armor Set +2: Fast Cast +1-4% (Requires Jhakri Ring to activate set effect)
-             {id = 118, items = {26211, 25569, 25797, 25385, 25886, 25953}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.STR, 8, 8, 0}, {xi.mod.DEX, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}} }, -- Flamma Armor Set +2 STR/DEX/VIT +8-32 (Requires Flamma Ring to activate set effect)
-             {id = 121, items = {26210, 25573, 25796, 25834, 25885, 25952}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.DEX, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}, {xi.mod.CHR, 8, 8, 0}} }, -- Tali'ah Armor Set +2 DEX/VIT/CHR +8-32 (Requires Tali'ah Ring to activate set effect}
-             {id = 124, items = {26212, 25570, 25798, 25836, 25887, 25954}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.DEX, 8, 8, 0}, {xi.mod.AGI, 8, 8, 0}, {xi.mod.CHR, 8, 8, 0}} }, -- Mummu Armor Set +2 DEX/AGI/CHR +8-32 (Requires Mummu Ring to activate set effect)
-             {id = 127, items = {26209, 25572, 25795, 25833, 25884, 25951}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.STR, 8, 8, 0}, {xi.mod.VIT, 8, 8, 0}, {xi.mod.MND, 8, 8, 0}} }, -- Ayanmo Armor Set +2 STR/VIT/MND +8-32 (Requires Ayanmo Ring to activate set effect)
-             {id = 130, items = {26213, 25571, 25799, 25837, 25888, 25955}, matches = 3, matchType = matchtype.ring_armor, mods = {{xi.mod.VIT, 8, 8, 0}, {xi.mod.INT, 8, 8, 0}, {xi.mod.MND, 8, 8, 0}} }, -- Mallquis Armor Set +2 VIT/INT/MND +8-32 (Requires Mallquis Ring to activate set effect)
-             {id = 133, items = {26191, 23308, 23643, 23241, 23576, 23174, 23509, 23107, 23442, 23040, 23375}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 WAR
-             {id = 136, items = {26191, 23309, 23644, 23242, 23577, 23175, 23510, 23108, 23443, 23041, 23376}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 MNK
-             {id = 139, items = {26085, 23310, 23645, 23243, 23578, 23176, 23511, 23109, 23444, 23042, 23377}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 WHM
-             {id = 142, items = {26085, 23311, 23646, 23244, 23579, 23177, 23512, 23110, 23445, 23043, 23378}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BLM
-             {id = 145, items = {26085, 23312, 23647, 23245, 23580, 23178, 23513, 23111, 23446, 23044, 23379}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RDM
-             {id = 148, items = {26191, 23313, 23648, 23246, 23581, 23179, 23514, 23112, 23447, 23045, 23380}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 THF
-             {id = 151, items = {26191, 23314, 23649, 23247, 23582, 23180, 23515, 23113, 23448, 23046, 23381}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 PLD
-             {id = 154, items = {26191, 23315, 23650, 23248, 23583, 23181, 23516, 23114, 23449, 23047, 23382}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DRK
-             {id = 157, items = {26191, 23316, 23651, 23249, 23584, 23182, 23517, 23115, 23450, 23048, 23383}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BST
-             {id = 160, items = {26085, 23317, 23652, 23250, 23585, 23183, 23518, 23116, 23451, 23049, 23384}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BRD
-             {id = 163, items = {26191, 23318, 23653, 23251, 23586, 23184, 23519, 23117, 23452, 23050, 23385}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RNG
-             {id = 166, items = {26191, 23319, 23654, 23252, 23587, 23185, 23520, 23118, 23453, 23051, 23386}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SAM
-             {id = 169, items = {26191, 23320, 23655, 23253, 23588, 23186, 23521, 23119, 23454, 23052, 23387}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 NIN
-             {id = 172, items = {26191, 23321, 23656, 23254, 23589, 23187, 23522, 23120, 23455, 23053, 23388}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DRG
-             {id = 175, items = {26342, 23322, 23657, 23255, 23590, 23188, 23523, 23121, 23456, 23054, 23389}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SMN
-             {id = 178, items = {26085, 23323, 23658, 23256, 23591, 23189, 23524, 23122, 23457, 23055, 23390}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 BLU
-             {id = 181, items = {26191, 23324, 23659, 23257, 23592, 23190, 23525, 23123, 23458, 23056, 23391}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 COR
-             {id = 184, items = {26191, 23325, 23660, 23258, 23593, 23191, 23526, 23124, 23459, 23057, 23392}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 PUP
-             {id = 187, items = {26191, 23326, 23661, 23259, 23594, 23192, 23527, 23125, 23460, 23058, 23393}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DNC (M)
-             {id = 190, items = {26191, 23327, 23662, 23260, 23595, 23193, 23528, 23126, 23461, 23059, 23394}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 DNC (F)
-             {id = 193, items = {26085, 23328, 23663, 23261, 23596, 23194, 23529, 23127, 23462, 23060, 23395}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 SCH
-             {id = 196, items = {26085, 23329, 23664, 23262, 23597, 23195, 23530, 23128, 23463, 23061, 23396}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 GEO
-             {id = 199, items = {26191, 23330, 23665, 23263, 23598, 23196, 23531, 23129, 23464, 23062, 23397}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 15, 0, 0}, {xi.mod.RACC, 15, 0, 0}, {xi.mod.MACC, 15, 0, 0}} }, -- AF1 119 +2/3 RUN
-
-             {id = 202, items = {27740, 27881, 28029, 28168, 28306},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.DMGPHYS, -1000, 0, 0}} },          -- Outrider set (Phys damage taken -10%)
-             {id = 203, items = {27741, 27882, 28030, 28169, 28307},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.CRIT_DMG_INCREASE, 10, 0, 0}} }, -- Espial set (Crit damage +10%)
-             {id = 204, items = {27742, 27883, 28031, 28170, 28308},  matches = 5, matchType = matchtype.any, mods = {{xi.mod.REFRESH, 3, 0, 0}} },            -- Wayfarer set (Refresh+3)
-             {id = 205, items = {26677, 26853, 27029, 27205, 27381}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.BP_DAMAGE, 4, 2, 0}} }, -- Apogee +1
-             {id = 206, items = {25612, 25685, 27116, 27301, 27472}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ATT, 20, 10, 0}} }, -- Ryuo +1
-             {id = 207, items = {26671, 26847, 27023, 27199, 27375}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DMG, -4, -2, 0}} }, -- Souveran +1
-             {id = 208, items = {25610, 25683, 27114, 27299, 27470}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 4, 2, 0}} }, -- Emicho +1
-             {id = 209, items = {25618, 25691, 27122, 27307, 27478}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CURE_POTENCY_II, 4, 2, 0}} }, -- Kaykaus +1
-             {id = 210, items = {26675, 26851, 27027, 27203, 27379}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MARTIAL_ARTS, 8, 4, 0}} }, -- Rao +1
-             {id = 211, items = {25614, 25687, 27118, 27303, 27474}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.CRITHITRATE, 4, 2, 0}} }, -- Adhemar +1
-             {id = 212, items = {26679, 26855, 27031, 27207, 27383}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 20, 10, 0}} }, -- Carmine +1
-             {id = 213, items = {26669, 26845, 27021, 27197, 27373}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0}} }, -- Lustratio +1
-             {id = 214, items = {26673, 26849, 27025, 27201, 27377}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 4, 2, 0}} }, -- Argosy +1
-             {id = 215, items = {25616, 25689, 27120, 27305, 27476}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 20, 10, 0}} }, -- Amalric +1
-             {id = 216, items = {18947, 15818}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 5, 0, 0}, {xi.mod.SOULEATER_EFFECT, 2, 0, 0}} }, -- Moliones's Sickle/Ring
-             -- next id = 218
+             -- next id = 255
         }
 
-             -- increment id by the number of mods in previous gearset (e.g. id 199 has 3 mods, 199 + 3 = 202)
-             -- so in this example, the next usable id after 199 would be 202.
+             -- increment id by the number of mods in previous gearset (e.g. id 198 has 3 mods, 198 + 3 = 201)
+             -- so in this example, the next usable id after 198 would be 201.
 
 --              {id, {item, ids, in, no, particular, order}, minimum matches required, match type, mods{id, value, modvalue for each additional match, additional whole set bonus}
 
-local cappedTierSets =
+local specialHandlingSets =
 {
-    -- stick the ids of sets that need their own handling here e.g. Rubeus
-    {id = 34, cappedTier = true},
-    -- AF1 119 +2/+3 sets have 6 possible matching slots, but only 4 tiers. Using cappedTier to enforce a cap on buff level above 5 matches.
-    {id = 133, cappedTier = true},
-    {id = 136, cappedTier = true},
-    {id = 139, cappedTier = true},
-    {id = 142, cappedTier = true},
-    {id = 145, cappedTier = true},
-    {id = 148, cappedTier = true},
-    {id = 151, cappedTier = true},
-    {id = 154, cappedTier = true},
-    {id = 157, cappedTier = true},
-    {id = 160, cappedTier = true},
-    {id = 163, cappedTier = true},
-    {id = 166, cappedTier = true},
-    {id = 169, cappedTier = true},
-    {id = 172, cappedTier = true},
-    {id = 175, cappedTier = true},
-    {id = 178, cappedTier = true},
-    {id = 181, cappedTier = true},
-    {id = 184, cappedTier = true},
-    {id = 187, cappedTier = true},
-    {id = 190, cappedTier = true},
-    {id = 193, cappedTier = true},
-    {id = 196, cappedTier = true},
-    {id = 199, cappedTier = true},
+    -- put the ids of sets that need their own handling here e.g. Rubeus
+    {id =  39, specialHandling = true}, -- Breeders
+    {id =  69, specialHandling = true}, -- RDM AF3 +2
+    {id =  98, specialHandling = true}, -- Ogiers
+    {id = 100, specialHandling = true}, -- Rubeus
+    {id = 102, specialHandling = true}, -- Phorcys
+    {id = 106, specialHandling = true}, -- Thaumas
+    {id = 110, specialHandling = true}, -- Nares
+    {id = 114, specialHandling = true}, -- Begin AF1 109/119 +2/3 ACC/RACC/MACC
+    {id = 118, specialHandling = true},
+    {id = 121, specialHandling = true},
+    {id = 124, specialHandling = true},
+    {id = 127, specialHandling = true},
+    {id = 130, specialHandling = true},
+    {id = 133, specialHandling = true},
+    {id = 136, specialHandling = true},
+    {id = 139, specialHandling = true},
+    {id = 142, specialHandling = true},
+    {id = 145, specialHandling = true},
+    {id = 148, specialHandling = true},
+    {id = 151, specialHandling = true},
+    {id = 154, specialHandling = true},
+    {id = 157, specialHandling = true},
+    {id = 160, specialHandling = true},
+    {id = 163, specialHandling = true},
+    {id = 166, specialHandling = true},
+    {id = 169, specialHandling = true},
+    {id = 172, specialHandling = true},
+    {id = 175, specialHandling = true},
+    {id = 178, specialHandling = true},
+    {id = 181, specialHandling = true}, -- End AF1 109/119 +2/3 ACC/RACC/MACC
+    {id = 219, specialHandling = true}, -- AF3 109/119 RDM
 }
 
 local function FindMatchByType(gearset, gearMatch)
@@ -229,23 +251,88 @@ local function FindMatchByType(gearset, gearMatch)
     return false
 end
 
-local function handleCappedTierSet(player, gearset, matches)
-    -- Rubeus Armor Set
-    if (gearset.id == 34) then
-        local modValue = 0
-
+local function doSpecialHandling(player, gearset, matches)
+    local modValue = 0
+    if gearset.id == 39 then -- Breeders
+        player:addGearSetMod(gearset.id, xi.mod.DEF, 10, 1)
+        player:addGearSetMod(gearset.id + 1, xi.mod.ENMITY, 5, 1)
+        return
+    elseif (gearset.id == 69 or gearset.id == 219) then -- RDM AF3 90/109/119
+        if matches == 2 then
+            modValue = 10
+        elseif matches == 3 then
+            modValue = 15
+        elseif matches == 4 then
+            modValue = 35
+        elseif matches == 5 then
+            modValue = 50
+        end
+        player:addGearSetMod(gearset.id, xi.mod.AUGMENT_COMPOSURE, modValue, 0)
+        return
+    elseif gearset.id == 98 then -- Ogiers
+        if (matches >=2 and matches <= 3) then
+            modValue = 1 -- 2 or 3 pieces
+        elseif (matches > 3) then
+            modValue = 2 -- 4 or 5 pieces
+        end
+        player:addGearSetMod(gearset.id, xi.mod.REFRESH, modValue, 0)
+        return
+    elseif gearset.id == 100 then -- Rubeus
         if (matches > 1 and matches < 4) then
             modValue = 4 -- 2 or 3 pieces
         elseif (matches > 3) then
             modValue = 10 -- 4 or 5 pieces
         end
-        -- printf("we have a special snowflake | gearset: %u | mod %u %u", gearset.id, xi.mod.FASTCAST, modValue)
-        player:addGearSetMod(gearset.id, xi.mod.FASTCAST, modValue)
+        -- printf("[DEBUG] Enabling Special Handling | gearset: %u | mod %u %u", gearset.id, xi.mod.FASTCAST, modValue)
+        player:addGearSetMod(gearset.id, xi.mod.FASTCAST, modValue, 0)
+        return
+    elseif gearset.id == 102 then -- Phorcys
+        if matches == 2 then
+            modValue = 2
+        elseif matches == 3 then
+            modValue = 5
+        elseif matches == 4 then
+            modValue = 10
+        elseif matches == 5 then
+            modValue = 15
+        end
+        player:addGearSetMod(gearset.id, xi.mod.STR, modValue, 0)
+        player:addGearSetMod(gearset.id + 1, xi.mod.VIT, modValue, 0)
+        player:addGearSetMod(gearset.id + 2, xi.mod.INT, modValue, 0)
+        player:addGearSetMod(gearset.id + 3, xi.mod.MND, modValue, 0)
+        return
+    elseif gearset.id == 106 then -- Thaumas
+        if matches == 2 then
+            modValue = 2
+        elseif matches == 3 then
+            modValue = 5
+        elseif matches == 4 then
+            modValue = 10
+        elseif matches == 5 then
+            modValue = 15
+        end
+        player:addGearSetMod(gearset.id, xi.mod.STR, modValue, 0)
+        player:addGearSetMod(gearset.id + 1, xi.mod.DEX, modValue, 0)
+        player:addGearSetMod(gearset.id + 2, xi.mod.AGI, modValue, 0)
+        player:addGearSetMod(gearset.id + 3, xi.mod.MND, modValue, 0)
+        return
+    elseif gearset.id == 110 then -- Nares
+        if matches == 2 then
+            modValue = 2
+        elseif matches == 3 then
+            modValue = 5
+        elseif matches == 4 then
+            modValue = 10
+        elseif matches == 5 then
+            modValue = 15
+        end
+        player:addGearSetMod(gearset.id, xi.mod.STR, modValue, 0)
+        player:addGearSetMod(gearset.id + 1, xi.mod.INT, modValue, 0)
+        player:addGearSetMod(gearset.id + 2, xi.mod.MND, modValue, 0)
+        player:addGearSetMod(gearset.id + 3, xi.mod.CHR, modValue, 0)
         return
     -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
-    elseif (gearset.id >= 133 and gearset.id <= 199 and gearset.id ~= 175) then
-        local modValue = 0
-
+    elseif (gearset.id >= 114 and gearset.id <= 181 and gearset.id ~= 157) then
         if (matches == 2) then
             modValue = 15 -- 2 matches
         elseif (matches == 3) then
@@ -255,15 +342,12 @@ local function handleCappedTierSet(player, gearset, matches)
         elseif (matches >= 5) then
             modValue = 60 -- 5 or more matches
         end
-        player:addGearSetMod(gearset.id, xi.mod.ACC, modValue)
-        player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue)
-        player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue)
+        player:addGearSetMod(gearset.id, xi.mod.ACC, modValue, 0)
+        player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue, 0)
+        player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue, 0)
         return
-    -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC (unimplemented)
-    --[[
-    elseif (gearset.id == 175) then
-        local modValue = 0
-
+    -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC
+    elseif (gearset.id == 157) then
         if (matches == 2) then
             modValue = 15 -- 2 matches
         elseif (matches == 3) then
@@ -273,9 +357,10 @@ local function handleCappedTierSet(player, gearset, matches)
         elseif (matches >= 5) then
             modValue = 60 -- 5 or more matches
         end
-        --Unimplemented method to add pet mods
+        player:addGearSetMod(gearset.id, xi.mod.ACC, modValue, 1)
+        player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue, 1)
+        player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue, 1)
         return
-    ]]--
     end
 end
 
@@ -284,9 +369,9 @@ end
 -----------------------------------
 local function ApplyMod(player, gearset, matches)
 
-    for _, set in pairs(cappedTierSets) do
+    for _, set in pairs(specialHandlingSets) do
         if (set.id == gearset.id) then
-            handleCappedTierSet(player, gearset, matches)
+            doSpecialHandling(player, gearset, matches)
             return
         end
     end
@@ -320,7 +405,7 @@ local function ApplyMod(player, gearset, matches)
             modValue = modValue + (addMatchValue * addMatches)
         end
         -- printf("gearset: %u, mod: %u, value %u", gearset.id, modId, modValue + addSetBonus)
-        player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus)
+        player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus, 0)
         i = i + 1
     end
     -- print("Gear set! Mod applied: ModNameId:" .. modNameId .. " ModId:" .. modId .. " Value:" .. modValue .. "\n")
@@ -371,39 +456,18 @@ function checkForGearSet(player)
 
             if (matches >= gearset.matches) then
                 if (FindMatchByType(gearset, gearMatch) == true) then
-                    ApplyMod(player, gearset, matches)
+                    ApplyMod(player, gearset, matches, 0)
                 end
             end
         end
     end
 end
 
---[[    Unimplemented sets below
+--[[    WIP/TODO sets below
 
 =======
 Empyrean +2
 =======
-
---Aoidos' Attire +2 Set
------------------------------------
-11073 -- Aoidos' Calot+2
-11093 -- Aoidos' Hongreline +2
-11113 -- Aoidos' Manchettes +2
-11133 -- Aoidos' Rhingrave +2
-11153 -- Aoidos' Cothurnes +2
--- Set Bonus: Augments Songs
--- Enhancing songs add an attribute bonus that corresponds to the element of the song (i.e. Thunder-based songs add +DEX). The attribute bonus begins at +1 for 2 pieces, increases by 1 for each additional piece, up to +5 for the whole set. For Dark-based songs, there is a bonus of +10 MP for 2 pieces, and increases by 10 for each additional piece.
-
---Ferine' Attire +2 Set
------------------------------------
-11072 -- Ferine Cabasset+2
-11092 -- Ferine Gausape+2
-11112 -- Ferine Manoplas+2
-11132 -- Ferine Quijotes+2
-11152 -- Ferine Ocreae+2
--- Set Bonus: Attack occ. varies with pet's HP
--- Occasionally increases damage in direct proportion to the percentage of pet's current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
--- 5% Proc Rate
 
 --Goetia Attire +2 Set
 -----------------------------------
@@ -423,39 +487,7 @@ Empyrean +2
 11139 -- Mavi Tayt+2
 11159 -- Mavi Basmak+2
 -- Set Bonus: Occ. augments blue magic spells.
--- no clue!
-
-
---Bale Armor +2 Set
------------------------------------
-11071 -- Bale Burgeonet+2
-11091 -- Bale Cuirass+2
-11111 -- Bale Gauntlets+2
-11131 -- Bale Flanchard+2
-11151 -- Bale Sollerets+2
--- Set Bonus: Attack occasionally varies with HP
--- Occasionally increases damage in direct proportion to the percentage of current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
-
---Lancer's Armor +2 Set
------------------------------------
-11077 -- Lancer's Mezail+2
-11097 -- Lancer's Plackart+2
-11117 -- Lancer's Vambrace+2
-11137 -- Lancer's Cuissots+2
-11157 -- Lancer's Schynbalds+2
--- Set Bonus: Attack occasionally varies with wyvern's HP.
--- Damage increases proportionate to Wyvern's HP, at 100%, damage is doubled. 2+ pieces required, more pieces increase proc rate. Full +2 set is about a 10% proc rate. (Confirmation needed)
-
-
---Cirque Attire +2 Set
------------------------------------
-11081 -- Cirque Capello+2
-11101 -- Cirque Farsetto+2
-11121 -- Cirque Gaunti+2
-11141 -- Cirque Pantaloni+2
-11161 -- Cirque Scarpe+2
--- Set Bonus: Attack occasionally varies with automaton's HP.
--- Occasionally increases damage in direct proportion to the percentage of Automaton's current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
+-- Occasionally increases the WSC value of the spell to 3x it's value. Stacks with Chain Affinity to make it 4x.
 
 --Estoqueur's Attire +2 Set
 -----------------------------------

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -257,7 +257,7 @@ local function doSpecialHandling(player, gearset, matches)
         player:addGearSetMod(gearset.id, xi.mod.DEF, 10, 1)
         player:addGearSetMod(gearset.id + 1, xi.mod.ENMITY, 5, 1)
         return
-    elseif (gearset.id == 69 or gearset.id == 219) then -- RDM AF3 90/109/119
+    elseif gearset.id == 69 or gearset.id == 219 then -- RDM AF3 90/109/119
         if matches == 2 then
             modValue = 10
         elseif matches == 3 then
@@ -270,17 +270,17 @@ local function doSpecialHandling(player, gearset, matches)
         player:addGearSetMod(gearset.id, xi.mod.AUGMENT_COMPOSURE, modValue, 0)
         return
     elseif gearset.id == 98 then -- Ogiers
-        if (matches >=2 and matches <= 3) then
+        if matches >=2 and matches <= 3 then
             modValue = 1 -- 2 or 3 pieces
-        elseif (matches > 3) then
+        elseif matches > 3 then
             modValue = 2 -- 4 or 5 pieces
         end
         player:addGearSetMod(gearset.id, xi.mod.REFRESH, modValue, 0)
         return
     elseif gearset.id == 100 then -- Rubeus
-        if (matches > 1 and matches < 4) then
+        if matches > 1 and matches < 4 then
             modValue = 4 -- 2 or 3 pieces
-        elseif (matches > 3) then
+        elseif matches > 3 then
             modValue = 10 -- 4 or 5 pieces
         end
         -- printf("[DEBUG] Enabling Special Handling | gearset: %u | mod %u %u", gearset.id, xi.mod.FASTCAST, modValue)
@@ -332,14 +332,14 @@ local function doSpecialHandling(player, gearset, matches)
         player:addGearSetMod(gearset.id + 3, xi.mod.CHR, modValue, 0)
         return
     -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
-    elseif (gearset.id >= 114 and gearset.id <= 181 and gearset.id ~= 157) then
-        if (matches == 2) then
+    elseif gearset.id >= 114 and gearset.id <= 181 and gearset.id ~= 157 then
+        if matches == 2 then
             modValue = 15 -- 2 matches
-        elseif (matches == 3) then
+        elseif matches == 3 then
             modValue = 30 -- 3 matches
-        elseif (matches == 4) then
+        elseif matches == 4 then
             modValue = 45 -- 4 matches
-        elseif (matches >= 5) then
+        elseif matches >= 5 then
             modValue = 60 -- 5 or more matches
         end
         player:addGearSetMod(gearset.id, xi.mod.ACC, modValue, 0)
@@ -347,14 +347,14 @@ local function doSpecialHandling(player, gearset, matches)
         player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue, 0)
         return
     -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC
-    elseif (gearset.id == 157) then
-        if (matches == 2) then
+    elseif gearset.id == 157 then
+        if matches == 2 then
             modValue = 15 -- 2 matches
-        elseif (matches == 3) then
+        elseif matches == 3 then
             modValue = 30 -- 3 matches
-        elseif (matches == 4) then
+        elseif matches == 4 then
             modValue = 45 -- 4 matches
-        elseif (matches >= 5) then
+        elseif matches >= 5 then
             modValue = 60 -- 5 or more matches
         end
         player:addGearSetMod(gearset.id, xi.mod.ACC, modValue, 1)
@@ -380,7 +380,7 @@ local function ApplyMod(player, gearset, matches)
     local addMatches = matches - gearset.matches
 
     -- just in case some d00d decides to customize things and complain the script is b0rked
-    if (addMatches < 0) then
+    if addMatches < 0 then
         return
     end
 
@@ -401,7 +401,7 @@ local function ApplyMod(player, gearset, matches)
         end
 
         -- add bonus mods per piece
-        if (addMatches ~= 0 and addMatchValue ~= 0) then
+        if addMatches ~= 0 and addMatchValue ~= 0 then
             modValue = modValue + (addMatchValue * addMatches)
         end
         -- printf("gearset: %u, mod: %u, value %u", gearset.id, modId, modValue + addSetBonus)

--- a/scripts/globals/spells/advancing_march.lua
+++ b/scripts/globals/spells/advancing_march.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/archers_prelude.lua
+++ b/scripts/globals/spells/archers_prelude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 2) then
+    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon.lua
+++ b/scripts/globals/spells/armys_paeon.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon_ii.lua
+++ b/scripts/globals/spells/armys_paeon_ii.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 2)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon_iii.lua
+++ b/scripts/globals/spells/armys_paeon_iii.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 3)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 3)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon_iv.lua
+++ b/scripts/globals/spells/armys_paeon_iv.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 4)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 4)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon_v.lua
+++ b/scripts/globals/spells/armys_paeon_v.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 5)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 5)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/armys_paeon_vi.lua
+++ b/scripts/globals/spells/armys_paeon_vi.lua
@@ -38,7 +38,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 6)) then
+    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 6)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/bewitching_etude.lua
+++ b/scripts/globals/spells/bewitching_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.CHR, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.CHR, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/blade_madrigal.lua
+++ b/scripts/globals/spells/blade_madrigal.lua
@@ -46,7 +46,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), 0, 2)) then
+    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/chocobo_mazurka.lua
+++ b/scripts/globals/spells/chocobo_mazurka.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/dark_carol.lua
+++ b/scripts/globals/spells/dark_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.DARK, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.DARK, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/dextrous_etude.lua
+++ b/scripts/globals/spells/dextrous_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.DEX, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.DEX, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/dragonfoe_mambo.lua
+++ b/scripts/globals/spells/dragonfoe_mambo.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MAMBO, power, 0, duration, caster:getID(), 0, 2)) then
+    if not (target:addBardSong(caster, xi.effect.MAMBO, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/earth_carol.lua
+++ b/scripts/globals/spells/earth_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.EARTH, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.EARTH, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/enchanting_etude.lua
+++ b/scripts/globals/spells/enchanting_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.CHR, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.CHR, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/fire_carol.lua
+++ b/scripts/globals/spells/fire_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.FIRE, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.FIRE, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/fowl_aubade.lua
+++ b/scripts/globals/spells/fowl_aubade.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.AUBADE, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.AUBADE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/goblin_gavotte.lua
+++ b/scripts/globals/spells/goblin_gavotte.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.GAVOTTE, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.GAVOTTE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/gold_capriccio.lua
+++ b/scripts/globals/spells/gold_capriccio.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAPRICCIO, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAPRICCIO, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/herb_pastoral.lua
+++ b/scripts/globals/spells/herb_pastoral.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.PASTORAL, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.PASTORAL, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/herculean_etude.lua
+++ b/scripts/globals/spells/herculean_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.STR, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.STR, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/hunters_prelude.lua
+++ b/scripts/globals/spells/hunters_prelude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 1) then
+    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/ice_carol.lua
+++ b/scripts/globals/spells/ice_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.ICE, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.ICE, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/knights_minne.lua
+++ b/scripts/globals/spells/knights_minne.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 1) then
+    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/knights_minne_ii.lua
+++ b/scripts/globals/spells/knights_minne_ii.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 2) then
+    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/knights_minne_iii.lua
+++ b/scripts/globals/spells/knights_minne_iii.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 3) then
+    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 3) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/knights_minne_iv.lua
+++ b/scripts/globals/spells/knights_minne_iv.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 4) then
+    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 4) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/knights_minne_v.lua
+++ b/scripts/globals/spells/knights_minne_v.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 5) then
+    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 5) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/learned_etude.lua
+++ b/scripts/globals/spells/learned_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.INT, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.INT, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/light_carol.lua
+++ b/scripts/globals/spells/light_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.LIGHT, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.LIGHT, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/lightning_carol.lua
+++ b/scripts/globals/spells/lightning_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.LIGHTNING, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.LIGHTNING, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/logical_etude.lua
+++ b/scripts/globals/spells/logical_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.MND, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.MND, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/mages_ballad.lua
+++ b/scripts/globals/spells/mages_ballad.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/mages_ballad_ii.lua
+++ b/scripts/globals/spells/mages_ballad_ii.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 2)) then
+    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/mages_ballad_iii.lua
+++ b/scripts/globals/spells/mages_ballad_iii.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 3)) then
+    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 3)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/puppets_operetta.lua
+++ b/scripts/globals/spells/puppets_operetta.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/quick_etude.lua
+++ b/scripts/globals/spells/quick_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.AGI, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.AGI, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/raptor_mazurka.lua
+++ b/scripts/globals/spells/raptor_mazurka.lua
@@ -31,7 +31,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/sage_etude.lua
+++ b/scripts/globals/spells/sage_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.INT, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.INT, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
        return xi.effect.ETUDE

--- a/scripts/globals/spells/scops_operetta.lua
+++ b/scripts/globals/spells/scops_operetta.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/sentinels_scherzo.lua
+++ b/scripts/globals/spells/sentinels_scherzo.lua
@@ -39,7 +39,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.SCHERZO, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.SCHERZO, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/sheepfoe_mambo.lua
+++ b/scripts/globals/spells/sheepfoe_mambo.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MAMBO, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.MAMBO, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/shining_fantasia.lua
+++ b/scripts/globals/spells/shining_fantasia.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.FANTASIA, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.FANTASIA, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/sinewy_etude.lua
+++ b/scripts/globals/spells/sinewy_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.STR, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.STR, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/spirited_etude.lua
+++ b/scripts/globals/spells/spirited_etude.lua
@@ -51,7 +51,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.MND, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.MND, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/swift_etude.lua
+++ b/scripts/globals/spells/swift_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.AGI, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.AGI, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/sword_madrigal.lua
+++ b/scripts/globals/spells/sword_madrigal.lua
@@ -46,7 +46,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/uncanny_etude.lua
+++ b/scripts/globals/spells/uncanny_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.DEX, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.DEX, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/valor_minuet.lua
+++ b/scripts/globals/spells/valor_minuet.lua
@@ -44,7 +44,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 1) then
+    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/valor_minuet_ii.lua
+++ b/scripts/globals/spells/valor_minuet_ii.lua
@@ -48,7 +48,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 2) then
+    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/valor_minuet_iii.lua
+++ b/scripts/globals/spells/valor_minuet_iii.lua
@@ -48,7 +48,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 3) then
+    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 3) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/valor_minuet_iv.lua
+++ b/scripts/globals/spells/valor_minuet_iv.lua
@@ -48,7 +48,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 4) then
+    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 4) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/valor_minuet_v.lua
+++ b/scripts/globals/spells/valor_minuet_v.lua
@@ -48,7 +48,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 5) then
+    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 5) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/victory_march.lua
+++ b/scripts/globals/spells/victory_march.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), 0, 2)) then
+    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/vital_etude.lua
+++ b/scripts/globals/spells/vital_etude.lua
@@ -45,7 +45,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.VIT, 2)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 10, duration, caster:getID(), xi.mod.VIT, 2)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
     return xi.effect.ETUDE

--- a/scripts/globals/spells/vivacious_etude.lua
+++ b/scripts/globals/spells/vivacious_etude.lua
@@ -50,7 +50,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.VIT, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ETUDE, power + caster:getMod(xi.mod.AUGMENT_SONG_STAT), 0, duration, caster:getID(), xi.mod.VIT, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/warding_round.lua
+++ b/scripts/globals/spells/warding_round.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.ROUND, power, 0, duration, caster:getID(), 0, 1)) then
+    if not (target:addBardSong(caster, xi.effect.ROUND, power, 0, duration, caster:getID(), caster:getMod(xi.mod.AUGMENT_SONG_STAT), 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/water_carol.lua
+++ b/scripts/globals/spells/water_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.WATER, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.WATER, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/wind_carol.lua
+++ b/scripts/globals/spells/wind_carol.lua
@@ -43,7 +43,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.WIND, 1)) then
+    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), (caster:getMod(xi.mod.AUGMENT_SONG_STAT) * 100) + xi.magic.ele.WIND, 1)) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1320,6 +1320,14 @@ xi.mod =
     REVERSE_FLOURISH_EFFECT         = 836, -- Reverse Flourish effect in tenths of squared term multiplier
     SENTINEL_EFFECT                 = 837, -- Sentinel effect in percents
     REGEN_MULTIPLIER                = 838, -- Regen base multiplier
+    AUGMENT_CONSERVE_MP             = 1003, -- Percent Chance to Deal extra damage based on Conserve MP
+    AUGMENT_COMPOSURE               = 1004, -- Percent Enhancing Duration Extension for Others
+    AUGMENT_DAMAGE_HP               = 1005, -- Percent Chance to Deal Damage Based on Current HP
+    AUGMENT_DAMAGE_PET_HP           = 1006, -- Percent Chance to Deal Damage Based on Pet HP
+    AUGMENT_SONG_STAT               = 1007, -- Stat MOD Value based on song element
+    AUGMENT_BLOOD_BOON              = 1008, -- Percent Chance to Deal extra damage based on Blood Boon
+    GEOMANCY_MP_NO_DEPLETE          = 1009, -- Percent Chance for Geomancy to cost 0 MP
+    AUGMENT_BLU_MAGIC               = 1010, -- Percent Chance for BLU Magic to receive 3x WSC value for spell.
 
     DOUBLE_SHOT_RATE                = 422, -- The rate that double shot can proc
     VELOCITY_SNAPSHOT_BONUS         = 423, -- Increases Snapshot whilst Velocity Shot is up.

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -525,6 +525,18 @@ void CAttack::ProcessDamage()
         m_damage = battleutils::doConsumeManaEffect((CCharEntity*)m_attacker, m_damage);
     }
 
+    // Damage Occasionally Varies with HP
+    if (m_attacker->objtype == TYPE_PC)
+    {
+        m_damage = battleutils::doDamageOccVariesWithHP((CCharEntity*)m_attacker, m_damage);
+    }
+
+    // Damage Occasionally Varies with Pet HP
+    if (m_attacker->objtype == TYPE_PC)
+    {
+        m_damage = battleutils::doDamageOccVariesWithPetHP((CCharEntity*)m_attacker, m_damage);
+    }
+
     // Set attack type to Samba if the attack type is normal.  Don't overwrite other types.  Used for Samba double damage.
     if (m_attackType == PHYSICAL_ATTACK_TYPE::NORMAL && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_DRAIN_SAMBA))
     {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -126,6 +126,7 @@ struct GearSetMod_t
     uint8  modNameId;
     Mod    modId;
     uint16 modValue;
+    uint8  modPet;
 };
 
 enum CHAR_HISTORY

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4070,7 +4070,9 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue, 
     if (gearSetMod.modPet > 0)
     {
         PChar->addPetModifier(gearSetMod.modId, PetModType::All, gearSetMod.modValue);
-    } else {
+    }
+    else
+    {
         PChar->addModifier(gearSetMod.modId, gearSetMod.modValue);
     }
 }
@@ -4092,7 +4094,9 @@ void CLuaBaseEntity::clearGearSetMods()
             if (gearSetMod.modPet > 0)
             {
                 PChar->delPetModifier(gearSetMod.modId, PetModType::All, gearSetMod.modValue);
-            } else {
+            }
+            else
+            {
                 PChar->delModifier(gearSetMod.modId, gearSetMod.modValue);
             }
         }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4042,11 +4042,11 @@ bool CLuaBaseEntity::hasGearSetMod(uint8 modNameId)
 /************************************************************************
  *  Function: addGearSetMod()
  *  Purpose : Need to research functionality more to provide description
- *  Example : player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus)
+ *  Example : player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus, PetMod)
  *  Notes   : Used exclusively in scripts/globals/gear_sets.lua
  ************************************************************************/
 
-void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
+void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue, uint8 modPet)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
@@ -4054,6 +4054,7 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
     gearSetMod.modNameId = modNameId;
     gearSetMod.modId     = modId;
     gearSetMod.modValue  = modValue;
+    gearSetMod.modPet    = modPet;
 
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4066,7 +4067,12 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
     }
 
     PChar->m_GearSetMods.push_back(gearSetMod);
-    PChar->addModifier(gearSetMod.modId, gearSetMod.modValue);
+    if (gearSetMod.modPet > 0)
+    {
+        PChar->addPetModifier(gearSetMod.modId, PetModType::All, gearSetMod.modValue);
+    } else {
+        PChar->addModifier(gearSetMod.modId, gearSetMod.modValue);
+    }
 }
 
 /************************************************************************
@@ -4083,7 +4089,12 @@ void CLuaBaseEntity::clearGearSetMods()
         for (uint8 i = 0; i < PChar->m_GearSetMods.size(); ++i)
         {
             GearSetMod_t gearSetMod = PChar->m_GearSetMods.at(i);
-            PChar->delModifier(gearSetMod.modId, gearSetMod.modValue);
+            if (gearSetMod.modPet > 0)
+            {
+                PChar->delPetModifier(gearSetMod.modId, PetModType::All, gearSetMod.modValue);
+            } else {
+                PChar->delModifier(gearSetMod.modId, gearSetMod.modValue);
+            }
         }
         PChar->m_GearSetMods.clear();
     }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -238,9 +238,9 @@ public:
 
     int8 getShieldSize(); // Gets shield size of character
 
-    bool hasGearSetMod(uint8 modNameId);                             // Checks if character already has a gear set mod
-    void addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue); // Sets the characters gear set mod
-    void clearGearSetMods();                                         // Clears a characters gear set mods
+    bool hasGearSetMod(uint8 modNameId);                                            // Checks if character already has a gear set mod
+    void addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue, uint8 modPet);  // Sets the characters gear set mod
+    void clearGearSetMods();                                                        // Clears a characters gear set mods
 
     // Storing
     auto  getStorageItem(uint8 container, uint8 slotID, uint8 equipID) -> std::optional<CLuaItem>; // returns item object player:getStorageItem(containerid, slotid, equipslotid)

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -330,15 +330,17 @@ enum class Mod
     REGEN_BONUS      = 989, // Increases the amount of HP restored by Regen
 
     // Black Mage
-    CLEAR_MIND  = 295, // Used in conjunction with HEALMP to increase amount between tics
-    CONSERVE_MP = 296, // Percent chance
+    CLEAR_MIND          = 295,  // Used in conjunction with HEALMP to increase amount between tics
+    CONSERVE_MP         = 296,  // Percent chance
+    AUGMENT_CONSERVE_MP = 1003, // Percent chance
 
     // Red Mage
-    BLINK             = 299, // Tracks blink shadows
-    STONESKIN         = 300, // Tracks stoneskin HP pool
-    PHALANX           = 301, // Tracks direct damage reduction
-    ENF_MAG_POTENCY   = 290, // Increases Enfeebling magic potency %
-    ENHANCES_SABOTEUR = 297, // Increases Saboteur Potency %
+    BLINK             = 299,  // Tracks blink shadows
+    STONESKIN         = 300,  // Tracks stoneskin HP pool
+    PHALANX           = 301,  // Tracks direct damage reduction
+    ENF_MAG_POTENCY   = 290,  // Increases Enfeebling magic potency %
+    ENHANCES_SABOTEUR = 297,  // Increases Saboteur Potency %
+    AUGMENT_COMPOSURE = 1004, // Percent Duration Extension for Others
 
     // Thief
     FLEE_DURATION     = 93,  // Flee duration in seconds
@@ -366,45 +368,48 @@ enum class Mod
     COVER_DURATION         = 967, // Increases Cover Duration
 
     // Dark Knight
-    ARCANE_CIRCLE_DURATION = 858, // Arcane Circle extended duration in seconds
-    SOULEATER_EFFECT       = 96,  // Souleater power in percents
-    DESPERATE_BLOWS        = 906, // Adds ability haste to Last Resort
-    STALWART_SOUL          = 907, // Reduces damage taken from Souleater
-    DREAD_SPIKES_EFFECT    = 998, // Percent increase to total HP drain for Dread Spikes
+    ARCANE_CIRCLE_DURATION = 858,  // Arcane Circle extended duration in seconds
+    SOULEATER_EFFECT       = 96,   // Souleater power in percents
+    DESPERATE_BLOWS        = 906,  // Adds ability haste to Last Resort
+    STALWART_SOUL          = 907,  // Reduces damage taken from Souleater
+    DREAD_SPIKES_EFFECT    = 998,  // Percent increase to total HP drain for Dread Spikes
+    AUGMENT_DAMAGE_HP      = 1005, // Percent chance
 
     // Beastmaster
-    TAME                = 304, // Additional percent chance to charm
-    CHARM_TIME          = 360, // extends the charm time only, no effect of charm chance
-    REWARD_HP_BONUS     = 364, // Percent to add to reward HP healed. (364)
-    CHARM_CHANCE        = 391, // extra chance to charm (light+apollo staff ect)
-    FERAL_HOWL_DURATION = 503, // +20% duration per merit when wearing augmented Monster Jackcoat +2
-    JUG_LEVEL_RANGE     = 564, // Decreases the level range of spawned jug pets. Maxes out at 2.
+    TAME                    = 304,  // Additional percent chance to charm
+    CHARM_TIME              = 360,  // extends the charm time only, no effect of charm chance
+    REWARD_HP_BONUS         = 364,  // Percent to add to reward HP healed. (364)
+    CHARM_CHANCE            = 391,  // extra chance to charm (light+apollo staff ect)
+    FERAL_HOWL_DURATION     = 503,  // +20% duration per merit when wearing augmented Monster Jackcoat +2
+    JUG_LEVEL_RANGE         = 564,  // Decreases the level range of spawned jug pets. Maxes out at 2.
+    AUGMENT_DAMAGE_PET_HP   = 1006, // Percent chance
 
     // Bard
-    MINNE_EFFECT           = 433, //
-    MINUET_EFFECT          = 434, //
-    PAEON_EFFECT           = 435, //
-    REQUIEM_EFFECT         = 436, //
-    THRENODY_EFFECT        = 437, //
-    MADRIGAL_EFFECT        = 438, //
-    MAMBO_EFFECT           = 439, //
-    LULLABY_EFFECT         = 440, //
-    ETUDE_EFFECT           = 441, //
-    BALLAD_EFFECT          = 442, //
-    MARCH_EFFECT           = 443, //
-    FINALE_EFFECT          = 444, //
-    CAROL_EFFECT           = 445, //
-    MAZURKA_EFFECT         = 446, //
-    ELEGY_EFFECT           = 447, //
-    PRELUDE_EFFECT         = 448, //
-    HYMNUS_EFFECT          = 449, //
-    VIRELAI_EFFECT         = 450, //
-    SCHERZO_EFFECT         = 451, //
-    ALL_SONGS_EFFECT       = 452, //
-    MAXIMUM_SONGS_BONUS    = 453, //
-    SONG_DURATION_BONUS    = 454, //
-    SONG_SPELLCASTING_TIME = 455, //
-    SONG_RECAST_DELAY      = 833, // Reduces song recast time in seconds.
+    MINNE_EFFECT           = 433,  //
+    MINUET_EFFECT          = 434,  //
+    PAEON_EFFECT           = 435,  //
+    REQUIEM_EFFECT         = 436,  //
+    THRENODY_EFFECT        = 437,  //
+    MADRIGAL_EFFECT        = 438,  //
+    MAMBO_EFFECT           = 439,  //
+    LULLABY_EFFECT         = 440,  //
+    ETUDE_EFFECT           = 441,  //
+    BALLAD_EFFECT          = 442,  //
+    MARCH_EFFECT           = 443,  //
+    FINALE_EFFECT          = 444,  //
+    CAROL_EFFECT           = 445,  //
+    MAZURKA_EFFECT         = 446,  //
+    ELEGY_EFFECT           = 447,  //
+    PRELUDE_EFFECT         = 448,  //
+    HYMNUS_EFFECT          = 449,  //
+    VIRELAI_EFFECT         = 450,  //
+    SCHERZO_EFFECT         = 451,  //
+    ALL_SONGS_EFFECT       = 452,  //
+    MAXIMUM_SONGS_BONUS    = 453,  //
+    SONG_DURATION_BONUS    = 454,  //
+    SONG_SPELLCASTING_TIME = 455,  //
+    SONG_RECAST_DELAY      = 833,  // Reduces song recast time in seconds.
+    AUGMENT_SONG_STAT      = 1007, // Bonus to Stat of Element of Enhancing Song.
 
     // Ranger
     CAMOUFLAGE_DURATION     = 98,  // Camouflage duration in percents
@@ -446,19 +451,21 @@ enum class Mod
     WYVERN_BREATH_MACC         = 986, // Increases accuracy of wyvern's breath. adds 10 magic accuracy per merit to the trait Strafe
 
     // Summoner
-    AVATAR_PERPETUATION       = 371, // stores base cost of current avatar
-    WEATHER_REDUCTION         = 372, // stores perpetuation reduction depending on weather
-    DAY_REDUCTION             = 373, // stores perpetuation reduction depending on day
-    PERPETUATION_REDUCTION    = 346, // stores the MP/tick reduction from gear
-    BP_DELAY                  = 357, // stores blood pact delay reduction
-    ENHANCES_ELEMENTAL_SIPHON = 540, // Bonus Base MP added to Elemental Siphon skill.
-    BP_DELAY_II               = 541, // Blood Pact Delay Reduction II
-    BP_DAMAGE                 = 126, // Blood Pact: Rage Damage increase percentage
-    BLOOD_BOON                = 913, // Occasionally cuts down MP cost of Blood Pact abilities. Does not affect abilities that require Astral Flow.
+    AVATAR_PERPETUATION       = 371,  // stores base cost of current avatar
+    WEATHER_REDUCTION         = 372,  // stores perpetuation reduction depending on weather
+    DAY_REDUCTION             = 373,  // stores perpetuation reduction depending on day
+    PERPETUATION_REDUCTION    = 346,  // stores the MP/tick reduction from gear
+    BP_DELAY                  = 357,  // stores blood pact delay reduction
+    ENHANCES_ELEMENTAL_SIPHON = 540,  // Bonus Base MP added to Elemental Siphon skill.
+    BP_DELAY_II               = 541,  // Blood Pact Delay Reduction II
+    BP_DAMAGE                 = 126,  // Blood Pact: Rage Damage increase percentage
+    BLOOD_BOON                = 913,  // Occasionally cuts down MP cost of Blood Pact abilities. Does not affect abilities that require Astral Flow.
+    AUGMENT_BLOOD_BOON        = 1008, // Percent chance
 
     // Blue Mage
-    BLUE_POINTS       = 309, // Tracks extra blue points
-    BLUE_LEARN_CHANCE = 945, // Additional chance to learn blue magic
+    BLUE_POINTS       = 309,  // Tracks extra blue points
+    BLUE_LEARN_CHANCE = 945,  // Additional chance to learn blue magic
+    AUGMENT_BLU_MAGIC = 1010, // Percent Chance for BLU Magic to receive 3x WSC value for spell.
 
     // Corsair
     EXP_BONUS        = 382, //
@@ -560,14 +567,15 @@ enum class Mod
     GRIMOIRE_SPELLCASTING    = 489, // "Grimoire: Reduces spellcasting time" bonus
 
     // Geo
-    CARDINAL_CHANT       = 959,
-    INDI_DURATION        = 960,
-    GEOMANCY             = 961,
-    WIDENED_COMPASS      = 962,
-    MENDING_HALATION     = 968,
-    RADIAL_ARCANA        = 969,
-    CURATIVE_RECANTATION = 970,
-    PRIMEVAL_ZEAL        = 971,
+    CARDINAL_CHANT         = 959,
+    INDI_DURATION          = 960,
+    GEOMANCY               = 961,
+    WIDENED_COMPASS        = 962,
+    MENDING_HALATION       = 968,
+    RADIAL_ARCANA          = 969,
+    CURATIVE_RECANTATION   = 970,
+    PRIMEVAL_ZEAL          = 971,
+    GEOMANCY_MP_NO_DEPLETE = 1009, // Percent chance
 
     ENSPELL           = 341, // stores the type of enspell active (0 if nothing)
     ENSPELL_DMG       = 343, // stores the base damage of the enspell before reductions
@@ -842,7 +850,7 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 1003,
+    // SPARE = 1011,
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4252,10 +4252,10 @@ namespace battleutils
     }
 
     /************************************************************************
-     *                                                                       *
-     *   Process Damage Occasionally Varies with HP                          *
-     *                                                                       *
-     ************************************************************************/
+    *                                                                       *
+    *   Process Damage Occasionally Varies with HP                          *
+    *                                                                       *
+    ************************************************************************/
 
     uint16 doDamageOccVariesWithHP(CCharEntity* m_PChar, uint32 damage)
     {
@@ -4268,10 +4268,10 @@ namespace battleutils
     }
 
     /************************************************************************
-     *                                                                       *
-     *   Process Damage Occasionally Varies with Pet HP                      *
-     *                                                                       *
-     ************************************************************************/
+    *                                                                       *
+    *   Process Damage Occasionally Varies with Pet HP                      *
+    *                                                                       *
+    ************************************************************************/
 
     uint16 doDamageOccVariesWithPetHP(CCharEntity* m_PChar, uint32 damage)
     {
@@ -4287,10 +4287,10 @@ namespace battleutils
     }
 
     /************************************************************************
-     *                                                                       *
-     *   get barrage shot count                                              *
-     *                                                                       *
-     ************************************************************************/
+    *                                                                       *
+    *   get barrage shot count                                              *
+    *                                                                       *
+    ************************************************************************/
 
     uint8 getBarrageShotCount(CCharEntity* PChar)
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4276,9 +4276,12 @@ namespace battleutils
     uint16 doDamageOccVariesWithPetHP(CCharEntity* m_PChar, uint32 damage)
     {
         // Damage Occasionally Varies with Pet's HP (e.g. PUP/DRG/BST AF3)
-        if (m_PChar->getMod(Mod::AUGMENT_DAMAGE_PET_HP) > xirand::GetRandomNumber(0, 99))
+        if (m_PChar->PPet != nullptr)
         {
-            damage = damage * ((( (m_PChar->PPet->health.hp / m_PChar->PPet->health.maxhp) * 100) + 100) / 100.00f);
+            if (m_PChar->getMod(Mod::AUGMENT_DAMAGE_PET_HP) > xirand::GetRandomNumber(0, 99))
+            {
+                damage = damage * ((( (m_PChar->PPet->health.hp / m_PChar->PPet->health.maxhp) * 100) + 100) / 100.00f);
+            }
         }
         return damage;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4253,6 +4253,38 @@ namespace battleutils
 
     /************************************************************************
      *                                                                       *
+     *   Process Damage Occasionally Varies with HP                          *
+     *                                                                       *
+     ************************************************************************/
+
+    uint16 doDamageOccVariesWithHP(CCharEntity* m_PChar, uint32 damage)
+    {
+        // Damage Occasionally Varies with HP (e.g. DRK AF3)
+        if (m_PChar->getMod(Mod::AUGMENT_DAMAGE_HP) > xirand::GetRandomNumber(0, 99))
+        {
+            damage = damage * ((( (m_PChar->health.hp / m_PChar->health.maxhp) * 100) + 100) / 100.00f);
+        }
+        return damage;
+    }
+
+    /************************************************************************
+     *                                                                       *
+     *   Process Damage Occasionally Varies with Pet HP                      *
+     *                                                                       *
+     ************************************************************************/
+
+    uint16 doDamageOccVariesWithPetHP(CCharEntity* m_PChar, uint32 damage)
+    {
+        // Damage Occasionally Varies with Pet's HP (e.g. PUP/DRG/BST AF3)
+        if (m_PChar->getMod(Mod::AUGMENT_DAMAGE_PET_HP) > xirand::GetRandomNumber(0, 99))
+        {
+            damage = damage * ((( (m_PChar->PPet->health.hp / m_PChar->PPet->health.maxhp) * 100) + 100) / 100.00f);
+        }
+        return damage;
+    }
+
+    /************************************************************************
+     *                                                                       *
      *   get barrage shot count                                              *
      *                                                                       *
      ************************************************************************/

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -193,6 +193,9 @@ namespace battleutils
     int32  getOverWhelmDamageBonus(CCharEntity* m_PChar, CBattleEntity* PDefender, int32 damage);
     uint16 jumpAbility(CBattleEntity* PAttacker, CBattleEntity* PVictim, uint8 tier);
 
+    uint16 doDamageOccVariesWithHP(CCharEntity* m_PChar, uint32 damage);
+    uint16 doDamageOccVariesWithPetHP(CCharEntity* m_PChar, uint32 damage);
+
     void  TransferEnmity(CBattleEntity* PHateReceiver, CBattleEntity* PHateGiver, CMobEntity* PMob, uint8 percentToTransfer);
     uint8 getBarrageShotCount(CCharEntity* PChar);
     uint8 getStoreTPbonusFromMerit(CBattleEntity* PEntity);


### PR DESCRIPTION
This update brings gear_sets up to date with all gear sets currently in the game as of September 2021, including a number of lower tier sets that were missing as well as all AF3 90/109/119 sets.
Arbitrarily reorders/renumbers the set ids in Gearsets starting from lowest level armor set and moving upwards.
This serves little purpose other than to help me identify which sets were missing as I added them in.
Updated and lined up comments where possible.
Moved Jailer weapons to the end of the stack.
Updated Gearset logic to apply buffs to pets (Breeders set and SMN AF1 119 +2/+3 currently).
addGearSetMod() now expects a 0 for standard sets and a 1 for petmod sets (see examples in `doSpecialHandling` and `addGearSetMod`)
Updated Gearset logic to rename `cappedTierSets` to the more aptly named `specialHandlingSets`.
Updated Gearset logic to standardize AF3 set bonuses where possible, and manually defined the outliers.
Added in missing `specialHandlingSets` and ensured that migrated sets matched their new id after refactor.
Wired up `AUGMENT_BLU_MAGIC` in bluemagic.lua.
Created new MODs for missing Empyrean Gear Sets:

Implemented with logic:
AUGMENT_DAMAGE_HP
AUGMENT_DAMAGE_PET_HP
AUGMENT_SONG_STAT*
AUGMENT_BLU_MAGIC

Place Holders: --TODO
AUGMENT_CONSERVE_MP
AUGMENT_BLOOD_BOON
AUGMENT_COMPOSURE
GEOMANCY_MP_NO_DEPLETE

*Regarding AUGMENT_SONG_STAT, due to the way that songs are applied, this is implemented in three different ways (depending on the existing song script):

1. The Lions share have the AUGMENT_SONG_STAT value passed as subPower in the song, and applied in the effect.
2. For etude, subpower is in use. The value is passed instead via power (elements of songs match the stat buff) and the etude effect, remaining unchanged, applies the bonus within the power.
3. For carol, subpower is also in use. The `AUGMENT_SONG_STAT` value is multiplied by 100, added to the element value, then deconstructed in the effect. This ensures that the buff and the base value can be cleanly separated and applied. Details and logic are commented in the effect.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
