### PR TITLE
[lua] Attach onMobDeathEx to global xi object

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -15,7 +15,7 @@ xi = xi or {}
 xi.mob = xi.mob or {}
 
 -- onMobDeathEx is called from the core
-function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
+xi.mob.onMobDeathEx = function(mob, player, isKiller, isWeaponSkillKill)
     -- Things that happen only to the person who landed killing blow
     if isKiller then
         -- DRK quest - Blade Of Darkness

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3062,8 +3062,7 @@ namespace luautils
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(PKiller);
         if (PChar && PMob->objtype == TYPE_MOB)
         {
-            // TODO: Don't save this globally
-            auto onMobDeathEx = lua["onMobDeathEx"];
+            auto onMobDeathEx = lua["xi"]["mob"]["onMobDeathEx"];
             if (!onMobDeathEx.valid())
             {
                 return -1;

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -69,7 +69,6 @@ global_objects=(
     Sequence
     Container
     Event
-    onMobDeathEx
 
     checkForGearSet
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Closes https://github.com/LandSandBoat/server/issues/1495