### PR TITLE
Correct logic of scripts/zones/Temple_of_Uggalepih/mobs/Manipulator.lua

### DIFF
--- a/scripts/zones/Temple_of_Uggalepih/mobs/Manipulator.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Manipulator.lua
@@ -7,7 +7,7 @@ require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
-local path =
+local pathNodes =
 {
     -17.930, -8.500, -93.215,
     -18.553, -7.713, -91.224,
@@ -64,18 +64,18 @@ local path =
     -17.573, -8.500, -95.179
 }
 
-entity.onMobSpawn = function(mob)
-    entity.onMobRoam(mob) -- what?
+entity.onPath = function(mob)
+    xi.path.patrol(mob, pathNodes)
 end
 
-entity.onPath = function(mob)
-    xi.path.patrol(mob, path)
+entity.onMobSpawn = function(mob)
+    entity.onPath(mob)
 end
 
 entity.onMobRoam = function(mob)
     -- move to start position if not moving
     if not mob:isFollowingPath() then
-        mob:pathThrough(xi.path.first(path))
+        mob:pathThrough(xi.path.first(pathNodes))
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This only makes the script logic conform to other entities known to work correctly. This doesn't mean the pathing is fixed yet.

TODO: look into path nodes, there is was known issue with float values that caused of issues previously. Not sure if that's still a thing, as this Mob seems t be working at my server.. But I'd prefer to make floats work properly again than truncate all the values again if thats still borked (that's how the last few mobs were fixed).