### PR TITLE
[LandKingSystem] Unhide ???

### DIFF
--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -46,6 +46,10 @@ entity.onMobDespawn = function(mob)
             SetServerVariable("[PH]King_Behemoth", kills + 1)
         end
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -60,6 +60,10 @@ entity.onMobDespawn = function(mob)
         UpdateNMSpawnPoint(ID.mob.BEHEMOTH)
         GetMobByID(ID.mob.BEHEMOTH):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -46,6 +46,10 @@ entity.onMobDespawn = function(mob)
             SetServerVariable("[PH]Nidhogg", kills + 1)
         end
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -53,6 +53,10 @@ entity.onMobDespawn = function(mob)
         UpdateNMSpawnPoint(ID.mob.FAFNIR)
         GetMobByID(ID.mob.FAFNIR):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -46,6 +46,10 @@ entity.onMobDespawn = function(mob)
             SetServerVariable("[PH]Aspidochelone", kills + 1)
         end
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -39,6 +39,10 @@ entity.onMobDespawn = function(mob)
         UpdateNMSpawnPoint(ID.mob.ADAMANTOISE)
         GetMobByID(ID.mob.ADAMANTOISE):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
     end
+    -- Respawn the ???
+    if xi.settings.LandKingSystem_HQ == 2 or xi.settings.LandKingSystem_NQ == 2 then
+        GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.FORCE_SPAWN_QM_RESET_TIME)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

When using the LandKingSystem with a value of 2(both time spawn and force spawn possible) you get in a situation where
the NM spawn and make a call to hide the QM (from mob lua). But unlike trading where the npcUtil.popFromQM take care to unhide the QM after mob despawn (from npcs.qm lua) the QM get hidden but never come back(until next server reset).