### PR TITLE
[RUN] Make enforceRuneCounts More Robust, Implement Action Packet 15 Handling, Add More Known Messages

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -34,19 +34,28 @@ local function enforceRuneCounts(target)
     local RUNLevel = getRUNLevel(target)
     local maxRunes = RUNLevel >= 65 and 3 or RUNLevel >= 35 and 2 or 1
     local effects = target:getStatusEffects()
-    local runes = {}
+    local oldestRune = nil
+    local oldestRuneDuration = 0
     local i = 0
 
     for _, effect in ipairs(effects) do
         local type = effect:getType()
         if type >= xi.effect.IGNIS and type <= xi.effect.TENEBRAE then
-            runes[i+1] = effect
+
+            local remainingDuration = effect:getTimeRemaining()
+
+            if oldestRune == nil then
+                oldestRune = type
+                oldestRuneDuration = remainingDuration
+            elseif remainingDuration < oldestRuneDuration then
+                oldestRune = type
+                oldestRuneDuration = remainingDuration
+            end
             i = i + 1
         end
     end
-
-    if i >= maxRunes then -- delete the first rune in the list with the least duration
-        target:delStatusEffect(runes[1]:getType())
+    if i >= maxRunes then -- delete the rune with the least duration
+        target:delStatusEffectSilent(oldestRune)
     end
 end
 

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -44,10 +44,7 @@ local function enforceRuneCounts(target)
 
             local remainingDuration = effect:getTimeRemaining()
 
-            if oldestRune == nil then
-                oldestRune = type
-                oldestRuneDuration = remainingDuration
-            elseif remainingDuration < oldestRuneDuration then
+            if oldestRune == nil or remainingDuration < oldestRuneDuration then
                 oldestRune = type
                 oldestRuneDuration = remainingDuration
             end

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -33,26 +33,10 @@ end
 local function enforceRuneCounts(target)
     local RUNLevel = getRUNLevel(target)
     local maxRunes = RUNLevel >= 65 and 3 or RUNLevel >= 35 and 2 or 1
-    local effects = target:getStatusEffects()
-    local oldestRune = nil
-    local oldestRuneDuration = 0
-    local i = 0
 
-    for _, effect in ipairs(effects) do
-        local type = effect:getType()
-        if type >= xi.effect.IGNIS and type <= xi.effect.TENEBRAE then
-
-            local remainingDuration = effect:getTimeRemaining()
-
-            if oldestRune == nil or remainingDuration < oldestRuneDuration then
-                oldestRune = type
-                oldestRuneDuration = remainingDuration
-            end
-            i = i + 1
-        end
-    end
-    if i >= maxRunes then -- delete the rune with the least duration
-        target:delStatusEffectSilent(oldestRune)
+    local activeRunes = target:getActiveRuneCount()
+    if activeRunes >= maxRunes then -- delete the rune with the least duration
+        target:removeOldestRune()
     end
 end
 

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -311,6 +311,15 @@ xi.msg.basic =
     LUOPAN_HP_RATE_UP      = 664, -- <player> uses <ability>. The luopan's HP consumption rate has been increased.
     HAS_LUOPON_NO_USE      = 665, -- <player> has a pet. Unable to use ability.
 
