### PR TITLE
Droplist audit for The Boyahda Tree issue #975

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -823,7 +823,8 @@ INSERT INTO `mob_droplist` VALUES (146,0,0,1000,1453,10);
 INSERT INTO `mob_droplist` VALUES (146,0,0,1000,1456,10);
 INSERT INTO `mob_droplist` VALUES (146,0,0,1000,3474,1000);
 INSERT INTO `mob_droplist` VALUES (146,0,0,1000,3497,15);
-INSERT INTO `mob_droplist` VALUES (147,2,0,1000,864,0);
+INSERT INTO `mob_droplist` VALUES (147,2,0,1000,868,333); -- (Demonic Pugil) Pugil Scales
+INSERT INTO `mob_droplist` VALUES (147,2,0,1000,4484,333); -- (Demonic Pugil) Shall Shell
 INSERT INTO `mob_droplist` VALUES (148,0,0,1000,2193,100);
 INSERT INTO `mob_droplist` VALUES (148,0,0,1000,17742,20);
 INSERT INTO `mob_droplist` VALUES (148,0,0,1000,17743,20);
@@ -1867,10 +1868,8 @@ INSERT INTO `mob_droplist` VALUES (305,0,0,1000,17926,100);
 INSERT INTO `mob_droplist` VALUES (306,0,0,1000,15529,100);
 INSERT INTO `mob_droplist` VALUES (306,0,0,1000,18066,100);
 INSERT INTO `mob_droplist` VALUES (307,2,0,1000,656,0);
-INSERT INTO `mob_droplist` VALUES (308,4,0,1000,922,0);
-INSERT INTO `mob_droplist` VALUES (308,0,0,1000,922,160);
-INSERT INTO `mob_droplist` VALUES (308,4,0,1000,930,0);
-INSERT INTO `mob_droplist` VALUES (308,0,0,1000,2919,90);
+INSERT INTO `mob_droplist` VALUES (308,4,0,1000,930,0); -- (Blood Ball) Beastmen's Blood
+INSERT INTO `mob_droplist` VALUES (308,0,0,1000,1125,24); -- (Blood Ball) Carbuncle's Ruby
 INSERT INTO `mob_droplist` VALUES (309,0,0,1000,856,150);
 INSERT INTO `mob_droplist` VALUES (309,2,0,1000,4358,0);
 INSERT INTO `mob_droplist` VALUES (309,0,0,1000,4358,120);
@@ -1990,15 +1989,15 @@ INSERT INTO `mob_droplist` VALUES (341,0,0,1000,13692,1000);
 INSERT INTO `mob_droplist` VALUES (341,0,0,1000,14763,270);
 INSERT INTO `mob_droplist` VALUES (341,0,0,1000,14874,380);
 INSERT INTO `mob_droplist` VALUES (342,0,0,1000,1125,20);
-INSERT INTO `mob_droplist` VALUES (343,0,0,1000,924,100);
-INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1125,20);
+INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1265,15); -- (Korrigan) Four-leaf Korrigan Bud
+INSERT INTO `mob_droplist` VALUES (343,0,0,1000,4368,71); -- (Korrigan) Two-leaf Mandragora Bud
+INSERT INTO `mob_droplist` VALUES (343,0,0,1000,17868,69); -- (Korrigan) Humus
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,924,100);
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,930,10);
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,1057,20);
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,1125,20);
-INSERT INTO `mob_droplist` VALUES (345,0,0,1000,4468,110);
-INSERT INTO `mob_droplist` VALUES (345,0,0,1000,5322,100);
-INSERT INTO `mob_droplist` VALUES (345,0,0,1000,17296,100);
+INSERT INTO `mob_droplist` VALUES (345,0,0,1000,574,60); -- (Boyahda Sapling) Fruit Seeds
+INSERT INTO `mob_droplist` VALUES (345,0,0,1000,953,190); -- (Boyahda Sapling) Treant Bulb
 INSERT INTO `mob_droplist` VALUES (346,2,0,1000,4373,0);
 INSERT INTO `mob_droplist` VALUES (346,0,0,1000,5680,50);
 INSERT INTO `mob_droplist` VALUES (347,0,0,1000,2626,1000);
