### PR TITLE
[wip][test] event system unique_ptr

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -204,9 +204,10 @@ public:
     jobs_t     jobs;       // доступрые профессии персонажа
     keyitems_t keys;       // таблица ключевых предметов
 
-    EventPrep* eventPreparation;      // Information about a potential upcoming event
-    EventInfo* currentEvent;          // The currently ongoing event playing for the player
-    std::list<EventInfo*> eventQueue; // The queued events to play for the player
+    std::unique_ptr<EventPrep> eventPreparation;      // Information about a potential upcoming event
+    std::unique_ptr<EventInfo> currentEvent;          // The currently ongoing event playing for the player
+    std::list<std::unique_ptr<EventInfo>> eventQueue; // The queued events to play for the player
+
     bool       inSequence;            // True if the player is locked in a NPC sequence
     bool       gotMessage;            // Used to let the interaction framework know that a message outside of it was triggered.
 
@@ -427,7 +428,7 @@ public:
 
     bool isInEvent();
     bool isNpcLocked();
-    void queueEvent(EventInfo* eventToQueue);
+    void queueEvent(std::unique_ptr<EventInfo>&& eventToQueue);
     void endCurrentEvent();
     void tryStartNextEvent();
     void skipEvent();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -803,16 +803,16 @@ void CLuaBaseEntity::StartEventHelper(int32 EventID, sol::variadic_args va, EVEN
         return;
     }
 
-    PChar->queueEvent(ParseEvent(EventID, va, PChar->eventPreparation, eventType));
+    PChar->queueEvent(ParseEvent(EventID, va, std::move(PChar->eventPreparation), eventType));
 }
 
 /************************************************************************
  *  Helper function for parsing event information from lua.
  ************************************************************************/
-EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, EventPrep* eventPreparation, EVENT_TYPE eventType)
+std::unique_ptr<EventInfo> CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, std::unique_ptr<EventPrep>&& eventPreparation, EVENT_TYPE eventType)
 {
-    EventInfo* eventToStart = new EventInfo();
-    eventToStart->eventId   = EventID;
+    auto eventToStart = std::make_unique<EventInfo>();
+    eventToStart->eventId = EventID;
     if (eventPreparation)
     {
         eventToStart->targetEntity = eventPreparation->targetEntity;
@@ -904,7 +904,6 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         eventToStart->textTable = va.get_type(8) == sol::type::number ? va.get<int16>(8) : -1;
     }
 
-
     if (eventType == OPTIONAL_CUTSCENE)
     {
         // If it's a teleporter or door, where the player has to select the option to
@@ -912,7 +911,7 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         eventToStart->cutsceneOptions = std::move(cutsceneOptions);
     }
 
-    return eventToStart;
+    return std::move(eventToStart);
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -80,7 +80,7 @@ public:
     void entityAnimationPacket(const char* command);
 
     void       StartEventHelper(int32 EventID, sol::variadic_args va, EVENT_TYPE eventType);
-    EventInfo* ParseEvent(int32 EventID, sol::variadic_args va, EventPrep* eventPreparation, EVENT_TYPE eventType);
+    std::unique_ptr<EventInfo> ParseEvent(int32 EventID, sol::variadic_args va, std::unique_ptr<EventPrep>&& eventPreparation, EVENT_TYPE eventType);
     void       startEvent(int32 EventID, sol::variadic_args va);
     void       startEventString(int32 EventID, sol::variadic_args va); // Begins Event with string param (0x33 packet)
     void       startCutscene(int32 EventID, sol::variadic_args va); // Begins cutscene which locks the character

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1877,8 +1877,8 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        EventPrep* previousPrep = PChar->eventPreparation;
-        PChar->eventPreparation = PChar->currentEvent;
+        auto previousPrep = std::move(PChar->eventPreparation);
+        //PChar->eventPreparation = std::move(PChar->currentEvent);
 
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
         if (!onEventUpdate.valid())
@@ -1901,7 +1901,7 @@ namespace luautils
             return -1;
         }
 
-        PChar->eventPreparation = previousPrep;
+        PChar->eventPreparation = std::move(previousPrep);
 
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
@@ -1915,8 +1915,8 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        EventPrep* previousPrep = PChar->eventPreparation;
-        PChar->eventPreparation = PChar->currentEvent;
+        auto previousPrep = std::move(PChar->eventPreparation);
+        //PChar->eventPreparation = std::move(PChar->currentEvent);
 
         auto onEventUpdateFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventUpdate"];
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
@@ -1935,7 +1935,7 @@ namespace luautils
             return -1;
         }
 
-        PChar->eventPreparation = previousPrep;
+        PChar->eventPreparation = std::move(previousPrep);
 
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
@@ -1944,8 +1944,8 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        EventPrep* previousPrep = PChar->eventPreparation;
-        PChar->eventPreparation = PChar->currentEvent;
+        auto previousPrep = std::move(PChar->eventPreparation);
+        //PChar->eventPreparation = std::move(PChar->currentEvent);
 
         auto onEventUpdateFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventUpdate"];
         auto onEventUpdate = LoadEventScript(PChar, "onEventUpdate");
@@ -1964,7 +1964,7 @@ namespace luautils
             return -1;
         }
 
-        PChar->eventPreparation = previousPrep;
+        PChar->eventPreparation = std::move(previousPrep);
 
         return 0;
     }
@@ -1979,8 +1979,8 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        EventPrep* previousPrep = PChar->eventPreparation;
-        PChar->eventPreparation = PChar->currentEvent;
+        auto previousPrep = std::move(PChar->eventPreparation);
+        //PChar->eventPreparation = std::move(PChar->currentEvent);
 
         auto onEventFinishFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onEventFinish"];
         auto onEventFinish = LoadEventScript(PChar, "onEventFinish");
