### PR TITLE
Change profile_t.rankpoints to uint16, add additional safety

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -58,7 +58,7 @@ struct profile_t
     uint16     title;      // звание
     uint16     fame[15];   // известность
     uint8      rank[3];    // рагн в трех государствах
-    uint32     rankpoints; // очки ранга в трех государствах
+    uint16     rankpoints; // очки ранга в трех государствах
     location_t home_point; // точка возрождения персонажа
     uint8      campaign_allegiance;
     uint8      unity_leader;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5693,7 +5693,7 @@ void CLuaBaseEntity::setRank(uint8 rank)
  *  Example : player:getRankPoints()
  ************************************************************************/
 
-uint32 CLuaBaseEntity::getRankPoints()
+uint16 CLuaBaseEntity::getRankPoints()
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
@@ -5707,13 +5707,13 @@ uint32 CLuaBaseEntity::getRankPoints()
  *  Notes   : Like, when you trade crystals
  ************************************************************************/
 
-void CLuaBaseEntity::addRankPoints(uint32 rankpoints)
+void CLuaBaseEntity::addRankPoints(uint16 rankPoints)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
-    PChar->profile.rankpoints += rankpoints;
+    PChar->profile.rankpoints = std::min<uint16>(PChar->profile.rankpoints + rankPoints, 4000);
 
     charutils::SaveMissionsList(PChar);
 }
@@ -5725,13 +5725,15 @@ void CLuaBaseEntity::addRankPoints(uint32 rankpoints)
  *  Notes   : player:setRankPoints(0) is called after switching nations
  ************************************************************************/
 
-void CLuaBaseEntity::setRankPoints(uint32 rankpoints)
+void CLuaBaseEntity::setRankPoints(uint16 rankPoints)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
-    PChar->profile.rankpoints = rankpoints;
+    // NOTE: Any value over 4000 currently causes visual defects in the client; therefore, is
+    // hard-coded here and in the above function to limit values.
+    PChar->profile.rankpoints = std::min<uint16>(rankPoints, 4000);
     charutils::SaveMissionsList(PChar);
 }
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -327,9 +327,9 @@ public:
 
     uint8  getRank(uint8 nation);            // Get Rank for current active nation
     void   setRank(uint8 rank);              // Set Rank
-    uint32 getRankPoints();                  // Get Current Rank points
-    void   addRankPoints(uint32 rankpoints); // Add rank points to existing rank point total
-    void   setRankPoints(uint32 rankpoints); // Set Current Rank points
+    uint16 getRankPoints();                  // Get Current Rank points
+    void   addRankPoints(uint16 rankpoints); // Add rank points to existing rank point total
+    void   setRankPoints(uint16 rankpoints); // Set Current Rank points
 
     void  addQuest(uint8 questLogID, uint16 questID);          // Add Quest to Entity Quest Log
     void  delQuest(uint8 questLogID, uint16 questID);          // Remove quest from quest log (should be used for debugging only)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #909 

Any value over 4000 for rankpoints will cause visual defects in the client.  This adds std::min checking for addRankPoints and setRankPoints bindings.

In addition, profile_t was storing rankpoints as a uint32 value, but packet output is uint16.  This PR also corrects that and fixes references.