### PR TITLE
[core] Don't show dev logging for outgoing packets anymore

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -737,7 +737,7 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
                 PSmallPacket = packetList.front();
                 packetList.pop_front();
 
-                ShowInfo("> Outgoing packet: Type: 0x%X, Size: (%d / 0x%X)", PSmallPacket->getType(), PSmallPacket->getSize(), PSmallPacket->getSize());
+                // ShowInfo("> Outgoing packet: Type: 0x%X, Size: (%d / 0x%X)", PSmallPacket->getType(), PSmallPacket->getSize(), PSmallPacket->getSize());
 
                 PSmallPacket->setSequence(map_session_data->server_packet_id);
                 memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->getSize());


### PR DESCRIPTION
Shouldn't have made it in, whoops!

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
