### PR TITLE
Adjust packet size to use number of bytes

### DIFF
--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -47,7 +47,7 @@
 CActionPacket::CActionPacket(action_t& action)
 {
     this->setType(0x28);
-    this->setSize(0x12);
+    this->setSize(0x24);
 
     ref<uint32>(0x05) = action.id;
 
@@ -384,7 +384,8 @@ CActionPacket::CActionPacket(action_t& action)
     ref<uint8>(0x09) = targets;
     uint8 WorkSize   = ((bitOffset >> 3) + (bitOffset % 8 != 0));
 
-    this->setSize((((WorkSize + 7) >> 1) + 1) & -2);
+    // TODO: Verify and improve math on this
+    this->setSize(((((WorkSize + 7) >> 1) + 1) & -2) * 2);
 
     ref<uint8>(0x04) = WorkSize;
 }

--- a/src/map/packets/auction_house.cpp
+++ b/src/map/packets/auction_house.cpp
@@ -35,7 +35,7 @@ bool IsAuctionOpen = true; // Trading is allowed at the auction
 CAuctionHousePacket::CAuctionHousePacket(uint8 action)
 {
     this->setType(0x4C);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint8>(0x04) = action;
     ref<uint8>(0x05) = 0xFF;
@@ -50,7 +50,7 @@ CAuctionHousePacket::CAuctionHousePacket(uint8 action)
 CAuctionHousePacket::CAuctionHousePacket(uint8 action, CItem* PItem, uint8 quantity, uint32 price)
 {
     this->setType(0x4C);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     uint32 auctionFee = 0;
     if (quantity == 0) // This is a stack..Yes, zero for stacks.. Why is this being called quantity?
@@ -81,7 +81,7 @@ CAuctionHousePacket::CAuctionHousePacket(uint8 action, CItem* PItem, uint8 quant
 CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 slot, CCharEntity* PChar)
 {
     this->setType(0x4C);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint8>(0x04) = action;
     ref<uint8>(0x05) = slot; // Serial number of the subject
@@ -104,7 +104,7 @@ CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 slot, CCharEntity* 
 CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 message, uint16 itemid, uint32 price)
 {
     this->setType(0x4C);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint8>(0x04)  = action;
     ref<uint8>(0x06)  = message;
@@ -115,7 +115,7 @@ CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 message, uint16 ite
 CAuctionHousePacket::CAuctionHousePacket(uint8 action, uint8 message, CCharEntity* PChar, uint8 slot, bool keepItem)
 {
     this->setType(0x4C);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint8>(0x04) = action;
     ref<uint8>(0x05) = slot;

--- a/src/map/packets/bazaar_check.cpp
+++ b/src/map/packets/bazaar_check.cpp
@@ -30,7 +30,7 @@
 CBazaarCheckPacket::CBazaarCheckPacket(CCharEntity* PChar, BAZAARCHECK type)
 {
     this->setType(0x108);
-    this->setSize(0x11);
+    this->setSize(0x22);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint8>(0x08)  = type;

--- a/src/map/packets/bazaar_close.cpp
+++ b/src/map/packets/bazaar_close.cpp
@@ -29,7 +29,7 @@
 CBazaarClosePacket::CBazaarClosePacket(CCharEntity* PChar)
 {
     this->setType(0x107);
-    this->setSize(0x0B);
+    this->setSize(0x16);
 
     memcpy(data + (0x04), PChar->GetName(), PChar->name.size());
 }

--- a/src/map/packets/bazaar_confirmation.cpp
+++ b/src/map/packets/bazaar_confirmation.cpp
@@ -31,7 +31,7 @@
 CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, uint8 SlotID, uint8 Quantity)
 {
     this->setType(0x109);
-    this->setSize(0x13);
+    this->setSize(0x26);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint8>(0x08)  = Quantity;
@@ -43,7 +43,7 @@ CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, uint8 S
 CBazaarConfirmationPacket::CBazaarConfirmationPacket(CCharEntity* PChar, CItem* PItem)
 {
     this->setType(0x10A);
-    this->setSize(0x11);
+    this->setSize(0x22);
 
     if (PItem)
     {

--- a/src/map/packets/bazaar_item.cpp
+++ b/src/map/packets/bazaar_item.cpp
@@ -32,7 +32,7 @@
 CBazaarItemPacket::CBazaarItemPacket(CItem* PItem, uint8 SlotID, uint16 Tax)
 {
     this->setType(0x105);
-    this->setSize(0x17);
+    this->setSize(0x2E);
 
     ref<uint8>(0x10) = SlotID;
 

--- a/src/map/packets/bazaar_message.cpp
+++ b/src/map/packets/bazaar_message.cpp
@@ -30,7 +30,7 @@
 CBazaarMessagePacket::CBazaarMessagePacket(CCharEntity* PChar)
 {
     this->setType(0xCA);
-    this->setSize(0x4A);
+    this->setSize(0x94);
 
     memcpy(data + 0x04, PChar->bazaar.message.c_str(), (PChar->bazaar.message.size() > 120) ? 120 : PChar->bazaar.message.size());
 

--- a/src/map/packets/bazaar_purchase.cpp
+++ b/src/map/packets/bazaar_purchase.cpp
@@ -30,7 +30,7 @@
 CBazaarPurchasePacket::CBazaarPurchasePacket(CCharEntity* PChar, bool result)
 {
     this->setType(0x106);
-    this->setSize(0x0D);
+    this->setSize(0x1A);
 
     ref<uint8>(0x04) = !result;
 

--- a/src/map/packets/blacklist.cpp
+++ b/src/map/packets/blacklist.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CBlacklistPacket::CBlacklistPacket(uint32 accid, const int8* targetName, int8 action)
 {
     this->setType(0x42);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     switch (action)
     {

--- a/src/map/packets/campaign_map.cpp
+++ b/src/map/packets/campaign_map.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -48,7 +48,7 @@ uint8 packet1[] = { 0x02, 0x01, 0xC4, 0x00, 0x01, 0x0D, 0x00, 0x00, 0x00, 0x00, 
 CCampaignPacket::CCampaignPacket(CCharEntity* PChar, uint8 number)
 {
     this->setType(0x71);
-    this->setSize(0x66);
+    this->setSize(0xCC);
 
     switch (number)
     {

--- a/src/map/packets/change_music.cpp
+++ b/src/map/packets/change_music.cpp
@@ -33,7 +33,7 @@ CChangeMusicPacket::CChangeMusicPacket(uint8 BlockID, uint8 MusicTrackID)
     // 4 Chocobo/Mount Music
 
     this->setType(0x5F);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = BlockID;      // block
     ref<uint8>(0x06) = MusicTrackID; // music

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -32,7 +32,7 @@
 CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask)
 {
     this->setType(0x0D);
-    this->setSize(0x3A);
+    this->setSize(0x74);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;

--- a/src/map/packets/char_abilities.cpp
+++ b/src/map/packets/char_abilities.cpp
@@ -30,7 +30,7 @@
 CCharAbilitiesPacket::CCharAbilitiesPacket(CCharEntity* PChar)
 {
     this->setType(0xAC);
-    this->setSize(0x72);
+    this->setSize(0xE4);
 
     memcpy(data + (0x04), PChar->m_WeaponSkills, 32);
     memcpy(data + (0x44), PChar->m_Abilities, 62);

--- a/src/map/packets/char_appearance.cpp
+++ b/src/map/packets/char_appearance.cpp
@@ -27,7 +27,7 @@
 CCharAppearancePacket::CCharAppearancePacket(CCharEntity* PChar)
 {
     this->setType(0x51);
-    this->setSize(0x0C);
+    this->setSize(0x18);
 
     look_t* look      = (PChar->getStyleLocked() ? &PChar->mainlook : &PChar->look);
     ref<uint8>(0x04)  = look->face;

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -33,7 +33,7 @@
 CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 {
     this->setType(0xC9);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     ref<uint32>(0x04) = PTarget->id;
     ref<uint16>(0x08) = PTarget->targid;
@@ -48,7 +48,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 
         if (PItem != nullptr)
         {
-            auto size = this->getSize();
+            auto size = this->getSize() / 2; // TODO: Verify this, size used to use the old two-byte value
             ref<uint16>(size * 2 + 0x00) = PItem->getID();
             ref<uint8>(size * 2 + 0x02)  = i;
 
@@ -77,7 +77,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 
             memcpy(data + (size * 2 + 0x10), PItem->getSignature(), std::clamp<size_t>(strlen((const char*)PItem->getSignature()), 0, 12));
 
-            this->setSize(size + 0x0E);
+            this->setSize(size * 2 + 0x1C);
             count++;
 
             if (count == 8)
@@ -86,7 +86,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 
                 PChar->pushPacket(new CBasicPacket(*this));
 
-                this->setSize(0x06);
+                this->setSize(0x0C);
                 memset(data + (0x0B), 0, PACKET_SIZE - 11);
             }
         }
@@ -94,7 +94,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
 
     if (count == 0)
     {
-        this->setSize(0x14);
+        this->setSize(0x28);
         PChar->pushPacket(new CBasicPacket(*this));
     }
     else if (count != 8)
@@ -103,7 +103,7 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
         PChar->pushPacket(new CBasicPacket(*this));
     }
 
-    this->setSize(0x2A);
+    this->setSize(0x54);
     memset(data + (0x0B), 0, PACKET_SIZE - 11);
 
     ref<uint8>(0x0A) = 0x01;

--- a/src/map/packets/char_emotion.cpp
+++ b/src/map/packets/char_emotion.cpp
@@ -27,7 +27,7 @@
 CCharEmotionPacket::CCharEmotionPacket(CCharEntity* PChar, uint32 TargetID, uint16 TargetIndex, Emote EmoteID, EmoteMode emoteMode, uint16 extra)
 {
     this->setType(0x5A);
-    this->setSize(56);
+    this->setSize(0x70);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint32>(0x08) = TargetID;

--- a/src/map/packets/char_equip.cpp
+++ b/src/map/packets/char_equip.cpp
@@ -26,7 +26,7 @@
 CEquipPacket::CEquipPacket(uint8 EquipSlot, uint8 SlotID, uint8 containerID)
 {
     this->setType(0x50);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = EquipSlot;
     ref<uint8>(0x05) = SlotID;

--- a/src/map/packets/char_health.cpp
+++ b/src/map/packets/char_health.cpp
@@ -29,7 +29,7 @@
 CCharHealthPacket::CCharHealthPacket(CCharEntity* PChar)
 {
     this->setType(0xDF);
-    this->setSize(0x14);
+    this->setSize(0x28);
 
     ref<uint32>(0x04) = PChar->id;
 
@@ -56,7 +56,7 @@ CCharHealthPacket::CCharHealthPacket(CCharEntity* PChar)
 CCharHealthPacket::CCharHealthPacket(CTrustEntity* PTrust)
 {
     this->setType(0xDF);
-    this->setSize(0x12);
+    this->setSize(0x24);
 
     ref<uint32>(0x04) = PTrust->id;
 

--- a/src/map/packets/char_job_extra.cpp
+++ b/src/map/packets/char_job_extra.cpp
@@ -33,7 +33,7 @@
 CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
 {
     this->setType(0x44);
-    this->setSize(0x50);
+    this->setSize(0xA0);
 
     JOBTYPE job = JOB_NON;
 

--- a/src/map/packets/char_jobs.cpp
+++ b/src/map/packets/char_jobs.cpp
@@ -29,7 +29,7 @@
 CCharJobsPacket::CCharJobsPacket(CCharEntity* PChar)
 {
     this->setType(0x1B);
-    this->setSize(0x34);
+    this->setSize(0x68);
 
     ref<uint8>(0x04) = PChar->look.race;
 

--- a/src/map/packets/char_mounts.cpp
+++ b/src/map/packets/char_mounts.cpp
@@ -30,7 +30,7 @@
 CCharMountsPacket::CCharMountsPacket(CCharEntity* PChar)
 {
     this->setType(0xAE);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     memcpy(data + (0x04), &(PChar->keys.tables[6].keyList), 0x0C);
 }

--- a/src/map/packets/char_recast.cpp
+++ b/src/map/packets/char_recast.cpp
@@ -32,7 +32,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CCharRecastPacket::CCharRecastPacket(CCharEntity* PChar)
 {
     this->setType(0x119);
-    this->setSize(0x83);
+    this->setSize(0x104);
 
     uint8 count = 0;
 

--- a/src/map/packets/char_skills.cpp
+++ b/src/map/packets/char_skills.cpp
@@ -31,7 +31,7 @@
 CCharSkillsPacket::CCharSkillsPacket(CCharEntity* PChar)
 {
     this->setType(0x62);
-    this->setSize(0x80);
+    this->setSize(0x100);
 
     memcpy(data + (0x80), &PChar->WorkingSkills, 128);
 

--- a/src/map/packets/char_spells.cpp
+++ b/src/map/packets/char_spells.cpp
@@ -30,7 +30,7 @@
 CCharSpellsPacket::CCharSpellsPacket(CCharEntity* PChar)
 {
     this->setType(0xAA);
-    this->setSize(0x42);
+    this->setSize(0x84);
 
     ref<std::bitset<1024>>(0x04) = PChar->m_SpellList;
 }

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -33,7 +33,7 @@
 CCharStatsPacket::CCharStatsPacket(CCharEntity* PChar)
 {
     this->setType(0x61);
-    this->setSize(0x70);
+    this->setSize(0xE0);
 
     ref<uint32>(0x04) = PChar->GetMaxHP();
     ref<uint32>(0x08) = PChar->GetMaxMP();

--- a/src/map/packets/char_sync.cpp
+++ b/src/map/packets/char_sync.cpp
@@ -29,7 +29,7 @@
 CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
 {
     this->setType(0x67);
-    this->setSize(0x14);
+    this->setSize(0x28);
 
     ref<uint8>(0x04)  = 0x02;
     ref<uint8>(0x05)  = 0x09;

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -36,7 +36,7 @@
 CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
 {
     this->setType(0x37);
-    this->setSize(0x30);
+    this->setSize(0x60);
 
     memcpy(data + (0x04), PChar->StatusEffectContainer->m_StatusIcons, 32);
 

--- a/src/map/packets/chat_message.cpp
+++ b/src/map/packets/chat_message.cpp
@@ -40,7 +40,7 @@ CChatMessagePacket::CChatMessagePacket(CCharEntity* PChar, CHAT_MESSAGE_TYPE Mes
 
     // 12 (base length / 2) + ((buffSize in chunks of 4) / 2)
     // this->size = 12 + ((buffSize / 4) + 1) * 2;
-    this->setSize(0x82);
+    this->setSize(0x104);
 
     ref<uint8>(0x04) = MessageType;
 

--- a/src/map/packets/chocobo_digging.cpp
+++ b/src/map/packets/chocobo_digging.cpp
@@ -28,7 +28,7 @@
 CChocoboDiggingPacket::CChocoboDiggingPacket(CCharEntity* PChar)
 {
     this->setType(0x2F);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;

--- a/src/map/packets/conquest_map.cpp
+++ b/src/map/packets/conquest_map.cpp
@@ -33,7 +33,7 @@
 CConquestPacket::CConquestPacket(CCharEntity* PChar)
 {
     this->setType(0x5E);
-    this->setSize(0x5A);
+    this->setSize(0xB4);
 
     const char* Query = "SELECT region_id, region_control, region_control_prev, \
                          sandoria_influence, bastok_influence, windurst_influence, \

--- a/src/map/packets/cs_position.cpp
+++ b/src/map/packets/cs_position.cpp
@@ -28,7 +28,7 @@
 CCSPositionPacket::CCSPositionPacket(CCharEntity* PChar)
 {
     this->setType(0x65);
-    this->setSize(0x10);
+    this->setSize(0x20);
 
     ref<float>(0x04) = PChar->loc.p.x;
     ref<float>(0x08) = PChar->loc.p.y;

--- a/src/map/packets/delivery_box.cpp
+++ b/src/map/packets/delivery_box.cpp
@@ -30,7 +30,7 @@
 CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, uint8 count, uint8 param)
 {
     this->setType(0x4B);
-    this->setSize(0x0A);
+    this->setSize(0x14);
 
     memset(data + 4, 0xFF, 12);
 
@@ -58,7 +58,7 @@ CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, uint8 count, u
 CDeliveryBoxPacket::CDeliveryBoxPacket(uint8 action, uint8 boxid, CItem* PItem, uint8 slotid, uint8 count, uint8 message)
 {
     this->setType(0x4B);
-    this->setSize(0x2C);
+    this->setSize(0x58);
 
     memset(data + 4, 0xFF, 12);
 

--- a/src/map/packets/downloading_data.cpp
+++ b/src/map/packets/downloading_data.cpp
@@ -24,5 +24,5 @@
 CDownloadingDataPacket::CDownloadingDataPacket()
 {
     this->setType(0x4F);
-    this->setSize(0x04);
+    this->setSize(0x08);
 }

--- a/src/map/packets/entity_animation.cpp
+++ b/src/map/packets/entity_animation.cpp
@@ -30,7 +30,7 @@ const char* CEntityAnimationPacket::Fade_Out = "kesu";
 CEntityAnimationPacket::CEntityAnimationPacket(CBaseEntity* PEntity, const char type[4])
 {
     this->setType(0x38);
-    this->setSize(0x0A);
+    this->setSize(0x14);
 
     ref<uint32>(0x04) = PEntity->id;
     ref<uint32>(0x08) = PEntity->id;

--- a/src/map/packets/entity_enable_list.cpp
+++ b/src/map/packets/entity_enable_list.cpp
@@ -7,7 +7,7 @@
 CEntityEnableList::CEntityEnableList(const std::vector<uint32>& list)
 {
     this->setType(0x77);
-    this->setSize(0x88);
+    this->setSize(0x110); // TODO: Verify
 
     ref<uint32>(0x04) = 1;
 

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -36,7 +36,7 @@
 CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask)
 {
     this->setType(0x0E);
-    this->setSize(0x2C);
+    this->setSize(0x58);
 
     ref<uint32>(0x04) = PEntity->id;
     ref<uint16>(0x08) = PEntity->targid;
@@ -146,7 +146,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             if (updatemask & UPDATE_NAME)
             {
                 // depending on size of name, this can be 0x20, 0x22, or 0x24
-                this->setSize(0x24);
+                this->setSize(0x48);
                 if (PMob->packetName.empty())
                 {
                     memcpy(data + (0x34), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
@@ -187,7 +187,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         case MODEL_EQUIPED:
         case MODEL_CHOCOBO:
         {
-            this->setSize(0x24);
+            this->setSize(0x48);
 
             memcpy(data + (0x30), &(PEntity->look), 20);
         }
@@ -196,7 +196,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         case MODEL_ELEVATOR:
         case MODEL_SHIP:
         {
-            this->setSize(0x24);
+            this->setSize(0x48);
 
             ref<uint16>(0x30) = PEntity->look.size;
             memcpy(data + (0x34), PEntity->GetName(), (PEntity->name.size() > 12 ? 12 : PEntity->name.size()));

--- a/src/map/packets/entity_visual.cpp
+++ b/src/map/packets/entity_visual.cpp
@@ -28,7 +28,7 @@
 CEntityVisualPacket::CEntityVisualPacket(CBaseEntity* PEntity, const char type[4])
 {
     this->setType(0x39);
-    this->setSize(0x0A);
+    this->setSize(0x14);
 
     if (PEntity)
     {

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -29,7 +29,7 @@
 CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
 {
     this->setType(0x32);
-    this->setSize(0x0A);
+    this->setSize(0x14);
 
     uint32 npcID = 0;
     auto*  PNpc  = eventInfo->targetEntity;
@@ -48,7 +48,7 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
     if (eventInfo->params.size() > 0 || eventInfo->textTable != -1)
     {
         this->setType(0x34);
-        this->setSize(0x1A);
+        this->setSize(0x34);
 
         for (auto paramPair : eventInfo->params)
         {

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -29,7 +29,7 @@
 CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
 {
     this->setType(0x33);
-    this->setSize(0x38);
+    this->setSize(0x70);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->m_TargID;

--- a/src/map/packets/event_update.cpp
+++ b/src/map/packets/event_update.cpp
@@ -27,7 +27,7 @@
 CEventUpdatePacket::CEventUpdatePacket(std::vector<std::pair<uint8, uint32>> params)
 {
     this->setType(0x5C);
-    this->setSize(0x12);
+    this->setSize(0x24);
 
     for (auto paramPair : params)
     {

--- a/src/map/packets/event_update_string.cpp
+++ b/src/map/packets/event_update_string.cpp
@@ -31,7 +31,7 @@ CEventUpdateStringPacket::CEventUpdateStringPacket(const std::string& string0, c
                                                    uint32 param5, uint32 param6, uint32 param7, uint32 param8)
 {
     this->setType(0x5D);
-    this->setSize(0x2C);
+    this->setSize(0x58);
 
     ref<uint32>(0x04) = param0;
     ref<uint32>(0x08) = param1;

--- a/src/map/packets/fishing.cpp
+++ b/src/map/packets/fishing.cpp
@@ -55,7 +55,7 @@ CFishingPacket::CFishingPacket(uint16 stamina, uint16 regen, uint16 response, ui
                                uint32 special)
 {
     this->setType(0x115);
-    this->setSize(0x0D);
+    this->setSize(0x1A);
 
     ref<uint16>(0x04) = stamina;    // fish HP, generally in thousands - (100 + x)(floor(fishLvl / 2) + 18)
     ref<uint16>(0x06) = arrowDelay; // how long you have to hit the arrows, generally low 10s, max 15? Increased by 2 by Penguin Ring

--- a/src/map/packets/furniture_interact.cpp
+++ b/src/map/packets/furniture_interact.cpp
@@ -31,7 +31,7 @@
 CFurnitureInteractPacket::CFurnitureInteractPacket(CItem* PItem, uint8 LocationID, uint8 SlotID)
 {
     this->setType(0xFA);
-    this->setSize(0x16);
+    this->setSize(0x2C);
 
     ref<uint32>(0x04) = PItem->getID();
 

--- a/src/map/packets/guild_menu.cpp
+++ b/src/map/packets/guild_menu.cpp
@@ -27,7 +27,7 @@
 CGuildMenuPacket::CGuildMenuPacket(GUILDSTATUS status, uint8 open, uint8 close, uint8 holiday)
 {
     this->setType(0x86);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     // XI_DEBUG_BREAK_IF(open > close);
 

--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -33,7 +33,7 @@
 CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGuild)
 {
     this->setType(0x83);
-    this->setSize(0x7C);
+    this->setSize(0xF8);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
     XI_DEBUG_BREAK_IF(PGuild == nullptr);

--- a/src/map/packets/guild_menu_buy_update.cpp
+++ b/src/map/packets/guild_menu_buy_update.cpp
@@ -33,7 +33,7 @@
 CGuildMenuBuyUpdatePacket::CGuildMenuBuyUpdatePacket(CCharEntity* PChar, uint8 stock, uint16 itemID, uint8 quantity)
 {
     this->setType(0x82);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 

--- a/src/map/packets/guild_menu_sell.cpp
+++ b/src/map/packets/guild_menu_sell.cpp
@@ -33,7 +33,7 @@
 CGuildMenuSellPacket::CGuildMenuSellPacket(CCharEntity* PChar, CItemContainer* PGuild)
 {
     this->setType(0x85);
-    this->setSize(0x7C);
+    this->setSize(0xF8);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
     XI_DEBUG_BREAK_IF(PGuild == nullptr);

--- a/src/map/packets/guild_menu_sell_update.cpp
+++ b/src/map/packets/guild_menu_sell_update.cpp
@@ -33,7 +33,7 @@
 CGuildMenuSellUpdatePacket::CGuildMenuSellUpdatePacket(CCharEntity* PChar, uint8 stock, uint16 itemID, uint8 quantity)
 {
     this->setType(0x84);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 

--- a/src/map/packets/independent_animation.cpp
+++ b/src/map/packets/independent_animation.cpp
@@ -7,7 +7,7 @@
 CIndependentAnimationPacket::CIndependentAnimationPacket(CBaseEntity* PEntity, CBaseEntity* PTarget, uint16 animId, uint8 type)
 {
     this->setType(0x3A);
-    this->setSize(0x14);
+    this->setSize(0x28);
 
     if (PEntity)
     {

--- a/src/map/packets/instance_entry.cpp
+++ b/src/map/packets/instance_entry.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CInstanceEntryPacket::CInstanceEntryPacket(CBaseEntity* PEntrance, uint32 response)
 {
     this->setType(0xBF);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint8>(0x06)  = response;
     ref<uint16>(0x0C) = PEntrance->targid;

--- a/src/map/packets/inventory_assign.cpp
+++ b/src/map/packets/inventory_assign.cpp
@@ -28,7 +28,7 @@
 CInventoryAssignPacket::CInventoryAssignPacket(CItem* PItem, uint8 Flag)
 {
     this->setType(0x1F);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = PItem->getQuantity();
     ref<uint16>(0x08) = PItem->getID();

--- a/src/map/packets/inventory_count.cpp
+++ b/src/map/packets/inventory_count.cpp
@@ -24,7 +24,7 @@
 CInventoryCountPacket::CInventoryCountPacket(uint8 locationId, uint8 slotId)
 {
     this->setType(0x26); // this->type = 0x026; // TODO
-    this->setSize(0x1C);
+    this->setSize(0x38);
 
     ref<uint8>(0x04) = locationId;
     ref<uint8>(0x05) = slotId;
@@ -34,7 +34,7 @@ CInventoryCountPacket::CInventoryCountPacket(uint8 locationId, uint8 slotId)
 CInventoryCountPacket::CInventoryCountPacket(uint8 locationId, uint8 slotId, uint16 headId, uint16 bodyId, uint16 handsId, uint16 legId, uint16 feetId, uint16 mainId, uint16 subId, uint16 rangeId)
 {
     this->setType(0x26);
-    this->setSize(0x1C);
+    this->setSize(0x38);
 
     ref<uint8>(0x04) = 0x01;
     ref<uint8>(0x05) = locationId;

--- a/src/map/packets/inventory_finish.cpp
+++ b/src/map/packets/inventory_finish.cpp
@@ -26,7 +26,7 @@
 CInventoryFinishPacket::CInventoryFinishPacket()
 {
     this->setType(0x1D);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = 1;
 }

--- a/src/map/packets/inventory_item.cpp
+++ b/src/map/packets/inventory_item.cpp
@@ -32,7 +32,7 @@
 CInventoryItemPacket::CInventoryItemPacket(CItem* PItem, uint8 LocationID, uint8 SlotID)
 {
     this->setType(0x20);
-    this->setSize(0x16);
+    this->setSize(0x2C);
 
     ref<uint8>(0x0E) = LocationID;
     ref<uint8>(0x0F) = SlotID;

--- a/src/map/packets/inventory_modify.cpp
+++ b/src/map/packets/inventory_modify.cpp
@@ -26,7 +26,7 @@
 CInventoryModifyPacket::CInventoryModifyPacket(uint8 LocationID, uint8 slotID, uint32 quantity)
 {
     this->setType(0x1E);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = quantity;
     ref<uint8>(0x08)  = LocationID;

--- a/src/map/packets/inventory_size.cpp
+++ b/src/map/packets/inventory_size.cpp
@@ -36,7 +36,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CInventorySizePacket::CInventorySizePacket(CCharEntity* PChar)
 {
     this->setType(0x1C);
-    this->setSize(0x1A);
+    this->setSize(0x34);
 
     ref<uint8>(0x04) = 1 + PChar->getStorage(LOC_INVENTORY)->GetSize();
     ref<uint8>(0x05) = 1 + PChar->getStorage(LOC_MOGSAFE)->GetSize();

--- a/src/map/packets/jobpoint_details.cpp
+++ b/src/map/packets/jobpoint_details.cpp
@@ -24,7 +24,7 @@
 CJobPointDetailsPacket::CJobPointDetailsPacket(CCharEntity* PChar)
 {
     this->setType(0x8D);
-    this->setSize(0x82);
+    this->setSize(0x104);
 
     JobPoints_t* PJobPoints = PChar->PJobPoints->GetAllJobPoints();
 

--- a/src/map/packets/jobpoint_update.cpp
+++ b/src/map/packets/jobpoint_update.cpp
@@ -24,7 +24,7 @@
 CJobPointUpdatePacket::CJobPointUpdatePacket(CCharEntity* PChar, JOBPOINT_TYPE jpType)
 {
     this->setType(0x8D);
-    this->setSize(0x82);
+    this->setSize(0x104);
 
     JobPointType_t* PJobPoint = PChar->PJobPoints->GetJobPointType(jpType);
 

--- a/src/map/packets/key_items.cpp
+++ b/src/map/packets/key_items.cpp
@@ -29,7 +29,7 @@
 CKeyItemsPacket::CKeyItemsPacket(CCharEntity* PChar, KEYS_TABLE KeyTable)
 {
     this->setType(0x55);
-    this->setSize(0x44);
+    this->setSize(0x88);
 
     XI_DEBUG_BREAK_IF(KeyTable >= MAX_KEYS_TABLE);
 

--- a/src/map/packets/linkshell_equip.cpp
+++ b/src/map/packets/linkshell_equip.cpp
@@ -29,7 +29,7 @@
 CLinkshellEquipPacket::CLinkshellEquipPacket(CCharEntity* PChar, uint8 number)
 {
     this->setType(0xE0);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = number;
     if (number == 1)

--- a/src/map/packets/linkshell_message.cpp
+++ b/src/map/packets/linkshell_message.cpp
@@ -28,7 +28,7 @@
 CLinkshellMessagePacket::CLinkshellMessagePacket(const int8* poster, const int8* message, const int8* lsname, uint32 posttime, bool ls1)
 {
     this->setType(id);
-    this->setSize(0x58);
+    this->setSize(0xB0);
 
     ref<uint8>(0x04) = 0x03;
     ref<uint8>(0x05) = 0x90;

--- a/src/map/packets/lock_on.cpp
+++ b/src/map/packets/lock_on.cpp
@@ -29,7 +29,7 @@
 CLockOnPacket::CLockOnPacket(CCharEntity* PChar, CBattleEntity* PTarget)
 {
     this->setType(0x58);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x0C) = PChar->targid;

--- a/src/map/packets/macroequipset.cpp
+++ b/src/map/packets/macroequipset.cpp
@@ -34,7 +34,7 @@ CAddtoEquipSet::CAddtoEquipSet(uint8* orig)
     // Should Push 0x116 (size 68) in responce
     // 0x04 is start, contains 16 4 byte parts repersently each slot in order
     this->setType(0x16); // TODO
-    this->setSize(0x23);
+    this->setSize(0x46);
 
     uint8 slotID = ::ref<uint8>(orig, 0x04);
     for (int i = 0; i < 0x10; i++)

--- a/src/map/packets/menu_config.cpp
+++ b/src/map/packets/menu_config.cpp
@@ -28,7 +28,7 @@
 CMenuConfigPacket::CMenuConfigPacket(CCharEntity* PChar)
 {
     this->setType(0xB4);
-    this->setSize(0x0C);
+    this->setSize(0x18);
 
     // Invite, Online/Away, and Anon are handled in the first byte.
     // Due to the way invites are cleared from nameflags when and handled in

--- a/src/map/packets/menu_merit.cpp
+++ b/src/map/packets/menu_merit.cpp
@@ -29,7 +29,7 @@
 CMenuMeritPacket::CMenuMeritPacket(CCharEntity* PChar)
 {
     this->setType(0x63);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint8>(0x04) = 0x02;
     ref<uint8>(0x06) = 0x0C;
@@ -59,7 +59,7 @@ CMenuMeritPacket::CMenuMeritPacket(CCharEntity* PChar)
     // Update Type 3 : Monstrosity 1 (Possible to move these packets out of here?)
     // --------------------------------------------
 
-    this->setSize(0x6E);
+    this->setSize(0xDC);
 
     memset(data + 4, 0, sizeof(PACKET_SIZE - 4));
 
@@ -75,7 +75,7 @@ CMenuMeritPacket::CMenuMeritPacket(CCharEntity* PChar)
     // Update Type 4 : Monstrosity 2
     // --------------------------------------------
 
-    this->setSize(0x5A);
+    this->setSize(0xB4);
 
     memset(data + 4, 0, sizeof(PACKET_SIZE - 4));
 

--- a/src/map/packets/menu_mog.cpp
+++ b/src/map/packets/menu_mog.cpp
@@ -26,5 +26,5 @@
 CMenuMogPacket::CMenuMogPacket()
 {
     this->setType(0x2E);
-    this->setSize(0x02);
+    this->setSize(0x04);
 }

--- a/src/map/packets/menu_raisetractor.cpp
+++ b/src/map/packets/menu_raisetractor.cpp
@@ -27,7 +27,7 @@
 CRaiseTractorMenuPacket::CRaiseTractorMenuPacket(CCharEntity* PChar, REVIVAL_TYPE type)
 {
     this->setType(0xF9);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;

--- a/src/map/packets/merit_points_categories.cpp
+++ b/src/map/packets/merit_points_categories.cpp
@@ -58,7 +58,7 @@ struct
 CMeritPointsCategoriesPacket::CMeritPointsCategoriesPacket(CCharEntity* PChar)
 {
     this->setType(0x8C);
-    this->setSize(0x80);
+    this->setSize(0x100);
 
     ref<uint8>(0x04) = MAX_MERITS_IN_PACKET;
 
@@ -80,7 +80,7 @@ CMeritPointsCategoriesPacket::CMeritPointsCategoriesPacket(CCharEntity* PChar)
 CMeritPointsCategoriesPacket::CMeritPointsCategoriesPacket(CCharEntity* PChar, MERIT_TYPE merit)
 {
     this->setType(0x8C);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint8>(0x04)  = 1;
     ref<uint32>(0x08) = PChar->PMeritPoints->GetMerit(merit)->data;

--- a/src/map/packets/message_basic.cpp
+++ b/src/map/packets/message_basic.cpp
@@ -28,7 +28,7 @@
 CMessageBasicPacket::CMessageBasicPacket(CBaseEntity* PSender, CBaseEntity* PTarget, int32 param, int32 value, uint16 messageID)
 {
     this->setType(0x29);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint32>(0x04) = PSender->id;
     ref<uint32>(0x08) = PTarget->id;

--- a/src/map/packets/message_combat.cpp
+++ b/src/map/packets/message_combat.cpp
@@ -27,8 +27,8 @@
 
 CMessageCombatPacket::CMessageCombatPacket(CBaseEntity* PSender, CBaseEntity* PTarget, int32 param0, int32 param1, uint16 messageID)
 {
-    this->setType(0x2d);
-    this->setSize(0x0e);
+    this->setType(0x2D);
+    this->setSize(0x1C);
 
     ref<uint32>(0x04) = PSender->id;
     ref<uint32>(0x08) = PTarget->id;

--- a/src/map/packets/message_special.cpp
+++ b/src/map/packets/message_special.cpp
@@ -31,7 +31,7 @@
 CMessageSpecialPacket::CMessageSpecialPacket(CBaseEntity* PEntity, uint16 messageID, uint32 param0, uint32 param1, uint32 param2, uint32 param3, bool ShowName)
 {
     this->setType(0x2A);
-    this->setSize(0x10);
+    this->setSize(0x20);
 
     // XI_DEBUG_BREAK_IF(PEntity == nullptr);
 
@@ -46,7 +46,7 @@ CMessageSpecialPacket::CMessageSpecialPacket(CBaseEntity* PEntity, uint16 messag
 
     if (ShowName)
     {
-        this->setSize(0x18);
+        this->setSize(0x30);
         memcpy(data + (0x1E), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
     }
     else if (PEntity->objtype == TYPE_PC)

--- a/src/map/packets/message_standard.cpp
+++ b/src/map/packets/message_standard.cpp
@@ -30,7 +30,7 @@
 CMessageStandardPacket::CMessageStandardPacket(MsgStd MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 }
@@ -38,7 +38,7 @@ CMessageStandardPacket::CMessageStandardPacket(MsgStd MessageID)
 CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint16 MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint16>(0x0A) = MessageID;
 
@@ -48,7 +48,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint16 MessageID)
 CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uint16 MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x24);
+    this->setSize(0x48);
 
     ref<uint16>(0x0A) = MessageID;
 
@@ -58,7 +58,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0, uint32 param1, MsgStd MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x12);
+    this->setSize(0x24);
 
     ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 
@@ -69,7 +69,7 @@ CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0
 
         if (MessageID == MsgStd::Examine)
         {
-            this->setSize(0x30);
+            this->setSize(0x60);
 
             ref<uint8>(0x0C) = 0x10;
 
@@ -85,7 +85,7 @@ CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0
 CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uint32 param2, uint32 param3, MsgStd MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint16>(0x0A) = static_cast<uint16>(MessageID);
 
@@ -98,7 +98,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0, MsgStd MessageID)
 {
     this->setType(0x09);
-    this->setSize(0x18);
+    this->setSize(0x30);
 
     // XI_DEBUG_BREAK_IF(MessageID != 0x58);
 

--- a/src/map/packets/message_system.cpp
+++ b/src/map/packets/message_system.cpp
@@ -26,7 +26,7 @@
 CMessageSystemPacket::CMessageSystemPacket(uint32 param0, uint32 param1, uint16 messageID)
 {
     this->setType(0x53);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = param0;
     ref<uint32>(0x08) = param1;

--- a/src/map/packets/message_text.cpp
+++ b/src/map/packets/message_text.cpp
@@ -27,7 +27,7 @@
 CMessageTextPacket::CMessageTextPacket(CBaseEntity* PEntity, uint16 messageID, bool showName, uint8 mode)
 {
     this->setType(0x36);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     // если в качестве объекта передается персонаж,
     // то не будем отображать имя

--- a/src/map/packets/party_define.cpp
+++ b/src/map/packets/party_define.cpp
@@ -34,7 +34,7 @@ const char* msg = "SELECT chars.charid, partyflag, pos_zone, pos_prevzone FROM a
 CPartyDefinePacket::CPartyDefinePacket(CParty* PParty, bool loadTrust)
 {
     this->setType(0xC8);
-    this->setSize(0x7C);
+    this->setSize(0xF8);
 
     if (PParty)
     {

--- a/src/map/packets/party_effects.cpp
+++ b/src/map/packets/party_effects.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CPartyEffectsPacket::CPartyEffectsPacket()
 {
     this->setType(0x76);
-    this->setSize(0x7A);
+    this->setSize(0xF4);
 }
 
 void CPartyEffectsPacket::AddMemberEffects(CBattleEntity* PMember)

--- a/src/map/packets/party_invite.cpp
+++ b/src/map/packets/party_invite.cpp
@@ -30,7 +30,7 @@
 CPartyInvitePacket::CPartyInvitePacket(uint32 id, uint16 targid, CCharEntity* PInviter, INVITETYPE InviteType)
 {
     this->setType(0xDC);
-    this->setSize(0x10);
+    this->setSize(0x20);
 
     // XI_DEBUG_BREAK_IF(PInviter->name.size() > 15);
 

--- a/src/map/packets/party_map.cpp
+++ b/src/map/packets/party_map.cpp
@@ -28,7 +28,7 @@
 CPartyMapPacket::CPartyMapPacket(CCharEntity* PChar)
 {
     this->setType(0xA0);
-    this->setSize(0x0C);
+    this->setSize(0x18);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 

--- a/src/map/packets/party_member_update.cpp
+++ b/src/map/packets/party_member_update.cpp
@@ -38,7 +38,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
     // 1. Trusts would not appear in the party list
     // 2. Players in a party would always appear as out of zone
     // Modify with caution for the below functions!
-    this->setSize(0x20);
+    this->setSize(0x40);
 
     XI_DEBUG_BREAK_IF(PChar == nullptr);
 
@@ -75,7 +75,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 MemberNumber)
 {
     this->setType(0xDD);
-    this->setSize(0x20);
+    this->setSize(0x40);
 
     XI_DEBUG_BREAK_IF(PTrust == nullptr);
 
@@ -101,7 +101,7 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 M
 CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(uint32 id, const int8* name, uint16 memberFlags, uint8 MemberNumber, uint16 ZoneID)
 {
     this->setType(0xDD);
-    this->setSize(0x20);
+    this->setSize(0x40);
 
     ref<uint32>(0x04) = id;
 

--- a/src/map/packets/party_search.cpp
+++ b/src/map/packets/party_search.cpp
@@ -29,7 +29,7 @@
 CPartySearchPacket::CPartySearchPacket(CCharEntity* PChar)
 {
     this->setType(0xE1);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     if (PChar->PParty != nullptr)
     {

--- a/src/map/packets/pet_sync.cpp
+++ b/src/map/packets/pet_sync.cpp
@@ -35,7 +35,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
 {
     this->setType(0x68);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint8>(0x04) |= 0x04;                    // Message Type
     packBitsBE(data + (0x04), (0x18), 0, 6, 10); // Message Size (0 for Despawn)
@@ -44,7 +44,7 @@ CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
 
     if (PChar->PPet != nullptr)
     {
-        this->setSize(0x16);
+        this->setSize(0x2C);
         packBitsBE(data + (0x04), (0x18) + PChar->PPet->name.size(), 0, 6, 10); // Message Size
         ref<uint16>(0x0C) = PChar->PPet->targid;
         ref<uint8>(0x0E)  = PChar->PPet->GetHPP();

--- a/src/map/packets/position.cpp
+++ b/src/map/packets/position.cpp
@@ -27,7 +27,7 @@
 CPositionPacket::CPositionPacket(CBaseEntity* PEntity)
 {
     this->setType(0x5B);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<float>(0x04) = PEntity->loc.p.x;
     ref<float>(0x08) = PEntity->loc.p.y;

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -29,7 +29,7 @@
 CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity* PChar, uint8 logID, LOG_TYPE logType)
 {
     this->setType(0x56);
-    this->setSize(0x14);
+    this->setSize(0x28);
 
     uint16 packetType = 0x00;
 

--- a/src/map/packets/release.cpp
+++ b/src/map/packets/release.cpp
@@ -27,7 +27,7 @@
 CReleasePacket::CReleasePacket(CCharEntity* PChar, RELEASE_TYPE releaseType)
 {
     this->setType(0x52);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = static_cast<uint8>(releaseType);
 

--- a/src/map/packets/server_ip.cpp
+++ b/src/map/packets/server_ip.cpp
@@ -28,7 +28,7 @@
 CServerIPPacket::CServerIPPacket(CCharEntity* PChar, uint8 type, uint64 ipp)
 {
     this->setType(0x0B);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint8>(0x04)  = type;
     ref<uint32>(0x08) = (uint32)ipp;

--- a/src/map/packets/server_message.cpp
+++ b/src/map/packets/server_message.cpp
@@ -27,7 +27,7 @@
 CServerMessagePacket::CServerMessagePacket(const string_t& message, int8 language, int32 timestamp, int32 message_offset)
 {
     this->setType(0x4D);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint8>(0x04)  = message_offset == 0 ? 1 : 2;
     ref<uint8>(0x05)  = 1;
@@ -51,6 +51,7 @@ CServerMessagePacket::CServerMessagePacket(const string_t& message, int8 languag
         memcpy((data + (0x18)), message.c_str() + message_offset, sndLength);
 
         auto textSize = (uint8)(sndLength + sndLength % 2);
-        this->setSize((((0x14 + textSize) + 4) >> 1) & 0xFE);
+        // TODO: Verify the below math
+        this->setSize(((((0x14 + textSize) + 4) >> 1) & 0xFE) * 2);
     }
 }

--- a/src/map/packets/shop_appraise.cpp
+++ b/src/map/packets/shop_appraise.cpp
@@ -26,7 +26,7 @@
 CShopAppraisePacket::CShopAppraisePacket(uint8 slotID, uint32 sellPrice)
 {
     this->setType(0x3D);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = sellPrice;
     ref<uint8>(0x08)  = slotID;

--- a/src/map/packets/shop_buy.cpp
+++ b/src/map/packets/shop_buy.cpp
@@ -26,7 +26,7 @@
 CShopBuyPacket::CShopBuyPacket(uint8 slotID, uint32 quantity)
 {
     this->setType(0x3F);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     ref<uint8>(0x04)  = slotID;
     ref<uint32>(0x08) = quantity;

--- a/src/map/packets/shop_items.cpp
+++ b/src/map/packets/shop_items.cpp
@@ -30,7 +30,7 @@
 CShopItemsPacket::CShopItemsPacket(CCharEntity* PChar)
 {
     this->setType(0x3C);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     uint8 ItemsCount = PChar->Container->getItemsCount();
 
@@ -42,10 +42,10 @@ CShopItemsPacket::CShopItemsPacket(CCharEntity* PChar)
             PChar->pushPacket(new CBasicPacket(*this));
 
             i          = 0;
-            this->setSize(0x04);
+            this->setSize(0x08);
             memset(data + 4, 0, PACKET_SIZE - 8);
         }
-        this->setSize(this->getSize() + 0x06);
+        this->setSize(this->getSize() + 0x0C); // TODO: Verify
 
         ref<uint32>(i * 12 + 0x08) = PChar->Container->getQuantity(slotID);
         ref<uint16>(i * 12 + 0x0C) = PChar->Container->getItemID(slotID);

--- a/src/map/packets/shop_menu.cpp
+++ b/src/map/packets/shop_menu.cpp
@@ -28,7 +28,7 @@
 CShopMenuPacket::CShopMenuPacket(CCharEntity* PChar)
 {
     this->setType(0x3E);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = PChar->Container->getItemsCount();
 }

--- a/src/map/packets/status_effects.cpp
+++ b/src/map/packets/status_effects.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CStatusEffectPacket::CStatusEffectPacket(CCharEntity* PChar)
 {
     this->setType(0x63);
-    this->setSize(0x64);
+    this->setSize(0xC8);
 
     int i = 0;
 

--- a/src/map/packets/stop_downloading.cpp
+++ b/src/map/packets/stop_downloading.cpp
@@ -29,7 +29,7 @@
 CStopDownloadingPacket::CStopDownloadingPacket(CCharEntity* PChar, std::vector<std::pair<uint32, string_t>> blacklist)
 {
     this->setType(0x41);
-    this->setSize(0x7C);
+    this->setSize(0xF8);
 
     for (size_t x = 0; x < blacklist.size(); x++)
     {

--- a/src/map/packets/synth_animation.cpp
+++ b/src/map/packets/synth_animation.cpp
@@ -27,7 +27,7 @@
 CSynthAnimationPacket::CSynthAnimationPacket(CCharEntity* PChar, uint16 effect, uint8 param)
 {
     this->setType(0x30);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;

--- a/src/map/packets/synth_result.cpp
+++ b/src/map/packets/synth_result.cpp
@@ -29,7 +29,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CSynthResultMessagePacket::CSynthResultMessagePacket(CCharEntity* PChar, SYNTH_MESSAGE messageID, uint16 itemID, uint8 quantity)
 {
     this->setType(0x70);
-    this->setSize(0x30);
+    this->setSize(0x60);
 
     ref<uint8>(0x04) = messageID;
 

--- a/src/map/packets/synth_suggestion.cpp
+++ b/src/map/packets/synth_suggestion.cpp
@@ -28,7 +28,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CSynthSuggestionPacket::CSynthSuggestionPacket(uint16 skillID, uint16 skillLevel)
 {
     this->setType(0x31);
-    this->setSize(0x1A);
+    this->setSize(0x34);
 
     char craftname[8];
     memset(craftname, 0, 8);

--- a/src/map/packets/timer_bar_util.cpp
+++ b/src/map/packets/timer_bar_util.cpp
@@ -7,7 +7,7 @@
 CTimerBarUtilPacket::CTimerBarUtilPacket()
 {
     this->setType(0x75);
-    this->setSize(0x56);
+    this->setSize(0xAC);
 }
 
 void CTimerBarUtilPacket::addCountdown(uint32 seconds)

--- a/src/map/packets/trade_action.cpp
+++ b/src/map/packets/trade_action.cpp
@@ -28,7 +28,7 @@
 CTradeActionPacket::CTradeActionPacket(CCharEntity* PChar, uint32 action)
 {
     this->setType(0x22);
-    this->setSize(0x08);
+    this->setSize(0x10);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint32>(0x08) = action;

--- a/src/map/packets/trade_item.cpp
+++ b/src/map/packets/trade_item.cpp
@@ -28,7 +28,7 @@
 CTradeItemPacket::CTradeItemPacket(CItem* PItem, uint8 slot)
 {
     this->setType(0x25);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     uint32 amount = PItem->getReserve();
 

--- a/src/map/packets/trade_request.cpp
+++ b/src/map/packets/trade_request.cpp
@@ -28,7 +28,7 @@
 CTradeRequestPacket::CTradeRequestPacket(CCharEntity* PChar)
 {
     this->setType(0x21);
-    this->setSize(0x06);
+    this->setSize(0x0C);
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;

--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -32,7 +32,7 @@
 CTradeUpdatePacket::CTradeUpdatePacket(CItem* PItem, uint8 SlotID)
 {
     this->setType(0x23);
-    this->setSize(0x14);
+    this->setSize(0x28);
 
     uint32 amount = PItem->getReserve();
 

--- a/src/map/packets/treasure_lot_item.cpp
+++ b/src/map/packets/treasure_lot_item.cpp
@@ -31,7 +31,7 @@
 CTreasureLotItemPacket::CTreasureLotItemPacket(uint8 slotID, ITEMLOTTYPE MessageType)
 {
     this->setType(0xD3);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint8>(0x14) = slotID;
     ref<uint8>(0x15) = MessageType;
@@ -40,7 +40,7 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(uint8 slotID, ITEMLOTTYPE Message
 CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PWinner, uint8 slotID, uint16 Lot, ITEMLOTTYPE MessageType)
 {
     this->setType(0xD3);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     ref<uint32>(0x04) = PWinner->id;
     ref<uint16>(0x0C) = PWinner->targid;
@@ -55,7 +55,7 @@ CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PWinner, uint8 slotI
 CTreasureLotItemPacket::CTreasureLotItemPacket(CBaseEntity* PHighestLotter, uint16 HighestLot, CBaseEntity* PLotter, uint8 SlotID, uint16 Lot)
 {
     this->setType(0xD3);
-    this->setSize(0x1E);
+    this->setSize(0x3C);
 
     if (PHighestLotter)
     {

--- a/src/map/packets/trust_sync.cpp
+++ b/src/map/packets/trust_sync.cpp
@@ -31,7 +31,7 @@ CTrustSyncPacket::CTrustSyncPacket(CCharEntity* PChar, CTrustEntity* PTrust)
     // The purpose of this packet is to make the client aware that this pet is a trust, and hence
     // to show trust options in the menu (like "Release").
     this->setType(0x67);
-    this->setSize(0x16);
+    this->setSize(0x2C);
 
     // Sample packet:
     // 67 0C 58 00 03 05 F4 07 F4 28 08 01 00 04 00 00

--- a/src/map/packets/wide_scan.cpp
+++ b/src/map/packets/wide_scan.cpp
@@ -29,7 +29,7 @@
 CWideScanPacket::CWideScanPacket(WIDESCAN_STATUS status)
 {
     this->setType(0xF6);
-    this->setSize(0x04);
+    this->setSize(0x08);
 
     ref<uint8>(0x04) = status;
 }
@@ -37,7 +37,7 @@ CWideScanPacket::CWideScanPacket(WIDESCAN_STATUS status)
 CWideScanPacket::CWideScanPacket(CCharEntity* PChar, CBaseEntity* PEntity)
 {
     this->setType(0xF4);
-    this->setSize(0x0E);
+    this->setSize(0x1C);
 
     ref<uint16>(0x04) = PEntity->targid;
     if (PEntity->objtype == TYPE_MOB)

--- a/src/map/packets/wide_scan_track.cpp
+++ b/src/map/packets/wide_scan_track.cpp
@@ -29,7 +29,7 @@
 CWideScanTrackPacket::CWideScanTrackPacket(CBaseEntity* PEntity)
 {
     this->setType(0xF5);
-    this->setSize(0x0C);
+    this->setSize(0x18);
 
     ref<float>(0x04) = PEntity->loc.p.x;
     ref<float>(0x08) = PEntity->loc.p.y;

--- a/src/map/packets/world_pass.cpp
+++ b/src/map/packets/world_pass.cpp
@@ -28,7 +28,7 @@
 CWorldPassPacket::CWorldPassPacket(uint32 WorldPass)
 {
     this->setType(0x59);
-    this->setSize(0x12);
+    this->setSize(0x24);
 
     ref<uint32>(0x0C) = 10000; // price
 

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -111,7 +111,7 @@ uint8 GetMogHouseFlag(CCharEntity* PChar)
 CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
 {
     this->setType(0x0A);
-    this->setSize(0x82);
+    this->setSize(0x104);
 
     // необходимо для работы manaklipper
     // последние 8 байт похожи на время

--- a/src/map/packets/zone_visited.cpp
+++ b/src/map/packets/zone_visited.cpp
@@ -29,7 +29,7 @@
 CZoneVisitedPacket::CZoneVisitedPacket(CCharEntity* PChar)
 {
     this->setType(0x08);
-    this->setSize(0x1A);
+    this->setSize(0x34);
 
     memcpy(data + 4, PChar->m_ZonesList, 36);
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x-ish] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Updates packet size to use number of bytes instead of byte pairs where packet's setSize function is newly used.