### PR TITLE
Modernize and correct Tavnazian Safehold NPC shops

### DIFF
--- a/scripts/zones/Tavnazian_Safehold/npcs/Caiphimonride.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Caiphimonride.lua
@@ -15,16 +15,20 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        16450, 1867,    -- Dagger
-        16566, 8478,    -- Longsword
-        17335,    8,    -- Rusty Bolt
+        16450, 2030, -- Dagger
+        16566, 9216, -- Longsword
+        17335,    4, -- Rusty Bolt
     }
 
     if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
-        table.insert(stock, 18375)    -- Falx
-        table.insert(stock, 93240)
-        table.insert(stock, 18214)    -- Voulge
-        table.insert(stock, 51905)
+        stock =
+        {
+            16450,  2030,  -- Dagger
+            16566,  9216,  -- Longsword
+            17335,     4,  -- Rusty Bolt
+            18375, 37296,  -- Falx
+            18214, 20762,  -- Voulge
+        }
     end
 
     player:showText(npc, ID.text.CAIPHIMONRIDE_SHOP_DIALOG)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Komalata.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Komalata.lua
@@ -15,25 +15,26 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        4376, 110,    -- Meat Jerky
-        936,   14,    -- Rock Salt
-        611,   36,    -- Rye Flour
-        4509,  10,    -- Distilled Water
+        4376, 110, -- Meat Jerky
+        936,   14, -- Rock Salt
+        611,   36, -- Rye Flour
+        4509,  10, -- Distilled Water
     }
 
     if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
-        table.insert(stock, 625)      -- Apple Vinegar
-        table.insert(stock, 91)
-        table.insert(stock, 4364)    -- Black Bread
-        table.insert(stock, 110)
-        table.insert(stock, 610)      -- San d'Orian Flour
-        table.insert(stock, 55)
-        table.insert(stock, 4389)     -- San d'Orian Carrot
-        table.insert(stock, 29)
-        table.insert(stock, 629)      -- Millioncorn
-        table.insert(stock, 44)
-        table.insert(stock, 1523)     -- Apple Mint
-        table.insert(stock, 290)
+        stock =
+        {
+            625,   88, -- Apple Vinegar
+            4364, 120, -- Black Bread
+            4376, 120, -- Meat Jerky
+            936,   16, -- Rock Salt
+            611,   40, -- Rye Flour
+            610,   60, -- San d'Orian Flour
+            4389,  32, -- San d'Orian Carrot
+            629,   48, -- Millioncorn
+            1523, 316, -- Apple Mint
+            4509,  12, -- Distilled Water
+        }
     end
 
     player:showText(npc, ID.text.KOMALATA_SHOP_DIALOG)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Mazuro-Oozuro.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Mazuro-Oozuro.lua
@@ -16,12 +16,26 @@ entity.onTrigger = function(player, npc)
     {
         17005,   108,    -- Lufaise Fly
         17383,  2640,    -- Clothespole
-        688,     200,    -- Arrowwood Log
+        688,      20,    -- Arrowwood Log
         690,    7800,    -- Elm Log
         2871,  10000,    -- Safehold Waystone
         4913, 175827,    -- Scroll of Distract II
         4915, 217000,    -- Scroll of Frazzle II
     }
+
+    if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
+        stock =
+        {
+            17005,   108,    -- Lufaise Fly
+            17383,  2640,    -- Clothespole
+            688,      20,    -- Arrowwood Log
+            690,    7800,    -- Elm Log
+            4638,  66000,    -- Banish III
+            2871,  10000,    -- Safehold Waystone
+            4913, 175827,    -- Scroll of Distract II
+            4915, 217000,    -- Scroll of Frazzle II
+        }
+    end
 
     player:showText(npc, ID.text.MAZUROOOZURO_SHOP_DIALOG)
     xi.shop.general(player, stock)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Melleupaux.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Melleupaux.lua
@@ -14,16 +14,20 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        16450, 1867,    -- Dagger
-        16566, 8478,    -- Longsword
-        17335,    8,    -- Rusty Bolt
+        16450, 2030, -- Dagger
+        16566, 9216, -- Longsword
+        17335,    4, -- Rusty Bolt
     }
 
     if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
-        table.insert(stock, 18375)    -- Falx
-        table.insert(stock, 93240)
-        table.insert(stock, 18214)    -- Voulge
-        table.insert(stock, 51905)
+        stock =
+        {
+            16450,  2030,  -- Dagger
+            16566,  9216,  -- Longsword
+            17335,     4,  -- Rusty Bolt
+            18375, 37296,  -- Falx
+            18214, 20762,  -- Voulge
+        }
     end
 
     player:showText(npc, ID.text.MELLEUPAUX_SHOP_DIALOG)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Migran.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Migran.lua
