### PR TITLE
[Dynamis Beaucedine] Drop items, 5 NM, Hydra split

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -1013,7 +1013,7 @@ INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1452,0); -- ordelle_bronzepiece
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1452,10);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1456,10); -- one_hundred_byne_bill
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,50); -- sparkling_stone
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1520,50); -- jar_of_goblin_grease
@@ -1604,7 +1604,7 @@ INSERT INTO `mob_droplist` VALUES (260,0,0,1000,1119,510);
 INSERT INTO `mob_droplist` VALUES (260,0,0,1000,1162,240);
 INSERT INTO `mob_droplist` VALUES (260,0,0,1000,16899,140);
 INSERT INTO `mob_droplist` VALUES (261,2,0,1000,1455,0); -- (Quadav lottery NMs, Dynamis Be) one_byne_bill
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1456,10); -- one_hundred_byne_bill
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1469,50); -- chunk_of_wootz_ore
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1470,50); -- sparkling_stone
@@ -1640,7 +1640,7 @@ INSERT INTO `mob_droplist` VALUES (264,2,0,1000,825,0);
 INSERT INTO `mob_droplist` VALUES (264,0,0,1000,825,380);
 INSERT INTO `mob_droplist` VALUES (264,0,0,1000,940,60);
 INSERT INTO `mob_droplist` VALUES (265,2,0,1000,1449,0); -- (Yagudo lottery NMs, Dynamis Be) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1449,100);
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1450,10); -- lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1464,50); -- lancewood_log
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1466,150); -- pile_of_relic_iron
@@ -2777,7 +2777,7 @@ INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5072,130);
 INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5073,30);
 INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5074,80);
 INSERT INTO `mob_droplist` VALUES (493,2,0,1000,1452,0); -- (Orc lottery NMs, Dynamis Be) ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1452,100);
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1470,50); -- sparkling_stone
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1516,50); -- griffon_hide

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -1015,8 +1015,8 @@ INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1453,10); -- montiont_silverpiec
 INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0); -- one_byne_bill
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1455,90);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1456,10); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1520,80); -- jar_of_goblin_grease
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1520,50); -- jar_of_goblin_grease
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,3357,240); -- leering_bijou
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,11292,10);
@@ -1606,9 +1606,9 @@ INSERT INTO `mob_droplist` VALUES (260,0,0,1000,16899,140);
 INSERT INTO `mob_droplist` VALUES (261,2,0,1000,1455,0); -- (Quadav lottery NMs, Dynamis Be) one_byne_bill
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1455,90);
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1456,10); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1469,80); -- chunk_of_wootz_ore
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1521,80); -- vial_of_slime_juice
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1469,50); -- chunk_of_wootz_ore
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1521,50); -- vial_of_slime_juice
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,3357,240); -- leering_bijou
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,11292,10);
@@ -1642,10 +1642,10 @@ INSERT INTO `mob_droplist` VALUES (264,0,0,1000,940,60);
 INSERT INTO `mob_droplist` VALUES (265,2,0,1000,1449,0); -- (Yagudo lottery NMs, Dynamis Be) tukuku_whiteshell
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1449,90);
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1450,10); -- lungo-nango_jadeshell
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1464,80); -- lancewood_log
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1466,200); -- pile_of_relic_iron
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1518,80); -- colossal_skull
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1464,50); -- lancewood_log
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1466,150); -- pile_of_relic_iron
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1518,50); -- colossal_skull
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,3357,240); -- leering_bijou
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,11292,10);
@@ -2779,10 +2779,10 @@ INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5074,80);
 INSERT INTO `mob_droplist` VALUES (493,2,0,1000,1452,0); -- (Orc lottery NMs, Dynamis Be) ordelle_bronzepiece
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1452,90);
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1453,10); -- montiont_silverpiece
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1516,80); -- griffon_hide
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1517,80); -- giant_frozen_head
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1519,80); -- fresh_orc_liver
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1516,50); -- griffon_hide
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1517,50); -- giant_frozen_head
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1519,50); -- fresh_orc_liver
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,3357,240); -- leering_bijou
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,11292,10);
@@ -8568,9 +8568,9 @@ INSERT INTO `mob_droplist` VALUES (1671,0,0,1000,5384,100);
 INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1450,10); -- (Mildaunegeux NM, Dynamis Beacedine) lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1456,10); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1556,330); -- attestation_of_might
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1564,330); -- attestation_of_legerity
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1570,330); -- attestation_of_accuracy
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1556,240); -- attestation_of_might
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1564,240); -- attestation_of_legerity
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1570,240); -- attestation_of_accuracy
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,939,390);
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,1288,70);
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,4754,20);
@@ -10827,9 +10827,9 @@ INSERT INTO `mob_droplist` VALUES (2065,0,0,1000,997,20);
 INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1450,10); -- (Quiebitiel ,Dynamis Beaucedine) lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1456,10); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1557,330); -- attestation_of_celerity
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1566,330); -- attestation_of_sacrifice
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1569,330); -- attestation_of_harmony
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1557,240); -- attestation_of_celerity
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1566,240); -- attestation_of_sacrifice
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1569,240); -- attestation_of_harmony
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,624,370);
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,4360,360);
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,4443,200);
@@ -13267,8 +13267,8 @@ INSERT INTO `mob_droplist` VALUES (2541,0,0,1000,16362,10);
 INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1449,0); -- (Goblin Vanguard, Dyanmis Beacedine) tukuku_whiteshell
 INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1452,0); -- ordelle_bronzepiece
 INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1520,80); -- jar_of_goblin_grease
+INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1520,50); -- jar_of_goblin_grease
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,11295,10);
@@ -13381,10 +13381,10 @@ INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,16362,10);
 INSERT INTO `mob_droplist` VALUES (2547,2,0,1000,1452,0); -- (Orc Vanguard, Dynamis Beaucedine) ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1516,80); -- griffon_hide
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1517,80); -- giant_frozen_head
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1519,80); -- fresh_orc_liver
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1516,50); -- griffon_hide
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1517,50); -- giant_frozen_head
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1519,50); -- fresh_orc_liver
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,11295,10);
@@ -13496,10 +13496,10 @@ INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,16362,10);
 INSERT INTO `mob_droplist` VALUES (2552,2,0,1000,1449,0); -- (Yagudo Vanguard, Dynamis Beaucedine) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1464,80); -- lancewood_log
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1466,80); -- pile_of_relic_iron
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1518,80); -- colossal_skull
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1464,50); -- lancewood_log
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1466,50); -- pile_of_relic_iron
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1518,50); -- colossal_skull
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,11295,10);
@@ -13612,9 +13612,9 @@ INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,16362,10);
 INSERT INTO `mob_droplist` VALUES (2557,2,0,1000,1455,0); -- (Quadav Vanguard, Dynamis Beaucedine) one_byne_bill
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1469,80); -- chunk_of_wootz_ore
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1470,80); -- sparkling_stone
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1521,80); -- vial_of_slime_juice
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1469,50); -- chunk_of_wootz_ore
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1470,50); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1521,50); -- vial_of_slime_juice
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,11295,10);
@@ -13793,9 +13793,9 @@ INSERT INTO `mob_droplist` VALUES (2573,0,0,1000,853,140);
 INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1450,10); -- (Velosareon, Dynamis Beacedine) lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1456,10); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1562,330); -- attestation_of_vigor
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1565,330); -- attestation_of_decisiveness
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1568,330); -- attestation_of_transcendence
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1562,240); -- attestation_of_vigor
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1565,240); -- attestation_of_decisiveness
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1568,240); -- attestation_of_transcendence
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,2635,1000);
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,16175,360);
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,16239,490);
@@ -17085,13 +17085,13 @@ INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,916,140); -- (Sabotender Bailar
 INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,1592,80); -- (Sabotender Bailarin) Cactaur Root
 INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,1236,180); -- (Sabotender Bailarin) Cactaur Stems
 INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1449,0); -- (Hitaume, Dynamis Beaucedine) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1449,100);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1450,10); -- lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1452,0); -- ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1452,100);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1456,10); -- one_hundred_byne_bill
 -- INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,3427,1000) -- fiendish_tome_chapter_24, lets not fill inventory befor Arch Angra Mainyu is added
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,3493,50); -- forgotten_thought
@@ -17099,7 +17099,7 @@ INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11298,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11918,500); -- khthonios_gloves
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11918,240); -- khthonios_gloves
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15088,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15089,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15090,10);
@@ -17117,13 +17117,13 @@ INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15140,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15142,10);
 INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,16360,10);
 INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1449,0); -- (Cavanneche, Dynamis Beaucedine) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1449,100);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1450,10); -- lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1452,0); -- ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1452,100);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1456,10); -- one_hundred_byne_bill
 -- INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,3428,1000) -- fiendish_tome_chapter_25, lets not fill inventory befor Arch Angra Mainyu is added
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,3493,50); -- forgotten_thought
@@ -17131,7 +17131,7 @@ INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11298,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11821,500); -- khthonios_helm
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11821,240); -- khthonios_helm
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15088,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15089,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15090,10);
@@ -17148,13 +17148,13 @@ INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15123,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15140,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15142,10);
 INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,16360,10);
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1450,20); -- (Arch_Angra_Mainyu, Dynamis Beaucedine) lungo-nango_jadeshell
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1453,20); -- montiont_silverpiece
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1456,20); -- one_hundred_byne_bill
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,3493,250); -- forgotten_thought
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,11919,500); -- avesta_bangles
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,18623,600); -- chtonic_staff
-INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,19763,250); -- oneiros_cluster
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1450,150); -- (Arch_Angra_Mainyu, Dynamis Beaucedine) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1453,150); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1456,150); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,3493,240); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,11919,240); -- avesta_bangles
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,18623,240); -- chtonic_staff
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,19763,240); -- oneiros_cluster
 -- Spliting Dynamis Beaucedine Hydra loot for the drop of odious item
 INSERT INTO `mob_droplist` VALUES (3213,2,0,1000,1449,0); -- Hydra Paladin (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (3213,2,0,1000,1452,0); -- Ordelle Bronzepiece
@@ -17365,13 +17365,13 @@ INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15140,10); -- Monster Gaiters
 INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15142,10); -- Scout's Socks
 INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,16360,10); -- Etoile TightsINSERT INTO `mob_droplist` VALUES (3208,2,0,1000,1449,0); -- (Taquede, Dynamis Beaucedine) tukuku_whiteshell
 INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1449,0); -- (Taquede, Dynamis Beaucedine) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1449,100);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1450,10); -- lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1452,0); -- ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1452,100);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1456,10); -- one_hundred_byne_bill
 -- INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,3425,1000) -- fiendish_tome_chapter_22, lets not fill inventory befor Arch Angra Mainyu is added
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,3493,50); -- forgotten_thought
@@ -17379,7 +17379,7 @@ INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11298,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11456,500); -- ryuga_sune-ate
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11456,240); -- ryuga_sune-ate
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15088,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15089,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15090,10);
@@ -17397,13 +17397,13 @@ INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15140,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15142,10);
 INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,16360,10);
 INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1449,0); -- (Pignonpausard, Dynamis Beaucedine) tukuku_whiteshell
-INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1449,100);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1450,10); -- lungo-nango_jadeshell
 INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1452,0); -- ordelle_bronzepiece
-INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1452,100);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1453,10); -- montiont_silverpiece
 INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1455,0); -- one_byne_bill
-INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1455,100);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1456,10); -- one_hundred_byne_bill
 -- INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,3426,1000) -- fiendish_tome_chapter_23, lets not fill inventory befor Arch Angra Mainyu is added
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,3493,50); -- forgotten_thought
@@ -17411,7 +17411,7 @@ INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11298,10);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11820,500); -- khthonios_mask
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11820,240); -- khthonios_mask
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15088,10);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15089,10);
 INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15090,10);

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -1012,7 +1012,7 @@ INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1450,10); -- lungo-nango_jadeshe
 INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1452,0); -- ordelle_bronzepiece
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1452,10);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1453,10); -- montiont_silverpiece
-INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0);-- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0); -- one_byne_bill
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1455,90);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1456,10); -- one_hundred_byne_bill
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,80); -- sparkling_stone
@@ -17238,7 +17238,7 @@ INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1449,0); -- Hydra Black Mage (D
 INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3360,100); -- Sadist's Fortune Parchment, 10% (normalized)
---INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3396,50); -- odious_talisman lets not fill inventory before Taquede is added
+-- INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3396,50); -- odious_talisman lets not fill inventory before Taquede is added
 INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11295,10); -- Commodore Frac

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -1006,17 +1006,19 @@ INSERT INTO `mob_droplist` VALUES (175,0,0,1000,3179,100);
 INSERT INTO `mob_droplist` VALUES (175,0,0,1000,3180,100);
 INSERT INTO `mob_droplist` VALUES (175,0,0,1000,3185,100);
 INSERT INTO `mob_droplist` VALUES (175,0,0,1000,18967,440);
-INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1449,0); -- (Goblin lottery NMs, Be)
+INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1449,0); -- (Goblin lottery NMs, Dynamis Be) tukuku_whiteshell
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1449,90);
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1452,0);
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1452,0); -- ordelle_bronzepiece
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1452,10);
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1453,10);
-INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0);
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (176,2,0,1000,1455,0);-- one_byne_bill
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1455,90);
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1520,80);
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1456,10); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,1520,80); -- jar_of_goblin_grease
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,3357,240); -- leering_bijou
+INSERT INTO `mob_droplist` VALUES (176,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (176,0,0,1000,11298,10);
@@ -1601,12 +1603,14 @@ INSERT INTO `mob_droplist` VALUES (259,0,0,1000,11937,170);
 INSERT INTO `mob_droplist` VALUES (260,0,0,1000,1119,510);
 INSERT INTO `mob_droplist` VALUES (260,0,0,1000,1162,240);
 INSERT INTO `mob_droplist` VALUES (260,0,0,1000,16899,140);
-INSERT INTO `mob_droplist` VALUES (261,2,0,1000,1455,0); -- (Quadav lottery NMs, Be)
+INSERT INTO `mob_droplist` VALUES (261,2,0,1000,1455,0); -- (Quadav lottery NMs, Dynamis Be) one_byne_bill
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1455,90);
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1469,80);
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1521,80);
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1456,10); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1469,80); -- chunk_of_wootz_ore
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,1521,80); -- vial_of_slime_juice
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,3357,240); -- leering_bijou
+INSERT INTO `mob_droplist` VALUES (261,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (261,0,0,1000,11298,10);
@@ -1635,12 +1639,15 @@ INSERT INTO `mob_droplist` VALUES (264,0,0,1000,529,20);
 INSERT INTO `mob_droplist` VALUES (264,2,0,1000,825,0);
 INSERT INTO `mob_droplist` VALUES (264,0,0,1000,825,380);
 INSERT INTO `mob_droplist` VALUES (264,0,0,1000,940,60);
-INSERT INTO `mob_droplist` VALUES (265,2,0,1000,1449,0); -- (Yagudo lottery NMs, Be)
+INSERT INTO `mob_droplist` VALUES (265,2,0,1000,1449,0); -- (Yagudo lottery NMs, Dynamis Be) tukuku_whiteshell
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1449,90);
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1464,80);
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1466,200);
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1518,80);
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1464,80); -- lancewood_log
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1466,200); -- pile_of_relic_iron
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,1518,80); -- colossal_skull
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,3357,240); -- leering_bijou
+INSERT INTO `mob_droplist` VALUES (265,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (265,0,0,1000,11298,10);
@@ -2769,12 +2776,15 @@ INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5045,150);
 INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5072,130);
 INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5073,30);
 INSERT INTO `mob_droplist` VALUES (492,0,0,1000,5074,80);
-INSERT INTO `mob_droplist` VALUES (493,2,0,1000,1452,0); -- (Orc lottery NMs, Be)
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1452,10);
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1516,80);
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1517,80);
-INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1519,80);
+INSERT INTO `mob_droplist` VALUES (493,2,0,1000,1452,0); -- (Orc lottery NMs, Dynamis Be) ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1516,80); -- griffon_hide
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1517,80); -- giant_frozen_head
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,1519,80); -- fresh_orc_liver
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,3357,240); -- leering_bijou
+INSERT INTO `mob_droplist` VALUES (493,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (493,0,0,1000,11298,10);
@@ -6903,10 +6913,12 @@ INSERT INTO `mob_droplist` VALUES (1342,0,0,1000,15123,10);
 INSERT INTO `mob_droplist` VALUES (1342,0,0,1000,15140,10);
 INSERT INTO `mob_droplist` VALUES (1342,0,0,1000,15142,10);
 INSERT INTO `mob_droplist` VALUES (1342,0,0,1000,16360,10);
-INSERT INTO `mob_droplist` VALUES (1343,2,0,1000,1449,0); -- Hydra Warrior, Paladin, Hydra Red Mage (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (1343,2,0,1000,1449,0); -- Hydra Warrior (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (1343,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (1343,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,3359,100); -- Despot's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,3398,50); -- odious_tree_root lets not fill inventory before Hitaume is added
+INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,11295,10); -- Commodore Frac
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,11298,10); -- Pantin Tobe
@@ -6927,10 +6939,12 @@ INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,15123,10); -- Valor Breeches
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,15140,10); -- Monster Gaiters
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,15142,10); -- Scout's Socks
 INSERT INTO `mob_droplist` VALUES (1343,0,0,1000,16360,10); -- Etoile Tights
-INSERT INTO `mob_droplist` VALUES (1344,2,0,1000,1449,0); -- Hydra Bard, White Mage, Black Mage (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (1344,2,0,1000,1449,0); -- Hydra Bard (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (1344,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (1344,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,3360,100); -- Sadist's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,3398,50); -- odious_tree_root lets not fill inventory before Hitaume is added
+INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,11295,10); -- Commodore Frac
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,11298,10); -- Pantin Tobe
@@ -6951,10 +6965,12 @@ INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,15123,10); -- Valor Breeches
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,15140,10); -- Monster Gaiters
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,15142,10); -- Scout's Socks
 INSERT INTO `mob_droplist` VALUES (1344,0,0,1000,16360,10); -- Etoile Tights
-INSERT INTO `mob_droplist` VALUES (1345,2,0,1000,1449,0); -- Hydra Monk, Ninja, Thief (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (1345,2,0,1000,1449,0); -- Hydra Monk, Ninja (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (1345,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (1345,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,3361,100); -- Villain's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,3398,50); -- odious_tree_root lets not fill inventory before Hitaume is added
+INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,11295,10); -- Commodore Frac
 INSERT INTO `mob_droplist` VALUES (1345,0,0,1000,11298,10); -- Pantin Tobe
@@ -7669,33 +7685,7 @@ INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,1450,20);
 INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,3497,30);
 INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,5902,30);
 INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,15128,130);
-INSERT INTO `mob_droplist` VALUES (1462,2,0,1000,1449,0);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1449,90);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1464,80);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1466,200);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,1518,80);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,11292,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,11295,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,11298,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15088,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15089,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15090,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15091,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15094,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15096,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15098,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15099,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15100,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15101,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15117,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15122,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15123,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15140,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,15142,10);
-INSERT INTO `mob_droplist` VALUES (1462,0,0,1000,16360,10);
+-- 1462 free
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5378,100);
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5379,100);
 INSERT INTO `mob_droplist` VALUES (1464,0,0,1000,888,207); -- (Kraken) seashell
@@ -8575,12 +8565,12 @@ INSERT INTO `mob_droplist` VALUES (1670,0,0,1000,4358,260);
 INSERT INTO `mob_droplist` VALUES (1671,0,0,1000,5366,100);
 INSERT INTO `mob_droplist` VALUES (1671,0,0,1000,5381,100);
 INSERT INTO `mob_droplist` VALUES (1671,0,0,1000,5384,100);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1453,10);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1556,330);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1564,330);
-INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1570,330);
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1450,10); -- (Mildaunegeux NM, Dynamis Beacedine) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1456,10); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1556,330); -- attestation_of_might
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1564,330); -- attestation_of_legerity
+INSERT INTO `mob_droplist` VALUES (1672,0,0,1000,1570,330); -- attestation_of_accuracy
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,939,390);
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,1288,70);
 INSERT INTO `mob_droplist` VALUES (1673,0,0,1000,4754,20);
@@ -8768,38 +8758,7 @@ INSERT INTO `mob_droplist` VALUES (1725,0,0,1000,642,10);
 INSERT INTO `mob_droplist` VALUES (1725,0,0,1000,736,10);
 INSERT INTO `mob_droplist` VALUES (1725,0,0,1000,768,30);
 INSERT INTO `mob_droplist` VALUES (1725,2,0,1000,17296,0);
-INSERT INTO `mob_droplist` VALUES (1726,2,0,1000,1449,0);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1449,90);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (1726,2,0,1000,1452,0);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1452,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1453,10);
-INSERT INTO `mob_droplist` VALUES (1726,2,0,1000,1455,0);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1455,90);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,1520,80);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,3357,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,11292,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,11295,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,11298,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15088,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15089,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15090,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15091,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15094,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15096,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15098,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15099,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15100,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15101,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15117,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15122,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15123,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15140,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,15142,10);
-INSERT INTO `mob_droplist` VALUES (1726,0,0,1000,16360,10);
+-- 1726 free
 INSERT INTO `mob_droplist` VALUES (1727,0,0,1000,846,60);
 INSERT INTO `mob_droplist` VALUES (1727,0,0,1000,1683,90);
 INSERT INTO `mob_droplist` VALUES (1728,0,0,1000,2518,120);
@@ -9748,31 +9707,7 @@ INSERT INTO `mob_droplist` VALUES (1830,0,0,1000,852,30);
 INSERT INTO `mob_droplist` VALUES (1830,0,0,1000,926,180);
 INSERT INTO `mob_droplist` VALUES (1830,0,0,1000,4362,30);
 INSERT INTO `mob_droplist` VALUES (1830,0,0,1000,14064,110);
-INSERT INTO `mob_droplist` VALUES (1831,2,0,1000,1455,0);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,1455,90);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,1469,80);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,1521,80);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,11292,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,11295,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,11298,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,11307,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15088,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15089,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15090,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15091,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15094,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15096,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15098,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15099,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15100,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15101,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15117,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15122,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15123,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15140,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,15142,10);
-INSERT INTO `mob_droplist` VALUES (1831,0,0,1000,16360,10);
+-- 1831 free
 INSERT INTO `mob_droplist` VALUES (1832,0,0,1000,2322,40);
 INSERT INTO `mob_droplist` VALUES (1832,0,0,1000,2323,30);
 INSERT INTO `mob_droplist` VALUES (1832,0,0,1000,2324,60);
@@ -10889,12 +10824,12 @@ INSERT INTO `mob_droplist` VALUES (2062,0,0,1000,4531,1000);
 INSERT INTO `mob_droplist` VALUES (2063,0,0,1000,1010,20);
 INSERT INTO `mob_droplist` VALUES (2064,0,0,1000,971,100);
 INSERT INTO `mob_droplist` VALUES (2065,0,0,1000,997,20);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1453,10);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1557,330);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1566,330);
-INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1569,330);
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1450,10); -- (Quiebitiel ,Dynamis Beaucedine) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1456,10); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1557,330); -- attestation_of_celerity
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1566,330); -- attestation_of_sacrifice
+INSERT INTO `mob_droplist` VALUES (2066,0,0,1000,1569,330); -- attestation_of_harmony
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,624,370);
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,4360,360);
 INSERT INTO `mob_droplist` VALUES (2067,0,0,1000,4443,200);
@@ -13329,11 +13264,12 @@ INSERT INTO `mob_droplist` VALUES (2541,0,0,1000,15125,10);
 INSERT INTO `mob_droplist` VALUES (2541,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2541,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2541,0,0,1000,16362,10);
-INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1449,0);
-INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1452,0);
-INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1455,0);
-INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1520,80);
+INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1449,0); -- (Goblin Vanguard, Dyanmis Beacedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1452,0); -- ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1455,0); -- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,1520,80); -- jar_of_goblin_grease
+INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (2542,0,0,1000,11298,10);
@@ -13444,11 +13380,12 @@ INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,15125,10);
 INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2546,0,0,1000,16362,10);
-INSERT INTO `mob_droplist` VALUES (2547,2,0,1000,1452,0);
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1516,80);
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1517,80);
-INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1519,80);
+INSERT INTO `mob_droplist` VALUES (2547,2,0,1000,1452,0); -- (Orc Vanguard, Dynamis Beaucedine) ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1516,80); -- griffon_hide
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1517,80); -- giant_frozen_head
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,1519,80); -- fresh_orc_liver
+INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (2547,0,0,1000,11298,10);
@@ -13558,11 +13495,12 @@ INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,15125,10);
 INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2551,0,0,1000,16362,10);
-INSERT INTO `mob_droplist` VALUES (2552,2,0,1000,1449,0);
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1464,80);
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1466,80);
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1518,80);
+INSERT INTO `mob_droplist` VALUES (2552,2,0,1000,1449,0); -- (Yagudo Vanguard, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1464,80); -- lancewood_log
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1466,80); -- pile_of_relic_iron
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,1518,80); -- colossal_skull
+INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (2552,0,0,1000,11298,10);
@@ -13673,10 +13611,11 @@ INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,15125,10);
 INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,15137,10);
 INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,15146,10);
 INSERT INTO `mob_droplist` VALUES (2556,0,0,1000,16362,10);
-INSERT INTO `mob_droplist` VALUES (2557,2,0,1000,1455,0);
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1469,80);
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1470,80);
-INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1521,80);
+INSERT INTO `mob_droplist` VALUES (2557,2,0,1000,1455,0); -- (Quadav Vanguard, Dynamis Beaucedine) one_byne_bill
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1469,80); -- chunk_of_wootz_ore
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1470,80); -- sparkling_stone
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,1521,80); -- vial_of_slime_juice
+INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,11292,10);
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,11295,10);
 INSERT INTO `mob_droplist` VALUES (2557,0,0,1000,11298,10);
