### PR TITLE
Update 'UNKNOWN' RELEASE_TYPE name to 'PLAYERINPUT'.

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3658,7 +3658,7 @@ void SmallPacket0x060(map_session_data_t* const PSession, CCharEntity* const PCh
     luautils::OnEventUpdate(PChar, updateString);
 
     PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::UNKNOWN));
+    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::PASSWORDINPUT));
 }
 
 /************************************************************************

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3658,7 +3658,7 @@ void SmallPacket0x060(map_session_data_t* const PSession, CCharEntity* const PCh
     luautils::OnEventUpdate(PChar, updateString);
 
     PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::EVENT));
-    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::PASSWORDINPUT));
+    PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::PLAYERINPUT));
 }
 
 /************************************************************************

--- a/src/map/packets/release.h
+++ b/src/map/packets/release.h
@@ -28,11 +28,11 @@
 
 enum class RELEASE_TYPE : uint8
 {
-    STANDARD = 0,
-    EVENT    = 1,
-    SKIPPING = 2,
-    UNKNOWN  = 3, /* Used by Event Update (String Update) - Packet 0x060  */
-    FISHING  = 4
+    STANDARD      = 0,
+    EVENT         = 1,
+    SKIPPING      = 2,
+    PASSWORDINPUT = 3, /* Used by Event Update (String Update) - Packet 0x060  */
+    FISHING       = 4
 };
 
 class CCharEntity;

--- a/src/map/packets/release.h
+++ b/src/map/packets/release.h
@@ -28,11 +28,11 @@
 
 enum class RELEASE_TYPE : uint8
 {
-    STANDARD      = 0,
-    EVENT         = 1,
-    SKIPPING      = 2,
-    PASSWORDINPUT = 3, /* Used by Event Update (String Update) - Packet 0x060  */
-    FISHING       = 4
+    STANDARD    = 0,
+    EVENT       = 1,
+    SKIPPING    = 2,
+    PLAYERINPUT = 3, /* Used by player input based event updates. Packet 0x060 (String and Numerical)*/
+    FISHING     = 4
 };
 
 class CCharEntity;


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

`RELEASE_TYPE::UNKNOWN` is used during events where the user is prompted to input a password. (ie. Castle Oztroja furnace, Strange Apparatus', etc.) It is also used when prompting the player for numerical input, such as returning seals from Shami in Port Jeuno and similar.

When the client inputs a password, it sends a `0x60` packet and sets an internal flag `RecPassWdWindowFlag` waiting for the server to respond. When the server responds, the flag is cleared and the prompt is closed.