@@ -15,21 +15,22 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        12577, 2485,      -- Brass Harness
-        12985, 1625,      -- Holly Clogs
+        12577, 2485, -- Brass Harness
+        12985, 1625, -- Holly Clogs
     }
 
     if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
-        table.insert(stock, 14317)    -- Barone Cosciales
-        table.insert(stock, 4042200)
-        table.insert(stock, 15305)    -- Barone Gambieras
-        table.insert(stock, 25210200)
-        table.insert(stock, 14848)    -- Barone Manopolas
-        table.insert(stock, 7276200)
-        table.insert(stock, 15389)    -- Vir Subligar
-        table.insert(stock, 8000000)
-        table.insert(stock, 15390)    -- Femina Subligar
-        table.insert(stock, 8000000)
+        stock =
+        {
+            14317, 101055,  -- Barone Cosciales
+            15305, 630255,  -- Barone Gambieras
+            14848, 181905,  -- Barone Manopolas
+            12577, 2485,    -- Brass Harness
+            12985, 1625,    -- Holly Clogs
+            15389, 8000000, -- Vir Subligar
+            15390, 8000000, -- Femina Subligar
+
+        }
     end
 
     player:showText(npc, ID.text.MIGRAN_SHOP_DIALOG)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Misseulieu.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Misseulieu.lua
@@ -15,21 +15,22 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        12577, 2485,      -- Brass Harness
-        12985, 1625,      -- Holly Clogs
+        12577, 2485, -- Brass Harness
+        12985, 1625, -- Holly Clogs
     }
 
     if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
-        table.insert(stock, 14317)    -- Barone Cosciales
-        table.insert(stock, 4042200)
-        table.insert(stock, 15305)    -- Barone Gambieras
-        table.insert(stock, 25210200)
-        table.insert(stock, 14848)    -- Barone Manopolas
-        table.insert(stock, 7276200)
-        table.insert(stock, 15389)    -- Vir Subligar
-        table.insert(stock, 8000000)
-        table.insert(stock, 15390)    -- Femina Subligar
-        table.insert(stock, 8000000)
+        stock =
+        {
+            14317, 101055,  -- Barone Cosciales
+            15305, 630255,  -- Barone Gambieras
+            14848, 181905,  -- Barone Manopolas
+            12577, 2485,    -- Brass Harness
+            12985, 1625,    -- Holly Clogs
+            15389, 8000000, -- Vir Subligar
+            15390, 8000000, -- Femina Subligar
+
+        }
     end
 
     player:showText(npc, ID.text.MISSEULIEU_SHOP_DIALOG)

--- a/scripts/zones/Tavnazian_Safehold/npcs/Nilerouche.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Nilerouche.lua
@@ -16,12 +16,26 @@ entity.onTrigger = function(player, npc)
     {
         17005,   108,    -- Lufaise Fly
         17383,  2640,    -- Clothespole
-        688,     200,    -- Arrowwood Log
+        688,      20,    -- Arrowwood Log
         690,    7800,    -- Elm Log
         2871,  10000,    -- Safehold Waystone
         4913, 175827,    -- Scroll of Distract II
         4915, 217000,    -- Scroll of Frazzle II
     }
+
+    if player:getCurrentMission(COP) >= xi.mission.id.cop.SHELTERING_DOUBT then
+        stock =
+        {
+            17005,   108,    -- Lufaise Fly
+            17383,  2640,    -- Clothespole
+            688,      20,    -- Arrowwood Log
+            690,    7800,    -- Elm Log
+            4638,  66000,    -- Banish III
+            2871,  10000,    -- Safehold Waystone
+            4913, 175827,    -- Scroll of Distract II
+            4915, 217000,    -- Scroll of Frazzle II
+        }
+    end
 
     player:showText(npc, ID.text.NILEROUCHE_SHOP_DIALOG)
     xi.shop.general(player, stock)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Source: fresh from my own 2 characters I used to check before and after mission progress on retail, guaranteed 100% retail accurate down to the item order in the shop list, which `table.insert` ruins _and is bad practice anyway mmmkaay kids?_ Which is a good thing I did, because both wikis miss mission requirements on Banish III along with other errors (ffxiclopedia has incorrect prices on virtually everything)

**Items now appear in the same order/slot placement as retail at the same prices and under the same conditions.**
