### PR TITLE
adjusting mobs.lua addl effect script - needed to avoid mp/tp drain causing damage

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -477,7 +477,7 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
                 power = addBonusesAbility(mob, ae.ele, target, power, ae.bonusAbilityParams)
                 power = power * applyResistanceAddEffect(mob, target, ae.ele, 0)
                 power = adjustForTarget(target, power, ae.ele)
-                if ae.sub ~= dsp.subEffect.TP_DRAIN or ae.sub ~= dsp.subEffect.MP_DRAIN then
+                if ae.sub ~= xi.subEffect.TP_DRAIN or ae.sub ~= xi.subEffect.MP_DRAIN then
                     power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)
                 end
 

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -477,7 +477,9 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
                 power = addBonusesAbility(mob, ae.ele, target, power, ae.bonusAbilityParams)
                 power = power * applyResistanceAddEffect(mob, target, ae.ele, 0)
                 power = adjustForTarget(target, power, ae.ele)
-                power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)
+                if ae.sub ~= dsp.subEffect.TP_DRAIN or ae.sub ~= dsp.subEffect.MP_DRAIN then
+                    power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)
+                end
 
                 -- target:PrintToPlayer(string.format("Adjusted Power: %f", power)) -- DEBUG
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Our server's ae effect code is similar to LSB and figured out that TP/MP drain was causing damage on top of returning the code (i.e. mp_drain value of 100 would drain 100 mp and hp), so making the adjustment here to bypass takedamage (also stoneskin/phalanx should have no effect on these kinds of drain values).

If there is a more developery way to do this, I'm happy to adjust. 
