### PR TITLE
[ci] Catch warnings in CI startup checks too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,19 +319,34 @@ jobs:
           EOF
           
           killall screen
-    - name: Check for errors
+    - name: Check for errors and warnings
       if: ${{ success() || failure() }}
       run: |
         cat login-server*.log
         cat map-server*.log
         cat search-server*.log
-        if grep -qi "Error" login-server*.log; then
+
+        if grep -qi "error" login-server*.log; then
             exit -1
         fi
-        if grep -qi "Error" map-server*.log; then
+
+        if grep -qi "error" map-server*.log; then
             exit -1
         fi
-        if grep -qi "Error" search-server*.log; then
+
+        if grep -qi "error" search-server*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" login-server*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" map-server*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" search-server*.log; then
             exit -1
         fi
 
@@ -394,7 +409,7 @@ jobs:
         screen -d -m -S topaz_game ./topaz_game --log map-server-1.log --port 54231
         sleep 2m
         killall screen
-    - name: Check for errors
+    - name: Check for errors and warnings
       if: ${{ success() || failure() }}
       run: |
         cat login-server*.log
@@ -402,18 +417,34 @@ jobs:
         cat map-server-0*.log
         cat map-server-1*.log
 
-        if grep -qi "Error" login-server*.log; then
+        if grep -qi "error" login-server*.log; then
             exit -1
         fi
 
-        if grep -qi "Error" search-server*.log; then
+        if grep -qi "error" search-server*.log; then
             exit -1
         fi
 
-        if grep -qi "Error" map-server-0*.log; then
+        if grep -qi "error" map-server-0*.log; then
             exit -1
         fi
 
-        if grep -qi "Error" map-server-1*.log; then
+        if grep -qi "error" map-server-1*.log; then
+          exit -1
+        fi
+
+        if grep -qi "warning" login-server*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" search-server*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" map-server-0*.log; then
+            exit -1
+        fi
+
+        if grep -qi "warning" map-server-1*.log; then
           exit -1
         fi


### PR DESCRIPTION
"error" and "warning" (lower case) are part of the logging category titles, so we can match on those also

Closes: https://github.com/LandSandBoat/server/issues/1050

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
