### PR TITLE
[lua] changed Zalsumn to not error out on the bad quest lookup

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Zalsuhm.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Zalsuhm.lua
@@ -13,7 +13,7 @@ require("scripts/globals/weaponskillids")
 local entity = {}
 
 local function getQuestId(mainJobId)
-    return xi.quest.jeuno.UNLOCKING_A_MYTH_WARRIOR - 1 + mainJobId
+    return xi.quest.id.jeuno.UNLOCKING_A_MYTH_WARRIOR - 1 + mainJobId
 end
 
 entity.onTrade = function(player, npc, trade)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
