### PR TITLE
Separate item purchase checks for Overseer into separate function

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1075,6 +1075,46 @@ xi.conquest.overseerOnEventUpdate = function(player, csid, option, guardNation)
     end
 end
 
+-- Additional checks to ensure that the player can actually purchase the item requested from the overseer.
+-- Returns price of the item if valid, -1 if invalid.
+local function canPurchaseItem(player, stock, pRank, guardNation, mOffset)
+    -- Validate stock
+    if stock == nil then
+        return -1
+    end
+
+    -- validate localVar (cheat protection)
+    local boughtItem = player:getLocalVar("boughtItemCP")
+    player:setLocalVar("boughtItemCP", 0)
+    if stock.item ~= boughtItem then
+        player:messageSpecial(mOffset + 61, stock.item) -- "Your rank is too low to purchase the <item>."
+        return -1
+    end
+
+    -- validate rank
+    if stock.rank and pRank < stock.rank then
+        player:messageSpecial(mOffset + 61, stock.item) -- "Your rank is too low to purchase the <item>."
+        return -1
+    end
+
+    -- validate price
+    local price = stock.cp
+    if stock.rank ~= nil and player:getNation() ~= guardNation and guardNation ~= xi.nation.OTHER then
+        if price <= 8000 then
+            price = price * 2
+        else
+            price = price + 8000
+        end
+    end
+
+    if player:getCP() < price then
+        player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- "You do not have enough conquest points to purchase the <item>."
+        return -1
+    end
+
+    return price
+end
+
 xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, guardType, guardRegion)
     local pNation  = player:getNation()
     local pRank    = player:getRank(pNation)
@@ -1135,37 +1175,10 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
 
     -- PURCHASE CP ITEM
     elseif option >= 32768 and option <= 32944 then
-        -- validate stock
         local stock = getStock(player, guardNation, option)
-        if stock == nil then
-            return
-        end
+        local price = canPurchaseItem(player, stock, pRank, guardNation, mOffset)
 
-        -- validate localVar (cheat protection)
-        local boughtItem = player:getLocalVar("boughtItemCP")
-        player:setLocalVar("boughtItemCP", 0)
-        if stock.item ~= boughtItem then
-            player:messageSpecial(mOffset + 61, stock.item) -- "Your rank is too low to purchase the <item>."
-            return
-        end
-
-        -- validate rank
-        if stock.rank and pRank < stock.rank then
-            player:messageSpecial(mOffset + 61, stock.item) -- "Your rank is too low to purchase the <item>."
-            return
-        end
-
-        -- validate price
-        local price = stock.cp
-        if stock.rank ~= nil and player:getNation() ~= guardNation and guardNation ~= xi.nation.OTHER then
-            if price <= 8000 then
-                price = price * 2
-            else
-                price = price + 8000
-            end
-        end
-        if player:getCP() < price then
-            player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- "You do not have enough conquest points to purchase the <item>."
+        if price < 0 then
             return
         end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Satisfies luacheck for overseer onEventFinish complexity.  Creates a separate function to handle item purchase validation, and returns negative value if invalid, causing the function to exit.