### PR TITLE
Fix Wamouracampa stance switching

### DIFF
--- a/scripts/globals/mobskills/cannonball.lua
+++ b/scripts/globals/mobskills/cannonball.lua
@@ -14,21 +14,23 @@ require("scripts/globals/mobskills")
 local mobskill_object = {}
 
 mobskill_object.onMobSkillCheck = function(target, mob, skill)
-    if (mob:getAnimationSub() ~=1) then
-        return 1
-    else
+    if mob:getAnimationSub() == 5 then
         return 0
+    else
+        return 1
     end
 end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
-    local numhits = 1
-    local accmod = 1
-    local dmgmod = 1.75
+    local numhits   = 1
+    local accmod    = 1
+    local dmgmod    = 1.75
     local offcratio = mob:getStat(xi.mod.DEF)
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1.75, 2.125, 2.75, offcratio)
-    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+    local info      = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1.75, 2.125, 2.75, offcratio)
+    local dmg       = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+
     return dmg
 end
 

--- a/scripts/mixins/families/wamouracampa.lua
+++ b/scripts/mixins/families/wamouracampa.lua
@@ -1,33 +1,45 @@
+-----------------------------------
 -- Wamouracampa family mixin
-
+-----------------------------------
 require("scripts/globals/mixins")
 require("scripts/globals/status")
 -----------------------------------
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
+-- This mobs curl up based on damage taken.
+-- If they take a hit higher than 5% oh their Max HP OR if they take a total of 1k (aprox) damage, they will curl.
+-- If they are already curled, they will reset conditions and remain curled.
+-- They will keep streched so long as none of the above conditions are met. Linked Wamouracampas will obviously stay streched.
+
 local function curlUpRoaming(mob)
     mob:setAnimationSub(5) -- Curl
     mob:setLocalVar("formTimeRoam", os.time() + math.random(43, 47))
     mob:setMobMod(xi.mobMod.SKILL_LIST, 1162) -- Set Curled Skill List. ("Cannonball" and "Heat Barrier" only)
-    -- TODO: Change resistances.
+    mob:addMod(xi.mod.DMGPHYS, -2500)
+    mob:delMod(xi.mod.DMGMAGIC, -2500)
 end
 
 local function strechUpRoaming(mob)
     mob:setAnimationSub(4) -- Strech
     mob:setLocalVar("formTimeRoam", os.time() + math.random(43, 47))
     mob:setMobMod(xi.mobMod.SKILL_LIST, 254) -- Set streched Skill List. (All TP moves except "Cannonball")
-    -- TODO: Change resistances.
+    mob:delMod(xi.mod.DMGPHYS, -2500)
+    mob:addMod(xi.mod.DMGMAGIC, -2500)
 end
 
 local function curlUpEngaged(mob)
     mob:setAnimationSub(5) -- Curl
-    mob:setMobMod(xi.mobMod.SKILL_LIST, 1162) -- Set Curled Skill List
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 1162) -- Set Curled Skill List. ("Cannonball" and "Heat Barrier" only)
+    mob:addMod(xi.mod.DMGPHYS, -2500)
+    mob:delMod(xi.mod.DMGMAGIC, -2500)
 end
 
 local function strechUpEngaged(mob)
     mob:setAnimationSub(4) -- Strech
-    mob:setMobMod(xi.mobMod.SKILL_LIST, 254) -- Set streched Skill List. (Cannonball and Heat Barrier ONLY)
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 254) -- Set streched Skill List. (All TP moves except "Cannonball")
+    mob:delMod(xi.mod.DMGPHYS, -2500)
+    mob:addMod(xi.mod.DMGMAGIC, -2500)
 end
 
 local function resetCount(mob)
@@ -36,14 +48,17 @@ local function resetCount(mob)
 end
 
 g_mixins.families.wamouracampa = function(wamouracampaMob)
+    -- Set spawn.
     wamouracampaMob:addListener("SPAWN", "WAMOURACAMPA_SPAWN", function(mob)
         mob:setAnimationSub(4)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 254)
+        mob:addMod(xi.mod.DMGMAGIC, -2500)
         mob:setLocalVar("hitPoints", mob:getHP())
-        mob:setLocalVar("formTimeRoam", os.time() + math.random(10, 60))
+        mob:setLocalVar("formTimeRoam", os.time() + math.random(30, 90))
         mob:setLocalVar("formTimeEngaged", os.time())
