### PR TITLE
QC: San d'Oria M4-1 - Magicite

### DIFF
--- a/scripts/missions/sandoria/4_1_Magicite.lua
+++ b/scripts/missions/sandoria/4_1_Magicite.lua
@@ -69,13 +69,15 @@ mission.sections =
             onEventFinish =
             {
                 [45] = function(player, csid, option, npc)
+                    -- TODO: Verify that the mission is displayed in the logs here.  It may not officially be logged
+                    -- until talking to the Ambassador.
                     mission:begin(player)
                 end,
             },
         },
     },
 
-    -- Section 1: Mandatory pre-requisites. Necesary steps required even when having completed this mission for another nation.
+    -- Section 1: Mandatory pre-requisites. Necessary steps required even when having completed this mission for another nation.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
@@ -103,10 +105,35 @@ mission.sections =
                 end,
             },
 
-            ['Nelcabrit'] =
+            ['High_Wind'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 1 then
+                        -- Note: The event parameter below corresponds to having keyItem for Audience Permit.
+                        -- Currently have not captured a case where the negative answer is displayed.
+                        return mission:progressEvent(164, 1)
+                    end
+                end,
+            },
+
+            ['Rainhard'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        return mission:progressEvent(165, 1)
+                    end
+                end,
+            },
+
+            ['Nelcabrit'] =
+            {
+                onTrigger = function(player, npc)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 0 then
+                        -- Nelcabrit will display this message until talking to Jima (Door)
+                        return mission:progressEvent(45)
+                    elseif missionStatus == 1 then
                         return mission:progressEvent(133)
                     else
                         return mission:progressEvent(136)
@@ -123,6 +150,7 @@ mission.sections =
 
                 [130] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 1)
+                    -- You Accept the Mission message here
                     npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,
             },
@@ -157,7 +185,7 @@ mission.sections =
         },
     },
 
-    -- Section 2: Key Item hunt and Magicite obtention. Several steps aren't required or may have been already completed in another nation.
+    -- Section 2: Key Item hunt and Magicite gathering. Several steps aren't required or may have been already completed in another nation.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
@@ -175,6 +203,24 @@ mission.sections =
                         else
                             return mission:progressEvent(60)
                         end
+                    end
+                end,
+            },
+
+            ['High_Wind'] =
+            {
+                onTrigger = function(player, npc)
+                    if magiciteCounter(player) == 3 then
+                        return mission:progressEvent(164, 1)
+                    end
+                end,
+            },
+
+            ['Rainhard'] =
+            {
+                onTrigger = function(player, npc)
+                    if magiciteCounter(player) == 3 then
+                        return mission:progressEvent(165, 1)
                     end
                 end,
             },
@@ -337,9 +383,9 @@ mission.sections =
                     if not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
                         if magiciteCounter(player) == 2 then
                             -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1)
+                            return mission:progressEvent(0, 1, 46, 47)
                         else
-                            return mission:progressEvent(0)
+                            return mission:progressEvent(0, 0, 46, 47)
                         end
                     end
                 end,
@@ -354,7 +400,7 @@ mission.sections =
         },
     },
 
-    -- Section 3: Magicite given to Jeuno totally-not-evil leader. Finish quest.
+    -- Section 3: Magicite given to Jeuno leader. Finish quest.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and

--- a/scripts/zones/Qulun_Dome/DefaultActions.lua
+++ b/scripts/zones/Qulun_Dome/DefaultActions.lua
@@ -1,6 +1,7 @@
 local ID = require("scripts/zones/Qulun_Dome/IDs")
 
 return {
+    ['_440']     = { messageSpecial = ID.text.IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC },
     ['Magicite'] = { messageSpecial = ID.text.THE_MAGICITE_GLOWS_OMINOUSLY },
     ['qm1']      = { messageSpecial = ID.text.YOU_FIND_NOTHING },
 }

--- a/scripts/zones/Qulun_Dome/npcs/_440.lua
+++ b/scripts/zones/Qulun_Dome/npcs/_440.lua
@@ -13,19 +13,14 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:hasKeyItem(xi.ki.SILVER_BELL) and player:hasKeyItem(xi.ki.CORUSCANT_ROSARY) and player:hasKeyItem(xi.ki.BLACK_MATINEE_NECKLACE)) then
-        if (player:getZPos() < -7.2) then
+    if player:hasKeyItem(xi.ki.SILVER_BELL) and player:hasKeyItem(xi.ki.CORUSCANT_ROSARY) and player:hasKeyItem(xi.ki.BLACK_MATINEE_NECKLACE) then
+        if player:getZPos() < -7.2 then
             player:startEvent(51)
         else
+            -- This event automatically handles the distance check
             player:startEvent(50)
         end
-    else
-        player:messageSpecial(ID.text.IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC)
     end
-
-    return 1
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
@@ -33,7 +28,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
 
-    if ((csid == 50 or csid == 51) and option == 1) then
+    if (csid == 50 or csid == 51) and option == 1 then
         player:messageSpecial(ID.text.THE_3_ITEMS_GLOW_FAINTLY, xi.ki.SILVER_BELL, xi.ki.CORUSCANT_ROSARY, xi.ki.BLACK_MATINEE_NECKLACE)
     end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Adds additional dialogue and parameters for San d'Oria M4-1