### PR TITLE
Damaging spells minor fixes

### DIFF
--- a/scripts/globals/magic_utils/spell_damage.lua
+++ b/scripts/globals/magic_utils/spell_damage.lua
@@ -209,7 +209,7 @@ xi.magic_utils.spell_damage.calculateSDT = function(caster, target, spell, spell
     local SDT    = 1 -- The variable we want to calculate
     local SDTMod = 0
 
-    if not spellElement == 0 then
+    if spellElement > 0 then
         SDTMod = target:getMod(xi.magic.specificDmgTakenMod[spellElement])
 
         -- TODO: Ths conversion right here needs to be updated once work on SDT modifiers is finished.

--- a/scripts/globals/magic_utils/spell_damage.lua
+++ b/scripts/globals/magic_utils/spell_damage.lua
@@ -65,7 +65,7 @@ xi.magic_utils.spell_damage.calculateBaseDamage = function(caster, target, spell
     -----------------------------------
     -- STEP 1: baseSpellDamage (V)
     -----------------------------------
-    if caster:isPC() then
+    if caster:isPC() and xi.settings.USE_OLD_MAGIC_DAMAGE == false then
         baseSpellDamage = spellTable[spellId][vPC] -- vPC
     else
         baseSpellDamage = spellTable[spellId][vNPC] -- vNPC
@@ -149,8 +149,8 @@ xi.magic_utils.spell_damage.calculateBaseDamage = function(caster, target, spell
         end
     end
 
-    -- TODO: Add baseSpellDamageBonus from equipment and other possible sources.
-    -- TODO: Find out if that modifier exists and which one is it.
+    -- Bonus to spell base damage from gear.
+    baseSpellDamageBonus = baseSpellDamageBonus + caster:getMod(xi.mod.MAGIC_DAMAGE)
 
     -----------------------------------
     -- STEP 4: Spell Damage
@@ -207,10 +207,14 @@ end
 -- Multiple things can affect dmg. in our core SDT is a % reduction in its own step.
 xi.magic_utils.spell_damage.calculateSDT = function(caster, target, spell, spellElement)
     local SDT    = 1 -- The variable we want to calculate
-    local SDTMod = target:getMod(xi.magic.specificDmgTakenMod[spellElement])
+    local SDTMod = 0
 
-    -- TODO: Ths conversion right here needs to be updated once work on SDT modifiers is finished.
-    SDT = (SDTMod / -100) + 1
+    if not spellElement == 0 then
+        SDTMod = target:getMod(xi.magic.specificDmgTakenMod[spellElement])
+
+        -- TODO: Ths conversion right here needs to be updated once work on SDT modifiers is finished.
+        SDT = (SDTMod / -100) + 1
+    end
 
     -- SDT (Species/Specific Damage Taken) is a stat/mod present in mobs and players that applies a % to specific damage types.
     -- Think of it as an extension (or the actual base) of elemental resistances in past FF games.


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Changes:
- Account for old era calculation setting.
- Add "Magic Damage" gear modifier into equation.
- Add a minor check in SDT step for non-elemental damage