### PR TITLE
Refactor of OnMonsterMagicPrepare into OnMobMagicPrepare

### DIFF
--- a/scripts/globals/spells/black/sleepga.lua
+++ b/scripts/globals/spells/black/sleepga.lua
@@ -30,7 +30,7 @@ spell_object.onSpellCast = function(caster, target, spell)
         -- Todo: get rid of this whole block by handling it in the mob script
         -- this requires a multi target enmity without specifying a target (have to get hate list from mob)
         -- OR by altering onSpellPrecast to have a target param..
-        -- onMonsterMagicPrepare is not a realistic option.
+        -- OnMobMagicPrepare is not a realistic option.
         -- You'd have to script the use of every individual spell in Amnaf's list..
     end
 

--- a/scripts/zones/Bibiki_Bay/mobs/Shen.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Shen.lua
@@ -18,7 +18,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     -- casts Water IV, Waterga III, Flood, Drown
     local rnd = math.random()
 

--- a/scripts/zones/Bibiki_Bay/mobs/Shen.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Shen.lua
@@ -18,7 +18,7 @@ end
 entity.onMobDeath = function(mob, player, isKiller)
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     -- casts Water IV, Waterga III, Flood, Drown
     local rnd = math.random()
 

--- a/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
+++ b/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
@@ -28,7 +28,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     if mob:getHPP() <= 25 then
         return 244 -- Death
     else

--- a/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
+++ b/scripts/zones/Dynamis-Beaucedine/mobs/Angra_Mainyu.lua
@@ -28,7 +28,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     if mob:getHPP() <= 25 then
         return 244 -- Death
     else

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -32,7 +32,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     end
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     -- Instant cast on spells - Waterga IV, Poisonga II, Drown, and Enwater
     local rnd = math.random()
 

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -32,7 +32,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
     end
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     -- Instant cast on spells - Waterga IV, Poisonga II, Drown, and Enwater
     local rnd = math.random()
 

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     local rnd = math.random()
 
     if rnd < 0.4 then

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Lord_of_Onzozo.lua
@@ -11,7 +11,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.DRAW_IN, 1)
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     local rnd = math.random()
 
     if rnd < 0.4 then

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
@@ -23,7 +23,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     local powerup = mob:getLocalVar("powerup")
     local rnd = math.random(1, 6)
     local warp = mob:getLocalVar("warp")

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
@@ -23,7 +23,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     local powerup = mob:getLocalVar("powerup")
     local rnd = math.random(1, 6)
     local warp = mob:getLocalVar("warp")

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -17,7 +17,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     if not mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) then
         local rnd = math.random()
         if rnd < 0.5 then

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -17,7 +17,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     if not mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) then
         local rnd = math.random()
         if rnd < 0.5 then

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -18,7 +18,7 @@ entity.onMobInitialize = function(mob)
 end
 
 -- Return the selected spell ID.
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     -- Suzaku uses     Burn, Fire IV, Firaga III, Flare
     -- Let's give -ga3 a higher distribution than the others.
     local rnd = math.random()

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -18,7 +18,7 @@ entity.onMobInitialize = function(mob)
 end
 
 -- Return the selected spell ID.
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     -- Suzaku uses     Burn, Fire IV, Firaga III, Flare
     -- Let's give -ga3 a higher distribution than the others.
     local rnd = math.random()

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
@@ -18,7 +18,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     local spellList =
     {
         [1] = 382,

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRGs_Wynav.lua
@@ -18,7 +18,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     local spellList =
     {
         [1] = 382,

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
@@ -6,7 +6,7 @@ require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     if (mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) == false) then
         local rnd = math.random()
         if (rnd < 0.5) then

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
@@ -6,7 +6,7 @@ require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     if (mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) == false) then
         local rnd = math.random()
         if (rnd < 0.5) then

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
@@ -8,7 +8,7 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 -- Return the selected spell ID.
-entity.onMonsterMagicPrepare = function(mob, target)
+entity.OnMobMagicPrepare = function(mob, spellId)
     -- Suzaku uses     Burn, Fire IV, Firaga III, Flare
     -- Let's give -ga3 a higher distribution than the others.
     local rnd = math.random()

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Suzaku.lua
@@ -8,7 +8,7 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 -- Return the selected spell ID.
-entity.OnMobMagicPrepare = function(mob, spellId)
+entity.onMobMagicPrepare = function(mob, target, spellId)
     -- Suzaku uses     Burn, Fire IV, Firaga III, Flare
     -- Let's give -ga3 a higher distribution than the others.
     local rnd = math.random()

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -37,7 +37,7 @@ CREATE TABLE `mob_pools` (
   `flag` int(11) unsigned NOT NULL DEFAULT 0,
   `entityFlags` int(11) unsigned NOT NULL DEFAULT 0,
   `animationsub` tinyint(1) NOT NULL DEFAULT 0,
-  `hasSpellScript` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `hasSpellScript` tinyint(1) unsigned NOT NULL DEFAULT 0, -- NO LONGER IN USE. DOES NOTHING. TODO: Remove me
   `spellList` smallint(4) NOT NULL DEFAULT 0,
   `namevis` tinyint(4) NOT NULL DEFAULT 1,
   `roamflag` smallint(3) unsigned NOT NULL DEFAULT 0,

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -425,45 +425,39 @@ bool CMobController::TryCastSpell()
 
     m_LastMagicTime = m_Tick - std::chrono::milliseconds(xirand::GetRandomNumber(PMob->getBigMobMod(MOBMOD_MAGIC_COOL) / 2));
 
-    if (PMob->m_HasSpellScript)
+    // Find random spell from list
+    std::optional<SpellID> chosenSpellId;
+    if (m_firstSpell)
     {
-        // skip logic and follow script
-        auto chosenSpellId = luautils::OnMonsterMagicPrepare(PMob, PTarget);
-        if (chosenSpellId)
-        {
-            CastSpell(chosenSpellId.value());
-            return true;
-        }
+        // mobs first spell, should be aggro spell
+        chosenSpellId = PMob->SpellContainer->GetAggroSpell();
+        m_firstSpell  = false;
     }
     else
     {
-        // find random spell
-        std::optional<SpellID> chosenSpellId;
-        if (m_firstSpell)
-        {
-            // mobs first spell, should be aggro spell
-            chosenSpellId = PMob->SpellContainer->GetAggroSpell();
-            m_firstSpell  = false;
-        }
-        else
-        {
-            chosenSpellId = PMob->SpellContainer->GetSpell();
-        }
-
-        if (chosenSpellId)
-        {
-            //#TODO: select target based on spell type
-            CastSpell(chosenSpellId.value());
-            return true;
-        }
+        chosenSpellId = PMob->SpellContainer->GetSpell();
     }
+
+    // Try to get an override spell from the script (if available)
+    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, chosenSpellId);
+    if (possibleOverriddenSpell.has_value())
+    {
+        chosenSpellId = possibleOverriddenSpell;
+    }
+
+    if (chosenSpellId.has_value())
+    {
+        CastSpell(chosenSpellId.value());
+        return true;
+    }
+
     return false;
 }
 
 bool CMobController::CanCastSpells()
 {
     TracyZoneScoped;
-    if (!PMob->SpellContainer->HasSpells() && !PMob->m_HasSpellScript)
+    if (!PMob->SpellContainer->HasSpells())
     {
         return false;
     }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -439,7 +439,7 @@ bool CMobController::TryCastSpell()
     }
 
     // Try to get an override spell from the script (if available)
