### PR TITLE
[Assault] adds can/cant equip on eventUpdate

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Bhoy_Yhupplo.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Bhoy_Yhupplo.lua
@@ -13,6 +13,21 @@ require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
+local items =
+{
+    [1]  = {itemid = xi.items.VELOCITY_EARRING,   price = 3000},
+    [2]  = {itemid = xi.items.GARRULOUS_RING,     price = 5000},
+    [3]  = {itemid = xi.items.GRANDIOSE_CHAIN,    price = 8000},
+    [4]  = {itemid = xi.items.HURLING_BELT,       price = 10000},
+    [5]  = {itemid = xi.items.INVIGORATING_CAPE,  price = 10000},
+    [6]  = {itemid = xi.items.IMPERIAL_KAMAN,     price = 15000},
+    [7]  = {itemid = xi.items.STORM_ZAGHNAL,      price = 15000},
+    [8]  = {itemid = xi.items.STORM_FIFE,         price = 15000},
+    [9]  = {itemid = xi.items.YIGIT_TURBAN,       price = 20000},
+    [10] = {itemid = xi.items.AMIR_DIRS,          price = 20000},
+    [11] = {itemid = xi.items.PAHLUWAN_KHAZAGAND, price = 20000},
+}
+
 entity.onTrade = function(player, npc, trade)
 end
 
@@ -29,6 +44,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    local selectiontype = bit.band(option, 0xF)
+    if csid == 277 and selectiontype == 2 then
+        local item = bit.rshift(option,14)
+        local choice = items[item]
+        local assaultPoints = player:getAssaultPoint(ILRUSI_ASSAULT_POINT)
+        local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
+
+        player:updateEvent(0, 0, assaultPoints, 0, canEquip)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -42,21 +66,6 @@ entity.onEventFinish = function(player, csid, option)
         elseif selectiontype == 2 then
             -- purchased an item
             local item = bit.rshift(option, 14)
-            local items =
-            {
-                [1]  = {itemid = xi.items.VELOCITY_EARRING,   price = 3000},
-                [2]  = {itemid = xi.items.GARRULOUS_RING,     price = 5000},
-                [3]  = {itemid = xi.items.GRANDIOSE_CHAIN,    price = 8000},
-                [4]  = {itemid = xi.items.HURLING_BELT,       price = 10000},
-                [5]  = {itemid = xi.items.INVIGORATING_CAPE,  price = 10000},
-                [6]  = {itemid = xi.items.IMPERIAL_KAMAN,     price = 15000},
-                [7]  = {itemid = xi.items.STORM_ZAGHNAL,      price = 15000},
-                [8]  = {itemid = xi.items.STORM_FIFE,         price = 15000},
-                [9]  = {itemid = xi.items.YIGIT_TURBAN,       price = 20000},
-                [10] = {itemid = xi.items.AMIR_DIRS,          price = 20000},
-                [11] = {itemid = xi.items.PAHLUWAN_KHAZAGAND, price = 20000},
-            }
-
             local choice = items[item]
             if choice and npcUtil.giveItem(player, choice.itemid) then
                 player:delAssaultPoint(xi.assaultUtil.assaultArea.ILRUSI_ATOLL, choice.price)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
@@ -13,6 +13,21 @@ require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
+local items =
+{
+    [1]  = {itemid = xi.items.INSOMNIA_EARRING,  price = 3000},
+    [2]  = {itemid = xi.items.HALE_RING,         price = 5000},
+    [3]  = {itemid = xi.items.CHIVALROUS_CHAIN,  price = 8000},
+    [4]  = {itemid = xi.items.PRECISE_BELT,      price = 10000},
+    [5]  = {itemid = xi.items.INTENSIFYING_CAPE, price = 10000},
+    [6]  = {itemid = xi.items.IMPERIAL_POLE,     price = 15000},
+    [7]  = {itemid = xi.items.DOOMBRINGER,       price = 15000},
+    [8]  = {itemid = xi.items.SAYOSAMONJI,       price = 15000},
+    [9]  = {itemid = xi.items.AMIR_KORAZIN,      price = 20000},
+    [10] = {itemid = xi.items.PAHLUWAN_DASTANAS, price = 20000},
+    [11] = {itemid = xi.items.YIGIT_CRACKOWS,    price = 20000},
+}
+
 entity.onTrade = function(player, npc, trade)
 end
 
