### PR TITLE
Fix Nomad Moogle default actions event parameters

### DIFF
--- a/scripts/zones/RuLude_Gardens/DefaultActions.lua
+++ b/scripts/zones/RuLude_Gardens/DefaultActions.lua
@@ -2,5 +2,5 @@ local ID = require("scripts/zones/RuLude_Gardens/IDs")
 
 return {
     ['Maat']          = { messageSpecial = ID.text.MAAT_DIALOG },
-    ['Nomad_Moogle']  = { event = 10045, 0, 2, 0, 0 }, -- doesnt work. returns 10045 alone
+    ['Nomad_Moogle']  = { event = 10045, options = { 0, 2, 0, 0 } },
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
