### PR TITLE
Add CLuaStatusEffect::getIcon() binding

### DIFF
--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -211,6 +211,11 @@ void CLuaStatusEffect::unsetFlag(uint32 flag)
     m_PLuaStatusEffect->UnsetFlag(flag);
 }
 
+uint16 CLuaStatusEffect::getIcon()
+{
+    return m_PLuaStatusEffect->GetIcon();
+}
+
 //======================================================//
 
 void CLuaStatusEffect::Register()
@@ -239,6 +244,7 @@ void CLuaStatusEffect::Register()
     SOL_REGISTER("getFlag", CLuaStatusEffect::getFlag);
     SOL_REGISTER("setFlag", CLuaStatusEffect::setFlag);
     SOL_REGISTER("unsetFlag", CLuaStatusEffect::unsetFlag);
+    SOL_REGISTER("getIcon", CLuaStatusEffect::getIcon);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaStatusEffect& effect)

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -51,6 +51,7 @@ public:
     uint32 getTimeRemaining();
     uint32 getTickCount();
     uint32 getTick();
+    uint16 getIcon();
 
     void setIcon(uint16 icon);
     void setPower(uint16 power);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

To be used in the future with Abyssea for Visitant Status (the same effect is used with no icon for the 5 minute timer on entry before gaining)