### PR TITLE
[tools] Add plumbing for fuzz testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,4 +111,6 @@ add_definitions(-DSOL_ALL_SAFETIES_ON=1 -DSOL_NO_CHECK_NUMBER_PRECISION=1)
 add_subdirectory(ext)
 
 include(ClangTidy)
+include(Fuzzing)
+
 add_subdirectory(src)

--- a/cmake/Fuzzing.cmake
+++ b/cmake/Fuzzing.cmake
@@ -1,0 +1,14 @@
+# Target is automatically added if you're using clang
+# AppleClang doesn't ship with libFuzzer
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Apple")
+    add_executable(packet_fuzzer ${CMAKE_SOURCE_DIR}/tools/fuzzer.cpp)
+    target_compile_options(packet_fuzzer
+        PUBLIC
+            -g -O1 -fsanitize=fuzzer
+    )
+
+    target_link_libraries(packet_fuzzer
+        PUBLIC
+            -fsanitize=fuzzer
+    )
+endif()

--- a/tools/fuzzer.cpp
+++ b/tools/fuzzer.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <cstddef>
+
+// https://llvm.org/docs/LibFuzzer.html
+// https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    // TODO:
+    //map_session_data_t map_session_data;
+    //CCharEntity CChar;
+
+    //auto packet = CBasicPacket(reinterpret_cast<uint8*>(Data));
+
+    //PacketParser[SmallPD_Type](&map_session_data, &CChar, packet);
+
+    return 0;
+}


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Doesn't do anything yet, but will become the tooling for fuzzing our packet system