### PR TITLE
[Limbus] Clean, sanitize and enable Apollyon NE and SE

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -152,8 +152,8 @@ local battlefields = {
     {
      -- { 0, 1291,    0},   -- SW Apollyon
      -- { 1, 1290,    0},   -- NW Apollyon
-     -- { 2, 1293,    0},   -- SE Apollyon
-     -- { 3, 1292,    0},   -- NE Apollyon
+        { 2, 1293,    0},   -- SE Apollyon
+        { 3, 1292,    0},   -- NE Apollyon
      -- { 4, 1296,   -2},   -- Central Apollyon (multiple items needed: 1909 1910 1987 1988)
      -- { 5, 1294, 2127},   -- CS Apollyon
      -- { 6, 1295,    0},   -- CS Apollyon II

--- a/scripts/globals/limbus.lua
+++ b/scripts/globals/limbus.lua
@@ -224,14 +224,14 @@ function xi.limbus.handleDoors(battlefield, open, door)
 
         -- NE Apollyon
         [1292] = function()
-            for i = 1, 5 do
+            for i = 1, 4 do
                 GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[i]):setAnimation(animation)
             end
         end,
 
         -- SE Apollyon
         [1293] = function()
-            for i = 1, 4 do
+            for i = 1, 3 do
                 GetNPCByID(ID.npc.APOLLYON_SE_PORTAL[i]):setAnimation(animation)
             end
         end,
@@ -391,8 +391,8 @@ function xi.limbus.spawnRandomCrate(npc, battlefield, var, mask, canMimic)
                 end
             end,
 
-
-            [2] = function() -- spawn bronze or blue
+            -- Spawn bronze or blue
+            [2] = function()
                 if spawnMimic and canMimic then
                     GetNPCByID(npc):setModelId(961) --mimic
                     GetNPCByID(npc):setStatus(xi.status.NORMAL)
@@ -402,8 +402,8 @@ function xi.limbus.spawnRandomCrate(npc, battlefield, var, mask, canMimic)
                     if random == 1 then random = 2 end
                     switch (random): caseof
                     {
-                        [0] = function() GetNPCByID(npc):setModelId(960) end, --bronze
-                        [2] = function() GetNPCByID(npc):setModelId(962) end, --blue
+                        [0] = function() GetNPCByID(npc):setModelId(960) end, -- Bronze
+                        [2] = function() GetNPCByID(npc):setModelId(962) end, -- Blue
                     }
                     GetNPCByID(npc):setStatus(xi.status.NORMAL)
                     battlefield:setLocalVar(var, bit.bor(math.pow(2,random), mask))

--- a/scripts/zones/Apollyon/IDs.lua
+++ b/scripts/zones/Apollyon/IDs.lua
@@ -92,14 +92,12 @@ zones[xi.zone.APOLLYON] =
             16933234, -- ne 2>3
             16933233, -- ne 3>4
             16933237, -- ne 4>5
-            16933236, -- ne 5>e
         },
         APOLLYON_SE_PORTAL =
         {
             16933239, -- se 1>2
             16933238, -- se 2>3
             16933241, -- se 3>4
-            16933240, -- se 4>e
         },
         APOLLYON_SW_CRATE =
         {

--- a/scripts/zones/Apollyon/Zone.lua
+++ b/scripts/zones/Apollyon/Zone.lua
@@ -22,13 +22,11 @@ zone_object.onInitialize = function(zone)
     zone:registerRegion(20, 396, -4, -522, 403, 4, -516) -- appolyon SE telporter floor 1 to floor 2
     zone:registerRegion(21, 116, -4, -443, 123, 4, -436) -- appolyon SE telporter floor 2 to floor 3
     zone:registerRegion(22, 276, -4, -283, 283, 4, -276) -- appolyon SE telporter floor 3 to floor 4
-    zone:registerRegion(23, 517, -4, -323, 523, 4, -316) -- appolyon SE telporter floor 4 to entrance
 
     zone:registerRegion(24, 396, -4,  76, 403, 4,  83) -- appolyon NE telporter floor 1 to floor 2
     zone:registerRegion(25, 276, -4, 356, 283, 4, 363) -- appolyon NE telporter floor 2 to floor 3
     zone:registerRegion(26, 236, -4, 517, 243, 4, 523) -- appolyon NE telporter floor 3 to floor 4
     zone:registerRegion(27, 517, -4, 637, 523, 4, 643) -- appolyon NE telporter floor 4 to floor 5
-    zone:registerRegion(28, 557, -4, 356, 563, 4, 363) -- appolyon NE telporter floor 5 to entrance
 
     zone:registerRegion(29, -403, -4, -523, -396, 4, -516) -- appolyon SW telporter floor 1 to floor 2
     zone:registerRegion(30, -123, -4, -443, -116, 4, -436) -- appolyon SW telporter floor 2 to floor 3
@@ -78,56 +76,44 @@ zone_object.onRegionEnter = function(player,region)
         -- Apollyon: SE Teleporters
         [20] = function()
             if GetNPCByID(ID.npc.APOLLYON_SE_PORTAL[1]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(219)
+                player:startOptionalCutscene(219)
             end
         end,
 
         [21] = function()
             if GetNPCByID(ID.npc.APOLLYON_SE_PORTAL[2]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(218)
+                player:startOptionalCutscene(218)
             end
         end,
 
         [22] = function()
             if GetNPCByID(ID.npc.APOLLYON_SE_PORTAL[3]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(216)
-            end
-        end,
-
-        [23] = function ()
-            if GetNPCByID(ID.npc.APOLLYON_SE_PORTAL[4]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(217)
+                player:startOptionalCutscene(216)
             end
         end,
 
         -- Apollyon: NE Teleporters
         [24] = function()
             if GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[1]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(214)
+                player:startOptionalCutscene(214)
             end
         end,
 
         [25] = function()
             if GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[2]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(212)
+                player:startOptionalCutscene(212)
             end
         end,
 
         [26] = function()
             if GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[3]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(210)
+                player:startOptionalCutscene(210)
             end
         end,
 
         [27] = function()
             if GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[4]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(215)
-            end
-        end,
-
-        [28] = function ()
-            if GetNPCByID(ID.npc.APOLLYON_NE_PORTAL[5]):getAnimation() == xi.animation.OPEN_DOOR then
-                player:startEvent(213)
+                player:startOptionalCutscene(215)
             end
         end,
 

--- a/scripts/zones/Apollyon/bcnms/ne_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/ne_apollyon.lua
@@ -6,11 +6,15 @@ local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/globals/limbus")
 require("scripts/globals/battlefield")
 require("scripts/globals/keyitems")
+require("scripts/globals/utils")
 -----------------------------------
 local battlefield_object = {}
 
 battlefield_object.onBattlefieldInitialise = function(battlefield)
-    battlefield:setLocalVar("randomF1", math.random(1, 6))
+    local F1key, F1chest = unpack(utils.uniqueRandomTable(1, 3, 2))
+
+    battlefield:setLocalVar("randomF1key", F1key)     -- Set var to determine Floor 1 Key Mob.
+    battlefield:setLocalVar("randomF1chest", F1chest) -- Set var to determine Floor 1 Chest Mob.
     battlefield:setLocalVar("loot", 1)
     SetServerVariable("[NE_Apollyon]Time", battlefield:getTimeLimit() / 60)
     xi.limbus.handleDoors(battlefield)
@@ -44,9 +48,9 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
 
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        player:startCutscene(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
-        player:startEvent(32002)
+        player:startCutscene(32002)
     end
 end
 

--- a/scripts/zones/Apollyon/bcnms/se_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/se_apollyon.lua
@@ -6,10 +6,16 @@ local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/globals/limbus")
 require("scripts/globals/battlefield")
 require("scripts/globals/keyitems")
+require("scripts/globals/utils")
 -----------------------------------
 local battlefield_object = {}
 
 battlefield_object.onBattlefieldInitialise = function(battlefield)
+    local randomOne, randomTwo, randomThree = unpack(utils.uniqueRandomTable(1, 6, 3))
+
+    battlefield:setLocalVar("randomCrate1", randomOne)
+    battlefield:setLocalVar("randomCrate2", randomTwo)
+    battlefield:setLocalVar("randomCrate3", randomThree)
     battlefield:setLocalVar("loot", 1)
     SetServerVariable("[SE_Apollyon]Time", battlefield:getTimeLimit() / 60)
     xi.limbus.handleDoors(battlefield)
@@ -43,9 +49,9 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
 
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        player:startCutscene(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
-        player:startEvent(32002)
+        player:startCutscene(32002)
     end
 end
 

--- a/scripts/zones/Apollyon/helpers/apollyon_ne.lua
+++ b/scripts/zones/Apollyon/helpers/apollyon_ne.lua
@@ -1,0 +1,187 @@
+-----------------------------------
+-- Global file for Apollyon NE
+-----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/globals/limbus")
+require("scripts/globals/utils")
+-----------------------------------
+xi = xi or {}
+xi.apollyon_ne = xi.apollyon_ne or {}
+
+-----------------------------------
+-- Floor 1
+-----------------------------------
+-- Mobs in floor: Goobbue Harvester x1, Barometz x6, Borametz x6
+
+-- Variable Pattern:
+-- 1: Goobue; 2: Barometz; 3: Borometz
+
+xi.apollyon_ne.handleMobDeathFloorOne = function(mob, player, isKiller, noKiller)
+    local mobId = mob:getID()
+
+    if
+        mobId == ID.mob.APOLLYON_NE_MOB[1] or
+        mobId == ID.mob.APOLLYON_NE_MOB[1] + 11 or
+        mobId == ID.mob.APOLLYON_NE_MOB[1] + 12
+    then
+        if isKiller or noKiller then
+            local battlefield = mob:getBattlefield()
+            local F1key       = battlefield:getLocalVar("randomF1key")
+            local F1chest     = battlefield:getLocalVar("randomF1chest")
+
+            -- Handle Teleporter
+            if
+                (F1key == 1 and mobId == ID.mob.APOLLYON_NE_MOB[1]) or      -- Goobbue is Key
+                (F1key == 2 and mobId == ID.mob.APOLLYON_NE_MOB[1] + 11) or -- Barometz is Key
+                (F1key == 3 and mobId == ID.mob.APOLLYON_NE_MOB[1] + 12)    -- Borametz is Key
+            then
+                xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[1])
+
+                -- Prepare Floor 2
+                local F2key, F2chest = unpack(utils.uniqueRandomTable(0, 3, 2))
+
+                battlefield:setLocalVar("randomF2key", ID.mob.APOLLYON_NE_MOB[2] + F2key)
+                battlefield:setLocalVar("randomF2chest", ID.mob.APOLLYON_NE_MOB[2] + F2chest)
+
+            -- Handle Treasure Crate
+            elseif
+                (F1chest == 1 and mobId == ID.mob.APOLLYON_NE_MOB[1]) or      -- Goobbue has Crate
+                (F1chest == 2 and mobId == ID.mob.APOLLYON_NE_MOB[1] + 11) or -- Barometz has Crate
+                (F1chest == 3 and mobId == ID.mob.APOLLYON_NE_MOB[1] + 12)    -- Borametz has Crate
+            then
+                local mobX = mob:getXPos()
+                local mobY = mob:getYPos()
+                local mobZ = mob:getZPos()
+                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setPos(mobX, mobY, mobZ)
+                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setStatus(xi.status.NORMAL)
+            end
+        end
+    end
+end
+
+-----------------------------------
+-- Floor 2
+-----------------------------------
+-- Mobs in floor: Thiazi x2, Bialozar x2, Cornu x4, Sirin x4
+
+xi.apollyon_ne.handleMobDeathFloorTwo = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local mobId       = mob:getID()
+        local battlefield = mob:getBattlefield()
+        local players     = battlefield:getPlayers()
+        local F2key       = battlefield:getLocalVar("randomF2key")
+        local F2chest     = battlefield:getLocalVar("randomF2chest")
+
+        -- Handle Teleporter
+        if mobId == F2key then
+            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[2])
+
+            -- Prepare Floor 3
+            if #players <= 6 then
+                battlefield:setLocalVar("randomF3key", ID.mob.APOLLYON_NE_MOB[3])
+                battlefield:setLocalVar("randomF3chest", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4))
+            elseif #players > 6 and #players <= 12 then
+                for i = 5, 9 do
+                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3] + i):spawn()
+                end
+
+                battlefield:setLocalVar("randomF3key", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 1) * 5))
+                battlefield:setLocalVar("randomF3chest", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0 ,1) * 5))
+            elseif #players > 12 then
+                for i = 5, 14 do
+                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3] + i):spawn()
+                end
+
+                battlefield:setLocalVar("randomF3key", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 2) * 5))
+                battlefield:setLocalVar("randomF3chest", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0, 2) * 5))
+            end
+
+        -- Handle treasure Crate
+        elseif mobId == F2chest then
+            local mobX = mob:getXPos()
+            local mobY = mob:getYPos()
+            local mobZ = mob:getZPos()
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setPos(mobX, mobY, mobZ)
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+-----------------------------------
+-- Floor 3
+-----------------------------------
+-- Mobs in floor: Apollyon Sweeper x(1, 2 or 3), Aollyon Cleaner x(4, 8 or 12)
+
+xi.apollyon_ne.handleMobDeathFloorThree = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local mobId       = mob:getID()
+        local battlefield = mob:getBattlefield()
+        local F3key       = battlefield:getLocalVar("randomF3key")
+        local F3chest     = battlefield:getLocalVar("randomF3chest")
+
+        -- Handle Teleporter
+        if F3key == mobId then
+            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[3])
+
+            -- Prepare Floor 4
+            battlefield:setLocalVar("randomF4key", ID.mob.APOLLYON_NE_MOB[4] + math.random(0, 2))
+
+        -- Handle treasure Crate
+        elseif F3chest == mobId then
+            local mobX = mob:getXPos()
+            local mobY = mob:getYPos()
+            local mobZ = mob:getZPos()
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[3][1]):setPos(mobX, mobY, mobZ)
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[3][1]):setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+-----------------------------------
+-- Floor 4
+-----------------------------------
+-- Mobs in floor: Hyperion x1, Okeanos x1, Cronos x1, Kerkopes x8
+
+xi.apollyon_ne.handleMobDeathFloorFour = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local mobId       = mob:getID()
+        local battlefield = mob:getBattlefield()
+        local F4key       = battlefield:getLocalVar("randomF4key")
+
+        -- Handle Teleporter
+        if F4key == mobId then
+            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[4])
+
+        -- Handle treasure Crate
+        elseif mobId == ID.mob.APOLLYON_NE_MOB[4] + 3 then
+            local mobX = mob:getXPos()
+            local mobY = mob:getYPos()
+            local mobZ = mob:getZPos()
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[4][1]):setPos(mobX, mobY, mobZ)
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[4][1]):setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+-----------------------------------
+-- Floor 5
+-----------------------------------
+-- Mobs in floor: Criosphinx x1, Hieracosphinx x1, Troglodyte Dhalmel x8
+
+xi.apollyon_ne.handleMobDeathFloorFive = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local allDead = true
+
+        for i = 2, 9 do
+            if GetMobByID(ID.mob.APOLLYON_NE_MOB[5] + i):isAlive() then
+                allDead = false
+
+                break
+            end
+        end
+
+        if allDead then
+            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[5]):setStatus(xi.status.NORMAL)
+        end
+    end
+end

