### PR TITLE
Fix CAddtoEquipSet Packet ID

### DIFF
--- a/src/map/packets/macroequipset.cpp
+++ b/src/map/packets/macroequipset.cpp
@@ -33,7 +33,7 @@ CAddtoEquipSet::CAddtoEquipSet(uint8* orig)
     // in this list the slot of whats being updated is old value, replace with new in 116
     // Should Push 0x116 (size 68) in responce
     // 0x04 is start, contains 16 4 byte parts repersently each slot in order
-    this->setType(0x16); // TODO
+    this->setType(0x116);
     this->setSize(0x46);
 
     uint8 slotID = ::ref<uint8>(orig, 0x04);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
