### PR TITLE
[Fix] And rewrite CoP 6-4 battlefield

### DIFF
--- a/scripts/zones/Sealions_Den/Zone.lua
+++ b/scripts/zones/Sealions_Den/Zone.lua
@@ -23,8 +23,6 @@ zone_object.onZoneIn = function(player, prevZone)
 
     if player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 1 then
         cs = 15
-    elseif player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 4 then
-        cs = 33
     elseif player:getCurrentMission(COP) == xi.mission.id.cop.CHAINS_AND_BONDS and player:getCharVar("PromathiaStatus") == 2 then
         cs = 14
     elseif
@@ -50,11 +48,6 @@ zone_object.onEventFinish = function(player, csid, option)
         player:setCharVar("PromathiaStatus", 3);
     elseif csid == 29 then
         player:setCharVar('ApocalypseNigh', 2)
-    elseif csid == 33 then
-        player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.ONE_TO_BE_FEARED)
-        player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.CHAINS_AND_BONDS)
-        player:setCharVar("PromathiaStatus", 0)
-        player:setPos(438, 0, -18, 11, xi.zone.LUFAISE_MEADOWS)
     end
 end
 

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -12,7 +12,7 @@ battlefield_object.onBattlefieldTick = function(battlefield, tick)
 end
 
 battlefield_object.onBattlefieldInitialise = function(battlefield)
-    battlefield:setLocalVar("phaseChange", 1)
+    battlefield:setLocalVar("phaseChange", 1) -- Prevent battlefield from being completed until we want to.
 end
 
 battlefield_object.onBattlefieldRegister = function(player, battlefield)
@@ -26,6 +26,7 @@ battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)
         local _, clearTime, partySize = battlefield:getRecord()
         local arg8 = (player:getCurrentMission(COP) ~= xi.mission.id.cop.ONE_TO_BE_FEARED or player:getCharVar("PromathiaStatus") ~= 2) and 1 or 0
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
+
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
     end
@@ -36,17 +37,17 @@ end
 
 battlefield_object.onEventFinish = function(player, csid, option)
     -- NOTE: On completion, all members are sent back to Sealion's Den.
-    --       If you're eligable for the cutscene when you zone in, you'll
-    --       be sent to Lufaise directly afterwards.
-
-    -- TODO: This transition from BCNM end to Sealion's Den to Lufaise is pretty ugly.
-    --       Could/should be fixed in the future.
+    --       If you're eligable for the cutscene when you zone in, you'll be sent to Lufaise directly afterwards.
     if csid == 32001 then
         if player:getCurrentMission(COP) == xi.mission.id.cop.ONE_TO_BE_FEARED and player:getCharVar("PromathiaStatus") == 3 then
-            player:setCharVar("PromathiaStatus", 4)
+            player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.ONE_TO_BE_FEARED)
+            player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.CHAINS_AND_BONDS)
+            player:setCharVar("PromathiaStatus", 0)
+            player:startEvent(33)
         end
         player:addExp(1500)
-        player:setPos(0, 0, 0, 0, xi.zone.SEALIONS_DEN) -- TODO: This might not be needed
+    elseif csid == 33 then
+        player:setPos(438, 0, -18, 11, xi.zone.LUFAISE_MEADOWS)
     end
 end
 

