### PR TITLE
Fix Experience rewards for quests

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -482,7 +482,11 @@ function npcUtil.completeQuest(player, area, quest, params)
         player:messageSpecial(ID.text.BAYLD_OBTAINED, params["bayld"] * xi.settings.BAYLD_RATE)
     end
 
-    if params["xp"] ~= nil and type(params["xp"]) == "number" then
+    -- TODO: Find a more elegant way to handle this, but allow for xp vs exp keys.  This should
+    -- be one or the other, not both.
+    if params["exp"] ~= nil and type(params["exp"]) == "number" then
+        player:addExp(params["exp"] * xi.settings.EXP_RATE)
+    elseif params["xp"] ~= nil and type(params["xp"]) == "number" then
         player:addExp(params["xp"] * xi.settings.EXP_RATE)
     end
 
@@ -567,7 +571,11 @@ function npcUtil.completeMission(player, logId, missionId, params)
         player:messageSpecial(ID.text.BAYLD_OBTAINED, params["bayld"] * xi.settings.BAYLD_RATE)
     end
 
-    if params["xp"] ~= nil and type(params["xp"]) == "number" then
+    -- TODO: Find a more elegant way to handle this, but allow for xp vs exp keys.  This should
+    -- be one or the other, not both.
+    if params["exp"] ~= nil and type(params["exp"]) == "number" then
+        player:addExp(params["exp"] * xi.settings.EXP_RATE)
+    elseif params["xp"] ~= nil and type(params["xp"]) == "number" then
         player:addExp(params["xp"] * xi.settings.EXP_RATE)
     end
 

--- a/scripts/quests/windurst/A_Smudge_on_Ones_Record.lua
+++ b/scripts/quests/windurst/A_Smudge_on_Ones_Record.lua
@@ -15,7 +15,7 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_SMUDGE_
 
 quest.reward =
 {
-    exp = 2000,
+    xp = 2000,
     fame = 120,
     gil = 5000,
     keyItem = xi.ki.MAP_OF_FEIYIN,

--- a/scripts/quests/windurst/Glyph_Hanger.lua
+++ b/scripts/quests/windurst/Glyph_Hanger.lua
@@ -16,7 +16,7 @@ local quest = Quest:new(xi.quest.log_id.WINDURST, xi.quest.id.windurst.GLYPH_HAN
 
 quest.reward =
 {
-    exp = 2000,
+    xp = 2000,
     fame = 120,
     keyItem = xi.ki.MAP_OF_THE_HORUTOTO_RUINS,
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #915 

npcUtil.completeQuest function expects 'xp' as key for experience reward, and not 'exp.'  Adjusts the two references in interaction scripts.