### PR TITLE
[core] Don't spawn other players if you're in Mog Garden & some basic plumbing

### DIFF
--- a/scripts/globals/mog_garden.lua
+++ b/scripts/globals/mog_garden.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- Mog Garden Global
+-----------------------------------
+require("scripts/globals/utils")
+local ID = require("scripts/zones/Mog_Garden/IDs")
+-----------------------------------
+xi = xi or {}
+xi.mog_garden = xi.mog_garden or {}
+
+xi.mog_garden.onInitialize = function(zone)
+    -- Hide all NPCs by default
+    local npcs = zone:getNPCs()
+    for _, npc in ipairs(npcs) do
+        npc:setStatus(xi.status.DISAPPEAR)
+    end
+
+    -- Un-hide default NPCS
+    GetNPCByID(ID.npc.GREEN_THUMB_MOOGLE):setStatus(xi.status.NORMAL)
+    GetNPCByID(ID.npc.MOG_DINGHY):setStatus(xi.status.NORMAL)
+    GetNPCByID(ID.npc.PORTER_MOOGLE):setStatus(xi.status.NORMAL)
+end
+
+xi.mog_garden.onZoneIn = function(player, prevZone)
+    -- TODO: Announcement about GPS Crystals etc.
+    -- TODO: System to un-hide specific NPCs for specific players
+end
+
+xi.mog_garden.onRegionEnter = function(player, region)
+end
+
+xi.mog_garden.onEventUpdate = function(player, csid, option)
+end
+
+xi.mog_garden.onEventFinish = function(player, csid, option)
+end

--- a/scripts/zones/Mog_Garden/IDs.lua
+++ b/scripts/zones/Mog_Garden/IDs.lua
@@ -30,6 +30,9 @@ zones[xi.zone.MOG_GARDEN] =
     },
     npc =
     {
+        GREEN_THUMB_MOOGLE = 17924124,
+        MOG_DINGHY         = 17924125,
+        PORTER_MOOGLE      = 17924220,
     },
 }
 

--- a/scripts/zones/Mog_Garden/IDs.lua
+++ b/scripts/zones/Mog_Garden/IDs.lua
@@ -6,6 +6,31 @@ require("scripts/globals/zone")
 
 zones = zones or {}
 
