### PR TITLE
[core] Remove CCharEntity Mutexes

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -288,8 +288,6 @@ void CCharEntity::pushPacket(CBasicPacket* packet)
     TracyZoneIString(GetName());
     TracyZoneHex16(packet->getType());
 
-    std::lock_guard<std::mutex> lk(m_PacketListMutex);
-
     // TODO: Iterating the entire queue like this isn't very efficient, but the server
     // can still _easily_ handle it
     // This could easily be accelerated by creating a lookup, building a key out of:
@@ -328,7 +326,6 @@ void CCharEntity::pushPacket(std::unique_ptr<CBasicPacket> packet)
 
 CBasicPacket* CCharEntity::popPacket()
 {
-    std::lock_guard<std::mutex> lk(m_PacketListMutex);
     CBasicPacket*               PPacket = PacketList.front();
     PacketList.pop_front();
     return PPacket;
@@ -336,13 +333,11 @@ CBasicPacket* CCharEntity::popPacket()
 
 PacketList_t CCharEntity::getPacketList()
 {
-    std::lock_guard<std::mutex> lk(m_PacketListMutex);
     return PacketList;
 }
 
 size_t CCharEntity::getPacketCount()
 {
-    std::lock_guard<std::mutex> lk(m_PacketListMutex);
     return PacketList.size();
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -29,7 +29,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include <bitset>
 #include <deque>
 #include <map>
-#include <mutex>
 #include <unordered_map>
 
 #include "battleentity.h"
@@ -496,8 +495,6 @@ private:
     bool m_reloadParty;
 
     PacketList_t PacketList; // the list of packets to be sent to the character during the next network cycle
-
-    std::mutex m_PacketListMutex;
 };
 
 #endif

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -28,7 +28,6 @@
 #include <bitset>
 #include <deque>
 #include <map>
-#include <mutex>
 #include <vector>
 
 class CBaseEntity;


### PR DESCRIPTION
We don't have threading in this area, so we don't need to be creating/locking/unlocking mutexes

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Sent some packets around, seems fine. If someone could check with two chars and a linkshell, that would be enough to merge I think