### PR TITLE
update item_usable.sql for scroll_of_curaga_v

### DIFF
--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -556,6 +556,7 @@ INSERT INTO `item_usable` VALUES (4615,'scroll_of_curaga',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4616,'scroll_of_curaga_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4617,'scroll_of_curaga_iii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4618,'scroll_of_curaga_iv',1,1,11,5,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4619,'scroll_of_curaga_v',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4620,'scroll_of_raise',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4621,'scroll_of_raise_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4622,'scroll_of_poisona',1,1,11,5,0,0,0,0);


### PR DESCRIPTION
modeling this entry as well as the new file (scripts/globals/items/scroll_of_curaga_v.lua) after existing curaga entries/files.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
