### PR TITLE
[fix] Only remove pets or mobs from the ally list if they're in the ally list

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -519,15 +519,22 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             // allies targid >= 0x700
             if (PEntity->targid >= 0x700)
             {
-                if (static_cast<CPetEntity*>(PEntity)->isAlive() && PEntity->PAI->IsSpawned())
+                if (auto* PPetEntity = dynamic_cast<CPetEntity*>(PEntity))
                 {
-                    static_cast<CPetEntity*>(PEntity)->Die();
+                    if (PPetEntity->isAlive() && PPetEntity->PAI->IsSpawned())
+                    {
+                        PPetEntity->Die();
+                    }
                 }
 
-                if (!m_AllyList.empty())
+                if (auto* PMobEntity = dynamic_cast<CMobEntity*>(PEntity))
                 {
-                    m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
+                    if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
+                    {
+                        m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
+                    }
                 }
+                
                 PEntity->status = STATUS_TYPE::DISAPPEAR;
                 return found;
             }


### PR DESCRIPTION
Closes: https://github.com/LandSandBoat/server/issues/652

Crash:
```
[09/15/21 23:48:19:543][topaz_game_64.exe][critical][stacktrace] 	at CBattlefield::RemoveEntity in C:\server-new\src\map\battlefield.cpp: line: 529: address: 0x7FF6ADF0DC90
```

Crashy code:
```cpp
                if (!m_AllyList.empty())
                {
                    m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                }
```

If there is **ANYTHING** in the AllyList - try to remove **ME** from the AllyList.
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞 ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
