### PR TITLE
Revert "Break out of latent check on null zone"

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -671,12 +671,6 @@ void CLatentEffectContainer::ProcessLatentEffects(const std::function<bool(CLate
 bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
 {
     TracyZoneScoped;
-    // player is logging in/zoning
-    if (m_POwner->loc.zone == nullptr)
-    {
-        return false;
-    }
-
     // Our default case un-finds our latent prevent us from toggling a latent we don't have programmed
     auto expression  = false;
     auto latentFound = true;
@@ -1058,6 +1052,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
             break;
         case LATENT::NATION_CONTROL:
         {
+            // player is logging in/zoning
+            if (m_POwner->loc.zone == nullptr)
+            {
+                break;
+            }
+
             auto region      = m_POwner->loc.zone->GetRegionID();
             auto hasSignet   = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
             auto hasSanction = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
@@ -1080,6 +1080,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         }
         case LATENT::ZONE_HOME_NATION:
         {
+            // player is logging in/zoning
+            if (m_POwner->loc.zone == nullptr)
+            {
+                break;
+            }
+
             auto* PZone  = m_POwner->loc.zone;
             auto  region = static_cast<REGION_TYPE>(latentEffect.GetConditionsValue());
 


### PR DESCRIPTION
This reverts commit 40a91091e4ba784fc84c754e20f788e36ab79442.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Equipment with latent effects lost effect when zoning and needed to be re-equiped for said latent effect to take effect again (if meeting the conditions for said latent, of course)
Easy to test with a character under lvl 31 and a Destrier Beret (Item ID: 11811)

The original fix was meant to fix a crash from when a latent check gets called before a players zone has been set.
So while this fixes latent effects not being loaded it may, or may not, re-introduce a crash.