--- a/scripts/zones/Sealions_Den/helpers/One_to_be_Feared.lua
+++ b/scripts/zones/Sealions_Den/helpers/One_to_be_Feared.lua
@@ -1,0 +1,150 @@
+-----------------------------------
+-- Global file for "One to be Feared" Battlefield
+-----------------------------------
+local ID = require("scripts/zones/Sealions_Den/IDs")
+require("scripts/globals/status")
+require("scripts/globals/titles")
+-----------------------------------
+local oneToBeFeared = {}
+-- Note:
+-- This battlefield uses the old BCNM "instance" system.
+-- That means there are several copies of the area and we are placed randomly in one.
+-- Not to be confused with an actual instance.
+
+local function healCharacter(player)
+    player:setHP(player:getMaxHP())
+    player:setMP(player:getMaxMP())
+    player:setTP(0)
+end
+
+local function returnToAirship(player)
+    local battlefield = player:getBattlefield()
+    local instance    = battlefield:getArea()
+
+    if instance == 1 then
+        player:setPos(-780.010, -103.348, -86.327, 193)
+    elseif instance == 2 then
+        player:setPos(-140.029, -23.348, -446.376, 193)
+    elseif instance == 3 then
+        player:setPos(499.969, 56.652, -806.132, 193)
+    end
+end
+
+-----------------------------------
+-- Battle 1: 5 Mammets
+-----------------------------------
+oneToBeFeared.handleMammetDeath = function(mob, player, isKiller)
+    -- Find mob offset for given battlefield instance
+    local battlefield  = mob:getBattlefield()
+    local mammetOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (battlefield:getArea() - 1))
+    local mammetDeathCount = 0
+
+    -- If all five mammets in this instance are dead, start event.
+    for i = mammetOffset + 0, mammetOffset + 4 do
+        if GetMobByID(i):isDead() then
+            mammetDeathCount = mammetDeathCount + 1
+        else
+            break
+        end
+    end
+
+    if mammetDeathCount == 5 and player:hasStatusEffect(xi.effect.BATTLEFIELD) and player:getLocalVar("[OTBF]MammetCS") == 0 then
+        player:setLocalVar("[OTBF]MammetCS", 1) -- Safety check to not trigger CS more than once when killing multile Mammets at the same time.
+        player:startEvent(10)
+    end
+end
+
+oneToBeFeared.handleMammetBattleEnding = function(player, csid, option)
+    if csid == 10 then
+        -- Players are healed in between fights, but their TP is set to 0
+        player:addTitle(xi.title.BRANDED_BY_LIGHTNING)
+        healCharacter(player)
+
+        -- Move player to instance start. End battle 1.
+        player:setLocalVar("[OTBF]battleCompleted", 1)
+        returnToAirship(player)
+    end
+end
+
+-----------------------------------
+-- Battle 2: Omega
+-----------------------------------
+oneToBeFeared.handleOmegaDeath = function(mob, player, isKiller)
+    if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
+        player:startEvent(11)
+    end
+end
+
+oneToBeFeared.handleOmegaBattleEnding = function(player, csid, option)
+    if csid == 11 then
+        -- Players are healed in between fights, but their TP is set to 0.
+        player:addTitle(xi.title.OMEGA_OSTRACIZER)
+        healCharacter(player)
+
+        -- Move player to instance start. End battle 2.
+        player:setLocalVar("[OTBF]battleCompleted", 2)
+        returnToAirship(player)
+    end
+end
+-----------------------------------
+-- Battle 3: Ultima
+-----------------------------------
+oneToBeFeared.handleUltimaDeath = function(mob, player, isKiller)
+    player:addTitle(xi.title.ULTIMA_UNDERTAKER)
+    player:setLocalVar("[OTBF]battleCompleted", 0)
+end
+
+-----------------------------------
+-- While on Airship
+-----------------------------------
+oneToBeFeared.handleAirshipDoorTrigger = function(player, npc)
+    player:startEvent(32003, npc:getID() - ID.npc.AIRSHIP_DOOR_OFFSET + 1, player:getLocalVar("[OTBF]battleCompleted") * 2)
+end
+
+oneToBeFeared.handleOnEventUpdate = function(player, csid, option)
+    local battlefield = player:getBattlefield()
+
+    -- Spawn Omega for given instance.
+    if csid == 1 and option == 0 then
+        local omegaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (battlefield:getArea() - 1)) + 5
+        if omegaId and not GetMobByID(omegaId):isSpawned() then
+            SpawnMob(omegaId)
+        end
+
+    -- Spawn Ultima for given instance.
+    elseif csid == 2 and option == 0 then
+        local ultimaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (battlefield:getArea() - 1)) + 6
+        if not GetMobByID(ultimaId):isSpawned() then
+            SpawnMob(ultimaId)
+            battlefield:setLocalVar("phaseChange", 0)
+        end
+    end
+end
+
+oneToBeFeared.handleOnEventFinish = function(player, csid, option)
+    if csid == 32003 then
+        if option >= 100 and option <= 102 then
+            local party = player:getParty()
+
+            if party ~= nil then
+                for _, v in pairs(party) do
+                    if v:hasStatusEffect(xi.effect.BATTLEFIELD) then
+                        v:startEvent(v:getLocalVar("[OTBF]battleCompleted"), option - 99)
+                    end
+                end
+            else
+                player:startEvent(player:getLocalVar("[OTBF]battleCompleted"), option - 99)
+            end
+
+        -- Leave battlefield.
+        elseif option == 4 then
+            if player:getBattlefield() then
+                player:leaveBattlefield(1)
+                player:setLocalVar("[OTBF]battleCompleted", 0)
+                player:setLocalVar("[OTBF]MammetCS", 0)
+            end
+        end
+    end
+end
+
+return oneToBeFeared

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -2,8 +2,7 @@
 -- Area: Sealions Den
 --  Mob: Mammet-22 Zeta
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs")
-require("scripts/globals/titles")
+local oneToBeFeared = require("scripts/zones/Sealions_Den/helpers/One_to_be_Feared")
 -----------------------------------
 local entity = {}
 
