### PR TITLE
[login] Fix startup logging

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -137,8 +137,8 @@ int32 do_init(int32 argc, char** argv)
 
     if (attached)
     {
+        ShowStatus("Console input thread is ready...");
         consoleInputThread = std::thread([&]() {
-            ShowStatus("Console input thread is ready..\r");
             // ctrl c apparently causes log spam
             auto lastInputTime = server_clock::now();
             while (consoleThreadRun)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Before:
```
[03/04/22 08:36:40:323][login][info][info] Console Silent Setting: 0 (login_config_read:398)
[03/04/22 08:36:40:324][login][info][status] The login-server-auth is ready (Server is listening on the port 54231). (do_init:103)
[03/04/22 08:36:40:324][login][info][status] The login-server-lobbydata is ready (Server is listening on the port 54230). (do_init:106)
[03/04/22 08:36:40:324][login][info][status] The login-server-lobbyview is ready (Server is listening on the port 54001). (do_init:109)
[03/04/22 08:36:40:694][login][info][status] The login-server is ready to work... (do_init:128)
 (do_init::<lambda_254583640ebf391bd983b4598bef0842>::operator ():141)eady..
```

After:
```
[03/04/22 08:34:50:508][login][info][info] Console Silent Setting: 0 (login_config_read:398)
[03/04/22 08:34:50:509][login][info][status] The login-server-auth is ready (Server is listening on the port 54231). (do_init:103)
[03/04/22 08:34:50:509][login][info][status] The login-server-lobbydata is ready (Server is listening on the port 54230). (do_init:106)
[03/04/22 08:34:50:509][login][info][status] The login-server-lobbyview is ready (Server is listening on the port 54001). (do_init:109)
[03/04/22 08:34:50:834][login][info][status] The login-server is ready to work... (do_init:128)
[03/04/22 08:34:50:834][login][info][status] Console input thread is ready... (do_init:140)
```
