### PR TITLE
[core, cop] Fix event target persistance and COP 6-4

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -664,7 +664,7 @@ local function checkReqs(player, npc, bfid, registrant)
         [ 963] = function() return ( player:hasKeyItem(xi.ki.MONARCH_BEARD)                                                                                                ) end, -- ENM: Bad Seed
         [ 964] = function() return ( player:hasKeyItem(xi.ki.MONARCH_BEARD)                                                                                                ) end, -- ENM: Bugard in the Clouds
         [ 965] = function() return ( player:hasKeyItem(xi.ki.MONARCH_BEARD)                                                                                                ) end, -- ENM: Beloved of Atlantes
-        [ 992] = function() return ( cop == mi.cop.ONE_TO_BE_FEARED and copStat == 2                                                                                        ) end, -- PM6-4: One to be Feared
+        [ 992] = function() return ( cop == mi.cop.ONE_TO_BE_FEARED and copStat == 3                                                                                        ) end, -- PM6-4: One to be Feared
         [ 993] = function() return ( cop == mi.cop.THE_WARRIOR_S_PATH                                                                                                       ) end, -- PM7-5: The Warrior's Path
         [1024] = function() return ( cop == mi.cop.WHEN_ANGELS_FALL and copStat == 4                                                                                        ) end, -- PM8-3: When Angels Fall
         [1056] = function() return ( cop == mi.cop.DAWN and copStat == 2                                                                                                    ) end, -- PM8-4: Dawn

--- a/scripts/globals/items/bottle_of_yellow_liquid.lua
+++ b/scripts/globals/items/bottle_of_yellow_liquid.lua
@@ -10,7 +10,8 @@ local item_object = {}
 item_object.onItemCheck = function(target)
     local result = 0
 
-    if (target:hasStatusEffect(xi.effect.FOOD)) then
+    -- TODO: Can this ONLY be used on Mammet types?
+    if target:hasStatusEffect(xi.effect.FOOD) then
         result = xi.msg.basic.IS_FULL
     end
 

--- a/scripts/zones/Lufaise_Meadows/Zone.lua
+++ b/scripts/zones/Lufaise_Meadows/Zone.lua
@@ -34,13 +34,13 @@ end
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(-475.825, -20.461, 281.149, 11)
     end
 
-    if (player:getCurrentMission(COP) == xi.mission.id.cop.AN_INVITATION_WEST and player:getCharVar("PromathiaStatus") == 0) then
+    if player:getCurrentMission(COP) == xi.mission.id.cop.AN_INVITATION_WEST and player:getCharVar("PromathiaStatus") == 0 then
         cs = 110
-    elseif (player:getCurrentMission(COP) == xi.mission.id.cop.CHAINS_AND_BONDS and player:getCharVar("PromathiaStatus") == 0) then
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.CHAINS_AND_BONDS and player:getCharVar("PromathiaStatus") == 0 then
         cs = 111
     end
 
@@ -49,7 +49,7 @@ end
 
 zone_object.onRegionEnter = function(player, region)
     local regionID = region:GetRegionID()
-    if (regionID == 1 and player:getCurrentMission(COP) == xi.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 6) then
+    if regionID == 1 and player:getCurrentMission(COP) == xi.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 6 then
         player:startEvent(116)
     end
 end
@@ -58,16 +58,19 @@ zone_object.onRegionLeave = function(player, region)
 end
 
 zone_object.onEventUpdate = function(player, csid, option)
+    if csid == 111 then
+        player:updateEvent(0, xi.items.DUCAL_GUARDS_RING)
+    end
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if (csid == 110) then
+    if csid == 110 then
         player:messageSpecial(ID.text.KI_STOLEN, 0, xi.ki.MYSTERIOUS_AMULET)
         player:delKeyItem(xi.ki.MYSTERIOUS_AMULET)
         player:setCharVar("PromathiaStatus", 1)
-    elseif (csid == 111 and npcUtil.giveItem(player, xi.items.DUCAL_GUARDS_RING)) then
+    elseif csid == 111 and npcUtil.giveItem(player, xi.items.DUCAL_GUARDS_RING) then
         player:setCharVar("PromathiaStatus", 1)
