### PR TITLE
[Fix] Additional effects lua file not loading on server start.

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -245,6 +245,7 @@ namespace luautils
         lua.script_file("./scripts/globals/battlefield.lua");
         lua.script_file("./scripts/globals/mobs.lua");
         lua.script_file("./scripts/globals/mixins.lua");
+        lua.script_file("./scripts/globals/additional_effects.lua");
 
         // Pet Scripts
         CacheLuaObjectFromFile("./scripts/globals/pets/automaton.lua");


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

The file wasn't loading, making additional effects not work until filewatcher re-loaded it.