### PR TITLE
[Fix] Change how mercenary rank is determined and vendor oddity

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -13,10 +13,10 @@ xi = xi or {}
 xi.besieged = xi.besieged or {}
 
 local function getMapBitmask(player)
-    local mamook = player:hasKeyItem(xi.ki.MAP_OF_MAMOOK) and 1 or 0 -- Map of Mammok
-    local halvung = player:hasKeyItem(xi.ki.MAP_OF_HALVUNG) and 2 or 0 -- Map of Halvung
+    local mamook   = player:hasKeyItem(xi.ki.MAP_OF_MAMOOK) and 1 or 0 -- Map of Mammok
+    local halvung  = player:hasKeyItem(xi.ki.MAP_OF_HALVUNG) and 2 or 0 -- Map of Halvung
     local arrapago = player:hasKeyItem(xi.ki.MAP_OF_ARRAPAGO_REEF) and 4 or 0 -- Map of Arrapago Reef
-    local astral = bit.lshift(xi.besieged.getAstralCandescence(), 31) -- Include astral candescence in the top byte
+    local astral   = bit.lshift(xi.besieged.getAstralCandescence(), 31) -- Include astral candescence in the top byte
 
     return bit.bor(mamook, halvung, arrapago, astral)
 end
@@ -180,11 +180,11 @@ end
 -----------------------------------
 -- Variable for addTeleport and getRegionPoint
 -----------------------------------
-LEUJAOAM_ASSAULT_POINT = 0
-MAMOOL_ASSAULT_POINT = 1
-LEBROS_ASSAULT_POINT = 2
-PERIQIA_ASSAULT_POINT = 3
-ILRUSI_ASSAULT_POINT = 4
+LEUJAOAM_ASSAULT_POINT   = 0
+MAMOOL_ASSAULT_POINT     = 1
+LEBROS_ASSAULT_POINT     = 2
+PERIQIA_ASSAULT_POINT    = 3
+ILRUSI_ASSAULT_POINT     = 4
 NYZUL_ISLE_ASSAULT_POINT = 5
 
 xi.besieged.addRunicPortal = function(player, portal)
@@ -216,14 +216,28 @@ xi.besieged.getAstralCandescence = function()
     return 1 -- Hardcoded to 1 for now
 end
 
-xi.besieged.badges = { 780, 783, 784, 794, 795, 825, 826, 827, 894, 900, 909 }
+xi.besieged.badges =
+{
+    xi.ki.PSC_WILDCAT_BADGE,
+    xi.ki.PFC_WILDCAT_BADGE,
+    xi.ki.SP_WILDCAT_BADGE,
+    xi.ki.LC_WILDCAT_BADGE,
+    xi.ki.C_WILDCAT_BADGE,
+    xi.ki.S_WILDCAT_BADGE,
+    xi.ki.SM_WILDCAT_BADGE,
+    xi.ki.CS_WILDCAT_BADGE,
+    xi.ki.SL_WILDCAT_BADGE,
+    xi.ki.FL_WILDCAT_BADGE,
+    xi.ki.CAPTAIN_WILDCAT_BADGE
+}
 
 xi.besieged.getMercenaryRank = function(player)
     local rank = 0
 
-    for _, v in ipairs(xi.besieged.badges) do
-        if player:hasKeyItem(v) then
-            rank = rank + 1
+    for k = #xi.besieged.badges, 1, -1 do
+        if player:hasKeyItem(xi.besieged.badges[k]) then
+            rank = k
+            break
         end
     end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
@@ -39,9 +39,13 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local rank = xi.besieged.getMercenaryRank(player)
-    local badge = xi.besieged.badges[rank]
     local points = player:getCurrency("imperial_standing")
+    local rank   = xi.besieged.getMercenaryRank(player)
+    local badge  = 0
+    if rank > 0 then
+        badge = xi.besieged.badges[rank]
+    end
+
     player:startEvent(150, rank, badge, points, 0, 0, 0, 0, 0, 0)
 end
 
@@ -49,13 +53,13 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 150 and option < 0x40000000 then
-        local quantity = bit.rshift(option, 0x8)
-        local stacks = math.floor(quantity / 99)
+    if csid == 150 and option < 0x40000000 and option > 255 then
+        local coinType  = bit.band(option, 0xFF)
+        local quantity  = bit.rshift(option, 0x8)
+        local stacks    = math.floor(quantity / 99)
         local remainder = quantity % 99
-        local coinType = bit.band(option, 0xFF)
-        local item = ImperialPieces[coinType].item
-        local price = ImperialPieces[coinType].price
+        local item      = ImperialPieces[coinType].item
+        local price     = ImperialPieces[coinType].price
 
         if player:getCurrency("imperial_standing") < quantity * price then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes check in Imperial piece vendors when no purchuase is made and when rank is 0
Changes how rank is determined, checking for the highest KI only.