### PR TITLE
Updated some packets for November update packet changes

### DIFF
--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -102,7 +102,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
         PChar->pushPacket(new CBasicPacket(*this));
     }
 
-    this->size = 0x28;
+    this->size = 0x2A;
     memset(data + (0x0B), 0, PACKET_SIZE - 11);
 
     ref<uint8>(0x0A) = 0x01;
@@ -111,18 +111,21 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 
     if ((PLinkshell != nullptr) && PLinkshell->isType(ITEM_LINKSHELL))
     {
-        // ref<uint16>(0x0C) = PLinkshell->GetLSID();
         ref<uint16>(0x0E) = PLinkshell->getID();
-        ref<uint16>(0x10) = PLinkshell->GetLSRawColor();
+        memcpy(data + (0x10), PLinkshell->getSignature(), std::clamp<size_t>(strlen((const char*)PLinkshell->getSignature()), 0, 15));
+        // ref<uint16>(0x0C) = PLinkshell->GetLSID();
+        ref<uint16>(0x20) = PLinkshell->GetLSRawColor();
 
-        memcpy(data + (0x14), PLinkshell->getSignature(), std::clamp<size_t>(strlen((const char*)PLinkshell->getSignature()), 0, 15));
     }
     if ((PChar->nameflags.flags & FLAG_GM) || !(PTarget->nameflags.flags & FLAG_ANON))
     {
-        ref<uint8>(0x12) = PTarget->GetMJob();
-        ref<uint8>(0x13) = PTarget->GetSJob();
+        ref<uint8>(0x22) = PTarget->GetMJob();
+        ref<uint8>(0x23) = PTarget->GetSJob();
         ref<uint8>(0x24) = PTarget->GetMLevel();
         ref<uint8>(0x25) = PTarget->GetSLevel();
+        ref<uint8>(0x26) = PTarget->GetMJob();
+        //0x27: master level
+        //0x28: bitflags, bit 0 = master breaker
     }
 
     // Chevron 32 bit Big Endean, starting at 0x2B

--- a/src/map/packets/char_health.cpp
+++ b/src/map/packets/char_health.cpp
@@ -29,7 +29,7 @@
 CCharHealthPacket::CCharHealthPacket(CCharEntity* PChar)
 {
     this->type = 0xDF;
-    this->size = 0x12;
+    this->size = 0x14;
 
     ref<uint32>(0x04) = PChar->id;
 
@@ -48,6 +48,8 @@ CCharHealthPacket::CCharHealthPacket(CCharEntity* PChar)
         ref<uint8>(0x21) = PChar->GetMLevel();
         ref<uint8>(0x22) = PChar->GetSJob();
         ref<uint8>(0x23) = PChar->GetSLevel();
+        //0x24: master level
+        //0x25: bitflags, bit 0 = master breaker
     }
 }
 

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -33,7 +33,7 @@
 CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
 {
     this->type = 0x61;
-    this->size = 0x64;
+    this->size = 0x70;
 
     ref<uint32>(0x04) = PChar->GetMaxHP();
     ref<uint32>(0x08) = PChar->GetMaxMP();
@@ -82,6 +82,11 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
     ref<uint8>(0x57) = charutils::getRangedItemLevel(PChar);     // Item level of Ranged (Ranged priority, ammo if only)
 
     ref<uint32>(0x58) = (charutils::GetPoints(PChar, "unity_accolades") << 10) | (0x00 << 5 | PChar->profile.unity_leader);
+    //TODO: these may no longer be correct
     ref<uint16>(0x5C) = charutils::GetPoints(PChar, "current_accolades") / 1000; // Partial Personal Eval
     ref<uint16>(0x5E) = charutils::GetPoints(PChar, "prev_accolades") / 1000;    // Personal Eval
+    //0x65: master level
+    //0x66: bitflags, bit 0 = master breaker
+    //0x68: current exemplar points
+    //0x6C: required exemplar points
 }

--- a/src/map/packets/party_member_update.cpp
+++ b/src/map/packets/party_member_update.cpp
@@ -33,7 +33,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 MemberNumber, uint16 memberflags, uint16 ZoneID)
 {
     this->type = 0xDD;
-    this->size = 0x20;
+    this->size = 0x21;
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 
@@ -64,13 +64,13 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
         }
     }
 
-    memcpy(data + (0x26), PChar->GetName(), PChar->name.size());
+    memcpy(data + (0x28), PChar->GetName(), PChar->name.size());
 }
 
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 MemberNumber)
 {
     this->type = 0xDD;
-    this->size = 0x20;
+    this->size = 0x21;
 
     XI_DEBUG_BREAK_IF(PTrust == nullptr);
 
@@ -90,18 +90,18 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 M
     ref<uint8>(0x24) = PTrust->GetSJob();
     ref<uint8>(0x25) = PTrust->GetSLevel();
 
-    memcpy(data + (0x26), PTrust->packetName.c_str(), PTrust->packetName.size());
+    memcpy(data + (0x28), PTrust->packetName.c_str(), PTrust->packetName.size());
 }
 
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(uint32 id, const int8* name, uint16 memberFlags, uint8 MemberNumber, uint16 ZoneID)
 {
     this->type = 0xDD;
-    this->size = 0x20;
+    this->size = 0x21;
 
     ref<uint32>(0x04) = id;
 
     ref<uint16>(0x14) = memberFlags;
     ref<uint16>(0x20) = ZoneID;
 
-    memcpy(data + (0x26), name, strlen((const char*)name));
+    memcpy(data + (0x28), name, strlen((const char*)name));
 }


### PR DESCRIPTION
mostly just names moving around a bit

it's possible linkshell colours are wrong even with this change, windower's packet implies the order of the colours changed, but I'm not sure if it's right.  If it has, the empty bits just moved to the front instead of the back.

this is just data according to Windower and some quick capping from myself.  might not be all right, I didn't test linkshell colour nor the party member packet.