### PR TITLE
Put settings check 1st in the order on LB06_New_Worlds_Await.lua 

### DIFF
--- a/scripts/quests/jeuno/LB06_New_Worlds_Await.lua
+++ b/scripts/quests/jeuno/LB06_New_Worlds_Await.lua
@@ -28,10 +28,10 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
+                xi.settings.MAX_LEVEL >= 75 and
                 player:getMainLvl() >= 75 and
                 player:getLevelCap() == 75 and
-                not player:hasKeyItem(xi.ki.LIMIT_BREAKER) and
-                xi.settings.MAX_LEVEL >= 75
+                not player:hasKeyItem(xi.ki.LIMIT_BREAKER)
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -63,10 +63,10 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
+                xi.settings.MAX_LEVEL == 75 and
                 player:getMainLvl() >= 75 and
                 player:getLevelCap() == 75 and
-                player:hasKeyItem(xi.ki.LIMIT_BREAKER) and
-                xi.settings.MAX_LEVEL == 75
+                player:hasKeyItem(xi.ki.LIMIT_BREAKER)
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -84,10 +84,10 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
+                xi.settings.MAX_LEVEL >= 80 and
                 player:getMainLvl() >= 75 and
                 player:getLevelCap() == 75 and
-                player:hasKeyItem(xi.ki.LIMIT_BREAKER) and
-                xi.settings.MAX_LEVEL >= 80
+                player:hasKeyItem(xi.ki.LIMIT_BREAKER)
         end,
 
         [xi.zone.RULUDE_GARDENS] =


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
