### PR TITLE
Misc minor script corrections

### DIFF
--- a/scripts/globals/items/leaf_bench.lua
+++ b/scripts/globals/items/leaf_bench.lua
@@ -20,7 +20,7 @@ end
 
 item_object.onItemUse = function(target)
     target:addKeyItem(keyItemId)
-    target:messageBasic(xi.basic.OBTAINED_KEY_ITEM, 6412, keyItemId)
+    target:messageBasic(xi.msg.basic.OBTAINED_KEY_ITEM, 6412, keyItemId)
 end
 
 return item_object

--- a/scripts/globals/items/redeyes.lua
+++ b/scripts/globals/items/redeyes.lua
@@ -15,7 +15,8 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addItem(5441, 99) -- angelwing
+    target:addItem(5441, 99) -- Angelwing x99
+    target:messageBasic(xi.msg.basic.ITEM_OBTAINED, 5441)
 end
 
 return item_object

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -689,7 +689,7 @@ enum class Mod
     PHYS_ABSORB      = 512, // Occasionally absorbs physical damage taken, in percents
     ABSORB_DMG_TO_MP = 516, // Unlike PLD gear mod, works on all damage types (Ethereal Earring)
 
-    ITEM_ADDEFFECT_TYPE       = 431, // see procType table in scripts\globals\assitional_effects.lua
+    ITEM_ADDEFFECT_TYPE       = 431, // see procType table in scripts\globals\additional_effects.lua
     ITEM_SUBEFFECT            = 499, // Animation ID of Spikes and Additional Effects
     ITEM_ADDEFFECT_DMG        = 500, // Damage of an items Additional Effect or Spikes
     ITEM_ADDEFFECT_CHANCE     = 501, // Chance of an items Additional Effect or Spikes


### PR DESCRIPTION
 1. Fix broken messageBasic call for KI obtained in items/leaf_bench.lua
 2. Add missing messageBasic call for obtained item in items/redeyes.lua
 3. A typo in a comment in modifier.h

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
