### PR TITLE
[Crafting] Implement Rank renouncement

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -1,8 +1,11 @@
 -----------------------------------
---    Crafting functions
---  Info from:
---      http://wiki.ffxiclopedia.org/wiki/Crafts_%26_Hobbies
+-- Crafting functions
+-- Info from:
+-- http://wiki.ffxiclopedia.org/wiki/Crafts_%26_Hobbies
 -----------------------------------
+require("scripts/globals/status")
+-----------------------------------
+
 xi = xi or {}
 xi.crafting = {}
 -----------------------------------
@@ -78,14 +81,13 @@ local HQCrystals = {
 -----------------------------------
 
 xi.crafting.isGuildMember = function(player, guild)
-
     local guildOK = player:getCharVar("Guild_Member")
     local bit = {}
 
     for i = 12, 1, -1 do
         local twop = 2^i
 
-        if (guildOK >= twop) then
+        if guildOK >= twop then
             bit[i]=1 guildOK = guildOK - twop
         else
             bit[i]=0
@@ -93,7 +95,6 @@ xi.crafting.isGuildMember = function(player, guild)
     end
 
     return bit[guild]
-
 end
 
 -----------------------------------
@@ -109,22 +110,21 @@ end
 -----------------------------------
 
 xi.crafting.getTestItem = function(player, npc, craftID)
-
     local TItemList = {}
-    local NextRank = player:getSkillRank(craftID) + 1
+    local NextRank  = player:getSkillRank(craftID) + 1
 
     switch (npc:getName()): caseof
     {
-        ["Abd-al-Raziq"] =      function (x)    TItemList = TI_Alchemy end,
-        ["Peshi_Yohnts"] =      function (x)    TItemList = TI_Bonecraft end,
-        ["Ponono"] =            function (x)    TItemList = TI_Clothcraft end,
-        ["Piketo-Puketo"] =     function (x)    TItemList = TI_Cooking end,
-        ["Thubu_Parohren"] =    function (x)    TItemList = TI_Fishing end,
-        ["Reinberta"] =         function (x)    TItemList = TI_Goldsmithing end,
-        ["Faulpie"] =           function (x)    TItemList = TI_Leathercraft end,
-        ["Mevreauche"] =        function (x)    TItemList = TI_Smithing end,
-        ["Ghemp"] =             function (x)    TItemList = TI_Smithing end,
-        ["Cheupirudaux"] =      function (x)    TItemList = TI_Woodworking end,
+        ["Abd-al-Raziq"]   = function (x) TItemList = TI_Alchemy end,
+        ["Peshi_Yohnts"]   = function (x) TItemList = TI_Bonecraft end,
+        ["Ponono"]         = function (x) TItemList = TI_Clothcraft end,
+        ["Piketo-Puketo"]  = function (x) TItemList = TI_Cooking end,
+        ["Thubu_Parohren"] = function (x) TItemList = TI_Fishing end,
+        ["Reinberta"]      = function (x) TItemList = TI_Goldsmithing end,
+        ["Faulpie"]        = function (x) TItemList = TI_Leathercraft end,
+        ["Mevreauche"]     = function (x) TItemList = TI_Smithing end,
+        ["Ghemp"]          = function (x) TItemList = TI_Smithing end,
+        ["Cheupirudaux"]   = function (x) TItemList = TI_Woodworking end,
     }
 
     return TItemList[NextRank]
@@ -138,17 +138,19 @@ local function canGetNewRank(player, skillLvL, craftID)
     local Rank = player:getSkillRank(craftID) + 1
     local canGet = 0
 
-    if (Rank == 1 and skillLvL >= 256 or
-       Rank ==  2 and skillLvL >= 577 or
-       Rank ==  3 and skillLvL >= 898 or
-       Rank ==  4 and skillLvL >= 1219 or
-       Rank ==  5 and skillLvL >= 1540 or
-       Rank ==  6 and skillLvL >= 1861 or
-       Rank ==  7 and skillLvL >= 2182 or
-       Rank ==  8 and skillLvL >= 2503 or
-       Rank ==  9 and skillLvL >= 2824 or
-       Rank == 10 and skillLvL >= 3145) then
-            canGet = 1
+    if
+        (Rank == 1 and skillLvL >= 256) or
+        (Rank == 2 and skillLvL >= 577) or
+        (Rank == 3 and skillLvL >= 898) or
+        (Rank == 4 and skillLvL >= 1219) or
+        (Rank == 5 and skillLvL >= 1540) or
+        (Rank == 6 and skillLvL >= 1861) or
+        (Rank == 7 and skillLvL >= 2182) or
+        (Rank == 8 and skillLvL >= 2503) or
+        (Rank == 9 and skillLvL >= 2824) or
+        (Rank == 10 and skillLvL >= 3145)
+    then
+        canGet = 1
     end
 
     return canGet
@@ -160,16 +162,17 @@ end
 -----------------------------------
 
 xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
-
-    local guildID = craftID - 48
+    local guildID  = craftID - 48
     local skillLvL = player:getSkillLevel(craftID)
-    local myTI = xi.crafting.getTestItem(player, npc, craftID)
-    local newRank = 0
+    local myTI     = xi.crafting.getTestItem(player, npc, craftID)
+    local newRank  = 0
     -- local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
 
-    if (canGetNewRank(player, skillLvL, craftID) == 1 and
+    if
+        canGetNewRank(player, skillLvL, craftID) == 1 and
         trade:hasItemQty(myTI, 1) and
-        trade:getItemCount() == 1) then
+        trade:getItemCount() == 1
+    then
         newRank = player:getSkillRank(craftID) + 1
         if player:getCharVar('[GUILD]currentGuild') == guildID + 1 then
             player:setCharVar('[GUILD]daily_points', -1)
@@ -177,7 +180,6 @@ xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
     end
 
     return newRank
-
 end
 
 -- 1: test item
@@ -190,30 +192,29 @@ end
 -- getCraftSkillCap
 -----------------------------------
 xi.crafting.getCraftSkillCap = function(player, craftID)
-
     local Rank = player:getSkillRank(craftID)
-    return (Rank+1)*10
-
+    return (Rank + 1) * 10
 end
 
 -----------------------------------
 -- getAdvImageSupportCost
 -----------------------------------
 xi.crafting.getAdvImageSupportCost = function(player, craftID)
-
     local Rank = player:getSkillRank(craftID)
-    return (Rank+1)*30
-
+    return (Rank + 1) * 30
 end
 
+-----------------------------------
+-- unionRepresentative
+-----------------------------------
 xi.crafting.unionRepresentativeTrigger = function(player, guildID, csid, currency, keyitems)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildID)
