### PR TITLE
[core] Replace C-Style cast in EquipItem, fixes occasional bug with unequipping sub-weapons

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2180,7 +2180,7 @@ namespace charutils
 
     void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID)
     {
-        CItemEquipment* PItem = (CItemEquipment*)PChar->getStorage(containerID)->GetItem(slotID);
+        CItemEquipment* PItem = dynamic_cast<CItemEquipment*>(PChar->getStorage(containerID)->GetItem(slotID));
 
         if (PItem && PItem == PChar->getEquip((SLOTTYPE)equipSlotID))
         {
@@ -2261,17 +2261,6 @@ namespace charutils
                 // If the weapon ISN'T a wind based instrument or a string based instrument
                 PChar->health.tp = 0;
             }
-
-            /*// fixes logging in with no h2h
-            if(PChar->m_Weapons[SLOT_MAIN]->getDmgType() == DAMAGE_NONE && PChar->GetMJob() == JOB_MNK)
-            {
-                PChar->m_Weapons[SLOT_MAIN] = itemutils::GetUnarmedH2HItem();
-            }
-            else if(PChar->m_Weapons[SLOT_MAIN] == itemutils::GetUnarmedH2HItem() && PChar->GetMJob() != JOB_MNK)
-            {
-                // return back to normal if changed jobs
-                PChar->m_Weapons[SLOT_MAIN] = itemutils::GetUnarmedItem();
-            }*/
 
             if (!PChar->getEquip(SLOT_MAIN) || !PChar->getEquip(SLOT_MAIN)->isType(ITEM_EQUIPMENT) ||
                 PChar->m_Weapons[SLOT_MAIN] == itemutils::GetUnarmedH2HItem())


### PR DESCRIPTION
Don't stuff bogus data into CItemEquipment*

Fixes: https://github.com/LandSandBoat/server/issues/1017

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
