### PR TITLE
Fix innodb migration syntax, and add stricter check to needs_to_run

### DIFF
--- a/tools/migrations/convert_tables_to_innodb.py
+++ b/tools/migrations/convert_tables_to_innodb.py
@@ -8,7 +8,10 @@ def check_preconditions(cur):
 	return
 
 def needs_to_run(cur):
-	cur.execute("SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'xidb' AND ENGINE = 'MyISAM' LIMIT 1")
+	cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'xidb' AND ENGINE = 'MyISAM' AND \
+				(TABLE_NAME LIKE 'char' OR TABLE_NAME LIKE 'account' OR TABLE_NAME LIKE 'audit' OR TABLE_NAME = 'delivery_box' OR \
+				TABLE_NAME = 'auction_house' OR TABLE_NAME = 'conquest_system' OR TABLE_NAME = 'unity_system' OR \
+				TABLE_NAME = 'server_variables' OR TABLE_NAME = 'linkshells' OR TABLE_NAME = 'bcnm_info')")
 	if cur.fetchone():
 		return True
 	return False
@@ -16,9 +19,9 @@ def needs_to_run(cur):
 def migrate(cur, db):
 	try:
 		cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'xidb' AND ENGINE = 'MyISAM' AND \
-					(TABLE_NAME LIKE 'char' OR TABLE_NAME LIKE 'account' OR TABLE_NAME LIKE 'audit' OR TABLE_NAME == 'delivery_box' OR \
-					TABLE_NAME == 'auction_house' OR TABLE_NAME == 'conquest_system' OR TABLE_NAME == 'unity_system' OR \
-					TABLE_NAME == 'server_variables' OR TABLE_NAME == 'linkshells' OR TABLE_NAME == 'bcnm_info'"))
+					(TABLE_NAME LIKE 'char' OR TABLE_NAME LIKE 'account' OR TABLE_NAME LIKE 'audit' OR TABLE_NAME = 'delivery_box' OR \
+					TABLE_NAME = 'auction_house' OR TABLE_NAME = 'conquest_system' OR TABLE_NAME = 'unity_system' OR \
+					TABLE_NAME = 'server_variables' OR TABLE_NAME = 'linkshells' OR TABLE_NAME = 'bcnm_info')")
 		for r in cur.fetchall():
 			cur.execute('ALTER TABLE `{}` ROW_FORMAT=DYNAMIC;'.format(r[0]))
 			cur.execute('ALTER TABLE `{}` ENGINE=InnoDB;'.format(r[0]))


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes query syntax, and applies the same check to need_to_run to prevent migration from always triggering