### PR TITLE
Additional Effects: safety check for statuses

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -56,10 +56,6 @@ xi.additionalEffect.levelCorrection = function(dLV, aLV, chance)
 end
 
 xi.additionalEffect.statusAttack = function(addStatus, defender)
-    if not addStatus then
-        return 0
-    end
-
     local effectList =
     {
         [xi.effect.DEFENSE_DOWN] = {tick = 0, strip = xi.effect.DEFENSE_BOOST},
@@ -69,8 +65,14 @@ xi.additionalEffect.statusAttack = function(addStatus, defender)
         [xi.effect.CHOKE]        = {tick = 3, strip = nil},
     }
     local effect = effectList[addStatus]
-    defender:delStatusEffect(effect.strip)
-    return effect.tick
+    if effect then
+        if effect.strip then
+            defender:delStatusEffect(effect.strip)
+        end
+        return effect.tick
+    end
+
+    return 0
 end
 
 xi.additionalEffect.calcDamage = function(attacker, element, defender, damage)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I broke the safety of this helper with my last minute split off of debuffs from damage into 2 types, causing it to be able to send nil into delStatusEffect.

The helper function here just looks for it the status effect is something that should remove a different effect or if the effect needs a tick value, and nothing else. I'm in the middle of restructuring this global to get rid of the if/else tower (parameterizing things into a keyed table) so more is coming and this may wind up looking very different but thought I should fix this nil bug in the meantime. 