### PR TITLE
Various Improvements to Dynamic Entities

### DIFF
--- a/modules/custom/test_npcs_in_gm_home.lua
+++ b/modules/custom/test_npcs_in_gm_home.lua
@@ -12,10 +12,6 @@ m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
     -- Call the zone's original function for onInitialize
     super(zone)
 
-    -----------------------------------
-    -- NOTE: THIS API IS EXPERIMENTAL AND LIKELY TO CHANGE. USE AT YOUR OWN RISK!
-    -----------------------------------
-
     -- Insert NPC into zone
     local horro = zone:insertDynamicEntity({
 
@@ -24,7 +20,9 @@ m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
 
         -- The name visible to players
         -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
-        --     : So populate it with something unique-ish even if you aren't going to use it
+        --     : So populate it with something unique-ish even if you aren't going to use it.
+        --     : You can then hide the name with entity:hideName(true)
+        -- NOTE: This name CAN include spaces and underscores.
         name = "Horro",
 
         -- You can use regular model ids (See documentation/model_ids.txt, or play around with !costume)
@@ -40,6 +38,9 @@ m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
 
         -- Rotation is scaled 0-255, with 0 being East
         rotation = 128,
+
+        -- Overriding widescan is only available to NPCs.
+        widescan = 1,
 
         -- onTrade and onTrigger can be hooked up to your dynamic entity,
         -- just like with regular entities. You can also omit these.

--- a/modules/custom/test_npcs_in_gm_home.lua
+++ b/modules/custom/test_npcs_in_gm_home.lua
@@ -8,6 +8,7 @@ local m = Module:new("test_npcs_in_gm_home")
 m:setEnabled(true)
 
 m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
+
     -- Call the zone's original function for onInitialize
     super(zone)
 
@@ -17,43 +18,52 @@ m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
 
     -- Insert NPC into zone
     local horro = zone:insertDynamicEntity({
+
+        -- NPC or MOB
         objtype = xi.objType.NPC,
+
+        -- The name visible to players
+        -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
+        --     : So populate it with something unique-ish even if you aren't going to use it
         name = "Horro",
-        -- See documentation model_ids.txt, or play around with !costume (remember that the bytes are swapped!)
-        modelId = 2430,
+
+        -- You can use regular model ids (See documentation/model_ids.txt, or play around with !costume)
+        look = 2430,
+
+        -- You can also use the raw packet look information (as a string), as seen in npc_list and mob_pools
+        -- look = "0x0100020500101120003000400050006000700000",
+
+        -- Set the position using in-game x, y and z
         x = 5.000,
         y = 0.000,
         z = 0.000,
+
+        -- Rotation is scaled 0-255, with 0 being East
         rotation = 128,
-        triggerable = true,
+
+        -- onTrade and onTrigger can be hooked up to your dynamic entity,
+        -- just like with regular entities. You can also omit these.
+        onTrade = function(player, npc, trade)
+            -- NOTE: We have to use getPacketName, because the regular name is modified and being used
+            --     : for internal lookups
+            player:PrintToPlayer("No, thanks!", 0, npc:getPacketName())
+        end,
+
+        -- The entity will not be "triggerable" unless you populate onTrigger
+        onTrigger = function(player, npc)
+            -- NOTE: We have to use getPacketName, because the regular name is modified and being used
+            --     : for internal lookups
+            player:PrintToPlayer("Welcome to GM Home!", 0, npc:getPacketName())
+        end,
     })
 
     -- Use the mob object however you like
     -- horro:getID() etc.
+    -- We're not doing anything with it, so ignore this object
     utils.unused(horro)
 
-    -- There might not be any NPCs populated for GM_Home,
-    -- (see npc_list.sql) so the npcs table might not exist.
-    -- We're going to make it now.
-    -- This shouldn't be needed for other zones.
-    xi.zones.GM_Home.npcs = xi.zones.GM_Home.npcs or {}
-
-    -- Build a cache entry for the new NPC
-    xi.zones.GM_Home.npcs.Horro = {}
-
-    -- Attach regular event handlers to that cache entry
-    xi.zones.GM_Home.npcs.Horro.onTrade = function(player, npc, trade)
-    end
-
-    xi.zones.GM_Home.npcs.Horro.onTrigger = function(player, npc)
-        player:PrintToPlayer("Welcome to GM Home!", 0, npc:getName())
-    end
-
-    xi.zones.GM_Home.npcs.Horro.onEventUpdate = function(player, csid, option)
-    end
-
-    xi.zones.GM_Home.npcs.Horro.onEventFinish = function(player, csid, option)
-    end
+    -- You could also just not capture the object
+    -- zone:insertDynamicEntity({ ...
 end)
 
 return m

--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -13,12 +13,18 @@ cmdprops =
 function onTrigger(player)
     local zone = player:getZone()
 
-
     local mob = zone:insertDynamicEntity({
+        -- NPC or MOB
         objtype = xi.objType.MOB,
 
+        -- The name visible to players
+        -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
+        --     : So populate it with something unique-ish even if you aren't going to use it.
+        --     : You can then hide the name with entity:hideName(true)
+        -- NOTE: This name CAN include spaces and underscores.
         name = "Fafnir",
 
+        -- Set the position using in-game x, y and z
         x = player:getXPos(),
         y = player:getYPos(),
         z = player:getZPos(),
@@ -30,11 +36,14 @@ function onTrigger(player)
         groupId = 5,
         groupZoneId = 154,
 
+        -- You can provide an onMobDeath function if you want: if you don't
+        -- add one, an empty one will be inserted for you behind the scenes.
         onMobDeath = function(mob, player, isKiller)
-            print("I AM DED")
+            -- Do stuff
         end,
     })
 
+    -- Use the mob object as you normally would
     mob:setSpawn(player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos())
 
     mob:setDropID(0) -- No loot!

--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -13,31 +13,31 @@ cmdprops =
 function onTrigger(player)
     local zone = player:getZone()
 
-    -- Fafnir's entry in mob_groups:
-    -- INSERT INTO `mob_groups` VALUES (5,1280,154,'Fafnir',0,128,805,70000,0,90,90,0);
-    --                       groupId ---^       ^--- groupZoneId
 
     local mob = zone:insertDynamicEntity({
         objtype = xi.objType.MOB,
+
+        name = "Fafnir",
+
         x = player:getXPos(),
         y = player:getYPos(),
         z = player:getZPos(),
         rotation = player:getRotPos(),
+
+        -- Fafnir's entry in mob_groups:
+        -- INSERT INTO `mob_groups` VALUES (5,1280,154,'Fafnir',0,128,805,70000,0,90,90,0);
+        --                       groupId ---^       ^--- groupZoneId
         groupId = 5,
         groupZoneId = 154,
+
+        onMobDeath = function(mob, player, isKiller)
+            print("I AM DED")
+        end,
     })
 
     mob:setSpawn(player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos())
 
     mob:setDropID(0) -- No loot!
-
-    -- Dynamic mobs skip the regular bindings for onMobDeath, so if you want to
-    -- add logic to their deaths, you need to use a listener:
-    mob:addListener("DEATH", "DYNAMIC_FAFNIR_DEATH", function(mobArg)
-        mobArg:removeListener("DYNAMIC_FAFNIR_DEATH")
-
-        -- Do stuff here
-    end)
 
     mob:spawn()
 

--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -38,7 +38,7 @@ function onTrigger(player)
 
         -- You can provide an onMobDeath function if you want: if you don't
         -- add one, an empty one will be inserted for you behind the scenes.
-        onMobDeath = function(mob, player, isKiller)
+        onMobDeath = function(mob, playerArg, isKiller)
             -- Do stuff
         end,
     })

--- a/scripts/zones/Nyzul_Isle/mobs/Razfahd.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Razfahd.lua
@@ -7,14 +7,11 @@ require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-end
-
 entity.onMobSpawn = function(mob)
     -- Wiki is wrong, he CAN melee: https://youtu.be/5ko8xHiHvYo?t=14m31s
     -- mob:SetAutoAttackEnabled(false)
     mob:setUnkillable(true)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
 end
 
 entity.onMobFight = function(mob, target)

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -23,6 +23,7 @@
 #include "../common/md52.h"
 #include "../common/logging.h"
 
+#include <charconv>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -716,6 +717,38 @@ std::vector<std::string> split(const std::string& s, char delim)
         elems.push_back(item);
     }
     return elems;
