### PR TITLE
[build] Link filewatcher to correct target and fix include path

### DIFF
--- a/ext/filewatch/CMakeLists.txt
+++ b/ext/filewatch/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(filewatch INTERFACE)
 target_link_libraries(filewatch INTERFACE no_warnings)
-target_include_directories(filewatch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(filewatch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/)

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -141,7 +141,6 @@ target_compile_definitions(
 
 target_link_libraries(topaz_game
     PUBLIC
-    filewatch
     sol2_single
     common
     ai

--- a/src/map/lua/CMakeLists.txt
+++ b/src/map/lua/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(lua_bindings STATIC ${SOURCES})
 target_link_libraries(lua_bindings
     PUBLIC
     common
+    filewatch
     project_options
     #project_warnings
 )

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -87,11 +87,11 @@
 #include "../vana_time.h"
 #include "../weapon_skill.h"
 
-// TODO: Implement FileWatch backend for OSX
 #ifndef __APPLE__
-// TODO: Fix path
-#include "../../ext/filewatch/filewatch/FileWatch.hpp"
+#include "filewatch/FileWatch.hpp"
 std::unique_ptr<filewatch::FileWatch<std::string>> watch = nullptr;
+#else
+// TODO: Implement FileWatch backend for OSX
 #endif // __APPLE__
 
 namespace luautils


### PR DESCRIPTION
Fixes: https://github.com/LandSandBoat/server/issues/1016

I was linking the `filewatcher` target to `topaz_game`, instead of where it's needed in `lua_bindings`. This means I had to use a relative path to get to it: which was very fragile and bad.

This also reminds me that we need to stop using relative paths everwhere and get our include tree sorted... Yay, more build+ci work for me

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