-    local rank = player:getSkillRank(guildID + 48)
-    local cap = (rank + 1) * 10
+    local rank   = player:getSkillRank(guildID + 48)
+    local cap    = (rank + 1) * 10
     local kibits = 0
 
     for kbit, ki in pairs(keyitems) do
-        if (rank >= ki.rank) then
+        if rank >= ki.rank then
             if not player:hasKeyItem(ki.id) then
                 kibits = bit.bor(kibits, bit.lshift(1, kbit))
             end
@@ -223,24 +224,58 @@ xi.crafting.unionRepresentativeTrigger = function(player, guildID, csid, currenc
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, guildID, currency, keyitems, items)
-    local rank = player:getSkillRank(guildID + 48)
-    local category = bit.band(bit.rshift(option, 2), 3)
-    local text = zones[player:getZoneID()].text
+xi.crafting.unionRepresentativeEventUpdateDenounce = function(player, craftID)
+    local ID   = zones[player:getZoneID()]
+    local rank = player:getSkillRank(craftID)
 
-    if (bit.tobit(option) == -1 and rank >= 3) then
+    player:setSkillRank(craftID, rank - 1)
+    player:setSkillLevel(craftID, rank * 100)
+    player:messageSpecial(ID.text.RENOUNCE_CRAFTSMAN, 0, craftID - 49)
+end
+
+xi.crafting.unionRepresentativeTriggerDenounceCheck = function(player, eventId, realSkill, rankCap, param3)
+    if player:getLocalVar("denounceDialog") == 0 then
+        local count   = 0
+        local bitmask = 0
+    
+        for craftID = xi.skill.WOODWORKING, xi.skill.COOKING do
+            local rank = player:getSkillRank(craftID)
+            if rank < 6 then
+                bitmask = bit.bor(bitmask, bit.lshift(1, craftID - 48))
+            else
+                count = count + 1
+            end
+        end
+
+        if count > 1 then
+            player:setLocalVar("denounceDialog", 1)
+            player:startEvent(eventId, VanadielTime(), realSkill, rankCap, param3, 0, 0, count, bitmask)
+            return true
+        end
+    end
+
+    return false
+end
+
+xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, guildID, currency, keyitems, items)
+    local rank     = player:getSkillRank(guildID + 48)
+    local category = bit.band(bit.rshift(option, 2), 3)
+    local text     = zones[player:getZoneID()].text
+
+    if bit.tobit(option) == -1 and rank >= 3 then
         local oldGuild = player:getCharVar('[GUILD]currentGuild') - 1
         player:setCharVar('[GUILD]currentGuild', guildID + 1)
 
