### PR TITLE
Fix Tidal Talisman

### DIFF
--- a/scripts/globals/items/tidal_talisman.lua
+++ b/scripts/globals/items/tidal_talisman.lua
@@ -11,7 +11,7 @@ item_object.onItemCheck = function(target)
     if (zone == 238 or zone == 239 or zone == 240 or zone == 241 or zone == 242 or -- Windurst
         zone == 234 or zone == 235 or zone == 236 or zone == 237 or -- Bastok
         zone == 230 or zone == 231 or zone == 232 or zone == 233 or -- San d'Oria
-        zone == 243 or zone == 244 or zone == 245 or zone == 246 or -- Jeuno
+        ((zone == 243 or zone == 244 or zone == 245 or zone == 246) and target:hasKeyItem(xi.ki.AIRSHIP_PASS_FOR_KAZHAM)) or -- Jeuno
         zone == 248 or -- Selbina
         zone == 249 or -- Mhaura
         zone == 250 or -- Kazham


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fix missing check in Tidal Talisman use