### PR TITLE
[Katana] ftp replication and refresh

### DIFF
--- a/scripts/globals/weaponskills/blade_chi.lua
+++ b/scripts/globals/weaponskills/blade_chi.lua
@@ -21,8 +21,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local params = {}
     params.numHits = 2
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
+    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
@@ -31,8 +31,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ele = xi.magic.ele.EARTH
     params.skill = xi.skill.KATANA
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        params.ftp200 = 1.375 params.ftp300 = 2.25 -- http://wiki.ffo.jp/html/720.html
+        params.str_wsc = 0.3 params.int_wsc = 0.3
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_ei.lua
+++ b/scripts/globals/weaponskills/blade_ei.lua
@@ -25,9 +25,10 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ele = xi.magic.ele.DARK
     params.skill = xi.skill.KATANA
     params.includemab = true
-
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    -- to do ignore shadow and blink https://www.bg-wiki.com/ffxi/Blade:_Ei
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.int_wsc = 0.4
+        params.ftp200 = 3 params.ftp300 = 5
     end
 
     local damage, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)

--- a/scripts/globals/weaponskills/blade_jin.lua
+++ b/scripts/globals/weaponskills/blade_jin.lua
@@ -29,7 +29,6 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/722.html
     end
 

--- a/scripts/globals/weaponskills/blade_jin.lua
+++ b/scripts/globals/weaponskills/blade_jin.lua
@@ -28,8 +28,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
+        params.multiHitfTP = true -- http://wiki.ffo.jp/html/722.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -32,7 +32,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.6 params.int_wsc = 0.6
-        params.atk100 = 3; params.atk200 = 3; params.atk300 = 3 -- http://wiki.ffo.jp/html/15893.html
+        params.ignoresDef = true
+        params.ignored100 = 0.25
+        params.ignored200 = 0.25
+        params.ignored300 = 0.25
+        params.atk100 = 2.25; params.atk200 = 2.25; params.atk300 = 2.25 -- http://wiki.ffo.jp/html/15893.html
     end
 
     -- Apply Aftermath

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -28,11 +28,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.atk100 = 1.3; params.atk200 = 1.3; params.atk300 = 1.3
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.6 params.int_wsc = 0.6
-        params.atk100 = 1.3125; params.atk200 = 1.3125; params.atk300 = 1.3125
+        params.atk100 = 3; params.atk200 = 3; params.atk300 = 3 -- http://wiki.ffo.jp/html/15893.html
     end
 
     -- Apply Aftermath

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -32,6 +32,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.canCrit = false
     params.acc100 = 0.9 params.acc200= 1 params.acc300= 1.1
     --  the TP bonus for TP 1,000 and above has been raised, which has substantially raised the hit rate http://wiki.ffo.jp/html/732.html
+    -- data on ws accuracy are difficult to come by, would need to decide on sane value for the accuracy boost stated in JPWiki for now I'm only adding 0.1 per tier
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGE then

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -37,6 +37,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/732.html
+        params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
         params.str_wsc = 0.3 params.dex_wsc = 0.3
     end
 

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     --  the TP bonus for TP 1,000 and above has been raised, which has substantially raised the hit rate http://wiki.ffo.jp/html/732.html
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGE then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/732.html
         params.str_wsc = 0.3 params.dex_wsc = 0.3
     end

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -35,7 +35,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     -- data on ws accuracy are difficult to come by, would need to decide on sane value for the accuracy boost stated in JPWiki for now I'm only adding 0.1 per tier
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGE then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/732.html
         params.str_wsc = 0.3 params.dex_wsc = 0.3
     end

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -30,11 +30,12 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.1 params.dex_wsc = 0.1 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1.0
+    params.acc100 = 0.9 params.acc200= 1 params.acc300= 1.1
+    --  the TP bonus for TP 1,000 and above has been raised, which has substantially raised the hit rate http://wiki.ffo.jp/html/732.html
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
+        params.multiHitfTP = true -- http://wiki.ffo.jp/html/732.html
         params.str_wsc = 0.3 params.dex_wsc = 0.3
     end
 

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -32,7 +32,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
+        -- http://wiki.ffo.jp/html/3090.html & FFXIclopedia both says ftp 3
         params.dex_wsc = 0.8
     end
 

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -32,7 +32,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        -- http://wiki.ffo.jp/html/3090.html & FFXIclopedia both says ftp 3
+        -- Ftp was Tested
+        params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
         params.dex_wsc = 0.8
     end
 

--- a/scripts/globals/weaponskills/blade_rin.lua
+++ b/scripts/globals/weaponskills/blade_rin.lua
@@ -24,11 +24,13 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
+    -- to do critical hit rate of this ws is base on amount of tp alone, does not consider Critical Hit Rate from dDEX, equipment, or likely merits/base
+    -- https://www.bg-wiki.com/ffxi/Blade:_Rin
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.6 params.dex_wsc = 0.6
     end
 

--- a/scripts/globals/weaponskills/blade_shun.lua
+++ b/scripts/globals/weaponskills/blade_shun.lua
@@ -31,9 +31,11 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
         params.dex_wsc = 0.7 + (player:getMerit(xi.merit.BLADE_SHUN) * 0.03)
+        params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Blade:_Shun
+        params.atk100 = 1; params.atk200 = 2; params.atk300 = 3 -- http://wiki.ffo.jp/html/25610.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_teki.lua
+++ b/scripts/globals/weaponskills/blade_teki.lua
@@ -29,8 +29,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ele = xi.magic.ele.WATER
     params.skill = xi.skill.KATANA
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.3 params.int_wsc = 0.3
+        params.ftp200 = 1.375 params.ftp300 = 2.25 -- http://wiki.ffo.jp/html/718.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_ten.lua
+++ b/scripts/globals/weaponskills/blade_ten.lua
@@ -28,7 +28,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 4.5 params.ftp200 = 11.5 params.ftp300 = 15.5
     end
 

--- a/scripts/globals/weaponskills/blade_to.lua
+++ b/scripts/globals/weaponskills/blade_to.lua
@@ -29,8 +29,9 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.ele = xi.magic.ele.ICE
     params.skill = xi.skill.KATANA
 
-    if (xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.int_wsc = 0.4
+        params.ftp200 = 1.5 params.ftp300 = 2.5 -- http://wiki.ffo.jp/html/719.html
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -21,7 +21,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     local params = {}
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.5 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.5 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.0 params.dex_wsc = 0.28 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.28 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    -- http://wiki.ffo.jp/html/20351.html
     params.ele = xi.magic.ele.WATER
     params.skill = xi.skill.KATANA
     params.includemab = true


### PR DESCRIPTION
Added ftp replication to katana ws Blade: Jin, Blade: Ku, Blade: Shun.
Refresh of ws parameter.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
