### PR TITLE
[Dagger] Add fTP replication WS and Refresh

### DIFF
--- a/scripts/globals/weaponskills/aeolian_edge.lua
+++ b/scripts/globals/weaponskills/aeolian_edge.lua
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.skill = xi.skill.DAGGER
     params.includemab = true
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 2 params.ftp200 = 3 params.ftp300 = 4.5 -- https://www.bg-wiki.com/bg/Aeolian_Edge
         params.dex_wsc = 0.4 params.int_wsc = 0.4
     end

--- a/scripts/globals/weaponskills/cyclone.lua
+++ b/scripts/globals/weaponskills/cyclone.lua
@@ -28,8 +28,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.skill = xi.skill.DAGGER
     params.includemab = true
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.4 params.int_wsc = 0.4
+        params.ftp300 = 3.75 -- http://wiki.ffo.jp/html/685.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)

--- a/scripts/globals/weaponskills/dancing_edge.lua
+++ b/scripts/globals/weaponskills/dancing_edge.lua
@@ -31,11 +31,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.4
-    end
-
-    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/688.html
-        params.dex_wsc = 0.4
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/dancing_edge.lua
+++ b/scripts/globals/weaponskills/dancing_edge.lua
@@ -29,7 +29,12 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        params.dex_wsc = 0.4
+    end
+
+    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
+        params.multiHitfTP = true -- http://wiki.ffo.jp/html/688.html
         params.dex_wsc = 0.4
     end
 

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -23,9 +23,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
-    local mpReturn = target:addMP(-damagemod)
-    player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
-    -- to do make undead undrainable
+
+    if not target:isUndead() then
+        local mpReturn = target:addMP(-damagemod)
+        player:addMP(mpReturn)
+    end
 
     return 1, 0, false, 0
 end

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -23,11 +23,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
-    mpReturn = target:addMP(-damagemod)
+    local mpReturn = target:addMP(-damagemod)
     player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
     -- to do make undead undrainable
 
