### PR TITLE
Fixed wrong Lebros Assault vendor item order

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
@@ -23,9 +23,9 @@ local items =
     [6]  = {itemid = xi.items.IMPERIAL_POLE,     price = 15000},
     [7]  = {itemid = xi.items.DOOMBRINGER,       price = 15000},
     [8]  = {itemid = xi.items.SAYOSAMONJI,       price = 15000},
-    [9]  = {itemid = xi.items.AMIR_KORAZIN,      price = 20000},
-    [10] = {itemid = xi.items.PAHLUWAN_DASTANAS, price = 20000},
-    [11] = {itemid = xi.items.YIGIT_CRACKOWS,    price = 20000},
+    [9]  = {itemid = xi.items.PAHLUWAN_DASTANAS, price = 20000},
+    [10] = {itemid = xi.items.YIGIT_CRACKOWS,    price = 20000},
+    [11] = {itemid = xi.items.AMIR_KORAZIN,      price = 20000},
 }
 
 entity.onTrade = function(player, npc, trade)


### PR DESCRIPTION
Ingame item showcased was different than what was given after the trade. All other Assault vendors are correct.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
