### PR TITLE
[core] Add missing CTaskMgr::RemoveTask impl

### DIFF
--- a/src/common/taskmgr.cpp
+++ b/src/common/taskmgr.cpp
@@ -62,7 +62,36 @@ CTaskMgr::CTask* CTaskMgr::AddTask(CTask* PTask)
 
 void CTaskMgr::RemoveTask(const std::string& TaskName)
 {
-    // empty method
+    // m_TaskList is a priority_queue, so we can't directly pull members out of it.
+    //
+    // Tasks are compared using their m_tick values, so we can safely remove all the tasks
+    // and re-insert them, sans the one we're trying to remove.
+
+    std::size_t tasksRemoved = 0;
+    TaskList_t newPq;
+    while (!m_TaskList.empty())
+    {
+        CTask* PTask = m_TaskList.top();
+        m_TaskList.pop();
+
+        // Don't add tasks we're trying to remove to the new pq
+        if (PTask->m_name != TaskName)
+        {
+            newPq.push(PTask);
+        }
+        else
+        {
+            ++tasksRemoved;
+        }
+    }
+
+    if (tasksRemoved == 0)
+    {
+        ShowWarning("Tried to remove task: %s, but didn't find it!", TaskName);
+    }
+
+    // Replace the old queue with the new queue
+    m_TaskList = newPq;
 }
 
 duration CTaskMgr::DoTimer(time_point tick)


### PR DESCRIPTION
Imagine my horror when I'm trying to remove tasks and they're getting called later on, after I've wiped all of their resources >.>

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