--- a/scripts/zones/Apollyon/helpers/apollyon_se.lua
+++ b/scripts/zones/Apollyon/helpers/apollyon_se.lua
@@ -1,0 +1,102 @@
+-----------------------------------
+-- Global file for Apollyon SE
+-----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/globals/limbus")
+-----------------------------------
+xi = xi or {}
+xi.apollyon_se = xi.apollyon_se or {}
+
+-----------------------------------
+-- Floor 1 to 4
+-----------------------------------
+-- Mobs in floor 1: Ghost Clot (Boss), Metalloid Amoeba x8
+-- Mobs in floor 2: Tieholtsodi (Boss), Adamantshell x8
+-- Mobs in floor 3: Grave Digger (Boss), Inhumer x8
+-- Mobs in floor 4: Evil Armory (Boss), Flying Spear x8
+
+xi.apollyon_se.handleMobDeathKey = function(mob, player, isKiller, noKiller, floor)
+    if isKiller or noKiller then
+        if floor == 4 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[4]):setStatus(xi.status.NORMAL)
+        else
+            xi.limbus.handleDoors(player:getBattlefield(), true, ID.npc.APOLLYON_SE_PORTAL[floor])
+        end
+    end
+end
+
+-- Floor 1: Crates spawn at mob location.
+xi.apollyon_se.handleMobDeathFloorOne = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local battlefield = mob:getBattlefield()
+        battlefield:setLocalVar("killCountF1", battlefield:getLocalVar("killCountF1") + 1)
+
+        -- Spawn crate.
+        local killCount = battlefield:getLocalVar("killCountF1")
+
+        if killCount == 2 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]):setPos(mob:getXPos(), mob:getYPos(), mob:getZPos())
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]):setStatus(xi.status.NORMAL)
+        elseif killCount == 4 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1] + 1):setPos(mob:getXPos(), mob:getYPos(), mob:getZPos())
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1] + 1):setStatus(xi.status.NORMAL)
+        elseif killCount == 8 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1] + 2):setPos(mob:getXPos(), mob:getYPos(), mob:getZPos())
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1] + 2):setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+-- Floor 2: Crates spawn at fixed locations.
+xi.apollyon_se.handleMobDeathFloorTwo = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local battlefield = mob:getBattlefield()
+        battlefield:setLocalVar("killCountF2", battlefield:getLocalVar("killCountF2") + 1)
+
+        -- Spawn crate.
+        local killCount = battlefield:getLocalVar("killCountF2")
+
+        if killCount == 2 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2]):setStatus(xi.status.NORMAL)
+        elseif killCount == 4 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2] + 1):setStatus(xi.status.NORMAL)
+        elseif killCount == 8 then
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2] + 2):setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+-- Floor 3: Crates spawn at random locations. Spawn pos handled on battlefield initialize.
+xi.apollyon_se.handleMobDeathFloorThree = function(mob, player, isKiller, noKiller)
+    if isKiller or noKiller then
+        local cratePos =
+        {
+            [1] = { 366.000, -0.500, -313.000 },
+            [2] = { 313.021,  0.000, -317.754 },
+            [3] = { 376.097,  0.000, -259.382 },
+            [4] = { 321.552,  0.000, -293.187 },
+            [5] = { 337.399, -0.388, -313.442 },
+            [6] = { 354.661, -0.072, -273.424 },
+        }
+
+        local battlefield = mob:getBattlefield()
+        battlefield:setLocalVar("killCountF3", battlefield:getLocalVar("killCountF3") + 1)
+
+        -- Spawn crate.
+        local killCount = battlefield:getLocalVar("killCountF3")
+
+        if killCount == 2 then
+            local pos = battlefield:getLocalVar("randomCrate1")
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]):setPos(cratePos[pos])
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]):setStatus(xi.status.NORMAL)
+        elseif killCount == 4 then
+            local pos = battlefield:getLocalVar("randomCrate2")
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3] + 1):setPos(cratePos[pos])
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3] + 1):setStatus(xi.status.NORMAL)
+        elseif killCount == 8 then
+            local pos = battlefield:getLocalVar("randomCrate3")
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3] + 2):setPos(cratePos[pos])
+            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3] + 2):setStatus(xi.status.NORMAL)
+        end
+    end
+end

