### PR TITLE
[core] Add extra validation to SmallPacket0x04D, disable fishing implementation

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2100,6 +2100,19 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
+    if (PChar->animation == ANIMATION_SYNTH)
+    {
+        ShowExploit("SmallPacket0x04D: %s attempting to access delivery box in the middle of a synth!", PChar->GetName());
+        return;
+    }
+
+    if ((PChar->animation >= ANIMATION_FISHING_FISH && PChar->animation <= ANIMATION_FISHING_STOP) ||
+        PChar->animation == ANIMATION_FISHING_START_OLD || PChar->animation == ANIMATION_FISHING_START)
+    {
+        ShowExploit("SmallPacket0x04D: %s attempting to access delivery box while fishing!", PChar->GetName());
+        return;
+    }
+
     // 0x01 - Send old items..
     // 0x02 - Add items to be sent..
     // 0x03 - Send confirmation..
@@ -2120,6 +2133,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         case 0x01:
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             const char* fmtQuery = "SELECT itemid, itemsubid, slot, quantity, sent, extra, sender, charname FROM delivery_box WHERE charid = %u AND box = %d "
                                    "AND slot < 8 ORDER BY slot;";
 
@@ -2175,9 +2194,16 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x02: // add items to send box
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             uint8  invslot  = data.ref<uint8>(0x07);
             uint32 quantity = data.ref<uint32>(0x08);
-            CItem* PItem    = PChar->getStorage(LOC_INVENTORY)->GetItem(invslot);
+
+            CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(invslot);
 
             if (quantity > 0 && PItem && PItem->getQuantity() >= quantity && PChar->UContainer->IsSlotEmpty(slotID))
             {
@@ -2232,6 +2258,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x03: // send items
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             uint8 send_items = 0;
             for (int i = 0; i < 8; i++)
             {
@@ -2295,6 +2327,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
             {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
                 return;
             }
 
@@ -2374,6 +2407,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
             // Send the player the new items count not seen..
             if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
             {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
                 return;
             }
 
@@ -2410,6 +2444,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x06: // Move item to received
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             if (boxtype == 1)
             {
                 bool isAutoCommitOn = Sql_GetAutoCommit(SqlHandle);
@@ -2488,6 +2528,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x07: // remove received items from send box
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             uint8 received_items = 0;
             uint8 slotID         = 0;
 
@@ -2520,15 +2566,27 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x08:
         {
-            if (PChar->UContainer->GetType() == UCONTAINER_DELIVERYBOX && !PChar->UContainer->IsSlotEmpty(slotID))
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
+            if (!PChar->UContainer->IsSlotEmpty(slotID))
             {
                 PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PChar->UContainer->GetItem(slotID), slotID, 1, 1));
             }
+
             return;
         }
         case 0x09: // Option: Return
         {
-            if (PChar->UContainer->GetType() == UCONTAINER_DELIVERYBOX && !PChar->UContainer->IsSlotEmpty(slotID))
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+            if (!PChar->UContainer->IsSlotEmpty(slotID))
             {
                 bool isAutoCommitOn = Sql_GetAutoCommit(SqlHandle);
                 bool commit         = false; // When in doubt back it out.
@@ -2593,7 +2651,13 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x0A: // Option: Take
         {
-            if (PChar->UContainer->GetType() == UCONTAINER_DELIVERYBOX && !PChar->UContainer->IsSlotEmpty(slotID))
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
+            if (!PChar->UContainer->IsSlotEmpty(slotID))
             {
                 bool isAutoCommitOn = Sql_GetAutoCommit(SqlHandle);
                 bool commit         = false;
@@ -2659,7 +2723,13 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x0B: // Option: Drop
         {
-            if (PChar->UContainer->GetType() == UCONTAINER_DELIVERYBOX && !PChar->UContainer->IsSlotEmpty(slotID))
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
+            if (!PChar->UContainer->IsSlotEmpty(slotID))
             {
                 int32 ret = Sql_Query(SqlHandle, "DELETE FROM delivery_box WHERE charid = %u AND slot = %u AND box = 1 LIMIT 1", PChar->id, slotID);
 
@@ -2676,6 +2746,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
         case 0x0C: // Confirm name (send box)
         {
+            if (PChar->UContainer->GetType() != UCONTAINER_DELIVERYBOX)
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
+                return;
+            }
+
             int32 ret = Sql_Query(SqlHandle, "SELECT accid FROM chars WHERE charname = '%s' LIMIT 1", data[0x10]);
 
             if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) > 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
@@ -2713,6 +2789,10 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
             if (PChar->UContainer->GetType() == UCONTAINER_DELIVERYBOX)
             {
                 PChar->UContainer->Clean();
+            }
+            else
+            {
+                ShowExploit("Delivery Box packet handler received action %u while UContainer is in a state other than UCONTAINER_DELIVERYBOX (%s)", action, PChar->GetName());
             }
         }
         break;

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -78,6 +78,10 @@ namespace fishingutils
 
     void StartFishing(CCharEntity* PChar)
     {
+        // NOTE: Fishing is disabled until further notice, since it is a security liability.
+        ShowWarning("Fishing is currently disabled");
+        return;
+
         if (PChar->animation != ANIMATION_NONE)
         {
             PChar->pushPacket(new CMessageSystemPacket(0, 0, 142));
@@ -375,6 +379,9 @@ namespace fishingutils
 
     void FishingAction(CCharEntity* PChar, FISH_ACTION action, uint16 stamina, uint32 special)
     {
+        ShowWarning("Fishing is currently disabled");
+        return;
+
         uint16 MessageOffset = GetMessageOffset(PChar->getZone());
 
         switch (action)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes https://github.com/LandSandBoat/server/issues/1121

Tested before/after with the steps in the issue above, is patched. 

Fixes https://github.com/LandSandBoat/server/issues/1120

I haven't tested the fishing side of this exploit, but since it relies on injecting the same dbox packets, this should also be closed.

In terms of the fishing code we have: "lol". I'm entirely on-board to just disable it and print a message to any player who tries saying that fishing is broken, sorry.