+}
+
+look_t stringToLook(std::string str)
+{
+    // Remove "0x" if found
+    if (str[0] == '0' && str[1] == 'x')
+    {
+        str = str.substr(2);
+    }
+
+    // A 16-bit number is represented by *4* string characters
+    // Iterate in groups of 4
+    std::vector<uint16> hex(str.size() / 4, 0);
+    uint16 value;
+    for (std::size_t i = 0; i < str.size() / 4; i++)
+    {
+        auto begin = str.data() + (i * 4);
+        auto end = str.data() + (i * 4) + 4;
+        auto base = 16; // Hex
+        std::from_chars(begin, end, value, base);
+        hex[i] = value;
+    }
+
+    for (auto& entry : hex)
+    {
+        // Swap endian-ness
+        entry = (entry >> 8) | (entry << 8);
+    }
+
+    look_t out;
+    memcpy(&out, hex.data(), sizeof(out));
+    return out;
 }
 
 bool approximatelyEqual(float a, float b)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -78,6 +78,7 @@ void        PackSoultrapperName(std::string name, uint8 output[], uint8 size);
 std::string escape(std::string const& s);
 
 std::vector<std::string> split(const std::string& s, char delim);
+look_t stringToLook(std::string str);
 
 // Float tools
 // https://stackoverflow.com/a/253874

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -177,3 +177,8 @@ uint16 CBaseEntity::GetModelId() const
 {
     return look.modelid;
 }
