### PR TITLE
[fix] OSX build: sol::nil -> sol::lua_nil

### DIFF
--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -102,8 +102,8 @@ namespace moduleutils
                 auto lastElem  = override.nameParts.back();
                 for (auto& part : override.nameParts)
                 {
-                    table = table[part].get_or<sol::table>(sol::nil);
-                    if (table == sol::nil)
+                    table = table[part].get_or<sol::table>(sol::lua_nil);
+                    if (table == sol::lua_nil)
                     {
                         break;
                     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Whoops, I broke the OSX build!