### PR TITLE
[PLD] moved Iron Will to Rampart instead of Magic Shield

### DIFF
--- a/scripts/globals/effects/magic_shield.lua
+++ b/scripts/globals/effects/magic_shield.lua
@@ -18,9 +18,6 @@ effect_object.onEffectGain = function(target, effect)
         target:addMod(xi.mod.DARK_ABSORB, 100)
     elseif effect:getPower() < 2 then
         target:addMod(xi.mod.UDMGMAGIC, -10000)
-        if target:isPC() and target:hasTrait(77) then -- Iron Will
-            target:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
-        end
     else
         target:addMod(xi.mod.MAGIC_ABSORB, 100)
     end
@@ -41,9 +38,6 @@ effect_object.onEffectLose = function(target, effect)
         target:delMod(xi.mod.DARK_ABSORB, 100)
     elseif effect:getPower() < 2 then
         target:delMod(xi.mod.UDMGMAGIC, -10000)
-        if target:isPC() and target:hasTrait(77) then -- Iron Will
-            target:delMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
-        end
     else
         target:delMod(xi.mod.MAGIC_ABSORB, 100)
     end

--- a/scripts/globals/effects/rampart.lua
+++ b/scripts/globals/effects/rampart.lua
@@ -11,6 +11,10 @@ effect_object.onEffectGain = function(target, effect)
     target:addMod(xi.mod.UDMGBREATH, -power)
     target:addMod(xi.mod.UDMGMAGIC, -power)
     target:addMod(xi.mod.UDMGRANGE, -power)
+
+    if target:isPC() and target:hasTrait(77) then -- Iron Will
+        target:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
+    end
 end
 
 effect_object.onEffectTick = function(target, effect)
@@ -22,6 +26,10 @@ effect_object.onEffectLose = function(target, effect)
     target:delMod(xi.mod.UDMGBREATH, -power)
     target:delMod(xi.mod.UDMGMAGIC, -power)
     target:delMod(xi.mod.UDMGRANGE, -power)
+
+    if target:isPC() and target:hasTrait(77) then -- Iron Will
+        target:delMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
+    end
 end
 
 return effect_object


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Years ago, Rampart was changed to its accurate version from the
old magic shield version to match: https://www.bg-wiki.com/ffxi/Rampart.

It would appear the Iron Will merit trait got left behind.