### PR TITLE
Correct message & technical behavior of "cap to max level".

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -254,7 +254,7 @@ void CBattlefield::ApplyLevelRestrictions(CCharEntity* PChar) const
         // Check if it's a mission and if config setting applies.
         if (map_config.lv_cap_mission_bcnm == 0 && m_isMission == 1)
         {
-            cap = PChar->GetMLevel(); // Cap to current level to strip buffs - this is the retail diff between uncapped and capped to max lv.
+            cap = luautils::GetSettingsVariable("MAX_LEVEL"); // Cap to server max level to strip buffs - this is the retail diff between uncapped and capped to max lv.
         }
 
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DEATH, true);
@@ -542,7 +542,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                         m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                     }
                 }
-                
+
                 PEntity->status = STATUS_TYPE::DISAPPEAR;
                 return found;
             }


### PR DESCRIPTION
We were getting players max level instead of servers max level, oops. No difference in game play, but it made the message wrong.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
