### PR TITLE
Shorten variable names for Moghouse Exposition

### DIFF
--- a/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
+++ b/scripts/quests/hiddenQuests/Moghouse_Exposition.lua
@@ -6,7 +6,7 @@ require('scripts/globals/zone')
 require('scripts/globals/interaction/hidden_quest')
 -----------------------------------
 
-local quest = HiddenQuest:new("moghouseExpo")
+local quest = HiddenQuest:new("mogExpo")
 
 quest.reward = {}
 
@@ -31,7 +31,7 @@ local moogleZoneInEvent =
     {
         [30000] = function(player, csid, option, npc)
             quest:complete(player)
-            quest:setVar(player, 'otherNation', 1)
+            quest:setVar(player, 'oNation', 1)
         end,
     },
 }
@@ -41,7 +41,7 @@ quest.sections[2] = {}
 quest.sections[2].check = function(player, currentMission, missionStatus, vars)
     return not xi.moghouse.isInMogHouseInHomeNation(player) and
         player:isInMogHouse() and
-        quest:getVar(player, 'otherNation') == 1
+        quest:getVar(player, 'oNation') == 1
 end
 
 local otherNationTriggerEvent =


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Possible to hit an invalid field length for the DB charvar name, shortened both the quest name and otherNation variable