### PR TITLE
[lua] Add missing requires to afkcheck, and some formatting

### DIFF
--- a/scripts/commands/afkcheck.lua
+++ b/scripts/commands/afkcheck.lua
@@ -5,6 +5,9 @@
 --     : If the target doesn't respond with a correct answer
 --     : within 30 seconds, they will be set to 0hp.
 -----------------------------------
+require("scripts/globals/msg")
+require("scripts/globals/utils")
+-----------------------------------
 
 cmdprops =
 {
@@ -33,7 +36,7 @@ function onTrigger(player)
 
         return
         {
-            string.format("%i + %i = %i", a, b, c),
+            string.format("%2i + %2i = %2i", a, b, c),
             function(playerArg)
                 playerArg:PrintToPlayer("AFK Check passed", xi.msg.channel.NS_SAY)
                 playerArg:setLocalVar("CAPTCHA", 0)
@@ -52,7 +55,7 @@ function onTrigger(player)
 
         return
         {
-            string.format("%i + %i = %i", a, b, c),
+            string.format("%2i + %2i = %2i", a, b, c),
             function(playerArg)
                 playerArg:PrintToPlayer("AFK Check failed", xi.msg.channel.NS_SAY)
                 playerArg:setHP(0)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
