### PR TITLE
Modify RoV M2-2 and M2-3 condition for clarity

### DIFF
--- a/scripts/missions/rov/2_02_Crashing_Waves.lua
+++ b/scripts/missions/rov/2_02_Crashing_Waves.lua
@@ -49,7 +49,7 @@ mission.sections =
                     if
                         xi.rhapsodies.charactersAvailable(player) and
                         player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.A_VESSEL_WITHOUT_A_CAPTAIN) and
-                        not mission:getVar(player, 'Retrieve') == 1
+                        mission:getVar(player, 'Retrieve') == 0
                     then
                         -- Note: There are 4 parameters that impact the message shown in this state which all appear to revolve
                         -- around Tenzen's knowledge of Prishe, and the status of the mission 'Darkness Named.'  This mission is

--- a/scripts/missions/rov/2_03_Call_to_Serve.lua
+++ b/scripts/missions/rov/2_03_Call_to_Serve.lua
@@ -47,7 +47,7 @@ mission.sections =
                 function(player, prevZone)
                     if
                         xi.rhapsodies.charactersAvailable(player) and
-                        not mission:getVar(player, 'Retrieve') == 1
+                        mission:getVar(player, 'Retrieve') == 0
                     then
                         -- Note: Working with the assumption that there are four variable parameters for this mission,
                         -- the following observations have been made.  The first parameter *does* have an impact on dialogue;


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

The two conditions for Retrieve status were not clear, simplified to checking if == 0