### PR TITLE
[Magic] Spell damage documentation and fixes

### DIFF
--- a/scripts/globals/magic_utils/spell_damage.lua
+++ b/scripts/globals/magic_utils/spell_damage.lua
@@ -219,7 +219,7 @@ xi.magic_utils.spell_damage.calculateSDT = function(caster, target, spell, spell
     -- A value of 5000 -> 50% LESS damage taken.
     -- A value of -5000 -> 50% MORE damage taken.
 
-        SDT = (SDTMod / -100) + 1
+        SDT = (SDTMod / -10000) + 1
     end
 
     -- A word on SDT as understood in some wikis, even if they are refering to resistance and not actual SDT
@@ -342,16 +342,20 @@ xi.magic_utils.spell_damage.calculateResist = function(caster, target, spell, sk
         end
         -- RDM Job Point: Magic Accuracy Bonus, All MACC + 1
         magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.RDM_MAGIC_ACC_BONUS)
-    -- NIN Job Points: Ninjutsu Accuracy Bonus
-    elseif casterJob == xi.job.NIN and skillType == xi.skill.NINJUTSU then
-        magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.NINJITSU_ACC_BONUS)
+    -- NIN Job Points
+    elseif casterJob == xi.job.NIN then
+        -- NIN Job Points: Ninjutsu Accuracy Bonus
+        if skillType == xi.skill.NINJUTSU then
+            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.NINJITSU_ACC_BONUS)
+        end
     -- SCH Job Points
-    elseif
-        casterJob == xi.job.SCH and
-        (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
-        (spellGroup == xi.magic.spellGroup.BLACK and caster:hasStatusEffect(xi.effect.PENURY))
-    then
-        magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.STRATEGEM_EFFECT_I)
+    elseif casterJob == xi.job.SCH then
+        if
+            (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
+            (spellGroup == xi.magic.spellGroup.BLACK and caster:hasStatusEffect(xi.effect.PENURY))
+        then
+            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.STRATEGEM_EFFECT_I)
+        end
     end
 
     -----------------------------------


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Changes:
- Fixes a problem with magic dmg taken modifiers being wrongly handled and MDB being handled 2 times in different places.
- Documents how SDT values are being handled in database, core and here. SDT conversion fixed for new database values.
- Failed to lower cyclomatic complexity, so that change was reverted. For now, I believe it is more important that this process is streamlined and easy to follow.