-    elseif (csid == 116) then
+    elseif csid == 116 then
         player:setCharVar("PromathiaStatus", 7)
         player:addTitle(xi.title.BANISHER_OF_EMPTINESS)
     end

--- a/scripts/zones/Sealions_Den/IDs.lua
+++ b/scripts/zones/Sealions_Den/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.SEALIONS_DEN] =
         CARRIED_OVER_POINTS     = 7000, -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY = 7001, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!<space>
         LOGIN_NUMBER            = 7002, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
+        IRON_GATE_LOCKED        = 7090, -- A solid iron gate. It is tightly locked...
         CONQUEST_BASE           = 7424, -- Tallying conquest results...
     },
     mob =

--- a/scripts/zones/Sealions_Den/Zone.lua
+++ b/scripts/zones/Sealions_Den/Zone.lua
@@ -1,7 +1,5 @@
 -----------------------------------
---
 -- Zone: Sealions_Den (32)
---
 -----------------------------------
 local ID = require("scripts/zones/Sealions_Den/IDs")
 require("scripts/globals/conquest")
@@ -18,18 +16,24 @@ end
 
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(600.101, 130.355, 797.612, 50)
     end
+
     if player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 1 then
         cs = 15
-    elseif (player:getCurrentMission(COP) == xi.mission.id.cop.CHAINS_AND_BONDS and
-        player:getCharVar("PromathiaStatus") == 2) then
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 4 then
+        cs = 33
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.CHAINS_AND_BONDS and player:getCharVar("PromathiaStatus") == 2 then
         cs = 14
-    elseif player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-        player:getCharVar('ApocalypseNigh') == 1 then
+    elseif
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
+        player:getCharVar('ApocalypseNigh') == 1
+    then
         cs = 29
     end
+
     return cs
 end
 
@@ -40,12 +44,17 @@ zone_object.onEventUpdate = function(player, csid, option)
 end
 
 zone_object.onEventFinish = function(player, csid, option)
-    if (csid == 15) then
+    if csid == 15 then
         player:setCharVar("PromathiaStatus", 2)
-    elseif (csid == 14) then
+    elseif csid == 14 then
         player:setCharVar("PromathiaStatus", 3);
     elseif csid == 29 then
         player:setCharVar('ApocalypseNigh', 2)
+    elseif csid == 33 then
+        player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.ONE_TO_BE_FEARED)
+        player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.CHAINS_AND_BONDS)
+        player:setCharVar("PromathiaStatus", 0)
+        player:setPos(438, 0, -18, 11, xi.zone.LUFAISE_MEADOWS)
     end
 end
 

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -35,14 +35,18 @@ battlefield_object.onEventUpdate = function(player, csid, option)
 end
 
 battlefield_object.onEventFinish = function(player, csid, option)
+    -- NOTE: On completion, all members are sent back to Sealion's Den.
+    --       If you're eligable for the cutscene when you zone in, you'll
+    --       be sent to Lufaise directly afterwards.
+
+    -- TODO: This transition from BCNM end to Sealion's Den to Lufaise is pretty ugly.
+    --       Could/should be fixed in the future.
     if csid == 32001 then
-        if player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 2 then
-            player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.ONE_TO_BE_FEARED)
-            player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.CHAINS_AND_BONDS)
-            player:setCharVar("PromathiaStatus", 0)
+        if player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 3 then
+            player:setCharVar("PromathiaStatus", 4)
         end
         player:addExp(1500)
-        player:setPos(438, 0, -18, 11, 24) -- Lufaise
+        player:setPos(0, 0, 0, 0, xi.zone.SEALIONS_DEN) -- TODO: This might not be needed
     end
 end
 

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -10,11 +10,92 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
     mob:setMobMod(xi.mobMod.GIL_MAX, -1)
