### PR TITLE
Don't try to proc spikes for offhand weapons

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -771,7 +771,7 @@ namespace battleutils
                 for (auto&& slot : { SLOT_SUB, SLOT_BODY, SLOT_LEGS, SLOT_HEAD, SLOT_HANDS, SLOT_FEET })
                 {
                     CItemEquipment* PItem = PCharDef->getEquip(slot);
-                    if (PItem)
+                    if (PItem && !PItem->isType(ITEM_WEAPON))
                     {
                         uint8 chance;
 


### PR DESCRIPTION
-<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Offhand weapons that have an additional effect were mistakenly giving the wielder spike effects in addition to their attacks, due to an oversight in checking SLOT_SUB in the item spikes block in battleutils.cpp

I've added a check for the item type to put a stop to that. _Eventually_ I'd like spikes to move to a global script like additional effects, handled in the same manner (there is an unused placeholder there now).