### PR TITLE
Fix packet issue for parties and trusts

### DIFF
--- a/src/map/packets/party_member_update.cpp
+++ b/src/map/packets/party_member_update.cpp
@@ -33,7 +33,12 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 MemberNumber, uint16 memberflags, uint16 ZoneID)
 {
     this->type = 0xDD;
-    this->size = 0x21;
+
+    // This packet size may have changed in the Nov 2021 Update with the introduction of master levels, but it broke things for us in the following ways:
+    // 1. Trusts would not appear in the party list
+    // 2. Players in a party would always appear as out of zone
+    // Modify with caution for the below functions!
+    this->size = 0x20;
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 
@@ -70,7 +75,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 MemberNumber)
 {
     this->type = 0xDD;
-    this->size = 0x21;
+    this->size = 0x20;
 
     XI_DEBUG_BREAK_IF(PTrust == nullptr);
 
@@ -96,7 +101,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 M
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(uint32 id, const int8* name, uint16 memberFlags, uint8 MemberNumber, uint16 ZoneID)
 {
     this->type = 0xDD;
-    this->size = 0x21;
+    this->size = 0x20;
 
     ref<uint32>(0x04) = id;
 

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -840,7 +840,7 @@ void CParty::ReloadPartyMembers(CCharEntity* PChar)
             alliance = memberinfo.flags & (PARTY_SECOND | PARTY_THIRD);
             j        = 0;
         }
-        CCharEntity* PPartyMember = zoneutils::GetChar(memberinfo.zone);
+        CCharEntity* PPartyMember = zoneutils::GetChar(memberinfo.id);
         if (PPartyMember)
         {
             PChar->pushPacket(new CPartyMemberUpdatePacket(PPartyMember, j, memberinfo.flags, PChar->getZone()));


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adjusts packet size, though this may have changed with the November update, client became very unhappy with using 0x21, which would result in Trusts not appearing in the party list, and players appearing as always out of zone.

Also changes ReloadPartyMembers to provide character ID as an argument, as opposed to zone.  This appears to be unrelated to the original issue, but does not follow the expected parameter.

EDIT(ZT):
Fixes https://github.com/LandSandBoat/server/issues/964