+    mob:setLocalVar("formHealthTracker", 100)
+end
+
+local forms =
+{
+    UNARMED = 0,
+    SWORD   = 1,
+    POLEARM = 2,
+    STAFF   = 3,
+}
+
+entity.onMobSpawn = function(mob)
+    mob:SetMagicCastingEnabled(false)
+end
+
+entity.onMobFight = function(mob, target)
+    -- TODO: What are the conditions for a Mammet to change forms?
+    --       For now we'll change forms every 20% health
+    local healthTracker = mob:getLocalVar("formHealthTracker")
+    local currentHealth = mob:getHPP()
+
+    -- NOTE: Yellow Liquid applies xi.effect.FOOD to the Mammets
+    local cannotChangeForm = mob:hasStatusEffect(xi.effect.FOOD)
+
+    if healthTracker - currentHealth > 20 and not cannotChangeForm then
+        -- Pick a new form
+        local rand = math.random(0, 3)
+        mob:setAnimationSub(rand)
+        switch (rand): caseof
+        {
+            [forms.UNARMED] = function()
+                mob:SetMagicCastingEnabled(false)
+                mob:setDelay(2400)
+                mob:setDamage(40)
+            end,
+            [forms.SWORD] = function()
+                mob:SetMagicCastingEnabled(false)
+                mob:setDelay(1500)
+                mob:setDamage(40)
+            end,
+            [forms.POLEARM] = function()
+                mob:SetMagicCastingEnabled(false)
+                mob:setDelay(3250)
+                mob:setDamage(75)
+            end,
+            [forms.STAFF] = function()
+                mob:setMobMod(xi.mobMod.MAGIC_COOL, 10)
+                mob:SetMagicCastingEnabled(true)
+                mob:setDelay(3700)
+                mob:setDamage(40)
+            end,
+        }
+        mob:setLocalVar("formHealthTracker", currentHealth)
+    end
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    -- NOTE: Mammets always have access to:
+    -- TODO: Transmogrification: Absorbs all physical damage for ~30 seconds
+    -- TODO: Tremorous Tread: Low AoE damage with a Stun effect, absorbed by Utsusemi.
+    switch (mob:getAnimationSub()): caseof
+    {
+        [forms.UNARMED] = function()
+            -- Just default moves
+        end,
+        [forms.SWORD] = function()
+            -- TODO: Velocious Blade: 5-hit attack, high damage.
+            -- TODO: Sonic Blade: High AoE damage.
+            -- TODO: Scission Thrust: Low conal AoE damage.
+        end,
+        [forms.POLEARM] = function()
+            -- TODO: Percussive Foin: Medium directional AoE damage.
+            -- TODO: Microquake: High single-target damage.
+            -- TODO: Gravity Wheel: High AoE damage and Gravity.
+        end,
+        [forms.STAFF] = function()
+            -- TODO: Psychomancy: AoE Aspir, drains 80+ MP.
+            -- TODO: Mind Wall: Gives the Mammet a special Magic Shield effect causing it to absorb offensive magic used against it for ~30 seconds.
+        end,
+    }
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
     -- find mob offset for given battlefield instance
-    local inst = mob:getBattlefield():getArea()
+    local battlefield = mob:getBattlefield()
+    local inst = battlefield:getArea()
     local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1))
 
     -- if all five mammets in this instance are dead, start event
@@ -25,9 +106,11 @@ entity.onMobDeath = function(mob, player, isKiller)
             break
         end
     end
-    if allMammetsDead then
-        player:release() -- prevents event collision if player kills multiple remaining mammets with an AOE move/spell
+
+    local mammetEventGuard = battlefield:getLocalVar("mammetEventGuard")
+    if allMammetsDead and mammetEventGuard == 0 then
         player:startEvent(11)
+        battlefield:setLocalVar("mammetEventGuard", 1)
     end
 end
 
@@ -35,11 +118,13 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 11 then
         local battlefield = player:getBattlefield()
         local inst = battlefield:getArea()
+
         -- players are healed in between fights, but their TP is set to 0
         player:addTitle(xi.title.BRANDED_BY_LIGHTNING)
         player:setHP(player:getMaxHP())
         player:setMP(player:getMaxMP())
         player:setTP(0)
+
         player:setLocalVar("[OTBF]cs", 1)
 
         -- move player to instance

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -33,23 +33,23 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 11 then
-        local inst = player:getBattlefield():getArea()
+        local battlefield = player:getBattlefield()
+        local inst = battlefield:getArea()
 
