### PR TITLE
[core] Some additional checks in HandleEnspell

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1101,24 +1101,29 @@ namespace battleutils
 
                 if (PAttacker->objtype == TYPE_PC && PAttacker->PParty != nullptr)
                 {
-                    auto* PLeader = static_cast<CCharEntity*>(PAttacker->PParty->GetLeader());
-                    PLeader->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                    if (auto* PLeader = dynamic_cast<CCharEntity*>(PAttacker->PParty->GetLeader()))
                     {
-                        if (attackerID == PMember->id)
+                        PLeader->ForPartyWithTrusts([&](CBattleEntity* PMember)
                         {
-                            power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
-                        }
-                    });
-
+                            if (attackerID == PMember->id)
+                            {
+                                power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
+                            }
+                        });
+                    }
                 }
-                else if (PAttacker->objtype == TYPE_TRUST && PAttacker->PMaster)
+                else if (PAttacker->objtype == TYPE_TRUST)
                 {
-                    static_cast<CCharEntity*>(PAttacker->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember) {
-                        if (attackerID == PMember->id)
+                    if (auto* PMaster = dynamic_cast<CCharEntity*>(PAttacker->PMaster))
+                    {
+                        PMaster->ForPartyWithTrusts([&](CBattleEntity* PMember)
                         {
-                            power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
-                        }
-                    });
+                            if (attackerID == PMember->id)
+                            {
+                                power = PDefender->StatusEffectContainer->GetStatusEffect(daze)->GetPower();
+                            }
+                        });
+                    }
                 }
                 else if (PAttacker->PMaster == nullptr)
                 {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

General changes from static_cast to  dynamic cast

_Might_ help with https://github.com/LandSandBoat/server/issues/1244

^ I wasn't able to repro though
