### PR TITLE
Attach CheckForGearSets to global xi object

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -5,6 +5,9 @@
 require("scripts/globals/status")
 -----------------------------------
 
+xi = xi or {}
+xi.gear_sets = xi.gear_sets or {}
+
 local matchtype = {
     any            = 0,
     earring_weapon = 1,
@@ -329,7 +332,7 @@ end
 -----------------------------------
 -- Checks for gear sets present on a player
 -----------------------------------
-function checkForGearSet(player)
+xi.gear_sets.checkForGearSet = function(player)
     -- print("---Removed existing gear set mods!---\n")
     player:clearGearSetMods()
 

--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -152,7 +152,7 @@ xi.player.onGameIn = function(player, firstLogin, zoning)
     end
 
     -- apply mods from gearsets (scripts/globals/gear_sets.lua)
-    checkForGearSet(player)
+    xi.gear_sets.checkForGearSet(player)
 
     -- god mode
     if player:getCharVar("GodMode") == 1 then

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2425,8 +2425,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        // TODO: This shouldn't be global, attach to xi.gear_sets or similar
-        auto checkForGearSet = lua["checkForGearSet"];
+        auto checkForGearSet = lua["xi"]["gear_sets"]["checkForGearSet"];
         if (!checkForGearSet.valid())
         {
             return 56;

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -70,8 +70,6 @@ global_objects=(
     Container
     Event
 
-    checkForGearSet
-
     removeSleepEffects
 
     SANDORIA


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Noticed another TODO after onMobDeathEx was moved