### PR TITLE
[Magic] Convert all enhancing songs.

### DIFF
--- a/scripts/globals/effects/marcato.lua
+++ b/scripts/globals/effects/marcato.lua
@@ -1,24 +1,17 @@
 -----------------------------------
 -- xi.effect.MARCATO
 -----------------------------------
-require("scripts/globals/jobpoints")
 require("scripts/globals/status")
 -----------------------------------
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.MARCATO_EFFECT)
-
-    target:addMod(xi.mod.SONG_DURATION_BONUS, jpValue)
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.MARCATO_EFFECT)
-
-    target:delMod(xi.mod.SONG_DURATION_BONUS, jpValue)
 end
 
 return effect_object

--- a/scripts/globals/effects/tenuto.lua
+++ b/scripts/globals/effects/tenuto.lua
@@ -1,24 +1,17 @@
 -----------------------------------
 -- xi.effect.TENUTO
 -----------------------------------
-require("scripts/globals/jobpoints")
 require("scripts/globals/status")
 -----------------------------------
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.TENUTO_EFFECT)
-
-    target:addMod(xi.mod.SONG_DURATION_BONUS, jpValue * 2)
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    local jpValue = target:getJobPointLevel(xi.jp.TENUTO_EFFECT)
-
-    target:delMod(xi.mod.SONG_DURATION_BONUS, jpValue * 2)
 end
 
 return effect_object

