### PR TITLE
Safety check on builds with no GIT_COMMIT_SUBJECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,9 @@ message(STATUS "GIT_BRANCH: ${GIT_BRANCH}")
 message(STATUS "GIT_DATE: ${GIT_DATE}")
 message(STATUS "GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT}")
 
-string(REGEX REPLACE "\"" "'" GIT_COMMIT_SUBJECT ${GIT_COMMIT_SUBJECT})
+if (GIT_COMMIT_SUBJECT)
+    string(REGEX REPLACE "\"" "'" GIT_COMMIT_SUBJECT ${GIT_COMMIT_SUBJECT})
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/common/version.cpp.in
                ${CMAKE_CURRENT_SOURCE_DIR}/src/common/version.cpp)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Not sure how many this would affect. However, if I'm building inside docker, I'm typically not moving my .git repo in. Thus, you run into an instance where an error occurs in cmake because there is no GIT_COMMIT_SUBJECT. Just in case, this is a "safer" more general purpose approach.
