### PR TITLE
[Fix] Bonecraft Guild Leader

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
         guildMember = 64
     end
 
-    if xi.crafting.unionRepresentativeTriggerDenounceCheck(player, 10016, realSkill, rankCap, 184549887) then
+    if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10016, realSkill, rankCap, 184549887) then
         return
     end
 
@@ -82,7 +82,7 @@ entity.onEventUpdate = function(player, csid, option)
         option >= xi.skill.WOODWORKING and
         option <= xi.skill.COOKING
     then
-        xi.crafting.unionRepresentativeEventUpdateDenounce(player, option)
+        xi.crafting.unionRepresentativeEventUpdateRenounce(player, option)
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes functions in Peshi_Yohnts.lua script missing when converting them from Denounce to Renounce.