@@ -29,6 +44,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    local selectiontype = bit.band(option, 0xF)
+    if csid == 275 and selectiontype == 2 then
+        local item = bit.rshift(option,14)
+        local choice = items[item]
+        local assaultPoints = player:getAssaultPoint(xi.assaultUtil.assaultArea.LEBROS_CAVERN)
+        local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
+
+        player:updateEvent(0, 0, assaultPoints, 0, canEquip)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -42,21 +66,6 @@ entity.onEventFinish = function(player, csid, option)
         elseif selectiontype == 2 then
             -- purchased an item
             local item = bit.rshift(option, 14)
-            local items =
-            {
-                [1]  = {itemid = xi.items.INSOMNIA_EARRING,  price = 3000},
-                [2]  = {itemid = xi.items.HALE_RING,         price = 5000},
-                [3]  = {itemid = xi.items.CHIVALROUS_CHAIN,  price = 8000},
-                [4]  = {itemid = xi.items.PRECISE_BELT,      price = 10000},
-                [5]  = {itemid = xi.items.INTENSIFYING_CAPE, price = 10000},
-                [6]  = {itemid = xi.items.IMPERIAL_POLE,     price = 15000},
-                [7]  = {itemid = xi.items.DOOMBRINGER,       price = 15000},
-                [8]  = {itemid = xi.items.SAYOSAMONJI,       price = 15000},
-                [9]  = {itemid = xi.items.AMIR_KORAZIN,      price = 20000},
-                [10] = {itemid = xi.items.PAHLUWAN_DASTANAS, price = 20000},
-                [11] = {itemid = xi.items.YIGIT_CRACKOWS,    price = 20000},
-            }
-
             local choice = items[item]
             if choice and npcUtil.giveItem(player, choice.itemid) then
                 player:delAssaultPoint(xi.assaultUtil.assaultArea.LEBROS_CAVERN, choice.price)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Isdebaaq.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Isdebaaq.lua
@@ -13,6 +13,21 @@ require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
+local items =
+{
+    [1]  = {itemid = xi.items.ANTIVENOM_EARRING,  price = 3000},
+    [2]  = {itemid = xi.items.EBULLIENT_RING,     price = 5000},
+    [3]  = {itemid = xi.items.ENLIGHTENED_CHAIN,  price = 8000},
+    [4]  = {itemid = xi.items.SPECTRAL_BELT,      price = 10000},
+    [5]  = {itemid = xi.items.BULLSEYE_CAPE,      price = 10000},
+    [6]  = {itemid = xi.items.STORM_TULWAR,       price = 15000},
+    [7]  = {itemid = xi.items.IMPERIAL_NEZA,      price = 15000},
+    [8]  = {itemid = xi.items.STORM_TABAR,        price = 15000},
+    [9]  = {itemid = xi.items.YIGIT_GAGES,        price = 20000},
+    [10] = {itemid = xi.items.AMIR_BOOTS,         price = 20000},
+    [11] = {itemid = xi.items.PAHLUWAN_SERAWEELS, price = 20000},
+}
+
 entity.onTrade = function(player, npc, trade)
 end
 
@@ -29,6 +44,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    local selectiontype = bit.band(option, 0xF)
+    if csid == 274 and selectiontype == 2 then
+        local item = bit.rshift(option,14)
+        local choice = items[item]
+        local assaultPoints = player:getAssaultPoint(xi.assaultUtil.assaultArea.MAMOOL_JA_TRAINING_GROUNDS)
+        local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
+
+        player:updateEvent(0, 0, assaultPoints, 0, canEquip)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -42,21 +66,6 @@ entity.onEventFinish = function(player, csid, option)
         elseif selectiontype == 2 then
             -- purchased an item
             local item = bit.rshift(option, 14)
