### PR TITLE
Dedication Item corrections - add scout/guide beret

### DIFF
--- a/scripts/globals/items/allied_ring.lua
+++ b/scripts/globals/items/allied_ring.lua
@@ -5,7 +5,7 @@
 -----------------------------------
 -- Bonus: +150%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 30000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -13,14 +13,14 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 150, 0, 43200, 0, 9000)
+    target:addStatusEffect(xi.effect.DEDICATION, 150, 0, 43200, 0, 30000)
 end
 
 return item_object

--- a/scripts/globals/items/anniversary_ring.lua
+++ b/scripts/globals/items/anniversary_ring.lua
@@ -5,7 +5,7 @@
 -----------------------------------
 -- Bonus: +100%
 -- Duration: 720 min
--- Max bonus: 3000 exp
+-- Max bonus: 10000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -13,14 +13,14 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 3000)
+    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 10000)
 end
 
 return item_object

--- a/scripts/globals/items/chariot_band.lua
+++ b/scripts/globals/items/chariot_band.lua
@@ -1,14 +1,11 @@
 -----------------------------------
 -- ID: 15761
--- Item: Chariot Band
------------------------------------
--- ID: 15761
 -- Item: chariot band
 -- Experience point bonus
 -----------------------------------
 -- Bonus: +75%
 -- Duration: 720 min
--- Max bonus: 750 exp
+-- Max bonus: 10000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -16,7 +13,7 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result

--- a/scripts/globals/items/duodecennial_ring.lua
+++ b/scripts/globals/items/duodecennial_ring.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- ID: 28562
--- Item: Duodecennial Ring 
+-- Item: Duodecennial Ring
 -- Experience point bonus
 -----------------------------------
 -- Bonus: +100%

--- a/scripts/globals/items/duodecennial_ring.lua
+++ b/scripts/globals/items/duodecennial_ring.lua
@@ -1,11 +1,11 @@
 -----------------------------------
--- ID: 11666
--- Item: novennial ring
+-- ID: 28562
+-- Item: Duodecennial Ring 
 -- Experience point bonus
 -----------------------------------
 -- Bonus: +100%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 12000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,7 +20,7 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 9000)
+   target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 12000)
 end
 
 return item_object

--- a/scripts/globals/items/echad_ring.lua
+++ b/scripts/globals/items/echad_ring.lua
@@ -13,7 +13,7 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result

--- a/scripts/globals/items/emperor_band.lua
+++ b/scripts/globals/items/emperor_band.lua
@@ -13,7 +13,7 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result

--- a/scripts/globals/items/empress_band.lua
+++ b/scripts/globals/items/empress_band.lua
@@ -13,7 +13,7 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result

--- a/scripts/globals/items/expertise_ring.lua
+++ b/scripts/globals/items/expertise_ring.lua
@@ -1,11 +1,11 @@
 -----------------------------------
--- ID: 11666
--- Item: novennial ring
+-- ID: 28569
+-- Item: Expertise Ring
 -- Experience point bonus
 -----------------------------------
--- Bonus: +100%
+-- Bonus: +75%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 30000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,7 +20,7 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 9000)
+   target:addStatusEffect(xi.effect.DEDICATION, 75, 0, 43200, 0, 30000)
 end
 
 return item_object

--- a/scripts/globals/items/guide_beret.lua
+++ b/scripts/globals/items/guide_beret.lua
@@ -1,11 +1,11 @@
 -----------------------------------
--- ID: 11666
--- Item: novennial ring
+-- ID: 15199
+-- Item: Guide Beret
 -- Experience point bonus
 -----------------------------------
--- Bonus: +100%
+-- Bonus: +150%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 30000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,7 +20,7 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 9000)
+   target:addStatusEffect(xi.effect.DEDICATION, 150, 0, 43200, 0, 30000)
 end
 
 return item_object

--- a/scripts/globals/items/kupofrieds_ring.lua
+++ b/scripts/globals/items/kupofrieds_ring.lua
@@ -4,8 +4,8 @@
 -- Experience point bonus
 -----------------------------------
 -- Bonus: +100%
--- Duration: 720 min
--- Max bonus: 3000 exp
+-- Duration: 1440 min/24hr
+-- Max bonus: 30000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -13,14 +13,14 @@ local item_object = {}
 
 item_object.onItemCheck = function(target)
     local result = 0
-    if (target:hasStatusEffect(xi.effect.DEDICATION) == true) then
+    if target:hasStatusEffect(xi.effect.DEDICATION) then
         result = 56
     end
     return result
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 86400, 0, 6000)
+    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 86400, 0, 30000)
 end
 
 return item_object

--- a/scripts/globals/items/sprout_beret.lua
+++ b/scripts/globals/items/sprout_beret.lua
@@ -1,11 +1,11 @@
 -----------------------------------
--- ID: 11666
--- Item: novennial ring
+-- ID: 15198
+-- Item: Sprout Beret
 -- Experience point bonus
 -----------------------------------
--- Bonus: +100%
+-- Bonus: +150%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 30000 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,7 +20,7 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 9000)
+   target:addStatusEffect(xi.effect.DEDICATION, 150, 0, 43200, 0, 30000)
 end
 
 return item_object

--- a/scripts/globals/items/undecennial_ring.lua
+++ b/scripts/globals/items/undecennial_ring.lua
@@ -1,11 +1,11 @@
 -----------------------------------
--- ID: 11666
--- Item: novennial ring
+-- ID: 28528
+-- Item: Undecennial Ring
 -- Experience point bonus
 -----------------------------------
 -- Bonus: +100%
 -- Duration: 720 min
--- Max bonus: 9000 exp
+-- Max bonus: 11111 exp
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
@@ -20,7 +20,7 @@ item_object.onItemCheck = function(target)
 end
 
 item_object.onItemUse = function(target)
-    target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 9000)
+   target:addStatusEffect(xi.effect.DEDICATION, 100, 0, 43200, 0, 11111)
 end
 
 return item_object


### PR DESCRIPTION
Added guide/sprout beret, expertise, duodecennial, undecennial rings to relect correct xp bonus and styles.  IAW https://ffxiclopedia.fandom.com/wiki/Dedication

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