-        if (oldGuild == -1) then
+        if oldGuild == -1 then
             player:messageSpecial(text.GUILD_NEW_CONTRACT, guildID)
         else
             player:messageSpecial(text.GUILD_TERMINATE_CONTRACT, guildID, oldGuild)
             player:setCharVar('[GUILD]daily_points', -1)
         end
-    elseif (category == 3) then -- keyitem
+    elseif category == 3 then -- keyitem
         local ki = keyitems[bit.band(bit.rshift(option, 5), 15) - 1]
-        if (ki and rank >= ki.rank) then
+
+        if ki and rank >= ki.rank then
             if (player:getCurrency(currency) >= ki.cost) then
                 player:delCurrency(currency, ki.cost)
                 player:addKeyItem(ki.id)
@@ -249,13 +284,14 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
                player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
         end
-    elseif (category == 2 or category == 1) then -- item
-        local idx = bit.band(option, 3)
-        local i = items[(category - 1) * 4 + idx]
+    elseif category == 2 or category == 1 then -- item
+        local idx      = bit.band(option, 3)
+        local i        = items[(category - 1) * 4 + idx]
         local quantity = math.min(bit.rshift(option, 9), 12)
-        local cost = quantity * i.cost
-        if (i and rank >= i.rank) then
-            if (player:getCurrency(currency) >= cost) then
+        local cost     = quantity * i.cost
+
+        if i and rank >= i.rank then
+            if player:getCurrency(currency) >= cost then
                 local delivered = 0
                 for count = 1, quantity do -- addItem does not appear to honor quantity if the item doesn't stack.
                     if (player:addItem(i.id, true)) then
@@ -264,20 +300,20 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
                         delivered = delivered + 1
                     end
                 end
-                if (delivered == 0) then
+                if delivered == 0 then
                     player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id)
                 end
             else
                player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
         end
-    elseif (category == 0 and option ~= 1073741824) then -- HQ crystal
+    elseif category == 0 and option ~= 1073741824 then -- HQ crystal
         local i = HQCrystals[bit.band(bit.rshift(option, 5), 15)]
         local quantity = bit.rshift(option, 9)
         local cost = quantity * i.cost
-        if (i and rank >= 3) then
-            if (player:getCurrency(currency) >= cost) then
-                if (player:addItem(i.id, quantity)) then
+        if i and rank >= 3 then
+            if player:getCurrency(currency) >= cost then
+                if player:addItem(i.id, quantity) then
                     player:delCurrency(currency, cost)
                     player:messageSpecial(text.ITEM_OBTAINED, i.id)
                 else