--- a/scripts/zones/Apollyon/mobs/Adamantshell.lua
+++ b/scripts/zones/Apollyon/mobs/Adamantshell.lua
@@ -1,8 +1,9 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 2
 --  Mob: Adamantshell
 -----------------------------------
 local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 require("scripts/globals/pathfind")
 -----------------------------------
 local entity = {}
@@ -42,19 +43,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local battlefield = mob:getBattlefield()
-        battlefield:setLocalVar("killCountF2", battlefield:getLocalVar("killCountF2") + 1)
-        local killCount = battlefield:getLocalVar("killCountF2")
-
-        if killCount == 2 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2]):setStatus(xi.status.NORMAL)
-        elseif killCount == 4 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2] + 1):setStatus(xi.status.NORMAL)
-        elseif killCount == 8 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[2] + 2):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_se.handleMobDeathFloorTwo(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Apollyon_Cleaner.lua
+++ b/scripts/zones/Apollyon/mobs/Apollyon_Cleaner.lua
@@ -1,25 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 3
 --  Mob: Apollyon Cleaner
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local itemF3      = battlefield:getLocalVar("itemF3")
-
-        if itemF3 == mobID then
-            local mobX = mob:getXPos()
-            local mobY = mob:getYPos()
-            local mobZ = mob:getZPos()
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[3][1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[3][1]):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorThree(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Apollyon_Sweeper.lua
+++ b/scripts/zones/Apollyon/mobs/Apollyon_Sweeper.lua
@@ -1,23 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 3
 --  Mob: Apollyon Sweeper
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID           = mob:getID()
-        local battlefield     = mob:getBattlefield()
-        local portalTriggerF3 = battlefield:getLocalVar("portalTriggerF3")
-
-        if portalTriggerF3 == mobID then
-            battlefield:setLocalVar("randomF4", ID.mob.APOLLYON_NE_MOB[4] + math.random(0, 2))
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[3])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorThree(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Barometz.lua
+++ b/scripts/zones/Apollyon/mobs/Barometz.lua
@@ -1,30 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 1
 --  Mob: Barometz
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if mob:getID() == ID.mob.APOLLYON_NE_MOB[1] + 11 then
-        if isKiller or noKiller then
-            local battlefield = mob:getBattlefield()
-            local randomF1    = battlefield:getLocalVar("randomF1")
-
-            if randomF1 == 1 or randomF1 == 5 then
-                local mobX = mob:getXPos()
-                local mobY = mob:getYPos()
-                local mobZ = mob:getZPos()
-                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setPos(mobX, mobY, mobZ)
-                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setStatus(xi.status.NORMAL)
-            elseif randomF1 == 2 or randomF1 == 6 then
-                battlefield:setLocalVar("randomF2", ID.mob.APOLLYON_NE_MOB[2] + math.random(0, 2))
-                xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[1])
-            end
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorOne(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Bialozar.lua
+++ b/scripts/zones/Apollyon/mobs/Bialozar.lua
@@ -1,50 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 2
 --  Mob: Bialozar
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local randomF2    = battlefield:getLocalVar("randomF2")
-
-        if randomF2 == mobID then
-            local mobX = mob:getXPos()
-            local mobY = mob:getYPos()
-            local mobZ = mob:getZPos()
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setStatus(xi.status.NORMAL)
-        elseif randomF2 + 1 == mobID then
-            battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3])
-            battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4))
-            local players = battlefield:getPlayers()
-
-            if #players > 6 then
-                for i = 5, 9 do
-                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3]+i):spawn()
-                end
-
-                battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 1) * 5))
-                battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0, 1) * 5))
-            end
-
-            if #players > 12 then
-                for i = 10, 14 do
-                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3] + i):spawn()
-                end
-
-                battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 2) * 5))
-                battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0, 2) * 5))
-            end
-
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[2])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorTwo(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Borametz.lua
+++ b/scripts/zones/Apollyon/mobs/Borametz.lua
@@ -1,30 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 1
 --  Mob: Borametz
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if mob:getID() == ID.mob.APOLLYON_NE_MOB[1] + 12 then
-        if isKiller or noKiller then
-            local battlefield = mob:getBattlefield()
-            local randomF1    = battlefield:getLocalVar("randomF1")
-
-            if randomF1 == 3 or randomF1 == 6 then
-                local mobX = mob:getXPos()
-                local mobY = mob:getYPos()
-                local mobZ = mob:getZPos()
-                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setPos(mobX, mobY, mobZ)
-                GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setStatus(xi.status.NORMAL)
-            elseif randomF1 == 4 or randomF1 == 5 then
-                battlefield:setLocalVar("randomF2", ID.mob.APOLLYON_NE_MOB[2] + math.random(0, 2))
-                xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[1])
-            end
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorOne(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Cronos.lua
+++ b/scripts/zones/Apollyon/mobs/Cronos.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 4
 --  Mob: Cronos
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
@@ -12,15 +11,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local randomF4    = battlefield:getLocalVar("randomF4")
-
-        if randomF4 == mobID then
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[4])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorFour(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Evil_Armory.lua
+++ b/scripts/zones/Apollyon/mobs/Evil_Armory.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 4
 --  Mob: Evil Armory
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 -----------------------------------
 local entity = {}
 
@@ -12,9 +12,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        GetNPCByID(ID.npc.APOLLYON_SE_CRATE[4]):setStatus(xi.status.NORMAL)
-    end
+    xi.apollyon_se.handleMobDeathKey(mob, player, isKiller, noKiller, 4)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Ghost_Clot.lua
+++ b/scripts/zones/Apollyon/mobs/Ghost_Clot.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 1
 --  Mob: Ghost Clot
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 -----------------------------------
 local entity = {}
 
@@ -14,9 +13,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        xi.limbus.handleDoors(player:getBattlefield(), true, ID.npc.APOLLYON_SE_PORTAL[1])
-    end
+    xi.apollyon_se.handleMobDeathKey(mob, player, isKiller, noKiller, 1)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Goobbue_Harvester.lua
+++ b/scripts/zones/Apollyon/mobs/Goobbue_Harvester.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 1
 --  Mob: Goobbue Harvester
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 require("scripts/globals/pathfind")
 -----------------------------------
 local entity = {}
@@ -11,8 +10,8 @@ local entity = {}
 local flags = xi.path.flag.NONE
 local path =
 {
-    { 424.271, 0.000, 22.975 },
-    { 496.692, 0.000, 22.934 }
+    {424.271, 0.000, 22.975},
+    {496.692, 0.000, 22.934}
 }
 
 entity.onMobRoam = function(mob)
@@ -27,21 +26,7 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local battlefield = mob:getBattlefield()
-        local randomF1    = battlefield:getLocalVar("randomF1")
-
-        if randomF1 == 2 or randomF1 == 4 then
-            local mobX = mob:getXPos()
-            local mobY = mob:getYPos()
-            local mobZ = mob:getZPos()
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[1][1]):setStatus(xi.status.NORMAL)
-        elseif randomF1 == 1 or randomF1 == 3 then
-            battlefield:setLocalVar("randomF2", ID.mob.APOLLYON_NE_MOB[2] + math.random(0, 2))
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[1])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorOne(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Grave_Digger.lua
+++ b/scripts/zones/Apollyon/mobs/Grave_Digger.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 3
 --  Mob: Grave Digger
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 -----------------------------------
 local entity = {}
 
@@ -14,9 +13,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        xi.limbus.handleDoors(mob:getBattlefield(), true, ID.npc.APOLLYON_SE_PORTAL[3])
-    end
+    xi.apollyon_se.handleMobDeathKey(mob, player, isKiller, noKiller, 3)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Hyperion.lua
+++ b/scripts/zones/Apollyon/mobs/Hyperion.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 4
 --  Mob: Hyperion
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
@@ -12,15 +11,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local randomF4    = battlefield:getLocalVar("randomF4")
-
-        if randomF4 == mobID then
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[4])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorFour(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Inhumer.lua
+++ b/scripts/zones/Apollyon/mobs/Inhumer.lua
@@ -1,8 +1,9 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 3
 --  Mob: Inhumer
 -----------------------------------
 local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 require("scripts/globals/pathfind")
 -----------------------------------
 local entity = {}
@@ -51,33 +52,7 @@ entity.onMobEngaged = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local cratePos =
-        {
-            [1] = { 366.000, -0.500, -313.000 },
-            [2] = { 313.021,  0.000, -317.754 },
-            [3] = { 376.097,  0.000, -259.382 },
-            [4] = { 321.552,  0.000, -293.187 },
-            [5] = { 337.399, -0.388, -313.442 },
-            [6] = { 354.661, -0.072, -273.424 },
-        }
-
-        local battlefield = mob:getBattlefield()
-        battlefield:setLocalVar("killCountF3", battlefield:getLocalVar("killCountF3") + 1)
-        local killCount = battlefield:getLocalVar("killCountF3")
-        local random    = math.random(1, 6)
-
-        if killCount == 2 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]):setPos(cratePos[random])
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]):setStatus(xi.status.NORMAL)
-        elseif killCount == 4 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]+1):setPos(cratePos[random])
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]+1):setStatus(xi.status.NORMAL)
-        elseif killCount == 8 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]+2):setPos(cratePos[random])
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[3]+2):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_se.handleMobDeathFloorThree(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Kerkopes.lua
+++ b/scripts/zones/Apollyon/mobs/Kerkopes.lua
@@ -1,23 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 4
 --  Mob: Kerkopes
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID = mob:getID()
-
-        if mobID == ID.mob.APOLLYON_NE_MOB[4] + 3 then
-            local mobX = mob:getXPos()
-            local mobY = mob:getYPos()
-            local mobZ = mob:getZPos()
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[4][1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[4][1]):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorFour(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Metalloid_Amoeba.lua
+++ b/scripts/zones/Apollyon/mobs/Metalloid_Amoeba.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 1
 --  Mob: Metalloid Amoeba
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 -----------------------------------
 local entity = {}
 
@@ -13,25 +13,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobX        = mob:getXPos()
-        local mobY        = mob:getYPos()
-        local mobZ        = mob:getZPos()
-        local battlefield = mob:getBattlefield()
-        battlefield:setLocalVar("killCountF1", battlefield:getLocalVar("killCountF1") + 1)
-        local killCount = battlefield:getLocalVar("killCountF1")
-
-        if killCount == 2 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]):setStatus(xi.status.NORMAL)
-        elseif killCount == 4 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]+1):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]+1):setStatus(xi.status.NORMAL)
-        elseif killCount == 8 then
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]+2):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_SE_CRATE[1]+2):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_se.handleMobDeathFloorOne(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Okeanos.lua
+++ b/scripts/zones/Apollyon/mobs/Okeanos.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 4
 --  Mob: Okeanos
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
@@ -12,15 +11,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local randomF4    = battlefield:getLocalVar("randomF4")
-
-        if randomF4 == mobID then
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[4])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorFour(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Thiazi.lua
+++ b/scripts/zones/Apollyon/mobs/Thiazi.lua
@@ -1,51 +1,13 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 2
 --  Mob: Thiazi
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local mobID       = mob:getID()
-        local battlefield = mob:getBattlefield()
-        local randomF2    = battlefield:getLocalVar("randomF2")
-
-        if randomF2 == mobID then
-            local mobX = mob:getXPos()
-            local mobY = mob:getYPos()
-            local mobZ = mob:getZPos()
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setPos(mobX, mobY, mobZ)
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[2][1]):setStatus(xi.status.NORMAL)
-
-        elseif randomF2 + 1 == mobID then
-            battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3])
-            battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4))
-            local players = battlefield:getPlayers()
-
-            if #players > 6 then
-                for i = 5, 9 do
-                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3] + i):spawn()
-                end
-
-                battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 1) * 5))
-                battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0 ,1) * 5))
-            end
-
-            if #players > 12 then
-                for i = 10, 14 do
-                    GetMobByID(ID.mob.APOLLYON_NE_MOB[3] + i):spawn()
-                end
-
-                battlefield:setLocalVar("portalTriggerF3", ID.mob.APOLLYON_NE_MOB[3] + (math.random(0, 2) * 5))
-                battlefield:setLocalVar("itemF3", ID.mob.APOLLYON_NE_MOB[3] + math.random(1, 4) + (math.random(0, 2) * 5))
-            end
-
-            xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NE_PORTAL[2])
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorTwo(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Tieholtsodi.lua
+++ b/scripts/zones/Apollyon/mobs/Tieholtsodi.lua
@@ -1,9 +1,8 @@
 -----------------------------------
--- Area: Apollyon SE
+-- Area: Apollyon SE, Floor 2
 --  Mob: Tieholtsodi
 -----------------------------------
-local ID = require("scripts/zones/Apollyon/IDs")
-require("scripts/globals/limbus")
+require("scripts/zones/Apollyon/helpers/apollyon_se")
 require("scripts/globals/pathfind")
 mixins = {require("scripts/mixins/job_special")}
 -----------------------------------
@@ -39,9 +38,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        xi.limbus.handleDoors(mob:getBattlefield(), true, ID.npc.APOLLYON_SE_PORTAL[2])
-    end
+    xi.apollyon_se.handleMobDeathKey(mob, player, isKiller, noKiller, 2)
 end
 
 return entity

--- a/scripts/zones/Apollyon/mobs/Troglodyte_Dhalmel.lua
+++ b/scripts/zones/Apollyon/mobs/Troglodyte_Dhalmel.lua
@@ -1,8 +1,9 @@
 -----------------------------------
--- Area: Apollyon NE
+-- Area: Apollyon NE, Floor 5
 --  Mob: Troglodyte Dhalmel
 -----------------------------------
 local ID = require("scripts/zones/Apollyon/IDs")
+require("scripts/zones/Apollyon/helpers/apollyon_ne")
 require("scripts/globals/pathfind")
 -----------------------------------
 local entity = {}
@@ -39,21 +40,7 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, isKiller, noKiller)
-    if isKiller or noKiller then
-        local allDead = true
-
-        for i = 2, 9 do
-            if GetMobByID(ID.mob.APOLLYON_NE_MOB[5]+i):isAlive() then
-                allDead = false
-
-                break
-            end
-        end
-
-        if allDead then
-            GetNPCByID(ID.npc.APOLLYON_NE_CRATE[5]):setStatus(xi.status.NORMAL)
-        end
-    end
+    xi.apollyon_ne.handleMobDeathFloorFive(mob, player, isKiller, noKiller)
 end
 
 return entity

