### PR TITLE
Fixed FoV not using exp multiplier

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1442,7 +1442,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- award XP every page completion
-    player:addExp(reward)
+    player:addExp(reward * FOV_EXP_RATE)
 
     -- repeating regimes
     if player:getCharVar("[regime]repeat") == 1 then

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1442,7 +1442,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- award XP every page completion
-    player:addExp(reward * xi.settings.FOV_EXP_RATE)
+    player:addExp(reward * xi.settings.BOOK_EXP_RATE)
 
     -- repeating regimes
     if player:getCharVar("[regime]repeat") == 1 then

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1442,7 +1442,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- award XP every page completion
-    player:addExp(reward * FOV_EXP_RATE)
+    player:addExp(reward * xi.settings.FOV_EXP_RATE)
 
     -- repeating regimes
     if player:getCharVar("[regime]repeat") == 1 then

--- a/scripts/settings/default/main.lua
+++ b/scripts/settings/default/main.lua
@@ -83,6 +83,7 @@ xi.settings =
     GIL_RATE        = 1.000, -- Multiplies gil earned from quests.  Won't always display in game.
     BAYLD_RATE      = 1.000, -- Multiples bayld earned from quests.
     EXP_RATE        = 1.000, -- Multiplies exp earned from fov and quests.
+    FOV_EXP_RATE	= 1.000, -- Multiplies exp from FoV.
     TABS_RATE       = 1.000, -- Multiplies tabs earned from fov.
     ROE_EXP_RATE    = 1.000, -- Multiplies exp earned from records of eminence.
     SPARKS_RATE     = 1.000, -- Multiplies sparks earned from records of eminence.

--- a/scripts/settings/default/main.lua
+++ b/scripts/settings/default/main.lua
@@ -82,8 +82,9 @@ xi.settings =
     SHOP_PRICE      = 1.000, -- Multiplies prices in NPC shops.
     GIL_RATE        = 1.000, -- Multiplies gil earned from quests.  Won't always display in game.
     BAYLD_RATE      = 1.000, -- Multiples bayld earned from quests.
-    EXP_RATE        = 1.000, -- Multiplies exp earned from fov and quests.
-    FOV_EXP_RATE	= 1.000, -- Multiplies exp from FoV.
+    -- Note: EXP rates are also influenced by conf setting
+    EXP_RATE        = 1.000, -- Multiplies exp from script (except FoV/GoV).
+    BOOK_EXP_RATE   = 1.000, -- Multiplies exp from FoV/GoV book pages.
     TABS_RATE       = 1.000, -- Multiplies tabs earned from fov.
     ROE_EXP_RATE    = 1.000, -- Multiplies exp earned from records of eminence.
     SPARKS_RATE     = 1.000, -- Multiplies sparks earned from records of eminence.


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored because making sure the box shows a check mark is what is important in PRs...
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

FoV wasn't using the exp multiplier from the settings lua. I also separated the exp multiplier from the quests one, cuz more customization is better.