@@ -12244,8 +12243,8 @@ INSERT INTO `mob_droplist` VALUES (2353,0,0,1000,18729,200);
 INSERT INTO `mob_droplist` VALUES (2354,2,0,1000,864,0);
 INSERT INTO `mob_droplist` VALUES (2354,0,0,1000,868,130);
 INSERT INTO `mob_droplist` VALUES (2354,0,0,1000,1888,200);
-INSERT INTO `mob_droplist` VALUES (2355,2,0,1000,864,0);
-INSERT INTO `mob_droplist` VALUES (2355,0,0,1000,1052,50);
+INSERT INTO `mob_droplist` VALUES (2355,2,0,1000,868,0); -- (Stygian Pugil) Pugil Scales
+INSERT INTO `mob_droplist` VALUES (2355,0,0,1000,1052,20); -- (Stygian Pugil) Shall Shell
 INSERT INTO `mob_droplist` VALUES (2356,2,0,1000,864,0);
 INSERT INTO `mob_droplist` VALUES (2356,0,0,1000,1051,50);
 INSERT INTO `mob_droplist` VALUES (2357,0,0,1000,3251,100);
@@ -17111,6 +17110,12 @@ INSERT INTO `mob_droplist` VALUES (3205,0,0,1000,3542,50); -- (Flume Toad) fossi
 INSERT INTO `mob_droplist` VALUES (3205,0,0,1000,4109,1); -- (Flume Toad) water_cluster
 INSERT INTO `mob_droplist` VALUES (3206,0,0,1000,2151,150); -- (Marid) marid_hide
 INSERT INTO `mob_droplist` VALUES (3206,0,0,1000,2166,5); -- (Marid) lock_of_marid_hair
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,919,233); -- (Old Goobbue) Boyahda Moss
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,959,0); -- (Old Goobbue) Dahlia
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,953,0); -- (Old Goobbue) Treant Bulb
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1052,41); -- (Old Goobbue) Boyahda Coffer key
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1181,65); -- (Old Goobbue) Goobbue Humus
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1237,158); -- (Old Goobbue) Tree Cuttings
 
 /*!40000 ALTER TABLE `mob_droplist` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10545,7 +10545,7 @@ INSERT INTO `mob_groups` VALUES (7,1201,153,'Ellyllon',0,32,2890,0,0,65,66,0);
 INSERT INTO `mob_groups` VALUES (8,2762,153,'Mourioche',960,0,1746,0,0,62,68,0);
 INSERT INTO `mob_groups` VALUES (9,2754,153,'Moss_Eater',960,0,1742,0,0,62,66,0);
 INSERT INTO `mob_groups` VALUES (10,2272,153,'Knight_Crawler',960,0,1456,0,0,62,67,0);
-INSERT INTO `mob_groups` VALUES (11,2962,153,'Old_Goobbue',960,0,0,0,0,65,68,0);
+INSERT INTO `mob_groups` VALUES (11,2962,153,'Old_Goobbue',960,0,3207,0,0,65,68,0);
 INSERT INTO `mob_groups` VALUES (12,3375,153,'Robber_Crab',960,0,2109,0,0,62,66,0);
 INSERT INTO `mob_groups` VALUES (13,4309,153,'Water_Elemental',960,4,2629,0,0,69,72,0);
 INSERT INTO `mob_groups` VALUES (14,206,153,'Aquarius',0,32,149,0,0,69,71,0);


### PR DESCRIPTION
First pass, would like an extra set of eyes. Did not mess with NM's. Updated a few droprates consistent with ffxidb. Added Old_goobbue ID as it did not have a dropID.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