--- a/scripts/globals/magic_utils/parameters.lua
+++ b/scripts/globals/magic_utils/parameters.lua
@@ -237,7 +237,7 @@ xi.magic_utils.parameters.enhancingSong =
     [xi.magic.spell.HERB_PASTORAL     ] = { 1, xi.effect.PASTORAL,  0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
     [xi.magic.spell.WARDING_ROUND     ] = { 1, xi.effect.ROUND,     0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
     -- Misc.
-    [xi.magic.spell.GODEDSSS_HYMNUS   ] = { 1, xi.effect.HYMNUS,    0,                      0,                      0,                        0,                    1,   0,   1,   0,  0, false },
+    [xi.magic.spell.GODDESSS_HYMNUS   ] = { 1, xi.effect.HYMNUS,    0,                      0,                      0,                        0,                    1,   0,   1,   0,  0, false },
     [xi.magic.spell.SENTINELS_SCHERZO ] = { 1, xi.effect.SCHERZO,   0,                      0,                      0,                        0,                    1, 350,  45,   1, 10, false },
     [xi.magic.spell.RAPTOR_MAZURKA    ] = { 1, xi.effect.MAZURKA,   0,                      0,                      0,                        0,                   12,   0,  12,   0,  0, false },
     [xi.magic.spell.CHOCOBO_MAZURKA   ] = { 1, xi.effect.MAZURKA,   0,                      0,                      0,                        0,                   24,   0,  24,   0,  0, false },

--- a/scripts/globals/magic_utils/parameters.lua
+++ b/scripts/globals/magic_utils/parameters.lua
@@ -158,3 +158,92 @@ xi.magic_utils.parameters.damageParams =
     [xi.magic.spell.HOLY_II     ] = { xi.mod.MND, 250,     2,  250, 300 },
 
 }
+
+xi.magic_utils.parameters.enhancingSong
+{
+--                                          1  2                    3                       4                       5                         6                     7    8    9   10  11  12
+-- Structure:                 [spellId] = {Tier, Main Effect,       subEffect,              Main Modifier,          Merit Effect,             Job-Point Effect,     power Scap Pcap Mult Div SVP},
+    -- Ballad
+    [xi.magic.spell.MAGES_BALLAD      ] = { 1, xi.effect.BALLAD,    0,                      xi.mod.BALLAD_EFFECT,   0,                        0,                    1,   0,   1,   1,  0, true  },
+    [xi.magic.spell.MAGES_BALLAD_II   ] = { 2, xi.effect.BALLAD,    0,                      xi.mod.BALLAD_EFFECT,   0,                        0,                    2,   0,   2,   1,  0, true  },
+    [xi.magic.spell.MAGES_BALLAD_III  ] = { 3, xi.effect.BALLAD,    0,                      xi.mod.BALLAD_EFFECT,   0,                        0,                    3,   0,   3,   1,  0, true  },
+    -- Carol - NOTE: CAROL II Gives a fixed elemental evasion. However, it also gives a Elemental Nullification effect, that follows regular song rules concerning power.
+    [xi.magic.spell.FIRE_CAROL        ] = { 1, xi.effect.CAROL,     xi.magic.ele.FIRE,      xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.FIRE_CAROL_II     ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.FIRE,      xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.ICE_CAROL         ] = { 1, xi.effect.CAROL,     xi.magic.ele.ICE,       xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.ICE_CAROL_II      ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.ICE,       xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.WIND_CAROL        ] = { 1, xi.effect.CAROL,     xi.magic.ele.WIND,      xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.WIND_CAROL_II     ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.WIND,      xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.EARTH_CAROL       ] = { 1, xi.effect.CAROL,     xi.magic.ele.EARTH,     xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.EARTH_CAROL_II    ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.EARTH,     xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.LIGHTNING_CAROL   ] = { 1, xi.effect.CAROL,     xi.magic.ele.LIGHTNING, xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.LIGHTNING_CAROL_II] = { 2, xi.effect.CAROL_II,  xi.magic.ele.LIGHTNING, xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.WATER_CAROL       ] = { 1, xi.effect.CAROL,     xi.magic.ele.WATER,     xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.WATER_CAROL_II    ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.WATER,     xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.LIGHT_CAROL       ] = { 1, xi.effect.CAROL,     xi.magic.ele.LIGHT,     xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.LIGHT_CAROL_II    ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.LIGHT,     xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    [xi.magic.spell.DARK_CAROL        ] = { 1, xi.effect.CAROL,     xi.magic.ele.DARK,      xi.mod.ETUDE_EFFECT,    0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- [xi.magic.spell.DARK_CAROL_II     ] = { 2, xi.effect.CAROL_II,  xi.magic.ele.DARK,      xi.mod.ETUDE_EFFECT,    0,                        0,                   10, 400,  15, 1.5, 10, true  },
+    -- Etude
+    [xi.magic.spell.SINEWY_ETUDE      ] = { 1, xi.effect.ETUDE,     xi.mod.STR,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.HERCULEAN_ETUDE   ] = { 2, xi.effect.ETUDE,     xi.mod.STR,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.DEXTROUS_ETUDE    ] = { 1, xi.effect.ETUDE,     xi.mod.DEX,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.UNCANNY_ETUDE     ] = { 2, xi.effect.ETUDE,     xi.mod.DEX,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.VIVACIOUS_ETUDE   ] = { 1, xi.effect.ETUDE,     xi.mod.VIT,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.VITAL_ETUDE       ] = { 2, xi.effect.ETUDE,     xi.mod.VIT,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.QUICK_ETUDE       ] = { 1, xi.effect.ETUDE,     xi.mod.AGI,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.SWIFT_ETUDE       ] = { 2, xi.effect.ETUDE,     xi.mod.AGI,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.LEARNED_ETUDE     ] = { 1, xi.effect.ETUDE,     xi.mod.INT,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.SAGE_ETUDE        ] = { 2, xi.effect.ETUDE,     xi.mod.INT,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.SPIRITED_ETUDE    ] = { 1, xi.effect.ETUDE,     xi.mod.MND,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.LOGICAL_ETUDE     ] = { 2, xi.effect.ETUDE,     xi.mod.MND,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    [xi.magic.spell.ENCHANTING_ETUDE  ] = { 1, xi.effect.ETUDE,     xi.mod.CHR,             xi.mod.ETUDE_EFFECT,    0,                        0,                    3,   0,   9,   1,  0, true  },
+    [xi.magic.spell.BEWITCHING_ETUDE  ] = { 2, xi.effect.ETUDE,     xi.mod.CHR,             xi.mod.ETUDE_EFFECT,    0,                        0,                   12,   0,  15,   1,  0, true  },
+    -- Madrigal
+    [xi.magic.spell.SWORD_MADRIGAL    ] = { 1, xi.effect.MADRIGAL,  0,                      xi.mod.MADRIGAL_EFFECT, xi.merit.MADRIGAL_EFFECT, 0,                    5,  85,  45, 4.5, 18, true  },
+    [xi.magic.spell.BLADE_MADRIGAL    ] = { 2, xi.effect.MADRIGAL,  0,                      xi.mod.MADRIGAL_EFFECT, xi.merit.MADRIGAL_EFFECT, 0,                    9, 130,  60,   6, 18, true  },
+    -- March
+    [xi.magic.spell.ADVANCING_MARCH   ] = { 1, xi.effect.MARCH,     0,                      xi.mod.MARCH_EFFECT,    0,                        0,                   35, 200, 108,  11,  7, true  },
+    [xi.magic.spell.VICTORY_MARCH     ] = { 2, xi.effect.MARCH,     0,                      xi.mod.MARCH_EFFECT,    0,                        0,                   43, 300, 163,  16,  7, true  },
+    [xi.magic.spell.HONOR_MARCH       ] = { 3, xi.effect.MARCH,     0,                      xi.mod.MARCH_EFFECT,    0,                        0,                   24, 400, 126,  12,  7, true  }, -- Not an error. It is weaker.
+    -- Minne: Skill Caps unknown?
+    [xi.magic.spell.KNIGHTS_MINNE     ] = { 1, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,   8,   0,  30,   3, 10, true  },
+    [xi.magic.spell.KNIGHTS_MINNE_II  ] = { 2, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,  12,   0,  69,   7, 10, true  },
+    [xi.magic.spell.KNIGHTS_MINNE_III ] = { 3, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,  18,   0, 108,  11, 10, true  },
+    [xi.magic.spell.KNIGHTS_MINNE_IV  ] = { 4, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,  30,   0, 164,  16, 10, true  },
+    [xi.magic.spell.KNIGHTS_MINNE_V   ] = { 5, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    xi.merit.MINNE_EFFECT,    xi.jp.MINNE_EFFECT,  50,   0, 204,  20, 10, true  },
+    -- Minuet
+    [xi.magic.spell.VALOR_MINUET      ] = { 1, xi.effect.MINUET,    0,                      xi.mod.MINUET_EFFECT,   xi.merit.MINUET_EFFECT,   xi.jp.MINUET_EFFECT,  5,  50,  32,   3,  8, true  },
+    [xi.magic.spell.VALOR_MINUET_II   ] = { 2, xi.effect.MINUET,    0,                      xi.mod.MINUET_EFFECT,   xi.merit.MINUET_EFFECT,   xi.jp.MINUET_EFFECT, 10, 100,  64,   6,  6, true  },
+    [xi.magic.spell.VALOR_MINUET_III  ] = { 3, xi.effect.MINUET,    0,                      xi.mod.MINUET_EFFECT,   xi.merit.MINUET_EFFECT,   xi.jp.MINUET_EFFECT, 24, 200,  96,   9,  6, true  },
+    [xi.magic.spell.VALOR_MINUET_IV   ] = { 4, xi.effect.MINUET,    0,                      xi.mod.MINUET_EFFECT,   xi.merit.MINUET_EFFECT,   xi.jp.MINUET_EFFECT, 31, 300, 112,  11,  6, true  },
+    [xi.magic.spell.VALOR_MINUET_V    ] = { 5, xi.effect.MINUET,    0,                      xi.mod.MINUET_EFFECT,   xi.merit.MINUET_EFFECT,   xi.jp.MINUET_EFFECT, 32, 500, 124,  12,  6, true  },
+    -- Paeon
+    [xi.magic.spell.ARMYS_PAEON       ] = { 1, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    1, 100,   2,   1,  0, true  },
+    [xi.magic.spell.ARMYS_PAEON_II    ] = { 2, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    2, 150,   3,   1,  0, true  },
+    [xi.magic.spell.ARMYS_PAEON_III   ] = { 3, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    3, 200,   4,   1,  0, true  },
+    [xi.magic.spell.ARMYS_PAEON_IV    ] = { 4, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    4, 250,   5,   1,  0, true  },
+    [xi.magic.spell.ARMYS_PAEON_V     ] = { 5, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    5, 350,   7,   1,  0, true  },
+    [xi.magic.spell.ARMYS_PAEON_VI    ] = { 6, xi.effect.PAEON,     0,                      xi.mod.PAEON_EFFECT,    0,                        0,                    6, 450,   8,   1,  0, true  },
+    -- Prelude
+    [xi.magic.spell.HUNTERS_PRELUDE   ] = { 1, xi.effect.PRELUDE,   0,                      xi.mod.PRELUDE_EFFECT,  0,                        0,                   10,  85,  45, 4.5, 18, true  },
+    [xi.magic.spell.ARCHERS_PRELUDE   ] = { 2, xi.effect.PRELUDE,   0,                      xi.mod.PRELUDE_EFFECT,  0,                        0,                   20, 130,  60,   6, 18, true  },
+    -- Status effect resistance: Aubade, Capriccio, Gavotte, Operetta, Pastoral,
+    [xi.magic.spell.FOWL_AUBADE       ] = { 1, xi.effect.AUBADE,    0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    [xi.magic.spell.GOLD_CAPRICCIO    ] = { 1, xi.effect.CAPRICCIO, 0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    [xi.magic.spell.GOBLIN_GAVOTTE    ] = { 1, xi.effect.GAVOTTE,   0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    [xi.magic.spell.SCOPS_OPERETTA    ] = { 1, xi.effect.OPERETTA,  0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    [xi.magic.spell.PUPPETS_OPERETTA  ] = { 2, xi.effect.OPERETTA,  0,                      0,                      0,                        0,                   40, 200, 120,   8, 10, true  },
+    [xi.magic.spell.HERB_PASTORAL     ] = { 1, xi.effect.PASTORAL,  0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    [xi.magic.spell.WARDING_ROUND     ] = { 1, xi.effect.ROUND,     0,                      0,                      0,                        0,                   20, 200,  80,   8, 10, true  },
+    -- Misc.
+    [xi.magic.spell.GODEDSSS_HYMNUS   ] = { 1, xi.effect.HYMNUS,    0,                      0,                      0,                        0,                    1,   0,   1,   0,  0, false },
+    [xi.magic.spell.SENTINELS_SCHERZO ] = { 1, xi.effect.SCHERZO,   0,                      0,                      0,                        0,                    1, 350,  45,   1, 10, false },
+    [xi.magic.spell.RAPTOR_MAZURKA    ] = { 1, xi.effect.MAZURKA,   0,                      0,                      0,                        0,                   12,   0,  12,   0,  0, false },
+    [xi.magic.spell.CHOCOBO_MAZURKA   ] = { 1, xi.effect.MAZURKA,   0,                      0,                      0,                        0,                   24,   0,  24,   0,  0, false },
+
+    -- Emnity Songs
+    -- [xi.magic.spell.FOE_SIRVENTE      ] = { 1, xi.effect.------,    0,                      0,                      0,                        0,                   35,   0,  35,   1,  0, true  },
+    -- [xi.magic.spell.FOWL_AUBADE       ] = { 1, xi.effect.------,    0,                      0,                      0,                        0,                   32,   0,  32,   0,  0, true  },
+
+}

--- a/scripts/globals/magic_utils/parameters.lua
+++ b/scripts/globals/magic_utils/parameters.lua
@@ -159,7 +159,7 @@ xi.magic_utils.parameters.damageParams =
 
 }
 
-xi.magic_utils.parameters.enhancingSong
+xi.magic_utils.parameters.enhancingSong =
 {
 --                                          1  2                    3                       4                       5                         6                     7    8    9   10  11  12
 -- Structure:                 [spellId] = {Tier, Main Effect,       subEffect,              Main Modifier,          Merit Effect,             Job-Point Effect,     power Scap Pcap Mult Div SVP},

--- a/scripts/globals/magic_utils/spell_song_enhancing.lua
+++ b/scripts/globals/magic_utils/spell_song_enhancing.lua
@@ -1,0 +1,180 @@
+-----------------------------------
+-- Song Utilities
+-----------------------------------
+require("scripts/globals/magic_utils/parameters")
+require("scripts/globals/spell_data")
+require("scripts/globals/jobpoints")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+require("scripts/globals/msg")
+-----------------------------------
+xi = xi or {}
+xi.magic_utils = xi.magic_utils or {}
+xi.magic_utils.spell_song_enhancing = xi.magic_utils.spell_song_enhancing or {}
+-----------------------------------
+-- File structure:
+-- 2 Basic Functions called by the main function.
+
+-- Table variables.
+local enhancingTable  = xi.magic_utils.parameters.enhancingSong
+
+-- Enhancing Song Potency function. (1/2)
+xi.magic_utils.spell_song_enhancing.calculateEnhancingPower = function(caster, target, spell, spellId, tier, songEffect, instrumentBoost, soulVoicePower)
+    local power       = enhancingTable[spellId][7] -- The variable we want to calculate.
+    local meritEffect = enhancingTable[spellId][5]
+    local jpEffect    = enhancingTable[spellId][6]
+    local skillCap    = enhancingTable[spellId][8]
+    local potencyCap  = enhancingTable[spellId][9]
+    local multiplier  = enhancingTable[spellId][10]
+    local divisor     = enhancingTable[spellId][11]
+
+    local singingLvl  = caster:getSkillLevel(xi.skill.SINGING) + caster:getWeaponSkillLevel(xi.slot.RANGED)
+
+    -- Get Potency bonuses from Singing Skill and Instrument Skill. TODO: Investigate JP-Wiki. Most of this makes no sense.
+    -- NOTE: Tier 1 Etudes.
+    if songEffect == xi.effect.ETUDE and tier == 1 then
+        if singingLvl >= 182 and singingLvl < 236 then
+            power = power + 1
+        elseif singingLvl >= 236 and singingLvl < 289 then
+            power = power + 2
+        elseif singingLvl >= 289 and singingLvl < 343 then
+            power = power + 3
+        elseif singingLvl >= 343 and singingLvl < 397 then
+            power = power + 4
+        elseif singingLvl >= 397 and singingLvl < 450 then
+            power = power + 5
+        elseif singingLvl >= 450 then
+            power = power + 6
+        end
+    -- NOTE: Tier 2 Etudes.
+    elseif songEffect == xi.effect.ETUDE and tier == 2 then
+        if singingLvl >= 417 and singingLvl < 446 then
+            power = power + 1
+        elseif singingLvl >= 446 and singingLvl < 475 then
+            power = power + 2
+        elseif singingLvl >= 475 then
+            power = power + 3
+        end
+    -- Other songs.
+    else
+        if singingLvl > skillCap then
+            -- NOTE: Paeon
+            if divisor == 0 then
+                if skillCap > 0 then
+                    power = power + 1
+                end
+            -- NOTE: Aubade, Capriccio, Gavotte, Madrigal, March, Minne, Minuet, Operetta, Pastoral, Prelude, Round.
+            elseif not divisor == 0 then
+                power = math.floor(power + (singingLvl - skillCap) / divisor)
+            end
+        end
+        -- NOTE: Ballad, Hymnus, Mazurka have constant base power.
+    end
+
+    -- Apply Cap to power. (Applied before Merits, Job-Points and Status-Effects)
+    if power > potencyCap then
+        power = potencyCap
+    end
+
+    -- Instrument song boost. (All Songs +X, SONG_NAME +X)
+    power = math.floor(power + instrumentBoost * multiplier)
+
+    -- Additional Potency from Merits.
+    if not meritEffect == 0 then
+        power = math.floor(power + caster:getMerit(meritEffect))
+    end
+
+    -- Additional Potency from Job Points.
+    if not jpEffect == 0 then
+        power = math.floor(power + caster:getJobPointLevel(jpEffect))
+    end
+
+    -- Additional Potency from Status Effects.
+    if soulVoicePower == true then -- Soul Voice/Macarato affects Power.
+        if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
+            power = math.floor(power * 2)
+        elseif caster:hasStatusEffect(xi.effect.MARCATO) then
+            power = math.floor(power * 1.5)
+        end
+    end
+
+    -- Finish
+    return power
+end
+
+-- Enhancing Song Duration function. (2/2)
+xi.magic_utils.spell_song_enhancing.calculateEnhancingDuration = function(caster, target, spell, instrumentBoost, soulVoicePower)
+    local duration = 120 -- The variable we want to calculate.
+
+    -- Additional duration from "Song Bonus" (from instruments) and "Duration Bonus" Modifier
+    duration = math.floor(duration * ((instrumentBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS) / 100) + 1))
+
+    -- Additional duration from Job points.
+    if caster:hasStatusEffect(xi.effect.CLARION_CALL) then
+        duration = math.floor(duration + caster:getJobPointLevel(xi.jp.CLARION_CALL_EFFECT) * 2)
+    end
+
+    if caster:hasStatusEffect(xi.effect.MARCATO) then
+        duration = math.floor(duration + caster:getJobPointLevel(xi.jp.MARCATO_EFFECT))
+        caster:delStatusEffect(xi.effect.MARCATO)
+    end
+
+    if caster:hasStatusEffect(xi.effect.TENUTO) then
+        duration = math.floor(duration + caster:getJobPointLevel(xi.jp.TENUTO_EFFECT) * 2)
+    end
+
+    -- Additional duration from Status Effects.
+    if soulVoicePower == false then -- Soul Voice/Macarato doesn't affect potency, so it affects Duration.
+        if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
+            duration = math.floor(duration * 2)
+        elseif caster:hasStatusEffect(xi.effect.MARCATO) then
+            duration = math.floor(duration * 1.5)
+        end
+    end
+
+    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
+        duration = math.floor(duration * 2)
+    end
+
+    -- Finish
+    return duration
+end
+
+-- Main function for Enhancing Songs.
+xi.magic_utils.spell_song_enhancing.useEnhancingSong = function(caster, target, spell)
+    local spellId         = spell:getID()
+    local paramFour       = 0
+
+    -- Get Variables from Parameters Table.
+    local tier            = enhancingTable[spellId][1]
+    local songEffect      = enhancingTable[spellId][2]
+    local subEffect       = enhancingTable[spellId][3]
+    local instrumentBoost = caster:getMod(enhancingTable[spellId][4]) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
+    local soulVoicePower  = enhancingTable[spellId][12]
+
+    -- Calculate Song Pottency, Duration and SubEffect.
+    local power    = xi.magic_utils.spell_song_enhancing.calculateEnhancingPower(caster, target, spell, spellId, tier, songEffect, instrumentBoost, soulVoicePower)
+    local duration = xi.magic_utils.spell_song_enhancing.calculateEnhancingDuration(caster, target, spell, instrumentBoost, soulVoicePower)
+
+    -- EXCEPTION: Tier 2 Ettudes Fourth Parameter.
+    if songEffect == xi.effect.ETUDE and tier == 2 then
+        paramFour = 10
+    end
+
+    -- EXCEPTION: March Songs effect conversion.
+    if songEffect == xi.effect.MARCH then
+        power = math.floor((power * 1024) / 10000)
+    end
+
+    -- Handle Status Effects.
+    if caster:hasStatusEffect(xi.effect.MARCATO) then
+        caster:delStatusEffect(xi.effect.MARCATO)
+    end
+
+    -- Change message when higher effect already in place.
+    if not target:addBardSong(caster, songEffect, power, paramFour, duration, caster:getID(), subEffect, tier) then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    end
+
+    return songEffect
+end

--- a/scripts/globals/magic_utils/spell_song_enhancing.lua
+++ b/scripts/globals/magic_utils/spell_song_enhancing.lua
@@ -33,27 +33,27 @@ xi.magic_utils.spell_song_enhancing.calculateEnhancingPower = function(caster, t
     -- Get Potency bonuses from Singing Skill and Instrument Skill. TODO: Investigate JP-Wiki. Most of this makes no sense.
     -- NOTE: Tier 1 Etudes.
     if songEffect == xi.effect.ETUDE and tier == 1 then
-        if singingLvl >= 182 and singingLvl < 236 then
-            power = power + 1
-        elseif singingLvl >= 236 and singingLvl < 289 then
-            power = power + 2
-        elseif singingLvl >= 289 and singingLvl < 343 then
-            power = power + 3
-        elseif singingLvl >= 343 and singingLvl < 397 then
-            power = power + 4
-        elseif singingLvl >= 397 and singingLvl < 450 then
-            power = power + 5
-        elseif singingLvl >= 450 then
+        if singingLvl >= 450 then
             power = power + 6
+        elseif singingLvl >= 397 then
+            power = power + 5
+        elseif singingLvl >= 343 then
+            power = power + 4
+        elseif singingLvl >= 289 then
+            power = power + 3
+        elseif singingLvl >= 236 then
+            power = power + 2
+        elseif singingLvl >= 182 then
+            power = power + 1
         end
     -- NOTE: Tier 2 Etudes.
     elseif songEffect == xi.effect.ETUDE and tier == 2 then
-        if singingLvl >= 417 and singingLvl < 446 then
-            power = power + 1
-        elseif singingLvl >= 446 and singingLvl < 475 then
-            power = power + 2
-        elseif singingLvl >= 475 then
+        if singingLvl >= 475 then
             power = power + 3
+        elseif singingLvl >= 446 then
+            power = power + 2
+        elseif singingLvl >= 417 then
+            power = power + 1
         end
     -- Other songs.
     else

--- a/scripts/globals/spells/songs/advancing_march.lua
+++ b/scripts/globals/spells/songs/advancing_march.lua
@@ -2,8 +2,7 @@
 -- Spell: Advancing March
 -- Gives party members Haste
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,44 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 35
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 7)
-    end
-
-    if (power >= 108) then
-        power = 108
-    end
-
-    local iBoost = caster:getMod(xi.mod.MARCH_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*11
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    -- convert to new haste system
-    power = (power / 1024) * 10000
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MARCH
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/archers_prelude.lua
+++ b/scripts/globals/spells/songs/archers_prelude.lua
@@ -1,9 +1,8 @@
 -----------------------------------
 -- Spell: Archer's Prelude
--- Enhances ranged attack for party members within area of effect.
+-- Enhances ranged attack accuracy for party members within area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,44 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if sLvl+iLvl > 130 then
-        power = power + math.floor((sLvl+iLvl - 130) / 18)
-    end
-
-    if power > 60 then
-        power = 60
-    end
-
-    local iBoost = caster:getMod(xi.mod.PRELUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + iBoost*6
-    end
-
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS) / 100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 2) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PRELUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon.lua
+++ b/scripts/globals/spells/songs/armys_paeon.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 1
-
-    if (sLvl+iLvl > 100) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon_ii.lua
+++ b/scripts/globals/spells/songs/armys_paeon_ii.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon II
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 2
-
-    if (sLvl+iLvl > 150) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon_iii.lua
+++ b/scripts/globals/spells/songs/armys_paeon_iii.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon III
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 3
-
-    if (sLvl+iLvl > 200) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 3)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon_iv.lua
+++ b/scripts/globals/spells/songs/armys_paeon_iv.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon IV
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 4
-
-    if (sLvl+iLvl > 250) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 4)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon_v.lua
+++ b/scripts/globals/spells/songs/armys_paeon_v.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon V
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 5
-
-    if (sLvl+iLvl > 350) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 5)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/armys_paeon_vi.lua
+++ b/scripts/globals/spells/songs/armys_paeon_vi.lua
@@ -2,8 +2,7 @@
 -- Spell: Army's Paeon VI
 -- Gradually restores target's HP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,37 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 6
-
-    if (sLvl+iLvl > 450) then
-        power = power + 1
-    end
-
-    local iBoost = caster:getMod(xi.mod.PAEON_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PAEON, power, 0, duration, caster:getID(), 0, 6)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PAEON
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/blade_madrigal.lua
+++ b/scripts/globals/spells/songs/blade_madrigal.lua
@@ -2,8 +2,7 @@
 -- Spell: Blade Madrigal
 -- Gives party members accuracy
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,45 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 9
-
-    if (sLvl+iLvl > 130) then
-        power = power + math.floor((sLvl+iLvl-130) / 18)
-    end
-
-    if (power >= 60) then
-        power = 60
-    end
-
-    local iBoost = caster:getMod(xi.mod.MADRIGAL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + iBoost*6
-    end
-
-    power =  power + caster:getMerit(xi.merit.MADRIGAL_EFFECT)
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), 0, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MADRIGAL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/chocobo_mazurka.lua
+++ b/scripts/globals/spells/songs/chocobo_mazurka.lua
@@ -2,8 +2,7 @@
 -- Spell: Chocobo Mazurka
 -- Gives party members enhanced movement
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,30 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 24
-
-    local iBoost = caster:getMod(xi.mod.MAZURKA_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-
-    local duration = 120
-
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        duration = duration * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        duration = duration * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MAZURKA
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 

--- a/scripts/globals/spells/songs/dark_carol.lua
+++ b/scripts/globals/spells/songs/dark_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Dark Carol
 -- Increases dark resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.DARK, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/dextrous_etude.lua
+++ b/scripts/globals/spells/songs/dextrous_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Dextrous Etude
 -- Static DEX Boost, BRD 32
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,49 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.DEX, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/earth_carol.lua
+++ b/scripts/globals/spells/songs/earth_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Earth Carol
 -- Increases earth resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.EARTH, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/enchanting_etude.lua
+++ b/scripts/globals/spells/songs/enchanting_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Enchanting Etude
 -- Static CHR Boost, BRD 22
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,49 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.CHR, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/fire_carol.lua
+++ b/scripts/globals/spells/songs/fire_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Fire Carol
 -- Increases fire resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.FIRE, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/fowl_aubade.lua
+++ b/scripts/globals/spells/songs/fowl_aubade.lua
@@ -2,9 +2,7 @@
 -- Spell: Fowl Aubade
 -- Enhances resistance against sleep for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.AUBADE, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.AUBADE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/goblin_gavotte.lua
+++ b/scripts/globals/spells/songs/goblin_gavotte.lua
@@ -2,9 +2,7 @@
 -- Spell: Goblin Gavotte
 -- Enhances resistance against bind for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.GAVOTTE, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.GAVOTTE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/goddesss_hymnus.lua
+++ b/scripts/globals/spells/songs/goddesss_hymnus.lua
@@ -1,24 +1,17 @@
 -----------------------------------
 -- Spell: Goddess's Hymnus
--- Grants Reraise.
+-- Grants pseudo Reraise III effect.
+-----------------------------------
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
-
-require("scripts/globals/status")
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     return 0
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-
-        local duration = 120
-
-        duration = duration * (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100)
-
-        target:addBardSong(caster, xi.effect.HYMNUS, 1, 0, duration, caster:getID(), 0, 1)
-
-    return xi.effect.HYMNUS
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/gold_capriccio.lua
+++ b/scripts/globals/spells/songs/gold_capriccio.lua
@@ -2,9 +2,7 @@
 -- Spell: Gold Capriccio
 -- Enhances resistance against petrification for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAPRICCIO, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAPRICCIO
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/herb_pastoral.lua
+++ b/scripts/globals/spells/songs/herb_pastoral.lua
@@ -2,9 +2,7 @@
 -- Spell: Herb Pastoral
 -- Enhances resistance against poison for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.PASTORAL, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PASTORAL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/herculean_etude.lua
+++ b/scripts/globals/spells/songs/herculean_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Herculean Etude
 -- Static STR Boost, BRD 74
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.STR, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/honor_march.lua
+++ b/scripts/globals/spells/songs/honor_march.lua
@@ -1,6 +1,6 @@
 -----------------------------------
--- Spell: Bewitching Etude
--- Static CHR Boost, BRD 62
+-- Spell: Honor March
+-- Gives party members Haste, Acc, Ranged Acc, Att, Ranged Att
 -----------------------------------
 require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------

--- a/scripts/globals/spells/songs/hunters_prelude.lua
+++ b/scripts/globals/spells/songs/hunters_prelude.lua
@@ -1,9 +1,8 @@
 -----------------------------------
 -- Spell: Hunter's Prelude
--- Enhances ranged attack for party members within area of effect.
+-- Enhances ranged attack accuracy for party members within area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,44 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 10
-
-    if sLvl+iLvl > 85 then
-        power = power + math.floor((sLvl+iLvl - 85) / 18)
-    end
-
-    if (power >= 60) then
-        power = 60
-    end
-
-    local iBoost = caster:getMod(xi.mod.PRELUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + iBoost*4.5
-    end
-
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS) / 100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 1) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.PRELUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/ice_carol.lua
+++ b/scripts/globals/spells/songs/ice_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Ice Carol
 -- Increases ice resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.ICE, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/knights_minne.lua
+++ b/scripts/globals/spells/songs/knights_minne.lua
@@ -2,9 +2,7 @@
 -- Spell: Knight's Minne I
 -- Grants Defense bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINNE_EFFECT)
-
-    local power = 8 + math.floor((sLvl + iLvl)/10)
-
-    if power >= 30 then
-        power = 30
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINNE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 3
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINNE_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 1) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINNE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/knights_minne_ii.lua
+++ b/scripts/globals/spells/songs/knights_minne_ii.lua
@@ -2,9 +2,7 @@
 -- Spell: Knight's Minne II
 -- Grants Defense bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINNE_EFFECT)
-
-    local power = 12 + math.floor((sLvl + iLvl)/10)
-
-    if power >= 69 then
-        power = 69
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINNE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 7
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINNE_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 2) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINNE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/knights_minne_iii.lua
+++ b/scripts/globals/spells/songs/knights_minne_iii.lua
@@ -2,9 +2,7 @@
 -- Spell: Knight's Minne III
 -- Grants Defense bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINNE_EFFECT)
