### PR TITLE
Change some startEvent calls to progressEvent

### DIFF
--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -40,11 +40,11 @@ mission.sections =
 
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.DULL_SWORD) then
-                        player:startEvent(40)
+                        return mission:progressEvent(40)
                     elseif player:getMissionStatus(player:getNation()) == 5 then
-                        player:startEvent(43)
+                        return mission:progressEvent(43)
                     else
-                        player:startEvent(44)
+                        return mission:progressEvent(44)
                     end
                 end,
             },

--- a/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
+++ b/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
@@ -111,7 +111,7 @@ mission.sections =
                             not GetMobByID(behemothsDominionID.mob.ANCIENT_WEAPON):isSpawned() and
                             not GetMobByID(behemothsDominionID.mob.LEGENDARY_WEAPON):isSpawned()
                         then
-                            player:startEvent(200, xi.ki.LIGHTNING_FRAGMENT)
+                            return mission:progressEvent(200, xi.ki.LIGHTNING_FRAGMENT)
                         else
                             player:messageSpecial(behemothsDominionID.text.SOMETHING_BETTER)
                         end
@@ -148,7 +148,7 @@ mission.sections =
                         player:messageSpecial(capeTerigganID.text.ALREADY_OBTAINED_FRAG, xi.ki.WIND_FRAGMENT)
                     elseif os.time() >= npc:getLocalVar('cooldown') then
                         if not GetMobByID(capeTerigganID.mob.AXESARION_THE_WANDERER):isSpawned() then
-                            player:startEvent(200, xi.ki.WIND_FRAGMENT)
+                            return mission:progressEvent(200, xi.ki.WIND_FRAGMENT)
                         else
                             player:messageSpecial(capeTerigganID.text.SOMETHING_BETTER)
                         end
@@ -181,7 +181,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.ICE_FRAGMENT) then
-                        player:startEvent(200, xi.ki.ICE_FRAGMENT)
+                        return mission:progressEvent(200, xi.ki.ICE_FRAGMENT)
                     elseif hasAllFragments(player) then
                         player:messageSpecial(cloisterOfFrostID.text.ALREADY_HAVE_ALL_FRAGS)
                     elseif player:hasKeyItem(xi.ki.ICE_FRAGMENT) then
@@ -213,7 +213,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.WATER_FRAGMENT) then
-                        player:startEvent(200, xi.ki.WATER_FRAGMENT)
+                        return mission:progressEvent(200, xi.ki.WATER_FRAGMENT)
                     elseif hasAllFragments(player) then
                         player:messageSpecial(laTheinePlateauID.text.ALREADY_HAVE_ALL_FRAGS)
                     elseif player:hasKeyItem(xi.ki.WATER_FRAGMENT) then
@@ -259,7 +259,7 @@ mission.sections =
                         player:messageSpecial(sanctuaryOfZitahID.text.ALREADY_OBTAINED_FRAG, xi.ki.LIGHT_FRAGMENT)
                     elseif os.time() >= npc:getLocalVar('cooldown') then
                         if not GetMobByID(sanctuaryOfZitahID.mob.DOOMED_PILGRIMS):isSpawned() then
-                            player:startEvent(200, xi.ki.LIGHT_FRAGMENT)
+                            return mission:progressEvent(200, xi.ki.LIGHT_FRAGMENT)
                         else
                             player:messageSpecial(sanctuaryOfZitahID.text.SOMETHING_BETTER)
                         end
@@ -292,7 +292,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.EARTH_FRAGMENT) then
-                        player:startEvent(200, xi.ki.EARTH_FRAGMENT)
+                        return mission:progressEvent(200, xi.ki.EARTH_FRAGMENT)
                     elseif hasAllFragments(player) then
                         player:messageSpecial(westernAltepaID.text.ALREADY_HAVE_ALL_FRAGS)
                     elseif player:hasKeyItem(xi.ki.EARTH_FRAGMENT) then
