### PR TITLE
fix itemid for bronze hammer in sparks shop

### DIFF
--- a/scripts/globals/sparkshop.lua
+++ b/scripts/globals/sparkshop.lua
@@ -84,7 +84,7 @@ local optionToItem = {
         [20] = { cost = 50, id = 17024 }, -- Ash club
         [21] = { cost = 50, id = 17034 }, -- Bronze mace
         [22] = { cost = 50, id = 17042 }, -- Bronze hammer
-        [23] = { cost = 50, id = 17042 }, -- Bronze rod
+        [23] = { cost = 50, id = 17059 }, -- Bronze rod
         [24] = { cost = 50, id = 17050 }, -- Willow wand
         [25] = { cost = 50, id = 17088 }, -- Ash staff
         [26] = { cost = 50, id = 17095 }, -- Ash pole

--- a/scripts/globals/sparkshop.lua
+++ b/scripts/globals/sparkshop.lua
@@ -83,7 +83,7 @@ local optionToItem = {
         [19] = { cost = 50, id = 16966 }, -- Tachi
         [20] = { cost = 50, id = 17024 }, -- Ash club
         [21] = { cost = 50, id = 17034 }, -- Bronze mace
-        [22] = { cost = 50, id = 4181  }, -- Bronze hammer
+        [22] = { cost = 50, id = 17042 }, -- Bronze hammer
         [23] = { cost = 50, id = 17042 }, -- Bronze rod
         [24] = { cost = 50, id = 17050 }, -- Willow wand
         [25] = { cost = 50, id = 17088 }, -- Ash staff


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Correct itemId for bronze hammer in sparks shop