### PR TITLE
Misc minor fixes

### DIFF
--- a/scripts/zones/Dynamis-Buburimu/mobs/Vanguard_Constable.lua
+++ b/scripts/zones/Dynamis-Buburimu/mobs/Vanguard_Constable.lua
@@ -16,7 +16,7 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.GIBHE_FLESHEATER_PH, 10, 1200) -- 20 minutes
+    xi.mob.phOnDespawn(mob, ID.mob.GIBHE_FLESHFEASTER_PH, 10, 1200) -- 20 minutes
 end
 
 return entity

--- a/scripts/zones/Riverne-Site_A01/mobs/Carmine_Dobsonfly.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Carmine_Dobsonfly.lua
@@ -40,7 +40,7 @@ entity.onMobDespawn = function(mob)
             GetMobByID(i):setRespawnTime(respawnTime)
         end
     -- else
-    --    DisallowRespawn(mobID, true)
+    --    DisallowRespawn(mob:getID(), true)
     end
 end
 

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -640,9 +640,6 @@ namespace mobutils
                 PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 60);
                 PMob->defaultMobMod(MOBMOD_MAGIC_DELAY, 10);
                 break;
-            case JOB_BLU:
-                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
-                break;
             case JOB_RDM:
                 PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
                 PMob->defaultMobMod(MOBMOD_GA_CHANCE, 15);
@@ -658,6 +655,18 @@ namespace mobutils
                 PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
                 PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 20);
                 PMob->defaultMobMod(MOBMOD_MAGIC_DELAY, 7);
+                break;
+            case JOB_BLU:
+                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
+                break;
+            case JOB_SCH:
+                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
+                break;
+            case JOB_GEO:
+                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
+                break;
+            case JOB_RUN:
+                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
                 break;
             default:
                 break;

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -604,11 +604,11 @@ namespace mobutils
         JOBTYPE sJob = PMob->GetSJob();
         JOBTYPE job;
 
-        if (grade::GetJobGrade(mJob, 1) > 0) // check if mainjob gives mp
+        if (grade::GetJobGrade(mJob, 1) > 0 || mJob == JOB_NIN) // check if mainjob gives mp or is NIN
         {
             job = mJob;
         }
-        else // if mainjob had no MP, use subjob in switch cases.
+        else // if mainjob had no MP (and isn't NIN), use subjob in switch cases.
         {
             job = sJob;
         }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

1. there was a typo in a dynamis mob so its NM could never spawn
2. its commented out but mobid was used without being defined, and shoudl have been mob:getID() in that specific case
3. we had a situation where ninja mobs might not have a casting cooldown set, which made a few NMs complain about having magic but no cooldown set unless their subjob was also a caster. Woopsie.
4. We had 3 caster jobs that didn't have a cooldown entry at all, so later if/when we add mobs for them we would have gotten log spam. 

Jus' doin my part to silence log noise _tips hat_