### PR TITLE
Start making use of startCutscene function

### DIFF
--- a/scripts/globals/effects/dynamis.lua
+++ b/scripts/globals/effects/dynamis.lua
@@ -58,7 +58,7 @@ effect_object.onEffectLose = function(target, effect)
         if effect:getTimeRemaining() == 0 then
             target:messageSpecial(zones[target:getZoneID()].text.DYNAMIS_TIME_EXPIRED)
             target:disengage()
-            target:startEvent(100)
+            target:startCutscene(100)
         end
     end
 end

--- a/scripts/globals/maws.lua
+++ b/scripts/globals/maws.lua
@@ -94,9 +94,9 @@ xi.maws.onTrigger = function(player, npc)
 
     if event then
         if event_params then
-            player:startEvent(event, unpack(event_params))
+            player:startCutscene(event, unpack(event_params))
         else
-            player:startEvent(event)
+            player:startOptionalCutscene(event)
         end
     else
         player:messageSpecial(ID.text.NOTHING_HAPPENS)

--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -132,7 +132,7 @@ xi.promyvion.onRegionEnter = function(player, region)
         end
 
         if event ~= nil then
-            player:startEvent(event)
+            player:startOptionalCutscene(event)
         end
     end
 end

--- a/scripts/zones/Castle_Zvahl_Keep/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/Zone.lua
@@ -10,13 +10,14 @@ require("scripts/globals/treasure")
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
+    -- TODO: Change this regions to radials.
     zone:registerRegion(1, -301, -50, -22, -297, -49, -17) -- central porter on map 3
-    zone:registerRegion(2, -275, -54, 3, -271, -53, 7)     -- NE porter on map 3
+    zone:registerRegion(2, -275, -54,   3, -271, -53,   7) -- NE porter on map 3
     zone:registerRegion(3, -275, -54, -47, -271, -53, -42) -- SE porter on map 3
-    zone:registerRegion(4, -330, -54, 3, -326, -53, 7)     -- NW porter on map 3
+    zone:registerRegion(4, -330, -54,   3, -326, -53,   7) -- NW porter on map 3
     zone:registerRegion(5, -328, -54, -47, -324, -53, -42) -- SW porter on map 3
-    zone:registerRegion(6, -528, -74, 84, -526, -73, 89)   -- N porter on map 4
-    zone:registerRegion(7, -528, -74, 30, -526, -73, 36)   -- S porter on map 4
+    zone:registerRegion(6, -528, -74,  84, -526, -73,  89) -- N porter on map 4
+    zone:registerRegion(7, -528, -74,  30, -526, -73,  36) -- S porter on map 4
 
     xi.treasure.initZone(zone)
 end
@@ -27,7 +28,11 @@ end
 
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-555.996, -71.691, 59.989, 254)
     end
     return cs
