### PR TITLE
Fix and re-enable the dropped item logging. 

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -377,7 +377,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                 }
             }
-        }   
+        }
     }
 
     PChar->pushPacket(new CDownloadingDataPacket());
@@ -1169,7 +1169,8 @@ void SmallPacket0x028(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (charutils::UpdateItem(PChar, container, slotID, -quantity) != 0)
         {
-            // ShowNotice(CL_CYAN"Player %s DROPPING itemID %u (quantity: %u)", PChar->GetName(), ItemID, quantity);
+            // Todo: add item NAME to this msg before ID. Problem is it's not a string.
+            ShowNotice("Player %s DROPPING itemID: %u quantity: %u", PChar->GetName(), ItemID, quantity);
             PChar->pushPacket(new CMessageStandardPacket(nullptr, ItemID, quantity, MsgStd::ThrowAway));
             PChar->pushPacket(new CInventoryFinishPacket());
         }
@@ -1763,7 +1764,7 @@ void SmallPacket0x03B(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
-    if (itemStorageLoc != LOC_STORAGE && action == 1) // Only valid for direct equip/unequip 
+    if (itemStorageLoc != LOC_STORAGE && action == 1) // Only valid for direct equip/unequip
     {
         ShowExploit("SmallPacket0x03B: Invalid item location passed to Mannequin Equip packet %u by %s", itemStorageLoc, PChar->GetName());
         return;
@@ -1869,7 +1870,7 @@ void SmallPacket0x03B(map_session_data_t* const PSession, CCharEntity* const PCh
     uint16 feetId  = getModelIdFromStorageSlot(PChar, PMannequin->m_extra[10 + 7]);
     // 10 + 8 = Race
     // 10 + 9 = Pose
- 
+
     // Write out to Mannequin
     char extra[sizeof(PMannequin->m_extra) * 2 + 1];
     Sql_EscapeStringLen(SqlHandle, extra, (const char*)PMannequin->m_extra, sizeof(PMannequin->m_extra));


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

While I was fixing an issue with a customization on my server, I noted this was still using the old `CL_CYAN` tag from before Zach reworked the messages. I have also chosen to un-comment it, as there was really no reason it should be commented out by default while all the other notices like it (even far less useful ones) are not. The entire message type can be filtered out in the map config anyway. This is also the only tracking a server operator currently has available to confirm an item was dropped (for example you've got a player begging to have a valuable thing restored saying the dropped by accident).

The commit also cleans some trailing space that has been left behind by other editors who ~~escaped my wrath~~ _slipped past review._