### PR TITLE
[core] Add xInRange helpers for Status Effects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,8 +505,9 @@ jobs:
 
         for proc in { p0, p1, p2 }:
             for line in io.TextIOWrapper(proc.stdout, encoding="utf-8"):
+                print(line)
                 if "error" in line or "warning" in line:
-                    print(line)
+                    print("^^^")
                     exit(-1)
         EOF
 

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -334,7 +334,7 @@ xi.automaton.onUseManeuver = function(player, target, ability, action)
 
         local bonus = 1 + (pupLevel / 15) + target:getMod(xi.mod.MANEUVER_BONUS)
 
-        if target:getActiveManeuvers() == 3 then
+        if target:getActiveManeuverCount() == 3 then
             target:removeOldestManeuver()
         end
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11784,24 +11784,24 @@ bool CLuaBaseEntity::unlockAttachment(uint16 itemID)
 }
 
 /************************************************************************
- *  Function: getActiveManeuvers()
+ *  Function: getActiveManeuverCount()
  *  Purpose : Get the amount of active maneuvers for an automation
- *  Example : if target:getActiveManeuvers() == 3 then
+ *  Example : if target:getActiveManeuverCount() == 3 then
  *  Notes   :
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getActiveManeuvers()
+uint8 CLuaBaseEntity::getActiveManeuverCount()
 {
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
 
-    return PEntity->StatusEffectContainer->GetActiveManeuvers();
+    return PEntity->StatusEffectContainer->GetActiveManeuverCount();
 }
 
 /************************************************************************
  *  Function: removeOldestManeuver()
  *  Purpose : Removes the oldest maneuver in an automation set (FIFO)
  *  Example : target:removeOldestManeuver()
- *  Notes   : Often used if (target:getActiveManeuvers() == 3)
+ *  Notes   : Often used if (target:getActiveManeuverCount() == 3)
  ************************************************************************/
 
 void CLuaBaseEntity::removeOldestManeuver()
@@ -11869,6 +11869,45 @@ void CLuaBaseEntity::reduceBurden(float percentReduction, sol::object const& int
     }
 
     PAutomaton->setBurdenArray(burden);
