### PR TITLE
Fix shrouded bijou

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -2894,16 +2894,17 @@ INSERT INTO `mob_droplist` VALUES (518,0,0,1000,16792,250); -- goshishos_scythe
 INSERT INTO `mob_droplist` VALUES (519,0,0,1000,1449,40);
 INSERT INTO `mob_droplist` VALUES (519,0,0,1000,1455,30);
 INSERT INTO `mob_droplist` VALUES (519,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (519,0,0,1000,3358,80);
+INSERT INTO `mob_droplist` VALUES (519,0,0,1000,3358,150);   -- (Count_Raum) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (519,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (519,0,0,1000,15107,90);
+INSERT INTO `mob_droplist` VALUES (520,0,0,1000,3358,240);   -- (Count_Vine) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (520,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (520,0,0,1000,1450,10);
 INSERT INTO `mob_droplist` VALUES (520,0,0,1000,1452,10);
 INSERT INTO `mob_droplist` VALUES (520,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (520,0,0,1000,15083,180);
 INSERT INTO `mob_droplist` VALUES (521,0,0,1000,1452,10);
-INSERT INTO `mob_droplist` VALUES (521,0,0,1000,3358,10);
+INSERT INTO `mob_droplist` VALUES (521,0,0,1000,3358,240);   -- (Count_Zaebos) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (521,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (521,0,0,1000,15087,70);
 INSERT INTO `mob_droplist` VALUES (522,0,0,1000,1722,537);
@@ -3730,12 +3731,12 @@ INSERT INTO `mob_droplist` VALUES (713,0,0,1000,1621,80);
 INSERT INTO `mob_droplist` VALUES (714,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (714,0,0,1000,1453,10);
 INSERT INTO `mob_droplist` VALUES (714,0,0,1000,1456,30);
-INSERT INTO `mob_droplist` VALUES (714,0,0,1000,3358,10);
+INSERT INTO `mob_droplist` VALUES (714,0,0,1000,3358,240);   -- (Duke_Berith) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (714,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (714,0,0,1000,15076,160);
 INSERT INTO `mob_droplist` VALUES (715,0,0,1000,1450,10);
 INSERT INTO `mob_droplist` VALUES (715,0,0,1000,1452,10);
-INSERT INTO `mob_droplist` VALUES (715,0,0,1000,3358,10);
+INSERT INTO `mob_droplist` VALUES (715,0,0,1000,3358,240);   -- (Duke_Gomory) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (715,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (715,0,0,1000,15073,110);
 INSERT INTO `mob_droplist` VALUES (716,0,0,1000,886,202);   -- (Duke_Haborym) demon_skull
@@ -3743,6 +3744,7 @@ INSERT INTO `mob_droplist` VALUES (716,0,0,1000,902,327);   -- demon_horn
 INSERT INTO `mob_droplist` VALUES (716,0,0,1000,4111,10);   -- dark_cluster
 INSERT INTO `mob_droplist` VALUES (716,0,0,1000,4875,298);  -- scroll_of_absorb-dex
 INSERT INTO `mob_droplist` VALUES (716,0,0,1000,16786,317); -- barbarians_scythe
+INSERT INTO `mob_droplist` VALUES (717,0,0,1000,3358,240);   -- (Prince_Seere) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (717,0,0,1000,1455,90);
 INSERT INTO `mob_droplist` VALUES (717,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (717,0,0,1000,15079,90);
@@ -7591,6 +7593,7 @@ INSERT INTO `mob_droplist` VALUES (1450,0,0,1000,1334,190);
 INSERT INTO `mob_droplist` VALUES (1451,0,0,1000,901,140);
 INSERT INTO `mob_droplist` VALUES (1451,0,0,1000,15223,430);
 INSERT INTO `mob_droplist` VALUES (1451,0,0,1000,18255,140);
+INSERT INTO `mob_droplist` VALUES (1452,0,0,1000,3358,240);   -- (King_Zagan) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1452,2,0,1000,1449,0);
 INSERT INTO `mob_droplist` VALUES (1452,2,0,1000,1452,0);
 INSERT INTO `mob_droplist` VALUES (1452,0,0,1000,1452,10);
@@ -8372,6 +8375,7 @@ INSERT INTO `mob_droplist` VALUES (1623,0,0,1000,4755,30);
 INSERT INTO `mob_droplist` VALUES (1623,0,0,1000,4784,50);
 INSERT INTO `mob_droplist` VALUES (1623,0,0,1000,4812,30);
 INSERT INTO `mob_droplist` VALUES (1623,0,0,1000,17232,100);
+INSERT INTO `mob_droplist` VALUES (1624,0,0,1000,3358,240);   -- (Marquis_Orias) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1624,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (1624,2,0,1000,1449,0);
 INSERT INTO `mob_droplist` VALUES (1624,2,0,1000,1452,0);
@@ -8380,18 +8384,21 @@ INSERT INTO `mob_droplist` VALUES (1624,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1624,0,0,1000,15110,130);
 INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,1452,10);
 INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,1455,90);
-INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,3358,10);
+INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,3358,240);   -- (Marquis_Cimeries) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1625,0,0,1000,15097,80);
+INSERT INTO `mob_droplist` VALUES (1626,0,0,1000,3358,240);   -- (Count_Vine) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1626,0,0,1000,1452,40);
 INSERT INTO `mob_droplist` VALUES (1626,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1626,0,0,1000,15126,120);
 INSERT INTO `mob_droplist` VALUES (1627,0,0,1000,2695,1000); -- (Marquis Forneus) bamboo_medicine_basket
 INSERT INTO `mob_droplist` VALUES (1627,0,0,1000,18952,131); -- (Marquis Forneus) faucheuse
 INSERT INTO `mob_droplist` VALUES (1627,0,0,1000,19040,131); -- (Marquis Forneus) shark_strap
+INSERT INTO `mob_droplist` VALUES (1628,0,0,1000,3358,150);   -- (Marquis_Gamygyn) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1628,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (1628,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1628,0,0,1000,15114,100);
+INSERT INTO `mob_droplist` VALUES (1629,0,0,1000,3358,240);   -- (Marquis_Nebiros) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1629,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (1629,2,0,1000,1449,0);
 INSERT INTO `mob_droplist` VALUES (1629,2,0,1000,1452,0);
@@ -8399,9 +8406,11 @@ INSERT INTO `mob_droplist` VALUES (1629,0,0,1000,1453,10);
 INSERT INTO `mob_droplist` VALUES (1629,2,0,1000,1455,0);
 INSERT INTO `mob_droplist` VALUES (1629,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1629,0,0,1000,15086,130);
+INSERT INTO `mob_droplist` VALUES (1630,0,0,1000,3358,150);   -- (Marquis_Orias) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1630,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (1630,0,0,1000,4249,1000);
 INSERT INTO `mob_droplist` VALUES (1630,0,0,1000,15075,60);
+INSERT INTO `mob_droplist` VALUES (1631,0,0,1000,3358,240);   -- (Marquis_Sabnak) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (1631,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (1631,2,0,1000,1449,0);
 INSERT INTO `mob_droplist` VALUES (1631,2,0,1000,1452,0);
@@ -10712,6 +10721,7 @@ INSERT INTO `mob_droplist` VALUES (2020,0,0,1000,5374,100);
 INSERT INTO `mob_droplist` VALUES (2020,0,0,1000,5375,100);
 INSERT INTO `mob_droplist` VALUES (2020,0,0,1000,5384,100);
 INSERT INTO `mob_droplist` VALUES (2020,0,0,1000,14555,1000);
+INSERT INTO `mob_droplist` VALUES (2021,0,0,1000,3358,240);   -- (Prince_Seere) shrouded_bijou
 INSERT INTO `mob_droplist` VALUES (2021,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (2021,0,0,1000,1456,10);
 INSERT INTO `mob_droplist` VALUES (2021,0,0,1000,4249,1000);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

It seems that Shrouded Bijou drops are really messed up in Dynamis - Xarcbard. I've added the item to several NM's that were missing it, and updated the drop rates in accordance with the "TH Level" chart from SE, using the TH0/TH2 columns from FFXIDB for each NM.
![image](https://user-images.githubusercontent.com/65316697/154404222-332c71c0-eeb4-4d85-936e-e153ec5845d7.png)
![image](https://user-images.githubusercontent.com/65316697/154404256-0a889465-a19c-4e30-9f4f-171c693469d7.png)