@@ -294,7 +330,7 @@ xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildI
     local _, remainingPoints = player:getCurrentGPItem(guildID)
     local text = zones[player:getZoneID()].text
 
-    if (player:getCharVar('[GUILD]currentGuild') - 1 == guildID) then
+    if player:getCharVar('[GUILD]currentGuild') - 1 == guildID then
         if remainingPoints == 0 then
             player:messageText(npc, text.NO_MORE_GP_ELIGIBLE)
         else
@@ -306,7 +342,7 @@ xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildI
                     trade:confirmSlot(i, items)
                 end
             end
-            if (totalPoints > 0) then
+            if totalPoints > 0 then
                 player:confirmTrade()
                 player:startEvent(csid, totalPoints)
             end

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -237,7 +237,7 @@ xi.crafting.unionRepresentativeTriggerDenounceCheck = function(player, eventId, 
     if player:getLocalVar("denounceDialog") == 0 then
         local count   = 0
         local bitmask = 0
-    
+
         for craftID = xi.skill.WOODWORKING, xi.skill.COOKING do
             local rank = player:getSkillRank(craftID)
             if rank < 6 then

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -224,23 +224,22 @@ xi.crafting.unionRepresentativeTrigger = function(player, guildID, csid, currenc
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-xi.crafting.unionRepresentativeEventUpdateDenounce = function(player, craftID)
+xi.crafting.unionRepresentativeEventUpdateRenounce = function(player, craftID)
     local ID   = zones[player:getZoneID()]
-    local rank = player:getSkillRank(craftID)
 
-    player:setSkillRank(craftID, rank - 1)
-    player:setSkillLevel(craftID, rank * 100)
+    player:setSkillRank(craftID, 6)
+    player:setSkillLevel(craftID, 700)
     player:messageSpecial(ID.text.RENOUNCE_CRAFTSMAN, 0, craftID - 49)
 end
 
-xi.crafting.unionRepresentativeTriggerDenounceCheck = function(player, eventId, realSkill, rankCap, param3)
-    if player:getLocalVar("denounceDialog") == 0 then
+xi.crafting.unionRepresentativeTriggerRenounceCheck = function(player, eventId, realSkill, rankCap, param3)
+    if player:getLocalVar("renounceDialog") == 0 then
         local count   = 0
         local bitmask = 0
 
         for craftID = xi.skill.WOODWORKING, xi.skill.COOKING do
             local rank = player:getSkillRank(craftID)
-            if rank < 6 then
+            if rank < 7 then
                 bitmask = bit.bor(bitmask, bit.lshift(1, craftID - 48))
             else
                 count = count + 1
@@ -248,7 +247,7 @@ xi.crafting.unionRepresentativeTriggerDenounceCheck = function(player, eventId, 
         end
 
         if count > 1 then
-            player:setLocalVar("denounceDialog", 1)
+            player:setLocalVar("renounceDialog", 1)
             player:startEvent(eventId, VanadielTime(), realSkill, rankCap, param3, 0, 0, count, bitmask)
             return true
         end

--- a/scripts/zones/Bastok_Markets/IDs.lua
+++ b/scripts/zones/Bastok_Markets/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.BASTOK_MARKETS] =
         NO_MORE_GP_ELIGIBLE          = 7113,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                  = 7118,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP           = 7119,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN           = 7135,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         FISHING_MESSAGE_OFFSET       = 7215,  -- You can't fish here.
         SOMNPAEMN_CLOSED_DIALOG      = 7581,  -- Sorry, I don't have anything to sell you. I'm trying to start a business selling goods from Sarutabaruta, but it's not easy getting stuff out of areas that aren't under Bastokan control.
         YAFAFA_CLOSED_DIALOG         = 7582,  -- Sorry, I don't have anything to sell you. I'm trying to start a business selling goods from Kolshushu, but it's not easy getting stuff out of areas that aren't under Bastokan control.

--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -36,14 +36,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.GOLDSMITHING)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.GOLDSMITHING)
+    local craftSkill  = player:getSkillLevel(xi.skill.GOLDSMITHING)
+    local testItem    = xi.crafting.getTestItem(player, npc, xi.skill.GOLDSMITHING)
     local guildMember = xi.crafting.isGuildMember(player, 6)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