+}
+
+/************************************************************************
+ *  Function: getActiveRunes()
+ *  Purpose : Returns the number of active runes
+ *  Example : local num = player:getActiveRunes()
+ *  Notes   :
+ ************************************************************************/
+
+uint8 CLuaBaseEntity::getActiveRuneCount()
+{
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    return PEntity->StatusEffectContainer->GetActiveRuneCount();
+}
+
+/************************************************************************
+ *  Function: removeOldestRune()
+ *  Purpose : Removes the oldest run (if available)
+ *  Example : player:removeOldestRune()
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::removeOldestRune()
+{
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    PEntity->StatusEffectContainer->RemoveOldestRune();
+}
+
+/************************************************************************
+ *  Function: removeAllRunes()
+ *  Purpose : Removes all runes (if available)
+ *  Example : player:removeAllRunes()
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::removeAllRunes()
+{
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    PEntity->StatusEffectContainer->RemoveAllRunes();
 }
 
 /************************************************************************
@@ -13747,11 +13786,15 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getAutomatonHead", CLuaBaseEntity::getAutomatonHead);
     SOL_REGISTER("unlockAttachment", CLuaBaseEntity::unlockAttachment);
 
-    SOL_REGISTER("getActiveManeuvers", CLuaBaseEntity::getActiveManeuvers);
+    SOL_REGISTER("getActiveManeuverCount", CLuaBaseEntity::getActiveManeuverCount);
     SOL_REGISTER("removeOldestManeuver", CLuaBaseEntity::removeOldestManeuver);
     SOL_REGISTER("removeAllManeuvers", CLuaBaseEntity::removeAllManeuvers);
     SOL_REGISTER("updateAttachments", CLuaBaseEntity::updateAttachments);
     SOL_REGISTER("reduceBurden", CLuaBaseEntity::reduceBurden);
+
+    SOL_REGISTER("getActiveRuneCount", CLuaBaseEntity::getActiveRuneCount);
+    SOL_REGISTER("removeOldestRune", CLuaBaseEntity::removeOldestRune);
+    SOL_REGISTER("removeAllRunes", CLuaBaseEntity::removeAllRunes);
 
     // Trust related
     SOL_REGISTER("spawnTrust", CLuaBaseEntity::spawnTrust);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -692,11 +692,15 @@ public:
     uint8 getAutomatonFrame();
     uint8 getAutomatonHead();
     bool  unlockAttachment(uint16 itemID);
-    uint8 getActiveManeuvers();
+    uint8 getActiveManeuverCount();
     void  removeOldestManeuver();
     void  removeAllManeuvers();
     void  updateAttachments();
     void  reduceBurden(float percentReduction, sol::object const& intReductionObj);
+
+    uint8 getActiveRuneCount();
+    void  removeOldestRune();
+    void  removeAllRunes();
 
     // Mob Entity-Specific
     void   setMobLevel(uint8 level);

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1122,32 +1122,32 @@ void CStatusEffectContainer::Fold(uint32 charid)
 
 uint8 CStatusEffectContainer::GetActiveManeuverCount()
 {
-    return GetStatusEffectCountInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
+    return GetStatusEffectCountInIDRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
 }
 
 void CStatusEffectContainer::RemoveOldestManeuver()
 {
-    RemoveOldestStatusEffectInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
+    RemoveOldestStatusEffectInIDRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
 }
 
 void CStatusEffectContainer::RemoveAllManeuvers()
 {
-    RemoveAllStatusEffectsInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
+    RemoveAllStatusEffectsInIDRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
 }
 
 uint8 CStatusEffectContainer::GetActiveRuneCount()
 {
-    return GetStatusEffectCountInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
+    return GetStatusEffectCountInIDRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
 }
 
 void CStatusEffectContainer::RemoveOldestRune()
 {
-    RemoveOldestStatusEffectInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
+    RemoveOldestStatusEffectInIDRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
 }
 
 void CStatusEffectContainer::RemoveAllRunes()
 {
-    RemoveAllStatusEffectsInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
+    RemoveAllStatusEffectsInIDRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
 }
 
 /************************************************************************
@@ -1300,7 +1300,7 @@ void CStatusEffectContainer::UpdateStatusIcons()
     }
 }
 
-uint8 CStatusEffectContainer::GetStatusEffectCountInRange(EFFECT start, EFFECT end)
+uint8 CStatusEffectContainer::GetStatusEffectCountInIDRange(EFFECT start, EFFECT end)
 {
     uint8 count = 0;
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
@@ -1313,7 +1313,7 @@ uint8 CStatusEffectContainer::GetStatusEffectCountInRange(EFFECT start, EFFECT e
     return count;
 }
 
-void CStatusEffectContainer::RemoveOldestStatusEffectInRange(EFFECT start, EFFECT end)
+void CStatusEffectContainer::RemoveOldestStatusEffectInIDRange(EFFECT start, EFFECT end)
 {
     CStatusEffect* oldest = nullptr;
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
@@ -1332,7 +1332,7 @@ void CStatusEffectContainer::RemoveOldestStatusEffectInRange(EFFECT start, EFFEC
     }
 }
 
-void CStatusEffectContainer::RemoveAllStatusEffectsInRange(EFFECT start, EFFECT end)
+void CStatusEffectContainer::RemoveAllStatusEffectsInIDRange(EFFECT start, EFFECT end)
 {
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
     {

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1120,47 +1120,34 @@ void CStatusEffectContainer::Fold(uint32 charid)
     }
 }
 
-uint8 CStatusEffectContainer::GetActiveManeuvers()
+uint8 CStatusEffectContainer::GetActiveManeuverCount()
 {
-    uint8 count = 0;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
-    {
-        if (PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER && PStatusEffect->GetStatusID() <= EFFECT_DARK_MANEUVER && !PStatusEffect->deleted)
-        {
-            count++;
-        }
-    }
-    return count;
+    return GetStatusEffectCountInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
 }
 
 void CStatusEffectContainer::RemoveOldestManeuver()
 {
-    CStatusEffect* oldest = nullptr;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
-    {
-        if (PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER && PStatusEffect->GetStatusID() <= EFFECT_DARK_MANEUVER && !PStatusEffect->deleted)
-        {
-            if (!oldest || PStatusEffect->GetStartTime() < oldest->GetStartTime())
-            {
-                oldest = PStatusEffect;
-            }
-        }
-    }
-    if (oldest)
-    {
-        RemoveStatusEffect(oldest, true);
-    }
+    RemoveOldestStatusEffectInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
 }
 
 void CStatusEffectContainer::RemoveAllManeuvers()
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
-    {
-        if (PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER && PStatusEffect->GetStatusID() <= EFFECT_DARK_MANEUVER)
-        {
-            RemoveStatusEffect(PStatusEffect, true);
-        }
-    }
+    RemoveAllStatusEffectsInRange(EFFECT_FIRE_MANEUVER, EFFECT_DARK_MANEUVER);
+}
+
+uint8 CStatusEffectContainer::GetActiveRuneCount()
+{
+    return GetStatusEffectCountInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
+}
+
+void CStatusEffectContainer::RemoveOldestRune()
+{
+    RemoveOldestStatusEffectInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
+}
+
+void CStatusEffectContainer::RemoveAllRunes()
+{
+    RemoveAllStatusEffectsInRange(EFFECT_IGNIS, EFFECT_TENEBRAE);
 }
 
 /************************************************************************
@@ -1310,6 +1297,49 @@ void CStatusEffectContainer::UpdateStatusIcons()
     if (PChar->PParty)
     {
         PChar->PParty->EffectsChanged();
+    }
+}
+
+uint8 CStatusEffectContainer::GetStatusEffectCountInRange(EFFECT start, EFFECT end)
+{
+    uint8 count = 0;
+    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    {
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        {
+            count++;
+        }
+    }
+    return count;
+}
+
+void CStatusEffectContainer::RemoveOldestStatusEffectInRange(EFFECT start, EFFECT end)
+{
+    CStatusEffect* oldest = nullptr;
+    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    {
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        {
+            if (!oldest || PStatusEffect->GetStartTime() < oldest->GetStartTime())
+            {
+                oldest = PStatusEffect;
+            }
+        }
+    }
+    if (oldest)
+    {
+        RemoveStatusEffect(oldest, true);
+    }
+}
+
+void CStatusEffectContainer::RemoveAllStatusEffectsInRange(EFFECT start, EFFECT end)
+{
+    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    {
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end)
+        {
+            RemoveStatusEffect(PStatusEffect, true);
+        }
     }
 }
 

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -70,6 +70,10 @@ public:
     CStatusEffect* GetStatusEffect(EFFECT StatusID);
     CStatusEffect* GetStatusEffect(EFFECT StatusID, uint32 SubID);
 
+    uint8 GetStatusEffectCountInRange(EFFECT start, EFFECT end);
+    void  RemoveOldestStatusEffectInRange(EFFECT start, EFFECT end);
+    void  RemoveAllStatusEffectsInRange(EFFECT start, EFFECT end);
+
     void UpdateStatusIcons(); // пересчитываем иконки эффектов
     void CheckEffectsExpiry(time_point tick);
     void TickEffects(time_point tick);
@@ -87,9 +91,13 @@ public:
     bool HasCorsairEffect(uint32 charid);
     void Fold(uint32 charid);
 
-    uint8 GetActiveManeuvers();
+    uint8 GetActiveManeuverCount();
     void  RemoveOldestManeuver();
     void  RemoveAllManeuvers();
+
+    uint8 GetActiveRuneCount();
+    void  RemoveOldestRune();
+    void  RemoveAllRunes();
 
     void WakeUp(); // remove sleep effects
     bool IsAsleep();

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -70,9 +70,9 @@ public:
     CStatusEffect* GetStatusEffect(EFFECT StatusID);
     CStatusEffect* GetStatusEffect(EFFECT StatusID, uint32 SubID);
 
-    uint8 GetStatusEffectCountInRange(EFFECT start, EFFECT end);
-    void  RemoveOldestStatusEffectInRange(EFFECT start, EFFECT end);
-    void  RemoveAllStatusEffectsInRange(EFFECT start, EFFECT end);
+    uint8 GetStatusEffectCountInIDRange(EFFECT start, EFFECT end);
+    void  RemoveOldestStatusEffectInIDRange(EFFECT start, EFFECT end);
+    void  RemoveAllStatusEffectsInIDRange(EFFECT start, EFFECT end);
 
     void UpdateStatusIcons(); // пересчитываем иконки эффектов
     void CheckEffectsExpiry(time_point tick);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