-            local items =
-            {
-                [1]  = {itemid = xi.items.ANTIVENOM_EARRING,  price = 3000},
-                [2]  = {itemid = xi.items.EBULLIENT_RING,     price = 5000},
-                [3]  = {itemid = xi.items.ENLIGHTENED_CHAIN,  price = 8000},
-                [4]  = {itemid = xi.items.SPECTRAL_BELT,      price = 10000},
-                [5]  = {itemid = xi.items.BULLSEYE_CAPE,      price = 10000},
-                [6]  = {itemid = xi.items.STORM_TULWAR,       price = 15000},
-                [7]  = {itemid = xi.items.IMPERIAL_NEZA,      price = 15000},
-                [8]  = {itemid = xi.items.STORM_TABAR,        price = 15000},
-                [9]  = {itemid = xi.items.YIGIT_GAGES,        price = 20000},
-                [10] = {itemid = xi.items.AMIR_BOOTS,         price = 20000},
-                [11] = {itemid = xi.items.PAHLUWAN_SERAWEELS, price = 20000},
-            }
-
             local choice = items[item]
             if choice and npcUtil.giveItem(player, choice.itemid) then
                 player:delAssaultPoint(xi.assaultUtil.assaultArea.MAMOOL_JA_TRAINING_GROUNDS, choice.price)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Lageegee.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Lageegee.lua
@@ -13,6 +13,21 @@ require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
+local items =
+{
+    [1]  = {itemid = xi.items.VISION_EARRING,    price = 3000},
+    [2]  = {itemid = xi.items.UNYIELDING_RING,   price = 5000},
+    [3]  = {itemid = xi.items.FORTIFIED_CHAIN,   price = 8000},
+    [4]  = {itemid = xi.items.RESOLUTE_BELT,     price = 10000},
+    [5]  = {itemid = xi.items.BUSHIDO_CAPE,      price = 10000},
+    [6]  = {itemid = xi.items.KHANJAR,           price = 15000},
+    [7]  = {itemid = xi.items.HOTARUMARU,        price = 15000},
+    [8]  = {itemid = xi.items.IMPERIAL_GUN,      price = 15000},
+    [9]  = {itemid = xi.items.AMIR_PUGGAREE,     price = 20000},
+    [10] = {itemid = xi.items.PAHLUWAN_CRACKOWS, price = 20000},
+    [11] = {itemid = xi.items.YIGIT_GOMLEK,      price = 20000},
+}
+
 entity.onTrade = function(player, npc, trade)
 end
 
@@ -29,6 +44,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    local selectiontype = bit.band(option, 0xF)
+    if csid == 276 and selectiontype == 2 then
+        local item = bit.rshift(option,14)
+        local choice = items[item]
+        local assaultPoints = player:getAssaultPoint(xi.assaultUtil.assaultArea.PERIQIA)
+        local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
+
+        player:updateEvent(0, 0, assaultPoints, 0, canEquip)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -42,21 +66,6 @@ entity.onEventFinish = function(player, csid, option)
         elseif selectiontype == 2 then
             -- purchased an item
             local item = bit.rshift(option, 14)
