### PR TITLE
[chocobo] Add GM commands for different coloured chocobos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,9 +126,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y software-properties-common clang-format cppcheck luajit-5.1-dev luarocks mariadb-server-10.3 mariadb-client-10.3 libmariadb-dev-compat
+        sudo apt-get install -y software-properties-common clang-format cppcheck luajit-5.1-dev luarocks mariadb-server mariadb-client libmariadb-dev-compat
         luarocks install luacheck --local
-        luarocks install lanes --local
     - id: changed-files
       name: Get Changed Files
       uses: jitterbit/get-changed-files@v1

--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -1,6 +1,13 @@
 -----------------------------------
--- func: chocobo <varType> <varName>
--- desc: checks player or server variable and returns result value.
+-- func: chocobo <colour> <head> <tail> <feet>
+-- desc: Register and use a chocobo with a specific look
+--
+-- examples:
+-- Plain chocobo: !chocobo
+-- Plain chocobo with enlarged tail: !chocobo yellow tail
+-- Green chocobo with enlarged beak: !chocobo green head
+-- Black chocobo with all look changes: !chocobo black head feet tail
+-- etc.
 -----------------------------------
 require("scripts/globals/status")
 
@@ -34,13 +41,18 @@ function onTrigger(player, arg, arg2, arg3, arg4)
     if chocobo.look[arg2] then
         look = look + chocobo.look[arg2]
     end
+
     if chocobo.look[arg3] then
         look = look + chocobo.look[arg3]
     end
+
     if chocobo.look[arg4] then
         look = look + chocobo.look[arg4]
     end
 
+
     player:registerChocobo(look)
-    player:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 1, 0, 1800, true)
+
+    player:delStatusEffectSilent(xi.effect.MOUNTED)
+    player:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, xi.mount.CHOCOBO, 0, 1800, 0, 64, true)
 end

--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -1,0 +1,46 @@
+-----------------------------------
+-- func: chocobo <varType> <varName>
+-- desc: checks player or server variable and returns result value.
+-----------------------------------
+require("scripts/globals/status")
+
+cmdprops =
+{
+    permission = 0,
+    parameters = "ssss"
+}
+
+local chocobo = {}
+
+chocobo.color =
+{
+    yellow = 0x0000,
+    black  = 0x0200,
+    blue   = 0x0400,
+    red    = 0x0600,
+    green  = 0x0800,
+}
+
+chocobo.look =
+{
+    head = 0x0001, -- enlarged beak and crest (discernment)
+    feet = 0x0008, -- bigger feet and talons  (strength)
+    tail = 0x0040, -- extra tail feathers     (endurance)
+}
+
+function onTrigger(player, arg, arg2, arg3, arg4)
+    local look = tonumber(arg) or chocobo.color[arg] or 0
+
+    if chocobo.look[arg2] then
+        look = look + chocobo.look[arg2]
+    end
+    if chocobo.look[arg3] then
+        look = look + chocobo.look[arg3]
+    end
+    if chocobo.look[arg4] then
+        look = look + chocobo.look[arg4]
+    end
+
+    player:registerChocobo(look)
+    player:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 1, 0, 1800, true)
+end

--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -50,7 +50,6 @@ function onTrigger(player, arg, arg2, arg3, arg4)
         look = look + chocobo.look[arg4]
     end
 
-
     player:registerChocobo(look)
 
     player:delStatusEffectSilent(xi.effect.MOUNTED)

--- a/scripts/globals/effects/mounted.lua
+++ b/scripts/globals/effects/mounted.lua
@@ -6,11 +6,9 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    --[[
-        Retail sends a music change packet (packet ID 0x5F) in both cases.
-    ]]
+    -- Retail sends a music change packet (packet ID 0x5F) in both cases.
 
-    if effect:getPower() == 0 then
+    if effect:getPower() < 2 then
         target:ChangeMusic(4, 212)
         target:setAnimation(xi.anim.CHOCOBO)
     else

--- a/scripts/globals/effects/mounted.lua
+++ b/scripts/globals/effects/mounted.lua
@@ -8,6 +8,8 @@ local effect_object = {}
 effect_object.onEffectGain = function(target, effect)
     -- Retail sends a music change packet (packet ID 0x5F) in both cases.
 
+    -- TODO: This isn't quite right. The IDs we use for mounts vs what we use for power etc.
+    -- seem to be off-by-one.
     if effect:getPower() < 2 then
         target:ChangeMusic(4, 212)
         target:setAnimation(xi.anim.CHOCOBO)

--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -669,6 +669,7 @@ xi.items =
     FORTIFIED_CHAIN                 = 15524,
     GRANDIOSE_CHAIN                 = 15525,
     TEMPERED_CHAIN                  = 15521,
