### PR TITLE
pr: changed addItem to accept a table of augments properly

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3233,11 +3233,10 @@ bool CLuaBaseEntity::addItem(sol::variadic_args va)
                     if (augmentsObj.is<sol::table>())
                     {
                         auto augmentsTable = augmentsObj.as<sol::table>();
-                        for (auto& entryPair : augmentsTable)
+                        for (const auto& entryPair : augmentsTable)
                         {
-                            auto   pair   = entryPair.second.as<sol::table>();
-                            uint16 augid  = pair[0];
-                            uint8  augval = pair[1];
+                            uint16 augid  = entryPair.first.as<uint16>();
+                            uint8  augval = entryPair.second.as<uint8>();
                             ((CItemEquipment*)PItem)->PushAugment(augid, augval);
                         }
                     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits


I know this doesn't really affect anyone but I had used it for some custom code that I'm reimplementing and it's a real bummer that it doesn't work like it used to. More details in the commit.

Also, const'd it because const is good.