### PR TITLE
[Trust] Corrected zone for hidden quests Trust Semih

### DIFF
--- a/scripts/quests/hiddenQuests/Trust_Semih.lua
+++ b/scripts/quests/hiddenQuests/Trust_Semih.lua
@@ -18,7 +18,7 @@ quest.sections =
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.THE_PATH_UNTRAVELED)
         end,
 
-        [xi.zone.CHATEAU_DORAGUILLE] =
+        [xi.zone.HEAVENS_TOWER] =
         {
             ['Kupipi'] =
             {


### PR DESCRIPTION
This hidden quest had the wrong zone set, 

Previously: xi.zone.CHATEAU_DORAGUILLE
now: xi.zone.HEAVENS_TOWER

https://www.bg-wiki.com/ffxi/Cipher_Of_Semih%27s_Alter_Ego

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
