### PR TITLE
Fix require in Heavens Tower for Celebratory Chest

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Celebratory_Chest.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Celebratory_Chest.lua
@@ -4,7 +4,7 @@
 -- Type: Merchant NPC
 -- !pos -7.600 0.249 25.239 242
 -----------------------------------
-local ID = require("scripts/zones/Windurst_Walls/IDs")
+local ID = require("scripts/zones/Heavens_Tower/IDs")
 require("scripts/globals/shop")
 -----------------------------------
 local entity = {}


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Change require to match zone