+    CHOCOBO_WHISTLE                 = 15533,
     AMIR_DIRS                       = 15604,
     YIGIT_SERAWEELS                 = 15606,
     PAHLUWAN_SERAWEELS              = 15609,

--- a/scripts/globals/items/chocobo_whistle.lua
+++ b/scripts/globals/items/chocobo_whistle.lua
@@ -25,7 +25,7 @@ item_object.onItemUse = function(target)
     -- Base duration 30 min, in seconds.
     local duration = 1800 + (target:getMod(xi.mod.CHOCOBO_RIDING_TIME) * 60)
 
-    target:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 0, 0, duration, true)
+    target:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 1, 0, duration, true)
 end
 
 return item_object

--- a/scripts/globals/items/chocobo_whistle.lua
+++ b/scripts/globals/items/chocobo_whistle.lua
@@ -15,7 +15,7 @@ local item_object = {}
 item_object.onItemCheck = function(target)
     if not target:canUseMisc(xi.zoneMisc.MOUNT) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif not target:hasKeyItem(xi.ki.CHOCOBO_LICENSE) then
+    elseif not target:hasKeyItem(xi.ki.CHOCOBO_LICENSE) or target:hasEnmity() then
         return xi.msg.basic.ITEM_UNABLE_TO_USE -- Todo: Verify/correct message, order of message priority.
     end
     return 0
@@ -24,8 +24,7 @@ end
 item_object.onItemUse = function(target)
     -- Base duration 30 min, in seconds.
     local duration = 1800 + (target:getMod(xi.mod.CHOCOBO_RIDING_TIME) * 60)
-
-    target:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, 1, 0, duration, true)
+    target:addStatusEffectEx(xi.effect.MOUNTED, xi.effect.MOUNTED, xi.mount.CHOCOBO, 0, duration, 0, 64, true)
 end
 
 return item_object

--- a/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mapitoto.lua
@@ -22,8 +22,8 @@ entity.onTrade = function(player,npc,trade)
     then
         local item = trade:getItemId(0)
         local mount = item - 10050
-        if item == 15533 then
-            player:startEvent(10227, 15533, xi.ki.TRAINERS_WHISTLE, xi.mount.CHOCOBO)
+        if item == xi.items.CHOCOBO_WHISTLE then
+            player:startEvent(10227, xi.items.CHOCOBO_WHISTLE, xi.ki.TRAINERS_WHISTLE, xi.mount.CHOCOBO)
             player:setLocalVar("FullSpeedAheadReward", xi.ki.CHOCOBO_COMPANION)
         elseif mount >= xi.mount.CHOCOBO and mount <= xi.mount.MOUNT_MAX then
             player:setLocalVar("FullSpeedAheadReward", xi.ki.TIGER_COMPANION + mount)
@@ -72,7 +72,11 @@ entity.onEventFinish = function(player,csid,option)
     elseif csid == 10227 then
         local rewardKI = player:getLocalVar("FullSpeedAheadReward")
         player:setLocalVar("FullSpeedAheadReward", 0)
-        if rewardKI ~= xi.ki.CHOCOBO_COMPANION then
+        if rewardKI == xi.ki.CHOCOBO_COMPANION then
+            -- NOTE: This does not consume the whistle, do not take it!
+            -- TODO: Get chocobo visual information from whistle
+            -- TODO: player:registerChocobo(info)
+        else
             player:tradeComplete()
         end
         npcUtil.giveKeyItem(player, rewardKI)