@@ -330,7 +330,7 @@ mission.sections =
                             not GetMobByID(yuhtungaJungleID.mob.TIPHA):isSpawned() and
                             not GetMobByID(yuhtungaJungleID.mob.CARTHI):isSpawned()
                         then
-                            player:startEvent(200, xi.ki.FIRE_FRAGMENT)
+                            return mission:progressEvent(200, xi.ki.FIRE_FRAGMENT)
                         else
                             player:messageSpecial(yuhtungaJungleID.text.SOMETHING_BETTER)
                         end

--- a/scripts/missions/sandoria/2_1_The_Rescue_Drill.lua
+++ b/scripts/missions/sandoria/2_1_The_Rescue_Drill.lua
@@ -171,7 +171,7 @@ mission.sections =
                         return mission:messageText(laTheinePlateauID.text.RESCUE_DRILL + 4)
                     elseif missionStatus == 8 then
                         if mission:getVar(player, 'Option') == 3 then
-                            player:startEvent(113)
+                            return mission:progressEvent(113)
                         else
                             return mission:messageText(laTheinePlateauID.text.RESCUE_DRILL + 21)
                         end

--- a/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
+++ b/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
@@ -94,9 +94,9 @@ mission.sections =
                         local missionStatus = player:getMissionStatus(mission.areaId)
 
                         if missionStatus == 5 then
-                            player:startEvent(455) -- Must deliver shield to Yagudo
+                            return mission:progressEvent(455) -- Must deliver shield to Yagudo
                         elseif missionStatus == 6 then
-                            player:startEvent(457) -- Has delivered shield
+                            return mission:progressEvent(457) -- Has delivered shield
                         end
                     end
                 end,

--- a/scripts/missions/sandoria/7_1_Prestige_of_the_Papsque.lua
+++ b/scripts/missions/sandoria/7_1_Prestige_of_the_Papsque.lua
@@ -74,11 +74,11 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        player:startEvent(7)
+                        return mission:progressEvent(7)
                     elseif missionStatus == 1 then
-                        player:startEvent(9)
+                        return mission:progressEvent(9)
                     elseif player:hasKeyItem(xi.ki.ANCIENT_SAN_DORIAN_TABLET) then
-                        player:startEvent(8)
+                        return mission:progressEvent(8)
                     end
                 end,
             },

--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -184,7 +184,7 @@ mission.sections =
                         (not nioHum:isSpawned() or nioHum:isDead())
                     then
                         if mission:getVar(player, 'Prog') > 0 then
-                            player:startEvent(65)
+                            return mission:progressEvent(65)
                         else
                             SpawnMob(uggalepihID.mob.NIO_A)
                             SpawnMob(uggalepihID.mob.NIO_HUM)

--- a/scripts/missions/sandoria/9_1_Breaking_Barriers.lua
+++ b/scripts/missions/sandoria/9_1_Breaking_Barriers.lua
@@ -161,7 +161,7 @@ mission.sections =
                         (not fledglingMob:isSpawned() or fledglingMob:isDead())
                     then
                         if mission:getVar(player, 'Prog') > 0 then
-                            player:startEvent(904)
+                            return mission:progressEvent(904)
                         else
                             SpawnMob(batalliaID.mob.SUPARNA)
                             SpawnMob(batalliaID.mob.SUPARNA_FLEDGLING)

--- a/scripts/missions/windurst/7_1_The_Sixth_Ministry.lua
+++ b/scripts/missions/windurst/7_1_The_Sixth_Ministry.lua
@@ -129,8 +129,7 @@ mission.sections =
                     for i = toraimaraiID.mob.HINGE_OILS_OFFSET, toraimaraiID.mob.HINGE_OILS_OFFSET + 3 do
                         if not GetMobByID(i):isDead() then
                              -- At least one Hinge Oil is alive
-                            player:startEvent(70, 0, 0, 0, 1)
-                            return
+                            return mission:progressEvent(70, 0, 0, 0, 1)
                         end
                     end
 