-        if inst >= 1 and inst <= 3 then
-            -- players are healed in between fights, but their TP is set to 0
-            player:setHP(player:getMaxHP())
-            player:setMP(player:getMaxMP())
-            player:setTP(0)
-            player:setLocalVar("[OTBF]cs", 2)
+        -- players are healed in between fights, but their TP is set to 0
+        player:setHP(player:getMaxHP())
+        player:setMP(player:getMaxMP())
+        player:setTP(0)
 
-            -- move player to instance
-            if inst == 1 then
-                player:setPos(-779, -103, -80)
-            elseif inst == 2 then
-                player:setPos(-140, -23, -440)
-            elseif inst == 3 then
-                player:setPos(499, 56, -802)
-            end
+        player:setLocalVar("[OTBF]cs", 2)
+
+        -- move player to instance
+        if inst == 1 then
+            player:setPos(-779, -103, -80)
+        elseif inst == 2 then
+            player:setPos(-140, -23, -440)
+        elseif inst == 3 then
+            player:setPos(499, 56, -802)
         end
     end
 end

--- a/scripts/zones/Sealions_Den/npcs/Sueleen.lua
+++ b/scripts/zones/Sealions_Den/npcs/Sueleen.lua
@@ -13,11 +13,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCurrentMission(COP) > xi.mission.id.cop.THE_WARRIOR_S_PATH) then
+    if player:getCurrentMission(COP) > xi.mission.id.cop.THE_WARRIOR_S_PATH then
         player:startEvent(12)
-    elseif (player:getCurrentMission(COP) == xi.mission.id.cop.FLAMES_IN_THE_DARKNESS and player:getCharVar("PromathiaStatus") == 1) then
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.FLAMES_IN_THE_DARKNESS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(16)
-    elseif (player:getCurrentMission(COP) == xi.mission.id.cop.CALM_BEFORE_THE_STORM and player:hasKeyItem(xi.ki.LETTERS_FROM_ULMIA_AND_PRISHE)) then
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.CALM_BEFORE_THE_STORM and player:hasKeyItem(xi.ki.LETTERS_FROM_ULMIA_AND_PRISHE) then
         player:startEvent(17)
     else
         player:startEvent(20)
@@ -25,19 +25,14 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    -- printf("onUpdate CSID: %u", csid)
-    -- printf("onUpdate RESULT: %u", option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- printf("onFinish CSID: %u", csid)
-    -- printf("onFinish RESULT: %u", option)
-
-    if (csid == 12 and option == 1) then
+    if csid == 12 and option == 1 then
         xi.teleport.to(player, xi.teleport.id.SEA)
-    elseif (csid == 16) then
+    elseif csid == 16 then
         player:setCharVar("PromathiaStatus", 2)
-    elseif (csid == 17) then
+    elseif csid == 17 then
         player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.CALM_BEFORE_THE_STORM)
         player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_WARRIOR_S_PATH)
         player:setCharVar("PromathiaStatus", 0)

--- a/scripts/zones/Sealions_Den/npcs/_0w0.lua
+++ b/scripts/zones/Sealions_Den/npcs/_0w0.lua
@@ -7,6 +7,7 @@ require("scripts/globals/teleports")
 require("scripts/globals/missions")
 require("scripts/globals/titles")
 require("scripts/globals/bcnm")
+local ID = require("scripts/zones/Sealions_Den/IDs")
 -----------------------------------
 local entity = {}
 
@@ -17,32 +18,35 @@ end
 entity.onTrigger = function(player, npc)
     if player:getCurrentMission(COP) == xi.mission.id.cop.SLANDEROUS_UTTERINGS and player:getCharVar("PromathiaStatus") == 1 then
         player:startEvent(13)
+    elseif player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 2 then
+        player:startEvent(31)
     elseif EventTriggerBCNM(player, npc) then
         return
-    elseif (player:getCurrentMission(COP) > xi.mission.id.cop.THE_WARRIOR_S_PATH) then
+    elseif player:getCurrentMission(COP) > xi.mission.id.cop.THE_WARRIOR_S_PATH then
         player:startEvent(12)
