### PR TITLE
[sql] Give Keepalive tasks unique names since CTaskMgr::RemoveTask filters all matching names

### DIFF
--- a/cmake/MariaDB.cmake
+++ b/cmake/MariaDB.cmake
@@ -55,7 +55,7 @@ if(WIN32)
     # Copy from ext folder into root
     add_custom_target(copy_mariadb_dll_to_root ALL)
     add_custom_command(TARGET copy_mariadb_dll_to_root POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${CMAKE_SOURCE_DIR}/ext/mariadb/${libpath}/libmariadb.dll
             ${CMAKE_SOURCE_DIR}
     )

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -9,6 +9,12 @@ add_subdirectory(spdlog)
 # CPM Modules
 CPMAddPackage(
     NAME efsw
-    GITHUB_REPOSITORY LandSandBoat/efsw
-    GIT_TAG b477e1c8f00bf483b1be256321d5e32784d6df96
+    GITHUB_REPOSITORY SpartanJ/efsw
+    GIT_TAG 74ca09bff89bc8de1f7b8bf3faaa6275ce23b4c5
+    OPTIONS
+        "VERBOSE OFF"
+        "NO_ATOMICS OFF"
+        "BUILD_SHARED_LIBS OFF"
+        "BUILD_TEST_APP OFF"
+        "EFSW_INSTALL OFF"
 )

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -19,10 +19,11 @@
 ===========================================================================
 */
 
-#include "../common/logging.h"
-#include "../common/taskmgr.h"
-#include "../common/timer.h"
-#include "../common/tracy.h"
+#include "logging.h"
+#include "taskmgr.h"
+#include "timer.h"
+#include "tracy.h"
+#include "xirand.h"
 
 #include "sql.h"
 
@@ -244,8 +245,10 @@ int32 Sql_Keepalive(Sql_t* self, std::string const& keepaliveTaskName)
         timeout = 60;
     }
 
+    auto randomOffset = xirand::GetRandomNumber(0, 10);
+
     // establish keepalive
-    ping_interval = timeout - 30; // 30-second reserve
+    ping_interval = timeout + randomOffset - 30; // 30-second reserve
     CTaskMgr::getInstance()->AddTask(keepaliveTaskName, server_clock::now() + std::chrono::seconds(ping_interval), self, CTaskMgr::TASK_INTERVAL,
                                      Sql_P_KeepaliveTimer, std::chrono::seconds(ping_interval));
     return 0;

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -4,9 +4,7 @@
 #ifndef _COMMON_SQL_H
 #define _COMMON_SQL_H
 
-#ifndef _CBASETYPES_H_
-#include "../common/cbasetypes.h"
-#endif
+#include "cbasetypes.h"
 
 #include <mysql.h>
 
@@ -58,20 +56,18 @@ enum SqlDataType
     SQLDT_LASTID
 };
 
-/*
- *
- *					SQL LEVEL
- *
- */
-
 struct Sql_t
 {
     std::string    buf;
+
+    // NOTE: Access to any of the MySQL resources is NOT thread-safe.
+    // You will encounter very difficult to debug crashes and failed
+    // operations if you're not careful!
     MYSQL          handle;
     MYSQL_RES*     result;
     MYSQL_ROW      row;
     unsigned long* lengths;
-    int            keepalive;
+    std::string    keepaliveTaskName;
 };
 
 /// Allocates and initializes a new Sql handle.
@@ -154,7 +150,7 @@ int32 Sql_NextRow(Sql_t* self);
 /// Establishes keepalive (periodic ping) on the connection
 ///
 /// @return the keepalive timer id, or INVALID_TIMER
-int32 Sql_Keepalive(Sql_t* self);
+int32 Sql_Keepalive(Sql_t* self, std::string const& keepalive_name);
 
 /// Gets the data of a column.
 /// The data remains valid until the next row is fetched or the result is freed.
@@ -189,8 +185,4 @@ bool Sql_TransactionStart(Sql_t* self);
 bool Sql_TransactionCommit(Sql_t* self);
 bool Sql_TransactionRollback(Sql_t* self);
 
