### PR TITLE
Apply status effects from triggers before displaying animation

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -763,20 +763,20 @@ function dynamis.procMonster(mob, player)
         if extensions > 2 then
             if player:getSubJob() == xi.job.NONE and math.random(0, 99) == 0 then
                 mob:setLocalVar("dynamis_proc", 4)
-                mob:weaknessTrigger(3)
                 mob:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
+                mob:weaknessTrigger(3)
             elseif extensions == 5 then
                 mob:setLocalVar("dynamis_proc", 3)
-                mob:weaknessTrigger(2)
                 mob:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
+                mob:weaknessTrigger(2)
             elseif extensions == 4 then
                 mob:setLocalVar("dynamis_proc", 2)
-                mob:weaknessTrigger(1)
                 mob:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
+                mob:weaknessTrigger(1)
             elseif extensions == 3 then
                 mob:setLocalVar("dynamis_proc", 1)
-                mob:weaknessTrigger(0)
                 mob:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
+                mob:weaknessTrigger(0)
             end
         end
     end

--- a/scripts/mixins/abyssea_nm.lua
+++ b/scripts/mixins/abyssea_nm.lua
@@ -19,8 +19,8 @@ g_mixins.abyssea_nm = function(abysseaMob)
         if target:canChangeState() then
             if spell:getID() == target:getLocalVar("abyssea_magic_weak") then
                 --TODO: weakness trigger message
-                target:weaknessTrigger(1)
                 target:addStatusEffect(xi.effect.SILENCE, 0, 0, 30)
+                target:weaknessTrigger(1)
                 target:setLocalVar("abyssea_yellow_proc_count", target:getLocalVar("abyssea_yellow_proc_count" + 1))
             else
                 --discernment
@@ -32,13 +32,13 @@ g_mixins.abyssea_nm = function(abysseaMob)
         if target:canChangeState() then
             if wsid == target:getLocalVar("abyssea_ele_ws_weak") then
                 --TODO: weakness trigger message
-                target:weaknessTrigger(2)
                 target:addStatusEffect(xi.effect.TERROR, 0, 0, 30)
+                target:weaknessTrigger(2)
                 target:setLocalVar("abyssea_red_proc_count", target:getLocalVar("abyssea_red_proc_count" + 1))
             elseif wsid == target:getLocalVar("abyssea_phys_ws_weak") then
                 --TODO: weakness trigger message
-                target:weaknessTrigger(0)
                 target:addStatusEffect(xi.effect.AMNESIA, 0, 0, 30)
+                target:weaknessTrigger(0)
                 target:setLocalVar("abyssea_blue_proc_count", target:getLocalVar("abyssea_blue_proc_count" + 1))
             else
                 --discernment (figure out if ws is elemental...)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Applies status effects such as Terror before firing off the mob action for the trigger animation.  This will prevent the mob from turning before being terrorized.  Applied this to other effects as well for consistency, but should not be noticeable.

Fixes #459 