+    local rankCap     = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
+    local Rank        = player:getSkillRank(xi.skill.GOLDSMITHING)
+    local realSkill   = (craftSkill - Rank) / 32
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.GOLDSMITHING)
-    local realSkill = (craftSkill - Rank) / 32
-    if (guildMember == 1) then guildMember = 150995375; end
+
+    if guildMember == 1 then
+        guildMember = 150995375
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 300, realSkill, rankCap, 184549887) then
+        return
+    end
+
     if player:getCharVar("GoldsmithingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_GOLDSMITH) then
             expertQuestStatus = 600
@@ -67,20 +75,26 @@ entity.onTrigger = function(player, npc)
     end
 end
 
--- 300  301  402
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 300 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 6)
 
-    if (csid == 300 and option == 2) then
+    if csid == 300 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("GoldsmithingExpertQuest",1)
         end
-    elseif (csid == 300 and option == 1) then
+    elseif csid == 300 and option == 1 then
         local crystal = 4096 -- fire crystal
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, crystal)
         else
             player:addItem(crystal)

--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 300, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 300, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -81,7 +81,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Bastok_Mines/IDs.lua
+++ b/scripts/zones/Bastok_Mines/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.BASTOK_MINES] =
         NO_MORE_GP_ELIGIBLE            = 7091,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                    = 7096,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP             = 7097,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN             = 7113,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         REGIME_CANCELED                = 7278,  -- Current training regime canceled.
         HUNT_ACCEPTED                  = 7296,  -- Hunt accepted!
         USE_SCYLDS                     = 7297,  -- You use <number> [scyld/scylds]. Scyld balance: <number>.

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -51,7 +51,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 120, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 120, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -103,7 +103,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -100,8 +100,8 @@ end
 entity.onEventUpdate = function(player, csid, option)
     if
         csid == 120 and
-        option >= tpz.skill.WOODWORKING and
-        option <= tpz.skill.COOKING
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
     then
         xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -51,6 +51,10 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 120, realSkill, rankCap, 184549887) then
+        return
+    end
+
     if player:getCharVar("AlchemyExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_ALCHEMIST) then
             expertQuestStatus = 550
@@ -94,6 +98,13 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 120 and
+        option >= tpz.skill.WOODWORKING and
+        option <= tpz.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)

--- a/scripts/zones/Metalworks/IDs.lua
+++ b/scripts/zones/Metalworks/IDs.lua
@@ -33,6 +33,7 @@ zones[xi.zone.METALWORKS] =
         NO_MORE_GP_ELIGIBLE         = 6893,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                 = 6898,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP          = 6899,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN          = 6915,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         GOOD_LUCK                   = 7451,  -- Good luck on your mission. Bastokers like to do things by the book, so stay out of trouble and follow their rules.
         MISSION_DIALOG_CID_TO_AYAME = 7578,  -- Give it to one of his Mythril Musketeers instead. Ayame and Naji should be on guard near the President's Office. Either one will do.
         ITS_LOCKED                  = 7989,  -- It's locked.

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 101, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 101, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -82,7 +82,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -12,7 +12,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local signed  = trade:getItem():getSignature() == player:getName() and 1 or 0
     local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.SMITHING)
 
     if
