### PR TITLE
Create scroll_of_curaga_v.lua

### DIFF
--- a/scripts/globals/items/scroll_of_curaga_v.lua
+++ b/scripts/globals/items/scroll_of_curaga_v.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- ID: 4619
+-- Scroll of Curaga V
+-- Teaches the white magic Curaga V
+-----------------------------------
+local item_object = {}
+
+item_object.onItemCheck = function(target)
+    return target:canLearnSpell(11)
+end
+
+item_object.onItemUse = function(target)
+    target:addSpell(11)
+end
+
+return item_object


### PR DESCRIPTION
Issue #846
modeled after scroll_of_curaga_iv.lua
spell ID's pulled from existing entries (4619, 11)
still need to add the entry in item_usable.sql for ID 4619 though

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
