### PR TITLE
[Interaction] [Fix] A Pose by Any Other Name / Angelica

### DIFF
--- a/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
+++ b/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
@@ -11,6 +11,32 @@ require('scripts/globals/titles')
 
 local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
 
+local poseItems =
+{
+    [xi.job.WAR] = xi.items.BRONZE_HARNESS,
+    [xi.job.MNK] = xi.items.ROBE,
+    [xi.job.WHM] = xi.items.TUNIC,
+    [xi.job.BLM] = xi.items.TUNIC,
+    [xi.job.RDM] = xi.items.TUNIC,
+    [xi.job.THF] = xi.items.LEATHER_VEST,
+    [xi.job.PLD] = xi.items.BRONZE_HARNESS,
+    [xi.job.DRK] = xi.items.BRONZE_HARNESS,
+    [xi.job.BST] = xi.items.LEATHER_VEST,
+    [xi.job.BRD] = xi.items.ROBE,
+    [xi.job.RNG] = xi.items.LEATHER_VEST,
+    [xi.job.SAM] = xi.items.KENPOGI,
+    [xi.job.NIN] = xi.items.KENPOGI,
+    [xi.job.DRG] = xi.items.BRONZE_HARNESS,
+    [xi.job.SMN] = xi.items.TUNIC,
+    [xi.job.BLU] = xi.items.ROBE,
+    [xi.job.COR] = xi.items.BRONZE_HARNESS,
+    [xi.job.PUP] = xi.items.TUNIC,
+    [xi.job.DNC] = xi.items.LEATHER_VEST,
+    [xi.job.SCH] = xi.items.TUNIC,
+    [xi.job.GEO] = xi.items.TUNIC,
+    [xi.job.RUN] = xi.items.BRONZE_HARNESS,
+}
+
 quest.reward =
 {
     fame = 75,
@@ -32,15 +58,37 @@ quest.sections =
             ['Angelica'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(90)
+                    local desiredBody = poseItems[player:getMainJob()]
+                    local currentBody = player:getEquipID(xi.slot.BODY)
+                    if currentBody ~= desiredBody then
+                        if quest:getVar(player, 'Prog') == 1 then
+                            return quest:progressEvent(90)
+                        else
+                            return quest:progressEvent(87)
+                        end
+                    else
+                        -- default dialogs
+                        local rand = math.random(1, 3)
+                        if rand == 1 then
+                            player:startEvent(86)
+                        elseif rand == 2 then
+                            player:startEvent(88)
+                        else
+                            player:startEvent(89)
+                        end
+                    end
                 end
             },
 
             onEventFinish =
             {
+                [87] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
                 [90] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:begin(player)
+                        quest:setVar(player, 'Prog', 0)
                     end
                 end,
             },
@@ -58,25 +106,12 @@ quest.sections =
             ['Angelica'] =
             {
                 onTrigger = function(player, npc)
-                    local gear = 0
-                    local mjob = player:getMainJob()
-
-                    if mjob == xi.job.WAR or mjob == xi.job.PLD or mjob == xi.job.DRK or mjob == xi.job.DRG or mjob == xi.job.COR then
-                        gear = xi.items.BRONZE_HARNESS
-                    elseif mjob == xi.job.MNK or mjob == xi.job.BRD or mjob == xi.job.BLU then
-                        gear = xi.items.ROBE
-                    elseif mjob == xi.job.THF or mjob == xi.job.BST or mjob == xi.job.RNG or mjob == xi.job.DNC then
-                        gear = xi.items.LEATHER_VEST
-                    elseif mjob == xi.job.WHM or mjob == xi.job.BLM or mjob == xi.job.SMN or mjob == xi.job.PUP or mjob == xi.job.SCH or mjob == xi.job.RDM then
-                        gear = xi.items.TUNIC
-                    elseif mjob == xi.job.SAM or mjob == xi.job.NIN then
-                        gear = xi.items.KENPOGI
-                    end
+                    local desiredBody = poseItems[player:getMainJob()]
 
                     quest:setVar(player, 'Stage', os.time() + 300)
-                    quest:setVar(player, 'Prog', gear)
+                    quest:setVar(player, 'Prog', desiredBody)
 
-                    return quest:progressEvent(92, {[2] = gear})
+                    return quest:progressEvent(92, {[2] = desiredBody})
                 end,
             },
         },
