### PR TITLE
[Fix] [Interaction] ZM 17 Lower Jeuno CS trigger

### DIFF
--- a/scripts/missions/rotz/17_Awakening.lua
+++ b/scripts/missions/rotz/17_Awakening.lua
@@ -46,9 +46,9 @@ mission.sections =
 
         [xi.zone.LOWER_JEUNO] =
         {
-            onRegionEnter =
+            ['_6tc'] =
             {
-                [1] = function(player, csid, option, npc)
+                onTrigger = function(player, csid, option, npc)
                     if not utils.mask.getBit(player:getMissionStatus(mission.areaId), 1) then
                         return mission:event(20)
                     end

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -14,7 +14,7 @@ require("scripts/globals/status")
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
-    zone:registerRegion(1, 23, 0, -43, 44, 7, -39) -- Inside Tenshodo HQ
+    zone:registerRegion(1, 23, 0, -43, 44, 7, -39) -- Inside Tenshodo HQ. TODO: Find out if this is used other than in ZM 17 (not anymore). Remove if not.
     xi.chocobo.initZone(zone)
 end
 
@@ -24,19 +24,29 @@ zone_object.onZoneIn = function(player, prevZone)
     local month = tonumber(os.date("%m"))
     local day = tonumber(os.date("%d"))
     -- Retail start/end dates vary, I am going with Dec 5th through Jan 5th.
-    if (month == 12 and day >= 5) or (month == 1 and day <= 5) then
+    if
+        (month == 12 and day >= 5) or
+        (month == 1 and day <= 5)
+    then
         player:ChangeMusic(0, 239)
         player:ChangeMusic(1, 239)
         -- No need for an 'else' to change it back outside these dates as a re-zone will handle that.
     end
 
-    if player:getCurrentMission(COP) == xi.mission.id.cop.TENDING_AGED_WOUNDS and player:getCharVar("PromathiaStatus") == 0 then
+    if
+        player:getCurrentMission(COP) == xi.mission.id.cop.TENDING_AGED_WOUNDS and
+        player:getCharVar("PromathiaStatus") == 0
+    then
         player:setCharVar("PromathiaStatus", 1)
         cs = 70
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(41.2, -5, 84, 85)
     end
 

--- a/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
@@ -2,6 +2,7 @@
 -- Area: Lower Jeuno
 --  NPC: Door: "Neptune's Spire"
 -- Starts and Finishes Quest: Beat Around the Bushin
+-- ZM 17 cutscene
 -- !pos 35 0 -15 245
 -----------------------------------
 require("scripts/settings/main")
@@ -15,28 +16,57 @@ local ID = require("scripts/zones/Lower_Jeuno/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEAT_AROUND_THE_BUSHIN) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(1526, 1) == true and trade:getItemCount() == 1 and player:getCharVar("BeatAroundTheBushin") == 2) then
+    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEAT_AROUND_THE_BUSHIN) == QUEST_ACCEPTED then
+        if
+            trade:hasItemQty(1526, 1) == true and
+            trade:getItemCount() == 1 and
+            player:getCharVar("BeatAroundTheBushin") == 2
+        then
             player:startEvent(156) -- After trade Wyrm Beard
-        elseif (trade:hasItemQty(1527, 1) == true and trade:getItemCount() == 1 and player:getCharVar("BeatAroundTheBushin") == 4) then
+
+        elseif
+            trade:hasItemQty(1527, 1) == true and
+            trade:getItemCount() == 1 and
+            player:getCharVar("BeatAroundTheBushin") == 4
+        then
             player:startEvent(157) -- After trade Behemoth Tongue
-        elseif (trade:hasItemQty(1525, 1) == true and trade:getItemCount() == 1 and player:getCharVar("BeatAroundTheBushin") == 6) then
+
+        elseif
+            trade:hasItemQty(1525, 1) == true and
+            trade:getItemCount() == 1 and
+            player:getCharVar("BeatAroundTheBushin") == 6
+        then
             player:startEvent(158) -- After trade Adamantoise Egg
-        elseif (trade:hasItemQty(13202, 1) == true and trade:getItemCount() == 1 and player:getCharVar("BeatAroundTheBushin") == 7) then
+
+        elseif
+            trade:hasItemQty(13202, 1) == true and
+            trade:getItemCount() == 1 and
+            player:getCharVar("BeatAroundTheBushin") == 7
+        then
             player:startEvent(159) -- After trade Brown Belt, Finish Quest "Beat around the Bushin"
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCurrentMission(COP) == xi.mission.id.cop.A_VESSEL_WITHOUT_A_CAPTAIN and player:getCharVar("PromathiaStatus") == 0) then
+    if
+        player:getCurrentMission(COP) == xi.mission.id.cop.A_VESSEL_WITHOUT_A_CAPTAIN and
+        player:getCharVar("PromathiaStatus") == 0
+    then
         player:startEvent(86) --COP event
-    elseif (player:getCurrentMission(COP) == xi.mission.id.cop.TENDING_AGED_WOUNDS and player:getCharVar("PromathiaStatus")==1) then
+
+    elseif
+        player:getCurrentMission(COP) == xi.mission.id.cop.TENDING_AGED_WOUNDS and
+        player:getCharVar("PromathiaStatus") == 1
+    then
         player:startEvent(22) --COP event
-    elseif (player:getCharVar("BeatAroundTheBushin") == 1) then
+
+    elseif player:getCharVar("BeatAroundTheBushin") == 1 then
         player:startEvent(155) -- Start Quest "Beat around the Bushin"
-    elseif (player:hasKeyItem(xi.ki.TENSHODO_MEMBERS_CARD) == true) then
+
+    elseif player:hasKeyItem(xi.ki.TENSHODO_MEMBERS_CARD) == true then
         player:startEvent(105) -- Open the door
+
     else
         player:messageSpecial(ID.text.ITS_LOCKED)
         return 1
@@ -47,28 +77,28 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 86 ) then
+    if csid == 86 then
         player:setCharVar("PromathiaStatus", 1)
         player:startEvent(9)
-    elseif (csid == 22 ) then
+    elseif csid == 22 then
         player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.TENDING_AGED_WOUNDS)
         player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.DARKNESS_NAMED)
         player:setCharVar("PromathiaStatus", 0)
         player:startEvent(10)
-    elseif (csid == 155) then
+    elseif csid == 155 then
         player:addQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEAT_AROUND_THE_BUSHIN)
         player:setCharVar("BeatAroundTheBushin", 2)
-    elseif (csid == 156) then
+    elseif csid == 156 then
         player:setCharVar("BeatAroundTheBushin", 3)
         player:tradeComplete()
-    elseif (csid == 157) then
+    elseif csid == 157 then
         player:setCharVar("BeatAroundTheBushin", 5)
         player:tradeComplete()
-    elseif (csid == 158) then
+    elseif csid == 158 then
         player:setCharVar("BeatAroundTheBushin", 7)
         player:tradeComplete()
-    elseif (csid == 159) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 159 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13186)
         else
             player:addTitle(xi.title.BLACK_BELT)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [?] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

As shown in videos posted in Issue 978, this changes the trigger of ZM 17 cutscene from a region to a npc trigger.
Also cleans npc script.
Closes #978