--- a/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
+++ b/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
@@ -164,9 +164,9 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        player:startEvent(264)
+                        return mission:progressEvent(264)
                     elseif missionStatus > 3 then
-                        player:startEvent(268)
+                        return mission:progressEvent(268)
                     end
                 end,
             },

--- a/scripts/missions/windurst/8_1_Vain.lua
+++ b/scripts/missions/windurst/8_1_Vain.lua
@@ -195,11 +195,11 @@ mission.sections =
 
                     if missionStatus >= 2 then
                         if player:hasKeyItem(xi.ki.STAR_SEEKER) then
-                            player:startEvent(118, 0, xi.items.CURSE_WAND, xi.ki.STAR_SEEKER)
+                            return mission:progressEvent(118, 0, xi.items.CURSE_WAND, xi.ki.STAR_SEEKER)
                         elseif player:hasKeyItem(xi.ki.MAGIC_DRAINED_STAR_SEEKER) and missionStatus == 4 then
-                            player:startEvent(121)
+                            return mission:progressEvent(121)
                         else
-                            player:startEvent(119, 0, xi.items.CURSE_WAND)
+                            return mission:progressEvent(119, 0, xi.items.CURSE_WAND)
                         end
                     end
                 end,

--- a/scripts/quests/windurst/As_Thick_as_Thieves.lua
+++ b/scripts/quests/windurst/As_Thick_as_Thieves.lua
@@ -282,7 +282,7 @@ quest.sections =
                         npcUtil.popFromQM(player, npc, northGustabergID.mob.GAMBILOX_WANDERLING, { hide = 0 })
                         return quest:messageSpecial(northGustabergID.text.SENSE_EVIL_PRESENCE)
                     elseif questProgress == 5 then
-                        player:startEvent(200, xi.items.REGAL_DIE)
+                        return quest:progressEvent(200, xi.items.REGAL_DIE)
                     end
                 end,
             },
@@ -369,9 +369,9 @@ quest.sections =
                         player:hasKeyItem(xi.ki.FIRST_SIGNED_FORGED_ENVELOPE) and
                         player:hasKeyItem(xi.ki.SECOND_SIGNED_FORGED_ENVELOPE)
                     then
-                        player:startEvent(508)
+                        return quest:progressEvent(508)
                     else
-                        player:startEvent(505, 0, xi.ki.GANG_WHEREABOUTS_NOTE)
+                        return quest:progressEvent(505, 0, xi.ki.GANG_WHEREABOUTS_NOTE)
                     end
                 end,
             },

--- a/scripts/quests/windurst/Food_for_Thought.lua
+++ b/scripts/quests/windurst/Food_for_Thought.lua
@@ -146,17 +146,17 @@ quest.sections =
                         -- Traded item without receiving order
                         if kenapaProg < 3 then
                             if math.random(1, 2) == 1 then
-                                player:startEvent(331)
+                                return quest:progressEvent(331)
                             else
-                                player:startEvent(330, 120)
+                                return quest:progressEvent(330, 120)
                             end
 
                         -- Traded item after receiving order
                         elseif kenapaProg == 3 then
-                            player:startEvent(327, 120)
+                            return quest:progressEvent(327, 120)
                         end
                     else
-                        player:startEvent(329)
+                        return quest:progressEvent(329)
                     end
                 end,
 
@@ -221,14 +221,14 @@ quest.sections =
                         -- Traded all 3 items & Didn't ask for order
                         if ohbiruProgress < 2 then
                             if math.random(1, 2) == 1 then
-                                player:startEvent(325, 440)
+                                return quest:progressEvent(325, 440)
                             else
-                                player:startEvent(326)
+                                return quest:progressEvent(326)
                             end
 
                         -- Traded all 3 items after receiving order
                         elseif ohbiruProgress == 2 then
-                            player:startEvent(322, 440)
+                            return quest:progressEvent(322, 440)
                         end
                     end
                 end,


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes some poor copy-paste on my part.  Unless queueing CS's, all event calls from an onTrigger should be returned as a member of the container.