+-- TODO:
+-- Server need NPC <17924154>
+-- Server need NPC <17924155>
+-- Server need NPC <17924156>
+-- Server need NPC <17924157>
+-- Server need NPC <17924162>
+-- Server need NPC <17924163>
+-- Server need NPC <17924164>
+-- Server need NPC <17924165>
+-- Server need NPC <17924170>
+-- Server need NPC <17924171>
+-- Server need NPC <17924172>
+-- Server need NPC <17924119>
+-- Server need NPC <17924120>
+-- Server need NPC <17924121>
+-- Server need NPC <17924122>
+-- Server need NPC <17924123>
+-- Server need NPC <17924223>
+-- Server need NPC <17924224>
+-- Server need NPC <17924225>
+-- Server need NPC <17924227>
+-- Server need NPC <17924229>
+-- Server need NPC <17924234>
+-- Server need NPC <17924235>
+
 zones[xi.zone.MOG_GARDEN] =
 {
     text =

--- a/scripts/zones/Mog_Garden/Zone.lua
+++ b/scripts/zones/Mog_Garden/Zone.lua
@@ -1,30 +1,36 @@
 -----------------------------------
---
 -- Zone: Mog Garden (280)
---
 -----------------------------------
+require("scripts/globals/mog_garden")
 local ID = require("scripts/zones/Mog_Garden/IDs")
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
+    xi.mog_garden.onInitialize(zone)
 end
 
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(-2.517, 0.452, -5.068, 190)
     end
+
+    cs = xi.mog_garden.onZoneIn(player, prevZone)
+
     return cs
 end
 
 zone_object.onRegionEnter = function(player, region)
+    xi.mog_garden.onRegionEnter(player, region)
 end
 
 zone_object.onEventUpdate = function(player, csid, option)
+    xi.mog_garden.onRegionEnter(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
+    xi.mog_garden.onRegionEnter(player, csid, option)
 end
 
 return zone_object

--- a/scripts/zones/Mog_Garden/npcs/Mog_Dinghy.lua
+++ b/scripts/zones/Mog_Garden/npcs/Mog_Dinghy.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Area: Mog Dinghy
+-- !zone 280
+-----------------------------------
+require("scripts/globals/zone")
+local ID = require("scripts/zones/Mog_Garden/IDs")
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    -- TODO: Cap and figure this out
+    player:startEvent(1015, 1, 1, 1, 1, 1, 1, 1, 1)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    if csid == 1015 then
+        -- TODO: Capture correct exit positions for all of these
+        if option == 1 then -- 1: Whence I came
+            player:warp() -- TODO: Workaround for now, the last zone seems to get messed up due to mog house issues.
+        elseif option == 2 then -- 2: Western Adoulin
+            player:setPos(0, 0, 0, 0, xi.zone.WESTERN_ADOULIN)
+        elseif option == 3 then -- 3: Eastern Adoulin
+            player:setPos(0, 0, 0, 0, xi.zone.EASTERN_ADOULIN)
+        end
+    elseif csid == 1089 then
+        -- TODO
+    end
+end
+
+return entity

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -24,6 +24,7 @@
 #include "../region.h"
 
 #include "../entities/charentity.h"
+#include "../entities/npcentity.h"
 #include "../zone.h"
 #include "lua_baseentity.h"
 #include "lua_zone.h"
@@ -84,7 +85,7 @@ sol::table CLuaZone::getPlayers()
 sol::table CLuaZone::getNPCs()
 {
     auto table = luautils::lua.create_table();
-    m_pLuaZone->ForEachNpc([&table](CNpcEntity* PNpc) { table.add(CLuaBaseEntity((CBaseEntity*)PNpc)); });
+    m_pLuaZone->ForEachNpc([&table](CNpcEntity* PNpc) { table.add(CLuaBaseEntity(PNpc)); });
     return table;
 }
 

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -81,6 +81,13 @@ sol::table CLuaZone::getPlayers()
     return table;
 }
 
+sol::table CLuaZone::getNPCs()
+{
+    auto table = luautils::lua.create_table();
+    m_pLuaZone->ForEachNpc([&table](CNpcEntity* PNpc) { table.add(CLuaBaseEntity((CBaseEntity*)PNpc)); });
+    return table;
+}
+
 ZONEID CLuaZone::getID()
 {
     return m_pLuaZone->GetID();
@@ -133,6 +140,7 @@ void CLuaZone::Register()
     SOL_REGISTER("registerRegion", CLuaZone::registerRegion);
     SOL_REGISTER("levelRestriction", CLuaZone::levelRestriction);
     SOL_REGISTER("getPlayers", CLuaZone::getPlayers);
+    SOL_REGISTER("getNPCs", CLuaZone::getNPCs);
     SOL_REGISTER("getID", CLuaZone::getID);
     SOL_REGISTER("getName", CLuaZone::getName);
     SOL_REGISTER("getRegionID", CLuaZone::getRegionID);

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -43,6 +43,7 @@ public:
     void        registerRegion(uint32 RegionID, float x1, float y1, float z1, float x2, float y2, float z2);
     sol::object levelRestriction();
     auto        getPlayers() -> sol::table;
+    auto        getNPCs() -> sol::table;
     ZONEID      getID();
     std::string getName();
     REGION_TYPE getRegionID();

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -617,7 +617,9 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
 
         if (PChar != PCurrentChar)
         {
-            if (distance(PChar->loc.p, PCurrentChar->loc.p) < 50 && PChar->m_moghouseID == PCurrentChar->m_moghouseID)
+            if (distance(PChar->loc.p, PCurrentChar->loc.p) < 50 &&
+                PChar->m_moghouseID == PCurrentChar->m_moghouseID &&
+                PChar->loc.zone->GetID() != ZONE_MOG_GARDEN)
             {
                 if (PC == PChar->SpawnPCList.end())
                 {


### PR DESCRIPTION
Conditions to spawn other players in a zone (instances excluded):
- They are within 50 yalms
- They have the same moghouse ID (hint hint, this is how we will do invite to moghouse)
- They are NOT in Mog Garden (makes Mog Garden private)

One downside of this approach is that you won't be able to be a GM and pester individual players. If someone works on Mog Garden later, this is probably a thing that'll need work.

I don't know what the NPCs will do if someone in a different Mog Garden interacts with them, hopefully nothing?

Fixes: https://github.com/LandSandBoat/server/issues/1021

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