@@ -2004,7 +2004,7 @@ namespace luautils
             return -1;
         }
 
-        PChar->eventPreparation = previousPrep;
+        PChar->eventPreparation = std::move(previousPrep);
 
         if (PChar->currentEvent->scriptFile.find("/bcnms/") > 0 && PChar->health.hp <= 0)
         { // for some reason the event doesnt enforce death afterwards

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -26,7 +26,7 @@
 #include "../entities/charentity.h"
 #include "event.h"
 
-CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
+CEventPacket::CEventPacket(CCharEntity* PChar, std::unique_ptr<EventInfo>&& eventInfo)
 {
     this->type = 0x32;
     this->size = 0x0A;

--- a/src/map/packets/event.h
+++ b/src/map/packets/event.h
@@ -40,7 +40,7 @@ class CCharEntity;
 class CEventPacket : public CBasicPacket
 {
 public:
-    CEventPacket(CCharEntity* PChar, EventInfo* eventInfo);
+    CEventPacket(CCharEntity* PChar, std::unique_ptr<EventInfo>&& eventInfo);
 };
 
 #endif

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -26,7 +26,7 @@
 #include "../entities/charentity.h"
 #include "event_string.h"
 
-CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
+CEventStringPacket::CEventStringPacket(CCharEntity* PChar, std::unique_ptr<EventInfo>&& eventInfo)
 {
     this->type = 0x33;
     this->size = 0x38;

--- a/src/map/packets/event_string.h
+++ b/src/map/packets/event_string.h
@@ -41,7 +41,7 @@ class CCharEntity;
 class CEventStringPacket : public CBasicPacket
 {
 public:
-    CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo);
+    CEventStringPacket(CCharEntity* PChar, std::unique_ptr<EventInfo>&& eventInfo);
 };
 
 #endif


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

We've had an intermittent crash with no 100% repro steps happening at the end of events.

**What I think was happening**
I think we were reusing eventPreparation and currentEvent, and one of them was having the memory for one of it's internal strings wiped. 

I think replacing these with unique_ptr's and handling the memory for these objects more carefully might solve the issue. I havent' been able to hit the crash since I made these changes.

**PLEASE** pull this branch down and test it!

Original crash
```
[01/25/22 20:53:19:071][critical][stacktrace] at std::_Narrow_char_traits<char,int>::assign in C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.30818\include\xstring: line: 438: address: 0x7FF73A9285D0
[01/25/22 20:53:19:071][critical][stacktrace] at std::basic_string<char,std::char_traits<char>,std::allocator<char> >::_Eos in C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.30818\include\xstring: line: 4609: address: 0x7FF73A927E80
[01/25/22 20:53:19:072][critical][stacktrace] at std::basic_string<char,std::char_traits<char>,std::allocator<char> >::clear in C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.30818\include\xstring: line: 3515: address: 0x7FF73A925C10
[01/25/22 20:53:19:073][critical][stacktrace] at EventPrep::reset in C:\ffxi\server\src\map\event_info.h: line: 45: address: 0x7FF73A9D89F0
[01/25/22 20:53:19:074][critical][stacktrace] at CCharEntity::endCurrentEvent in C:\ffxi\server\src\map\entities\charentity.cpp: line: 2190: address: 0x7FF73AAC1DE0
[01/25/22 20:53:19:074][critical][stacktrace] at SmallPacket0x05B in C:\ffxi\server\src\map\packet_system.cpp: line: 3343: address: 0x7FF73A9F0380
[01/25/22 20:53:19:075][critical][stacktrace] at parse in C:\ffxi\server\src\map\map.cpp: line: 660: address: 0x7FF73A9B7570
[01/25/22 20:53:19:075][critical][stacktrace] at do_sockets in C:\ffxi\server\src\map\map.cpp: line: 416: address: 0x7FF73A9B65A0
[01/25/22 20:53:19:077][critical][stacktrace] at main in C:\ffxi\server\src\common\kernel.cpp: line: 269: address: 0x7FF73AA79F80
```

First iteration of unique_ptr changes:
``` 
[01/25/22 21:54:28:357][critical][stacktrace] at std::basic_string<char,std::char_traits<char>,std::allocator<char> >::_Construct_lv_contents in C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.30818\include\xstring: line: 2935: address: 0x7FF78A8F8240
[01/25/22 21:54:28:357][critical][stacktrace] at std::basic_string<char,std::char_traits<char>,std::allocator<char> >::basic_string<char,std::char_traits<char>,std::allocator<char> > in C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.30818\include\xstring: line: 2468: address: 0x7FF78A8F62D0
[01/25/22 21:54:28:369][critical][stacktrace] at luautils::LoadEventScript in C:\ffxi\server\src\map\lua\luautils.cpp: line: 4543: address: 0x7FF78AADDDB0
[01/25/22 21:54:28:369][critical][stacktrace] at luautils::OnEventFinish in C:\ffxi\server\src\map\lua\luautils.cpp: line: 1986: address: 0x7FF78AABF120
[01/25/22 21:54:28:370][critical][stacktrace] at SmallPacket0x05B in C:\ffxi\server\src\map\packet_system.cpp: line: 3336: address: 0x7FF78A9C03A0
[01/25/22 21:54:28:371][critical][stacktrace] at parse in C:\ffxi\server\src\map\map.cpp: line: 660: address: 0x7FF78A987570
[01/25/22 21:54:28:371][critical][stacktrace] at do_sockets in C:\ffxi\server\src\map\map.cpp: line: 416: address: 0x7FF78A9865A0
[01/25/22 21:54:28:371][critical][stacktrace] at main in C:\ffxi\server\src\common\kernel.cpp: line: 269: address: 0x7FF78AA49FE0
[01/25/22 21:54:28:371][critical][stacktrace] 
```
