### PR TITLE
Kupipi will now give proper cs after accepting mission

### DIFF
--- a/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
+++ b/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
@@ -37,6 +37,7 @@ mission.reward =
 local handleAcceptMission = function(player, csid, option, npc)
     if option == 5 then
         mission:begin(player)
+        player:setMissionStatus(mission.areaId, 1)
         player:messageSpecial(zones[player:getZoneID()].text.YOU_ACCEPT_THE_MISSION)
     end
 end
@@ -114,7 +115,7 @@ mission.sections =
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
-                    if missionStatus == 0 then
+                    if missionStatus == 1 and not player:hasKeyItem(xi.ki.LETTER_TO_THE_CONSULS_WINDURST) then
                         return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                     elseif missionStatus == 11 then
                         return mission:progressEvent(101, 0, 0, xi.ki.ADVENTURERS_CERTIFICATE)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Previously, when accepting the mission, you would go to Kupipi and she'd say "I told you to go to the consuls!" rather than giving you the cs with the letter to the consuls.