+    --- RUN
+    REQUIRE_RUNE           = 666, -- That action requires the ability Rune Enchantment.
+    SWORDPLAY_GAIN         = 667, -- <Player> uses <Ability>. Accuracy and evasion are enhanced.
+    VALLATION_GAIN         = 668, -- <Target> receives the effect of Vallation, reducing damage taken from certain elemental magic spells. -- Vallation and Valiance both use this message for the RUN using the ja
+    VALIANCE_GAIN_PARTY    = 669, -- Magic damage of a certain element is reduced for <Target>                                             -- This message is when a party member recieves the aoe effect of Valiance
+    LIEMENT_GAIN           = 670, -- <Player> uses <Ability>. <Target> can now absorb magic damage of a certain element.
+    PFLUG_GAIN             = 671, -- <Player> uses <Ability>. <Target> now has enhanced resistance.
+    GAMBIT_GAIN            = 672, -- <Player> uses <Ability>. <Target> receives the effect of Gambit, reducing magic defense against magic of a certain element.
+
     -- Fields / Grounds of Valor
     FOV_DEFEATED_TARGET     = 558,  -- You defeated a designated target.${lb}(Progress: ${number}/${number2})
     FOV_COMPLETED_REGIME    = 559,  -- You have successfully completed the training regime.

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -370,19 +370,19 @@ INSERT INTO `abilities` VALUES (362,'sulpor',22,5,1,5,10,0,0,295,2000,0,6,0.0,0,
 INSERT INTO `abilities` VALUES (363,'unda',22,5,1,5,10,0,0,296,2000,0,6,0.0,0,0,0,0,0,'SOA');
 INSERT INTO `abilities` VALUES (364,'lux',22,5,1,5,10,0,0,297,2000,0,6,0.0,0,0,0,0,0,'SOA');
 INSERT INTO `abilities` VALUES (365,'tenebrae',22,5,1,5,10,0,0,298,2000,0,6,0.0,0,0,0,0,0,'SOA');
--- INSERT INTO `abilities` VALUES (366,'vallation',22,10,1,180,23,668,0,0,2000,0,15,0.0,0,450,900,1794,0,'SOA'); -- check merit
+INSERT INTO `abilities` VALUES (366,'vallation',22,10,1,180,23,668,366,0,2000,0,15,0.0,0,450,900,1794,0,'SOA');
 INSERT INTO `abilities` VALUES (367,'swordplay',22,20,1,300,24,667,0,299,2000,0,6,0.0,0,160,320,0,0,'SOA');
--- INSERT INTO `abilities` VALUES (368,'lunge',22,25,4,180,25,110,0,8,2000,0,15,4.0,0,0,0,1796,0,'SOA'); -- check merit
--- INSERT INTO `abilities` VALUES (369,'pflug',22,40,1,180,59,671,0,1,2000,0,15,0.0,0,450,900,1798,0,'SOA'); -- check merit
+-- INSERT INTO `abilities` VALUES (368,'lunge',22,25,4,180,25,110,0,8,2000,0,15,4.0,0,0,0,1796,0,'SOA');
+INSERT INTO `abilities` VALUES (369,'pflug',22,40,1,180,59,671,369,1,2000,0,15,0.0,0,450,900,1798,0,'SOA');
 INSERT INTO `abilities` VALUES (370,'embolden',22,60,1,600,72,100,0,300,2000,0,6,0.0,0,160,320,0,0,'SOA');
--- INSERT INTO `abilities` VALUES (371,'valiance',22,50,1,300,113,668,0,2,2000,0,15,0.0,0,450,900,0,0,'SOA');
--- INSERT INTO `abilities` VALUES (372,'gambit',22,70,4,300,116,0,0,4,2000,0,15,4.0,0,640,1280,1800,0,'SOA'); -- check animation
--- INSERT INTO `abilities` VALUES (373,'liement',22,85,1,180,117,0,0,4,2000,0,15,0.0,0,450,900,0,0,'SOA'); -- check animation
+INSERT INTO `abilities` VALUES (371,'valiance',22,50,1,300,113,668,0,2,2000,0,15,14.0,1,450,900,1794,0,'SOA');
+-- INSERT INTO `abilities` VALUES (372,'gambit',22,70,4,300,116,672,372,4,2000,0,15,4.0,0,640,1280,1800,0,'SOA'); -- check animation
+INSERT INTO `abilities` VALUES (373,'liement',22,85,1,180,117,670,373,4,2000,0,15,0.0,0,450,900,0,0,'SOA'); -- check animation
 INSERT INTO `abilities` VALUES (374,'one_for_all',22,95,1,300,118,100,0,301,2000,0,6,0.0,1,160,320,0,0,'SOA');
 -- INSERT INTO `abilities` VALUES (375,'rayke',22,75,4,300,119,0,0,4,2000,0,15,4.0,0,640,1260,0,0,'SOA'); -- check animation
--- INSERT INTO `abilities` VALUES (376,'battuta',22,75,1,300,120,100,0,4,2000,0,15,0.0,0,450,900,0,0,'SOA');
+INSERT INTO `abilities` VALUES (376,'battuta',22,75,1,300,120,100,0,4,2000,0,15,0.0,0,450,900,0,0,'SOA');
 INSERT INTO `abilities` VALUES (377,'widened_compass',21,96,1,3600,130,100,0,276,2000,0,6,0.0,0,1,300,0,0,'SOA');
--- INSERT INTO `abilities` VALUES (378,'odyllic_subterfuge',22,96,4,3600,131,0,0,10,2000,0,15,8.0,15,1,318,0,0,NULL); -- check 6 or 15 animation
+INSERT INTO `abilities` VALUES (378,'odyllic_subterfuge',22,96,4,3600,131,0,0,277,2000,0,6,8.0,6,1,318,0,0,'SOA');
 INSERT INTO `abilities` VALUES (379,'ward',22,1,1,0,142,0,0,0,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (380,'effusion',22,1,1,0,143,0,0,0,2000,0,6,0.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (381,'chocobo_jig_ii',19,70,1,60,218,126,0,13,2000,0,14,0.0,1,1,300,0,0,'SOA');

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -290,6 +290,8 @@ uint16 CAbility::getAoEMsg() const
         case 437:
         case 439:
             return m_message + 1;
+        case 668: // Valiance has a seperate message for party member who gain the effect.
+            return m_message + 1;
 
         default:
             return m_message;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -687,6 +687,9 @@ void CLuaBaseEntity::injectActionPacket(uint16 action, uint16 anim, uint16 spec,
         case 14:
             actiontype = ACTION_DANCE;
             break;
+        case 15:
+            actiontype = ACTION_RUN_WARD_EFFUSION;
+            break;
     }
 
     action_t Action;

--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -80,6 +80,11 @@ CActionPacket::CActionPacket(action_t& action)
             packBitsBE(data, action.recast, 118, 10);
         }
         break;
+        case ACTION_RUN_WARD_EFFUSION:
+        {
+            packBitsBE(data, action.actionid, 86, 10);
+        }
+        break;
         case ACTION_WEAPONSKILL_START:
         case ACTION_MOBABILITY_START:
         {

--- a/src/map/packets/action.h
+++ b/src/map/packets/action.h
@@ -47,8 +47,9 @@ enum ACTIONTYPE : uint8
     ACTION_RANGED_START          = 12,
     ACTION_PET_MOBABILITY_FINISH = 13,
     ACTION_DANCE                 = 14,
-    ACTION_QUARRY                = 15,
-    ACTION_SPRINT                = 16,
+    ACTION_RUN_WARD_EFFUSION     = 15,
+    ACTION_QUARRY                = 21,
+    ACTION_SPRINT                = 22,
 
     // these aren't actual action packet IDs - they exist for simplicity
     // because we are too lazy to figure out 0x0A - 0x0F in the action packet

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -140,6 +140,14 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_LUOPAN_HP_RATE_DOWN   = 663, /* <player> uses <ability>. The luopan's HP consumption rate has been reduced. */
     MSGBASIC_LUOPAN_HP_RATE_UP     = 664, /* <player> uses <ability>. The luopan's HP consumption rate has been increased. */
     MSGBASIC_HAS_LUOPON_NO_USE     = 665, /* <player> has a pet. Unable to use ability. */
+    /* RUN */
+    MSGBASIC_REQUIRE_RUNE                 = 666, /* That action requires the ability Rune Enchantment. */
+    MSGBASIC_SWORDPLAY_GAIN               = 667, /* <Player> uses <Ability>. Accuracy and evasion are enhanced. */
+    MSGBASIC_VALLATION_GAIN               = 668, /* <Target> receives the effect of Vallation, reducing damage taken from certain elemental magic spells. */ /* Vallation and Valiance both use this message for the RUN using the ja */
+    MSGBASIC_VALIANCE_GAIN_PARTY_MEMBER   = 669, /* Magic damage of a certain element is reduced for <Target> */ /* This message is when a party member recieves the aoe effect of Valiance */
+    MSGBASIC_LIEMENT_GAIN                 = 670, /* <Player> uses <Ability>. <Target> can now absorb magic damage of a certain element. */
+    MSGBASIC_PFLUG_GAIN                   = 671, /* <Player> uses <Ability>. <Target> now has enhanced resistance. */
+    MSGBASIC_GAMBIT_GAIN                  = 672, /* <Player> uses <Ability>. <Target> receives the effect of Gambit, reducing magic defense against magic of a certain element. */
     /* ROE */
     MSGBASIC_ROE_START    = 704,
     MSGBASIC_ROE_TIMED    = 705, // You have undertaken the timed record X.


### PR DESCRIPTION
Smaller PR this time, I had to add some packet handling and would like more sets of eyes to check it out.

Action Packet 15 was not being handled, though the sql/abilities.sql were using it. That was causing messages from Wards to be a bit bugged as they were not packing in the ability ID into the message. Additionally, I had to add an AoE message case just for Valiance, as for some reason it's seemingly the most verbose JA I've ever seen in FFXI.

![image](https://user-images.githubusercontent.com/60417494/156910756-7ad76a61-d015-4c73-b57f-fd3a0eeddd4d.png)
(pic is from retail)

Here is a packet capture of Valiance from retail with one party member (using an event in windower, plus the "inspect" lua library to print the table)

```
{
  actor_id = omitted,
  category = 15,
  param = 371,
  recast = 0,
  target_count = 2,
  targets = { {
      action_count = 1,
      actions = { {
          add_effect_animation = 0,
          add_effect_effect = 0,
          add_effect_message = 0,
          add_effect_param = 0,
          animation = 2,
          effect = 1,
          has_add_effect = false,
          has_spike_effect = false,
          knockback = 0,
          message = 668,
          param = 535,
          reaction = 24,
          spike_effect_animation = 0,
          spike_effect_effect = 0,
          spike_effect_message = 0,
          spike_effect_param = 0,
          stagger = 0,
          unknown = 0
        } },
      id = omitted
    }, {
      action_count = 1,
      actions = { {
          add_effect_animation = 0,
          add_effect_effect = 0,
          add_effect_message = 0,
          add_effect_param = 0,
          animation = 2,
          effect = 1,
          has_add_effect = false,
          has_spike_effect = false,
          knockback = 0,
          message = 669,
          param = 535,
          reaction = 24,
          spike_effect_animation = 0,
          spike_effect_effect = 0,
          spike_effect_message = 0,
          spike_effect_param = 0,
          stagger = 0,
          unknown = 0
        } },
      id = omitted
    } },
  unknown = 0
}
```

Note: I still haven't figured out what  the "param" and "reaction" do, but they are currently zeroed but seem to work identically. And yes, for some reason SE doesn't send the recast ID. I replicated this in the action packet 15 handling.

**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
