### PR TITLE
Luacheck - Convert duration conditional to utils.clamp

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -437,13 +437,7 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
                         duration = duration - dLevel
                     end
 
-                    if ae.minDuration and duration < ae.minDuration then
-                        duration = ae.minDuration
-                    elseif ae.maxDuration and duration > ae.maxDuration then
-                        duration = ae.maxDuration
-                    end
-
-                    duration = duration * resist
+                    duration = utils.clamp(duration, ae.minDuration, ae.maxDuration) * resist
 
                     target:addStatusEffect(ae.eff, power, tick, duration)
 

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -42,7 +42,7 @@ function utils.permgen(max_val, min_val)
 end
 
 function utils.clamp(input, min_val, max_val)
-    if input < min_val then
+    if min_val ~= nil and input < min_val then
         input = min_val
     elseif max_val ~= nil and input > max_val then
         input = max_val


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds nil check to utils.clamp min value, and replaces code block in onAddEffect for mobs.