-            local items =
-            {
-                [1]  = {itemid = xi.items.VISION_EARRING,    price = 3000},
-                [2]  = {itemid = xi.items.UNYIELDING_RING,   price = 5000},
-                [3]  = {itemid = xi.items.FORTIFIED_CHAIN,   price = 8000},
-                [4]  = {itemid = xi.items.RESOLUTE_BELT,     price = 10000},
-                [5]  = {itemid = xi.items.BUSHIDO_CAPE,      price = 10000},
-                [6]  = {itemid = xi.items.KHANJAR,           price = 15000},
-                [7]  = {itemid = xi.items.HOTARUMARU,        price = 15000},
-                [8]  = {itemid = xi.items.IMPERIAL_GUN,      price = 15000},
-                [9]  = {itemid = xi.items.AMIR_PUGGAREE,     price = 20000},
-                [10] = {itemid = xi.items.PAHLUWAN_CRACKOWS, price = 20000},
-                [11] = {itemid = xi.items.YIGIT_GOMLEK,      price = 20000},
-            }
-
             local choice = items[item]
             if choice and npcUtil.giveItem(player, choice.itemid) then
                 player:delAssaultPoint(xi.assaultUtil.assaultArea.PERIQIA, choice.price)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Yahsra.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Yahsra.lua
@@ -13,6 +13,21 @@ require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
 
+local items =
+{
+    [1]  = {itemid = xi.items.STOIC_EARRING,      price = 3000},
+    [2]  = {itemid = xi.items.UNFETTERED_RING,    price = 5000},
+    [3]  = {itemid = xi.items.TEMPERED_CHAIN,     price = 8000},
+    [4]  = {itemid = xi.items.POTENT_BELT,        price = 10000},
+    [5]  = {itemid = xi.items.MIRACULOUS_CAPE,    price = 10000},
+    [6]  = {itemid = xi.items.YIGIT_BULAWA,       price = 10000},
+    [7]  = {itemid = xi.items.IMPERIAL_BHUJ,      price = 15000},
+    [8]  = {itemid = xi.items.PAHLUWAN_PATAS,     price = 15000},
+    [9]  = {itemid = xi.items.AMIR_KOLLUKS,       price = 15000},
+    [10] = {itemid = xi.items.PAHLUWAN_QALANSUWA, price = 20000},
+    [11] = {itemid = xi.items.YIGIT_SERAWEELS,    price = 20000},
+}
+
 entity.onTrade = function(player, npc, trade)
 end
 
@@ -29,6 +44,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    local selectiontype = bit.band(option, 0xF)
+    if csid == 273 and selectiontype == 2 then
+        local item = bit.rshift(option,14)
+        local choice = items[item]
+        local assaultPoints = player:getAssaultPoint(xi.assaultUtil.assaultArea.LEUJAOAM_SANCTUM)
+        local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
+
+        player:updateEvent(0, 0, assaultPoints, 0, canEquip)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -42,21 +66,6 @@ entity.onEventFinish = function(player, csid, option)
         elseif selectiontype == 2 then
             -- purchased an item
             local item = bit.rshift(option, 14)
-            local items =
-            {
-                [1]  = {itemid = xi.items.STOIC_EARRING,      price = 3000},
-                [2]  = {itemid = xi.items.UNFETTERED_RING,    price = 5000},
-                [3]  = {itemid = xi.items.TEMPERED_CHAIN,     price = 8000},
-                [4]  = {itemid = xi.items.POTENT_BELT,        price = 10000},
-                [5]  = {itemid = xi.items.MIRACULOUS_CAPE,    price = 10000},
-                [6]  = {itemid = xi.items.YIGIT_BULAWA,       price = 10000},
-                [7]  = {itemid = xi.items.IMPERIAL_BHUJ,      price = 15000},
-                [8]  = {itemid = xi.items.PAHLUWAN_PATAS,     price = 15000},
-                [9]  = {itemid = xi.items.AMIR_KOLLUKS,       price = 15000},
-                [10] = {itemid = xi.items.PAHLUWAN_QALANSUWA, price = 20000},
-                [11] = {itemid = xi.items.YIGIT_SERAWEELS,    price = 20000},
-            }
-
             local choice = items[item]
             if choice and npcUtil.giveItem(player, choice.itemid) then
                 player:delAssaultPoint(xi.assaultUtil.assaultArea.LEUJAOAM_SANCTUM, choice.price)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
