### PR TITLE
[CI] Add client version string to HeadlessXI constructor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
           python3 << EOF
           import time
           from headlessxi import HXIClient
-          hxi_client = HXIClient('admin', 'admin', 'localhost')
+          hxi_client = HXIClient('admin', 'admin', 'localhost', 1, '30210904_1')
           hxi_client.login()
           print('Sleeping 30s')
           time.sleep(30)


### PR DESCRIPTION
I'm not gonna be back at a full development environment for a little while, but I've made the client version for headless xi configurable:
https://github.com/zach2good/HeadlessXI/commit/4911bee991125141558bf220432500ea599c23e3

This updates the CI to use that. Next stage would be scraping the client string out of the default conf file

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
