### PR TITLE
Fix dropId in Golden-Tongue Culberry's Lua

### DIFF
--- a/scripts/zones/PsoXja/npcs/qm_culberry.lua
+++ b/scripts/zones/PsoXja/npcs/qm_culberry.lua
@@ -19,7 +19,7 @@ entity.onTrade = function(player, npc, trade)
 
     if pendantChance > 0 and npcUtil.popFromQM(player, npc, ID.mob.GOLDEN_TONGUED_CULBERRY) then
         player:confirmTrade()
-        SetDropRate(1512, 13145, pendantChance)
+        SetDropRate(1190, 13145, pendantChance)
     end
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
