### PR TITLE
Update migration for MyISAM to InnoDB - now only converts tables we write to.

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -61,7 +61,7 @@ from migrations import eminence_blob
 from migrations import char_timestamp
 from migrations import currency_columns
 from migrations import add_instance_zone_column
-from migrations import convert_all_tables_to_innodb
+from migrations import convert_tables_to_innodb
 from migrations import char_points_weekly_unity
 from migrations import char_profile_unity_leader
 from migrations import convert_mission_status
@@ -89,7 +89,7 @@ migrations = [
     char_timestamp,
     currency_columns,
     add_instance_zone_column,
-    convert_all_tables_to_innodb,
+    convert_tables_to_innodb,
     char_points_weekly_unity,
     char_profile_unity_leader,
     convert_mission_status,

--- a/tools/migrations/convert_tables_to_innodb.py
+++ b/tools/migrations/convert_tables_to_innodb.py
@@ -2,7 +2,7 @@ import array
 import mysql.connector
 
 def migration_name():
-	return "Converting DB engine for all tables from MyISAM to InnoDB"
+	return "Converting DB engine for tables from MyISAM to InnoDB"
 
 def check_preconditions(cur):
 	return
@@ -15,10 +15,14 @@ def needs_to_run(cur):
 
 def migrate(cur, db):
 	try:
-		cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'xidb' AND ENGINE = 'MyISAM'") 
+		cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'xidb' AND ENGINE = 'MyISAM' AND \
+					(TABLE_NAME LIKE 'char' OR TABLE_NAME LIKE 'account' OR TABLE_NAME LIKE 'audit' OR TABLE_NAME == 'delivery_box' OR \
+					TABLE_NAME == 'auction_house' OR TABLE_NAME == 'conquest_system' OR TABLE_NAME == 'unity_system' OR \
+					TABLE_NAME == 'server_variables' OR TABLE_NAME == 'linkshells' OR TABLE_NAME == 'bcnm_info'"))
 		for r in cur.fetchall():
 			cur.execute('ALTER TABLE `{}` ROW_FORMAT=DYNAMIC;'.format(r[0]))
 			cur.execute('ALTER TABLE `{}` ENGINE=InnoDB;'.format(r[0]))
 		db.commit()
 	except mysql.connector.Error as err:
 		print("Something went wrong: {}".format(err))
+


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Tables that should be MyISAM will be made so by re-importing anyway, and contain no char data.