@@ -36,14 +36,21 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.SMITHING)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
+    local craftSkill        = player:getSkillLevel(xi.skill.SMITHING)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
+    local guildMember       = xi.crafting.isGuildMember(player, 8)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.SMITHING)
-    local realSkill = (craftSkill - Rank) / 32
-    if (guildMember == 1) then guildMember = 150995375; end
+    local Rank              = player:getSkillRank(xi.skill.SMITHING)
+    local realSkill         = (craftSkill - Rank) / 32
+
+    if guildMember == 1 then
+        guildMember = 150995375
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 101, realSkill, rankCap, 184549887) then
+        return
+    end
 
     if player:getCharVar("SmithingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_BLACKSMITH) then
@@ -70,17 +77,24 @@ end
 
 -- 908  909  910  920  927  101  102
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 101 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 8)
 
-    if (csid == 101 and option == 2) then
+    if csid == 101 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("SmithingExpertQuest",1)
         end
-    elseif (csid == 101 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 101 and option == 1 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4096)
         else
             player:addItem(4096)

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -31,6 +31,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         NO_MORE_GP_ELIGIBLE      = 6991,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED              = 6996,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP       = 6997,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN       = 7013,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         CONQUEST_BASE            = 7267,  -- Tallying conquest results...
         FISHING_MESSAGE_OFFSET   = 7426,  -- You can't fish here.
         REGIME_CANCELED          = 7977,  -- Current training regime canceled.

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local signed  = trade:getItem():getSignature() == player:getName() and 1 or 0
     local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.WOODWORKING)
 
     if
@@ -37,14 +37,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.WOODWORKING)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.WOODWORKING)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
+    local craftSkill        = player:getSkillLevel(xi.skill.WOODWORKING)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.WOODWORKING)
+    local guildMember       = xi.crafting.isGuildMember(player, 9)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.WOODWORKING)
-    local realSkill = (craftSkill - Rank) / 32
-    if (guildMember == 1) then guildMember = 150995375; end
+    local Rank              = player:getSkillRank(xi.skill.WOODWORKING)
+    local realSkill         = (craftSkill - Rank) / 32
+
+    if guildMember == 1 then
+        guildMember = 150995375
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 621, realSkill, rankCap, 184549887) then
+        return
+    end
+
     if player:getCharVar("WoodworkingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_CARPENTER) then
             expertQuestStatus = 550
@@ -70,17 +78,24 @@ end
 
 -- 621  622  759  16  0
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 621 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 9)
 
-    if (csid == 621 and option == 2) then
+    if csid == 621 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("WoodworkingExpertQuest",1)
         end
-    elseif (csid == 621 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 621 and option == 1 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4098)
         else
             player:addItem(4098)

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -49,7 +49,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 621, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 621, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -83,7 +83,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -12,7 +12,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local signed  = trade:getItem():getSignature() == player:getName() and 1 or 0
     local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.SMITHING)
 
     if
@@ -36,14 +36,21 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.SMITHING)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
+    local craftSkill        = player:getSkillLevel(xi.skill.SMITHING)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
+    local guildMember       = xi.crafting.isGuildMember(player, 8)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.SMITHING)
-    local realSkill = (craftSkill - Rank) / 32
-    if (guildMember == 1) then guildMember = 150995375; end
+    local Rank              = player:getSkillRank(xi.skill.SMITHING)
+    local realSkill         = (craftSkill - Rank) / 32
+
+    if guildMember == 1 then
+        guildMember = 150995375
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 626, realSkill, rankCap, 184549887) then
+        return
+    end
 
     if player:getCharVar("SmithingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_BLACKSMITH) then
@@ -70,17 +77,24 @@ end
 
 -- 626  627  16  0  73  74
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 626 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeTriggerDenounceCheck(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 8)
 
-    if (csid == 626 and option == 2) then
+    if csid == 626 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("SmithingExpertQuest",1)
         end
-    elseif (csid == 626 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 626 and option == 1 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4096)
         else
             player:addItem(4096)

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 626, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 626, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -82,7 +82,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeTriggerDenounceCheck(player, option)
+        xi.crafting.unionRepresentativeTriggerRenounceCheck(player, option)
     end
 end
 

--- a/scripts/zones/Southern_San_dOria/IDs.lua
+++ b/scripts/zones/Southern_San_dOria/IDs.lua
@@ -33,6 +33,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA] =
         NO_MORE_GP_ELIGIBLE            = 6813,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                    = 6818,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP             = 6819,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN             = 6835,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         CONQUEST_BASE                  = 7041,  -- Tallying conquest results...
         YOU_ACCEPT_THE_MISSION         = 7205,  -- You accept the mission.
         ORIGINAL_MISSION_OFFSET        = 7216,  -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!