-#endif
-
-//											End level
-////
-//////////////////////////////////////////////////////////////////////////////////////////
+#endif // _COMMON_SQL_H

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -58,7 +58,7 @@ enum SqlDataType
 
 struct Sql_t
 {
-    std::string    buf;
+    std::string buf;
 
     // NOTE: Access to any of the MySQL resources is NOT thread-safe.
     // You will encounter very difficult to debug crashes and failed
@@ -165,15 +165,6 @@ float  Sql_GetFloatData(Sql_t* self, size_t col);
 
 /// Frees the result of the query.
 void Sql_FreeResult(Sql_t* self);
-
-#if defined(SQL_REMOVE_SHOWDEBUG)
-#define Sql_ShowDebug(self) (void)0
-#else
-#define Sql_ShowDebug(self) Sql_ShowDebug_(self, __FILE__, __LINE__)
-#endif
-
-/// Shows debug information (last query).
-void Sql_ShowDebug_(Sql_t* self, const char* debug_file, const unsigned long debug_line);
 
 /// Frees a Sql handle returned by Sql_Malloc.
 void Sql_Free(Sql_t* self);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -114,7 +114,7 @@ int32 do_init(int32 argc, char** argv)
     {
         exit(EXIT_FAILURE);
     }
-    Sql_Keepalive(SqlHandle);
+    Sql_Keepalive(SqlHandle, "LoginKeepalive");
 
     const char* fmtQuery = "OPTIMIZE TABLE `accounts`,`accounts_banned`, `accounts_sessions`, `chars`,`char_equip`, \
                            `char_inventory`, `char_jobs`,`char_look`,`char_stats`, `char_vars`, `char_bazaar_msg`, \

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -282,7 +282,7 @@ void message_server_init()
         exit(EXIT_FAILURE);
     }
 
-    Sql_Keepalive(ChatSqlHandle);
+    Sql_Keepalive(ChatSqlHandle, "MessageKeepalive");
 
     zContext = zmq::context_t(1);
     zSocket  = new zmq::socket_t(zContext, ZMQ_ROUTER);

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -60,7 +60,7 @@ CInstanceLoader::CInstanceLoader(uint16 instanceid, CCharEntity* PRequester)
     {
         do_final(EXIT_FAILURE);
     }
-    Sql_Keepalive(SqlInstanceHandle);
+    Sql_Keepalive(SqlInstanceHandle, "InstanceKeepalive");
 }
 
 CInstanceLoader::~CInstanceLoader()

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -206,7 +206,7 @@ int32 do_init(int32 argc, char** argv)
     {
         do_final(EXIT_FAILURE);
     }
-    Sql_Keepalive(SqlHandle);
+    Sql_Keepalive(SqlHandle, "MapKeepalive");
 
     // We clear the session table at server start (temporary solution)
     Sql_Query(SqlHandle, "DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);", map_ip.s_addr, map_port,

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -22,15 +22,15 @@
 #ifndef _MAP_H
 #define _MAP_H
 
-#include "../common/cbasetypes.h"
+#include "common/cbasetypes.h"
 
-#include "../common/blowfish.h"
-#include "../common/kernel.h"
-#include "../common/mmo.h"
-#include "../common/socket.h"
-#include "../common/sql.h"
-#include "../common/taskmgr.h"
-#include "../common/xirand.h"
+#include "common/blowfish.h"
+#include "common/kernel.h"
+#include "common/mmo.h"
+#include "common/socket.h"
+#include "common/sql.h"
+#include "common/taskmgr.h"
+#include "common/xirand.h"
 
 #include <list>
 #include <map>

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -603,7 +603,7 @@ namespace message
         {
             exit(EXIT_FAILURE);
         }
-        Sql_Keepalive(SqlHandle);
+        Sql_Keepalive(SqlHandle, "MessageKeepalive");
 
         zContext = zmq::context_t(1);
         zSocket  = new zmq::socket_t(zContext, ZMQ_DEALER);


### PR DESCRIPTION
Sniffing around our sql stuff. Since I removed the multi-threading from the instance loader, we don't need a separate SQL handle for it.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I went on a deep dive during my stream, I found out that the SqlHandle is entirely not threadsafe and that we have multiple threads in the map server (map, zmq and formerly instance loading) that all keep their own handles. This means that making them all share a handle will end the universe. 

In 2022 refresh, I'll need to have a think about a better way of allowing easy global access to the SQL connection, while maintaining safety and a nice API.

Closes https://github.com/LandSandBoat/server/issues/1341