### PR TITLE
[core] Add additional safety checks when removing TYPE_NPC from battlefields

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -498,7 +498,8 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
     }
     else
     {
-        auto check = [PEntity, &found](auto entity) {
+        auto check = [PEntity, &found](auto entity)
+        {
             if (PEntity == entity)
             {
                 found = true;
@@ -511,7 +512,14 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
         {
             PEntity->status = STATUS_TYPE::DISAPPEAR;
             PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, new CEntityUpdatePacket(PEntity, ENTITY_DESPAWN, UPDATE_ALL_MOB));
-            m_NpcList.erase(std::remove_if(m_NpcList.begin(), m_NpcList.end(), check), m_NpcList.end());
+
+            if (auto* PNpcEntity = dynamic_cast<CNpcEntity*>(PEntity))
+            {
+                if (std::find(m_NpcList.begin(), m_NpcList.end(), PNpcEntity) != m_NpcList.end())
+                {
+                    m_NpcList.erase(std::remove_if(m_NpcList.begin(), m_NpcList.end(), check), m_NpcList.end());
+                }
+            }
         }
         else if (PEntity->objtype == TYPE_MOB || PEntity->objtype == TYPE_PET)
         {


### PR DESCRIPTION
Web-client drive-by!

We need to do an audit of entity(mob/pet/npc/etc.) insertion/removal from battlefields and instances. 

Here we have a trace of:
- Player leaving instance zone
- The instance object being destructed
- NPCs associated with that instance being destructed
- Them trying to remove themselves from a battlefield... which they're not in... because... instance? :shrug:

At this point, we have to find some reasonable steps to allow us to repro this locally, because we're flying blind

Reported crash (from https://github.com/LandSandBoat/server/pull/736):
```
[11/18/21 18:59:24:419][map][debug][debug] [CZoneInstance]DecreaseZoneCounter cleaned up Instance imperial_agent_rescue (CZoneInstance::DecreaseZoneCounter:171)
[11/18/21 18:59:24:419][topaz_game_64.exe][critical][fatalerror] Exception STATUS_ACCESS_VIOLATION (0XC0000005) occured!
[11/18/21 18:59:24:432][topaz_game_64.exe][debug][debug] Message: Received message 9 from message server
[11/18/21 18:59:24:516][topaz_game_64.exe][critical][stacktrace] 	at CBattlefield::RemoveEntity in C:\server\src\map\battlefield.cpp: line: 514: address: 0x7FF7598BDC90
[11/18/21 18:59:24:516][topaz_game_64.exe][critical][stacktrace] 	at CBaseEntity::~CBaseEntity in C:\server\src\map\entities\baseentity.cpp: line: 64: address: 0x7FF759983600
[11/18/21 18:59:24:517][topaz_game_64.exe][critical][stacktrace] 	at CNpcEntity::`scalar deleting destructor', address 0x7FF759983CA0.
[11/18/21 18:59:24:517][topaz_game_64.exe][critical][stacktrace] in C:\server\topaz_game_64.exe
[11/18/21 18:59:24:517][topaz_game_64.exe][critical][stacktrace] 	at CInstance::~CInstance in C:\server\src\map\instance.cpp: line: 50: address: 0x7FF7598D1210
[11/18/21 18:59:24:517][topaz_game_64.exe][critical][stacktrace] 	at std::vector<std::unique_ptr<CInstance,std::default_delete<CInstance> >,std::allocator<std::unique_ptr<CInstance,std::default_delete<CInstance> > > >::erase in C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector: line: 1420: address: 0x7FF759949FF0
[11/18/21 18:59:24:517][topaz_game_64.exe][critical][stacktrace] 	at CZoneInstance::DecreaseZoneCounter in C:\server\src\map\zone_instance.cpp: line: 180: address: 0x7FF759948AB0
[11/18/21 18:59:24:518][topaz_game_64.exe][critical][stacktrace] 	at SmallPacket0x00D in C:\server\src\map\packet_system.cpp: line: 535: address: 0x7FF7598F45F0
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at parse in C:\server\src\map\map.cpp: line: 659: address: 0x7FF7598DD230
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at do_sockets in C:\server\src\map\map.cpp: line: 416: address: 0x7FF7598DC310
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at main in C:\server\src\common\kernel.cpp: line: 495: address: 0x7FF75995BCD0
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at __scrt_common_main_seh in d:\a01\_work\6\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl: line: 288: address: 0x7FF759BAE2A0
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at BaseThreadInitThunk, address 0x7FFFAF557960.
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] in C:\Windows\System32\KERNEL32.DLL
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] 	at RtlUserThreadStart, address 0x7FFFB08BA2D0.
[11/18/21 18:59:24:519][topaz_game_64.exe][critical][stacktrace] in C:\Windows\SYSTEM32\ntdll.dll```
```

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [TODO] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