+
+bool CBaseEntity::IsDynamicEntity() const
+{
+    return this->targid >= 0x800;
+}

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -241,12 +241,15 @@ public:
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&){};
 
+    bool IsDynamicEntity() const;
+
     uint32          id;           // global identifier unique on the server
     uint16          targid;       // local identifier unique to the zone
     ENTITYTYPE      objtype;      // тип сущности
     STATUS_TYPE     status;       // статус сущности (разные сущности - разные статусы)
     uint16          m_TargID;     // the targid of the object the entity is looking at
-    string_t        name;         // имя сущности
+    string_t        name;         // Entity name
+    string_t        packetName;   // Used to override name when being sent to the client
     look_t          look;         // внешний вид всех сущностей
     look_t          mainlook;     // only used if mob use changeSkin() or player /lockstyle
     location_t      loc;          // местоположение сущности
@@ -258,7 +261,6 @@ public:
     ALLEGIANCE_TYPE allegiance; // what types of targets the entity can fight
     uint8           updatemask; // what to update next server tick to players nearby
 
-    bool isDynamicEntity = false; // For use with insertDynamicEntity()
 
     std::unique_ptr<CAIContainer> PAI;          // AI container
     CBattlefield*                 PBattlefield; // pointer to battlefield (if in one)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -247,7 +247,6 @@ public:
 
     uint32   m_flags;       // includes the CFH flag and whether the HP bar should be shown or not (e.g. Yilgeban doesnt)
     uint8    m_name_prefix; // The ding bats VS Ding bats
-    string_t packetName;    // Used for battle allies
 
     CEnmityContainer* PEnmityContainer; // система ненависти монстров
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -289,14 +289,14 @@ void CLuaBaseEntity::messageText(CLuaBaseEntity* PLuaBaseEntity, uint16 messageI
  *          : Can modify the name shown through explicit declaration
  ************************************************************************/
 
-void CLuaBaseEntity::PrintToPlayer(std::string const& message, sol::object messageType, sol::object name)
+void CLuaBaseEntity::PrintToPlayer(std::string const& message, sol::object const& messageTypeObj, sol::object const& nameObj)
 {
-    CHAT_MESSAGE_TYPE int_messageType = (messageType == sol::lua_nil) ? MESSAGE_SYSTEM_1 : messageType.as<CHAT_MESSAGE_TYPE>();
-    const char*       cstr_name       = (name == sol::lua_nil) ? "" : name.as<const char*>();
+    auto messageType = (messageTypeObj == sol::lua_nil) ? MESSAGE_SYSTEM_1 : messageTypeObj.as<CHAT_MESSAGE_TYPE>();
+    auto name        = (nameObj == sol::lua_nil) ? "" : nameObj.as<std::string>();
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->pushPacket(new CChatMessagePacket(PChar, int_messageType, message, cstr_name));
+        PChar->pushPacket(new CChatMessagePacket(PChar, messageType, message, name));
     }
 }
 
