### PR TITLE
Fix !chocobo command permissions

### DIFF
--- a/scripts/commands/chocobo.lua
+++ b/scripts/commands/chocobo.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status")
 
 cmdprops =
 {
-    permission = 0,
+    permission = 1,
     parameters = "ssss"
 }
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

current permissions of the !chocobo command allows regular users (non-gm's) to summon a chocobo in any zone. I doubt this was the intent as this is not in-line with retail behavior