@@ -37,46 +42,32 @@ zone_object.onRegionEnter = function(player, region)
 
     switch (region:GetRegionID()): caseof
     {
-        -----------------------------------
-        [1] = function (x)  --
-        -----------------------------------
-            player:startEvent(0) -- ports player to far NE corner
+        [1] = function (x)
+            player:startCutscene(0) -- ports player to far NE corner
         end,
 
-        -----------------------------------
-        [2] = function (x)  --
-        -----------------------------------
-            player:startEvent(2) -- ports player to
+        [2] = function (x)
+            player:startCutscene(2) -- ports player to
         end,
 
-        -----------------------------------
-        [3] = function (x)  --
-        -----------------------------------
-            player:startEvent(1) -- ports player to far SE corner
+        [3] = function (x)
+            player:startCutscene(1) -- ports player to far SE corner
         end,
 
-        -----------------------------------
-        [4] = function (x)  --
-        -----------------------------------
-            player:startEvent(1) -- ports player to far SE corner
+        [4] = function (x)
+            player:startCutscene(1) -- ports player to far SE corner
         end,
 
-        -----------------------------------
-        [5] = function (x)  --
-        -----------------------------------
-            player:startEvent(5) -- ports player to H-7 on map 4 (south or north part, randomly)
+        [5] = function (x)
+            player:startCutscene(5) -- ports player to H-7 on map 4 (south or north part, randomly)
         end,
 
-        -----------------------------------
-        [6] = function (x)  --
-        -----------------------------------
-            player:startEvent(6) -- ports player to position "A" on map 2
+        [6] = function (x)
+            player:startCutscene(6) -- ports player to position "A" on map 2
         end,
 
-        -----------------------------------
-        [7] = function (x)  --
-        -----------------------------------
-            player:startEvent(7) -- ports player to position G-8 on map 2
+        [7] = function (x)
+            player:startCutscene(7) -- ports player to position G-8 on map 2
         end,
 
         default = function (x)

--- a/scripts/zones/King_Ranperres_Tomb/Zone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/Zone.lua
@@ -36,7 +36,7 @@ end
 
 zone_object.onRegionEnter = function(player, region)
     if region:GetRegionID() == 1 then
-        player:startEvent(9)
+        player:startCutscene(9)
     end
 end
 

--- a/scripts/zones/King_Ranperres_Tomb/npcs/qm1.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/qm1.lua
@@ -10,7 +10,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(10)
+    player:startOptionalCutscene(10)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Lower_Delkfutts_Tower/npcs/_544.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/npcs/_544.lua
@@ -12,13 +12,13 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if npcUtil.tradeHas(trade, 549) then -- Delkfutt Key
-        player:startEvent(16)
+        player:startOptionalCutscene(16)
     end
 end
 
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-        player:startEvent(16)
+        player:startOptionalCutscene(16)
     else
         player:startEvent(10) -- door is firmly shut
     end

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
@@ -78,7 +78,7 @@ entity.onTrigger = function(player, npc)
             elseif eventID == 99 then
                 player:messageSpecial(ID.text.DOOR_SEALED_SHUT)
             else
-                player:startEvent(eventID)
+                player:startOptionalCutscene(eventID)
             end
         end
     end

--- a/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
@@ -12,9 +12,9 @@ end
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.DISPLACEMENT_OFFSET
     if (offset >= 0 and offset <= 2) then
-        player:startEvent(offset + 2)
+        player:startOptionalCutscene(offset + 2)
     elseif (offset >= 7 and offset <= 39) then
-        player:startEvent(offset)
+        player:startOptionalCutscene(offset)
     end
 end
 

--- a/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
@@ -12,13 +12,13 @@ end
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.DISPLACEMENT_OFFSET
     if offset >= 0 and offset <= 31 then
-        player:startEvent(offset + 2)
+        player:startOptionalCutscene(offset + 2)
     elseif offset == 34 then
-        player:startEvent(22)
+        player:startOptionalCutscene(22)
     elseif offset == 35 then
-        player:startEvent(32003)
+        player:startOptionalCutscene(32003)
     elseif offset > 35 and offset <= 41 then
-        player:startEvent(offset)
+        player:startOptionalCutscene(offset)
     end
 end
 

--- a/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -63,49 +63,49 @@ zone_object.onRegionEnter = function(player, region)
     switch (region:GetRegionID()): caseof
     {
         [1] = function (x)
-            player:startEvent(17) --> F
+            player:startOptionalCutscene(17) --> F
         end,
         [2] = function (x)
-            player:startEvent(16) --> E
+            player:startOptionalCutscene(16) --> E
         end,
         [3] = function (x)
-            player:startEvent(5) --> L --> Kirin !
+            player:startOptionalCutscene(5) --> L --> Kirin !
         end,
         [4] = function (x)
-            player:startEvent(4) --> G
+            player:startOptionalCutscene(4) --> G
         end,
         [5] = function (x)
-            player:startEvent(1) --> J
+            player:startOptionalCutscene(1) --> J
         end,
         [6] = function (x)
-            player:startEvent(3) --> H
+            player:startOptionalCutscene(3) --> H
         end,
         [7] = function (x)
-            player:startEvent(7) --> I
+            player:startOptionalCutscene(7) --> I
         end,
         [8] = function (x)
-            player:startEvent(6) --> K
+            player:startOptionalCutscene(6) --> K
         end,
         [9] = function (x)
-            player:startEvent(10) --> L'
+            player:startOptionalCutscene(10) --> L'
         end,
         [10] = function (x)
-            player:startEvent(11)
+            player:startOptionalCutscene(11)
         end,
         [11] = function (x)
-            player:startEvent(8)
+            player:startOptionalCutscene(8)
         end,
         [12] = function (x)
-            player:startEvent(15) --> D
+            player:startOptionalCutscene(15) --> D
         end,
         [13] = function (x)
-            player:startEvent(14) --> P
+            player:startOptionalCutscene(14) --> P
         end,
         [14] = function (x)
-            player:startEvent(13) --> M
+            player:startOptionalCutscene(13) --> M
         end,
         [15] = function (x)
-            player:startEvent(12) --> C
+            player:startOptionalCutscene(12) --> C
         end,
 
         default = function (x)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -73,7 +73,7 @@ bool CMobController::TryDeaggro()
     // target is no longer valid, so wipe them from our enmity list
     if (!PTarget || PTarget->isDead() || PTarget->isMounted() || PTarget->loc.zone->GetID() != PMob->loc.zone->GetID() ||
         PMob->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect() ||
-        PMob->allegiance == PTarget->allegiance || CheckDetection(PTarget) || CheckHide(PTarget))
+        PMob->allegiance == PTarget->allegiance || CheckDetection(PTarget) || CheckHide(PTarget) || CheckLock(PTarget))
     {
         if (PTarget)
         {
@@ -111,6 +111,36 @@ bool CMobController::CheckHide(CBattleEntity* PTarget)
     }
     return false;
 }
+
+bool CMobController::CheckLock(CBattleEntity* PTarget)
+{
+    TracyZoneScoped;
+    if (PTarget->objtype == TYPE_PC)
+    {
+        CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
+        if (PChar->m_Locked)
+        {
+            return !CanPursueTarget(PTarget);
+        }
+    }
+    else if (PTarget->objtype == TYPE_PET)
+    {
+        CPetEntity*  PPet  = dynamic_cast<CPetEntity*>(PTarget);
+        CCharEntity* PChar = dynamic_cast<CCharEntity*>(PPet->PMaster);
+
+        if (PChar == nullptr)
+        {
+            return false;
+        }
+
+        if (PChar->m_Locked)
+        {
+            return !CanPursueTarget(PTarget);
+        }
+    }
+    return false;
+}
+
 
 bool CMobController::CheckDetection(CBattleEntity* PTarget)
 {

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -57,6 +57,7 @@ protected:
     bool         CanDetectTarget(CBattleEntity* PTarget, bool forceSight = false);
     bool         CanPursueTarget(CBattleEntity* PTarget);
     bool         CheckHide(CBattleEntity* PTarget);
+    bool         CheckLock(CBattleEntity* PTarget);
     bool         CheckDetection(CBattleEntity* PTarget);
     bool         CanSeePoint(position_t pos);
     virtual bool CanCastSpells();

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -98,11 +98,33 @@ bool CMagicState::Update(time_point tick)
 
         action_t action;
 
-        if (!PTarget || m_errorMsg ||
-            (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)) ||
-            !CanCastSpell(PTarget))
+        if (!PTarget || m_errorMsg || !CanCastSpell(PTarget) ||
+            (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
         {
             m_interrupted = true;
+        }
+        else if (PTarget->objtype == TYPE_PC)
+        {
+            CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
+            if (PChar->m_Locked)
+            {
+                m_interrupted = true;
+            }
+        }
+        else if (PTarget->objtype == TYPE_PET)
+        {
+            CPetEntity*  PPet  = dynamic_cast<CPetEntity*>(PTarget);
+            CCharEntity* PChar = dynamic_cast<CCharEntity*>(PPet->PMaster);
+
+            if (PChar == nullptr)
+            {
+                return false;
+            }
+
+            if (PChar->m_Locked)
+            {
+                m_interrupted = true;
+            }
         }
         else if (battleutils::IsParalyzed(m_PEntity))
         {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2266,12 +2266,12 @@ void CCharEntity::setLocked(bool locked)
     m_Locked = locked;
     if (locked)
     {
+        // Player and pet enmity are handled in mobcontroler.cpp, CheckLock() fucntion.
+        // Mob casting interruption handled in magic_state.cpp, CMagicState::Update boolean.
         PAI->Disengage();
-        // TODO: clear enmity
         if (PPet)
         {
             PPet->PAI->Disengage();
-            // TODO: clear enmity for pet and make pet retreat to master
         }
         battleutils::RelinquishClaim(this);
     }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -453,6 +453,8 @@ public:
     virtual void           OnRaise() override;
     virtual void           OnItemFinish(CItemState&, action_t&);
 
+    bool m_Locked; // Is the player locked in a cutscene
+
     CCharEntity();  // constructor
     ~CCharEntity(); // destructor
 
@@ -475,7 +477,6 @@ private:
     std::unique_ptr<CItemContainer> m_Wardrobe3;
     std::unique_ptr<CItemContainer> m_Wardrobe4;
 
-    bool m_Locked; // Is the player locked in a cutscene
     bool m_isStyleLocked;
     bool m_isBlockingAid;
     bool m_reloadParty;


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Replaces certain events with startCutscene and startOptionalCutscene.

This fuctions replace player:startEvent(). It works the same, except it locks the charater and clears enmity, preventing blackscreens and other funny behaviour.

If you happen to know any other place where this could be used, please comment.

DONE:
- Catle Zvahl Keep
- Dynamis (No time left kick event)
- Kings Ransberre Tomb
- Phomiuna Ladders
- Promyvion zones
- Riverne A01 and B01 zones
- Shrine of Ru'Avitau
- WotG Maws

-- Intended for late PRs
TODO:
- Delkfutts Tower teleports.
- BCNM exits
- staging point doors
- ZNM teleports
- Psoxja
- Limbus. Apollion and all SEA in general