-
-    local power = 18 + math.floor((sLvl + iLvl)/10)
-
-    if power >= 108 then
-        power = 108
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINNE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 11
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINNE_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 3) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINNE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/knights_minne_iv.lua
+++ b/scripts/globals/spells/songs/knights_minne_iv.lua
@@ -2,9 +2,7 @@
 -- Spell: Knight's Minne IV
 -- Grants Defense bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINNE_EFFECT)
-
-    local power = 30 + math.floor((sLvl + iLvl)/10)
-
-    if power >= 164 then
-        power = 164
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINNE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 16
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINNE_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 4) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINNE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/knights_minne_v.lua
+++ b/scripts/globals/spells/songs/knights_minne_v.lua
@@ -2,9 +2,7 @@
 -- Spell: Knight's Minne V
 -- Grants Defense bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINNE_EFFECT)
-
-    local power = 50 + math.floor((sLvl + iLvl)/10)
-
-    if power >= 204 then
-        power = 204
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINNE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 20
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINNE_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINNE, power, 0, duration, caster:getID(), 0, 5) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINNE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/learned_etude.lua
+++ b/scripts/globals/spells/songs/learned_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Learned Etude
 -- Static INT Boost, BRD 26
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,49 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.INT, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/light_carol.lua
+++ b/scripts/globals/spells/songs/light_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Light Carol
 -- Increases light resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.LIGHT, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/lightning_carol.lua
