### PR TITLE
Fix CEventPacket to allow for text_table only

### DIFF
--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -45,7 +45,7 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
     }
     ref<uint32>(0x04) = npcID;
 
-    if (eventInfo->params.size() > 0)
+    if (eventInfo->params.size() > 0 || eventInfo->textTable != -1)
     {
         this->type = 0x34;
         this->size = 0x1A;


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Current event packet relies on params list to be > 0 to support text_table values (and different event structure).  By default, if no parameters are supplied, there is no 0 value for the first 8 params.  This caused the following implementation of events to not function:
```
quest:progressEvent(3073, { text_table = 0 })
```

This fix adds an additional check to the event packet if textTable != -1
