### PR TITLE
Add support for calculated Traverser Stones and add migration script

### DIFF
--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -13,6 +13,8 @@ CREATE TABLE `char_unlocks` (
   `campaign_windy` int(10) unsigned NOT NULL DEFAULT 0,
   `homepoints` blob DEFAULT NULL,
   `survivals` blob DEFAULT NULL,
+  `traverser_start` int(10) unsigned NOT NULL DEFAULT 0,
+  `traverser_claimed` int(10) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`charid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13213,6 +13213,103 @@ void CLuaBaseEntity::addDropListModification(uint16 id, uint16 newRate, sol::var
 }
 
 /************************************************************************
+ *  Function: getAvailableTraverserStones()
+ *  Purpose : Returns the number of Traverser Stones available for claim
+ *  Note: Does not yet account for KI reduction
+ ************************************************************************/
+
+uint32 CLuaBaseEntity::getAvailableTraverserStones()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return 0;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return charutils::getAvailableTraverserStones(PChar);
+}
+
+/************************************************************************
+ *  Function: getTraverserEpoch()
+ *  Purpose : Returns the number of Traverser Stones claimed by the player
+ ************************************************************************/
+
+time_t CLuaBaseEntity::getTraverserEpoch()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return 0;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return charutils::getTraverserEpoch(PChar);
+}
+
+/************************************************************************
+ *  Function: setTraverserEpoch()
+ *  Purpose : Returns the number of Traverser Stones claimed by the player
+ ************************************************************************/
+
+void CLuaBaseEntity::setTraverserEpoch()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    charutils::setTraverserEpoch(PChar);
+}
+
+/************************************************************************
+ *  Function: getClaimedTraverserStones()
+ *  Purpose : Returns the number of Traverser Stones claimed by the player
+ ************************************************************************/
+
+uint32 CLuaBaseEntity::getClaimedTraverserStones()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return 0;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return charutils::getClaimedTraverserStones(PChar);
+}
+
+/************************************************************************
+ *  Function: addClaimedTraverserStones()
+ *  Purpose : Increments number of Traverser Stones claimed by the player
+ ************************************************************************/
+
+void CLuaBaseEntity::addClaimedTraverserStones(uint16 numStones)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    charutils::addClaimedTraverserStones(PChar, numStones);
+}
+
+/************************************************************************
+ *  Function: setClaimedTraverserStones()
+ *  Purpose : Sets number of Traverser Stones claimed by the player.
+ ************************************************************************/
+
+void CLuaBaseEntity::setClaimedTraverserStones(uint16 totalStones)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    charutils::setClaimedTraverserStones(PChar, totalStones);
+}
+
+/************************************************************************
  *  Function: getHistory()
  *  Purpose : Gets a single entry of character history statistics
  *  Example : player:getHistory(xi.history.enemiesDefeated) -- Returns the relevant stat
@@ -14005,6 +14102,14 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getPlayerRegionInZone", CLuaBaseEntity::getPlayerRegionInZone);
     SOL_REGISTER("updateToEntireZone", CLuaBaseEntity::updateToEntireZone);
+
+    // Abyssea
+    SOL_REGISTER("getAvailableTraverserStones", CLuaBaseEntity::getAvailableTraverserStones);
+    SOL_REGISTER("getTraverserEpoch", CLuaBaseEntity::getTraverserEpoch);
+    SOL_REGISTER("setTraverserEpoch", CLuaBaseEntity::setTraverserEpoch);
+    SOL_REGISTER("getClaimedTraverserStones", CLuaBaseEntity::getClaimedTraverserStones);
+    SOL_REGISTER("addClaimedTraverserStones", CLuaBaseEntity::addClaimedTraverserStones);
+    SOL_REGISTER("setClaimedTraverserStones", CLuaBaseEntity::setClaimedTraverserStones);
 
     SOL_REGISTER("getHistory", CLuaBaseEntity::getHistory);
 }

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -788,6 +788,13 @@ public:
     int16  getTHlevel();                                                                 // Returns the Monster's current Treasure Hunter Tier
     void   addDropListModification(uint16 id, uint16 newRate, sol::variadic_args va);    // Adds a modification to the drop list of this mob, erased on death
 
+    uint32 getAvailableTraverserStones();
+    time_t getTraverserEpoch();
+    void   setTraverserEpoch();
+    uint32 getClaimedTraverserStones();
+    void   addClaimedTraverserStones(uint16 numStones);
+    void   setClaimedTraverserStones(uint16 totalStones);
+
     uint32 getHistory(uint8 index);
 
     static void Register();

--- a/src/map/packets/currency1.cpp
+++ b/src/map/packets/currency1.cpp
@@ -24,6 +24,7 @@
 #include "currency1.h"
 
 #include "../entities/charentity.h"
+#include "../utils/charutils.h"
 
 CCurrencyPacket1::CCurrencyPacket1(CCharEntity* PChar)
 {
@@ -43,7 +44,7 @@ CCurrencyPacket1::CCurrencyPacket1(CCharEntity* PChar)
                         therion_ichor, allied_notes, aman_vouchers, login_points, cruor, resistance_credit, \
                         dominion_note, fifth_echelon_trophy, fourth_echelon_trophy, third_echelon_trophy, \
                         second_echelon_trophy, first_echelon_trophy, cave_points, id_tags, op_credits, \
-                        traverser_stones, voidstones, kupofried_corundums, pheromone_sacks, rems_ch1, rems_ch2, \
+                        voidstones, kupofried_corundums, pheromone_sacks, rems_ch1, rems_ch2, \
                         rems_ch3, rems_ch4, rems_ch5, rems_ch6, rems_ch7, rems_ch8, rems_ch9, rems_ch10, \
                         reclamation_marks, unity_accolades, fire_crystals, ice_crystals, wind_crystals, \
                         earth_crystals, lightning_crystals, water_crystals, light_crystals, dark_crystals, deeds \
@@ -136,36 +137,37 @@ CCurrencyPacket1::CCurrencyPacket1(CCharEntity* PChar)
 
         ref<uint8>(0xBF) = sql->GetUIntData(68); // op_credits
 
-        ref<uint32>(0xC0) = sql->GetIntData(69); // traverser_stones
-        ref<uint32>(0xC4) = sql->GetIntData(70); // voidstones
-        ref<uint32>(0xC8) = sql->GetIntData(71); // kupofried_corundums
+        ref<uint32>(0xC4) = sql->GetIntData(69); // voidstones
+        ref<uint32>(0xC8) = sql->GetIntData(70); // kupofried_corundums
 
-        ref<uint8>(0xCC) = sql->GetUIntData(72); // pheromone_sacks
+        ref<uint8>(0xCC) = sql->GetUIntData(71); // pheromone_sacks
 
-        ref<uint8>(0xCE) = sql->GetUIntData(73); // rems_ch1
-        ref<uint8>(0xCF) = sql->GetUIntData(74); // rems_ch2
-        ref<uint8>(0xD0) = sql->GetUIntData(75); // rems_ch3
-        ref<uint8>(0xD1) = sql->GetUIntData(76); // rems_ch4
-        ref<uint8>(0xD2) = sql->GetUIntData(77); // rems_ch5
-        ref<uint8>(0xD3) = sql->GetUIntData(78); // rems_ch6
-        ref<uint8>(0xD4) = sql->GetUIntData(79); // rems_ch7
-        ref<uint8>(0xD5) = sql->GetUIntData(80); // rems_ch8
-        ref<uint8>(0xD6) = sql->GetUIntData(81); // rems_ch9
-        ref<uint8>(0xD7) = sql->GetUIntData(82); // rems_ch10
+        ref<uint8>(0xCE) = sql->GetUIntData(72); // rems_ch1
+        ref<uint8>(0xCF) = sql->GetUIntData(73); // rems_ch2
+        ref<uint8>(0xD0) = sql->GetUIntData(74); // rems_ch3
+        ref<uint8>(0xD1) = sql->GetUIntData(75); // rems_ch4
+        ref<uint8>(0xD2) = sql->GetUIntData(76); // rems_ch5
+        ref<uint8>(0xD3) = sql->GetUIntData(77); // rems_ch6
+        ref<uint8>(0xD4) = sql->GetUIntData(78); // rems_ch7
+        ref<uint8>(0xD5) = sql->GetUIntData(79); // rems_ch8
+        ref<uint8>(0xD6) = sql->GetUIntData(80); // rems_ch9
+        ref<uint8>(0xD7) = sql->GetUIntData(81); // rems_ch10
 
-        ref<uint16>(0xE0) = sql->GetUIntData(83); // reclamation_marks
-        ref<uint32>(0xE4) = sql->GetIntData(84);  // unity_accolades
+        ref<uint16>(0xE0) = sql->GetUIntData(82); // reclamation_marks
+        ref<uint32>(0xE4) = sql->GetIntData(83);  // unity_accolades
 
         // Crystal storage
-        ref<uint16>(0xE8) = sql->GetUIntData(85); // Fire Crystals
-        ref<uint16>(0xEA) = sql->GetUIntData(86); // Ice Crystals
-        ref<uint16>(0xEC) = sql->GetUIntData(87); // Wind Crystals
-        ref<uint16>(0xEE) = sql->GetUIntData(88); // Earth Crystals
-        ref<uint16>(0xF0) = sql->GetUIntData(89); // Lightning Crystals
-        ref<uint16>(0xF2) = sql->GetUIntData(90); // Water Crystals
-        ref<uint16>(0xF4) = sql->GetUIntData(91); // Light Crystals
-        ref<uint16>(0xF6) = sql->GetUIntData(92); // Dark Crystals
+        ref<uint16>(0xE8) = sql->GetUIntData(84); // Fire Crystals
+        ref<uint16>(0xEA) = sql->GetUIntData(85); // Ice Crystals
+        ref<uint16>(0xEC) = sql->GetUIntData(86); // Wind Crystals
+        ref<uint16>(0xEE) = sql->GetUIntData(87); // Earth Crystals
+        ref<uint16>(0xF0) = sql->GetUIntData(88); // Lightning Crystals
+        ref<uint16>(0xF2) = sql->GetUIntData(89); // Water Crystals
+        ref<uint16>(0xF4) = sql->GetUIntData(90); // Light Crystals
+        ref<uint16>(0xF6) = sql->GetUIntData(91); // Dark Crystals
 
-        ref<uint16>(0xF8) = sql->GetUIntData(93); // deeds
+        ref<uint16>(0xF8) = sql->GetUIntData(92); // deeds
     }
+
+    ref<uint32>(0xC0) = charutils::getAvailableTraverserStones(PChar); // traverser_stones
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5967,6 +5967,80 @@ namespace charutils
         PChar->pushPacket(timerPacket);
     }
 
+    time_t getTraverserEpoch(CCharEntity* PChar)
+    {
+        auto fmtQuery = "SELECT unix_timestamp(traverser_start) FROM char_unlocks WHERE charid = %u;";
+
+        auto ret = sql->Query(fmtQuery, PChar->id);
+        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+        {
+            return sql->GetUIntData(0);
+        }
+
+        return 0;
+    }
+
+    // TODO: Perhaps allow for optional argument to support GM Commands
+    void setTraverserEpoch(CCharEntity* PChar)
+    {
+        auto fmtQuery = "UPDATE char_unlocks SET traverser_start = unix_timestamp() WHERE charid = %u;";
+
+        sql->Query(fmtQuery, PChar->id);
+    }
+
+    uint32 getClaimedTraverserStones(CCharEntity* PChar)
+    {
+        auto fmtQuery = "SELECT traverser_claimed FROM char_unlocks WHERE charid = %u;";
+
+        auto ret = sql->Query(fmtQuery, PChar->id);
+        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+        {
+            return sql->GetUIntData(0);
+        }
+
+        return 0;
+    }
+
+    void addClaimedTraverserStones(CCharEntity* PChar, uint16 numStones)
+    {
+        auto fmtQuery = "UPDATE char_unlocks SET traverser_claimed = traverser_claimed + %u WHERE charid = %u;";
+
+        sql->Query(fmtQuery, numStones, PChar->id);
+    }
+
+    void setClaimedTraverserStones(CCharEntity* PChar, uint16 stoneTotal)
+    {
+        auto fmtQuery = "UPDATE char_unlocks SET traverser_claimed = %u WHERE charid = %u;";
+
+        sql->Query(fmtQuery, stoneTotal, PChar->id);
+    }
+
+    uint32 getAvailableTraverserStones(CCharEntity* PChar)
+    {
+        auto fmtQuery = "SELECT unix_timestamp(traverser_start), traverser_claimed FROM char_unlocks WHERE charid = %u;";
+        time_t traverserEpoch = 0;
+        uint32 traverserClaimed = 0;
+
+        auto ret = sql->Query(fmtQuery, PChar->id);
+        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+        {
+            traverserEpoch = sql->GetUIntData(0);
+            traverserClaimed = sql->GetUIntData(1);
+        }
+
+        // Handle reduction for Celerity Key Items
+        uint8 stoneWaitHours = 20;
+        for (int keyItem = 1385; keyItem <= 1387; ++keyItem)
+        {
+            if (hasKeyItem(PChar, keyItem))
+            {
+                stoneWaitHours -= 4;
+            }
+        }
+
+        return floor((std::time(nullptr) - traverserEpoch) / (stoneWaitHours * 3600)) - traverserClaimed;
+    }
+
     void ReadHistory(CCharEntity* PChar)
     {
         if (PChar == nullptr)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -223,6 +223,13 @@ namespace charutils
     void SendTimerPacket(CCharEntity* PChar, duration dur);
     void SendClearTimerPacket(CCharEntity* PChar);
 
+    time_t getTraverserEpoch(CCharEntity* PChar);
+    void   setTraverserEpoch(CCharEntity* PChar);
+    uint32 getClaimedTraverserStones(CCharEntity* PChar);
+    void   addClaimedTraverserStones(CCharEntity* PChar, uint16 numStones);
+    void   setClaimedTraverserStones(CCharEntity* PChar, uint16 stoneTotal);
+    uint32 getAvailableTraverserStones(CCharEntity* PChar);
+
     void ReadHistory(CCharEntity* PChar);
     void WriteHistory(CCharEntity* PChar);
 

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -69,6 +69,7 @@ from migrations import currency2
 from migrations import languages
 from migrations import add_field_chocobo_column
 from migrations import add_new_wardrobe_columns
+from migrations import abyssea_unlocks
 
 # Append new migrations to this list and import above
 migrations = [
@@ -98,6 +99,7 @@ migrations = [
     languages,
     add_field_chocobo_column,
     add_new_wardrobe_columns
+    abyssea_unlocks,
 ]
 
 # These are the 'protected' files

--- a/tools/migrations/abyssea_unlocks.py
+++ b/tools/migrations/abyssea_unlocks.py
@@ -1,0 +1,24 @@
+import array
+import mysql.connector
+
+def migration_name():
+	return "Adding traverser_start column to char_unlocks table"
+
+def check_preconditions(cur):
+	return
+
+def needs_to_run(cur):
+	# Ensure unity_leader column exists in char_profile
+	cur.execute("SHOW COLUMNS FROM char_unlocks LIKE 'traverser_start'")
+	if not cur.fetchone():
+		return True
+	return False
+
+def migrate(cur, db):
+	try:
+		cur.execute("ALTER TABLE char_unlocks \
+		ADD COLUMN `traverser_start` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, \
+		ADD COLUMN `traverser_claimed` int(10) unsigned NOT NULL DEFAULT '0';")
+		db.commit()
+	except mysql.connector.Error as err:
+		print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Going to slowly start pulling apart the old Abyssea branch into sane chunks.  This does not implement function yet, but adds core support for calculated vs claimed traverser stones based on an epoch that is set upon starting abyssea questlines.