### PR TITLE
Stop defender from removing berserk - fixes #868

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -20,7 +20,7 @@ CREATE TABLE `status_effects` (
   `id` smallint(5) unsigned NOT NULL,
   `name` varchar(50) NOT NULL,
   `flags` int(8) unsigned NOT NULL DEFAULT 0,
-  `type` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `type` smallint(5) unsigned NOT NULL DEFAULT 0, -- This needs renamed eventually. See struct EffectParams_t in status_effect_container.cpp
   `negative_id` smallint(5) unsigned DEFAULT 0,
   `overwrite` smallint(5) unsigned NOT NULL DEFAULT 0,
   `block_id` smallint(5) unsigned DEFAULT 0,
@@ -90,8 +90,8 @@ INSERT INTO `status_effects` VALUES (52,'soul_voice',32,0,0,0,0,0,7,0,0);
 INSERT INTO `status_effects` VALUES (53,'eagle_eye_shot',32,0,0,0,0,0,5,0,0);
 INSERT INTO `status_effects` VALUES (54,'meikyo_shisui',32,0,0,0,0,0,5,0,0);
 INSERT INTO `status_effects` VALUES (55,'astral_flow',32,0,0,0,0,0,5,0,0);
-INSERT INTO `status_effects` VALUES (56,'berserk',41,56,0,0,0,0,1,0,0);
-INSERT INTO `status_effects` VALUES (57,'defender',33,56,0,0,0,0,4,0,0);
+INSERT INTO `status_effects` VALUES (56,'berserk',41,0,0,0,0,0,1,0,0);
+INSERT INTO `status_effects` VALUES (57,'defender',33,0,0,0,0,0,4,0,0);
 INSERT INTO `status_effects` VALUES (58,'aggressor',33,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (59,'focus',41,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (60,'dodge',41,0,0,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

The overwrite flag on these already says to allow them to overwrite themselves, but the type flag was telling them to erase effect ID 56, which was berserk..

On retail you can in fact use both and both stay, allowing you to temporarily compensate for one and click one back off as needed. They have exactly opposite effects and this was what the wiki page that says "canceled out" meant. This is why we're always insisting on in game verification and not just blindly trusting wiki pages!