+    else
+        player:messageSpecial(ID.text.IRON_GATE_LOCKED)
     end
 end
 
 entity.onEventUpdate = function(player, csid, option, extras)
     EventUpdateBCNM(player, csid, option, extras)
-        return
 end
 
 entity.onEventFinish = function(player, csid, option)
-    -- printf("onFinish CSID: %u", csid)
-    -- printf("onFinish RESULT: %u", option)
-
-    if (EventFinishBCNM(player, csid, option)) then
+    if EventFinishBCNM(player, csid, option) then
         return
     end
-    if (csid == 12 and option == 1) then
+
+    if csid == 12 and option == 1 then
         player:setPos(-31.8, 0, -618.7, 190, 33)
-    elseif (csid == 13) then
+    elseif csid == 13 then
         player:setCharVar("PromathiaStatus", 0)
         player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.SLANDEROUS_UTTERINGS)
         player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_ENDURING_TUMULT_OF_WAR)
         player:addTitle(xi.title.THE_LOST_ONE)
+    elseif csid == 31 then
+        player:setCharVar("PromathiaStatus", 3)
     end
 end
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1845,6 +1845,9 @@ namespace luautils
     {
         TracyZoneScoped;
 
+        EventPrep* previousPrep = PChar->eventPreparation;
+        PChar->eventPreparation = PChar->currentEvent;
+
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
         if (!onEventUpdate.valid())
         {
@@ -1866,6 +1869,8 @@ namespace luautils
             return -1;
         }
 
+        PChar->eventPreparation = previousPrep;
+
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
 
@@ -1877,6 +1882,9 @@ namespace luautils
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
         TracyZoneScoped;
+
+        EventPrep* previousPrep = PChar->eventPreparation;
+        PChar->eventPreparation = PChar->currentEvent;
 
         auto onEventUpdateFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventUpdate"];
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
@@ -1895,12 +1903,17 @@ namespace luautils
             return -1;
         }
 
+        PChar->eventPreparation = previousPrep;
+
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
 
     int32 OnEventUpdate(CCharEntity* PChar, std::string const& updateString)
     {
         TracyZoneScoped;
+
+        EventPrep* previousPrep = PChar->eventPreparation;
+        PChar->eventPreparation = PChar->currentEvent;
 
         auto onEventUpdateFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventUpdate"];
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
@@ -1919,6 +1932,8 @@ namespace luautils
             return -1;
         }
 
+        PChar->eventPreparation = previousPrep;
+
         return 0;
     }
 
@@ -1931,6 +1946,9 @@ namespace luautils
     int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result)
     {
         TracyZoneScoped;
+
+        EventPrep* previousPrep = PChar->eventPreparation;
+        PChar->eventPreparation = PChar->currentEvent;
 
         auto onEventFinishFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventFinish"];
         auto onEventFinish = LoadEventScript(PChar, "onEventFinish");
@@ -1953,6 +1971,8 @@ namespace luautils
             ShowError("luautils::onEventFinish %s", err.what());
             return -1;
         }
+
+        PChar->eventPreparation = previousPrep;
 
         if (PChar->currentEvent->scriptFile.find("/bcnms/") > 0 && PChar->health.hp <= 0)
         { // for some reason the event doesnt enforce death afterwards


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This appears to be the same issue we're facing in the TOAU rewrite branch, so I'll bring the fix out here. Thanks @InoUno for the advice about this!

Fixes https://github.com/LandSandBoat/server/issues/698
Fixes https://github.com/LandSandBoat/server/discussions/696

**Still TODO:**
- Omega and Ultima are facing the wrong direction when they're spawned
- Exit CS didn't play correctly for me (but I hadn't set up the missions and PromathiaStatus var correctly, needs a bit of testing)
- Mammets, Omega and Ultima seem to be marked incorrectly in the db, we shouldn't need this in their scripts:
```lua
    mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
    mob:setMobMod(xi.mobMod.GIL_MAX, -1)
```
- Don't know if we hand out rewards/exp correctly, should check (https://ffxiclopedia.fandom.com/wiki/One_to_be_Feared)
- Battlefield picks up Ultima's death _very_ slowly, we can do better than that I'm sure
- I didn't notice if the Mammets change form or not (compared to my caps), so I assume we haven't done that yet