### PR TITLE
Fix onBattlefieldEnter randomly being skiped

### DIFF
--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -149,14 +149,14 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, uint16 battlefiel
                 return BATTLEFIELD_RETURN_CODE_WAIT;
             }
 
-            PBattlefield->InsertEntity(PChar, true);
-
             if (lootid != 0)
             {
                 PBattlefield->SetLocalVar("loot", lootid);
             }
 
             luautils::OnBattlefieldInitialise(PBattlefield);
+            PBattlefield->InsertEntity(PChar, true);
+
             return BATTLEFIELD_RETURN_CODE_CUTSCENE;
         }
     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
