### PR TITLE
Allow double quotes in the most recent git commit subject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ message(STATUS "GIT_BRANCH: ${GIT_BRANCH}")
 message(STATUS "GIT_DATE: ${GIT_DATE}")
 message(STATUS "GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT}")
 
+string(REGEX REPLACE "\"" "'" GIT_COMMIT_SUBJECT ${GIT_COMMIT_SUBJECT})
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/common/version.cpp.in
                ${CMAKE_CURRENT_SOURCE_DIR}/src/common/version.cpp)
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Here's a fun one, if your most recent git commit has double quotes in the subject, the project won't build. This fixes that. 

I don't know if there is a better way to do this, like update the .in file with a special quote like languages such as python or lua have so they can write any symbol in a string freely, but I don't know of any capability in C++. If you do, I'd be glad to change to that, but this works for now.