### PR TITLE
[Trusts] Add scaling factor to Shantotto II

### DIFF
--- a/scripts/globals/spells/trust/naji.lua
+++ b/scripts/globals/spells/trust/naji.lua
@@ -19,7 +19,10 @@ spell_object.onSpellCast = function(caster, target, spell)
     local bastokFirstTrust = caster:getCharVar("Quest[1][92]Prog")
     local zone = caster:getZoneID()
 
-    if bastokFirstTrust == 1 and (zone == xi.zone.NORTH_GUSTABERG or zone == xi.zone.SOUTH_GUSTABERG) then
+    if
+        bastokFirstTrust == 1 and
+        (zone == xi.zone.NORTH_GUSTABERG or zone == xi.zone.SOUTH_GUSTABERG)
+    then
         caster:setCharVar("Quest[1][92]Prog", 2)
     end
 

--- a/scripts/globals/spells/trust/shantotto_ii.lua
+++ b/scripts/globals/spells/trust/shantotto_ii.lua
@@ -21,11 +21,22 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.MB_AVAILABLE, 0, ai.r.MA, ai.s.MB_ELEMENT, xi.magic.spellFamily.NONE)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.NONE, 45)
 
-    local power = mob:getMainLvl() / 5
+    local trustLevel  = mob:getMainLvl()
+    local power       = trustLevel / 5
+    local spellDamage = trustLevel * math.floor((trustLevel + 1) / 10)
+
     mob:addMod(xi.mod.MATT, power)
     mob:addMod(xi.mod.MACC, power)
     mob:addMod(xi.mod.HASTE_MAGIC, 10)
-    mob:SetAutoAttackEnabled(false)
+
+    -- Shantotto's tier I spells scale up to mimic tier 2, 3, etc, spells.
+    mob:addMod(xi.mod.MAGIC_DAMAGE, spellDamage)
+
+    -- Shantotto has 100% melee hit rate always.
+    -- TODO: Add support for "perfect accuracy" in c++ land and stop hacking her accuracy.
+    mob:addMod(xi.mod.ACC, 1000)
+    -- TODO: Shantotto II attack type is suposed to be "typeless physical, like requiescat WS."
+    -- TODO: Her regular attacks have a big range (distance from mob, not AoE)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -18,21 +18,41 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local params = {}
     params.numHits = 5
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 + (player:getMerit(xi.merit.REQUIESCAT) * 0.17) params.chr_wsc = 0.0
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
+
+    params.ftp100 = 1
+    params.ftp200 = 1
+    params.ftp300 = 1
+
+    params.str_wsc = 0.0
+    params.dex_wsc = 0.0
+    params.vit_wsc = 0.0
+    params.agi_wsc = 0.0
+    params.int_wsc = 0.0
+    params.mnd_wsc = 0.0 + (player:getMerit(xi.merit.REQUIESCAT) * 0.17)
+    params.chr_wsc = 0.0
+
     params.canCrit = false
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 0.8; params.atk200 = 0.9; params.atk300 = 1.0
+    params.crit100 = 0.0
+    params.crit200 = 0.0
+    params.crit300 = 0.0
+
+    params.acc100 = 0.0
+    params.acc200 = 0.0
+    params.acc300 = 0.0
+
+    params.atk100 = 0.8
+    params.atk200 = 0.9
+    params.atk300 = 1.0
+
     params.formless = true
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true then
         params.mnd_wsc = 0.7 + (player:getMerit(xi.merit.REQUIESCAT) * 0.03)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [?] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Shantotto's Tier I spell damage scale with level to match higher tier spell damage.
This scaling makes it so at lvl 99, her Tier I spell damage does aproximately the same damage as Tier VI spells.

Also added some TODOs to her script and gave her some insane accuracy, since she isn't supposed to miss her attacks.
(Temporal measure. We should probably add some short of "perfect_acc" mod or something similar).

The other 2 files are not important, just changing formating,