+++ b/scripts/globals/spells/songs/lightning_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Lightning Carol
 -- Increases lightning resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.LIGHTNING, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/logical_etude.lua
+++ b/scripts/globals/spells/songs/logical_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Logical Etude
 -- Static MND Boost, BRD 64
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.MND, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/mages_ballad.lua
+++ b/scripts/globals/spells/songs/mages_ballad.lua
@@ -2,8 +2,7 @@
 -- Spell: Mage's Ballad
 -- Gradually restores target's MP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,30 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 1
-
-    local iBoost = caster:getMod(xi.mod.BALLAD_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.BALLAD
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/mages_ballad_ii.lua
+++ b/scripts/globals/spells/songs/mages_ballad_ii.lua
@@ -2,8 +2,7 @@
 -- Spell: Mage's Ballad II
 -- Gradually restores target's MP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,30 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 2
-
-    local iBoost = caster:getMod(xi.mod.BALLAD_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.BALLAD
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/mages_ballad_iii.lua
+++ b/scripts/globals/spells/songs/mages_ballad_iii.lua
@@ -2,8 +2,7 @@
 -- Spell: Mage's Ballad III
 -- Gradually restores target's MP.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,30 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 3
-
-    local iBoost = caster:getMod(xi.mod.BALLAD_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.BALLAD, power, 0, duration, caster:getID(), 0, 3)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.BALLAD
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/puppets_operetta.lua
+++ b/scripts/globals/spells/songs/puppets_operetta.lua
@@ -2,9 +2,7 @@
 -- Spell: Puppet's Operetta
 -- Enhances resistance against silence for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 40 -- needs verification
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 120) then -- needs verification
-        power = 120
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.OPERETTA
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/quick_etude.lua
+++ b/scripts/globals/spells/songs/quick_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Quick Etude
 -- Static AGI Boost, BRD 28
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,49 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.AGI, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/raptor_mazurka.lua
+++ b/scripts/globals/spells/songs/raptor_mazurka.lua
@@ -2,8 +2,7 @@
 -- Spell: Raptor Mazurka
 -- Gives party members enhanced movement
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,30 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local power = 12
-
-    local iBoost = caster:getMod(xi.mod.MAZURKA_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-
-    local duration = 120
-
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        duration = duration * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        duration = duration * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MAZURKA, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MAZURKA
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 

--- a/scripts/globals/spells/songs/sage_etude.lua
+++ b/scripts/globals/spells/songs/sage_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Sage Etude
 -- Static INT Boost, BRD 66
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.INT, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-       return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/scops_operetta.lua
+++ b/scripts/globals/spells/songs/scops_operetta.lua
@@ -1,10 +1,8 @@
 -----------------------------------
--- Spell: Puppet's Operetta
+-- Spell: Scop's Operetta
 -- Enhances resistance against silence for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 40
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 120) then
-        power = 120
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.OPERETTA, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.OPERETTA
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/sentinels_scherzo.lua
+++ b/scripts/globals/spells/songs/sentinels_scherzo.lua
@@ -2,8 +2,7 @@
 -- Spell: Sentinel's Scherzo
 -- Mitigates the impact of severely damaging attacks for party members within an area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,38 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = math.floor((sLvl+iLvl-350) / 10)
-
-    if (power >= 45) then
-        power = 45
-    end
-
-    local iBoost = caster:getMod(xi.mod.SCHERZO_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    local duration = 120
-
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        duration = duration * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        duration = duration * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.SCHERZO, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.SCHERZO
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/sinewy_etude.lua
+++ b/scripts/globals/spells/songs/sinewy_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Sinewy Etude
 -- Static STR Boost, BRD 24
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,48 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.STR, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/spirited_etude.lua
+++ b/scripts/globals/spells/songs/spirited_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Spirited Etude
 -- Static MND Boost, BRD 24
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,49 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.MND, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/swift_etude.lua
+++ b/scripts/globals/spells/songs/swift_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Swift Etude
 -- Static AGI Boost, BRD 68
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.AGI, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/sword_madrigal.lua
+++ b/scripts/globals/spells/songs/sword_madrigal.lua
@@ -2,8 +2,7 @@
 -- Spell: Sword Madrigal
 -- Gives party members accuracy
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,45 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 5
-
-    if (sLvl+iLvl > 85) then
-        power = power + math.floor((sLvl+iLvl-85) / 18)
-    end
-
-    if (power >= 45) then
-        power = 45
-    end
-
-    local iBoost = caster:getMod(xi.mod.MADRIGAL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + iBoost*4.5
-    end
-
-    power =  power + caster:getMerit(xi.merit.MADRIGAL_EFFECT)
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MADRIGAL, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MADRIGAL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/uncanny_etude.lua
+++ b/scripts/globals/spells/songs/uncanny_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Uncanny Etude
 -- Static DEX Boost, BRD 72
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.DEX, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/valor_minuet.lua
+++ b/scripts/globals/spells/songs/valor_minuet.lua
@@ -2,9 +2,7 @@
 -- Spell: Valor Minuet
 -- Grants Attack bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINUET_EFFECT)
-
-    local power = 5 + math.floor((sLvl + iLvl) / 8)
-
-    if power >= 32 then
-        power = 32
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINUET_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 3
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINUET_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 1) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINUET
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/valor_minuet_ii.lua
+++ b/scripts/globals/spells/songs/valor_minuet_ii.lua
@@ -2,9 +2,7 @@
 -- Spell: Valor Minuet II
 -- Grants Attack bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,46 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINUET_EFFECT)
