### PR TITLE
Luacheck: Matrimonial Coffer Global

### DIFF
--- a/scripts/globals/matrimonialcoffer.lua
+++ b/scripts/globals/matrimonialcoffer.lua
@@ -20,35 +20,53 @@ function xi.matrimonialcoffer.finishEvent(player, csid, option)
     local zone = player:getZoneID()
     local ID = zones[zone]
     local playerGender = player:getGender()
-    if playerGender == 1 and csid == 2000 then
-        if option == 1 and player:getGil() >= 200000 and
-        (not player:hasItem(xi.items.BENEDIGHT_HOSE) or not player:hasItem(xi.items.BENEDIGHT_COAT)) then
-            if npcUtil.giveItem(player, {xi.items.BENEDIGHT_HOSE, xi.items.BENEDIGHT_COAT}) then
-                player:delGil(200000)
+
+    if csid == 2000 then
+        if playerGender == 1 then
+            if option == 1 then
+                if
+                    player:getGil() >= 200000 and
+                    (not player:findItem(xi.items.BENEDIGHT_HOSE) or not player:findItem(xi.items.BENEDIGHT_COAT))
+                then
+                    if npcUtil.giveItem(player, { xi.items.BENEDIGHT_HOSE, xi.items.BENEDIGHT_COAT }) then
+                        player:delGil(200000)
+                    end
+                elseif player:getGil() < 200000 then
+                    player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
+                end
+            elseif option == 2 then
+                if player:getGil() >= 100000 then
+                    if npcUtil.giveItem(player, {xi.items.MATRIMONY_BAND}) then
+                        player:delGil(100000)
+                    end
+                else
+                    player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
+                end
             end
-        elseif option == 1 and player:getGil() < 200000 then
-            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
-        elseif option == 2 and player:getGil() >= 100000 then
-            if npcUtil.giveItem(player, {xi.items.MATRIMONY_BAND}) then
-                player:delGil(100000)
+        elseif playerGender == 0 then
+            if option == 1 then
+                if
+                    player:getGil() >= 400000 and
+                    (not player:findItem(xi.items.BRIDAL_CORSAGE) or
+                    not player:findItem(xi.items.WEDDING_DRESS) or
+                    not player:findItem(xi.items.WEDDING_HOSE) or
+                    not player:findItem(xi.items.WEDDING_BOOTS))
+                then
+                    if npcUtil.giveItem(player, { xi.items.BRIDAL_CORSAGE, xi.items.WEDDING_DRESS, xi.items.WEDDING_HOSE, xi.items.WEDDING_BOOTS }) then
+                        player:delGil(400000)
+                    end
+                elseif player:getGil() < 400000 then
+                    player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
+                end
+            elseif option == 2 then
+                if player:getGil() >= 80000 then
+                    if npcUtil.giveItem(player, xi.items.MATRIMONY_RING) then
+                        player:delGil(80000)
+                    end
+                elseif player:getGil() < 80000 then
+                    player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
+                end
             end
-        elseif option == 2 and player:getGil() < 100000 then
-            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
-        end
-    elseif playerGender == 0 and csid == 2000 then
-        if option == 1 and player:getGil() >= 400000 and (not player:hasItem(xi.items.BRIDAL_CORSAGE) or
-            not player:hasItem(xi.items.WEDDING_DRESS) or not player:hasItem(xi.items.WEDDING_HOSE) or not player:hasItem(xi.items.WEDDING_BOOTS)) then
-            if npcUtil.giveItem(player, {xi.items.BRIDAL_CORSAGE, xi.items.WEDDING_DRESS, xi.items.WEDDING_HOSE, xi.items.WEDDING_BOOTS}) then
-                player:delGil(400000)
-            end
-        elseif option == 1 and player:getGil() < 400000 then
-            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
-        elseif option == 2 and player:getGil() >= 80000 then
-            if npcUtil.giveItem(player, {xi.items.MATRIMONY_RING}) then
-                player:delGil(80000)
-            end
-        elseif option == 2 and player:getGil() < 80000 then
-            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
         end
     end
 end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

No fancy tables with this one yet, just breaks out conditionals a bit and formats to style guide.