### PR TITLE
updated Catastrophe drain to 30-70%

### DIFF
--- a/scripts/globals/weaponskills/catastrophe.lua
+++ b/scripts/globals/weaponskills/catastrophe.lua
@@ -39,8 +39,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     if not target:isUndead() then
-        local drain = math.floor(damage * 0.4)
-        player:addHP(drain)
+    player:addHP(math.floor(damage * math.random(3, 7) / 10))
     end
 
     return tpHits, extraHits, criticalHit, damage


### PR DESCRIPTION
added random drain 30-70% of damage return got info from BG
https://www.bg-wiki.com/ffxi/Catastrophe
credit to Xaver for helping with it as well

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