--- a/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
@@ -50,7 +50,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 648, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 648, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -101,7 +101,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Windurst_Waters/IDs.lua
+++ b/scripts/zones/Windurst_Waters/IDs.lua
@@ -31,6 +31,7 @@ zones[xi.zone.WINDURST_WATERS] =
         NO_MORE_GP_ELIGIBLE        = 7188,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                = 7193,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP         = 7194,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN         = 7210,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         KOPOPO_SHOP_DIALOG         = 7849,  -- Cooking is as much an art as music and painting are. Can your taste buds appreciate the full value of our works of art?
         CHOMOJINJAHL_SHOP_DIALOG   = 7854,  -- The qualities needed to be a good cook are strong arms, a sense of taste, and devotion.
         ENSASA_SHOP_DIALOG         = 8921,  -- Welcome to my little catalyst shop, where you'll find a range of general and unusual goods!

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 150995375
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10013, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10013, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -82,7 +82,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -12,7 +12,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local signed  = trade:getItem():getSignature() == player:getName() and 1 or 0
     local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.COOKING)
 
     if
@@ -36,14 +36,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.COOKING)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.COOKING)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
+    local craftSkill        = player:getSkillLevel(xi.skill.COOKING)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.COOKING)
+    local guildMember       = xi.crafting.isGuildMember(player, 4)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.COOKING)
-    local realSkill = (craftSkill - Rank) / 32
-    if (guildMember == 1) then guildMember = 150995375; end
+    local Rank              = player:getSkillRank(xi.skill.COOKING)
+    local realSkill         = (craftSkill - Rank) / 32
+
+    if guildMember == 1 then
+        guildMember = 150995375
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10013, realSkill, rankCap, 184549887) then
+        return
+    end
+
     if player:getCharVar("CookingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_CULINARIAN) then
             expertQuestStatus = 550
@@ -69,18 +77,25 @@ end
 
 -- 978  983  980  981  10013  10014
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 10013 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 4)
 
-    if (csid == 10013 and option == 2) then
+    if csid == 10013 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("CookingExpertQuest",1)
         end
-    elseif (csid == 10013 and option == 1) then
+    elseif csid == 10013 and option == 1 then
         local crystal = 4096 -- fire crystal
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, crystal)
         else
             player:addItem(crystal)

--- a/scripts/zones/Windurst_Woods/IDs.lua
+++ b/scripts/zones/Windurst_Woods/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.WINDURST_WOODS] =
         NO_MORE_GP_ELIGIBLE          = 7238,  -- You are not eligible to receive guild points at this time.
         GP_OBTAINED                  = 7243,  -- Obtained: <number> guild points.
         NOT_HAVE_ENOUGH_GP           = 7244,  -- You do not have enough guild points.
+        RENOUNCE_CRAFTSMAN           = 7260,  -- You have successfully renounced your status as a <Multiple Choice (Parameter 5)>[craftsman/artisan/adept] of the <Multiple Choice (Parameter 1)>[Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         VALERIANO_SHOP_DIALOG        = 7554,  -- Halfling philosophers and heroine beauties, welcome to the Troupe Valeriano show! And how gorgeous and green this fair town is!
         RAKOHBUUMA_OPEN_DIALOG       = 7651,  -- To expel those who would subvert the law and order of Windurst Woods... To protect the Mithra populace from all manner of threats and dangers... That is the job of us guards.
         RETTO_MARUTTO_DIALOG         = 7967,  -- Allo-allo! If you're after boneworking materials, then make sure you buy them herey in Windurst! We're the cheapest in the whole wide worldy!

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -12,10 +12,10 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local signed  = trade:getItem():getSignature() == player:getName() and 1 or 0
     local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.BONECRAFT)
 