@@ -93,49 +92,11 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    -- find mob offset for given battlefield instance
-    local battlefield = mob:getBattlefield()
-    local inst = battlefield:getArea()
-    local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1))
-
-    -- if all five mammets in this instance are dead, start event
-    local allMammetsDead = true
-    for i = instOffset + 0, instOffset + 4 do
-        if not GetMobByID(i):isDead() then
-            allMammetsDead = false
-            break
-        end
-    end
-
-    local mammetEventGuard = battlefield:getLocalVar("mammetEventGuard")
-    if allMammetsDead and mammetEventGuard == 0 then
-        player:startEvent(11)
-        battlefield:setLocalVar("mammetEventGuard", 1)
-    end
+    oneToBeFeared.handleMammetDeath(mob, player, isKiller)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 11 then
-        local battlefield = player:getBattlefield()
-        local inst = battlefield:getArea()
-
-        -- players are healed in between fights, but their TP is set to 0
-        player:addTitle(xi.title.BRANDED_BY_LIGHTNING)
-        player:setHP(player:getMaxHP())
-        player:setMP(player:getMaxMP())
-        player:setTP(0)
-
-        player:setLocalVar("[OTBF]cs", 1)
-
-        -- move player to instance
-        if inst == 1 then
-            player:setPos(-779, -103, -80)
-        elseif inst == 2 then
-            player:setPos(-140, -23, -440)
-        elseif inst == 3 then
-            player:setPos(499, 56, -802)
-        end
-    end
+    oneToBeFeared.handleMammetBattleEnding(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -2,8 +2,7 @@
 -- Area: Sealions Den
 --  Mob: Omega
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs")
-require("scripts/globals/titles")
+local oneToBeFeared = require("scripts/zones/Sealions_Den/helpers/One_to_be_Feared")
 require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
@@ -27,31 +26,11 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    player:addTitle(xi.title.OMEGA_OSTRACIZER)
-    player:startEvent(11)
+    oneToBeFeared.handleOmegaDeath(mob, player, isKiller)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 11 then
-        local battlefield = player:getBattlefield()
-        local inst = battlefield:getArea()
-
-        -- players are healed in between fights, but their TP is set to 0
-        player:setHP(player:getMaxHP())
-        player:setMP(player:getMaxMP())
-        player:setTP(0)
-
-        player:setLocalVar("[OTBF]cs", 2)
-
-        -- move player to instance
-        if inst == 1 then
-            player:setPos(-779, -103, -80)
-        elseif inst == 2 then
-            player:setPos(-140, -23, -440)
-        elseif inst == 3 then
-            player:setPos(499, 56, -802)
-        end
-    end
+    oneToBeFeared.handleOmegaBattleEnding(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -2,7 +2,7 @@
 -- Area: Sealions Den
 --   NM: Ultima
 -----------------------------------
-require("scripts/globals/titles")
+local oneToBeFeared = require("scripts/zones/Sealions_Den/helpers/One_to_be_Feared")
 require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
@@ -26,8 +26,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
-    player:addTitle(xi.title.ULTIMA_UNDERTAKER)
-    player:setLocalVar("[OTBF]cs", 0)
+    oneToBeFeared.handleUltimaDeath(mob, player, isKiller)
 end
 
 return entity

--- a/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
+++ b/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
@@ -2,7 +2,7 @@
 -- Area: Sealion's Den
 --  NPC: Airship_Door
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs")
+local oneToBeFeared = require("scripts/zones/Sealions_Den/helpers/One_to_be_Feared")
 -----------------------------------
 local entity = {}
 
@@ -10,36 +10,15 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local offset = npc:getID() - ID.npc.AIRSHIP_DOOR_OFFSET
-    player:startEvent(32003, offset + 1)
+    oneToBeFeared.handleAirshipDoorTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    local battlefield = player:getBattlefield()
-    local inst = battlefield:getArea()
-
-    -- spawn omega for given instance
-    if csid == 1 and option == 0 then
-        local omegaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 5
-        if omegaId and not GetMobByID(omegaId):isSpawned() then
-            SpawnMob(omegaId)
-        end
-
-    -- spawn ultima for given instance
-    elseif csid == 2 and option == 0 then
-        local ultimaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 6
-        if ultimaId and not GetMobByID(ultimaId):isSpawned() then
-            SpawnMob(ultimaId)
-            battlefield:setLocalVar("phaseChange", 0)
-        end
-    end
+    oneToBeFeared.handleOnEventUpdate(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 32003 and option >= 100 and option <= 102 then
-        local inst = option - 99
-        player:startEvent(player:getLocalVar("[OTBF]cs"), inst)
-    end
+    oneToBeFeared.handleOnEventFinish(player, csid, option)
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes:
- Battlefield not triggering final cutscenes, making the mission impossible to complete.
- Battlefield not properly clearing itself when leaving.
- Incorrect event being played after first battle.
- Post mammet batle event being played multiple times when killing several mammets at the same time.
- Airship door giving incorrect options after mammets battle.
- Player Position and rotation when returning to the airship after each fight.
- Removed some unused logic and simplified quest logic (a little).

Closes #1262