### PR TITLE
[trust] prevent "openers" from seeing themselves as the one with 1000 tp

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -681,8 +681,8 @@ namespace gambits
                 case G_TP_TRIGGER::OPENER:
                 {
                     bool result = false;
-                    static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&result](CBattleEntity* PMember) {
-                        if (PMember->health.tp >= 1000)
+                    static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember) {
+                        if (PMember->health.tp >= 1000 && PMember != POwner)
                         {
                             result = true;
                         }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This partially addresses #53. I think though, according to
 - https://ffxiclopedia.fandom.com/wiki/Trust:_Ayame
 - https://www.bg-wiki.com/ffxi/Ayame
she waits for the player.

This fix will just mean that at least SOMEONE else in the pt (not necessarily
her) has enough TP to follow up. It could be another trust, perhaps a closer
trust?