-        if
+    if
         newRank > 9 and
         player:getCharVar("BonecraftExpertQuest") == 1 and
         player:hasKeyItem(xi.keyItem.WAY_OF_THE_BONEWORKER)
@@ -36,16 +36,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local craftSkill = player:getSkillLevel(xi.skill.BONECRAFT)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.BONECRAFT)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
+    local craftSkill        = player:getSkillLevel(xi.skill.BONECRAFT)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.BONECRAFT)
+    local guildMember       = xi.crafting.isGuildMember(player, 2)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.BONECRAFT)
-    local realSkill = (craftSkill - Rank) / 32
+    local Rank              = player:getSkillRank(xi.skill.BONECRAFT)
+    local realSkill         = (craftSkill - Rank) / 32
+
     if guildMember == 1 then
         guildMember = 64
     end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10016, realSkill, rankCap, 184549887) then
+        return
+    end
+
     if player:getCharVar("BonecraftExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_BONEWORKER) then
             expertQuestStatus = 600
@@ -71,16 +77,23 @@ end
 
 -- 10016  10017  710  711  712  713  714  715  764
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 10016 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
     local guildMember = xi.crafting.isGuildMember(player, 2)
 
-    if (csid == 10016 and option == 2) then
+    if csid == 10016 and option == 2 then
         if guildMember == 1 then
             player:setCharVar("BonecraftExpertQuest",1)
         end
-    elseif (csid == 10016 and option == 1) then
+    elseif csid == 10016 and option == 1 then
         local crystal = 4098 -- wind crystal
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, crystal)

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -16,8 +16,8 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
-    local newRank = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.CLOTHCRAFT)
+    local signed        = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local newRank       = xi.crafting.tradeTestItem(player, npc, trade, xi.skill.CLOTHCRAFT)
     local moralManifest = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST)
 
     if
@@ -50,15 +50,21 @@ end
 entity.onTrigger = function(player, npc)
     local moralManifest = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST)
 
-    local craftSkill = player:getSkillLevel(xi.skill.CLOTHCRAFT)
-    local testItem = xi.crafting.getTestItem(player, npc, xi.skill.CLOTHCRAFT)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
-    local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
+    local craftSkill        = player:getSkillLevel(xi.skill.CLOTHCRAFT)
+    local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.CLOTHCRAFT)
+    local guildMember       = xi.crafting.isGuildMember(player, 3)
+    local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local expertQuestStatus = 0
-    local Rank = player:getSkillRank(xi.skill.CLOTHCRAFT)
-    local realSkill = (craftSkill - Rank) / 32
+    local Rank              = player:getSkillRank(xi.skill.CLOTHCRAFT)
+    local realSkill         = (craftSkill - Rank) / 32
 
-    if guildMember == 1 then guildMember = 10000; end
+    if guildMember == 1 then
+        guildMember = 10000
+    end
+
+    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10011, realSkill, rankCap, 184549887) then
+        return
+    end
 
     if player:getCharVar("ClothcraftExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_WEAVER) then
@@ -92,6 +98,13 @@ end
 
 -- 10011  10012  700  701  702  703  704  705  832  765
 entity.onEventUpdate = function(player, csid, option)
+    if
+        csid == 10011 and
+        option >= xi.skill.WOODWORKING and
+        option <= xi.skill.COOKING
+    then
+        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -62,7 +62,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 10000
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10011, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10011, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -103,7 +103,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 


### PR DESCRIPTION
Co-Authored-By: MGramolini <1774728+MGramolini@users.noreply.github.com>

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Allows players to re-lock themselves to a lower crafting rank.
I just converted/adapted it. (Permission was granted)