### PR TITLE
Match Silent Potion, Prism Powder, Rainbow Powder, and Deodorizer to match retail accuracy at duration of 10min.

### DIFF
--- a/scripts/globals/items/flask_of_deodorizer.lua
+++ b/scripts/globals/items/flask_of_deodorizer.lua
@@ -13,8 +13,8 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    if (not target:hasStatusEffect(xi.effect.DEODORIZE)) then
-        target:addStatusEffect(xi.effect.DEODORIZE, 1, 10, 180)
+    if  not target:hasStatusEffect(xi.effect.DEODORIZE) then
+        target:addStatusEffect(xi.effect.DEODORIZE, 1, 10, 600)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end

--- a/scripts/globals/items/pinch_of_prism_powder.lua
+++ b/scripts/globals/items/pinch_of_prism_powder.lua
@@ -13,8 +13,11 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-
-    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, 600)
+local duration = (600)
+    if target:hasStatusEffect(xi.effect.INVISIBLE) then
+        target:delStatusEffect(xi.effect.INVISIBLE)
+    end
+        target:addStatusEffect(xi.effect.INVISIBLE, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
 end
 
 return item_object

--- a/scripts/globals/items/pinch_of_prism_powder.lua
+++ b/scripts/globals/items/pinch_of_prism_powder.lua
@@ -13,11 +13,8 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    local duration = math.random(300, 480)
-    if (target:hasStatusEffect(xi.effect.INVISIBLE)) then
-        target:delStatusEffect(xi.effect.INVISIBLE)
-    end
-    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+
+    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, 600)
 end
 
 return item_object

--- a/scripts/globals/items/pinch_of_prism_powder.lua
+++ b/scripts/globals/items/pinch_of_prism_powder.lua
@@ -13,11 +13,11 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-local duration = (600)
     if target:hasStatusEffect(xi.effect.INVISIBLE) then
         target:delStatusEffect(xi.effect.INVISIBLE)
     end
-        target:addStatusEffect(xi.effect.INVISIBLE, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+
+    target:addStatusEffect(xi.effect.INVISIBLE,1,10, math.floor(600 * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
 end
 
 return item_object

--- a/scripts/globals/items/pinch_of_rainbow_powder.lua
+++ b/scripts/globals/items/pinch_of_rainbow_powder.lua
@@ -14,9 +14,11 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-
-    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, 600)
-
+local duration = (600)
+    if target:hasStatusEffect(xi.effect.INVISIBLE) then
+        target:delStatusEffect(xi.effect.INVISIBLE)
+    end
+        target:addStatusEffect(xi.effect.INVISIBLE, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
 end
 
 return item_object

--- a/scripts/globals/items/pinch_of_rainbow_powder.lua
+++ b/scripts/globals/items/pinch_of_rainbow_powder.lua
@@ -14,11 +14,11 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-local duration = (600)
     if target:hasStatusEffect(xi.effect.INVISIBLE) then
-        target:delStatusEffect(xi.effect.INVISIBLE)
+       target:delStatusEffect(xi.effect.INVISIBLE)
     end
-        target:addStatusEffect(xi.effect.INVISIBLE, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+
+    target:addStatusEffect(xi.effect.INVISIBLE, 1, 10, math.floor(600 * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
 end
 
 return item_object

--- a/scripts/globals/items/pinch_of_rainbow_powder.lua
+++ b/scripts/globals/items/pinch_of_rainbow_powder.lua
@@ -2,25 +2,21 @@
 -- ID: 5362
 -- Rainbow Powder
 -- When applied, it makes things invisible.
+-- Removed Medicated status as per https://www.bg-wiki.com/ffxi/Rainbow_Powder
 -----------------------------------
 require("scripts/settings/main")
 require("scripts/globals/status")
-require("scripts/globals/msg")
 -----------------------------------
 local item_object = {}
 
 item_object.onItemCheck = function(target)
-    if (target:hasStatusEffect(xi.effect.MEDICINE)) then
-        return xi.msg.basic.ITEM_NO_USE_MEDICATED
-    end
     return 0
 end
 
 item_object.onItemUse = function(target)
-    local duration = 600
-    target:delStatusEffect(xi.effect.INVISIBLE)
-    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
-    target:addStatusEffect(xi.effect.MEDICINE, 0, 0, 180)
+
+    target:addStatusEffect(xi.effect.INVISIBLE, 0, 10, 600)
+
 end
 
 return item_object

--- a/scripts/globals/items/pot_of_silent_oil.lua
+++ b/scripts/globals/items/pot_of_silent_oil.lua
@@ -13,9 +13,10 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    local duration = math.random(300, 480)
-    if (not target:hasStatusEffect(xi.effect.SNEAK)) then
-        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+    if  not target:hasStatusEffect(xi.effect.SNEAK) then
+        target:addStatusEffect(xi.effect.SNEAK, 1, 10, 600)
+    else
+        target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end
 

--- a/scripts/globals/items/pot_of_silent_oil.lua
+++ b/scripts/globals/items/pot_of_silent_oil.lua
@@ -13,9 +13,8 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    local duration = (600)
-    if (not target:hasStatusEffect(xi.effect.SNEAK)) then
-        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+    if not target:hasStatusEffect(xi.effect.SNEAK) then
+        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.floor(600 * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
     end
 end
 

--- a/scripts/globals/items/pot_of_silent_oil.lua
+++ b/scripts/globals/items/pot_of_silent_oil.lua
@@ -15,7 +15,7 @@ end
 item_object.onItemUse = function(target)
     local duration = (600)
     if (not target:hasStatusEffect(xi.effect.SNEAK)) then
-        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.max(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
+        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.floor(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
     end
 end
 

--- a/scripts/globals/items/pot_of_silent_oil.lua
+++ b/scripts/globals/items/pot_of_silent_oil.lua
@@ -13,10 +13,9 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    if  not target:hasStatusEffect(xi.effect.SNEAK) then
-        target:addStatusEffect(xi.effect.SNEAK, 1, 10, 600)
-    else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    local duration = (600)
+    if (not target:hasStatusEffect(xi.effect.SNEAK)) then
+        target:addStatusEffect(xi.effect.SNEAK, 1, 10, math.max(duration * xi.settings.SNEAK_INVIS_DURATION_MULTIPLIER))
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