-
-    local power = 10
-
-    if sLvl + iLvl > 85 then
-        power = power + math.floor((sLvl + iLvl - 85) / 6)
-    end
-
-    if power >= 64 then
-        power = 64
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINUET_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 6
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINUET_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 2) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINUET
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/valor_minuet_iii.lua
+++ b/scripts/globals/spells/songs/valor_minuet_iii.lua
@@ -2,9 +2,7 @@
 -- Spell: Valor Minuet III
 -- Grants Attack bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,46 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINUET_EFFECT)
-
-    local power = 24
-
-    if sLvl + iLvl > 200 then
-        power = power + math.floor((sLvl + iLvl - 200) / 6)
-    end
-
-    if power >= 96 then
-        power = 96
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINUET_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 9
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINUET_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 3) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINUET
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/valor_minuet_iv.lua
+++ b/scripts/globals/spells/songs/valor_minuet_iv.lua
@@ -2,9 +2,7 @@
 -- Spell: Valor Minuet IV
 -- Grants Attack bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,46 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINUET_EFFECT)
-
-    local power = 31
-
-    if sLvl + iLvl > 300 then
-        power = power + math.floor((sLvl + iLvl - 300) / 6)
-    end
-
-    if power >= 112 then
-        power = 112
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINUET_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 11
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINUET_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 4) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINUET
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/valor_minuet_v.lua
+++ b/scripts/globals/spells/songs/valor_minuet_v.lua
@@ -2,9 +2,7 @@
 -- Spell: Valor Minuet V
 -- Grants Attack bonus to all allies.
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,46 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local jpValue = caster:getJobPointLevel(xi.jp.MINUET_EFFECT)
-
-    local power = 32
-
-    if sLvl + iLvl > 500 then
-        power = power + math.floor((sLvl + iLvl - 500) / 6)
-    end
-
-    if power >= 124 then
-        power = 124
-    end
-
-    local iBoost = caster:getMod(xi.mod.MINUET_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    if iBoost > 0 then
-        power = power + iBoost * 12
-    end
-
-    power =  power + caster:getMerit(xi.merit.MINUET_EFFECT) + jpValue
-
-    if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
-        power = power * 2
-    elseif caster:hasStatusEffect(xi.effect.MARCATO) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if caster:hasStatusEffect(xi.effect.TROUBADOUR) then
-        duration = duration * 2
-    end
-
-    if not target:addBardSong(caster, xi.effect.MINUET, power, 0, duration, caster:getID(), 0, 5) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MINUET
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/victory_march.lua
+++ b/scripts/globals/spells/songs/victory_march.lua
@@ -2,8 +2,7 @@
 -- Spell: Victory March
 -- Gives party members Haste
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -12,44 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 43
-
-    if (sLvl+iLvl > 300) then
-        power = power + math.floor((sLvl+iLvl-300) / 7)
-    end
-
-    if (power >= 163) then
-        power = 163
-    end
-
-    local iBoost = caster:getMod(xi.mod.MARCH_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*16
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    -- convert to new haste system
-    power = (power / 1024) * 10000
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.MARCH, power, 0, duration, caster:getID(), 0, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.MARCH
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/vital_etude.lua
+++ b/scripts/globals/spells/songs/vital_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Vital Etude
 -- Static VIT Boost, BRD 70
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,42 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 0
-
-    if (sLvl+iLvl <= 416) then
-        power = 12
-    elseif ((sLvl+iLvl >= 417) and (sLvl+iLvl <= 445)) then
-        power = 13
-    elseif ((sLvl+iLvl >= 446) and (sLvl+iLvl <= 474)) then
-        power = 14
-    elseif (sLvl+iLvl >= 475) then
-        power = 15
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 10, duration, caster:getID(), xi.mod.VIT, 2)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/vivacious_etude.lua
+++ b/scripts/globals/spells/songs/vivacious_etude.lua
@@ -2,9 +2,7 @@
 -- Spell: Vivacious Etude
 -- Static VIT Boost, BRD 30
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,48 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-    local power = 0
-
-    if (sLvl+iLvl <= 181) then
-        power = 3
-    elseif ((sLvl+iLvl >= 182) and (sLvl+iLvl <= 235)) then
-        power = 4
-    elseif ((sLvl+iLvl >= 236) and (sLvl+iLvl <= 288)) then
-        power = 5
-    elseif ((sLvl+iLvl >= 289) and (sLvl+iLvl <= 342)) then
-        power = 6
-    elseif ((sLvl+iLvl >= 343) and (sLvl+iLvl <= 396)) then
-        power = 7
-    elseif ((sLvl+iLvl >= 397) and (sLvl+iLvl <= 449)) then
-        power = 8
-    elseif (sLvl+iLvl >= 450) then
-        power = 9
-    end
-
-    local iBoost = caster:getMod(xi.mod.ETUDE_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ETUDE, power, 0, duration, caster:getID(), xi.mod.VIT, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ETUDE
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/warding_round.lua
+++ b/scripts/globals/spells/songs/warding_round.lua
@@ -2,9 +2,7 @@
 -- Spell: Warding Round
 -- Enhances resistance against curse for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.ROUND, power, 0, duration, caster:getID(), 0, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.ROUND
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/water_carol.lua
+++ b/scripts/globals/spells/songs/water_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Water Carol
 -- Increases water resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.WATER, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object

--- a/scripts/globals/spells/songs/wind_carol.lua
+++ b/scripts/globals/spells/songs/wind_carol.lua
@@ -2,9 +2,7 @@
 -- Spell: Wind Carol
 -- Increases wind resistance for party members within the area of effect.
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/magic_utils/spell_song_enhancing")
 -----------------------------------
 local spell_object = {}
 
@@ -13,41 +11,7 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local sLvl = caster:getSkillLevel(xi.skill.SINGING) -- Gets skill level of Singing
-    local iLvl = caster:getWeaponSkillLevel(xi.slot.RANGED)
-
-    local power = 20
-
-    if (sLvl+iLvl > 200) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
-    end
-
-    if (power >= 80) then
-        power = 80
-    end
-
-    local iBoost = caster:getMod(xi.mod.CAROL_EFFECT) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
-    power = power + iBoost*8
-
-    if (caster:hasStatusEffect(xi.effect.SOUL_VOICE)) then
-        power = power * 2
-    elseif (caster:hasStatusEffect(xi.effect.MARCATO)) then
-        power = power * 1.5
-    end
-    caster:delStatusEffect(xi.effect.MARCATO)
-
-    local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(xi.mod.SONG_DURATION_BONUS)/100) + 1)
-
-    if (caster:hasStatusEffect(xi.effect.TROUBADOUR)) then
-        duration = duration * 2
-    end
-
-    if not (target:addBardSong(caster, xi.effect.CAROL, power, 0, duration, caster:getID(), xi.magic.ele.WIND, 1)) then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    end
-
-    return xi.effect.CAROL
+    return xi.magic_utils.spell_song_enhancing.useEnhancingSong(caster, target, spell)
 end
 
 return spell_object


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Converts all songs that apply status effects to party members, to use a magic_utils global.
While this is intended as a conversion only, there are some minimal corrections.
- Fixed Job point effects for this songs.
- Floor operations.
- Some base values for power/potency were corrected.

Decided to limit PR to enhancing songs only, to ease review.