--- a/sql/char_pet.sql
+++ b/sql/char_pet.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS `char_pet` (
   `unlocked_attachments` blob,
   `equipped_attachments` blob,
   `adventuringfellowid` smallint(3) unsigned NOT NULL DEFAULT '0',
-  `chocoboid` int(11) unsigned NOT NULL DEFAULT '0',  
+  `chocoboid` int(11) unsigned NOT NULL DEFAULT '0',
+  `field_chocobo` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`charid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -141,6 +141,7 @@ CCharEntity::CCharEntity()
     memset(&m_PetCommands, 0, sizeof(m_PetCommands));
     memset(&m_WeaponSkills, 0, sizeof(m_WeaponSkills));
     memset(&m_SetBlueSpells, 0, sizeof(m_SetBlueSpells));
+    memset(&m_FieldChocobo, 0, sizeof(m_FieldChocobo));
     memset(&m_unlockedAttachments, 0, sizeof(m_unlockedAttachments));
 
     memset(&m_questLog, 0, sizeof(m_questLog));

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -249,6 +249,7 @@ public:
     void              setPetZoningInfo();            // set pet zoning info (when zoning and logging out)
     void              resetPetZoningInfo();          // reset pet zoning info (when changing job ect)
     uint8             m_SetBlueSpells[20];           // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
+    uint32            m_FieldChocobo;
 
     UnlockedAttachments_t m_unlockedAttachments; // Unlocked Automaton Attachments (1 bit per attachment)
     CAutomatonEntity*     PAutomaton;            // Automaton statistics

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11538,6 +11538,19 @@ void CLuaBaseEntity::setPetName(uint8 pType, uint16 value, sol::object const& ar
     }
 }
 
+void CLuaBaseEntity::registerChocobo(uint32 value)
+{
+    if (m_PBaseEntity == nullptr || m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid Entity");
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    PChar->m_FieldChocobo = value;
+    Sql_Query(SqlHandle, "UPDATE char_pet SET field_chocobo = %u WHERE charid = %u;", value, PChar->id);
+}
+
 /************************************************************************
  *  Function: getCharmChance()
  *  Purpose : Returns decimal value of the chances of charming an Entity
@@ -13708,6 +13721,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getPetName", CLuaBaseEntity::getPetName);
     SOL_REGISTER("setPetName", CLuaBaseEntity::setPetName);
+    SOL_REGISTER("registerChocobo", CLuaBaseEntity::registerChocobo);
 
     SOL_REGISTER("getCharmChance", CLuaBaseEntity::getCharmChance);
     SOL_REGISTER("charmPet", CLuaBaseEntity::charmPet);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -673,6 +673,7 @@ public:
 
     auto getPetName() -> const char*;
     void setPetName(uint8 pType, uint16 value, sol::object const& arg2);
+    void registerChocobo(uint32 value);
 
     float getCharmChance(CLuaBaseEntity const* target, sol::object const& mods); // Gets the chance the entity has to charm its target.
     void  charmPet(CLuaBaseEntity const* target);                                // Charms Pet (Beastmaster ability only)

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1031,7 +1031,15 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                     return;
                 }
 
-                PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_MOUNTED, EFFECT_MOUNTED, (MountID ? ++MountID : 0), 0, 1800), true);
+                PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(
+                    EFFECT_MOUNTED,
+                    EFFECT_MOUNTED,
+                    MountID ? ++MountID : 0,
+                    0,
+                    1800,
+                    0,
+                    FLAG_CHOCOBO), true);
+
                 PChar->PRecastContainer->Add(RECAST_ABILITY, 256, 60);
                 PChar->pushPacket(new CCharRecastPacket(PChar));
             }

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -115,8 +115,10 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
 
                 ref<uint32>(0x34) = 0x010CA248; // black chocobo
 
-                if (PChar->animation == ANIMATION_MOUNT)
+                if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
                 {
+                    ref<uint8>(0x20) |= static_cast<uint8>(PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower());
+                    ref<uint32>(0x34) = PChar->m_FieldChocobo;
                     ref<uint16>(0x44) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetPower() << 4;
                 }
             }

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -113,8 +113,6 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
                     ref<uint8>(0x2A) |= 0x80;
                 }
 
-                ref<uint32>(0x34) = 0x010CA248; // black chocobo
-
                 if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
                 {
                     ref<uint8>(0x20) |= static_cast<uint8>(PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower());
@@ -122,6 +120,7 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
                     ref<uint16>(0x44) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetPower() << 4;
                 }
             }
+
             if (PChar->PPet != nullptr)
             {
                 ref<uint16>(0x3C) = PChar->PPet->targid;

--- a/src/map/packets/char_sync.cpp
+++ b/src/map/packets/char_sync.cpp
@@ -35,7 +35,27 @@ CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
     ref<uint8>(0x05)  = 0x09;
     ref<uint16>(0x06) = PChar->targid;
     ref<uint32>(0x08) = PChar->id;
-    ref<uint8>(0x10)  = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC) ? 4 : 0; // 0x02 - Campaign Battle, 0x04 - Level Sync
-    ref<uint8>(0x25)  = PChar->jobs.job[PChar->GetMJob()]; // реальный уровень персонажа (при ограничении уровня отличается от m_mlvl)
+    //ref<uint16>(0x0C) = PChar->PFellow ? PChar->PFellow->targid : 0
+
+    ref<uint8>(0x10) = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_ALLIED_TAGS) ? 2 : 0; // 0x02 - Campaign Battle, 0x04 - Level Sync
+
+    if (PChar->m_LevelRestriction)
+    {
+        ref<uint8>(0x10) |= 6;
+
+        if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
+        {
+            ref<uint8>(0x10) |= 4;
+            ref<uint8>(0x26) = PChar->m_LevelRestriction;
+        }
+    }
+
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
+    {
+        ref<uint16>(0x13) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower();
+        ref<uint32>(0x18) = PChar->m_FieldChocobo;
+    }
+
+    ref<uint8>(0x25)  = PChar->jobs.job[PChar->GetMJob()];
     ref<uint8>(0x27)  = 0x01;
 }

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -120,8 +120,9 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
         ref<uint8>(0x58) += 0x80;
     }
 
-    if (PChar->animation == ANIMATION_MOUNT)
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
     {
+        ref<uint8>(0x29) |= static_cast<uint8>(PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower());
         ref<uint16>(0x5B) = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetPower();
     }
 }

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -25,6 +25,7 @@
 
 #include "../entities/charentity.h"
 #include "../instance.h"
+#include "../status_effect_container.h"
 #include "../utils/zoneutils.h"
 #include "../vana_time.h"
 
@@ -135,6 +136,12 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
     ref<uint8>(0x1D) = PChar->speedsub;
     ref<uint8>(0x1E) = PChar->GetHPP();
     ref<uint8>(0x1F) = PChar->animation;
+
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))
+    {
+        ref<uint8>(0x20) = static_cast<uint8>(PChar->StatusEffectContainer->GetStatusEffect(EFFECT_MOUNTED)->GetSubPower());
+    }
+
     ref<uint8>(0x21) = PChar->GetGender() * 128 + (1 << PChar->look.size);
 
     look_t* look      = (PChar->getStyleLocked() ? &PChar->mainlook : &PChar->look);
@@ -190,8 +197,8 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
     {
         ref<uint8>(0x80)  = 2;
         ref<uint16>(0xAA) = 0x01FF;
-        ref<uint8>(0xAC)  = csid > 0 ? 0x01 : 0x00;                   // if 0x01 then pause between zone
-        ref<uint8>(0xAF) = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // флаг, позволяет использовать mog menu за пределами mog house
+        ref<uint8>(0xAC)  = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
+        ref<uint8>(0xAF)  = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // флаг, позволяет использовать mog menu за пределами mog house
     }
 
     ref<uint32>(0xA0) = PChar->GetPlayTime(); // время, проведенное персонажем в игре с момента создания
@@ -213,5 +220,5 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
 
     // ref<uint8>(0xF4) = 0x18; // Replace with menuConfigFlags
 
-    ref<uint8>(0x100) = 0x01;
+    ref<uint8>(0x100) = 0x01; // observed: RoZ = 3, CoP = 5, ToAU = 9, WoTG = 11, SoA/original areas = 1
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -804,6 +804,15 @@ namespace charutils
             PChar->menuConfigFlags.flags = (uint32)Sql_GetUIntData(SqlHandle, 3);
         }
 
+        ret = Sql_Query(SqlHandle, "SELECT field_chocobo FROM char_pet WHERE charid = %u;", PChar->id);
+
+        if (ret != SQL_ERROR &&
+            Sql_NumRows(SqlHandle) != 0 &&
+            Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            PChar->m_FieldChocobo = static_cast<uint32>(Sql_GetUIntData(SqlHandle, 0));
+        }
+
         charutils::LoadInventory(PChar);
 
         CalculateStats(PChar);

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -70,6 +70,7 @@ from migrations import add_job_master_column_chars
 from migrations import currency2
 from migrations import extend_valid_targets
 from migrations import languages
+from migrations import add_field_chocobo_column
 
 # Append new migrations to this list and import above
 migrations = [
@@ -97,7 +98,8 @@ migrations = [
     add_job_master_column_chars,
     currency2,
     extend_valid_targets,
-    languages
+    languages,
+    add_field_chocobo_column
 ]
 
 # These are the 'protected' files

--- a/tools/migrations/add_field_chocobo_column.py
+++ b/tools/migrations/add_field_chocobo_column.py
@@ -1,0 +1,22 @@
+import mysql.connector
+
+def migration_name():
+    return "Adding field_chocobo column to char_pet table"
+
+def check_preconditions(cur):
+    return
+
+def needs_to_run(cur):
+    # Ensure timecreated column exists in chars
+    cur.execute("SHOW COLUMNS FROM char_pet LIKE 'field_chocobo'")
+    if not cur.fetchone():
+        return True
+    return False
+
+def migrate(cur, db):
+    try:
+        cur.execute("ALTER TABLE char_pet \
+        ADD COLUMN `field_chocobo` int(11) unsigned NOT NULL DEFAULT '0';")
+        db.commit()
+    except mysql.connector.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Found these changes by Ivaar in an old DSP branch and ported them over to LSB for future use with my chocobo raising stuff.
https://github.com/DarkstarProject/darkstar/compare/master...Ivaar:chocobo

Mapitoto was already 99% prepared for this change.

Tested on stream, all works fine, don't ask about the magic numbers 🎉 