-    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, chosenSpellId);
+    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, PTarget, chosenSpellId);
     if (possibleOverriddenSpell.has_value())
     {
         chosenSpellId = possibleOverriddenSpell;

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -252,7 +252,6 @@ public:
     CEnmityContainer* PEnmityContainer; // система ненависти монстров
 
     CMobSpellContainer* SpellContainer;   // retrieves spells for the mob
-    uint8               m_HasSpellScript; // 1 if they have a spell script to use for working out what to cast.
 
     static constexpr float sound_range{ 8.f };
     static constexpr float sight_range{ 15.f };

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -44,7 +44,6 @@ CPetEntity::CPetEntity(PET_TYPE petType)
     m_EcoSystem      = ECOSYSTEM::UNCLASSIFIED;
     allegiance       = ALLEGIANCE_TYPE::PLAYER;
     m_MobSkillList   = 0;
-    m_HasSpellScript = 0;
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CPetController>(this), std::make_unique<CTargetFind>(this));
 }
 

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -180,8 +180,9 @@ CInstance* CInstanceLoader::LoadInstance()
             PMob->HPscale = sql->GetFloatData(62);
             PMob->MPscale = sql->GetFloatData(63);
 
+            // TODO: Remove me
             // Check if we should be looking up scripts for this mob
-            PMob->m_HasSpellScript = (uint8)sql->GetIntData(64);
+            //PMob->m_HasSpellScript = (uint8)sql->GetIntData(64);
 
             PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(sql->GetIntData(65));
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2475,26 +2475,32 @@ namespace luautils
         return 0;
     }
 
-    std::optional<SpellID> OnMonsterMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget)
+    std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, std::optional<SpellID> startingSpellId)
     {
         TracyZoneScoped;
 
-        if (PCaster == nullptr || PTarget == nullptr)
+        if (PCaster == nullptr)
         {
             return {};
         }
 
-        sol::function onMonsterMagicPrepare = getEntityCachedFunction(PCaster, "onMonsterMagicPrepare");
-        if (!onMonsterMagicPrepare.valid())
+        sol::function OnMobMagicPrepare = getEntityCachedFunction(PCaster, "OnMobMagicPrepare");
+        if (!OnMobMagicPrepare.valid())
         {
             return {};
         }
 
-        auto result = onMonsterMagicPrepare(CLuaBaseEntity(PCaster), CLuaBaseEntity(PTarget));
+        std::optional<CLuaSpell> luaSpell;
+        if (startingSpellId.has_value())
+        {
+            luaSpell = spell::GetSpell(startingSpellId.value());
+        }
+
+        auto result = OnMobMagicPrepare(CLuaBaseEntity(PCaster), luaSpell);
         if (!result.valid())
         {
             sol::error err = result;
-            ShowError("luautils::onMonsterMagicPrepare: %s", err.what());
+            ShowError("luautils::OnMobMagicPrepare: %s", err.what());
             return {};
         }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2475,7 +2475,7 @@ namespace luautils
         return 0;
     }
 
