### PR TITLE
Correct spelling for Royal Saute in item_basic.sql to make it usable again as noted in issue #836

### DIFF
--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -1,4 +1,4 @@
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+﻿/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8 */;
@@ -4048,7 +4048,7 @@ INSERT INTO `item_basic` VALUES (4291,0,'sandfish','sandfish',12,1548,51,0,26);
 INSERT INTO `item_basic` VALUES (4292,0,'loaf_of_pain_de_neige','pain_de_neige',12,1548,56,0,56);
 INSERT INTO `item_basic` VALUES (4293,0,'serving_of_monastic_saute','monastic_saute',1,1580,54,0,533);  -- https://www.bg-wiki.com/bg/Monastic_Saute
 INSERT INTO `item_basic` VALUES (4294,0,'serving_of_medicinal_quus','medicinal_quus',1,1580,53,0,70);
-INSERT INTO `item_basic` VALUES (4295,0,'plate_of_royal_sautee','royal_sautee',1,1580,52,0,70);         -- https://www.bg-wiki.com/bg/Royal_Saute
+INSERT INTO `item_basic` VALUES (4295,0,'plate_of_royal_saute','royal_saute',1,1580,52,0,70);         -- https://www.bg-wiki.com/bg/Royal_Saute
 INSERT INTO `item_basic` VALUES (4296,0,'serving_of_green_curry','green_curry',1,1580,55,0,270);
 INSERT INTO `item_basic` VALUES (4297,0,'serving_of_black_curry','black_curry',1,1580,55,0,748);
 INSERT INTO `item_basic` VALUES (4298,0,'serving_of_red_curry','red_curry',1,1580,55,0,831);
@@ -19227,7 +19227,7 @@ INSERT INTO `item_basic` VALUES (25572,0,'ayanmo_zucchetto_+2','aya._zucchetto_+
 INSERT INTO `item_basic` VALUES (25573,0,'taliah_turban_+2','taliah_turban_+2',1,63552,0,0,0);
 INSERT INTO `item_basic` VALUES (25574,0,'sulevias_mask_+2','sulevias_mask_+2',1,63552,0,0,0);
 INSERT INTO `item_basic` VALUES (25575,0,'meghanada_visor_+2','meghanada_visor_+2',1,63552,0,0,0);
-INSERT INTO `item_basic` VALUES (25576,0,'hizamaru_somen_+2','hiza._somen　+2',1,63552,0,0,0);
+INSERT INTO `item_basic` VALUES (25576,0,'hizamaru_somen_+2','hiza._somen_+2',1,63552,0,0,0);
 INSERT INTO `item_basic` VALUES (25577,0,'inyanga_tiara_+2','inyanga_tiara_+2',1,63552,0,0,0);
 INSERT INTO `item_basic` VALUES (25578,0,'jhakri_coronal_+2','jhakri_coronal_+2',1,63552,0,0,0);
 INSERT INTO `item_basic` VALUES (25579,0,'flamma_zucchetto','flamma_zucchetto',1,63552,0,1,0);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