@@ -13851,12 +13790,12 @@ INSERT INTO `mob_droplist` VALUES (2572,4,0,1000,853,0);
 INSERT INTO `mob_droplist` VALUES (2572,0,0,1000,853,160);
 INSERT INTO `mob_droplist` VALUES (2573,4,0,1000,853,0);
 INSERT INTO `mob_droplist` VALUES (2573,0,0,1000,853,140);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1450,10);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1453,10);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1456,10);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1562,330);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1565,330);
-INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1568,330);
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1450,10); -- (Velosareon, Dynamis Beacedine) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1456,10); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1562,330); -- attestation_of_vigor
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1565,330); -- attestation_of_decisiveness
+INSERT INTO `mob_droplist` VALUES (2574,0,0,1000,1568,330); -- attestation_of_transcendence
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,2635,1000);
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,16175,360);
 INSERT INTO `mob_droplist` VALUES (2575,0,0,1000,16239,490);
@@ -16584,10 +16523,12 @@ INSERT INTO `mob_droplist` VALUES (3143,0,0,1000,2384,80); -- smoke-filled_flask
 INSERT INTO `mob_droplist` VALUES (3144,0,0,1000,637,150); -- (Panna Cotta) vial_of_slime_oil
 INSERT INTO `mob_droplist` VALUES (3144,0,0,1000,3541,50); -- (Panna Cotta) seasoning_stone
 INSERT INTO `mob_droplist` VALUES (3144,0,0,1000,3543,50); -- (Panna Cotta) fossilized_fang
-INSERT INTO `mob_droplist` VALUES (3145,2,0,1000,1449,0); -- Hydra Samurai, Dark Knight, Ranger (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3145,2,0,1000,1449,0); -- Hydra Ranger (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (3145,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (3145,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,3362,100); -- Deluder's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,3396,50); -- odious_talisman, lets not fill inventory before Taquede is added
+INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,11295,10); -- Commodore Frac
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,11298,10); -- Pantin Tobe
@@ -16608,10 +16549,12 @@ INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,15123,10); -- Valor Breeches
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,15140,10); -- Monster Gaiters
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,15142,10); -- Scout's Socks
 INSERT INTO `mob_droplist` VALUES (3145,0,0,1000,16360,10); -- Etoile Tights
-INSERT INTO `mob_droplist` VALUES (3146,2,0,1000,1449,0); -- Hydra Beastmaster, Summoner, Dragoon (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3146,2,0,1000,1449,0); -- Hydra Summoner (Dynamis Beaucedine) - Tukuku Whiteshell
 INSERT INTO `mob_droplist` VALUES (3146,2,0,1000,1452,0); -- Ordelle Bronzepiece
 INSERT INTO `mob_droplist` VALUES (3146,2,0,1000,1455,0); -- One Byne Bill
 INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,3363,100); -- Traitor's fortune parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,3396,50); -- odious_talisman, lets not fill inventory before Taquede is added
+INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,11292,10); -- Mirage Jubbah
 INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,11295,10); -- Commodore Frac
 INSERT INTO `mob_droplist` VALUES (3146,0,0,1000,11298,10); -- Pantin Tobe
@@ -17126,7 +17069,11 @@ INSERT INTO `mob_droplist` VALUES (3205,0,0,1000,3542,50); -- (Flume Toad) fossi
 INSERT INTO `mob_droplist` VALUES (3205,0,0,1000,4109,1); -- (Flume Toad) water_cluster
 INSERT INTO `mob_droplist` VALUES (3206,0,0,1000,2151,150); -- (Marid) marid_hide
 INSERT INTO `mob_droplist` VALUES (3206,0,0,1000,2166,5); -- (Marid) lock_of_marid_hair
-INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,3424,1000); -- (Angra Mainyu) fiendish_tome_chapter_21
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1450,5); -- (Angra Mainyu) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1453,5); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,1456,5); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,3424,1000); -- fiendish_tome_chapter_21
+INSERT INTO `mob_droplist` VALUES (3207,0,0,1000,3493,50); -- forgotten_thought
 INSERT INTO `mob_droplist` VALUES (3208,0,0,1000,18138,150); -- (Sabotender Bailarin) Bailathorn
 INSERT INTO `mob_droplist` VALUES (3208,0,0,1000,18138,150); -- (Sabotender Bailarin) Bailathorn
 INSERT INTO `mob_droplist` VALUES (3208,0,0,1000,18138,0); -- (Sabotender Bailarin) Bailathorn
@@ -17137,6 +17084,351 @@ INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,14168,1000); -- (Sabotender Bai
 INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,916,140); -- (Sabotender Bailarin) Cactaur Needle
 INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,1592,80); -- (Sabotender Bailarin) Cactaur Root
 INSERT INTO `mob_droplist` VALUES (3209,0,0,1000,1236,180); -- (Sabotender Bailarin) Cactaur Stems
+INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1449,0); -- (Hitaume, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1452,0); -- ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3210,2,0,1000,1455,0); -- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,1456,10); -- one_hundred_byne_bill
+-- INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,3427,1000) -- fiendish_tome_chapter_24, lets not fill inventory befor Arch Angra Mainyu is added
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11292,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11295,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11298,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11307,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,11918,500); -- khthonios_gloves
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15088,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15089,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15090,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15091,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15094,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15096,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15098,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15099,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15100,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15101,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15117,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15122,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15123,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15140,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,15142,10);
+INSERT INTO `mob_droplist` VALUES (3210,0,0,1000,16360,10);
+INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1449,0); -- (Cavanneche, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1452,0); -- ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3211,2,0,1000,1455,0); -- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,1456,10); -- one_hundred_byne_bill
+-- INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,3428,1000) -- fiendish_tome_chapter_25, lets not fill inventory befor Arch Angra Mainyu is added
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11292,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11295,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11298,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11307,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,11821,500); -- khthonios_helm
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15088,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15089,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15090,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15091,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15094,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15096,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15098,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15099,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15100,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15101,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15117,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15122,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15123,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15140,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,15142,10);
+INSERT INTO `mob_droplist` VALUES (3211,0,0,1000,16360,10);
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1450,20); -- (Arch_Angra_Mainyu, Dynamis Beaucedine) lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1453,20); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,1456,20); -- one_hundred_byne_bill
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,3493,250); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,11919,500); -- avesta_bangles
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,18623,600); -- chtonic_staff
+INSERT INTO `mob_droplist` VALUES (3212,0,0,1000,19763,250); -- oneiros_cluster
+-- Spliting Dynamis Beaucedine Hydra loot for the drop of odious item
+INSERT INTO `mob_droplist` VALUES (3213,2,0,1000,1449,0); -- Hydra Paladin (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3213,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3213,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,3359,100); -- Despot's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,3396,50); -- odious_talisman, lets not fill inventory before Taquede is added
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3213,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3214,2,0,1000,1449,0); -- Hydra Red Mage (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3214,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3214,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,3359,100); -- Despot's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,3397,50); -- odious_bell lets not fill inventory before Pignonpausard is added
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3214,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3215,2,0,1000,1449,0); -- Hydra White Mage (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3215,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3215,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,3360,100); -- Sadist's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,3399,50); -- odious_mirror lets not fill inventory before Cananneche is added
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3215,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1449,0); -- Hydra Black Mage (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3216,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3360,100); -- Sadist's Fortune Parchment, 10% (normalized)
+--INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3396,50); -- odious_talisman lets not fill inventory before Taquede is added
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3216,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3217,2,0,1000,1449,0); -- Hydra Thief (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3217,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3217,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,3361,100); -- Villain's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,3399,50); -- odious_mirror lets not fill inventory before Cananneche is added
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3217,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3218,2,0,1000,1449,0); -- Hydra Dark Knight, Samurai (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3218,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3218,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,3361,100); -- Villain's Fortune Parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,3397,50); -- odious_bell lets not fill inventory before Pignonpausard is added
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3218,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3219,2,0,1000,1449,0); -- Hydra Beastmaster (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3219,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3219,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,3363,100); -- Traitor's fortune parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,3397,50); -- odious_bell lets not fill inventory before Pignonpausard is added
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3219,0,0,1000,16360,10); -- Etoile Tights
+INSERT INTO `mob_droplist` VALUES (3220,2,0,1000,1449,0); -- Hydra Dragoon (Dynamis Beaucedine) - Tukuku Whiteshell
+INSERT INTO `mob_droplist` VALUES (3220,2,0,1000,1452,0); -- Ordelle Bronzepiece
+INSERT INTO `mob_droplist` VALUES (3220,2,0,1000,1455,0); -- One Byne Bill
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,3363,100); -- Traitor's fortune parchment, 10% (normalized)
+-- INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,3399,50); -- odious_mirror lets not fill inventory before Cananneche is added
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,11292,10); -- Mirage Jubbah
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,11295,10); -- Commodore Frac
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,11298,10); -- Pantin Tobe
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,11307,10); -- Argute Gown
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15088,10); -- Melee Cyclas
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15089,10); -- Cleric's Briault
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15090,10); -- Sorcerer's Coat
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15091,10); -- Duelist's Tabard
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15094,10); -- Abyss Cuirass
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15096,10); -- Bard's Justaucorps
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15098,10); -- Saotome Domaru
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15099,10); -- Koga Chainmail
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15100,10); -- Wyrm Mail
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15101,10); -- Summoner's Doublet
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15117,10); -- Warrior's Cuisses
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15122,10); -- Assassin's Culottes
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15123,10); -- Valor Breeches
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15140,10); -- Monster Gaiters
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,15142,10); -- Scout's Socks
+INSERT INTO `mob_droplist` VALUES (3220,0,0,1000,16360,10); -- Etoile TightsINSERT INTO `mob_droplist` VALUES (3208,2,0,1000,1449,0); -- (Taquede, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1449,0); -- (Taquede, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1452,0); -- ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3221,2,0,1000,1455,0); -- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,1456,10); -- one_hundred_byne_bill
+-- INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,3425,1000) -- fiendish_tome_chapter_22, lets not fill inventory befor Arch Angra Mainyu is added
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11292,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11295,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11298,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11307,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,11456,500); -- ryuga_sune-ate
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15088,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15089,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15090,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15091,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15094,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15096,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15098,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15099,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15100,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15101,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15117,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15122,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15123,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15140,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,15142,10);
+INSERT INTO `mob_droplist` VALUES (3221,0,0,1000,16360,10);
+INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1449,0); -- (Pignonpausard, Dynamis Beaucedine) tukuku_whiteshell
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1449,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1450,10); -- lungo-nango_jadeshell
+INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1452,0); -- ordelle_bronzepiece
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1452,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1453,10); -- montiont_silverpiece
+INSERT INTO `mob_droplist` VALUES (3222,2,0,1000,1455,0); -- one_byne_bill
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1455,90);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,1456,10); -- one_hundred_byne_bill
+-- INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,3426,1000) -- fiendish_tome_chapter_23, lets not fill inventory befor Arch Angra Mainyu is added
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,3493,50); -- forgotten_thought
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11292,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11295,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11298,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11307,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,11820,500); -- khthonios_mask
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15088,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15089,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15090,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15091,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15094,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15096,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15098,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15099,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15100,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15101,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15117,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15122,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15123,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15140,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,15142,10);
+INSERT INTO `mob_droplist` VALUES (3222,0,0,1000,16360,10);
+
 
 /*!40000 ALTER TABLE `mob_droplist` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -9178,12 +9178,12 @@ INSERT INTO `mob_groups` VALUES (9,4219,134,'Velosareon',0,128,2574,0,0,81,83,0)
 INSERT INTO `mob_groups` VALUES (10,892,134,'Dagourmarche',0,128,559,0,0,81,83,0);
 INSERT INTO `mob_groups` VALUES (11,893,134,'Dagourmarches_Wyvern',0,128,0,0,0,77,79,0);
 INSERT INTO `mob_groups` VALUES (12,1179,134,'Dagourmarches_Avatar',0,128,0,0,0,77,79,0);
-INSERT INTO `mob_groups` VALUES (13,6094,134,'Taquede',0,128,0,8000,8000,95,95,0);
-INSERT INTO `mob_groups` VALUES (14,2169,134,'Taquedes_Wyvern',0,128,0,8000,8000,95,95,0);
-INSERT INTO `mob_groups` VALUES (15,6065,134,'Pignonpausard',0,128,0,8000,8000,95,95,0);
-INSERT INTO `mob_groups` VALUES (16,6066,134,'Hitaume',0,128,0,8000,8000,95,95,0);
-INSERT INTO `mob_groups` VALUES (17,6067,134,'Cavanneche',0,128,0,8000,8000,95,95,0);
-INSERT INTO `mob_groups` VALUES (18,6093,134,'Arch_Angra_Mainyu',0,128,0,0,0,95,95,0);
+INSERT INTO `mob_groups` VALUES (13,6094,134,'Taquede',0,128,3221,8000,8000,95,95,0);
+INSERT INTO `mob_groups` VALUES (14,2169,134,'Taquedes_Wyvern',0,128,0,8000,8000,95,95,0); -- Same hp as 82 NM
+INSERT INTO `mob_groups` VALUES (15,6065,134,'Pignonpausard',0,128,3222,8000,8000,95,95,0); -- Same hp as 82 NM
+INSERT INTO `mob_groups` VALUES (16,6066,134,'Hitaume',0,128,3210,8000,8000,95,95,0); -- Looks like place holder hp,mp war/rng should not have mp
+INSERT INTO `mob_groups` VALUES (17,6067,134,'Cavanneche',0,128,3211,8000,8000,95,95,0); -- Same hp as 82 NM
+INSERT INTO `mob_groups` VALUES (18,6093,134,'Arch_Angra_Mainyu',0,128,3212,0,0,95,95,0); -- Todo capture HP,MP from retail
 INSERT INTO `mob_groups` VALUES (19,4197,134,'Vanguard_Vindicator',600,0,2557,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (20,4177,134,'Vanguard_Protector',600,0,2557,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (21,4139,134,'Vanguard_Beasttender',600,0,2557,4000,0,75,77,0);
@@ -9206,7 +9206,7 @@ INSERT INTO `mob_groups` VALUES (37,2151,134,'JiFhu_Infiltrator',0,32,261,8000,0
 INSERT INTO `mob_groups` VALUES (38,4196,134,'Vanguard_Vigilante',600,0,2557,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (39,1484,134,'GaFho_Venomtouch',0,32,261,8000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (40,3857,134,'TaHyu_Gallanthunter',0,32,261,8000,0,80,81,0);
-INSERT INTO `mob_groups` VALUES (41,2928,134,'NuBhi_Spiraleye',0,32,1831,8000,0,80,81,0);
+INSERT INTO `mob_groups` VALUES (41,2928,134,'NuBhi_Spiraleye',0,32,261,8000,0,80,81,0); -- Dynamis Beaucedine normal Quadaav NM
 INSERT INTO `mob_groups` VALUES (42,4191,134,'Vanguard_Thaumaturge',600,0,2557,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (43,1021,134,'DeBho_Pyrohand',0,32,261,8000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (44,1784,134,'GoTyo_Magenapper',0,32,261,8000,0,80,81,0);
@@ -9267,7 +9267,7 @@ INSERT INTO `mob_groups` VALUES (98,4148,134,'Vanguard_Exemplar',600,0,2552,4000
 INSERT INTO `mob_groups` VALUES (99,4167,134,'Vanguard_Ogresoother',600,0,2552,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (100,4186,134,'Vanguards_Crow',0,128,0,2400,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (101,4176,134,'Vanguard_Priest',600,0,2552,4000,0,75,77,0);
-INSERT INTO `mob_groups` VALUES (102,2281,134,'Koo_Saxu_the_Everfast',0,32,1462,8000,0,80,81,0);
+INSERT INTO `mob_groups` VALUES (102,2281,134,'Koo_Saxu_the_Everfast',0,32,265,8000,0,80,81,0); -- Dynamis Beacedine Yagudo like the ohter NM
 INSERT INTO `mob_groups` VALUES (103,4157,134,'Vanguard_Inciter',600,0,2552,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (104,4141,134,'Vanguard_Chanter',600,0,2552,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (105,4175,134,'Vanguard_Prelate',600,0,2552,4000,0,75,77,0);
@@ -9301,11 +9301,11 @@ INSERT INTO `mob_groups` VALUES (132,4199,134,'Vanguard_Welldigger',600,0,2542,4
 INSERT INTO `mob_groups` VALUES (133,4136,134,'Vanguard_Armorer',600,0,2542,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (134,4134,134,'Vanguard_Ambusher',600,0,2542,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (135,4166,134,'Vanguard_Necromancer',600,0,2542,4000,0,75,77,0);
-INSERT INTO `mob_groups` VALUES (136,2728,134,'Moltenox_Stubthumbs',0,32,1726,8000,0,80,81,0);
+INSERT INTO `mob_groups` VALUES (136,2728,134,'Moltenox_Stubthumbs',0,32,176,8000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (137,4179,134,'Vanguard_Ronin',600,0,2542,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (138,4155,134,'Vanguard_Hitman',600,0,2542,4000,0,75,77,0);
-INSERT INTO `mob_groups` VALUES (139,1125,134,'Droprix_Granitepalms',0,32,176,8000,0,80,81,0);
-INSERT INTO `mob_groups` VALUES (140,4649,134,'Vanguard_Dragontamer',600,0,2539,4000,0,75,77,0);
+INSERT INTO `mob_groups` VALUES (139,1125,134,'Droprix_Granitepalms',0,32,176,8000,0,80,81,0); -- Dynamis Beaucedine normal Goblin NM
+INSERT INTO `mob_groups` VALUES (140,4649,134,'Vanguard_Dragontamer',600,0,2542,4000,0,75,77,0); -- Drop was for Valkurn zone but is a Beaucedine mob
 INSERT INTO `mob_groups` VALUES (141,4133,134,'Vanguard_Alchemist',600,0,2542,4000,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (142,529,134,'Brewnix_Bittypupils',0,32,176,8000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (143,257,134,'Ascetox_Ratgums',0,32,176,8000,0,80,81,0);
@@ -9320,48 +9320,48 @@ INSERT INTO `mob_groups` VALUES (151,3399,134,'Routsix_Rubbertendon',0,32,176,80
 INSERT INTO `mob_groups` VALUES (152,4189,134,'Vanguards_Slime',0,128,0,2400,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (153,2740,134,'Morblox_Chubbychin',0,32,176,8000,0,80,81,0);
 INSERT INTO `mob_groups` VALUES (154,4330,134,'Whistrix_Toadthroat',0,32,176,8000,0,80,81,0);
-INSERT INTO `mob_groups` VALUES (155,3671,134,'Slinkix_Trufflesniff',0,32,1726,8000,0,80,81,0);
-INSERT INTO `mob_groups` VALUES (156,3606,134,'Shisox_Widebrow',0,32,1726,8000,0,80,81,0);
+INSERT INTO `mob_groups` VALUES (155,3671,134,'Slinkix_Trufflesniff',0,32,176,8000,0,80,81,0); -- Dynamis Beaucedine normal Goblin NM
+INSERT INTO `mob_groups` VALUES (156,3606,134,'Shisox_Widebrow',0,32,176,8000,0,80,81,0); -- Dynamis Beaucedine normal Goblin NM
 INSERT INTO `mob_groups` VALUES (157,1707,134,'Goblin_Replica',0,128,3116,1000,1000,70,70,0);
 INSERT INTO `mob_groups` VALUES (158,1716,134,'Goblin_Statue',0,128,0,1000,1000,70,70,0);
 INSERT INTO `mob_groups` VALUES (159,2035,134,'Hydra_Warrior',600,0,1343,5500,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (160,2024,134,'Hydra_Monk',600,0,1345,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (161,2036,134,'Hydra_White_Mage',600,0,1344,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (162,2028,134,'Hydra_Red_Mage',600,0,1343,5500,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (161,2036,134,'Hydra_White_Mage',600,0,3215,5500,0,80,82,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (162,2028,134,'Hydra_Red_Mage',600,0,3214,5500,0,80,82,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (163,4149,134,'Vanguard_Eye',0,128,2561,2000,2000,70,70,0);
-INSERT INTO `mob_groups` VALUES (164,2021,134,'Hydra_Black_Mage',600,0,1344,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (165,2034,134,'Hydra_Thief',600,0,1345,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (166,2026,134,'Hydra_Paladin',600,0,1343,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (167,2022,134,'Hydra_Dark_Knight',600,0,3145,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (168,2020,134,'Hydra_Beastmaster',600,0,3146,5500,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (164,2021,134,'Hydra_Black_Mage',600,0,3216,5500,0,80,82,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (165,2034,134,'Hydra_Thief',600,0,3217,5500,0,80,82,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (166,2026,134,'Hydra_Paladin',600,0,3213,5500,0,80,82,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (167,2022,134,'Hydra_Dark_Knight',600,0,3218,5500,0,80,82,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (168,2020,134,'Hydra_Beastmaster',600,0,3219,5500,0,80,82,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (169,2032,134,'Hydras_Hound',0,128,0,3300,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (170,2019,134,'Hydra_Bard',600,0,1344,5500,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (171,2027,134,'Hydra_Ranger',600,0,3145,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (172,2029,134,'Hydra_Samurai',600,0,3145,5500,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (172,2029,134,'Hydra_Samurai',600,0,3218,5500,0,80,82,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (173,2025,134,'Hydra_Ninja',600,0,1345,5500,0,80,82,0);
-INSERT INTO `mob_groups` VALUES (174,2023,134,'Hydra_Dragoon',600,0,3146,5500,0,80,82,0);
+INSERT INTO `mob_groups` VALUES (174,2023,134,'Hydra_Dragoon',600,0,3220,5500,0,80,82,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (175,2033,134,'Hydras_Wyvern',0,128,0,3300,1000,80,80,0);
 INSERT INTO `mob_groups` VALUES (176,2030,134,'Hydra_Summoner',600,0,3146,5500,0,80,82,0);
 INSERT INTO `mob_groups` VALUES (177,2031,134,'Hydras_Avatar',0,128,0,3300,1000,80,80,0);
-INSERT INTO `mob_groups` VALUES (178,6487,134,'Hydra_Beastmaster',600,0,3146,5500,0,92,95,0);
+INSERT INTO `mob_groups` VALUES (178,6487,134,'Hydra_Beastmaster',600,0,3219,5500,0,92,95,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (179,2032,134,'Hydras_Hound',0,128,0,3300,0,92,92,0);
-INSERT INTO `mob_groups` VALUES (180,6498,134,'Hydra_Thief',600,0,1345,5500,0,92,95,0);
-INSERT INTO `mob_groups` VALUES (181,6489,134,'Hydra_Dark_Knight',600,0,3145,5500,0,92,95,0);
+INSERT INTO `mob_groups` VALUES (180,6498,134,'Hydra_Thief',600,0,3217,5500,0,92,95,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (181,6489,134,'Hydra_Dark_Knight',600,0,3218,5500,0,92,95,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (182,4149,134,'Vanguard_Eye',0,128,2561,2000,2000,82,82,0);
 INSERT INTO `mob_groups` VALUES (183,6499,134,'Hydra_Warrior',600,0,1343,5500,0,92,95,0);
 INSERT INTO `mob_groups` VALUES (184,6486,134,'Hydra_Bard',600,0,1344,5500,0,92,95,0);
 INSERT INTO `mob_groups` VALUES (185,6494,134,'Hydra_Ranger',600,0,3145,5500,0,92,95,0);
-INSERT INTO `mob_groups` VALUES (186,6500,134,'Hydra_White_Mage',600,0,1344,5500,0,92,95,0);
+INSERT INTO `mob_groups` VALUES (186,6500,134,'Hydra_White_Mage',600,0,3215,5500,0,92,95,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (187,6491,134,'Hydra_Monk',600,0,1345,5500,0,92,95,0);
 INSERT INTO `mob_groups` VALUES (188,6492,134,'Hydra_Ninja',600,0,1345,5500,0,92,95,0);
 INSERT INTO `mob_groups` VALUES (189,6497,134,'Hydra_Summoner',600,0,3146,5500,0,92,95,0);
 INSERT INTO `mob_groups` VALUES (190,2031,134,'Hydras_Avatar',0,128,0,3300,1000,92,92,0);
-INSERT INTO `mob_groups` VALUES (191,6488,134,'Hydra_Black_Mage',600,0,1344,5500,0,92,95,0);
-INSERT INTO `mob_groups` VALUES (192,6490,134,'Hydra_Dragoon',600,0,3146,5500,0,92,95,0);
+INSERT INTO `mob_groups` VALUES (191,6488,134,'Hydra_Black_Mage',600,0,3216,5500,0,92,95,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (192,6490,134,'Hydra_Dragoon',600,0,3220,5500,0,92,95,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (193,2033,134,'Hydras_Wyvern',0,128,0,3300,1000,92,92,0);
-INSERT INTO `mob_groups` VALUES (194,6495,134,'Hydra_Red_Mage',600,0,1343,5500,0,92,95,0);
-INSERT INTO `mob_groups` VALUES (195,6493,134,'Hydra_Paladin',600,0,1343,5500,0,92,95,0);
-INSERT INTO `mob_groups` VALUES (196,6496,134,'Hydra_Samurai',600,0,3145,5500,0,92,95,0);
+INSERT INTO `mob_groups` VALUES (194,6495,134,'Hydra_Red_Mage',600,0,3214,5500,0,92,95,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (195,6493,134,'Hydra_Paladin',600,0,3213,5500,0,92,95,0); -- New drop id for Odious item
+INSERT INTO `mob_groups` VALUES (196,6496,134,'Hydra_Samurai',600,0,3218,5500,0,92,95,0); -- New drop id for Odious item
 INSERT INTO `mob_groups` VALUES (197,6064,134,'Rearguard_Eye',0,128,0,8000,8000,82,82,0);
 
 -- ------------------------------------------------------------


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This is an update to add missing items from the drop list. Mostly leering_bijou, forgotten_thought and odious item(added but commented out until NM can be spawn).

Added the 4 NM drop list popped by the odious item and the final NM drop list popped by the fiendish chapter's.
Had to split many Hydra monster drop pool because they do not share de same odious item.
Took the liberty to change a few leftover NM that are normal beastman NM but for some reason(have the same drop) had there own drop list.

All added information was based on already decided drop rate for same item and used http://www.ffxidb.com/zones/134/ for complete drop list per mob. The yaggudo information was incomplete but by looking at multiple NM drop you can still see that they should drop the same expected item for their family as the other beastman do. Used same drop rate as other family.

New item drop rate where based on 
http://www.ffxidb.com/zones/134/