### PR TITLE
Avoid locking client when player attempts fishing. Fixes issue #???? that nobody reported to our tracker.

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -36,6 +36,7 @@
 #include "../packets/message_system.h"
 #include "../packets/message_text.h"
 #include "../packets/release.h"
+#include "../packets/chat_message.h"
 
 #include "../map.h"
 #include "../vana_time.h"
@@ -80,6 +81,8 @@ namespace fishingutils
     {
         // NOTE: Fishing is disabled until further notice, since it is a security liability.
         ShowWarning("Fishing is currently disabled");
+        PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Fishing is currently disabled"));
+        PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
         return;
 
         if (PChar->animation != ANIMATION_NONE)
@@ -379,7 +382,10 @@ namespace fishingutils
 
     void FishingAction(CCharEntity* PChar, FISH_ACTION action, uint16 stamina, uint32 special)
     {
-        ShowWarning("Fishing is currently disabled");
+        // NOTE: Fishing is disabled until further notice, since it is a security liability.
+        ShowWarning("Fishing is currently disabled, but somehow we have somone commencing a fishing action");
+        // Unlikely anyone can get here legit, since we already disabled "startFishing"
+        PChar->animation = ANIMATION_FISHING_STOP;
         return;
 
         uint16 MessageOffset = GetMessageOffset(PChar->getZone());


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

In the future if you do not put it on the tracker the bug doesn't exist. And learn to check your logs. It becomes painful obvious to hunt down where that message is, if you look at what the log said.

I've added a message TO THE PLAYER as well in this PR, so that they don't start reporting that fishing "does nothing" over it. Servers can re-enable fishing AT THEIR OWN RISK by just commenting these messages and the return lines out.

Until fishing is overhauled again, there is no fishing on stock base branch.