### PR TITLE
[avatar] Make Crimson-toothed Pawberry only summon Carbuncle

### DIFF
--- a/scripts/mixins/families/avatar.lua
+++ b/scripts/mixins/families/avatar.lua
@@ -1,5 +1,18 @@
 require("scripts/globals/mixins")
 
+-- If you subtract 790 from the modelId, you're left with a key into to this table :)
+local abilityIds =
+{
+    919, -- [modelId: 791] Carbuncle
+    839, -- [modelId: 792] Fenrir
+    913, -- [modelId: 793] Ifrit
+    914, -- [modelId: 794] Titan
+    915, -- [modelId: 795] Leviathan
+    916, -- [modelId: 796] Garuda
+    917, -- [modelId: 797] Shiva
+    918, -- [modelId: 798] Ramuh
+}
+
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
@@ -11,26 +24,21 @@ g_mixins.families.avatar = function(avatarMob)
         mob:setUnkillable(true)
         mob:SetAutoAttackEnabled(false)
         mob:SetMagicCastingEnabled(false)
+
+        -- If something goes wrong, the avatar will clean itself up in 5s
+        mob:timer(5000, function(mobArg)
+            if mobArg:isAlive() then
+                mobArg:setUnkillable(false)
+                mobArg:setHP(0)
+            end
+        end)
     end)
 
     avatarMob:addListener("ENGAGE", "AVATAR_ENGAGE", function(mob, target)
-        local abilityID = nil
-        local modelID = mob:getModelId()
-
-        switch (modelID) : caseof
-        {
-             [791] = function (x) abilityID = 919 end, -- Carbuncle
-             [792] = function (x) abilityID = 839 end, -- Fenrir
-             [793] = function (x) abilityID = 913 end, -- Ifrit
-             [794] = function (x) abilityID = 914 end, -- Titan
-             [795] = function (x) abilityID = 915 end, -- Leviathan
-             [796] = function (x) abilityID = 916 end, -- Garuda
-             [797] = function (x) abilityID = 917 end, -- Shiva
-             [798] = function (x) abilityID = 918 end, -- Ramuh
-        }
-
-        if (abilityID ~= nil) then
-            mob:useMobAbility(abilityID)
+        local modelId = mob:getModelId()
+        local abilityId = abilityIds[modelId - 790]
+        if abilityId ~= nil then
+            mob:useMobAbility(abilityId)
         end
     end)
 

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
@@ -11,6 +11,35 @@ mixins =
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    local mobID = mob:getID()
+    local avatarID = mobID + 2
+    local avatarMob = GetMobByID(avatarID)
+    if avatarMob then
+        -- Remove the original listener set from mixins/families/avatar
+        avatarMob:removeListener("AVATAR_SPAWN")
+
+        -- Replace with a similar listener which is hardcoded to use Carbuncle
+        avatarMob:addListener("SPAWN", "AVATAR_SPAWN", function(mobArg)
+            local modelId = 791 -- Carbuncle
+            mobArg:setModelId(modelId)
+            mobArg:hideName(false)
+            mobArg:untargetable(true)
+            mobArg:setUnkillable(true)
+            mobArg:SetAutoAttackEnabled(false)
+            mobArg:SetMagicCastingEnabled(false)
+
+            -- If something goes wrong, the avatar will clean itself up in 5s
+            mobArg:timer(5000, function(mobTimerArg)
+                if mobTimerArg:isAlive() then
+                    mobTimerArg:setUnkillable(false)
+                    mobTimerArg:setHP(0)
+                end
+            end)
+        end)
+    end
+end
+
 entity.onMobDeath = function(mob, player, isKiller)
     xi.hunts.checkHunt(mob, player, 392)
 end

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1115,7 +1115,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                         StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_BLOODPACT);
                     }
 
-                    // Blood Boon (does not affect Astra Flow BPs)
+                    // Blood Boon (does not affect Astral Flow BPs)
                     if ((PAbility->getAddType() & ADDTYPE_ASTRAL_FLOW) == 0)
                     {
                         int16 bloodBoonRate = getMod(Mod::BLOOD_BOON);


### PR DESCRIPTION
After flailing around on stream trying to pass local vars to the avatar from the summoner, this was the only localised solution I could come up with 🤷 

Solves a little bit of https://github.com/LandSandBoat/server/issues/903

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
