### PR TITLE
[WIP] [ci] Add Windows_Full_Startup_Checks & FileWatcher checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install MySQL Server
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install mysql
+          args: install mysql --params "/dataLocation:${{ env.GITHUB_WORKSPACE }}"
       - name: Check MySQL connection
         run: |
           mysql -uroot -proot -e "SHOW DATABASES"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
           path: .
       - name: Start MySQL service
         run: |
-          mysqld --datadir=.
+          mysqld --install --datadir=.
           mysql -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,6 +441,7 @@ jobs:
           path: .
       - name: Verify MySQL connection from container
         run: |
+          mysqlds
           mysql -h localhost -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
           path: .
       - name: Verify MySQL connection from container
         run: |
-          mysqld
+          mysqld --datadir=.
           mysql -h localhost -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,14 +441,14 @@ jobs:
           path: .
       - name: Verify MySQL connection from container
         run: |
-          mysql -h 127.0.0.1 -uroot -proot -e "SHOW DATABASES"
+          mysql -h localhost -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |
           for f in sql/*.sql; do
             echo -e "Importing $f into the database..."
-            mysql xidb -h 127.0.0.1 -uroot -proot < $f
+            mysql xidb -h localhost -uroot -proot < $f
           done
-          mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
+          mysql xidb -h localhost -uroot -proot -e "SHOW tables"
       - name: Copy confs
         run: |
           cp conf/default/* conf/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install MySQL Server
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: -h
+          args: install mysql
       - name: Check MySQL connection
         run: |
           mysql -uroot -proot -e "SHOW DATABASES"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,14 @@ jobs:
         shell: cmd
         run: |
           cmake --build .
+      - name: Archive Executables
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows_executables
+          path: |
+            topaz_connect_64.exe
+            topaz_game_64.exe
+            topaz_search_64.exe
 
   MacOS_BigSur_11:
     # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
@@ -212,7 +220,7 @@ jobs:
             exit -1
         fi
 
-  Full_Startup_Checks_2004:
+  Linux_Full_Startup_Checks_2004:
     runs-on: ubuntu-20.04
     needs: Linux_2004_Clang11_64bit
     services:
@@ -335,7 +343,7 @@ jobs:
             exit -1
         fi
 
-  MultiInstance_Startup_Checks_2004:
+  Linux_MultiInstance_Startup_Checks_2004:
     runs-on: ubuntu-20.04
     needs: Linux_2004_Clang11_64bit
     services:
@@ -417,3 +425,42 @@ jobs:
         if grep -qi "Error" map-server-1*.log; then
           exit -1
         fi
+
+  Windows_Full_Startup_Checks:
+    needs: Windows_2019_64bit
+    runs-on: windows-2019
+    env:
+      MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
+    services:
+      mysql:
+        image: mariadb
+        env:
+          MYSQL_DATABASE: xidb
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows_executables
+          path: .
+      - name: Verify MySQL connection from container
+        run: |
+          mysql -h 127.0.0.1 -uroot -proot -e "SHOW DATABASES"
+      - name: Import SQL files
+        run: |
+          for f in sql/*.sql; do
+            echo -e "Importing $f into the database..."
+            mysql xidb -h 127.0.0.1 -uroot -proot < $f
+          done
+          mysql xidb -h 127.0.0.1 -uroot -proot -e "SHOW tables"
+      - name: Copy confs
+        run: |
+          cp conf/default/* conf/
+      - name: Copy settings
+        run: |
+          cp scripts/settings/default/* scripts/settings/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install MySQL Server
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install mysql --params "/installLocation:. /dataLocation:."
+          args: install mysql  --no-progress --params "/installLocation:. /dataLocation:."
       - name: Check MySQL connection
         run: |
           mysql -uroot -e "SHOW DATABASES"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,10 +442,10 @@ jobs:
       - name: Install MySQL Server
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install mysql --params "/dataLocation:${{ env.GITHUB_WORKSPACE }}"
+          args: install mysql --params "/installLocation:${{ env.GITHUB_WORKSPACE }} /dataLocation:${{ env.GITHUB_WORKSPACE }}"
       - name: Check MySQL connection
         run: |
-          mysql -uroot -proot -e "SHOW DATABASES"
+          mysql -uroot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |
           for f in sql/*.sql; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Install MySQL Server
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install mysql --params "/installLocation:${{ env.GITHUB_WORKSPACE }} /dataLocation:${{ env.GITHUB_WORKSPACE }}"
+          args: install mysql --params "/installLocation:. /dataLocation:."
       - name: Check MySQL connection
         run: |
           mysql -uroot -e "SHOW DATABASES"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,6 +445,8 @@ jobs:
           args: install mysql  --no-progress --params "/installLocation:. /dataLocation:."
       - name: Check MySQL connection
         run: |
+          refreshenv
+          mysqld
           mysql -uroot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,7 +427,7 @@ jobs:
         fi
 
   Windows_Full_Startup_Checks:
-    needs: Windows_2019_64bit
+    #needs: Windows_2019_64bit
     runs-on: windows-2019
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
@@ -435,13 +435,16 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - uses: actions/download-artifact@v2
+      #- uses: actions/download-artifact@v2
+      #  with:
+      #    name: windows_executables
+      #    path: .
+      - name: Install MySQL Server
+        uses: crazy-max/ghaction-chocolatey@v1
         with:
-          name: windows_executables
-          path: .
-      - name: Start MySQL service
+          args: -h
+      - name: Check MySQL connection
         run: |
-          mysqld --install --datadir=.
           mysql -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -441,7 +441,7 @@ jobs:
           path: .
       - name: Verify MySQL connection from container
         run: |
-          mysqlds
+          mysqld
           mysql -h localhost -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,10 +439,10 @@ jobs:
         with:
           name: windows_executables
           path: .
-      - name: Verify MySQL connection from container
+      - name: Start MySQL service
         run: |
           mysqld --datadir=.
-          mysql -h localhost -uroot -proot -e "SHOW DATABASES"
+          mysql -uroot -proot -e "SHOW DATABASES"
       - name: Import SQL files
         run: |
           for f in sql/*.sql; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,15 +431,6 @@ jobs:
     runs-on: windows-2019
     env:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
-    services:
-      mysql:
-        image: mariadb
-        env:
-          MYSQL_DATABASE: xidb
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Time to do the CI dance again.

- We should be verifying Windows startup.
- We should be verifying that FileWatcher works on Linux and Windows

(Should hopefully):
Fixes: https://github.com/LandSandBoat/server/issues/433

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
