### PR TITLE
Ranged attack crit rate fix

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1341,7 +1341,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             }
             else
             {
-                bool  isCritical = xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, true);
+                bool  isCritical = xirand::GetRandomNumber(100) < battleutils::GetRangedCritHitRate(this, PTarget);
                 float pdif       = battleutils::GetRangedDamageRatio(this, PTarget, isCritical);
 
                 if (isCritical)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2498,7 +2498,7 @@ namespace battleutils
 
     uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack)
     {
-        int32 crithitrate = 5;
+        int32 critHitRate = 5;
         if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIGHTY_STRIKES, 0) ||
             PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIGHTY_STRIKES))
         {
@@ -2508,7 +2508,7 @@ namespace battleutils
         {
             if (behind(PAttacker->loc.p, PDefender->loc.p, 64) || PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE))
             {
-                crithitrate = 100;
+                critHitRate = 100;
             }
         }
         else if (PAttacker->objtype == TYPE_PC && PAttacker->GetMJob() == JOB_THF && charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_ASSASSIN) &&
@@ -2517,7 +2517,7 @@ namespace battleutils
             CBattleEntity* taChar = battleutils::getAvailableTrickAttackChar(PAttacker, PDefender);
             if (taChar != nullptr)
             {
-                crithitrate = 100;
+                critHitRate = 100;
             }
         }
         else
@@ -2526,7 +2526,7 @@ namespace battleutils
             if (PAttacker->objtype == TYPE_PC)
             {
                 CCharEntity* PCharAttacker = static_cast<CCharEntity*>(PAttacker);
-                crithitrate += PCharAttacker->PMeritPoints->GetMeritValue(MERIT_CRIT_HIT_RATE, PCharAttacker);
+                critHitRate += PCharAttacker->PMeritPoints->GetMeritValue(MERIT_CRIT_HIT_RATE, PCharAttacker);
 
                 // Add Fencer crit hit rate
                 CItemWeapon* PMain = dynamic_cast<CItemWeapon*>(PCharAttacker->m_Weapons[SLOT_MAIN]);
@@ -2534,43 +2534,43 @@ namespace battleutils
                 if (PMain && !PMain->isTwoHanded() && !PMain->isHandToHand() &&
                     (!PSub || PSub->getSkillType() == SKILL_NONE || PCharAttacker->m_Weapons[SLOT_SUB]->IsShield()))
                 {
-                    crithitrate += PCharAttacker->getMod(Mod::FENCER_CRITHITRATE);
+                    critHitRate += PCharAttacker->getMod(Mod::FENCER_CRITHITRATE);
                 }
             }
 
             // ShowDebug("Crit rate mod before Innin/Yonin: %d", crithitrate);
             if (PDefender->objtype == TYPE_PC)
             {
-                crithitrate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
+                critHitRate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
             }
 
             // Check for Innin crit rate bonus from behind target
             if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PAttacker->loc.p, PDefender->loc.p, 64))
             {
-                crithitrate += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
+                critHitRate += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
             }
             // Check for Yonin enemy crit rate reduction while in front of target
             if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
             {
-                crithitrate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
+                critHitRate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
             }
 
             // ShowDebug("Crit rate mod after Innin/Yonin: %d", crithitrate);
 
-            crithitrate += GetDexCritBonus(PAttacker, PDefender);
-            crithitrate += PAttacker->getMod(Mod::CRITHITRATE);
-            crithitrate += PDefender->getMod(Mod::ENEMYCRITRATE);
-            crithitrate = std::clamp(crithitrate, 0, 100);
+            critHitRate += GetDexCritBonus(PAttacker, PDefender);
+            critHitRate += PAttacker->getMod(Mod::CRITHITRATE);
+            critHitRate += PDefender->getMod(Mod::ENEMYCRITRATE);
+            critHitRate = std::clamp(critHitRate, 0, 100);
         }
-        return (uint8)crithitrate;
+        return (uint8)critHitRate;
     }
 
     int8 GetDexCritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
         // https://www.bg-wiki.com/bg/Critical_Hit_Rate
-        int32 attackerdex = PAttacker->DEX();
-        int32 defenderagi = PDefender->AGI();
-        int32 dDex        = attackerdex - defenderagi;
+        int32 attackerDex = PAttacker->DEX();
+        int32 defenderAgi = PDefender->AGI();
+        int32 dDex        = attackerDex - defenderAgi;
         int32 dDexAbs     = std::abs(dDex);
         int32 sign        = 1;
 
@@ -2619,36 +2619,36 @@ namespace battleutils
 
     uint8 GetRangedCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        int32 crithitrate = 5;
+        int32 critHitRate = 5;
         // apply merit mods and traits
         if (PAttacker->objtype == TYPE_PC)
         {
                 CCharEntity* PCharAttacker = static_cast<CCharEntity*>(PAttacker);
-                crithitrate += PCharAttacker->PMeritPoints->GetMeritValue(MERIT_CRIT_HIT_RATE, PCharAttacker);
+                critHitRate += PCharAttacker->PMeritPoints->GetMeritValue(MERIT_CRIT_HIT_RATE, PCharAttacker);
         }
 
         if (PDefender->objtype == TYPE_PC)
         {
-            crithitrate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
+            critHitRate -= ((CCharEntity*)PDefender)->PMeritPoints->GetMeritValue(MERIT_ENEMY_CRIT_RATE, (CCharEntity*)PDefender);
         }
 
         // Check for Innin crit rate bonus from behind target
         if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_INNIN) && behind(PAttacker->loc.p, PDefender->loc.p, 64))
         {
-            crithitrate += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
+            critHitRate += PAttacker->StatusEffectContainer->GetStatusEffect(EFFECT_INNIN)->GetPower();
         }
         // Check for Yonin enemy crit rate reduction while in front of target
         if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_YONIN) && infront(PDefender->loc.p, PAttacker->loc.p, 64))
         {
-            crithitrate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
+            critHitRate -= PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_YONIN)->GetPower();
         }
 
-        crithitrate += GetAGICritBonus(PAttacker, PDefender);
-        crithitrate += PAttacker->getMod(Mod::CRITHITRATE);
-        crithitrate += PDefender->getMod(Mod::ENEMYCRITRATE);
-        crithitrate = std::clamp(crithitrate, 0, 100);
+        critHitRate += GetAGICritBonus(PAttacker, PDefender);
+        critHitRate += PAttacker->getMod(Mod::CRITHITRATE);
+        critHitRate += PDefender->getMod(Mod::ENEMYCRITRATE);
+        critHitRate = std::clamp(critHitRate, 0, 100);
 
-        return (uint8)crithitrate;
+        return (uint8)critHitRate;
     }
 
     int8 GetAGICritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -140,7 +140,9 @@ namespace battleutils
     uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber);
     uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int8 offsetAccuracy);
     uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack);
+    uint8 GetRangedCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     int8  GetDexCritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
+    int8  GetAGICritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);


### PR DESCRIPTION
Randed attack crit hit rate adjustments

fix for issue #1302

Added a new GetRangedCritHitRate to replace GetCritHitRate that ranged attack currently uses.

Added a new GetAGICritBonus to replace GetDexCritBonus that ranged attack currently uses.

Tested on multiple mobs at verious levels from 1 - 119+, also tested with +0 agility and +150 agility.
Needs validation, but crit hit rates fall within expected ranges compared to retail from my testing.

As this stands, you would need an absurd amount of agility to outshine a crit hit build,
From testing having 250 more agi than a mob resulted in a figure of around 20% crit hit rate.

- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
