### PR TITLE
[trust] Pianissimo trust fix and trust cool down adjustments

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -234,7 +234,7 @@ CCharEntity::CCharEntity()
 
     m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
 
-    m_TimeLastMemberJoined = server_clock::now() - std::chrono::seconds(120); // default time
+    m_LeaderCreatedPartyTime = server_clock::now() - std::chrono::seconds(120); // default time
 
     PAI = std::make_unique<CAIContainer>(this, nullptr, std::make_unique<CPlayerController>(this), std::make_unique<CTargetFind>(this));
 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -234,6 +234,8 @@ CCharEntity::CCharEntity()
 
     m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
 
+    m_TimeLastMemberJoined = server_clock::now() - std::chrono::seconds(120); // default time
+
     PAI = std::make_unique<CAIContainer>(this, nullptr, std::make_unique<CPlayerController>(this), std::make_unique<CTargetFind>(this));
 }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -234,8 +234,6 @@ CCharEntity::CCharEntity()
 
     m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
 
-    m_LeaderCreatedPartyTime = server_clock::now() - std::chrono::seconds(120); // default time
-
     PAI = std::make_unique<CAIContainer>(this, nullptr, std::make_unique<CPlayerController>(this), std::make_unique<CTargetFind>(this));
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -366,6 +366,8 @@ public:
 
     uint32 m_LastYell;
 
+    time_point m_TimeLastMemberJoined; // Time that a party member joined and this player was leader.
+
     uint8 m_GMlevel;    // Level of the GM flag assigned to this character
     bool  m_isGMHidden; // GM Hidden flag to prevent player updates from being processed.
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -366,7 +366,7 @@ public:
 
     uint32 m_LastYell;
 
-    time_point m_TimeLastMemberJoined; // Time that a party member joined and this player was leader.
+    time_point m_LeaderCreatedPartyTime; // Time that a party member joined and this player was leader.
 
     uint8 m_GMlevel;    // Level of the GM flag assigned to this character
     bool  m_isGMHidden; // GM Hidden flag to prevent player updates from being processed.

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -433,6 +433,11 @@ bool CTrustEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
         return true;
     }
 
+    if ((targetFlags & TARGET_PLAYER_PARTY_PIANISSIMO) && PInitiator->allegiance == allegiance && PMaster && PInitiator != this)
+    {
+        return true;
+    }
+
     if (targetFlags & TARGET_PLAYER_PARTY && PInitiator->objtype == TYPE_PET && PInitiator->allegiance == allegiance)
     {
         return true;

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -499,7 +499,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
     if (PEntity->objtype == TYPE_PC && this->members.size() > 1)
     {
         auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
-        PLeader->m_TimeLastMemberJoined = server_clock::now();
+        PLeader->m_LeaderCreatedPartyTime = server_clock::now();
     }
 
     if (m_PartyType == PARTY_PCS)
@@ -1217,7 +1217,7 @@ uint32 CParty::GetTimeLastMemberJoined()
 {
     auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
 
-    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(PLeader->m_TimeLastMemberJoined).time_since_epoch().count();
+    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(PLeader->m_LeaderCreatedPartyTime).time_since_epoch().count();
 }
 
 bool CParty::HasTrusts()

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -498,7 +498,8 @@ void CParty::AddMember(CBattleEntity* PEntity)
 
     if (PEntity->objtype == TYPE_PC && this->members.size() > 1)
     {
-        this->m_TimeLastMemberJoined = server_clock::now();
+        auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
+        PLeader->m_TimeLastMemberJoined = server_clock::now();
     }
 
     if (m_PartyType == PARTY_PCS)
@@ -1214,7 +1215,9 @@ void CParty::SetPartyNumber(uint8 number)
 
 uint32 CParty::GetTimeLastMemberJoined()
 {
-    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(m_TimeLastMemberJoined).time_since_epoch().count();
+    auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
+
+    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(PLeader->m_TimeLastMemberJoined).time_since_epoch().count();
 }
 
 bool CParty::HasTrusts()

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -499,7 +499,11 @@ void CParty::AddMember(CBattleEntity* PEntity)
     if (PEntity->objtype == TYPE_PC && this->members.size() > 1)
     {
         auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
-        PLeader->m_LeaderCreatedPartyTime = server_clock::now();
+
+        if (PLeader)
+        {
+            PLeader->m_LeaderCreatedPartyTime = server_clock::now();
+        }
     }
 
     if (m_PartyType == PARTY_PCS)
@@ -1216,8 +1220,14 @@ void CParty::SetPartyNumber(uint8 number)
 uint32 CParty::GetTimeLastMemberJoined()
 {
     auto* PLeader = dynamic_cast<CCharEntity*>(CParty::GetLeader());
+    auto LeaderMemberLastJoinedTime = server_clock::now();
 
-    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(PLeader->m_LeaderCreatedPartyTime).time_since_epoch().count();
+    if (PLeader)
+    {
+        LeaderMemberLastJoinedTime = PLeader->m_LeaderCreatedPartyTime;
+    }
+
+    return (uint32)std::chrono::time_point_cast<std::chrono::seconds>(LeaderMemberLastJoinedTime).time_since_epoch().count();
 }
 
 bool CParty::HasTrusts()

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -119,8 +119,6 @@ private:
     void                     RemovePartyLeader(CBattleEntity* PEntity); // лидер покидает группу
     std::vector<partyInfo_t> GetPartyInfo() const;
     void                     RefreshFlags(std::vector<partyInfo_t>&);
-
-    time_point m_TimeLastMemberJoined;
 };
 
 #endif


### PR DESCRIPTION
This PR is to fix two issues:
1: Enable Pianissimo to be used on trust.
fixes issue #1348 

2: Allow a party leader with a trust cool down to change leader and the new leader can cast trust right away if they currently have no cool down themselves.
fixes issue #800

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
