### PR TITLE
[Mission] Sandoria 4-1 Fix wrong event

### DIFF
--- a/scripts/missions/sandoria/4_1_Magicite.lua
+++ b/scripts/missions/sandoria/4_1_Magicite.lua
@@ -89,7 +89,7 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 0 then
                         local hasKIParam = player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and 1 or 0
-                        return mission:progressEvent(129, hasKIParam)
+                        return mission:progressEvent(130, hasKIParam)
                     end
                 end,
             },
@@ -121,7 +121,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ALDO)
                 end,
 
-                [129] = function(player, csid, option, npc)
+                [130] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 1)
                     npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes a wrong event playing when talking to nation emmisary