### PR TITLE
Fix crash issue when onEventFinish lua function failed

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1880,14 +1880,15 @@ namespace luautils
         }
 
         auto func_result = onEventUpdate(CLuaBaseEntity(PChar), eventID, result, extras, optTarget);
+
+        PChar->eventPreparation = previousPrep;
+
         if (!func_result.valid())
         {
             sol::error err = func_result;
             ShowError("luautils::onEventUpdate: %s", err.what());
             return -1;
         }
-
-        PChar->eventPreparation = previousPrep;
 
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
@@ -1914,14 +1915,15 @@ namespace luautils
         }
 
         auto func_result = onEventUpdateFramework(CLuaBaseEntity(PChar), eventID, result, optTarget, onEventUpdate);
+
+        PChar->eventPreparation = previousPrep;
+
         if (!func_result.valid())
         {
             sol::error err = func_result;
             ShowError("luautils::onEventUpdate: %s", err.what());
             return -1;
         }
-
-        PChar->eventPreparation = previousPrep;
 
         return func_result.get_type() == sol::type::number ? func_result.get<int32>() : 1;
     }
@@ -1943,14 +1945,15 @@ namespace luautils
         }
 
         auto result = onEventUpdateFramework(CLuaBaseEntity(PChar), PChar->currentEvent->eventId, updateString, optTarget, onEventUpdate);
+
+        PChar->eventPreparation = previousPrep;
+
         if (!result.valid())
         {
             sol::error err = result;
             ShowError("luautils::onEventUpdate: %s", err.what());
             return -1;
         }
-
-        PChar->eventPreparation = previousPrep;
 
         return 0;
     }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1983,14 +1983,16 @@ namespace luautils
         }
 
         auto func_result = onEventFinishFramework(CLuaBaseEntity(PChar), eventID, result, optTarget, onEventFinish);
+
+        // Restore eventPreparation before potentially bailing out of function due to errors
+        PChar->eventPreparation = previousPrep;
+
         if (!func_result.valid())
         {
             sol::error err = func_result;
             ShowError("luautils::onEventFinish %s", err.what());
             return -1;
         }
-
-        PChar->eventPreparation = previousPrep;
 
         if (PChar->currentEvent->scriptFile.find("/bcnms/") > 0 && PChar->health.hp <= 0)
         { // for some reason the event doesnt enforce death afterwards


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

eventPreparation had the potential to not be restored in onEventFinish should the lua function be invalid.  This moves up that swap before potentially bailing out.

#1210 