@@ -107,15 +142,32 @@ quest.sections =
 
             onEventFinish =
             {
-                [96] = function(player, csid, option, npc)
+                [96] = function(player, csid, option, npc) -- Quest completed
                     quest:complete(player)
                 end,
-                [102] = function(player, csid, option, npc)
+                [102] = function(player, csid, option, npc) -- Quest failed
                     player:delQuest(WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
-                    quest:setVar(player, 'Prog', 0)
+                    quest:setVar(player, 'Prog', 0) -- TODO: Confirm that initial CS has to be repeated aswell upon quest failure. If not, set var to 1 here.
                     quest:setVar(player, 'Stage', 0)
                     player:addTitle(xi.title.LOWER_THAN_THE_LOWEST_TUNNEL_WORM)
                     player:needToZone(true)
+                end,
+            },
+        },
+    },
+
+    -- Section: Quest Completed
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Angelica'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(101):replaceDefault()
                 end,
             },
         },

--- a/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
+++ b/scripts/quests/windurst/A_Pose_by_Any_Other_Name.lua
@@ -106,12 +106,12 @@ quest.sections =
             ['Angelica'] =
             {
                 onTrigger = function(player, npc)
-                    local desiredBody = poseItems[player:getMainJob()]
+                    local requestedBody = poseItems[player:getMainJob()]
 
                     quest:setVar(player, 'Stage', os.time() + 300)
-                    quest:setVar(player, 'Prog', desiredBody)
+                    quest:setVar(player, 'Prog', requestedBody)
 
-                    return quest:progressEvent(92, {[2] = desiredBody})
+                    return quest:progressEvent(92, 0, 0, 0, requestedBody)
                 end,
             },
         },
