### PR TITLE
Fix syntax for migrations list

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -98,7 +98,7 @@ migrations = [
     currency2,
     languages,
     add_field_chocobo_column,
-    add_new_wardrobe_columns
+    add_new_wardrobe_columns,
     abyssea_unlocks,
 ]
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #1466 