### PR TITLE
ID_SHIFTS_FEB22

### DIFF
--- a/scripts/zones/Quicksand_Caves/IDs.lua
+++ b/scripts/zones/Quicksand_Caves/IDs.lua
@@ -102,11 +102,11 @@ zones[xi.zone.QUICKSAND_CAVES] =
             [3] = {479.000, -14.000, -815.000},
             [4] = {814.000, -14.000, -761.000}
         },
-        CASKET_BASE            = 17629663,
-        ORNATE_DOOR_OFFSET     = 17629685,
-        CHAINS_THAT_BIND_US_QM = 17629738,
-        TREASURE_COFFER        = 17629739,
-        ANTICAN_TAG_QM         = 17629761,
+        CASKET_BASE            = 17629671,
+        ORNATE_DOOR_OFFSET     = 17629693,
+        CHAINS_THAT_BIND_US_QM = 17629746,
+        TREASURE_COFFER        = 17629747,
+        ANTICAN_TAG_QM         = 17629769,
     },
 }
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

The ornate doors onRegion need to be looked at as I think they are wonky from something else unrelated to NPCshifts. 
