### PR TITLE
fix caster and target mixups in doBoostGain()

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -310,9 +310,8 @@ end
 function doBoostGain(caster, target, spell, effect)
     local duration = calculateDuration(300, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-    --calculate potency
+    -- calculate potency
     local magicskill = caster:getSkillLevel(spell:getSkillType())
-
     local potency = math.floor((magicskill - 300) / 10) + 5
 
     if potency > 25 then
@@ -321,9 +320,9 @@ function doBoostGain(caster, target, spell, effect)
         potency = 5
     end
 
-    --printf("BOOST-GAIN: POTENCY = %d", potency)
+    -- printf("BOOST-GAIN: POTENCY = %d", potency)
 
-    --Only one Boost Effect can be active at once, so if the player has any we have to cancel & overwrite
+    -- Only one Boost Effect can be active at once, so if the player has any we have to cancel & overwrite
     local effectOverwrite =
     {
         xi.effect.STR_BOOST,
@@ -336,9 +335,9 @@ function doBoostGain(caster, target, spell, effect)
     }
 
     for i, effectValue in ipairs(effectOverwrite) do
-        --printf("BOOST-GAIN: CHECKING FOR EFFECT %d...", effect)
+        -- printf("BOOST-GAIN: CHECKING FOR EFFECT %d...", effect)
         if target:hasStatusEffect(effectValue) then
-            --printf("BOOST-GAIN: HAS EFFECT %d, DELETING...", effect)
+            -- printf("BOOST-GAIN: HAS EFFECT %d, DELETING...", effect)
             target:delStatusEffect(effectValue)
         end
     end

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -311,7 +311,7 @@ function doBoostGain(caster, target, spell, effect)
     local duration = calculateDuration(300, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
     --calculate potency
-    local magicskill = target:getSkillLevel(spell:getSkillType())
+    local magicskill = caster:getSkillLevel(spell:getSkillType())
 
     local potency = math.floor((magicskill - 300) / 10) + 5
 
@@ -336,11 +336,11 @@ function doBoostGain(caster, target, spell, effect)
     }
 
     for i, effectValue in ipairs(effectOverwrite) do
-            --printf("BOOST-GAIN: CHECKING FOR EFFECT %d...", effect)
-            if caster:hasStatusEffect(effectValue) then
-                --printf("BOOST-GAIN: HAS EFFECT %d, DELETING...", effect)
-                caster:delStatusEffect(effectValue)
-            end
+        --printf("BOOST-GAIN: CHECKING FOR EFFECT %d...", effect)
+        if target:hasStatusEffect(effectValue) then
+            --printf("BOOST-GAIN: HAS EFFECT %d, DELETING...", effect)
+            target:delStatusEffect(effectValue)
+        end
     end
 
     if target:addStatusEffect(effect, potency, 0, duration) then


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**made @Heepster03 test my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

it was getting the targets skill instead of the caster, then removing only the casters status and not the party members in aoe version (whm "boost" is aoe, rdm "gain" is self target)