-    std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, std::optional<SpellID> startingSpellId)
+    std::optional<SpellID> OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId)
     {
         TracyZoneScoped;
 
@@ -2484,8 +2484,8 @@ namespace luautils
             return {};
         }
 
-        sol::function OnMobMagicPrepare = getEntityCachedFunction(PCaster, "OnMobMagicPrepare");
-        if (!OnMobMagicPrepare.valid())
+        sol::function onMobMagicPrepare = getEntityCachedFunction(PCaster, "onMobMagicPrepare");
+        if (!onMobMagicPrepare.valid())
         {
             return {};
         }
@@ -2496,7 +2496,7 @@ namespace luautils
             luaSpell = spell::GetSpell(startingSpellId.value());
         }
 
-        auto result = OnMobMagicPrepare(CLuaBaseEntity(PCaster), luaSpell);
+        auto result = onMobMagicPrepare(CLuaBaseEntity(PCaster), CLuaBaseEntity(PTarget), luaSpell);
         if (!result.valid())
         {
             sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -223,12 +223,12 @@ namespace luautils
     auto  OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr) -> std::tuple<int32, int32, int32>; // check to see if item can be used
     int32 CheckForGearSet(CBaseEntity* PTarget);                                                                                                                 // check for gear sets
 
-    int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);                   // triggers when a player attempts to cast a spell
+    int32  OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);                   // triggers when a player attempts to cast a spell
     uint32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                     // triggered when casting a spell
-    int32 OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);                                          // triggered just before casting a spell
-    auto  OnMonsterMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget) -> std::optional<SpellID>; // triggered when monster wants to use a spell on target
-    int32 OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                      // triggered when spell cast on monster
-    int32 OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);              // Triggered when Weaponskill strikes monster
+    int32  OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);                                          // triggered just before casting a spell
+    auto   OnMobMagicPrepare(CBattleEntity* PCaster, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>; // triggered when monster wants to use a spell on target
+    int32  OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                      // triggered when spell cast on monster
+    int32  OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);              // Triggered when Weaponskill strikes monster
 
     int32 OnMobInitialize(CBaseEntity* PMob); // Used for passive trait
     int32 ApplyMixins(CBaseEntity* PMob);

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -226,7 +226,7 @@ namespace luautils
     int32  OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);                   // triggers when a player attempts to cast a spell
     uint32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                     // triggered when casting a spell
     int32  OnSpellPrecast(CBattleEntity* PCaster, CSpell* PSpell);                                          // triggered just before casting a spell
-    auto   OnMobMagicPrepare(CBattleEntity* PCaster, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>; // triggered when monster wants to use a spell on target
+    auto   OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>; // triggered when monster wants to use a spell on target
     int32  OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                      // triggered when spell cast on monster
     int32  OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);              // Triggered when Weaponskill strikes monster
 

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1348,8 +1348,9 @@ Usage:
                 PMob->HPscale = sql->GetFloatData(59);
                 PMob->MPscale = sql->GetFloatData(60);
 
+                // TODO: Remove me
                 // Check if we should be looking up scripts for this mob
-                PMob->m_HasSpellScript = (uint8)sql->GetIntData(61);
+                //PMob->m_HasSpellScript = (uint8)sql->GetIntData(61);
 
                 PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(sql->GetIntData(62));
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -887,7 +887,6 @@ namespace petutils
         PPet->m_Element        = petData->m_Element;
         PPet->HPscale          = petData->HPscale;
         PPet->MPscale          = petData->MPscale;
-        PPet->m_HasSpellScript = petData->hasSpellScript;
 
         PPet->allegiance = PMaster->allegiance;
         PMaster->StatusEffectContainer->CopyConfrontationEffect(PPet);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -320,7 +320,6 @@ namespace trustutils
         PTrust->HPscale          = trustData->HPscale;
         PTrust->MPscale          = trustData->MPscale;
         PTrust->speed            = trustData->speed;
-        PTrust->m_HasSpellScript = trustData->hasSpellScript;
         PTrust->m_TrustID        = trustData->trustID;
         PTrust->status           = STATUS_TYPE::NORMAL;
         PTrust->m_ModelSize      = trustData->size;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -494,8 +494,9 @@ namespace zoneutils
                     PMob->HPscale = sql->GetFloatData(63);
                     PMob->MPscale = sql->GetFloatData(64);
 
+                    // TODO: Remove me
                     // Check if we should be looking up scripts for this mob
-                    PMob->m_HasSpellScript = (uint8)sql->GetIntData(65);
+                    //PMob->m_HasSpellScript = (uint8)sql->GetIntData(65);
 
                     PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(sql->GetIntData(66));
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This replaces the need for `m_HasSpellScript` with the presence of the `entity.onMobMagicPrepare` function in the entity script.