### PR TITLE
Interaction - Hidden Quest: Moghouse Exposition

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -102,12 +102,7 @@ xi.moghouse.moogleTrigger = function(player, npc)
             end
         end
 
-        if player:getCharVar("MoghouseExplication") == 1 then
-            player:startEvent(30000)
-
-        else
-            player:sendMenu(1)
-        end
+        player:sendMenu(1)
     end
 end
 
@@ -115,11 +110,6 @@ xi.moghouse.moogleEventUpdate = function(player, csid, option)
 end
 
 xi.moghouse.moogleEventFinish = function(player, csid, option)
-    if player:isInMogHouse() then
-        if csid == 30000 then
-            player:setCharVar("MoghouseExplication", 0)
-        end
-    end
 end
 
 -- Unlocks a mog locker for a player. Returns the 'expired' timestamp (-1)

--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -125,7 +125,7 @@ local function CharCreate(player)
 
     player:addItem(536) -- adventurer coupon
     player:addTitle(xi.title.NEW_ADVENTURER)
-    player:setCharVar("MoghouseExplication", 1) -- needs Moghouse intro
+    player:setCharVar("HQuest[moghouseExpo]notSeen", 1) -- needs Moghouse intro
     player:setCharVar("spokeKindlix", 1) -- Kindlix introduction
     player:setCharVar("spokePyropox", 1) -- Pyropox introduction
     player:setCharVar("TutorialProgress", 1) -- Has not started tutorial

--- a/scripts/missions/amk/01_A_Moogle_Kupo_dEtat.lua
+++ b/scripts/missions/amk/01_A_Moogle_Kupo_dEtat.lua
@@ -27,7 +27,7 @@ mission.sections[1].check = function(player, currentMission, missionStatus, vars
         xi.settings.ENABLE_AMK == 1 and
         xi.moghouse.isInMogHouseInHomeNation(player) and
         player:getMainLvl() >= 10 and
-        player:getCharVar("MoghouseExplication") == 0
+        player:getCharVar("HQuest[moghouseExpo]notSeen") == 0
 end
 
 local moogleTriggerEvent =

--- a/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
+++ b/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
@@ -1,0 +1,42 @@
+-----------------------------------
+-- Moghouse Exposition
+-----------------------------------
+require('scripts/globals/moghouse')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/hidden_quest')
+-----------------------------------
+
+local quest = HiddenQuest:new("moghouseExpo")
+
+quest.reward = {}
+
+quest.sections    = {}
+quest.sections[1] = {}
+
+quest.sections[1].check = function(player, currentMission, missionStatus, vars)
+    return xi.moghouse.isInMogHouseInHomeNation(player) and
+        quest:getVar(player, 'notSeen') == 1
+end
+
+local moogleZoneInEvent =
+{
+    onZoneIn =
+    {
+        function(player, prevZone)
+            return 30000
+        end,
+    },
+
+    onEventFinish =
+    {
+        [30000] = function(player, csid, option, npc)
+            quest:complete(player)
+        end,
+    },
+}
+
+for i, zoneId in ipairs(xi.moghouse.moghouseZones) do
+    quest.sections[1][zoneId] = moogleZoneInEvent
+end
+
+return quest


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Converts Moghouse Exposition to a Hidden Quest in Interaction Framework
* Changes behavior from onTrigger to onZoneIn to mog house
* Requires home nation mog house to trigger