-        -- mob:setLocalVar("morphTime", os.time() + math.random(300, 600))
     end)
 
+    -- Handle regular changes on roam.
     wamouracampaMob:addListener("ROAM_TICK", "WAMOURACAMPA_ROAM", function(mob)
         if os.time() - mob:getLocalVar("formTimeRoam") > 0 then
             if mob:getAnimationSub() == 4 then
@@ -67,10 +82,6 @@ g_mixins.families.wamouracampa = function(wamouracampaMob)
 
     -- Handle streching from curl.
     wamouracampaMob:addListener("COMBAT_TICK", "WAMOURACAMPA_COMBAT", function(mob)
-        -- This mobs curl up based on damage taken.
-        -- If they take a hit higher than 5% oh their Max HP OR if they take a total of 1k (aprox) damage, they will curl.
-        -- If they are already curled, they will reset conditions and remain curled.
-        -- They will keep streched so long as none of the above conditions are met. Linked Wamouracampas will obviously stay streched.
         if
             mob:getAnimationSub() == 5 and
             os.time() - mob:getLocalVar("formTimeEngaged") > 0 and -- IF safety timer is over

--- a/scripts/mixins/families/wamouracampa.lua
+++ b/scripts/mixins/families/wamouracampa.lua
@@ -72,7 +72,7 @@ g_mixins.families.wamouracampa = function(wamouracampaMob)
         -- If they are already curled, they will reset conditions and remain curled.
         -- They will keep streched so long as none of the above conditions are met. Linked Wamouracampas will obviously stay streched.
         if
-            mob:getAnimationSub() == 5 and 
+            mob:getAnimationSub() == 5 and
             os.time() - mob:getLocalVar("formTimeEngaged") > 0 and -- IF safety timer is over
             os.time() - mob:getLocalVar("formTimeRoam") > 0 and    -- Additional check in case its already curled.
             mob:getLocalVar("hitPoints") < mob:getHP()

--- a/scripts/mixins/families/wamouracampa.lua
+++ b/scripts/mixins/families/wamouracampa.lua
@@ -1,0 +1,101 @@
+-- Wamouracampa family mixin
+
+require("scripts/globals/mixins")
+require("scripts/globals/status")
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+local function curlUpRoaming(mob)
+    mob:setAnimationSub(5) -- Curl
+    mob:setLocalVar("formTimeRoam", os.time() + math.random(43, 47))
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 1162) -- Set Curled Skill List. ("Cannonball" and "Heat Barrier" only)
+    -- TODO: Change resistances.
+end
+
+local function strechUpRoaming(mob)
+    mob:setAnimationSub(4) -- Strech
+    mob:setLocalVar("formTimeRoam", os.time() + math.random(43, 47))
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 254) -- Set streched Skill List. (All TP moves except "Cannonball")
+    -- TODO: Change resistances.
+end
+
+local function curlUpEngaged(mob)
+    mob:setAnimationSub(5) -- Curl
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 1162) -- Set Curled Skill List
+end
+
+local function strechUpEngaged(mob)
+    mob:setAnimationSub(4) -- Strech
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 254) -- Set streched Skill List. (Cannonball and Heat Barrier ONLY)
+end
+
+local function resetCount(mob)
+    mob:setLocalVar("formTimeEngaged", os.time() + math.random(40, 50))
+    mob:setLocalVar("hitPoints",  mob:getHP() - math.floor(mob:getMaxHP() * 20 / 100))
+end
+
+g_mixins.families.wamouracampa = function(wamouracampaMob)
+    wamouracampaMob:addListener("SPAWN", "WAMOURACAMPA_SPAWN", function(mob)
+        mob:setAnimationSub(4)
+        mob:setLocalVar("hitPoints", mob:getHP())
+        mob:setLocalVar("formTimeRoam", os.time() + math.random(10, 60))
+        mob:setLocalVar("formTimeEngaged", os.time())
+        -- mob:setLocalVar("morphTime", os.time() + math.random(300, 600))
+    end)
+
+    wamouracampaMob:addListener("ROAM_TICK", "WAMOURACAMPA_ROAM", function(mob)
+        if os.time() - mob:getLocalVar("formTimeRoam") > 0 then
+            if mob:getAnimationSub() == 4 then
+                curlUpRoaming(mob)
+            elseif mob:getAnimationSub() == 5 then
+                strechUpRoaming(mob)
+            end
+        end
+    end)
+
+    -- First damaging hit makes mob curl if not already.
+    wamouracampaMob:addListener("ENGAGE", "WAMOURACAMPA_ENGAGE", function(mob)
+        if
+            mob:getLocalVar("hitPoints") < mob:getHP() and
+            mob:getAnimationSub() == 4
+        then
+            curlUpEngaged(mob)
+            resetCount(mob)
+        end
+    end)
+
+    -- Handle streching from curl.
+    wamouracampaMob:addListener("COMBAT_TICK", "WAMOURACAMPA_COMBAT", function(mob)
+        -- This mobs curl up based on damage taken.
+        -- If they take a hit higher than 5% oh their Max HP OR if they take a total of 1k (aprox) damage, they will curl.
+        -- If they are already curled, they will reset conditions and remain curled.
+        -- They will keep streched so long as none of the above conditions are met. Linked Wamouracampas will obviously stay streched.
+        if
+            mob:getAnimationSub() == 5 and 
+            os.time() - mob:getLocalVar("formTimeEngaged") > 0 and -- IF safety timer is over
+            os.time() - mob:getLocalVar("formTimeRoam") > 0 and    -- Additional check in case its already curled.
+            mob:getLocalVar("hitPoints") < mob:getHP()
+        then
+            strechUpEngaged(mob)
+            resetCount(mob)
+        end
+    end)
+
+    -- Handle curling from being streched or remaining curled.
+    wamouracampaMob:addListener("TAKE_DAMAGE", "WAMOURACAMPA_TAKE_DAMAGE", function(mob, amount, attacker, attackType, damageType)
+        if
+            os.time() - mob:getLocalVar("formTimeEngaged") > 0 and
+            (amount > math.floor(mob:getMaxHP() * 5 / 100) or
+            mob:getLocalVar("hitPoints") > mob:getHP())
+        then
+            if mob:getAnimationSub() == 4 then
+                curlUpEngaged(mob)
+            end
+
+            resetCount(mob)
+        end
+    end)
+end
+
+return g_mixins.families.wamouracampa