@@ -128,13 +128,14 @@ quest.sections =
             ['Angelica'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Stage') >= os.time() then
-                        if player:getEquipID(xi.slot.BODY) == quest:getVar(player, 'Prog') then
+                    local requestedBody = quest:getVar(player, 'Prog')
+                    if quest:getVar(player, 'Stage') >= os.time() then -- Under time. Quest completed.
+                        if player:getEquipID(xi.slot.BODY) == requestedBody then
                             return quest:progressEvent(96)
                         else
-                            return quest:progressEvent(93, {[2] = quest:getVar(player, 'Prog')})
+                            return quest:progressEvent(93, 0, 0, 0, requestedBody)
                         end
-                    else
+                    else -- Over time. Quest failed.
                         return quest:progressEvent(102)
                     end
                 end,
@@ -145,7 +146,7 @@ quest.sections =
                 [96] = function(player, csid, option, npc) -- Quest completed
                     quest:complete(player)
                 end,
-                [102] = function(player, csid, option, npc) -- Quest failed
+                [102] = function(player, csid, option, npc) -- Quest failed.
                     player:delQuest(WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
                     quest:setVar(player, 'Prog', 0) -- TODO: Confirm that initial CS has to be repeated aswell upon quest failure. If not, set var to 1 here.
                     quest:setVar(player, 'Stage', 0)

--- a/scripts/zones/Windurst_Waters/npcs/Angelica.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Angelica.lua
@@ -4,123 +4,18 @@
 -- Starts and Finished Quest: A Pose By Any Other Name
 -- !pos -70 -10 -6 238
 -----------------------------------
-require("scripts/globals/keyitems")
-require("scripts/globals/npc_util")
-require("scripts/globals/quests")
-require("scripts/globals/status")
-require("scripts/globals/titles")
------------------------------------
 local entity = {}
-
-local poseItems =
-{
-    [xi.job.WAR] = 12576,
-    [xi.job.MNK] = 12600,
-    [xi.job.WHM] = 12608,
-    [xi.job.BLM] = 12608,
-    [xi.job.RDM] = 12608,
-    [xi.job.THF] = 12568,
-    [xi.job.PLD] = 12576,
-    [xi.job.DRK] = 12576,
-    [xi.job.BST] = 12568,
-    [xi.job.BRD] = 12600,
-    [xi.job.RNG] = 12568,
-    [xi.job.SAM] = 12584,
-    [xi.job.NIN] = 12584,
-    [xi.job.DRG] = 12576,
-    [xi.job.SMN] = 12608,
-    [xi.job.BLU] = 12600,
-    [xi.job.COR] = 12576,
-    [xi.job.PUP] = 12608,
-    [xi.job.DNC] = 12568,
-    [xi.job.SCH] = 12608,
-    [xi.job.GEO] = 12608,
-    [xi.job.RUN] = 12576,
-}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local aPose = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
-    local aPoseProg = player:getCharVar("QuestAPoseByOtherName_prog")
-    local desiredBody = poseItems[player:getMainJob()]
-    local currentBody = player:getEquipID(xi.slot.BODY)
-
-    -- pre-quest CS
-    if aPose == QUEST_AVAILABLE and aPoseProg == 0 and not player:needToZone() and currentBody ~= desiredBody then
-        player:startEvent(87) -- pre-quest CS
-
-    -- start quest
-    elseif aPose == QUEST_AVAILABLE and aPoseProg == 1 and currentBody ~= desiredBody then
-        player:startEvent(92, 0, 0, 0, desiredBody)
-
-    -- check in during quest
-    elseif aPose == QUEST_ACCEPTED then
-        local starttime = player:getCharVar("QuestAPoseByOtherName_time")
-        if os.time() - starttime < 600 then -- took less than 10 minutes
-            if currentBody == player:getCharVar("QuestAPoseByOtherName_equip") then
-                player:startEvent(96) -- complete quest
-            else
-                player:startEvent(93, 0, desiredBody, 0, player:getCharVar("QuestAPoseByOtherName_equip")) -- reminder
-            end
-        else
-            player:startEvent(102) -- fail quest
-        end
-
-    -- post-quest dialog
-    elseif aPose == QUEST_COMPLETED and player:needToZone() then
-        player:startEvent(101)
-
-    -- default dialogs
-    else
-        local rand = math.random(1, 3)
-        if rand == 1 then
-            player:startEvent(86)
-        elseif rand == 2 then
-            player:startEvent(88)
-        else
-            player:startEvent(89)
-        end
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- pre-quest CS
-    if csid == 87 then
-        player:setCharVar("QuestAPoseByOtherName_prog", 1)
-
-    -- start quest
-    elseif csid == 92 then
-        local desiredBody = poseItems[player:getMainJob()]
-
-        player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
-        player:setCharVar("QuestAPoseByOtherName_time", os.time())
-        player:setCharVar("QuestAPoseByOtherName_prog", 2)
-        player:setCharVar("QuestAPoseByOtherName_equip", desiredBody)
-
-    -- complete quest
-    elseif csid == 96 and npcUtil.completeQuest(player, WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME, {
-        item = 206, -- copy_of_ancient_blood
-        ki = xi.ki.ANGELICAS_AUTOGRAPH,
-        fame = 75,
-        title = xi.title.SUPER_MODEL,
-        var = {"QuestAPoseByOtherName_time", "QuestAPoseByOtherName_equip", "QuestAPoseByOtherName_prog"},
-    }) then
-        player:needToZone(true)
-
-    -- fail quest
-    elseif csid == 102 then
-        player:delQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_POSE_BY_ANY_OTHER_NAME)
-        player:addTitle(xi.title.LOWER_THAN_THE_LOWEST_TUNNEL_WORM)
-        player:setCharVar("QuestAPoseByOtherName_time", 0)
-        player:setCharVar("QuestAPoseByOtherName_equip", 0)
-        player:setCharVar("QuestAPoseByOtherName_prog", 0)
-        player:needToZone(true)
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Clean Angelica script.
Add missing bits to quest script and change logic a little, to use a table.

Closes #755 