@@ -4326,10 +4326,9 @@ uint8 CLuaBaseEntity::getGender()
  *  Example : player:getName()
  ************************************************************************/
 
-const char* CLuaBaseEntity::getName()
+std::string CLuaBaseEntity::getName()
 {
-    // TODO: Fix C-style cast
-    return (const char*)m_PBaseEntity->GetName();
+    return m_PBaseEntity->name;
 }
 
 /************************************************************************
@@ -4341,7 +4340,7 @@ const char* CLuaBaseEntity::getName()
  *          : Dynamic Entities etc.
  ************************************************************************/
 
-void CLuaBaseEntity::setName(const char* name)
+void CLuaBaseEntity::setName(std::string const& name)
 {
     m_PBaseEntity->name = name;
     m_PBaseEntity->updatemask |= UPDATE_NAME;
@@ -4353,13 +4352,9 @@ void CLuaBaseEntity::setName(const char* name)
  *  Example : mob:getPacketName()
  ************************************************************************/
 
-const char* CLuaBaseEntity::getPacketName()
+std::string CLuaBaseEntity::getPacketName()
 {
-    if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
-    {
-        return PMob->packetName.c_str();
-    }
-    return "";
+    return m_PBaseEntity->packetName;
 }
 
 /************************************************************************
@@ -4371,13 +4366,10 @@ const char* CLuaBaseEntity::getPacketName()
  *          : Dynamic Entities etc.
  ************************************************************************/
 
-void CLuaBaseEntity::setPacketName(const char* name)
+void CLuaBaseEntity::setPacketName(std::string const& name)
 {
-    if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
-    {
-        PMob->packetName = name;
-        PMob->updatemask |= UPDATE_NAME;
-    }
+    m_PBaseEntity->packetName = name;
+    m_PBaseEntity->updatemask |= UPDATE_NAME;
 }
 
 /************************************************************************
@@ -14024,6 +14016,7 @@ std::ostream& operator<<(std::ostream& os, const CLuaBaseEntity& entity)
     {
         std::string id   = std::to_string(entity.m_PBaseEntity->id);
         std::string name = entity.m_PBaseEntity->name;
+        std::string packetName = entity.m_PBaseEntity->packetName;
         std::string type = "";
         switch (entity.m_PBaseEntity->objtype)
         {
@@ -14074,7 +14067,8 @@ std::ostream& operator<<(std::ostream& os, const CLuaBaseEntity& entity)
             }
         }
 
-        return os << "CLuaBaseEntity(" << type << " | " << id << " | " << name << ")";
+        std::string ending = (packetName.empty()) ? ")" : " | " + packetName + ")";
+        return os << "CLuaBaseEntity(" << type << " | " << id << " | " << name << ending;
     }
 
     return os << "CLuaBaseEntity(nullptr)";

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -51,7 +51,7 @@ public:
     // Messaging System
     void showText(CLuaBaseEntity* mob, uint16 messageID, sol::object const& p0, sol::object const& p1, sol::object const& p2, sol::object const& p3); // Displays Dialog for npc
     void messageText(CLuaBaseEntity* PLuaBaseEntity, uint16 messageID, sol::object const& arg2, sol::object const& arg3);
-    void PrintToPlayer(std::string const& message, sol::object messageType, sol::object name);                               // for sending debugging messages/command confirmations to the player's client
+    void PrintToPlayer(std::string const& message, sol::object const& messageTypeObj, sol::object const& nameObj);                               // for sending debugging messages/command confirmations to the player's client
     void PrintToArea(std::string const& message, sol::object const& arg1, sol::object const& arg2, sol::object const& arg3); // for sending area messages to multiple players at once
     void messageBasic(uint16 messageID, sol::object const& p0, sol::object const& p1, sol::object const& target);            // Sends Basic Message
     void messageName(uint16 messageID, sol::object const& entity, sol::object const& p0, sol::object const& p1,
@@ -251,10 +251,10 @@ public:
     // Player Appearance
     uint8  getRace();
     uint8  getGender();              // Returns the player character's gender
-    auto   getName() -> const char*; // Gets Entity Name
-    void   setName(const char* name);
-    auto   getPacketName() -> const char*;
-    void   setPacketName(const char* name);
+    auto   getName() -> std::string; // Gets Entity Name
+    void   setName(std::string const& name);
+    auto   getPacketName() -> std::string;
+    void   setPacketName(std::string const& name);
     void   hideName(bool isHidden);
     bool   checkNameFlags(uint32 flags); // this is check and not get because it tests for a flag, it doesn't return all flags
     uint16 getModelId();

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -163,6 +163,8 @@ void CLuaZone::reloadNavmesh()
 
 std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
 {
+    auto& lua = luautils::lua;
+
     CBaseEntity* PEntity = nullptr;
     if (table.get_or<uint8>("objtype", TYPE_NPC) == TYPE_NPC)
     {
@@ -175,8 +177,6 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
 
         PEntity = mobutils::InstantiateDynamicMob(groupId, groupZoneId, m_pLuaZone->GetID());
     }
-
-    PEntity->isDynamicEntity = true;
 
     // NOTE: Mob allegiance is the default for NPCs
     PEntity->allegiance = static_cast<ALLEGIANCE_TYPE>(table.get_or<uint8>("allegiance", ALLEGIANCE_TYPE::MOB));
@@ -196,30 +196,69 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     PEntity->loc.p.z        = table.get_or<float>("z", 0.01);
     PEntity->loc.p.moving   = 0;
 
-    PEntity->updatemask |= UPDATE_ALL_MOB;
+    auto name = table.get_or<std::string>("name", "");
+    if (name.empty())
+    {
+        ShowWarning("Trying to spawn dynamic entity without a name! (%s)", (const char*)m_pLuaZone->GetName());
+    }
+
+    auto lookupName = "DE_" + name;
+
+    PEntity->name = lookupName;
+    PEntity->packetName = name;
+
+    auto typeKey = (PEntity->objtype == TYPE_NPC) ? "npcs" : "mobs";
+    auto& cacheEntry = lua[sol::create_if_nil]["xi"]["zones"][(const char*)m_pLuaZone->GetName()][typeKey][lookupName];
 
     if (auto* PNpc = dynamic_cast<CNpcEntity*>(PEntity))
     {
         PNpc->namevis       = table.get_or<uint8>("namevis", 0);
         PNpc->status        = STATUS_TYPE::NORMAL;
-        PNpc->m_flags       = table.get_or<uint32>("m_flags", 0);
-        PNpc->name_prefix   = table.get_or<uint8>("name_prefix", 32);
+        PNpc->m_flags       = 0;
+        PNpc->name_prefix   = 32;
         PNpc->widescan      = 0;
-        PNpc->m_triggerable = table.get_or("triggerable", false);
-        PNpc->SetModelId(table.get_or<uint16>("modelId", 0));
+
+        auto onTrade = table["onTrade"].get_or<sol::function>(sol::lua_nil);
+        if (onTrade.valid())
+        {
+            cacheEntry["onTrade"] = onTrade;
+        }
+
+        auto onTrigger = table["onTrigger"].get_or<sol::function>(sol::lua_nil);
+        if (onTrigger.valid())
+        {
+            PNpc->m_triggerable = true;
+            cacheEntry["onTrigger"] = onTrigger;
+        }
 
         m_pLuaZone->InsertNPC(PNpc);
     }
     else if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
     {
+        auto onMobDeath = table["onMobDeath"].get_or<sol::function>(sol::lua_nil);
+        if (onMobDeath.valid())
+        {
+            cacheEntry["onMobDeath"] = onMobDeath;
+        }
+        else
+        {
+            cacheEntry["onMobDeath"] = [](){}; // Empty func
+        }
+
         m_pLuaZone->InsertMOB(PMob);
     }
 
-    auto maybeName = table.get<std::optional<std::string>>("name");
-    if (maybeName.has_value())
+    if (table["look"].get_type() == sol::type::number)
     {
-        PEntity->name.insert(0, maybeName.value().c_str());
+        PEntity->SetModelId(table.get<uint16>("look"));
     }
+    else if (table["look"].get_type() == sol::type::string)
+    {
+        auto look = stringToLook(table.get<std::string>("look"));
+        std::memcpy(&PEntity->look, &look, sizeof(PEntity->look));
+    }
+
+    PEntity->updatemask |= UPDATE_ALL_MOB;
 
     return CLuaBaseEntity(PEntity);
 }

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -169,6 +169,7 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     if (table.get_or<uint8>("objtype", TYPE_NPC) == TYPE_NPC)
     {
         PEntity = new CNpcEntity();
+        PEntity->name = "DefaultName";
     }
     else
     {
@@ -199,7 +200,8 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     auto name = table.get_or<std::string>("name", "");
     if (name.empty())
     {
-        ShowWarning("Trying to spawn dynamic entity without a name! (%s)", (const char*)m_pLuaZone->GetName());
+        ShowFatalError("Trying to spawn dynamic entity without a name! (%s)", (const char*)m_pLuaZone->GetName());
+        std::exit(-1);
     }
 
     auto lookupName = "DE_" + name;
@@ -216,7 +218,9 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         PNpc->status        = STATUS_TYPE::NORMAL;
         PNpc->m_flags       = 0;
         PNpc->name_prefix   = 32;
-        PNpc->widescan      = 0;
+
+        // TODO: Does this even work?
+        PNpc->widescan      = table.get_or<uint8>("widescan", 1);
 
         auto onTrade = table["onTrade"].get_or<sol::function>(sol::lua_nil);
         if (onTrade.valid())

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -200,8 +200,11 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     auto name = table.get_or<std::string>("name", "");
     if (name.empty())
     {
-        ShowFatalError("Trying to spawn dynamic entity without a name! (%s)", (const char*)m_pLuaZone->GetName());
-        std::exit(-1);
+        ShowWarning("Trying to spawn dynamic entity without a name! (%s - %s)",
+            PEntity->name.c_str(), (const char*)m_pLuaZone->GetName());
+
+        // If the name hasn't been provided, use "DefaultName" for NPCs, and whatever comes from the mob_pool for Mobs
+        name = PEntity->name;
     }
 
     auto lookupName = "DE_" + name;
@@ -210,7 +213,7 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     PEntity->packetName = name;
 
     auto typeKey = (PEntity->objtype == TYPE_NPC) ? "npcs" : "mobs";
-    auto& cacheEntry = lua[sol::create_if_nil]["xi"]["zones"][(const char*)m_pLuaZone->GetName()][typeKey][lookupName];
+    auto cacheEntry = lua[sol::create_if_nil]["xi"]["zones"][(const char*)m_pLuaZone->GetName()][typeKey][lookupName];
 
     if (auto* PNpc = dynamic_cast<CNpcEntity*>(PEntity))
     {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3053,11 +3053,6 @@ namespace luautils
             return -1;
         }
 
-        if (PMob->isDynamicEntity)
-        {
-            return -1;
-        }
-
         // TODO: These int8 string need to die.
         std::string zone_name = (const char*)PMob->loc.zone->GetName();
         std::string mob_name  = (const char*)PMob->GetName();

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -59,7 +59,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             }
             if (PEntity->objtype == TYPE_TRUST)
             {
-                //  ref<uint8>(0x28) = 0x45;
+                ref<uint8>(0x28) = 0x45;
             }
             if (PEntity->look.size == MODEL_EQUIPED || PEntity->look.size == MODEL_CHOCOBO)
             {
@@ -107,8 +107,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
 
             if (updatemask & UPDATE_HP)
             {
-                // HPP
-                ref<uint8>(0x1E) = 0x64; // 100
+                ref<uint8>(0x1E) = 0x64; // HPP: 100
                 ref<uint8>(0x1F) = PEntity->animation;
                 ref<uint8>(0x2A) |= PEntity->animationsub;
 
@@ -120,16 +119,8 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
                     ref<uint8>(0x28) |= 0x40;
                 }
 
-                ref<uint8>(0x29)  = static_cast<uint8>(PEntity->allegiance);
-                ref<uint8>(0x2B)  = PEntity->namevis;
-            }
-
-            // TODO: Unify name logic
-            if (updatemask & UPDATE_NAME)
-            {
-                // depending on size of name, this can be 0x20, 0x22, or 0x24
-                this->setSize(0x48);
-                memcpy(data + (0x34), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
+                ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);
+                ref<uint8>(0x2B) = PEntity->namevis;
             }
         }
         break;
@@ -162,19 +153,6 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
                     ref<uint32>(0x2C) = PMob->m_OwnerID.id;
                 }
             }
-            if (updatemask & UPDATE_NAME)
-            {
-                // depending on size of name, this can be 0x20, 0x22, or 0x24
-                this->setSize(0x48);
-                if (PMob->packetName.empty())
-                {
-                    memcpy(data + (0x34), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
-                }
-                else
-                {
-                    memcpy(data + (0x34), PMob->packetName.c_str(), std::min<size_t>(PMob->packetName.size(), PacketNameLength));
-                }
-            }
         }
         break;
         default:
@@ -183,32 +161,20 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         }
     }
 
-    // TODO: Read from the trust model itself
-    if (PEntity->objtype == TYPE_TRUST)
-    {
-        // ref<uint32>(0x21) = 0x21b;
-        // ref<uint8>(0x2B) = 0x06;
-        // ref<uint8>(0x2A) = 0x08;
-        // ref<uint8>(0x25) = 0x0f;
-        // ref<uint8>(0x27) = 0x28;
-        ref<uint8>(0x28) = 0x45;
-    }
-
     switch (PEntity->look.size)
     {
         case MODEL_STANDARD:
         case MODEL_UNK_5:
         case MODEL_AUTOMATON:
         {
+            this->setSize(0x48);
             ref<uint32>(0x30) = ::ref<uint32>(&PEntity->look, 0);
         }
         break;
         case MODEL_EQUIPED:
         case MODEL_CHOCOBO:
         {
-            this->setSize(0x48);
-
-            memcpy(data + (0x30), &(PEntity->look), 20);
+            std::memcpy(data + 0x30, &PEntity->look, sizeof(PEntity->look));
         }
         break;
         case MODEL_DOOR:
@@ -216,10 +182,15 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         case MODEL_SHIP:
         {
             this->setSize(0x48);
-
             ref<uint16>(0x30) = PEntity->look.size;
-            memcpy(data + (0x34), PEntity->GetName(), (PEntity->name.size() > 12 ? 12 : PEntity->name.size()));
         }
         break;
+    }
+
+    if (updatemask & UPDATE_HP || updatemask & UPDATE_NAME)
+    {
+        auto nameOffset = (PEntity->look.size == MODEL_EQUIPED) ? 0x44 : 0x34;
+        auto name       = (PEntity->packetName.empty()) ? PEntity->name : PEntity->packetName;
+        std::memcpy(data + nameOffset, name.c_str(), std::min<size_t>(name.size(), PacketNameLength));
     }
 }

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -69,6 +69,18 @@ namespace moduleutils
                 std::string relPath   = path.relative_path().generic_string();
                 std::string pathNoExt = path.relative_path().replace_extension("").generic_string();
 
+                // Execute the script once in "safe mode" to check it for syntax errors
+                // lua.require_file will crash if it's given a bad script
+                auto res = lua.safe_script_file(relPath);
+                if (!res.valid())
+                {
+                    sol::error err = res;
+                    ShowError("Failed to load module: %s", filename);
+                    ShowError(err.what());
+                    continue;
+                }
+
+                // Run for real
                 sol::table table = lua.require_file(pathNoExt, relPath);
                 if (table["enabled"])
                 {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Improves the API for dynamic entities, fixes some problems with the entity_update packet, makes module loading more sturdy