--- a/scripts/zones/Halvung/mobs/Wamouracampa.lua
+++ b/scripts/zones/Halvung/mobs/Wamouracampa.lua
@@ -5,32 +5,17 @@
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
+mixins = {require("scripts/mixins/families/wamouracampa")}
+-----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar("formTime", os.time() + math.random(44, 45))
 end
 
 entity.onMobRoam = function(mob)
-    local roamTime = mob:getLocalVar("formTime")
-    if mob:getAnimationSub() == 0 and os.time() > roamTime then
-        mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    elseif mob:getAnimationSub() == 1 and os.time() > roamTime then
-        mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    end
 end
 
 entity.onMobFight = function(mob, target)
-    local fightTime = mob:getLocalVar("formTime")
-    if mob:getAnimationSub() == 0 and os.time() > fightTime then
-        mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    elseif mob:getAnimationSub() == 1 and os.time() > fightTime then
-        mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    end
 end
 
 entity.onMobDeath = function(mob)

--- a/scripts/zones/Halvung/mobs/Wamouracampa.lua
+++ b/scripts/zones/Halvung/mobs/Wamouracampa.lua
@@ -8,29 +8,28 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+    mob:setLocalVar("formTime", os.time() + math.random(44, 45))
 end
 
 entity.onMobRoam = function(mob)
     local roamTime = mob:getLocalVar("formTime")
     if mob:getAnimationSub() == 0 and os.time() > roamTime then
         mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     elseif mob:getAnimationSub() == 1 and os.time() > roamTime then
         mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     end
 end
 
 entity.onMobFight = function(mob, target)
     local fightTime = mob:getLocalVar("formTime")
-
     if mob:getAnimationSub() == 0 and os.time() > fightTime then
         mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     elseif mob:getAnimationSub() == 1 and os.time() > fightTime then
         mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     end
 end
 

--- a/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
@@ -8,17 +8,17 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+    mob:setLocalVar("formTime", os.time() + math.random(44, 45))
 end
 
 entity.onMobRoam = function(mob)
     local roamTime = mob:getLocalVar("formTime")
     if mob:getAnimationSub() == 0 and os.time() > roamTime then
         mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     elseif mob:getAnimationSub() == 1 and os.time() > roamTime then
         mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     end
 end
 
@@ -26,10 +26,10 @@ entity.onMobFight = function(mob, target)
     local fightTime = mob:getLocalVar("formTime")
     if mob:getAnimationSub() == 0 and os.time() > fightTime then
         mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     elseif mob:getAnimationSub() == 1 and os.time() > fightTime then
         mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(43, 47))