--- a/scripts/zones/Apollyon/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Apollyon/npcs/Armoury_Crate.lua
@@ -2,11 +2,11 @@
 -- Area: Apollyon
 --  NPC: Armoury Crate
 -----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/globals/titles")
 require("scripts/globals/quests")
 require("scripts/globals/limbus")
 require("scripts/globals/zone")
-local ID = require("scripts/zones/Apollyon/IDs")
 -----------------------------------
 local entity = {}
 
@@ -392,6 +392,8 @@ local loot =
             },
         },
     },
+
+    -- Apollyon: SW
     [1291] =
     {
         -- SW_Apollyon floor 1
@@ -562,6 +564,8 @@ local loot =
             },
         },
     },
+
+    -- Apollyon: NW
     [1290] =
     {
         -- NW_Apollyon floor 1
@@ -805,9 +809,10 @@ local loot =
             },
         },
     },
+
+    -- CS Apollyon
     [1294] =
     {
-        -- CS_Apollyon
         [1] =
         {
             {
@@ -839,9 +844,11 @@ local loot =
             },
         },
     },
+
+    -- Central Apollyon
     [1296] =
     {
-        -- omega
+        -- Proto-Omega
         [1] =
         {
             {
@@ -888,20 +895,24 @@ end
 
 entity.onTrigger = function(player, npc)
     local battlefield = player:getBattlefield()
+
     if not battlefield then
         return
     end
+
     local crateID = npc:getID()
-    local model = npc:getModelId()
-    local X = npc:getXPos()
-    local Y = npc:getYPos()
-    local Z = npc:getZPos()
-    local bfid = battlefield:getID()
-    local hold = false
+    local model   = npc:getModelId()
+    local X       = npc:getXPos()
+    local Y       = npc:getYPos()
+    local Z       = npc:getZPos()
+    local bfid    = battlefield:getID()
+    local hold    = false
+
     if npc:getLocalVar("open") == 0 then
         switch (bfid): caseof
         {
-            [1290] = function() -- NW Apollyon Crate Handling
+            -- NW Apollyon Crate Handling
+            [1290] = function()
                 if crateID ~= ID.npc.APOLLYON_NW_CRATE[5] then
                     for i = 1, 4 do
                         for j = 1, 5 do
@@ -922,7 +933,9 @@ entity.onTrigger = function(player, npc)
                     battlefield:setLocalVar("lootSeen", 1)
                 end
             end,
-            [1291] = function() -- SW Apollyon Crate Handling
+
+            -- SW Apollyon Crate Handling
+            [1291] = function()
                 if crateID ~= ID.npc.APOLLYON_SW_CRATE[4] then
                     for i = 1, 3 do
                         if i == 3 then
@@ -988,7 +1001,10 @@ entity.onTrigger = function(player, npc)
                     battlefield:setLocalVar("lootSeen", 1)
                 end
             end,
-            [1292] = function() -- NE Apollyon Crate Handling
+
+            -- NE Apollyon Crate Handling
+            [1292] = function()
+                -- Floors 1 to 4
                 if crateID ~= ID.npc.APOLLYON_NE_CRATE[5] then
                     for i = 1, 4 do
                         for j = 1, 5 do
@@ -1003,13 +1019,16 @@ entity.onTrigger = function(player, npc)
                             end
                         end
                     end
+                -- Floor 5 (Last)
                 else
                     xi.limbus.handleLootRolls(battlefield, loot[bfid][5], nil, npc)
                     battlefield:setLocalVar("cutsceneTimer", 10)
                     battlefield:setLocalVar("lootSeen", 1)
                 end
             end,
-            [1293] = function() -- SE Apollyon Crate Handling
+
+            -- SE Apollyon Crate Handling
+            [1293] = function()
                 if crateID ~= ID.npc.APOLLYON_SE_CRATE[4] then
                     for i = 1, 3 do
                         for j = 0, 2 do
@@ -1033,7 +1052,9 @@ entity.onTrigger = function(player, npc)
                     battlefield:setLocalVar("lootSeen", 1)
                 end
             end,
-            [1294] = function() -- CS Apollyon Crate Handling
+
+            -- CS Apollyon Crate Handling
+            [1294] = function()
                 if crateID ~= ID.npc.APOLLYON_CS_CRATE then
                     xi.limbus.extendTimeLimit(battlefield, 5, xi.zone.APOLLYON)
                 else
@@ -1042,12 +1063,15 @@ entity.onTrigger = function(player, npc)
                     battlefield:setLocalVar("lootSeen", 1)
                 end
             end,
-            [1296] = function() -- Central Apollyon Crate Handling
+
+            -- Central Apollyon Crate Handling
+            [1296] = function()
                 xi.limbus.handleLootRolls(battlefield, loot[bfid][1], nil, npc)
                 battlefield:setLocalVar("cutsceneTimer", 10)
                 battlefield:setLocalVar("lootSeen", 1)
             end,
         }
+
         if not hold then
             npc:entityAnimationPacket("open")
             npc:setLocalVar("open", 1)

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -293,7 +293,7 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
                 m_EnteredPlayers.emplace(PEntity->id);
                 PChar->ClearTrusts();
                 luautils::OnBattlefieldEnter(PChar, this);
-                charutils::SendTimerPacket(PChar, m_TimeLimit);
+                charutils::SendTimerPacket(PChar, GetRemainingTime());
             }
             else if (!IsRegistered(PChar))
             {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Changes Global:
- Moved battlefield logic from mob scripts to a single global file.
- Fixed portal at floor 5 in NE and 4 in SE opening, wich shouldn't.
- Fixed oddity with battlefield timer returning max time remaining when entering instead of actual time remaining.
- Removed unused regions and unused NPC IDs.
- Changed player:startEvent to player:startCutscene or player:startOptionalCutscene, when aplicable.

NE
- Fixed Floor 2 never selecting 4th mob as "Portal Opener"

SE
- Fixed treasure chests in floor 3 poping on top of each other.

Notes:
- Non-boss mobs in floors 1 to 4 superlink. They shouldn't.
- Battlefield timer doesn't update when recieving a time extension. (Nevermind the fact this zones don't have a timer in retail.)