### PR TITLE
Stop using magic numbers in Mapitoto.lua

### DIFF
--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -25,7 +25,7 @@ entity.onTrade = function(player,npc,trade)
         if item == 15533 then
             player:startEvent(10227, 15533, xi.ki.TRAINERS_WHISTLE, xi.mount.CHOCOBO)
             player:setLocalVar("FullSpeedAheadReward", xi.ki.CHOCOBO_COMPANION)
-        elseif mount >= 0 and mount <= 30 then
+        elseif mount >= xi.mount.CHOCOBO and mount <= xi.mount.MOUNT_MAX then
             player:setLocalVar("FullSpeedAheadReward", xi.ki.TIGER_COMPANION + mount)
             player:startEvent(10227, item, xi.ki.TRAINERS_WHISTLE, xi.mount.TIGER + mount - 1)
         end


### PR DESCRIPTION
gets rid of magic number for mount

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [ ] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Didn't test the code as all it does is replace a magic number for an existing global in status.lua 