### PR TITLE
[WIP] SightMesh impl

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(detour)
 # add_subdirectory(lua) # Handled globally 
 # add_subdirectory(mysql) # Handled globally
 add_subdirectory(recast)
+add_subdirectory(sightmesh)
 add_subdirectory(sol)
 add_subdirectory(spdlog)
 # add_subdirectory(zmq) # Handled globally

--- a/ext/sightmesh/CMakeLists.txt
+++ b/ext/sightmesh/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCES
+    RaycastMesh.cpp
+    RaycastMesh.h
+    wavefront.cpp
+    wavefront.h)
+
+add_library(sightmesh STATIC ${SOURCES})
+target_link_libraries(sightmesh PRIVATE no_warnings)
+target_include_directories(sightmesh PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/ext/sightmesh/CMakeLists.txt
+++ b/ext/sightmesh/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     RaycastMesh.cpp
     RaycastMesh.h
+    tiny_obj_loader.h
     wavefront.cpp
     wavefront.h)
 

--- a/ext/sightmesh/RaycastMesh.cpp
+++ b/ext/sightmesh/RaycastMesh.cpp
@@ -1,0 +1,895 @@
+#include "RaycastMesh.h"
+
+// This code snippet allows you to create an axis aligned bounding volume tree for a triangle mesh so that you can do
+// high-speed raycasting.
+//
+// There are much better implementations of this available on the internet.  In particular I recommend that you use
+// OPCODE written by Pierre Terdiman.
+// @see: http://www.codercorner.com/Opcode.htm
+//
+// OPCODE does a whole lot more than just raycasting, and is a rather significant amount of source code.
+//
+// I am providing this code snippet for the use case where you *only* want to do quick and dirty optimized raycasting.
+// I have not done performance testing between this version and OPCODE; so I don't know how much slower it is.  However,
+// anytime you switch to using a spatial data structure for raycasting, you increase your performance by orders and orders
+// of magnitude; so this implementation should work fine for simple tools and utilities.
+//
+// It also serves as a nice sample for people who are trying to learn the algorithm of how to implement AABB trees.
+// AABB = Axis Aligned Bounding Volume trees.
+//
+// http://www.cgal.org/Manual/3.5/doc_html/cgal_manual/AABB_tree/Chapter_main.html
+//
+//
+// This code snippet was written by John W. Ratcliff on August 18, 2011 and released under the MIT. license.
+//
+// mailto:jratcliffscarab@gmail.com
+//
+// The official source can be found at:  http://code.google.com/p/raycastmesh/
+//
+//
+
+#include <memory>
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#pragma warning(disable : 4100)
+
+/**
+*	A method to compute a ray-AABB intersection.
+*	Original code by Andrew Woo, from "Graphics Gems", Academic Press, 1990
+*	Optimized code by Pierre Terdiman, 2000 (~20-30% faster on my Celeron 500)
+*	Epsilon value added by Klaus Hartmann. (discarding it saves a few cycles only)
+*
+*	Hence this version is faster as well as more robust than the original one.
+*
+*	Should work provided:
+*	1) the integer representation of 0.0f is 0x00000000
+*	2) the sign bit of the float is the most significant one
+*
+*	Report bugs: p.terdiman@codercorner.com
+*
+*	\param		aabb		[in] the axis-aligned bounding box
+*	\param		origin		[in] ray origin
+*	\param		dir			[in] ray direction
+*	\param		coord		[out] impact coordinates
+*	\return		true if ray intersects AABB
+*/
+
+#define RAYAABB_EPSILON 0.00001f
+//! Integer representation of a floating-point value.
+#define IR(x) ((unsigned int&)x)
+
+bool intersectRayAABB(const float MinB[3], const float MaxB[3], const float origin[3], const float dir[3], float coord[3])
+{
+    bool  Inside = true;
+    float MaxT[3];
+    MaxT[0] = MaxT[1] = MaxT[2] = -1.0f;
+
+    // Find candidate planes.
+    for (unsigned int i = 0; i < 3; i++)
+    {
+        if (origin[i] < MinB[i])
+        {
+            coord[i] = MinB[i];
+            Inside   = false;
+
+            // Calculate T distances to candidate planes
+            if (IR(dir[i]))
+                MaxT[i] = (MinB[i] - origin[i]) / dir[i];
+        }
+        else if (origin[i] > MaxB[i])
+        {
+            coord[i] = MaxB[i];
+            Inside   = false;
+
+            // Calculate T distances to candidate planes
+            if (IR(dir[i]))
+                MaxT[i] = (MaxB[i] - origin[i]) / dir[i];
+        }
+    }
+
+    // Ray origin inside bounding box
+    if (Inside)
+    {
+        coord[0] = origin[0];
+        coord[1] = origin[1];
+        coord[2] = origin[2];
+        return true;
+    }
+
+    // Get largest of the maxT's for final choice of intersection
+    unsigned int WhichPlane = 0;
+    if (MaxT[1] > MaxT[WhichPlane])
+        WhichPlane = 1;
+    if (MaxT[2] > MaxT[WhichPlane])
+        WhichPlane = 2;
+
+    // Check final candidate actually inside box
+    if (IR(MaxT[WhichPlane]) & 0x80000000)
+        return false;
+
+    for (unsigned int i = 0; i < 3; i++)
+    {
+        if (i != WhichPlane)
+        {
+            coord[i] = origin[i] + MaxT[WhichPlane] * dir[i];
+#ifdef RAYAABB_EPSILON
+            if (coord[i] < MinB[i] - RAYAABB_EPSILON || coord[i] > MaxB[i] + RAYAABB_EPSILON)
+                return false;
+#else
+            if (coord[i] < MinB[i] || coord[i] > MaxB[i])
+                return false;
+#endif
+        }
+    }
+    return true; // ray hits box
+}
+
+bool intersectLineSegmentAABB(const float bmin[3], const float bmax[3], const float p1[3], const float dir[3], float& dist, float intersect[3])
+{
+    bool ret = false;
+
+    if (dist > RAYAABB_EPSILON)
+    {
+        ret = intersectRayAABB(bmin, bmax, p1, dir, intersect);
+        if (ret)
+        {
+            float dx = p1[0] - intersect[0];
+            float dy = p1[1] - intersect[1];
+            float dz = p1[2] - intersect[2];
+            float d  = dx * dx + dy * dy + dz * dz;
+            if (d < dist * dist)
+            {
+                dist = sqrtf(d);
+            }
+            else
+            {
+                ret = false;
+            }
+        }
+    }
+    return ret;
+}
+
+/* a = b - c */
+#define vector(a, b, c)       \
+    (a)[0] = (b)[0] - (c)[0]; \
+    (a)[1] = (b)[1] - (c)[1]; \
+    (a)[2] = (b)[2] - (c)[2];
+
+#define innerProduct(v, q) \
+    ((v)[0] * (q)[0] +     \
+     (v)[1] * (q)[1] +     \
+     (v)[2] * (q)[2])
+
+#define crossProduct(a, b, c)                   \
+    (a)[0] = (b)[1] * (c)[2] - (c)[1] * (b)[2]; \
+    (a)[1] = (b)[2] * (c)[0] - (c)[2] * (b)[0]; \
+    (a)[2] = (b)[0] * (c)[1] - (c)[0] * (b)[1];
+
+static inline bool rayIntersectsTriangle(const float* p, const float* d, const float* v0, const float* v1, const float* v2, float& t)
+{
+    float e1[3], e2[3], h[3], s[3], q[3];
+    float a, f, u, v;
+
+    vector(e1, v1, v0);
+    vector(e2, v2, v0);
+    crossProduct(h, d, e2);
+    a = innerProduct(e1, h);
+
+    if (a > -0.00001 && a < 0.00001)
+        return (false);
+
+    f = 1 / a;
+    vector(s, p, v0);
+    u = f * (innerProduct(s, h));
+
+    if (u < 0.0 || u > 1.0)
+        return (false);
+
+    crossProduct(q, s, e1);
+    v = f * innerProduct(d, q);
+    if (v < 0.0 || u + v > 1.0)
+        return (false);
+    // at this stage we can compute t to find out where
+    // the intersection point is on the line
+    t = f * innerProduct(e2, q);
+    if (t > 0) // ray intersection
+        return (true);
+    else // this means that there is a line intersection
+        // but not a ray intersection
+        return (false);
+}
+
+static float computePlane(const float* A, const float* B, const float* C, float* n) // returns D
+{
+    float vx = (B[0] - C[0]);
+    float vy = (B[1] - C[1]);
+    float vz = (B[2] - C[2]);
+
+    float wx = (A[0] - B[0]);
+    float wy = (A[1] - B[1]);
+    float wz = (A[2] - B[2]);
+
+    float vw_x = vy * wz - vz * wy;
+    float vw_y = vz * wx - vx * wz;
+    float vw_z = vx * wy - vy * wx;
+
+    float mag = sqrt((vw_x * vw_x) + (vw_y * vw_y) + (vw_z * vw_z));
+
+    if (mag < 0.000001f)
+    {
+        mag = 0;
+    }
+    else
+    {
+        mag = 1.0f / mag;
+    }
+
+    float x = vw_x * mag;
+    float y = vw_y * mag;
+    float z = vw_z * mag;
+
+    float D = 0.0f - ((x * A[0]) + (y * A[1]) + (z * A[2]));
+
+    n[0] = x;
+    n[1] = y;
+    n[2] = z;
+
+    return D;
+}
+
+#define TRI_EOF 0xFFFFFFFF
+
+enum AxisAABB
+{
+    AABB_XAXIS,
+    AABB_YAXIS,
+    AABB_ZAXIS
+};
+
+enum ClipCode
+{
+    CC_MINX = (1 << 0),
+    CC_MAXX = (1 << 1),
+    CC_MINY = (1 << 2),
+    CC_MAXY = (1 << 3),
+    CC_MINZ = (1 << 4),
+    CC_MAXZ = (1 << 5),
+};
+
+class BoundsAABB
+{
+public:
+    void setMin(const float* v)
+    {
+        mMin[0] = v[0];
+        mMin[1] = v[1];
+        mMin[2] = v[2];
+    }
+
+    void setMax(const float* v)
+    {
+        mMax[0] = v[0];
+        mMax[1] = v[1];
+        mMax[2] = v[2];
+    }
+
+    void setMin(float x, float y, float z)
+    {
+        mMin[0] = x;
+        mMin[1] = y;
+        mMin[2] = z;
+    }
+
+    void setMax(float x, float y, float z)
+    {
+        mMax[0] = x;
+        mMax[1] = y;
+        mMax[2] = z;
+    }
+
+    void include(const float* v)
+    {
+        if (v[0] < mMin[0])
+            mMin[0] = v[0];
+        if (v[1] < mMin[1])
+            mMin[1] = v[1];
+        if (v[2] < mMin[2])
+            mMin[2] = v[2];
+
+        if (v[0] > mMax[0])
+            mMax[0] = v[0];
+        if (v[1] > mMax[1])
+            mMax[1] = v[1];
+        if (v[2] > mMax[2])
+            mMax[2] = v[2];
+    }
+
+    void getCenter(float* center) const
+    {
+        center[0] = (mMin[0] + mMax[0]) * 0.5f;
+        center[1] = (mMin[1] + mMax[1]) * 0.5f;
+        center[2] = (mMin[2] + mMax[2]) * 0.5f;
+    }
+
+    bool intersects(const BoundsAABB& b) const
+    {
+        if ((mMin[0] > b.mMax[0]) || (b.mMin[0] > mMax[0]))
+            return false;
+        if ((mMin[1] > b.mMax[1]) || (b.mMin[1] > mMax[1]))
+            return false;
+        if ((mMin[2] > b.mMax[2]) || (b.mMin[2] > mMax[2]))
+            return false;
+        return true;
+    }
+
+    bool containsTriangle(const float* p1, const float* p2, const float* p3) const
+    {
+        BoundsAABB b;
+        b.setMin(p1);
+        b.setMax(p1);
+        b.include(p2);
+        b.include(p3);
+        return intersects(b);
+    }
+
+    bool containsTriangleExact(const float* p1, const float* p2, const float* p3, unsigned int& orCode) const
+    {
+        bool ret = false;
+
+        unsigned int andCode;
+        orCode = getClipCode(p1, p2, p3, andCode);
+        if (andCode == 0)
+        {
+            ret = true;
+        }
+
+        return ret;
+    }
+
+    inline unsigned int getClipCode(const float* p1, const float* p2, const float* p3, unsigned int& andCode) const
+    {
+        andCode         = 0xFFFFFFFF;
+        unsigned int c1 = getClipCode(p1);
+        unsigned int c2 = getClipCode(p2);
+        unsigned int c3 = getClipCode(p3);
+        andCode &= c1;
+        andCode &= c2;
+        andCode &= c3;
+        return c1 | c2 | c3;
+    }
+
+    inline unsigned int getClipCode(const float* p) const
+    {
+        unsigned int ret = 0;
+
+        if (p[0] < mMin[0])
+        {
+            ret |= CC_MINX;
+        }
+        else if (p[0] > mMax[0])
+        {
+            ret |= CC_MAXX;
+        }
+
+        if (p[1] < mMin[1])
+        {
+            ret |= CC_MINY;
+        }
+        else if (p[1] > mMax[1])
+        {
+            ret |= CC_MAXY;
+        }
+
+        if (p[2] < mMin[2])
+        {
+            ret |= CC_MINZ;
+        }
+        else if (p[2] > mMax[2])
+        {
+            ret |= CC_MAXZ;
+        }
+
+        return ret;
+    }
+
+    inline void clamp(const BoundsAABB& aabb)
+    {
+        if (mMin[0] < aabb.mMin[0])
+            mMin[0] = aabb.mMin[0];
+        if (mMin[1] < aabb.mMin[1])
+            mMin[1] = aabb.mMin[1];
+        if (mMin[2] < aabb.mMin[2])
+            mMin[2] = aabb.mMin[2];
+        if (mMax[0] > aabb.mMax[0])
+            mMax[0] = aabb.mMax[0];
+        if (mMax[1] > aabb.mMax[1])
+            mMax[1] = aabb.mMax[1];
+        if (mMax[2] > aabb.mMax[2])
+            mMax[2] = aabb.mMax[2];
+    }
+
+    float mMin[3];
+    float mMax[3];
+};
+
+class NodeAABB;
+
+class NodeAABB
+{
+public:
+    NodeAABB(void)
+    {
+        mLeft              = NULL;
+        mRight             = NULL;
+        mLeafTriangleIndex = TRI_EOF;
+    }
+
+    NodeAABB(unsigned int vcount, const float* vertices, unsigned int tcount, unsigned int* indices,
+             unsigned int               maxDepth,    // Maximum recursion depth for the triangle mesh.
+             unsigned int               minLeafSize, // minimum triangles to treat as a 'leaf' node.
+             float                      minAxisSize,
+             NodeInterface*             callback,
+             std::vector<unsigned int>& leafTriangles) // once a particular axis is less than this size, stop sub-dividing.
+
+    {
+        mLeft              = NULL;
+        mRight             = NULL;
+        mLeafTriangleIndex = TRI_EOF;
+        std::vector<unsigned int> triangles;
+        triangles.reserve(tcount);
+        for (unsigned int i = 0; i < tcount; i++)
+        {
+            triangles.push_back(i);
+        }
+        mBounds.setMin(vertices);
+        mBounds.setMax(vertices);
+        const float* vtx = vertices + 3;
+        for (unsigned int i = 1; i < vcount; i++)
+        {
+            mBounds.include(vtx);
+            vtx += 3;
+        }
+        split(triangles, vcount, vertices, tcount, indices, 0, maxDepth, minLeafSize, minAxisSize, callback, leafTriangles);
+    }
+
+    NodeAABB(const BoundsAABB& aabb)
+    : mBounds(aabb)
+    {
+        mLeft              = NULL;
+        mRight             = NULL;
+        mLeafTriangleIndex = TRI_EOF;
+    }
+
+    ~NodeAABB(void)
+    {
+    }
+
+    // here is where we split the mesh..
+    void split(const std::vector<unsigned int>& triangles,
+               unsigned int                     vcount,
+               const float*                     vertices,
+               unsigned int                     tcount,
+               const unsigned int*              indices,
+               unsigned int                     depth,
+               unsigned int                     maxDepth,    // Maximum recursion depth for the triangle mesh.
+               unsigned int                     minLeafSize, // minimum triangles to treat as a 'leaf' node.
+               float                            minAxisSize,
+               NodeInterface*                   callback,
+               std::vector<unsigned int>&       leafTriangles) // once a particular axis is less than this size, stop sub-dividing.
+
+    {
+        // Find the longest axis of the bounding volume of this node
+        float dx = mBounds.mMax[0] - mBounds.mMin[0];
+        float dy = mBounds.mMax[1] - mBounds.mMin[1];
+        float dz = mBounds.mMax[2] - mBounds.mMin[2];
+
+        AxisAABB axis  = AABB_XAXIS;
+        float    laxis = dx;
+
+        if (dy > dx)
+        {
+            axis  = AABB_YAXIS;
+            laxis = dy;
+        }
+
+        if (dz > dx && dz > dy)
+        {
+            axis  = AABB_ZAXIS;
+            laxis = dz;
+        }
+
+        unsigned int count = triangles.size();
+
+        // if the number of triangles is less than the minimum allowed for a leaf node or...
+        // we have reached the maximum recursion depth or..
+        // the width of the longest axis is less than the minimum axis size then...
+        // we create the leaf node and copy the triangles into the leaf node triangle array.
+        if (count < minLeafSize || depth >= maxDepth || laxis < minAxisSize)
+        {
+            // Copy the triangle indices into the leaf triangles array
+            mLeafTriangleIndex = leafTriangles.size(); // assign the array start location for these leaf triangles.
+            leafTriangles.push_back(count);
+            for (std::vector<unsigned int>::const_iterator i = triangles.begin(); i != triangles.end(); ++i)
+            {
+                unsigned int tri = *i;
+                leafTriangles.push_back(tri);
+            }
+        }
+        else
+        {
+            float center[3];
+            mBounds.getCenter(center);
+            BoundsAABB b1, b2;
+            splitRect(axis, mBounds, b1, b2, center);
+
+            // Compute two bounding boxes based upon the split of the longest axis
+
+            BoundsAABB leftBounds, rightBounds;
+
+            std::vector<unsigned int> leftTriangles;
+            std::vector<unsigned int> rightTriangles;
+
+            // Create two arrays; one of all triangles which intersect the 'left' half of the bounding volume node
+            // and another array that includes all triangles which intersect the 'right' half of the bounding volume node.
+            for (std::vector<unsigned int>::const_iterator i = triangles.begin(); i != triangles.end(); ++i)
+            {
+                unsigned int tri = (*i);
+
+                {
+                    unsigned int i1 = indices[tri * 3 + 0];
+                    unsigned int i2 = indices[tri * 3 + 1];
+                    unsigned int i3 = indices[tri * 3 + 2];
+
+                    const float* p1 = &vertices[i1 * 3];
+                    const float* p2 = &vertices[i2 * 3];
+                    const float* p3 = &vertices[i3 * 3];
+
+                    unsigned int addCount = 0;
+                    unsigned int orCode   = 0xFFFFFFFF;
+                    if (b1.containsTriangleExact(p1, p2, p3, orCode))
+                    {
+                        addCount++;
+                        if (leftTriangles.empty())
+                        {
+                            leftBounds.setMin(p1);
+                            leftBounds.setMax(p1);
+                        }
+                        leftBounds.include(p1);
+                        leftBounds.include(p2);
+                        leftBounds.include(p3);
+                        leftTriangles.push_back(tri); // Add this triangle to the 'left triangles' array and revise the left triangles bounding volume
+                    }
+                    // if the orCode is zero; meaning the triangle was fully self-contiained int he left bounding box; then we don't need to test against the right
+                    if (orCode && b2.containsTriangleExact(p1, p2, p3, orCode))
+                    {
+                        addCount++;
+                        if (rightTriangles.empty())
+                        {
+                            rightBounds.setMin(p1);
+                            rightBounds.setMax(p1);
+                        }
+                        rightBounds.include(p1);
+                        rightBounds.include(p2);
+                        rightBounds.include(p3);
+                        rightTriangles.push_back(tri); // Add this triangle to the 'right triangles' array and revise the right triangles bounding volume.
+                    }
+                    assert(addCount);
+                }
+            }
+
+            if (!leftTriangles.empty()) // If there are triangles in the left half then...
+            {
+                leftBounds.clamp(b1);             // we have to clamp the bounding volume so it stays inside the parent volume.
+                mLeft = callback->getNode();      // get a new AABB node
+                new (mLeft) NodeAABB(leftBounds); // initialize it to default constructor values.
+                // Then recursively split this node.
+                mLeft->split(leftTriangles, vcount, vertices, tcount, indices, depth + 1, maxDepth, minLeafSize, minAxisSize, callback, leafTriangles);
+            }
+
+            if (!rightTriangles.empty()) // If there are triangles in the right half then..
+            {
+                rightBounds.clamp(b2);        // clamps the bounding volume so it stays restricted to the size of the parent volume.
+                mRight = callback->getNode(); // allocate and default initialize a new node
+                new (mRight) NodeAABB(rightBounds);
+                // Recursively split this node.
+                mRight->split(rightTriangles, vcount, vertices, tcount, indices, depth + 1, maxDepth, minLeafSize, minAxisSize, callback, leafTriangles);
+            }
+        }
+    }
+
+    void splitRect(AxisAABB axis, const BoundsAABB& source, BoundsAABB& b1, BoundsAABB& b2, const float* midpoint)
+    {
+        switch (axis)
+        {
+            case AABB_XAXIS:
+            {
+                b1.setMin(source.mMin);
+                b1.setMax(midpoint[0], source.mMax[1], source.mMax[2]);
+
+                b2.setMin(midpoint[0], source.mMin[1], source.mMin[2]);
+                b2.setMax(source.mMax);
+            }
+            break;
+            case AABB_YAXIS:
+            {
+                b1.setMin(source.mMin);
+                b1.setMax(source.mMax[0], midpoint[1], source.mMax[2]);
+
+                b2.setMin(source.mMin[0], midpoint[1], source.mMin[2]);
+                b2.setMax(source.mMax);
+            }
+            break;
+            case AABB_ZAXIS:
+            {
+                b1.setMin(source.mMin);
+                b1.setMax(source.mMax[0], source.mMax[1], midpoint[2]);
+
+                b2.setMin(source.mMin[0], source.mMin[1], midpoint[2]);
+                b2.setMax(source.mMax);
+            }
+            break;
+        }
+    }
+
+    virtual void raycast(bool&                            hit,
+                         const float*                     from,
+                         const float*                     to,
+                         const float*                     dir,
+                         float*                           hitLocation,
+                         float*                           hitNormal,
+                         float*                           hitDistance,
+                         const float*                     vertices,
+                         const unsigned int*              indices,
+                         float&                           nearestDistance,
+                         NodeInterface*                   callback,
+                         unsigned int*                    raycastTriangles,
+                         unsigned int                     raycastFrame,
+                         const std::vector<unsigned int>& leafTriangles,
+                         unsigned int&                    nearestTriIndex)
+    {
+        float sect[3];
+        float nd = nearestDistance;
+        if (!intersectLineSegmentAABB(mBounds.mMin, mBounds.mMax, from, dir, nd, sect))
+        {
+            return;
+        }
+        if (mLeafTriangleIndex != TRI_EOF)
+        {
+            const unsigned int* scan  = &leafTriangles[mLeafTriangleIndex];
+            unsigned int        count = *scan++;
+            for (unsigned int i = 0; i < count; i++)
+            {
+                unsigned int tri = *scan++;
+                if (raycastTriangles[tri] != raycastFrame)
+                {
+                    raycastTriangles[tri] = raycastFrame;
+                    unsigned int i1       = indices[tri * 3 + 0];
+                    unsigned int i2       = indices[tri * 3 + 1];
+                    unsigned int i3       = indices[tri * 3 + 2];
+
+                    const float* p1 = &vertices[i1 * 3];
+                    const float* p2 = &vertices[i2 * 3];
+                    const float* p3 = &vertices[i3 * 3];
+
+                    float t;
+                    if (rayIntersectsTriangle(from, dir, p1, p2, p3, t))
+                    {
+                        bool accept = false;
+                        if (t == nearestDistance && tri < nearestTriIndex)
+                        {
+                            accept = true;
+                        }
+                        if (t < nearestDistance || accept)
+                        {
+                            nearestDistance = t;
+                            if (hitLocation)
+                            {
+                                hitLocation[0] = from[0] + dir[0] * t;
+                                hitLocation[1] = from[1] + dir[1] * t;
+                                hitLocation[2] = from[2] + dir[2] * t;
+                            }
+                            if (hitNormal)
+                            {
+                                callback->getFaceNormal(tri, hitNormal);
+                            }
+                            if (hitDistance)
+                            {
+                                *hitDistance = t;
+                            }
+                            nearestTriIndex = tri;
+                            hit             = true;
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (mLeft)
+            {
+                mLeft->raycast(hit, from, to, dir, hitLocation, hitNormal, hitDistance, vertices, indices, nearestDistance, callback, raycastTriangles, raycastFrame, leafTriangles, nearestTriIndex);
+            }
+            if (mRight)
+            {
+                mRight->raycast(hit, from, to, dir, hitLocation, hitNormal, hitDistance, vertices, indices, nearestDistance, callback, raycastTriangles, raycastFrame, leafTriangles, nearestTriIndex);
+            }
+        }
+    }
+
+    NodeAABB*    mLeft;              // left node
+    NodeAABB*    mRight;             // right node
+    BoundsAABB   mBounds;            // bounding volume of node
+    unsigned int mLeafTriangleIndex; // if it is a leaf node; then these are the triangle indices.
+};
+
+RaycastMesh::RaycastMesh(unsigned int vcount, const float* vertices, unsigned int tcount, const unsigned int* indices, unsigned int maxDepth, unsigned int minLeafSize, float minAxisSize)
+{
+    mRaycastFrame = 0;
+
+    if (maxDepth < 2)
+    {
+        maxDepth = 2;
+    }
+
+    if (maxDepth > 15)
+    {
+        maxDepth = 15;
+    }
+    unsigned int pow2Table[16] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 65536 };
+    mMaxNodeCount              = 0;
+    for (unsigned int i = 0; i <= maxDepth; i++)
+    {
+        mMaxNodeCount += pow2Table[i];
+    }
+    mNodes     = new NodeAABB[mMaxNodeCount];
+    mNodeCount = 0;
+    mVcount    = vcount;
+    mVertices  = (float*)::malloc(sizeof(float) * 3 * vcount);
+    memcpy(mVertices, vertices, sizeof(float) * 3 * vcount);
+    mTcount  = tcount;
+    mIndices = (unsigned int*)::malloc(sizeof(unsigned int) * tcount * 3);
+    memcpy(mIndices, indices, sizeof(unsigned int) * tcount * 3);
+    mRaycastTriangles = (unsigned int*)::malloc(tcount * sizeof(unsigned int));
+    memset(mRaycastTriangles, 0, tcount * sizeof(unsigned int));
+    mRoot        = getNode();
+    mFaceNormals = NULL;
+    new (mRoot) NodeAABB(mVcount, mVertices, mTcount, mIndices, maxDepth, minLeafSize, minAxisSize, this, mLeafTriangles);
+}
+
+RaycastMesh::~RaycastMesh(void)
+{
+    delete[] mNodes;
+    ::free(mVertices);
+    ::free(mIndices);
+    ::free(mFaceNormals);
+    ::free(mRaycastTriangles);
+}
+
+bool RaycastMesh::raycast(const float* from, const float* to, float* hitLocation, float* hitNormal, float* hitDistance)
+{
+    bool ret = false;
+
+    float dir[3];
+    dir[0]         = to[0] - from[0];
+    dir[1]         = to[1] - from[1];
+    dir[2]         = to[2] - from[2];
+    float distance = sqrtf(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]);
+    if (distance < 0.0000000001f)
+        return false;
+    float recipDistance = 1.0f / distance;
+    dir[0] *= recipDistance;
+    dir[1] *= recipDistance;
+    dir[2] *= recipDistance;
+    mRaycastFrame++;
+    unsigned int nearestTriIndex = TRI_EOF;
+    mRoot->raycast(ret, from, to, dir, hitLocation, hitNormal, hitDistance, mVertices, mIndices, distance, this, mRaycastTriangles, mRaycastFrame, mLeafTriangles, nearestTriIndex);
+    return ret;
+}
+
+const float* RaycastMesh::getBoundMin(void) const // return the minimum bounding box
+{
+    return mRoot->mBounds.mMin;
+}
+
+const float* RaycastMesh::getBoundMax(void) const // return the maximum bounding box.
+{
+    return mRoot->mBounds.mMax;
+}
+
+NodeAABB* RaycastMesh::getNode(void)
+{
+    assert(mNodeCount < mMaxNodeCount);
+    NodeAABB* ret = &mNodes[mNodeCount];
+    mNodeCount++;
+    return ret;
+}
+
+void RaycastMesh::getFaceNormal(unsigned int tri, float* faceNormal)
+{
+    if (mFaceNormals == NULL)
+    {
+        mFaceNormals = (float*)::malloc(sizeof(float) * 3 * mTcount);
+        for (unsigned int i = 0; i < mTcount; i++)
+        {
+            unsigned int i1   = mIndices[i * 3 + 0];
+            unsigned int i2   = mIndices[i * 3 + 1];
+            unsigned int i3   = mIndices[i * 3 + 2];
+            const float* p1   = &mVertices[i1 * 3];
+            const float* p2   = &mVertices[i2 * 3];
+            const float* p3   = &mVertices[i3 * 3];
+            float*       dest = &mFaceNormals[i * 3];
+            computePlane(p3, p2, p1, dest);
+        }
+    }
+    const float* src = &mFaceNormals[tri * 3];
+    faceNormal[0]    = src[0];
+    faceNormal[1]    = src[1];
+    faceNormal[2]    = src[2];
+}
+
+bool RaycastMesh::bruteForceRaycast(const float* from, const float* to, float* hitLocation, float* hitNormal, float* hitDistance)
+{
+    bool ret = false;
+
+    float dir[3];
+
+    dir[0] = to[0] - from[0];
+    dir[1] = to[1] - from[1];
+    dir[2] = to[2] - from[2];
+
+    float distance = sqrtf(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]);
+    if (distance < 0.0000000001f)
+        return false;
+
+    float recipDistance = 1.0f / distance;
+    dir[0] *= recipDistance;
+    dir[1] *= recipDistance;
+    dir[2] *= recipDistance;
+    const unsigned int* indices         = mIndices;
+    const float*        vertices        = mVertices;
+    float               nearestDistance = distance;
+
+    for (unsigned int tri = 0; tri < mTcount; tri++)
+    {
+        unsigned int i1 = indices[tri * 3 + 0];
+        unsigned int i2 = indices[tri * 3 + 1];
+        unsigned int i3 = indices[tri * 3 + 2];
+
+        const float* p1 = &vertices[i1 * 3];
+        const float* p2 = &vertices[i2 * 3];
+        const float* p3 = &vertices[i3 * 3];
+
+        float t;
+        if (rayIntersectsTriangle(from, dir, p1, p2, p3, t))
+        {
+            if (t < nearestDistance)
+            {
+                nearestDistance = t;
+                if (hitLocation)
+                {
+                    hitLocation[0] = from[0] + dir[0] * t;
+                    hitLocation[1] = from[1] + dir[1] * t;
+                    hitLocation[2] = from[2] + dir[2] * t;
+                }
+
+                if (hitNormal)
+                {
+                    getFaceNormal(tri, hitNormal);
+                }
+
+                if (hitDistance)
+                {
+                    *hitDistance = t;
+                }
+                ret = true;
+            }
+        }
+    }
+    return ret;
+}

--- a/ext/sightmesh/RaycastMesh.h
+++ b/ext/sightmesh/RaycastMesh.h
@@ -29,6 +29,7 @@
 //
 //
 
+#include <string>
 #include <vector>
 
 class NodeAABB;
@@ -43,6 +44,8 @@ public:
 class RaycastMesh : public NodeInterface
 {
 public:
+    RaycastMesh(std::string const& filename);
+
     RaycastMesh(unsigned int        vcount,            // The number of vertices in the source triangle mesh
                 const float*        vertices,          // The array of vertex positions in the format x1,y1,z1..x2,y2,z2.. etc.
                 unsigned int        tcount,            // The number of triangles in the source triangle mesh

--- a/ext/sightmesh/RaycastMesh.h
+++ b/ext/sightmesh/RaycastMesh.h
@@ -1,0 +1,80 @@
+#ifndef RAYCAST_MESH_H
+#define RAYCAST_MESH_H
+
+// This code snippet allows you to create an axis aligned bounding volume tree for a triangle mesh so that you can do
+// high-speed raycasting.
+//
+// There are much better implementations of this available on the internet.  In particular I recommend that you use
+// OPCODE written by Pierre Terdiman.
+// @see: http://www.codercorner.com/Opcode.htm
+//
+// OPCODE does a whole lot more than just raycasting, and is a rather significant amount of source code.
+//
+// I am providing this code snippet for the use case where you *only* want to do quick and dirty optimized raycasting.
+// I have not done performance testing between this version and OPCODE; so I don't know how much slower it is.  However,
+// anytime you switch to using a spatial data structure for raycasting, you increase your performance by orders and orders
+// of magnitude; so this implementation should work fine for simple tools and utilities.
+//
+// It also serves as a nice sample for people who are trying to learn the algorithm of how to implement AABB trees.
+// AABB = Axis Aligned Bounding Volume trees.
+//
+// http://www.cgal.org/Manual/3.5/doc_html/cgal_manual/AABB_tree/Chapter_main.html
+//
+//
+// This code snippet was written by John W. Ratcliff on August 18, 2011 and released under the MIT. license.
+//
+// mailto:jratcliffscarab@gmail.com
+//
+// The official source can be found at:  http://code.google.com/p/raycastmesh/
+//
+//
+
+#include <vector>
+
+class NodeAABB;
+
+class NodeInterface
+{
+public:
+    virtual NodeAABB* getNode(void)                                      = 0;
+    virtual void      getFaceNormal(unsigned int tri, float* faceNormal) = 0;
+};
+
+class RaycastMesh : public NodeInterface
+{
+public:
+    RaycastMesh(unsigned int        vcount,            // The number of vertices in the source triangle mesh
+                const float*        vertices,          // The array of vertex positions in the format x1,y1,z1..x2,y2,z2.. etc.
+                unsigned int        tcount,            // The number of triangles in the source triangle mesh
+                const unsigned int* indices,           // The triangle indices in the format of i1,i2,i3 ... i4,i5,i6, ...
+                unsigned int        maxDepth    = 15,  // Maximum recursion depth for the triangle mesh.
+                unsigned int        minLeafSize = 4,   // minimum triangles to treat as a 'leaf' node.
+                float               minAxisSize = 0.1f // once a particular axis is less than this size, stop sub-dividing.
+    );
+
+    virtual ~RaycastMesh();
+
+    bool raycast(const float* from, const float* to, float* hitLocation, float* hitNormal, float* hitDistance);
+    bool bruteForceRaycast(const float* from, const float* to, float* hitLocation, float* hitNormal, float* hitDistance);
+
+    const float* getBoundMin(void) const; // return the minimum bounding box
+    const float* getBoundMax(void) const; // return the maximum bounding box.
+
+    NodeAABB* getNode(void);
+    void      getFaceNormal(unsigned int tri, float* faceNormal);
+
+    unsigned int              mRaycastFrame;
+    unsigned int*             mRaycastTriangles;
+    unsigned int              mVcount;
+    float*                    mVertices;
+    float*                    mFaceNormals;
+    unsigned int              mTcount;
+    unsigned int*             mIndices;
+    NodeAABB*                 mRoot;
+    unsigned int              mNodeCount;
+    unsigned int              mMaxNodeCount;
+    NodeAABB*                 mNodes;
+    std::vector<unsigned int> mLeafTriangles;
+};
+
+#endif // RAYCAST_MESH_H

--- a/ext/sightmesh/tiny_obj_loader.h
+++ b/ext/sightmesh/tiny_obj_loader.h
@@ -1,0 +1,2029 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2012-2016 Syoyo Fujita and many contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+//
+// version 1.0.6 : Add TINYOBJLOADER_USE_DOUBLE option(#124)
+// version 1.0.5 : Ignore `Tr` when `d` exists in MTL(#43)
+// version 1.0.4 : Support multiple filenames for 'mtllib'(#112)
+// version 1.0.3 : Support parsing texture options(#85)
+// version 1.0.2 : Improve parsing speed by about a factor of 2 for large
+// files(#105)
+// version 1.0.1 : Fixes a shape is lost if obj ends with a 'usemtl'(#104)
+// version 1.0.0 : Change data structure. Change license from BSD to MIT.
+//
+
+//
+// Use this in *one* .cc
+//   #define TINYOBJLOADER_IMPLEMENTATION
+//   #include "tiny_obj_loader.h"
+//
+
+#ifndef TINY_OBJ_LOADER_H_
+#define TINY_OBJ_LOADER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace tinyobj {
+
+// https://en.wikipedia.org/wiki/Wavefront_.obj_file says ...
+//
+//  -blendu on | off                       # set horizontal texture blending
+//  (default on)
+//  -blendv on | off                       # set vertical texture blending
+//  (default on)
+//  -boost real_value                      # boost mip-map sharpness
+//  -mm base_value gain_value              # modify texture map values (default
+//  0 1)
+//                                         #     base_value = brightness,
+//                                         gain_value = contrast
+//  -o u [v [w]]                           # Origin offset             (default
+//  0 0 0)
+//  -s u [v [w]]                           # Scale                     (default
+//  1 1 1)
+//  -t u [v [w]]                           # Turbulence                (default
+//  0 0 0)
+//  -texres resolution                     # texture resolution to create
+//  -clamp on | off                        # only render texels in the clamped
+//  0-1 range (default off)
+//                                         #   When unclamped, textures are
+//                                         repeated across a surface,
+//                                         #   when clamped, only texels which
+//                                         fall within the 0-1
+//                                         #   range are rendered.
+//  -bm mult_value                         # bump multiplier (for bump maps
+//  only)
+//
+//  -imfchan r | g | b | m | l | z         # specifies which channel of the file
+//  is used to
+//                                         # create a scalar or bump texture.
+//                                         r:red, g:green,
+//                                         # b:blue, m:matte, l:luminance,
+//                                         z:z-depth..
+//                                         # (the default for bump is 'l' and
+//                                         for decal is 'm')
+//  bump -imfchan r bumpmap.tga            # says to use the red channel of
+//  bumpmap.tga as the bumpmap
+//
+// For reflection maps...
+//
+//   -type sphere                           # specifies a sphere for a "refl"
+//   reflection map
+//   -type cube_top    | cube_bottom |      # when using a cube map, the texture
+//   file for each
+//         cube_front  | cube_back   |      # side of the cube is specified
+//         separately
+//         cube_left   | cube_right
+
+#ifdef TINYOBJLOADER_USE_DOUBLE
+  //#pragma message "using double"
+  typedef double real_t;
+#else
+  //#pragma message "using float"
+  typedef float real_t;
+#endif
+
+typedef enum {
+  TEXTURE_TYPE_NONE,  // default
+  TEXTURE_TYPE_SPHERE,
+  TEXTURE_TYPE_CUBE_TOP,
+  TEXTURE_TYPE_CUBE_BOTTOM,
+  TEXTURE_TYPE_CUBE_FRONT,
+  TEXTURE_TYPE_CUBE_BACK,
+  TEXTURE_TYPE_CUBE_LEFT,
+  TEXTURE_TYPE_CUBE_RIGHT
+} texture_type_t;
+
+typedef struct {
+  texture_type_t type;     // -type (default TEXTURE_TYPE_NONE)
+  real_t sharpness;         // -boost (default 1.0?)
+  real_t brightness;        // base_value in -mm option (default 0)
+  real_t contrast;          // gain_value in -mm option (default 1)
+  real_t origin_offset[3];  // -o u [v [w]] (default 0 0 0)
+  real_t scale[3];          // -s u [v [w]] (default 1 1 1)
+  real_t turbulence[3];     // -t u [v [w]] (default 0 0 0)
+  // int   texture_resolution; // -texres resolution (default = ?) TODO
+  bool clamp;    // -clamp (default false)
+  char imfchan;  // -imfchan (the default for bump is 'l' and for decal is 'm')
+  bool blendu;   // -blendu (default on)
+  bool blendv;   // -blendv (default on)
+  real_t bump_multiplier;  // -bm (for bump maps only, default 1.0)
+} texture_option_t;
+
+typedef struct {
+  std::string name;
+
+  real_t ambient[3];
+  real_t diffuse[3];
+  real_t specular[3];
+  real_t transmittance[3];
+  real_t emission[3];
+  real_t shininess;
+  real_t ior;       // index of refraction
+  real_t dissolve;  // 1 == opaque; 0 == fully transparent
+  // illumination model (see http://www.fileformat.info/format/material/)
+  int illum;
+
+  int dummy;  // Suppress padding warning.
+
+  std::string ambient_texname;             // map_Ka
+  std::string diffuse_texname;             // map_Kd
+  std::string specular_texname;            // map_Ks
+  std::string specular_highlight_texname;  // map_Ns
+  std::string bump_texname;                // map_bump, bump
+  std::string displacement_texname;        // disp
+  std::string alpha_texname;               // map_d
+
+  texture_option_t ambient_texopt;
+  texture_option_t diffuse_texopt;
+  texture_option_t specular_texopt;
+  texture_option_t specular_highlight_texopt;
+  texture_option_t bump_texopt;
+  texture_option_t displacement_texopt;
+  texture_option_t alpha_texopt;
+
+  // PBR extension
+  // http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
+  real_t roughness;            // [0, 1] default 0
+  real_t metallic;             // [0, 1] default 0
+  real_t sheen;                // [0, 1] default 0
+  real_t clearcoat_thickness;  // [0, 1] default 0
+  real_t clearcoat_roughness;  // [0, 1] default 0
+  real_t anisotropy;           // aniso. [0, 1] default 0
+  real_t anisotropy_rotation;  // anisor. [0, 1] default 0
+  real_t pad0;
+  real_t pad1;
+  std::string roughness_texname;  // map_Pr
+  std::string metallic_texname;   // map_Pm
+  std::string sheen_texname;      // map_Ps
+  std::string emissive_texname;   // map_Ke
+  std::string normal_texname;     // norm. For normal mapping.
+
+  texture_option_t roughness_texopt;
+  texture_option_t metallic_texopt;
+  texture_option_t sheen_texopt;
+  texture_option_t emissive_texopt;
+  texture_option_t normal_texopt;
+
+  int pad2;
+
+  std::map<std::string, std::string> unknown_parameter;
+} material_t;
+
+typedef struct {
+  std::string name;
+
+  std::vector<int> intValues;
+  std::vector<real_t> floatValues;
+  std::vector<std::string> stringValues;
+} tag_t;
+
+// Index struct to support different indices for vtx/normal/texcoord.
+// -1 means not used.
+typedef struct {
+  int vertex_index;
+  int normal_index;
+  int texcoord_index;
+} index_t;
+
+typedef struct {
+  std::vector<index_t> indices;
+  std::vector<unsigned char> num_face_vertices;  // The number of vertices per
+                                                 // face. 3 = polygon, 4 = quad,
+                                                 // ... Up to 255.
+  std::vector<int> material_ids;                 // per-face material ID
+  std::vector<tag_t> tags;                       // SubD tag
+} mesh_t;
+
+typedef struct {
+  std::string name;
+  mesh_t mesh;
+} shape_t;
+
+// Vertex attributes
+typedef struct {
+  std::vector<real_t> vertices;   // 'v'
+  std::vector<real_t> normals;    // 'vn'
+  std::vector<real_t> texcoords;  // 'vt'
+} attrib_t;
+
+typedef struct callback_t_ {
+  // W is optional and set to 1 if there is no `w` item in `v` line
+  void (*vertex_cb)(void *user_data, real_t x, real_t y, real_t z, real_t w);
+  void (*normal_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // y and z are optional and set to 0 if there is no `y` and/or `z` item(s) in
+  // `vt` line.
+  void (*texcoord_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // called per 'f' line. num_indices is the number of face indices(e.g. 3 for
+  // triangle, 4 for quad)
+  // 0 will be passed for undefined index in index_t members.
+  void (*index_cb)(void *user_data, index_t *indices, int num_indices);
+  // `name` material name, `material_id` = the array index of material_t[]. -1
+  // if
+  // a material not found in .mtl
+  void (*usemtl_cb)(void *user_data, const char *name, int material_id);
+  // `materials` = parsed material data.
+  void (*mtllib_cb)(void *user_data, const material_t *materials,
+                    int num_materials);
+  // There may be multiple group names
+  void (*group_cb)(void *user_data, const char **names, int num_names);
+  void (*object_cb)(void *user_data, const char *name);
+
+  callback_t_()
+      : vertex_cb(NULL),
+        normal_cb(NULL),
+        texcoord_cb(NULL),
+        index_cb(NULL),
+        usemtl_cb(NULL),
+        mtllib_cb(NULL),
+        group_cb(NULL),
+        object_cb(NULL) {}
+} callback_t;
+
+class MaterialReader {
+ public:
+  MaterialReader() {}
+  virtual ~MaterialReader();
+
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap,
+                          std::string *err) = 0;
+};
+
+class MaterialFileReader : public MaterialReader {
+ public:
+  explicit MaterialFileReader(const std::string &mtl_basedir)
+      : m_mtlBaseDir(mtl_basedir) {}
+  virtual ~MaterialFileReader() {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *err);
+
+ private:
+  std::string m_mtlBaseDir;
+};
+
+class MaterialStreamReader : public MaterialReader {
+ public:
+  explicit MaterialStreamReader(std::istream &inStream)
+      : m_inStream(inStream) {}
+  virtual ~MaterialStreamReader() {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *err);
+
+ private:
+  std::istream &m_inStream;
+};
+
+/// Loads .obj from a file.
+/// 'attrib', 'shapes' and 'materials' will be filled with parsed shape data
+/// 'shapes' will be filled with parsed shape data
+/// Returns true when loading .obj become success.
+/// Returns warning and error message into `err`
+/// 'mtl_basedir' is optional, and used for base directory for .mtl file.
+/// In default(`NULL'), .mtl file is searched from an application's working
+/// directory.
+/// 'triangulate' is optional, and used whether triangulate polygon face in .obj
+/// or not.
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *err,
+             const char *filename, const char *mtl_basedir = NULL,
+             bool triangulate = true);
+
+/// Loads .obj from a file with custom user callback.
+/// .mtl is loaded as usual and parsed material_t data will be passed to
+/// `callback.mtllib_cb`.
+/// Returns true when loading .obj/.mtl become success.
+/// Returns warning and error message into `err`
+/// See `examples/callback_api/` for how to use this function.
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data = NULL,
+                         MaterialReader *readMatFn = NULL,
+                         std::string *err = NULL);
+
+/// Loads object from a std::istream, uses GetMtlIStreamFn to retrieve
+/// std::istream for materials.
+/// Returns true when loading .obj become success.
+/// Returns warning and error message into `err`
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *err,
+             std::istream *inStream, MaterialReader *readMatFn = NULL,
+             bool triangulate = true);
+
+/// Loads materials into std::map
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning);
+
+}  // namespace tinyobj
+
+#endif  // TINY_OBJ_LOADER_H_
+
+#ifdef TINYOBJLOADER_IMPLEMENTATION
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+#include <fstream>
+#include <sstream>
+
+namespace tinyobj {
+
+MaterialReader::~MaterialReader() {}
+
+#define TINYOBJ_SSCANF_BUFFER_SIZE (4096)
+
+struct vertex_index {
+  int v_idx, vt_idx, vn_idx;
+  vertex_index() : v_idx(-1), vt_idx(-1), vn_idx(-1) {}
+  explicit vertex_index(int idx) : v_idx(idx), vt_idx(idx), vn_idx(idx) {}
+  vertex_index(int vidx, int vtidx, int vnidx)
+      : v_idx(vidx), vt_idx(vtidx), vn_idx(vnidx) {}
+};
+
+struct tag_sizes {
+  tag_sizes() : num_ints(0), num_reals(0), num_strings(0) {}
+  int num_ints;
+  int num_reals;
+  int num_strings;
+};
+
+struct obj_shape {
+  std::vector<real_t> v;
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+};
+
+// See
+// http://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+static std::istream &safeGetline(std::istream &is, std::string &t) {
+  t.clear();
+
+  // The characters in the stream are read one-by-one using a std::streambuf.
+  // That is faster than reading them one-by-one using the std::istream.
+  // Code that uses streambuf this way must be guarded by a sentry object.
+  // The sentry object performs various tasks,
+  // such as thread synchronization and updating the stream state.
+
+  std::istream::sentry se(is, true);
+  std::streambuf *sb = is.rdbuf();
+
+  for (;;) {
+    int c = sb->sbumpc();
+    switch (c) {
+      case '\n':
+        return is;
+      case '\r':
+        if (sb->sgetc() == '\n') sb->sbumpc();
+        return is;
+      case EOF:
+        // Also handle the case when the last line has no line ending
+        if (t.empty()) is.setstate(std::ios::eofbit);
+        return is;
+      default:
+        t += static_cast<char>(c);
+    }
+  }
+}
+
+#define IS_SPACE(x) (((x) == ' ') || ((x) == '\t'))
+#define IS_DIGIT(x) \
+  (static_cast<unsigned int>((x) - '0') < static_cast<unsigned int>(10))
+#define IS_NEW_LINE(x) (((x) == '\r') || ((x) == '\n') || ((x) == '\0'))
+
+// Make index zero-base, and also support relative index.
+static inline int fixIndex(int idx, int n) {
+  if (idx > 0) return idx - 1;
+  if (idx == 0) return 0;
+  return n + idx;  // negative value = relative
+}
+
+static inline std::string parseString(const char **token) {
+  std::string s;
+  (*token) += strspn((*token), " \t");
+  size_t e = strcspn((*token), " \t\r");
+  s = std::string((*token), &(*token)[e]);
+  (*token) += e;
+  return s;
+}
+
+static inline int parseInt(const char **token) {
+  (*token) += strspn((*token), " \t");
+  int i = atoi((*token));
+  (*token) += strcspn((*token), " \t\r");
+  return i;
+}
+
+// Tries to parse a floating point number located at s.
+//
+// s_end should be a location in the string where reading should absolutely
+// stop. For example at the end of the string, to prevent buffer overflows.
+//
+// Parses the following EBNF grammar:
+//   sign    = "+" | "-" ;
+//   END     = ? anything not in digit ?
+//   digit   = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//   integer = [sign] , digit , {digit} ;
+//   decimal = integer , ["." , integer] ;
+//   float   = ( decimal , END ) | ( decimal , ("E" | "e") , integer , END ) ;
+//
+//  Valid strings are for example:
+//   -0  +3.1417e+2  -0.0E-3  1.0324  -1.41   11e2
+//
+// If the parsing is a success, result is set to the parsed value and true
+// is returned.
+//
+// The function is greedy and will parse until any of the following happens:
+//  - a non-conforming character is encountered.
+//  - s_end is reached.
+//
+// The following situations triggers a failure:
+//  - s >= s_end.
+//  - parse failure.
+//
+static bool tryParseDouble(const char *s, const char *s_end, double *result) {
+  if (s >= s_end) {
+    return false;
+  }
+
+  double mantissa = 0.0;
+  // This exponent is base 2 rather than 10.
+  // However the exponent we parse is supposed to be one of ten,
+  // thus we must take care to convert the exponent/and or the
+  // mantissa to a * 2^E, where a is the mantissa and E is the
+  // exponent.
+  // To get the final double we will use ldexp, it requires the
+  // exponent to be in base 2.
+  int exponent = 0;
+
+  // NOTE: THESE MUST BE DECLARED HERE SINCE WE ARE NOT ALLOWED
+  // TO JUMP OVER DEFINITIONS.
+  char sign = '+';
+  char exp_sign = '+';
+  char const *curr = s;
+
+  // How many characters were read in a loop.
+  int read = 0;
+  // Tells whether a loop terminated due to reaching s_end.
+  bool end_not_reached = false;
+
+  /*
+          BEGIN PARSING.
+  */
+
+  // Find out what sign we've got.
+  if (*curr == '+' || *curr == '-') {
+    sign = *curr;
+    curr++;
+  } else if (IS_DIGIT(*curr)) { /* Pass through. */
+  } else {
+    goto fail;
+  }
+
+  // Read the integer part.
+  end_not_reached = (curr != s_end);
+  while (end_not_reached && IS_DIGIT(*curr)) {
+    mantissa *= 10;
+    mantissa += static_cast<int>(*curr - 0x30);
+    curr++;
+    read++;
+    end_not_reached = (curr != s_end);
+  }
+
+  // We must make sure we actually got something.
+  if (read == 0) goto fail;
+  // We allow numbers of form "#", "###" etc.
+  if (!end_not_reached) goto assemble;
+
+  // Read the decimal part.
+  if (*curr == '.') {
+    curr++;
+    read = 1;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      static const double pow_lut[] = {
+          1.0, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001, 0.0000001,
+      };
+      const int lut_entries = sizeof pow_lut / sizeof pow_lut[0];
+
+      // NOTE: Don't use powf here, it will absolutely murder precision.
+      mantissa += static_cast<int>(*curr - 0x30) *
+                  (read < lut_entries ? pow_lut[read] : std::pow(10.0, -read));
+      read++;
+      curr++;
+      end_not_reached = (curr != s_end);
+    }
+  } else if (*curr == 'e' || *curr == 'E') {
+  } else {
+    goto assemble;
+  }
+
+  if (!end_not_reached) goto assemble;
+
+  // Read the exponent part.
+  if (*curr == 'e' || *curr == 'E') {
+    curr++;
+    // Figure out if a sign is present and if it is.
+    end_not_reached = (curr != s_end);
+    if (end_not_reached && (*curr == '+' || *curr == '-')) {
+      exp_sign = *curr;
+      curr++;
+    } else if (IS_DIGIT(*curr)) { /* Pass through. */
+    } else {
+      // Empty E is not allowed.
+      goto fail;
+    }
+
+    read = 0;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      exponent *= 10;
+      exponent += static_cast<int>(*curr - 0x30);
+      curr++;
+      read++;
+      end_not_reached = (curr != s_end);
+    }
+    exponent *= (exp_sign == '+' ? 1 : -1);
+    if (read == 0) goto fail;
+  }
+
+assemble:
+  *result =
+      (sign == '+' ? 1 : -1) *
+      (exponent ? std::ldexp(mantissa * std::pow(5.0, exponent), exponent) : mantissa);
+  return true;
+fail:
+  return false;
+}
+
+static inline real_t parseReal(const char **token, double default_value = 0.0) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val = default_value;
+  tryParseDouble((*token), end, &val);
+  real_t f = static_cast<real_t>(val);
+  (*token) = end;
+  return f;
+}
+
+static inline void parseReal2(real_t *x, real_t *y, const char **token,
+                               const double default_x = 0.0,
+                               const double default_y = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+}
+
+static inline void parseReal3(real_t *x, real_t *y, real_t *z, const char **token,
+                               const double default_x = 0.0,
+                               const double default_y = 0.0,
+                               const double default_z = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+}
+
+static inline void parseV(real_t *x, real_t *y, real_t *z, real_t *w,
+                          const char **token, const double default_x = 0.0,
+                          const double default_y = 0.0,
+                          const double default_z = 0.0,
+                          const double default_w = 1.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+  (*w) = parseReal(token, default_w);
+}
+
+static inline bool parseOnOff(const char **token, bool default_value = true) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+
+  bool ret = default_value;
+  if ((0 == strncmp((*token), "on", 2))) {
+    ret = true;
+  } else if ((0 == strncmp((*token), "off", 3))) {
+    ret = false;
+  }
+
+  (*token) = end;
+  return ret;
+}
+
+static inline texture_type_t parseTextureType(
+    const char **token, texture_type_t default_value = TEXTURE_TYPE_NONE) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  texture_type_t ty = default_value;
+
+  if ((0 == strncmp((*token), "cube_top", strlen("cube_top")))) {
+    ty = TEXTURE_TYPE_CUBE_TOP;
+  } else if ((0 == strncmp((*token), "cube_bottom", strlen("cube_bottom")))) {
+    ty = TEXTURE_TYPE_CUBE_BOTTOM;
+  } else if ((0 == strncmp((*token), "cube_left", strlen("cube_left")))) {
+    ty = TEXTURE_TYPE_CUBE_LEFT;
+  } else if ((0 == strncmp((*token), "cube_right", strlen("cube_right")))) {
+    ty = TEXTURE_TYPE_CUBE_RIGHT;
+  } else if ((0 == strncmp((*token), "cube_front", strlen("cube_front")))) {
+    ty = TEXTURE_TYPE_CUBE_FRONT;
+  } else if ((0 == strncmp((*token), "cube_back", strlen("cube_back")))) {
+    ty = TEXTURE_TYPE_CUBE_BACK;
+  } else if ((0 == strncmp((*token), "sphere", strlen("sphere")))) {
+    ty = TEXTURE_TYPE_SPHERE;
+  }
+
+  (*token) = end;
+  return ty;
+}
+
+static tag_sizes parseTagTriple(const char **token) {
+  tag_sizes ts;
+
+  ts.num_ints = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+  (*token)++;
+
+  ts.num_reals = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+  (*token)++;
+
+  ts.num_strings = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r") + 1;
+
+  return ts;
+}
+
+// Parse triples with index offsets: i, i/j/k, i//k, i/j
+static vertex_index parseTriple(const char **token, int vsize, int vnsize,
+                                int vtsize) {
+  vertex_index vi(-1);
+
+  vi.v_idx = fixIndex(atoi((*token)), vsize);
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    vi.vn_idx = fixIndex(atoi((*token)), vnsize);
+    (*token) += strcspn((*token), "/ \t\r");
+    return vi;
+  }
+
+  // i/j/k or i/j
+  vi.vt_idx = fixIndex(atoi((*token)), vtsize);
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  vi.vn_idx = fixIndex(atoi((*token)), vnsize);
+  (*token) += strcspn((*token), "/ \t\r");
+  return vi;
+}
+
+// Parse raw triples: i, i/j/k, i//k, i/j
+static vertex_index parseRawTriple(const char **token) {
+  vertex_index vi(static_cast<int>(0));  // 0 is an invalid index in OBJ
+
+  vi.v_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    vi.vn_idx = atoi((*token));
+    (*token) += strcspn((*token), "/ \t\r");
+    return vi;
+  }
+
+  // i/j/k or i/j
+  vi.vt_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  vi.vn_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  return vi;
+}
+
+static bool ParseTextureNameAndOption(std::string *texname,
+                                      texture_option_t *texopt,
+                                      const char *linebuf, const bool is_bump) {
+  // @todo { write more robust lexer and parser. }
+  bool found_texname = false;
+  std::string texture_name;
+
+  // Fill with default value for texopt.
+  if (is_bump) {
+    texopt->imfchan = 'l';
+  } else {
+    texopt->imfchan = 'm';
+  }
+  texopt->bump_multiplier = 1.0f;
+  texopt->clamp = false;
+  texopt->blendu = true;
+  texopt->blendv = true;
+  texopt->sharpness = 1.0f;
+  texopt->brightness = 0.0f;
+  texopt->contrast = 1.0f;
+  texopt->origin_offset[0] = 0.0f;
+  texopt->origin_offset[1] = 0.0f;
+  texopt->origin_offset[2] = 0.0f;
+  texopt->scale[0] = 1.0f;
+  texopt->scale[1] = 1.0f;
+  texopt->scale[2] = 1.0f;
+  texopt->turbulence[0] = 0.0f;
+  texopt->turbulence[1] = 0.0f;
+  texopt->turbulence[2] = 0.0f;
+  texopt->type = TEXTURE_TYPE_NONE;
+
+  const char *token = linebuf;  // Assume line ends with NULL
+
+  while (!IS_NEW_LINE((*token))) {
+    if ((0 == strncmp(token, "-blendu", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendu = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-blendv", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendv = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-clamp", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->clamp = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-boost", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->sharpness = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-bm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      texopt->bump_multiplier = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-o", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->origin_offset[0]), &(texopt->origin_offset[1]),
+                  &(texopt->origin_offset[2]), &token);
+    } else if ((0 == strncmp(token, "-s", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->scale[0]), &(texopt->scale[1]), &(texopt->scale[2]),
+                  &token, 1.0, 1.0, 1.0);
+    } else if ((0 == strncmp(token, "-t", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->turbulence[0]), &(texopt->turbulence[1]),
+                  &(texopt->turbulence[2]), &token);
+    } else if ((0 == strncmp(token, "-type", 5)) && IS_SPACE((token[5]))) {
+      token += 5;
+      texopt->type = parseTextureType((&token), TEXTURE_TYPE_NONE);
+    } else if ((0 == strncmp(token, "-imfchan", 8)) && IS_SPACE((token[8]))) {
+      token += 9;
+      token += strspn(token, " \t");
+      const char *end = token + strcspn(token, " \t\r");
+      if ((end - token) == 1) {  // Assume one char for -imfchan
+        texopt->imfchan = (*token);
+      }
+      token = end;
+    } else if ((0 == strncmp(token, "-mm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      parseReal2(&(texopt->brightness), &(texopt->contrast), &token, 0.0, 1.0);
+    } else {
+      // Assume texture filename
+      token += strspn(token, " \t");         // skip space
+      size_t len = strcspn(token, " \t\r");  // untile next space
+      texture_name = std::string(token, token + len);
+      token += len;
+
+      token += strspn(token, " \t");  // skip space
+
+      found_texname = true;
+    }
+  }
+
+  if (found_texname) {
+    (*texname) = texture_name;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static void InitMaterial(material_t *material) {
+  material->name = "";
+  material->ambient_texname = "";
+  material->diffuse_texname = "";
+  material->specular_texname = "";
+  material->specular_highlight_texname = "";
+  material->bump_texname = "";
+  material->displacement_texname = "";
+  material->alpha_texname = "";
+  for (int i = 0; i < 3; i++) {
+    material->ambient[i] = 0.f;
+    material->diffuse[i] = 0.f;
+    material->specular[i] = 0.f;
+    material->transmittance[i] = 0.f;
+    material->emission[i] = 0.f;
+  }
+  material->illum = 0;
+  material->dissolve = 1.f;
+  material->shininess = 1.f;
+  material->ior = 1.f;
+
+  material->roughness = 0.f;
+  material->metallic = 0.f;
+  material->sheen = 0.f;
+  material->clearcoat_thickness = 0.f;
+  material->clearcoat_roughness = 0.f;
+  material->anisotropy_rotation = 0.f;
+  material->anisotropy = 0.f;
+  material->roughness_texname = "";
+  material->metallic_texname = "";
+  material->sheen_texname = "";
+  material->emissive_texname = "";
+  material->normal_texname = "";
+
+  material->unknown_parameter.clear();
+}
+
+static bool exportFaceGroupToShape(
+    shape_t *shape, const std::vector<std::vector<vertex_index> > &faceGroup,
+    const std::vector<tag_t> &tags, const int material_id,
+    const std::string &name, bool triangulate) {
+  if (faceGroup.empty()) {
+    return false;
+  }
+
+  // Flatten vertices and indices
+  for (size_t i = 0; i < faceGroup.size(); i++) {
+    const std::vector<vertex_index> &face = faceGroup[i];
+
+    vertex_index i0 = face[0];
+    vertex_index i1(-1);
+    vertex_index i2 = face[1];
+
+    size_t npolys = face.size();
+
+    if (triangulate) {
+      // Polygon -> triangle fan conversion
+      for (size_t k = 2; k < npolys; k++) {
+        i1 = i2;
+        i2 = face[k];
+
+        index_t idx0, idx1, idx2;
+        idx0.vertex_index = i0.v_idx;
+        idx0.normal_index = i0.vn_idx;
+        idx0.texcoord_index = i0.vt_idx;
+        idx1.vertex_index = i1.v_idx;
+        idx1.normal_index = i1.vn_idx;
+        idx1.texcoord_index = i1.vt_idx;
+        idx2.vertex_index = i2.v_idx;
+        idx2.normal_index = i2.vn_idx;
+        idx2.texcoord_index = i2.vt_idx;
+
+        shape->mesh.indices.push_back(idx0);
+        shape->mesh.indices.push_back(idx1);
+        shape->mesh.indices.push_back(idx2);
+
+        shape->mesh.num_face_vertices.push_back(3);
+        shape->mesh.material_ids.push_back(material_id);
+      }
+    } else {
+      for (size_t k = 0; k < npolys; k++) {
+        index_t idx;
+        idx.vertex_index = face[k].v_idx;
+        idx.normal_index = face[k].vn_idx;
+        idx.texcoord_index = face[k].vt_idx;
+        shape->mesh.indices.push_back(idx);
+      }
+
+      shape->mesh.num_face_vertices.push_back(
+          static_cast<unsigned char>(npolys));
+      shape->mesh.material_ids.push_back(material_id);  // per face
+    }
+  }
+
+  shape->name = name;
+  shape->mesh.tags = tags;
+
+  return true;
+}
+
+// Split a string with specified delimiter character.
+// http://stackoverflow.com/questions/236129/split-a-string-in-c
+static void SplitString(const std::string &s, char delim,
+                        std::vector<std::string> &elems) {
+  std::stringstream ss;
+  ss.str(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    elems.push_back(item);
+  }
+}
+
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning) {
+  // Create a default material anyway.
+  material_t material;
+  InitMaterial(&material);
+
+  // Issue 43. `d` wins against `Tr` since `Tr` is not in the MTL specification.
+  bool has_d = false;
+  bool has_tr = false;
+
+  std::stringstream ss;
+
+  std::string linebuf;
+  while (inStream->peek() != -1) {
+    safeGetline(*inStream, linebuf);
+
+    // Trim trailing whitespace.
+    if (linebuf.size() > 0) {
+      linebuf = linebuf.substr(0, linebuf.find_last_not_of(" \t") + 1);
+    }
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // new mtl
+    if ((0 == strncmp(token, "newmtl", 6)) && IS_SPACE((token[6]))) {
+      // flush previous material.
+      if (!material.name.empty()) {
+        material_map->insert(std::pair<std::string, int>(
+            material.name, static_cast<int>(materials->size())));
+        materials->push_back(material);
+      }
+
+      // initial temporary material
+      InitMaterial(&material);
+
+      has_d = false;
+      has_tr = false;
+
+      // set new mtl name
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
+      token += 7;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+      material.name = namebuf;
+      continue;
+    }
+
+    // ambient
+    if (token[0] == 'K' && token[1] == 'a' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.ambient[0] = r;
+      material.ambient[1] = g;
+      material.ambient[2] = b;
+      continue;
+    }
+
+    // diffuse
+    if (token[0] == 'K' && token[1] == 'd' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.diffuse[0] = r;
+      material.diffuse[1] = g;
+      material.diffuse[2] = b;
+      continue;
+    }
+
+    // specular
+    if (token[0] == 'K' && token[1] == 's' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.specular[0] = r;
+      material.specular[1] = g;
+      material.specular[2] = b;
+      continue;
+    }
+
+    // transmittance
+    if ((token[0] == 'K' && token[1] == 't' && IS_SPACE((token[2]))) ||
+        (token[0] == 'T' && token[1] == 'f' && IS_SPACE((token[2])))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.transmittance[0] = r;
+      material.transmittance[1] = g;
+      material.transmittance[2] = b;
+      continue;
+    }
+
+    // ior(index of refraction)
+    if (token[0] == 'N' && token[1] == 'i' && IS_SPACE((token[2]))) {
+      token += 2;
+      material.ior = parseReal(&token);
+      continue;
+    }
+
+    // emission
+    if (token[0] == 'K' && token[1] == 'e' && IS_SPACE(token[2])) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.emission[0] = r;
+      material.emission[1] = g;
+      material.emission[2] = b;
+      continue;
+    }
+
+    // shininess
+    if (token[0] == 'N' && token[1] == 's' && IS_SPACE(token[2])) {
+      token += 2;
+      material.shininess = parseReal(&token);
+      continue;
+    }
+
+    // illum model
+    if (0 == strncmp(token, "illum", 5) && IS_SPACE(token[5])) {
+      token += 6;
+      material.illum = parseInt(&token);
+      continue;
+    }
+
+    // dissolve
+    if ((token[0] == 'd' && IS_SPACE(token[1]))) {
+      token += 1;
+      material.dissolve = parseReal(&token);
+
+      if (has_tr) {
+        ss << "WARN: Both `d` and `Tr` parameters defined for \""
+           << material.name << "\". Use the value of `d` for dissolve."
+           << std::endl;
+      }
+      has_d = true;
+      continue;
+    }
+    if (token[0] == 'T' && token[1] == 'r' && IS_SPACE(token[2])) {
+      token += 2;
+      if (has_d) {
+        // `d` wins. Ignore `Tr` value.
+        ss << "WARN: Both `d` and `Tr` parameters defined for \""
+           << material.name << "\". Use the value of `d` for dissolve."
+           << std::endl;
+      } else {
+        // We invert value of Tr(assume Tr is in range [0, 1])
+        // NOTE: Interpretation of Tr is application(exporter) dependent. For
+        // some application(e.g. 3ds max obj exporter), Tr = d(Issue 43)
+        material.dissolve = 1.0f - parseReal(&token);
+      }
+      has_tr = true;
+      continue;
+    }
+
+    // PBR: roughness
+    if (token[0] == 'P' && token[1] == 'r' && IS_SPACE(token[2])) {
+      token += 2;
+      material.roughness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: metallic
+    if (token[0] == 'P' && token[1] == 'm' && IS_SPACE(token[2])) {
+      token += 2;
+      material.metallic = parseReal(&token);
+      continue;
+    }
+
+    // PBR: sheen
+    if (token[0] == 'P' && token[1] == 's' && IS_SPACE(token[2])) {
+      token += 2;
+      material.sheen = parseReal(&token);
+      continue;
+    }
+
+    // PBR: clearcoat thickness
+    if (token[0] == 'P' && token[1] == 'c' && IS_SPACE(token[2])) {
+      token += 2;
+      material.clearcoat_thickness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: clearcoat roughness
+    if ((0 == strncmp(token, "Pcr", 3)) && IS_SPACE(token[3])) {
+      token += 4;
+      material.clearcoat_roughness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: anisotropy
+    if ((0 == strncmp(token, "aniso", 5)) && IS_SPACE(token[5])) {
+      token += 6;
+      material.anisotropy = parseReal(&token);
+      continue;
+    }
+
+    // PBR: anisotropy rotation
+    if ((0 == strncmp(token, "anisor", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      material.anisotropy_rotation = parseReal(&token);
+      continue;
+    }
+
+    // ambient texture
+    if ((0 == strncmp(token, "map_Ka", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.ambient_texname),
+                                &(material.ambient_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // diffuse texture
+    if ((0 == strncmp(token, "map_Kd", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.diffuse_texname),
+                                &(material.diffuse_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // specular texture
+    if ((0 == strncmp(token, "map_Ks", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.specular_texname),
+                                &(material.specular_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // specular highlight texture
+    if ((0 == strncmp(token, "map_Ns", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.specular_highlight_texname),
+                                &(material.specular_highlight_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // bump texture
+    if ((0 == strncmp(token, "map_bump", 8)) && IS_SPACE(token[8])) {
+      token += 9;
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), token,
+                                /* is_bump */ true);
+      continue;
+    }
+
+    // bump texture
+    if ((0 == strncmp(token, "bump", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), token,
+                                /* is_bump */ true);
+      continue;
+    }
+
+    // alpha texture
+    if ((0 == strncmp(token, "map_d", 5)) && IS_SPACE(token[5])) {
+      token += 6;
+      material.alpha_texname = token;
+      ParseTextureNameAndOption(&(material.alpha_texname),
+                                &(material.alpha_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // displacement texture
+    if ((0 == strncmp(token, "disp", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // PBR: roughness texture
+    if ((0 == strncmp(token, "map_Pr", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.roughness_texname),
+                                &(material.roughness_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // PBR: metallic texture
+    if ((0 == strncmp(token, "map_Pm", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.metallic_texname),
+                                &(material.metallic_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // PBR: sheen texture
+    if ((0 == strncmp(token, "map_Ps", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.sheen_texname),
+                                &(material.sheen_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // PBR: emissive texture
+    if ((0 == strncmp(token, "map_Ke", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.emissive_texname),
+                                &(material.emissive_texopt), token,
+                                /* is_bump */ false);
+      continue;
+    }
+
+    // PBR: normal map texture
+    if ((0 == strncmp(token, "norm", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(
+          &(material.normal_texname), &(material.normal_texopt), token,
+          /* is_bump */ false);  // @fixme { is_bump will be true? }
+      continue;
+    }
+
+    // unknown parameter
+    const char *_space = strchr(token, ' ');
+    if (!_space) {
+      _space = strchr(token, '\t');
+    }
+    if (_space) {
+      std::ptrdiff_t len = _space - token;
+      std::string key(token, static_cast<size_t>(len));
+      std::string value = _space + 1;
+      material.unknown_parameter.insert(
+          std::pair<std::string, std::string>(key, value));
+    }
+  }
+  // flush last material.
+  material_map->insert(std::pair<std::string, int>(
+      material.name, static_cast<int>(materials->size())));
+  materials->push_back(material);
+
+  if (warning) {
+    (*warning) = ss.str();
+  }
+}
+
+bool MaterialFileReader::operator()(const std::string &matId,
+                                    std::vector<material_t> *materials,
+                                    std::map<std::string, int> *matMap,
+                                    std::string *err) {
+  std::string filepath;
+
+  if (!m_mtlBaseDir.empty()) {
+    filepath = std::string(m_mtlBaseDir) + matId;
+  } else {
+    filepath = matId;
+  }
+
+  std::ifstream matIStream(filepath.c_str());
+  if (!matIStream) {
+    std::stringstream ss;
+    ss << "WARN: Material file [ " << filepath << " ] not found." << std::endl;
+    if (err) {
+      (*err) += ss.str();
+    }
+    return false;
+  }
+
+  std::string warning;
+  LoadMtl(matMap, materials, &matIStream, &warning);
+
+  if (!warning.empty()) {
+    if (err) {
+      (*err) += warning;
+    }
+  }
+
+  return true;
+}
+
+bool MaterialStreamReader::operator()(const std::string &matId,
+                                      std::vector<material_t> *materials,
+                                      std::map<std::string, int> *matMap,
+                                      std::string *err) {
+  (void)matId;
+  if (!m_inStream) {
+    std::stringstream ss;
+    ss << "WARN: Material stream in error state. " << std::endl;
+    if (err) {
+      (*err) += ss.str();
+    }
+    return false;
+  }
+
+  std::string warning;
+  LoadMtl(matMap, materials, &m_inStream, &warning);
+
+  if (!warning.empty()) {
+    if (err) {
+      (*err) += warning;
+    }
+  }
+
+  return true;
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *err,
+             const char *filename, const char *mtl_basedir, bool trianglulate) {
+  attrib->vertices.clear();
+  attrib->normals.clear();
+  attrib->texcoords.clear();
+  shapes->clear();
+
+  std::stringstream errss;
+
+  std::ifstream ifs(filename);
+  if (!ifs) {
+    errss << "Cannot open file [" << filename << "]" << std::endl;
+    if (err) {
+      (*err) = errss.str();
+    }
+    return false;
+  }
+
+  std::string baseDir;
+  if (mtl_basedir) {
+    baseDir = mtl_basedir;
+  }
+  MaterialFileReader matFileReader(baseDir);
+
+  return LoadObj(attrib, shapes, materials, err, &ifs, &matFileReader,
+                 trianglulate);
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *err,
+             std::istream *inStream, MaterialReader *readMatFn /*= NULL*/,
+             bool triangulate) {
+  std::stringstream errss;
+
+  std::vector<real_t> v;
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+  std::vector<tag_t> tags;
+  std::vector<std::vector<vertex_index> > faceGroup;
+  std::string name;
+
+  // material
+  std::map<std::string, int> material_map;
+  int material = -1;
+
+  shape_t shape;
+
+  std::string linebuf;
+  while (inStream->peek() != -1) {
+    safeGetline(*inStream, linebuf);
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // vertex
+    if (token[0] == 'v' && IS_SPACE((token[1]))) {
+      token += 2;
+      real_t x, y, z;
+      parseReal3(&x, &y, &z, &token);
+      v.push_back(x);
+      v.push_back(y);
+      v.push_back(z);
+      continue;
+    }
+
+    // normal
+    if (token[0] == 'v' && token[1] == 'n' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;
+      parseReal3(&x, &y, &z, &token);
+      vn.push_back(x);
+      vn.push_back(y);
+      vn.push_back(z);
+      continue;
+    }
+
+    // texcoord
+    if (token[0] == 'v' && token[1] == 't' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y;
+      parseReal2(&x, &y, &token);
+      vt.push_back(x);
+      vt.push_back(y);
+      continue;
+    }
+
+    // face
+    if (token[0] == 'f' && IS_SPACE((token[1]))) {
+      token += 2;
+      token += strspn(token, " \t");
+
+      std::vector<vertex_index> face;
+      face.reserve(3);
+
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index vi = parseTriple(&token, static_cast<int>(v.size() / 3),
+                                      static_cast<int>(vn.size() / 3),
+                                      static_cast<int>(vt.size() / 2));
+        face.push_back(vi);
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      // replace with emplace_back + std::move on C++11
+      faceGroup.push_back(std::vector<vertex_index>());
+      faceGroup[faceGroup.size() - 1].swap(face);
+
+      continue;
+    }
+
+    // use mtl
+    if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
+      token += 7;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+
+      int newMaterialId = -1;
+      if (material_map.find(namebuf) != material_map.end()) {
+        newMaterialId = material_map[namebuf];
+      } else {
+        // { error!! material not found }
+      }
+
+      if (newMaterialId != material) {
+        // Create per-face material. Thus we don't add `shape` to `shapes` at
+        // this time.
+        // just clear `faceGroup` after `exportFaceGroupToShape()` call.
+        exportFaceGroupToShape(&shape, faceGroup, tags, material, name,
+                               triangulate);
+        faceGroup.clear();
+        material = newMaterialId;
+      }
+
+      continue;
+    }
+
+    // load mtl
+    if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {
+      if (readMatFn) {
+        token += 7;
+
+        std::vector<std::string> filenames;
+        SplitString(std::string(token), ' ', filenames);
+
+        if (filenames.empty()) {
+          if (err) {
+            (*err) +=
+                "WARN: Looks like empty filename for mtllib. Use default "
+                "material. \n";
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), materials,
+                                   &material_map, &err_mtl);
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;  // This should be warn message.
+            }
+
+            if (ok) {
+              found = true;
+              break;
+            }
+          }
+
+          if (!found) {
+            if (err) {
+              (*err) +=
+                  "WARN: Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          }
+        }
+      }
+
+      continue;
+    }
+
+    // group name
+    if (token[0] == 'g' && IS_SPACE((token[1]))) {
+      // flush previous face group.
+      bool ret = exportFaceGroupToShape(&shape, faceGroup, tags, material, name,
+                                        triangulate);
+      if (ret) {
+        shapes->push_back(shape);
+      }
+
+      shape = shape_t();
+
+      // material = -1;
+      faceGroup.clear();
+
+      std::vector<std::string> names;
+      names.reserve(2);
+
+      while (!IS_NEW_LINE(token[0])) {
+        std::string str = parseString(&token);
+        names.push_back(str);
+        token += strspn(token, " \t\r");  // skip tag
+      }
+
+      assert(names.size() > 0);
+
+      // names[0] must be 'g', so skip the 0th element.
+      if (names.size() > 1) {
+        name = names[1];
+      } else {
+        name = "";
+      }
+
+      continue;
+    }
+
+    // object name
+    if (token[0] == 'o' && IS_SPACE((token[1]))) {
+      // flush previous face group.
+      bool ret = exportFaceGroupToShape(&shape, faceGroup, tags, material, name,
+                                        triangulate);
+      if (ret) {
+        shapes->push_back(shape);
+      }
+
+      // material = -1;
+      faceGroup.clear();
+      shape = shape_t();
+
+      // @todo { multiple object name? }
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
+      token += 2;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+      name = std::string(namebuf);
+
+      continue;
+    }
+
+    if (token[0] == 't' && IS_SPACE(token[1])) {
+      tag_t tag;
+
+      char namebuf[4096];
+      token += 2;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+      tag.name = std::string(namebuf);
+
+      token += tag.name.size() + 1;
+
+      tag_sizes ts = parseTagTriple(&token);
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = atoi(token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = parseReal(&token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        char stringValueBuffer[4096];
+
+#ifdef _MSC_VER
+        sscanf_s(token, "%s", stringValueBuffer,
+                 (unsigned)_countof(stringValueBuffer));
+#else
+        std::sscanf(token, "%s", stringValueBuffer);
+#endif
+        tag.stringValues[i] = stringValueBuffer;
+        token += tag.stringValues[i].size() + 1;
+      }
+
+      tags.push_back(tag);
+    }
+
+    // Ignore unknown command.
+  }
+
+  bool ret = exportFaceGroupToShape(&shape, faceGroup, tags, material, name,
+                                    triangulate);
+  // exportFaceGroupToShape return false when `usemtl` is called in the last
+  // line.
+  // we also add `shape` to `shapes` when `shape.mesh` has already some
+  // faces(indices)
+  if (ret || shape.mesh.indices.size()) {
+    shapes->push_back(shape);
+  }
+  faceGroup.clear();  // for safety
+
+  if (err) {
+    (*err) += errss.str();
+  }
+
+  attrib->vertices.swap(v);
+  attrib->normals.swap(vn);
+  attrib->texcoords.swap(vt);
+
+  return true;
+}
+
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data /*= NULL*/,
+                         MaterialReader *readMatFn /*= NULL*/,
+                         std::string *err /*= NULL*/) {
+  std::stringstream errss;
+
+  // material
+  std::map<std::string, int> material_map;
+  int material_id = -1;  // -1 = invalid
+
+  std::vector<index_t> indices;
+  std::vector<material_t> materials;
+  std::vector<std::string> names;
+  names.reserve(2);
+  std::string name;
+  std::vector<const char *> names_out;
+
+  std::string linebuf;
+  while (inStream.peek() != -1) {
+    safeGetline(inStream, linebuf);
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // vertex
+    if (token[0] == 'v' && IS_SPACE((token[1]))) {
+      token += 2;
+      real_t x, y, z, w;  // w is optional. default = 1.0
+      parseV(&x, &y, &z, &w, &token);
+      if (callback.vertex_cb) {
+        callback.vertex_cb(user_data, x, y, z, w);
+      }
+      continue;
+    }
+
+    // normal
+    if (token[0] == 'v' && token[1] == 'n' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;
+      parseReal3(&x, &y, &z, &token);
+      if (callback.normal_cb) {
+        callback.normal_cb(user_data, x, y, z);
+      }
+      continue;
+    }
+
+    // texcoord
+    if (token[0] == 'v' && token[1] == 't' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;  // y and z are optional. default = 0.0
+      parseReal3(&x, &y, &z, &token);
+      if (callback.texcoord_cb) {
+        callback.texcoord_cb(user_data, x, y, z);
+      }
+      continue;
+    }
+
+    // face
+    if (token[0] == 'f' && IS_SPACE((token[1]))) {
+      token += 2;
+      token += strspn(token, " \t");
+
+      indices.clear();
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index vi = parseRawTriple(&token);
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        indices.push_back(idx);
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      if (callback.index_cb && indices.size() > 0) {
+        callback.index_cb(user_data, &indices.at(0),
+                          static_cast<int>(indices.size()));
+      }
+
+      continue;
+    }
+
+    // use mtl
+    if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
+      token += 7;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf,
+               static_cast<unsigned int>(_countof(namebuf)));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+
+      int newMaterialId = -1;
+      if (material_map.find(namebuf) != material_map.end()) {
+        newMaterialId = material_map[namebuf];
+      } else {
+        // { error!! material not found }
+      }
+
+      if (newMaterialId != material_id) {
+        material_id = newMaterialId;
+      }
+
+      if (callback.usemtl_cb) {
+        callback.usemtl_cb(user_data, namebuf, material_id);
+      }
+
+      continue;
+    }
+
+    // load mtl
+    if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {
+      if (readMatFn) {
+        token += 7;
+
+        std::vector<std::string> filenames;
+        SplitString(std::string(token), ' ', filenames);
+
+        if (filenames.empty()) {
+          if (err) {
+            (*err) +=
+                "WARN: Looks like empty filename for mtllib. Use default "
+                "material. \n";
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), &materials,
+                                   &material_map, &err_mtl);
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;  // This should be warn message.
+            }
+
+            if (ok) {
+              found = true;
+              break;
+            }
+          }
+
+          if (!found) {
+            if (err) {
+              (*err) +=
+                  "WARN: Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          } else {
+            if (callback.mtllib_cb) {
+              callback.mtllib_cb(user_data, &materials.at(0),
+                                 static_cast<int>(materials.size()));
+            }
+          }
+        }
+      }
+
+      continue;
+    }
+
+    // group name
+    if (token[0] == 'g' && IS_SPACE((token[1]))) {
+      names.clear();
+
+      while (!IS_NEW_LINE(token[0])) {
+        std::string str = parseString(&token);
+        names.push_back(str);
+        token += strspn(token, " \t\r");  // skip tag
+      }
+
+      assert(names.size() > 0);
+
+      // names[0] must be 'g', so skip the 0th element.
+      if (names.size() > 1) {
+        name = names[1];
+      } else {
+        name.clear();
+      }
+
+      if (callback.group_cb) {
+        if (names.size() > 1) {
+          // create const char* array.
+          names_out.resize(names.size() - 1);
+          for (size_t j = 0; j < names_out.size(); j++) {
+            names_out[j] = names[j + 1].c_str();
+          }
+          callback.group_cb(user_data, &names_out.at(0),
+                            static_cast<int>(names_out.size()));
+
+        } else {
+          callback.group_cb(user_data, NULL, 0);
+        }
+      }
+
+      continue;
+    }
+
+    // object name
+    if (token[0] == 'o' && IS_SPACE((token[1]))) {
+      // @todo { multiple object name? }
+      char namebuf[TINYOBJ_SSCANF_BUFFER_SIZE];
+      token += 2;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+      std::string object_name = std::string(namebuf);
+
+      if (callback.object_cb) {
+        callback.object_cb(user_data, object_name.c_str());
+      }
+
+      continue;
+    }
+
+#if 0  // @todo
+    if (token[0] == 't' && IS_SPACE(token[1])) {
+      tag_t tag;
+
+      char namebuf[4096];
+      token += 2;
+#ifdef _MSC_VER
+      sscanf_s(token, "%s", namebuf, (unsigned)_countof(namebuf));
+#else
+      std::sscanf(token, "%s", namebuf);
+#endif
+      tag.name = std::string(namebuf);
+
+      token += tag.name.size() + 1;
+
+      tag_sizes ts = parseTagTriple(&token);
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = atoi(token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = parseReal(&token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        char stringValueBuffer[4096];
+
+#ifdef _MSC_VER
+        sscanf_s(token, "%s", stringValueBuffer,
+                 (unsigned)_countof(stringValueBuffer));
+#else
+        std::sscanf(token, "%s", stringValueBuffer);
+#endif
+        tag.stringValues[i] = stringValueBuffer;
+        token += tag.stringValues[i].size() + 1;
+      }
+
+      tags.push_back(tag);
+    }
+#endif
+
+    // Ignore unknown command.
+  }
+
+  if (err) {
+    (*err) += errss.str();
+  }
+
+  return true;
+}
+}  // namespace tinyobj
+
+#endif

--- a/ext/sightmesh/wavefront.cpp
+++ b/ext/sightmesh/wavefront.cpp
@@ -1,0 +1,814 @@
+#ifndef __PPCGEKKO__
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+
+#include "wavefront.h"
+
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#endif
+
+#pragma warning(disable : 4996)
+
+typedef std::vector<int>   IntVector;
+typedef std::vector<float> FloatVector;
+
+namespace WAVEFRONT
+{
+    /*******************************************************************/
+    /******************** InParser.h  ********************************/
+    /*******************************************************************/
+    class InPlaceParserInterface
+    {
+    public:
+        virtual int ParseLine(int lineno, int argc, const char** argv) = 0; // return TRUE to continue parsing, return FALSE to abort parsing process
+    };
+
+    enum SeparatorType
+    {
+        ST_DATA, // is data
+        ST_HARD, // is a hard separator
+        ST_SOFT, // is a soft separator
+        ST_EOS   // is a comment symbol, and everything past this character should be ignored
+    };
+
+    class InPlaceParser
+    {
+    public:
+        InPlaceParser(void)
+        {
+            Init();
+        }
+
+        InPlaceParser(char* data, int len)
+        {
+            Init();
+            SetSourceData(data, len);
+        }
+
+        InPlaceParser(const char* fname)
+        {
+            Init();
+            SetFile(fname);
+        }
+
+        ~InPlaceParser(void);
+
+        void Init(void)
+        {
+            mQuoteChar = 34;
+            mData      = 0;
+            mLen       = 0;
+            mMyAlloc   = false;
+            for (int i = 0; i < 256; i++)
+            {
+                mHard[i]               = ST_DATA;
+                mHardString[i * 2]     = (char)i;
+                mHardString[i * 2 + 1] = 0;
+            }
+            mHard[0]  = ST_EOS;
+            mHard[32] = ST_SOFT;
+            mHard[9]  = ST_SOFT;
+            mHard[13] = ST_SOFT;
+            mHard[10] = ST_SOFT;
+        }
+
+        void SetFile(const char* fname); // use this file as source data to parse.
+
+        void SetSourceData(char* data, int len)
+        {
+            mData    = data;
+            mLen     = len;
+            mMyAlloc = false;
+        };
+
+        int Parse(InPlaceParserInterface* callback); // returns true if entire file was parsed, false if it aborted for some reason
+
+        int ProcessLine(int lineno, char* line, InPlaceParserInterface* callback);
+
+        const char** GetArglist(char* source, int& count); // convert source string into an arg list, this is a destructive parse.
+
+        void SetHardSeparator(char c) // add a hard separator
+        {
+            mHard[c] = ST_HARD;
+        }
+
+        void SetHard(char c) // add a hard separator
+        {
+            mHard[c] = ST_HARD;
+        }
+
+        void SetCommentSymbol(char c) // comment character, treated as 'end of string'
+        {
+            mHard[c] = ST_EOS;
+        }
+
+        void ClearHardSeparator(char c)
+        {
+            mHard[c] = ST_DATA;
+        }
+
+        void DefaultSymbols(void); // set up default symbols for hard seperator and comment symbol of the '#' character.
+
+        bool EOS(char c)
+        {
+            if (mHard[c] == ST_EOS)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        void SetQuoteChar(char c)
+        {
+            mQuoteChar = c;
+        }
+
+    private:
+        inline char* AddHard(int& argc, const char** argv, char* foo);
+        inline bool  IsHard(char c);
+        inline char* SkipSpaces(char* foo);
+        inline bool  IsWhiteSpace(char c);
+        inline bool  IsNonSeparator(char c); // non seperator,neither hard nor soft
+
+        bool          mMyAlloc; // whether or not *I* allocated the buffer and am responsible for deleting it.
+        char*         mData;    // ascii data to parse.
+        int           mLen;     // length of data
+        SeparatorType mHard[256];
+        char          mHardString[256 * 2];
+        char          mQuoteChar;
+    };
+
+    /*******************************************************************/
+    /******************** InParser.cpp  ********************************/
+    /*******************************************************************/
+    void InPlaceParser::SetFile(const char* fname)
+    {
+        if (mMyAlloc)
+        {
+            free(mData);
+        }
+        mData    = 0;
+        mLen     = 0;
+        mMyAlloc = false;
+
+        FILE* fph = fopen(fname, "rb");
+        if (fph)
+        {
+            fseek(fph, 0L, SEEK_END);
+            mLen = ftell(fph);
+            fseek(fph, 0L, SEEK_SET);
+            if (mLen)
+            {
+                mData     = (char*)malloc(sizeof(char) * (mLen + 1));
+                size_t ok = fread(mData, mLen, 1, fph);
+                if (!ok)
+                {
+                    free(mData);
+                    mData = 0;
+                }
+                else
+                {
+                    mData[mLen] = 0; // zero byte terminate end of file marker.
+                    mMyAlloc    = true;
+                }
+            }
+            fclose(fph);
+        }
+    }
+
+    InPlaceParser::~InPlaceParser(void)
+    {
+        if (mMyAlloc)
+        {
+            free(mData);
+        }
+    }
+
+#define MAXARGS 512
+
+    bool InPlaceParser::IsHard(char c)
+    {
+        return mHard[c] == ST_HARD;
+    }
+
+    char* InPlaceParser::AddHard(int& argc, const char** argv, char* foo)
+    {
+        while (IsHard(*foo))
+        {
+            const char* hard = &mHardString[*foo * 2];
+            if (argc < MAXARGS)
+            {
+                argv[argc++] = hard;
+            }
+            foo++;
+        }
+        return foo;
+    }
+
+    bool InPlaceParser::IsWhiteSpace(char c)
+    {
+        return mHard[c] == ST_SOFT;
+    }
+
+    char* InPlaceParser::SkipSpaces(char* foo)
+    {
+        while (!EOS(*foo) && IsWhiteSpace(*foo))
+            foo++;
+        return foo;
+    }
+
+    bool InPlaceParser::IsNonSeparator(char c)
+    {
+        if (!IsHard(c) && !IsWhiteSpace(c) && c != 0)
+            return true;
+        return false;
+    }
+
+    int InPlaceParser::ProcessLine(int lineno, char* line, InPlaceParserInterface* callback)
+    {
+        int ret = 0;
+
+        const char* argv[MAXARGS];
+        int         argc = 0;
+
+        char* foo = line;
+
+        while (!EOS(*foo) && argc < MAXARGS)
+        {
+            foo = SkipSpaces(foo); // skip any leading spaces
+
+            if (EOS(*foo))
+                break;
+
+            if (*foo == mQuoteChar) // if it is an open quote
+            {
+                foo++;
+                if (argc < MAXARGS)
+                {
+                    argv[argc++] = foo;
+                }
+                while (!EOS(*foo) && *foo != mQuoteChar)
+                    foo++;
+                if (!EOS(*foo))
+                {
+                    *foo = 0; // replace close quote with zero byte EOS
+                    foo++;
+                }
+            }
+            else
+            {
+                foo = AddHard(argc, argv, foo); // add any hard separators, skip any spaces
+
+                if (IsNonSeparator(*foo)) // add non-hard argument.
+                {
+                    bool quote = false;
+                    if (*foo == mQuoteChar)
+                    {
+                        foo++;
+                        quote = true;
+                    }
+
+                    if (argc < MAXARGS)
+                    {
+                        argv[argc++] = foo;
+                    }
+
+                    if (quote)
+                    {
+                        while (*foo && *foo != mQuoteChar)
+                            foo++;
+                        if (*foo)
+                            *foo = 32;
+                    }
+
+                    // continue..until we hit an eos ..
+                    while (!EOS(*foo)) // until we hit EOS
+                    {
+                        if (IsWhiteSpace(*foo)) // if we hit a space, stomp a zero byte, and exit
+                        {
+                            *foo = 0;
+                            foo++;
+                            break;
+                        }
+                        else if (IsHard(*foo)) // if we hit a hard separator, stomp a zero byte and store the hard separator argument
+                        {
+                            const char* hard = &mHardString[*foo * 2];
+                            *foo             = 0;
+                            if (argc < MAXARGS)
+                            {
+                                argv[argc++] = hard;
+                            }
+                            foo++;
+                            break;
+                        }
+                        foo++;
+                    } // end of while loop...
+                }
+            }
+        }
+
+        if (argc)
+        {
+            ret = callback->ParseLine(lineno, argc, argv);
+        }
+
+        return ret;
+    }
+
+    int InPlaceParser::Parse(InPlaceParserInterface* callback) // returns true if entire file was parsed, false if it aborted for some reason
+    {
+        assert(callback);
+        if (!mData)
+            return 0;
+
+        int ret = 0;
+
+        int lineno = 0;
+
+        char* foo   = mData;
+        char* begin = foo;
+
+        while (*foo)
+        {
+            if (*foo == 10 || *foo == 13)
+            {
+                lineno++;
+                *foo = 0;
+
+                if (*begin) // if there is any data to parse at all...
+                {
+                    int v = ProcessLine(lineno, begin, callback);
+                    if (v)
+                        ret = v;
+                }
+
+                foo++;
+                if (*foo == 10)
+                    foo++; // skip line feed, if it is in the carraige-return line-feed format...
+                begin = foo;
+            }
+            else
+            {
+                foo++;
+            }
+        }
+
+        lineno++; // lasst line.
+
+        int v = ProcessLine(lineno, begin, callback);
+        if (v)
+            ret = v;
+        return ret;
+    }
+
+    void InPlaceParser::DefaultSymbols(void)
+    {
+        SetHardSeparator(',');
+        SetHardSeparator('(');
+        SetHardSeparator(')');
+        SetHardSeparator('=');
+        SetHardSeparator('[');
+        SetHardSeparator(']');
+        SetHardSeparator('{');
+        SetHardSeparator('}');
+        SetCommentSymbol('#');
+    }
+
+    const char** InPlaceParser::GetArglist(char* line, int& count) // convert source string into an arg list, this is a destructive parse.
+    {
+        const char** ret = 0;
+
+        static const char* argv[MAXARGS];
+        int                argc = 0;
+
+        char* foo = line;
+
+        while (!EOS(*foo) && argc < MAXARGS)
+        {
+            foo = SkipSpaces(foo); // skip any leading spaces
+
+            if (EOS(*foo))
+                break;
+
+            if (*foo == mQuoteChar) // if it is an open quote
+            {
+                foo++;
+                if (argc < MAXARGS)
+                {
+                    argv[argc++] = foo;
+                }
+                while (!EOS(*foo) && *foo != mQuoteChar)
+                    foo++;
+                if (!EOS(*foo))
+                {
+                    *foo = 0; // replace close quote with zero byte EOS
+                    foo++;
+                }
+            }
+            else
+            {
+                foo = AddHard(argc, argv, foo); // add any hard separators, skip any spaces
+
+                if (IsNonSeparator(*foo)) // add non-hard argument.
+                {
+                    bool quote = false;
+                    if (*foo == mQuoteChar)
+                    {
+                        foo++;
+                        quote = true;
+                    }
+
+                    if (argc < MAXARGS)
+                    {
+                        argv[argc++] = foo;
+                    }
+
+                    if (quote)
+                    {
+                        while (*foo && *foo != mQuoteChar)
+                            foo++;
+                        if (*foo)
+                            *foo = 32;
+                    }
+
+                    // continue..until we hit an eos ..
+                    while (!EOS(*foo)) // until we hit EOS
+                    {
+                        if (IsWhiteSpace(*foo)) // if we hit a space, stomp a zero byte, and exit
+                        {
+                            *foo = 0;
+                            foo++;
+                            break;
+                        }
+                        else if (IsHard(*foo)) // if we hit a hard separator, stomp a zero byte and store the hard separator argument
+                        {
+                            const char* hard = &mHardString[*foo * 2];
+                            *foo             = 0;
+                            if (argc < MAXARGS)
+                            {
+                                argv[argc++] = hard;
+                            }
+                            foo++;
+                            break;
+                        }
+                        foo++;
+                    } // end of while loop...
+                }
+            }
+        }
+
+        count = argc;
+        if (argc)
+        {
+            ret = argv;
+        }
+
+        return ret;
+    }
+
+    /*******************************************************************/
+    /******************** Geometry.h  ********************************/
+    /*******************************************************************/
+
+    class GeometryVertex
+    {
+    public:
+        float mPos[3];
+        float mNormal[3];
+        float mTexel[2];
+    };
+
+    class GeometryInterface
+    {
+    public:
+        virtual void NodeTriangle(const GeometryVertex* /*v1*/, const GeometryVertex* /*v2*/, const GeometryVertex* /*v3*/, bool /*textured*/)
+        {
+        }
+    };
+
+    /*******************************************************************/
+    /******************** Obj.h  ********************************/
+    /*******************************************************************/
+
+    class OBJ : public InPlaceParserInterface
+    {
+    public:
+        int LoadMesh(const char* fname, GeometryInterface* callback, bool textured);
+        int ParseLine(int lineno, int argc, const char** argv); // return TRUE to continue parsing, return FALSE to abort parsing process
+    private:
+        void GetVertex(GeometryVertex& v, const char* face) const;
+
+        FloatVector mVerts;
+        FloatVector mTexels;
+        FloatVector mNormals;
+
+        bool mTextured;
+
+        GeometryInterface* mCallback;
+    };
+
+    /*******************************************************************/
+    /******************** Obj.cpp  ********************************/
+    /*******************************************************************/
+
+    int OBJ::LoadMesh(const char* fname, GeometryInterface* iface, bool textured)
+    {
+        mTextured = textured;
+        int ret   = 0;
+
+        mVerts.clear();
+        mTexels.clear();
+        mNormals.clear();
+
+        mCallback = iface;
+
+        InPlaceParser ipp(fname);
+
+        ipp.Parse(this);
+
+        return ret;
+    }
+
+    /***
+static const char * GetArg(const char **argv,int i,int argc)
+{
+  const char * ret = 0;
+  if ( i < argc ) ret = argv[i];
+  return ret;
+}
+****/
+
+    void OBJ::GetVertex(GeometryVertex& v, const char* face) const
+    {
+        v.mPos[0] = 0;
+        v.mPos[1] = 0;
+        v.mPos[2] = 0;
+
+        v.mTexel[0] = 0;
+        v.mTexel[1] = 0;
+
+        v.mNormal[0] = 0;
+        v.mNormal[1] = 1;
+        v.mNormal[2] = 0;
+
+        int index = atoi(face) - 1;
+
+        const char* texel = strstr(face, "/");
+
+        if (texel)
+        {
+            int tindex = atoi(texel + 1) - 1;
+
+            if (tindex >= 0 && tindex < (int)(mTexels.size() / 2))
+            {
+                const float* t = &mTexels[tindex * 2];
+
+                v.mTexel[0] = t[0];
+                v.mTexel[1] = t[1];
+            }
+
+            const char* normal = strstr(texel + 1, "/");
+            if (normal)
+            {
+                int nindex = atoi(normal + 1) - 1;
+
+                if (nindex >= 0 && nindex < (int)(mNormals.size() / 3))
+                {
+                    const float* n = &mNormals[nindex * 3];
+
+                    v.mNormal[0] = n[0];
+                    v.mNormal[1] = n[1];
+                    v.mNormal[2] = n[2];
+                }
+            }
+        }
+
+        if (index >= 0 && index < (int)(mVerts.size() / 3))
+        {
+            const float* p = &mVerts[index * 3];
+
+            v.mPos[0] = p[0];
+            v.mPos[1] = p[1];
+            v.mPos[2] = p[2];
+        }
+    }
+
+    int OBJ::ParseLine(int /*lineno*/, int argc, const char** argv) // return TRUE to continue parsing, return FALSE to abort parsing process
+    {
+        int ret = 0;
+
+        if (argc >= 1)
+        {
+            const char* foo = argv[0];
+            if (*foo != '#')
+            {
+                if (strcasecmp(argv[0], "v") == 0 && argc == 4)
+                {
+                    float vx = (float)atof(argv[1]);
+                    float vy = (float)atof(argv[2]);
+                    float vz = (float)atof(argv[3]);
+                    mVerts.push_back(vx);
+                    mVerts.push_back(vy);
+                    mVerts.push_back(vz);
+                }
+                else if (strcasecmp(argv[0], "vt") == 0 && (argc == 3 || argc == 4))
+                {
+                    // ignore 4rd component if present
+                    float tx = (float)atof(argv[1]);
+                    float ty = (float)atof(argv[2]);
+                    mTexels.push_back(tx);
+                    mTexels.push_back(ty);
+                }
+                else if (strcasecmp(argv[0], "vn") == 0 && argc == 4)
+                {
+                    float normalx = (float)atof(argv[1]);
+                    float normaly = (float)atof(argv[2]);
+                    float normalz = (float)atof(argv[3]);
+                    mNormals.push_back(normalx);
+                    mNormals.push_back(normaly);
+                    mNormals.push_back(normalz);
+                }
+                else if (strcasecmp(argv[0], "f") == 0 && argc >= 4)
+                {
+                    GeometryVertex v[32];
+
+                    int vcount = argc - 1;
+
+                    for (int i = 1; i < argc; i++)
+                    {
+                        GetVertex(v[i - 1], argv[i]);
+                    }
+
+                    mCallback->NodeTriangle(&v[0], &v[1], &v[2], mTextured);
+
+                    if (vcount >= 3) // do the fan
+                    {
+                        for (int i = 2; i < (vcount - 1); i++)
+                        {
+                            mCallback->NodeTriangle(&v[0], &v[i], &v[i + 1], mTextured);
+                        }
+                    }
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    class BuildMesh : public GeometryInterface
+    {
+    public:
+        int GetIndex(const float* p, const float* texCoord)
+        {
+            int vcount = (int)mVertices.size() / 3;
+
+            if (vcount > 0)
+            {
+                //New MS STL library checks indices in debug build, so zero causes an assert if it is empty.
+                const float* v = &mVertices[0];
+                const float* t = texCoord != NULL ? &mTexCoords[0] : NULL;
+
+                for (int i = 0; i < vcount; i++)
+                {
+                    if (v[0] == p[0] && v[1] == p[1] && v[2] == p[2])
+                    {
+                        if (texCoord == NULL || (t[0] == texCoord[0] && t[1] == texCoord[1]))
+                        {
+                            return i;
+                        }
+                    }
+                    v += 3;
+                    if (t != NULL)
+                        t += 2;
+                }
+            }
+
+            mVertices.push_back(p[0]);
+            mVertices.push_back(p[1]);
+            mVertices.push_back(p[2]);
+
+            if (texCoord != NULL)
+            {
+                mTexCoords.push_back(texCoord[0]);
+                mTexCoords.push_back(texCoord[1]);
+            }
+
+            return vcount;
+        }
+
+        virtual void NodeTriangle(const GeometryVertex* v1, const GeometryVertex* v2, const GeometryVertex* v3, bool textured)
+        {
+            mIndices.push_back(GetIndex(v1->mPos, textured ? v1->mTexel : NULL));
+            mIndices.push_back(GetIndex(v2->mPos, textured ? v2->mTexel : NULL));
+            mIndices.push_back(GetIndex(v3->mPos, textured ? v3->mTexel : NULL));
+        }
+
+        const FloatVector& GetVertices(void) const
+        {
+            return mVertices;
+        };
+        const FloatVector& GetTexCoords(void) const
+        {
+            return mTexCoords;
+        };
+        const IntVector& GetIndices(void) const
+        {
+            return mIndices;
+        };
+
+    private:
+        FloatVector mVertices;
+        FloatVector mTexCoords;
+        IntVector   mIndices;
+    };
+
+}; // namespace WAVEFRONT
+
+using namespace WAVEFRONT;
+
+WavefrontObj::WavefrontObj(void)
+{
+    mVertexCount = 0;
+    mTriCount    = 0;
+    mIndices     = 0;
+    mVertices    = NULL;
+    mTexCoords   = NULL;
+}
+
+WavefrontObj::~WavefrontObj(void)
+{
+    delete mIndices;
+    delete mVertices;
+}
+
+unsigned int WavefrontObj::loadObj(const char* fname, bool textured) // load a wavefront obj returns number of triangles that were loaded.  Data is persists until the class is destructed.
+{
+    unsigned int ret = 0;
+
+    delete mVertices;
+    mVertices = 0;
+    delete mIndices;
+    mIndices     = 0;
+    mVertexCount = 0;
+    mTriCount    = 0;
+
+    BuildMesh bm;
+
+    OBJ obj;
+
+    obj.LoadMesh(fname, &bm, textured);
+
+    const FloatVector& vlist   = bm.GetVertices();
+    const IntVector&   indices = bm.GetIndices();
+    if (vlist.size())
+    {
+        mVertexCount = (int)vlist.size() / 3;
+        mVertices    = new float[mVertexCount * 3];
+        memcpy(mVertices, &vlist[0], sizeof(float) * mVertexCount * 3);
+
+        if (textured)
+        {
+            mTexCoords               = new float[mVertexCount * 2];
+            const FloatVector& tList = bm.GetTexCoords();
+            memcpy(mTexCoords, &tList[0], sizeof(float) * mVertexCount * 2);
+        }
+
+        mTriCount = (int)indices.size() / 3;
+        mIndices  = new int[mTriCount * 3 * sizeof(int)];
+        memcpy(mIndices, &indices[0], sizeof(int) * mTriCount * 3);
+        ret = mTriCount;
+    }
+
+    return ret;
+}
+
+bool WavefrontObj::saveObj(const char* fname, int vcount, const float* vertices, int tcount, const int* indices)
+{
+    bool ret = false;
+
+    FILE* fph = fopen(fname, "wb");
+    if (fph)
+    {
+        for (int i = 0; i < vcount; i++)
+        {
+            fprintf(fph, "v %0.9f %0.9f %0.9f\n", vertices[0], vertices[1], vertices[2]);
+            vertices += 3;
+        }
+        for (int i = 0; i < tcount; i++)
+        {
+            fprintf(fph, "f %d %d %d\n", indices[0] + 1, indices[1] + 1, indices[2] + 1);
+            indices += 3;
+        }
+        fclose(fph);
+        ret = true;
+    }
+    return ret;
+}
+
+#endif

--- a/ext/sightmesh/wavefront.h
+++ b/ext/sightmesh/wavefront.h
@@ -1,0 +1,22 @@
+#ifndef WAVEFRONT_OBJ_H
+
+#define WAVEFRONT_OBJ_H
+
+class WavefrontObj
+{
+public:
+    WavefrontObj(void);
+    ~WavefrontObj(void);
+
+    unsigned int loadObj(const char* fname, bool textured); // load a wavefront obj returns number of triangles that were loaded.  Data is persists until the class is destructed.
+
+    static bool saveObj(const char* fname, int vcount, const float* vertices, int tcount, const int* indices);
+
+    int    mVertexCount;
+    int    mTriCount;
+    int*   mIndices;
+    float* mVertices;
+    float* mTexCoords;
+};
+
+#endif

--- a/scripts/commands/see.lua
+++ b/scripts/commands/see.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- func: see
+-- desc: Informs the user if they can see the target
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+function onTrigger(player)
+    local cursorTarget = player:getCursorTarget()
+    if cursorTarget == nil then
+        player:PrintToPlayer("No target selected")
+        return
+    end
+
+    if player:canSee(cursorTarget) then
+        player:PrintToPlayer(player:getName() .. " CAN SEE " .. cursorTarget:getName())
+    else
+        player:PrintToPlayer(player:getName() .. " CANNOT SEE " .. cursorTarget:getName())
+    end
+end

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(common
     sol2_single
     efsw
     concurrentqueue
+    sightmesh
     project_options
     #PRIVATE
     #project_warnings

--- a/src/common/zlib.h
+++ b/src/common/zlib.h
@@ -9,6 +9,11 @@ static inline size_t zlib_compressed_size(const size_t sz)
     return (sz + 7) / 8;
 }
 
+static inline size_t zlib_decompressed_size(const size_t sz)
+{
+    return (sz * 8) - 7;
+}
+
 int32 zlib_init();
 int32 zlib_compress(const int8* in, const uint32 in_sz, int8* out, const uint32 out_sz);
 int32 zlib_decompress(const int8* in, const uint32 in_sz, int8* out, const uint32 out_sz);

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -82,6 +82,8 @@ set(SOURCES
     region.h
     roe.cpp
     roe.h
+    sightmesh.cpp
+    sightmesh.h
     spell.cpp
     spell.h
     status_effect_container.cpp

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -335,7 +335,7 @@ void CTrustController::PathOutToDistance(CBattleEntity* PTarget, float amount)
         for (auto& potential_position : positions)
         {
             // Validate position
-            if (!position_found && POwner->PAI->PathFind->ValidPosition(potential_position) && POwner->PAI->PathFind->CanSeePoint(potential_position, false))
+            if (!position_found && POwner->PAI->PathFind->ValidPosition(potential_position) && POwner->PAI->PathFind->CanSeePoint(potential_position))
             {
                 position_found  = true;
                 target_position = potential_position;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -483,13 +483,12 @@ bool CPathFind::InWater()
     return false;
 }
 
-bool CPathFind::CanSeePoint(const position_t& point, bool lookOffMesh)
+bool CPathFind::CanSeePoint(const position_t& point)
 {
-    if (isNavMeshEnabled())
+    if (m_PTarget->loc.zone->m_sightMesh)
     {
-        return m_PTarget->loc.zone->m_navMesh->raycast(m_PTarget->loc.p, point, lookOffMesh);
+        return m_PTarget->loc.zone->m_sightMesh->raycast(m_PTarget->loc.p, point);
     }
-
     return true;
 }
 

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -113,7 +113,7 @@ public:
 
     // checks if raycast was broken between current point and given
     // returns true if raycast didn't hit any walls
-    bool CanSeePoint(const position_t& point, bool lookOffMesh = true);
+    bool CanSeePoint(const position_t& point);
 
     // returns the final destination of the current path
     const position_t& GetDestination() const;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2463,6 +2463,30 @@ void CLuaBaseEntity::setRotation(uint8 rotation)
 }
 
 /************************************************************************
+ *  Function: canSee()
+ *  Purpose : Uses sight mesh to determine if one entity can see the other.
+ *  Example : if player:canSee(mob) then ... end
+ *  Notes   : Does not take facing angles into account
+ ************************************************************************/
+bool CLuaBaseEntity::canSee(CLuaBaseEntity* PTarget)
+{
+    if (!PTarget)
+    {
+        ShowWarning("Invalid Target");
+        return false;
+    }
+
+    auto* PZone = m_PBaseEntity->loc.zone;
+    if (!PZone->m_sightMesh)
+    {
+        ShowWarning("Zone does not have valid SightMesh");
+        return false;
+    }
+
+    return PZone->m_sightMesh->raycast(m_PBaseEntity->loc.p, PTarget->GetBaseEntity()->loc.p);;
+}
+
+/************************************************************************
  *  Function: setPos()
  *  Purpose : Sends a PC to a new position
  *  Example : player:setPos(x,y,z,rot,zone) -- zone value is optional
@@ -13524,6 +13548,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getRotPos", CLuaBaseEntity::getRotPos);
     SOL_REGISTER("setPos", CLuaBaseEntity::setPos);
     SOL_REGISTER("setRotation", CLuaBaseEntity::setRotation);
+
+    SOL_REGISTER("canSee", CLuaBaseEntity::canSee);
 
     SOL_REGISTER("warp", CLuaBaseEntity::warp);
     SOL_REGISTER("teleport", CLuaBaseEntity::teleport);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -182,6 +182,8 @@ public:
     uint8 getRotPos();                 // Get Entity Rot position
     void  setRotation(uint8 rotation); // Set Entity rotation
 
+    bool canSee(CLuaBaseEntity* PTarget);
+
     void setPos(sol::variadic_args va);                                       // Set Entity position (x,y,z,rot) or (x,y,z,rot,zone)
     void warp();                                                              // Returns Character to home point
     void teleport(std::map<std::string, float> pos, sol::object const& arg1); // Set Entity position (without entity despawn/spawn packets)

--- a/src/map/sightmesh.cpp
+++ b/src/map/sightmesh.cpp
@@ -1,5 +1,6 @@
-#include "sightmesh.h"
+﻿#include "sightmesh.h"
 
+#include "spdlog/fmt/fmt.h"
 #include "navmesh.h"
 
 CSightMesh::CSightMesh(uint16 id)
@@ -11,13 +12,10 @@ bool CSightMesh::load(std::string const& filename)
 {
     TracyZoneScoped;
 
-    // Load OBJ
-    WavefrontObj obj;
-    obj.loadObj(filename.c_str(), false);
+    // TODO: Read from pre-processed nav files, not from the original obj files
+    m_mesh = std::make_unique<RaycastMesh>(fmt::format("obj/{}.obj", filename));
 
-    // Generate RaycastMesh
-    // TODO: Serialize this object out to a file
-    m_mesh = std::make_unique<RaycastMesh>(obj.mVertexCount, obj.mVertices, obj.mTriCount, (const unsigned int*)obj.mIndices);
+    return true;
 }
 
 bool CSightMesh::raycast(position_t const& start, position_t const& end)

--- a/src/map/sightmesh.cpp
+++ b/src/map/sightmesh.cpp
@@ -1,0 +1,53 @@
+#include "sightmesh.h"
+
+#include "navmesh.h"
+
+CSightMesh::CSightMesh(uint16 id)
+: m_zoneID(id)
+{
+}
+
+bool CSightMesh::load(std::string const& filename)
+{
+    TracyZoneScoped;
+
+    // Load OBJ
+    WavefrontObj obj;
+    obj.loadObj(filename.c_str(), false);
+
+    // Generate RaycastMesh
+    // TODO: Serialize this object out to a file
+    m_mesh = std::make_unique<RaycastMesh>(obj.mVertexCount, obj.mVertices, obj.mTriCount, (const unsigned int*)obj.mIndices);
+}
+
+bool CSightMesh::raycast(position_t const& start, position_t const& end)
+{
+    TracyZoneScoped;
+
+    float startArr[3];
+    float endArr[3];
+
+    // From FFXI space to regular space
+    CNavMesh::ToDetourPos(&start, startArr);
+    CNavMesh::ToDetourPos(&end, endArr);
+
+    // A small boost to avoid clipping the floor
+    startArr[1] += 1.5f;
+    endArr[1] += 1.5f;
+
+    float hitLocation[3];
+    float normal[3];
+    float hitDistance;
+
+    // If can see (there were no obstacles)
+    if (!m_mesh->raycast(startArr, endArr, hitLocation, normal, &hitDistance))
+    {
+        return true;
+    }
+
+    // Otherwise, the ray hit something, transform the hit location back to FFXI space
+    CNavMesh::ToFFXIPos(hitLocation);
+    CNavMesh::ToFFXIPos(normal);
+
+    return false;
+}

--- a/src/map/sightmesh.h
+++ b/src/map/sightmesh.h
@@ -1,11 +1,10 @@
-#pragma once
+﻿#pragma once
 
 #include <memory>
 
 #include "../common/mmo.h"
 
 #include "RaycastMesh.h"
-#include "wavefront.h"
 
 class CSightMesh
 {

--- a/src/map/sightmesh.h
+++ b/src/map/sightmesh.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+
+#include "../common/mmo.h"
+
+#include "RaycastMesh.h"
+#include "wavefront.h"
+
+class CSightMesh
+{
+public:
+    CSightMesh(uint16 id);
+
+    bool load(std::string const& filename);
+
+    // Returns true if the raycast between the two points is uninterrupted (CAN SEE)
+    // Returns false if the raycast in interrupted (CANNOT SEE)
+    // NOTE: The height between two points is arbitrarily boosted by 1.5' to ensure
+    // the floor is not wrongly clipped.
+    bool raycast(position_t const& start, position_t const& end);
+
+    uint16 m_zoneID;
+
+private:
+    std::unique_ptr<RaycastMesh> m_mesh;
+};

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -444,7 +444,7 @@ void CZone::LoadSightMesh()
         m_sightMesh = std::make_unique<CSightMesh>((uint16)GetID());
     }
 
-    if (!m_sightMesh->load(fmt::format("sightmeshes/{}.nav", GetName())))
+    if (!m_sightMesh->load(this->m_zoneName))
     {
         m_sightMesh = nullptr;
     }

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -156,18 +156,13 @@ CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID)
     LoadZoneLines();
     LoadZoneWeather();
     LoadNavMesh();
+    LoadSightMesh();
 }
 
 CZone::~CZone()
 {
     delete m_zoneEntities;
 }
-
-/************************************************************************
- *                                                                       *
- *  Функции доступа к полям класса                                       *
- *                                                                       *
- ************************************************************************/
 
 ZONEID CZone::GetID()
 {
@@ -428,19 +423,30 @@ void CZone::LoadZoneSettings()
 void CZone::LoadNavMesh()
 {
     TracyZoneScoped;
+
     if (m_navMesh == nullptr)
     {
-        m_navMesh = new CNavMesh((uint16)GetID());
+        m_navMesh = std::make_unique<CNavMesh>((uint16)GetID());
     }
 
-    char file[255];
-    memset(file, 0, sizeof(file));
-    snprintf(file, sizeof(file), "navmeshes/%s.nav", GetName());
-
-    if (!m_navMesh->load(file))
+    if (!m_navMesh->load(fmt::format("navmeshes/{}.nav", GetName())))
     {
-        delete m_navMesh;
         m_navMesh = nullptr;
+    }
+}
+
+void CZone::LoadSightMesh()
+{
+    TracyZoneScoped;
+
+    if (m_sightMesh == nullptr)
+    {
+        m_sightMesh = std::make_unique<CSightMesh>((uint16)GetID());
+    }
+
+    if (!m_sightMesh->load(fmt::format("sightmeshes/{}.nav", GetName())))
+    {
+        m_sightMesh = nullptr;
     }
 }
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -36,6 +36,7 @@
 #include "vana_time.h"
 
 #include "navmesh.h"
+#include "sightmesh.h"
 #include "packets/weather.h"
 
 enum ZONEID : uint16
@@ -619,7 +620,8 @@ public:
     CBattlefieldHandler* m_BattlefieldHandler; // BCNM Instances in this zone
     CCampaignHandler*    m_CampaignHandler;    // WOTG campaign information for this zone
 
-    CNavMesh* m_navMesh; // zones navmesh for finding paths
+    std::unique_ptr<CNavMesh>   m_navMesh;   // zone's navmesh for finding paths
+    std::unique_ptr<CSightMesh> m_sightMesh; // zone's sightmesh for determining line of sight
 
 private:
     ZONEID         m_zoneID; // ID зоны
@@ -645,10 +647,11 @@ private:
     regionList_t   m_regionList;   // список активных областей зоны
     zoneLineList_t m_zoneLineList; // список всех доступных zonelines для зоны
 
-    void LoadZoneLines();    // список zonelines (можно было бы заменить этот метод методом InsertZoneLine)
-    void LoadZoneWeather();  // погода
-    void LoadZoneSettings(); // настройки зоны
-    void LoadNavMesh();      // Load the zones navmesh. Must exist in scripts/zones/:zone/NavMesh.nav
+    void LoadZoneLines();    // List of zonelines (one could replace this method using insertzoneline)
+    void LoadZoneWeather();
+    void LoadZoneSettings();
+    void LoadNavMesh();      // Load the zone's navmesh. Must exist in navmeshes/{zone name}.nav
+    void LoadSightMesh();    // Load the zone's sightmesh. Must exist in sightmeshes/{zone name}.nav
 
     CTreasurePool* m_TreasurePool; // глобальный TreasuerPool
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [nope] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

I did an analysis in this ticket:
https://github.com/LandSandBoat/server/issues/1470

Without using _filthy_ hacks like reducing the vertical detection range for mobs etc., recast+detour isn't able to handle navigation/raycasting between multiple floors, and it never will be.

So I did a little googling, and found a lib that can take an OBJ file, and then allows you to raycast between points of it arbitrarily. It also _seems_ fast, but I've only done very very basic measurements so far.

```
zachtoogood@FVFFK42EQ05P build % ./raycastmeshtest ../models/Ship_bound_for_Mhaura.obj
Loading wavefront obj file '../models/Ship_bound_for_Mhaura.obj'
Creating Raycast Mesh. Building AABB
Performing 65536 raycasts.
Finished raycasting; converting image to grayscale.
Saving image file RaycastMesh.png
Average Time: 22 ns
Min Time: 0 ns
Max Time: 92500 ns
```

Based on my optimisations in this PR: https://github.com/LandSandBoat/server/pull/294

Our current raycast is is in the region of `18us`, this implementation _seems_ to be `22ns` -> `1000x faster`

In the end it might not even work properly. But it might!