### PR TITLE
removing double flameholder effect

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -589,7 +589,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
     -- Factor in "all hits" bonus damage mods
     local bonusdmg = attacker:getMod(xi.mod.ALL_WSDMG_ALL_HITS) -- For any WS
 
-    if attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then -- For specific WS
+    if attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 and not attacker:isPet() then -- For specific WS
         bonusdmg = bonusdmg + attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)
     end
 
@@ -812,7 +812,7 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
 
         -- Factor in "all hits" bonus damage mods
         local bonusdmg = attacker:getMod(xi.mod.ALL_WSDMG_ALL_HITS) -- For any WS
-        if attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 then -- For specific WS
+        if attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID) > 0 and not attacker:isPet() then -- For specific WS
             bonusdmg = bonusdmg + attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)
         end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

~~(i'll get lsb running today and test and check the box, just didnt want to forget)~~
tested: ftp bonus remains, extra bonus dmg multiplier is now 0

in the flameholder script, the weaponskill_damage_base mod is added based on the number of maneuvers
https://github.com/LandSandBoat/server/blob/f98d90c88cfadcb1a4e8536bcdd184e1bb3ef0fd/scripts/globals/abilities/pets/attachments/flame_holder.lua#L41
in automatonweaponskills, the flameholder bonus is added (flameholder adds bonus ftp to the weaponskill), on https://github.com/LandSandBoat/server/blob/f98d90c88cfadcb1a4e8536bcdd184e1bb3ef0fd/scripts/globals/automatonweaponskills.lua#L183 https://github.com/LandSandBoat/server/blob/f98d90c88cfadcb1a4e8536bcdd184e1bb3ef0fd/scripts/globals/automatonweaponskills.lua#L217 and used in the weaponskills file at https://github.com/LandSandBoat/server/blob/f98d90c88cfadcb1a4e8536bcdd184e1bb3ef0fd/scripts/globals/weaponskills.lua#L464
this bonus is then added again as a bonus damage multiplier to the final damage value in the weaponskills file https://github.com/LandSandBoat/server/blob/f98d90c88cfadcb1a4e8536bcdd184e1bb3ef0fd/scripts/globals/weaponskills.lua#L592, which results in some astronomical numbers with three fire maneuvers up. 
this pr removes the second addition of the weaponskill_damage_base value in the weaponskills file from pets (which would just be autos) so that the ftp bonus is counted only in the right place. 
i would venture to question the inclusion of the weaponskill_dmg_base at the very end of weaponskills functions anyway, since it implies bonus ftp vs end damage multiplier, but there may be modern uses im unaware of. 

the alternative is to move flameholder's mod to something else, so if you'd prefer that i can certainly make the change, this is just super abusable atm and wanted to get a fix in.