### PR TITLE
[core] Refactor charutils::AvatarPerpetuationReduction

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5149,8 +5149,8 @@ namespace charutils
         ELEMENT dayElement       = battleutils::GetDayElement();
         WEATHER weather          = battleutils::GetWeather(PChar, false);
         int16   perpReduction    = PChar->getMod(Mod::PERPETUATION_REDUCTION);
-        int16   dayReduction     = PChar->getMod(Mod::DAY_REDUCTION);
-        int16   weatherReduction = PChar->getMod(Mod::WEATHER_REDUCTION);
+        int16   dayReduction     = PChar->getMod(Mod::DAY_REDUCTION); // As seen on Summoner's Doublet (Depending On Day: Avatar perpetuation cost -3) etc.
+        int16   weatherReduction = PChar->getMod(Mod::WEATHER_REDUCTION); // As seen on Summoner's Horn (Weather: Avatar perpetuation cost -3) etc.
 
         static const Mod strong[8] = { Mod::FIRE_AFFINITY_PERP, Mod::ICE_AFFINITY_PERP, Mod::WIND_AFFINITY_PERP, Mod::EARTH_AFFINITY_PERP,
                                        Mod::THUNDER_AFFINITY_PERP, Mod::WATER_AFFINITY_PERP, Mod::LIGHT_AFFINITY_PERP, Mod::DARK_AFFINITY_PERP };
@@ -5167,6 +5167,7 @@ namespace charutils
             perpReduction += dayReduction;
         }
 
+        // TODO: #793 Whats the deal with the +1 to weather result here?
         if (weather == weatherStrong[petElementIdx] || weather == weatherStrong[petElementIdx] + 1)
         {
             perpReduction += weatherReduction;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5136,13 +5136,21 @@ namespace charutils
 
     uint16 AvatarPerpetuationReduction(CCharEntity* PChar)
     {
-        auto*   PPet           = static_cast<CPetEntity*>(PChar->PPet);
-        ELEMENT petElement     = static_cast<ELEMENT>(PPet->m_Element) - 1;
-        ELEMENT dayElement     = battleutils::GetDayElement();
-        WEATHER weather        = battleutils::GetWeather(PChar, false);
-        int16 perpReduction    = PChar->getMod(Mod::PERPETUATION_REDUCTION);
-        int16 dayReduction     = PChar->getMod(Mod::DAY_REDUCTION);
-        int16 weatherReduction = PChar->getMod(Mod::WEATHER_REDUCTION);
+        // REMEMBER:
+        // Elements start at 0 and the 0th element is ELEMENT_NONE
+        // Weather starts at 0 and the 0th weather is WEATHER_NONE
+        // Days start at 0 and the 0th day is Firesday
+        // Affinity starts at 0 and the 0th affinity is FIRE_AFFINITY
+        // petElement and petElementIdx exist to bridge these gaps here!
+
+        auto*   PPet             = static_cast<CPetEntity*>(PChar->PPet);
+        ELEMENT petElement       = static_cast<ELEMENT>(PPet->m_Element);
+        uint8   petElementIdx    = static_cast<uint8>(petElement) - 1;
+        ELEMENT dayElement       = battleutils::GetDayElement();
+        WEATHER weather          = battleutils::GetWeather(PChar, false);
+        int16   perpReduction    = PChar->getMod(Mod::PERPETUATION_REDUCTION);
+        int16   dayReduction     = PChar->getMod(Mod::DAY_REDUCTION);
+        int16   weatherReduction = PChar->getMod(Mod::WEATHER_REDUCTION);
 
         static const Mod strong[8] = { Mod::FIRE_AFFINITY_PERP, Mod::ICE_AFFINITY_PERP, Mod::WIND_AFFINITY_PERP, Mod::EARTH_AFFINITY_PERP,
                                        Mod::THUNDER_AFFINITY_PERP, Mod::WATER_AFFINITY_PERP, Mod::LIGHT_AFFINITY_PERP, Mod::DARK_AFFINITY_PERP };
@@ -5151,16 +5159,15 @@ namespace charutils
                                                   WEATHER_THUNDER, WEATHER_RAIN, WEATHER_AURORAS, WEATHER_GLOOM };
 
         // If you wear a fire staff, you have +2 perp affinity reduction for fire, but -2 for ice as mods.
-        perpReduction += PChar->getMod(strong[petElement]);
+        perpReduction += PChar->getMod(strong[petElementIdx]);
 
-        // +1 to petElement to account for ELEMENT_NONE not being able to index into dayElement
-        if (dayElement == petElement + 1)
+        // Compare day element and pet element (both ELEMENT, both 0-based)
+        if (dayElement == petElement)
         {
             perpReduction += dayReduction;
         }
 
-        // TODO: What is this?
-        if (weather == weatherStrong[petElement] || weather == weatherStrong[petElement] + 1)
+        if (weather == weatherStrong[petElementIdx] || weather == weatherStrong[petElementIdx] + 1)
         {
             perpReduction += weatherReduction;
         }


### PR DESCRIPTION
Fixes https://github.com/LandSandBoat/server/issues/778
It's a little confusing in there, there was an off-by-one for the DAY_REDUCTION mod lookup. 
I went through the affinity stuff, that all seems OK.
Don't really understand whats going on with the WEATHER_REDUCTION thing.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
