### PR TITLE
Correct Survival guide Gil / Tab cost

### DIFF
--- a/scripts/globals/survival_guide.lua
+++ b/scripts/globals/survival_guide.lua
@@ -155,12 +155,12 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option)
                 local teleportCostGil = SURVIVAL_GUIDE_TELEPORT_COST_GIL
                 local teleportCostTabs = SURVIVAL_GUIDE_TELEPORT_COST_TABS
 
-                -- If the player has the rhapsody in white, the cost is 10% of original gil or 20% of original tabs.
-                -- GIL: 1000 -> 200
-                -- TABS: 100 -> 10
+                -- If the player has the "Rhapsody in White" KI, the cost is 10% of original gil or 20% of original tabs.
+                -- GIL: 1000 -> 100
+                -- TABS: 50 -> 10
                 if player:hasKeyItem(xi.ki.RHAPSODY_IN_WHITE) then
-                    teleportCostGil = teleportCostGil * .2
-                    teleportCostTabs = teleportCostTabs * .2
+                    teleportCostGil = teleportCostGil / 10
+                    teleportCostTabs = teleportCostTabs / 5
                 end
 
                 local canTeleport = false


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

If anything, it corrects 3 self-contradictory statements