+        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
     end
 end
 

--- a/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
@@ -3,34 +3,17 @@
 --   NM: Wamoura Prince
 -- TODO: Damage resistances in streched and curled stances. Halting movement during stance change. Morph into Wamoura.
 -----------------------------------
-require("scripts/globals/status")
+mixins = {require("scripts/mixins/families/wamouracampa")}
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar("formTime", os.time() + math.random(44, 45))
 end
 
 entity.onMobRoam = function(mob)
-    local roamTime = mob:getLocalVar("formTime")
-    if mob:getAnimationSub() == 0 and os.time() > roamTime then
-        mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    elseif mob:getAnimationSub() == 1 and os.time() > roamTime then
-        mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    end
 end
 
 entity.onMobFight = function(mob, target)
-    local fightTime = mob:getLocalVar("formTime")
-    if mob:getAnimationSub() == 0 and os.time() > fightTime then
-        mob:setAnimationSub(1)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    elseif mob:getAnimationSub() == 1 and os.time() > fightTime then
-        mob:setAnimationSub(0)
-        mob:setLocalVar("formTime", os.time() + math.random(44, 45))
-    end
 end
 
 entity.onMobDeath = function(mob)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1130,9 +1130,10 @@ INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1955);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1815);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1816);
 INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1817);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1818);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1819);
--- INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1820);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1819); -- Heat Barrier
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1820);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',1162,1818); -- Cannonball
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',1162,1819); -- Heat Barrier
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,388);
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,389);
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,390);
@@ -3754,7 +3755,7 @@ INSERT INTO `mob_skill_lists` VALUES ('The_Briars_elv',1160,42); -- Savage Blade
 INSERT INTO `mob_skill_lists` VALUES ('The_Briars_gal',1161,86); -- Raging Rush
 INSERT INTO `mob_skill_lists` VALUES ('The_Briars_gal',1161,91); -- Fell Cleave
 
--- Next available ID: 1162
+-- Next available ID: 1163
 
 -- ------------------------------------------------------------
 -- Start of Ambuscade section

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1127,13 +1127,13 @@ INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1953);
 INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1954);
 INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1955);
 -- INSERT INTO `mob_skill_lists` VALUES ('Wamoura',253,1956);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1815);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1816);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1817);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1819); -- Heat Barrier
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',254,1820);
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',1162,1818); -- Cannonball
-INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa',1162,1819); -- Heat Barrier
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1815);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1816);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1817);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1819); -- Heat Barrier
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_strech',254,1820);
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_curl',1162,1818); -- Cannonball
+INSERT INTO `mob_skill_lists` VALUES ('Wamouracampa_curl',1162,1819); -- Heat Barrier
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,388);
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,389);
 INSERT INTO `mob_skill_lists` VALUES ('Wanderer',255,390);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1982,7 +1982,7 @@ INSERT INTO `mob_skills` VALUES (2159,1568,'pandemic_nip',0,7.0,2000,1500,4,0,0,
 INSERT INTO `mob_skills` VALUES (2160,1569,'bombilation',1,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2161,1570,'cimicine_discharge',0,10.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2162,1571,'emetic_discharge',0,7.0,2000,1000,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2163,1549,'seedspray',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2163,1549,'seedspray',0,11.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2164,1550,'viscid_emission',4,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2165,1909,'rotten_stench',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2166,1910,'floral_bouquet',0,7.0,2000,1500,4,0,0,0,0,0,0);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1982,7 +1982,7 @@ INSERT INTO `mob_skills` VALUES (2159,1568,'pandemic_nip',0,7.0,2000,1500,4,0,0,
 INSERT INTO `mob_skills` VALUES (2160,1569,'bombilation',1,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2161,1570,'cimicine_discharge',0,10.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2162,1571,'emetic_discharge',0,7.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (2163,1549,'seedspray',0,11.5,2000,1500,4,0,0,0,0,0,0);
+-- INSERT INTO `mob_skills` VALUES (2163,1549,'seedspray',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2164,1550,'viscid_emission',4,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2165,1909,'rotten_stench',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2166,1910,'floral_bouquet',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
-- They wouldn't switch their stance at all.
-- Used !mobsub command to determine the ID's for their stances.
-- 44 is stretched out, 45 is curled up.
-- BLU should finally be able to learn Cannonball.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
