### PR TITLE
[module] Changed module initialization order

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -244,8 +244,6 @@ namespace luautils
         // Handle settings
         contentRestrictionEnabled = GetSettingsVariable("RESTRICT_CONTENT") != 0;
 
-        moduleutils::LoadLuaModules();
-
         TracyReportLuaMemory(lua.lua_state());
 
         return 0;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -59,6 +59,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "utils/instanceutils.h"
 #include "utils/itemutils.h"
 #include "utils/mobutils.h"
+#include "utils/moduleutils.h"
 #include "utils/petutils.h"
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
@@ -261,6 +262,8 @@ int32 do_init(int32 argc, char** argv)
     CVanaTime::getInstance()->setCustomEpoch(map_config.vanadiel_time_epoch);
 
     zoneutils::InitializeWeather(); // Need VanaTime initialized
+
+    moduleutils::LoadLuaModules();
 
     CTransportHandler::getInstance()->InitializeTransport();
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

It seemed to me that loading modules and then potentially loading other lua stuff (such as spells) is a bit counter productive. Modules should probably be loaded last so that modules effecting spells are not overwritten.
