### PR TITLE
[Hold] Change spell damage resist check from 3 checks to 1 check

### DIFF
--- a/scripts/globals/magic_utils/spell_damage.lua
+++ b/scripts/globals/magic_utils/spell_damage.lua
@@ -414,14 +414,22 @@ xi.magic_utils.spell_damage.calculateResist = function(caster, target, spell, sk
     -- STEP 4: Get Resist Tier
     -----------------------------------
     local resistTier = 0
-    local randomVar  = math.random(1, 100)
+    local randomVar  = math.random()
 
-    -- 3 random rolls.
-    for i = 3, 1, -1 do
-        if randomVar > magicHitRate then
-            resistTier = resistTier + 1
-        end
-        randomVar = math.random(1, 100)
+    -- Define tresholds for resists
+    local p = magicHitRate / 100
+    local half = (1 - p)
+	local quart = ((1 - p)^2)
+	local eighth = ((1 - p)^3)
+
+    if randomVar <= eighth then
+        resistTier = 3
+    elseif randomVar <= quart then
+        resistTier = 2
+    elseif randomVar <= half then
+        resistTier = 1
+    else
+        resistTier = 0
     end
 
     -- Apply extra roll for elemental resistance boons. Testimonial. This needs retail testing.


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

BLMs got a lot more resists recently, and this is because Magic Hit Rate is now checked 3 times instead of just once. This means that even with 95% MHR, you only get a 85.7% unresist rate. This drops down dramatically: at 75% MHR, you get a 42.2% unresist rate:
![image](https://user-images.githubusercontent.com/16270541/159702037-5495dc8c-7aa7-4431-aad0-d8cbfc0c2302.png)


This change is even more pronounced when we average damage over X nukes:
_EDIT: dumbass me forgot to triple the numbers for 1/2 and 1/4 resists (there are 3 ways to get a 1/2 resist on 3 rolls, not one) so the change isn't as dramatic but the point still stands._
![image](https://user-images.githubusercontent.com/16270541/159702131-7b234e96-e0b3-4058-a82f-0ab0437bc91f.png)

The [BG wiki Resist page](https://www.bg-wiki.com/ffxi/Resist) shows how it used to be done, and that's what I changed it to now: we pre-calculate the tiers based on the MHR and random once. This brings it in line with idea of "rolling again if you resisted" as described on the BG page.