-    return 1, 0, false, damagemod
+    return 1, 0, false, 0
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -8,9 +8,9 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-   -- TODO: Should not wake the mob involved. Not tested on sleeping mob
-
-    local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it was between 60 and 120 and always higher than Energy Steal
+    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
+    --[[
+    local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2 -- to follow earlier statement of been always higher than Energy Steal
     -- params.mnd_wsc = 1
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if not target:isUndead() then
         player:addMP(target:addMP(-damagemod))
     end
-
+    --]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -18,8 +18,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        local attMind = player:getStat(xi.mod.MND)
-        damagemod = damagemod + attMind * 1
+        damagemod = damagemod + player:getStat(xi.mod.MND)
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -8,25 +8,30 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
+    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior.
 
-    -- local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
+    --[[
+    local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2 -- to follow earlier statement of been always higher than Energy Steal
     -- params.mnd_wsc = 1
 
-    -- local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
-    -- if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-    --     damagemod = damagemod + player:getStat(xi.mod.MND)
-    -- end
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        damagemod = damagemod + player:getStat(xi.mod.MND)
+    end
 
-    -- damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
-    -- if not target:isUndead() then
-    --     player:addMP(target:addMP(-damagemod))
-    -- end
+    if not target:isUndead() then
+        player:addMP(target:addMP(-damagemod))
+    end
 
+    if not target:isUndead() then
+        player:addMP(target:addMP(-damagemod))
+    end
+    --]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -9,24 +9,24 @@ local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
---[[
-    local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
+
+    -- local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2 -- to follow earlier statement of been always higher than Energy Steal
     -- params.mnd_wsc = 1
 
-    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+    -- local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
-    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        damagemod = damagemod + player:getStat(xi.mod.MND)
-    end
+    -- if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+    --     damagemod = damagemod + player:getStat(xi.mod.MND)
+    -- end
 
-    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    -- damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
-    if not target:isUndead() then
-        player:addMP(target:addMP(-damagemod))
-    end
---]]
+    -- if not target:isUndead() then
+    --     player:addMP(target:addMP(-damagemod))
+    -- end
+
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -1,11 +1,33 @@
 -----------------------------------
 -- Energy Drain
 -----------------------------------
+require("scripts/globals/status")
+require("scripts/settings/main")
+require("scripts/globals/weaponskills")
+-----------------------------------
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-   -- TODO: Should steal MP based on TP and not wake the mob involved.
-    return 1, 0, false, 65
+   -- TODO: Should not wake the mob involved. Not tested on sleeping mob
+
+    local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it was between 60 and 120 and always higher than Energy Steal
+
+    -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2 -- to follow earlier statement of been always higher than Energy Steal
+    -- params.mnd_wsc = 1
+
+    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        local attMind = player:getStat(xi.mod.MND)
+        damagemod = damagemod + attMind * 1
+    end
+
+    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    mpReturn = target:addMP(-damagemod)
+    player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
+    -- to do make undead undrainable
+
+    return 1, 0, false, damagemod
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -24,8 +24,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
     if not target:isUndead() then
-        local mpReturn = target:addMP(-damagemod)
-        player:addMP(mpReturn)
+        player:addMP(target:addMP(-damagemod))
     end
 
     return 1, 0, false, 0

--- a/scripts/globals/weaponskills/energy_drain.lua
+++ b/scripts/globals/weaponskills/energy_drain.lua
@@ -9,7 +9,7 @@ local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
-    --[[
+--[[
     local damage = 60 -- Base mp absorbtion from http://wiki.ffo.jp/html/687.html saying it was between 60 and 120 and always higher than Energy Steal this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2 -- to follow earlier statement of been always higher than Energy Steal
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if not target:isUndead() then
         player:addMP(target:addMP(-damagemod))
     end
-    --]]
+--]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -25,8 +25,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
     if not target:isUndead() then
-        local mpReturn = target:addMP(-damagemod)
-        player:addMP(mpReturn)
+        player:addMP(target:addMP(-damagemod))
     end
 
     return 1, 0, false, 0

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -1,11 +1,34 @@
 -----------------------------------
 -- Energy Steal
 -----------------------------------
+require("scripts/globals/status")
+require("scripts/settings/main")
+require("scripts/globals/weaponskills")
+require("scripts/globals/msg")
+-----------------------------------
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-   -- TODO: Should steal MP based on TP and not wake the mob involved.
-    return 1, 0, false, 65
+    -- TODO: Should not wake the mob involved. Not tested on sleeping mob
+
+    local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80
+   
+    -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal 
+    -- params.mnd_wsc = 1
+
+    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then 
+        local attMind = player:getStat(xi.mod.MND)
+        damagemod = damagemod + attMind * 1
+    end
+
+    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    mpReturn = target:addMP(-damagemod)
+    player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
+    -- to do make undead undrainable
+
+    return 1, 0, false, 0
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -12,19 +12,19 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     -- TODO: Should not wake the mob involved. Not tested on sleeping mob
 
     local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80
-   
-    -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal 
+
+    -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal
     -- params.mnd_wsc = 1
 
     local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
-    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then 
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         local attMind = player:getStat(xi.mod.MND)
         damagemod = damagemod + attMind * 1
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
-    mpReturn = target:addMP(-damagemod)
+    local mpReturn = target:addMP(-damagemod)
     player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
     -- to do make undead undrainable
 

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -9,25 +9,30 @@ require("scripts/globals/msg")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
+    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior.
 
-    -- local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
+    --[[
+    local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal
     -- params.mnd_wsc = 1
 
-    -- local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
-    -- if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-    --     damagemod = damagemod + player:getStat(xi.mod.MND)
-    -- end
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        damagemod = damagemod + player:getStat(xi.mod.MND)
+    end
 
-    -- damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
-    -- if not target:isUndead() then
-    --     player:addMP(target:addMP(-damagemod))
-    -- end
+    if not target:isUndead() then
+        player:addMP(target:addMP(-damagemod))
+    end
 
+    if not target:isUndead() then
+        player:addMP(target:addMP(-damagemod))
+    end
+    --]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -24,9 +24,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
-    local mpReturn = target:addMP(-damagemod)
-    player:addMP(mpReturn) -- this isnt the right way but the only way I could figure out
-    -- to do make undead undrainable
+
+    if not target:isUndead() then
+        local mpReturn = target:addMP(-damagemod)
+        player:addMP(mpReturn)
+    end
 
     return 1, 0, false, 0
 end

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -19,8 +19,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        local attMind = player:getStat(xi.mod.MND)
-        damagemod = damagemod + attMind * 1
+        damagemod = damagemod + player:getStat(xi.mod.MND)
     end
 
     damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -10,7 +10,7 @@ local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
-    --[[
+--[[
     local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if not target:isUndead() then
         player:addMP(target:addMP(-damagemod))
     end
-    --]]
+--]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -9,9 +9,9 @@ require("scripts/globals/msg")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    -- TODO: Should not wake the mob involved. Not tested on sleeping mob
-
-    local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80
+    -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
+    --[[
+    local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal
     -- params.mnd_wsc = 1
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if not target:isUndead() then
         player:addMP(target:addMP(-damagemod))
     end
-
+    --]]
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/energy_steal.lua
+++ b/scripts/globals/weaponskills/energy_steal.lua
@@ -10,24 +10,24 @@ local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     -- TODO: Should not wake the mob involved. Not tested on sleeping mob. Need to add Darkness element and resistance. More testing needed to understand retail behavior. 
---[[
-    local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
+
+    -- local damage = 40 -- Base mp absorbtion from http://wiki.ffo.jp/html/686.html saying it would do between 40 and 80 this is before adoulin era
 
     -- params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2  from https://ffxiclopedia.fandom.com/wiki/Energy_Steal
     -- params.mnd_wsc = 1
 
-    local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
+    -- local damagemod = damage * ((tp - 1000) / 2000 + 1) -- Simplified formula for getting difference in tp return from 1000 tp to 3000 tp
 
-    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        damagemod = damagemod + player:getStat(xi.mod.MND)
-    end
+    -- if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+    --     damagemod = damagemod + player:getStat(xi.mod.MND)
+    -- end
 
-    damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
+    -- damagemod = damagemod * xi.settings.WEAPON_SKILL_POWER
 
-    if not target:isUndead() then
-        player:addMP(target:addMP(-damagemod))
-    end
---]]
+    -- if not target:isUndead() then
+    --     player:addMP(target:addMP(-damagemod))
+    -- end
+
     return 1, 0, false, 0
 end
 

--- a/scripts/globals/weaponskills/evisceration.lua
+++ b/scripts/globals/weaponskills/evisceration.lua
@@ -29,7 +29,14 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
+        params.crit200 = 0.25
+        params.dex_wsc = 0.5
+    end
+
+    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
+        params.multiHitfTP = true
         params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
         params.crit200 = 0.25
         params.dex_wsc = 0.5

--- a/scripts/globals/weaponskills/evisceration.lua
+++ b/scripts/globals/weaponskills/evisceration.lua
@@ -30,12 +30,6 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
-        params.crit200 = 0.25
-        params.dex_wsc = 0.5
-    end
-
-    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true
         params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
         params.crit200 = 0.25

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -31,11 +31,6 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1.0; params.atk200 = 1.0; params.atk300 = 1.0
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.agi_wsc = 0.7 + (player:getMerit(xi.merit.EXENTERATOR) * 0.03)
-        params.ftp100 = 2.0 params.ftp200 = 2.0 params.ftp300 = 2.0 -- http://wiki.ffo.jp/html/25595.html
-    end
-
-    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true
         params.agi_wsc = 0.7 + (player:getMerit(xi.merit.EXENTERATOR) * 0.03)
         params.ftp100 = 1.1875 params.ftp200 = 1.1875 params.ftp300 = 1.1875

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -30,8 +30,15 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1.0; params.atk200 = 1.0; params.atk300 = 1.0
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.agi_wsc = 0.7 + (player:getMerit(xi.merit.EXENTERATOR) * 0.03)
+        params.ftp100 = 2.0 params.ftp200 = 2.0 params.ftp300 = 2.0 -- http://wiki.ffo.jp/html/25595.html
+    end
+
+    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
+        params.multiHitfTP = true
+        params.agi_wsc = 0.7 + (player:getMerit(xi.merit.EXENTERATOR) * 0.03)
+        params.ftp100 = 1.1875 params.ftp200 = 1.1875 params.ftp300 = 1.1875
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/gust_slash.lua
+++ b/scripts/globals/weaponskills/gust_slash.lua
@@ -27,8 +27,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.skill = xi.skill.DAGGER
     params.includemab = true
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.4 params.int_wsc = 0.4
+        params.ftp300 = 3 -- http://wiki.ffo.jp/html/682.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -36,6 +36,12 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
         params.str_wsc = 0.4 params.dex_wsc = 0.4
     end
 
+    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
+        params.multiHitfTP = true -- http://wiki.ffo.jp/html/15896.html
+        params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
+        params.str_wsc = 0.4 params.dex_wsc = 0.4
+    end
+
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Apply Aftermath

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -32,11 +32,6 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
-        params.str_wsc = 0.4 params.dex_wsc = 0.4
-    end
-
-    if xi.settings.USE_MULTI_HIT_FTP_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/15896.html
         params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
         params.str_wsc = 0.4 params.dex_wsc = 0.4

--- a/scripts/globals/weaponskills/shark_bite.lua
+++ b/scripts/globals/weaponskills/shark_bite.lua
@@ -29,7 +29,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 4.5 params.ftp200 = 6.8 params.ftp300 = 8.5
         params.dex_wsc = 0.4 params.agi_wsc = 0.4
     end


### PR DESCRIPTION
Adding fTP relpication to Dancing Edge, Evisceration, Exenterator and Pyrrhic Kleos. General refresh of the ws parameter where needed. Added mp drain and scale base on tp to Energy Steal and Energy Drain.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
