### PR TITLE
[NPC] Walk of Echo Missin info change wrong value

### DIFF
--- a/scripts/zones/Walk_of_Echoes/npcs/_521.lua
+++ b/scripts/zones/Walk_of_Echoes/npcs/_521.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Walk Of Echoes
+--  NPC: Ornate Door
+-- !pos -700 -20.250 -303.399 0
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity


### PR DESCRIPTION
Adding Ornate door (_521) to Walk of Echo change value of npc_list according to
https://drive.google.com/file/d/166mZ1RlfvjfXplGfX6FwQL8jj-_2wraC/view

https://drive.google.com/drive/folders/1ZFOrZUGQr1G4EJ89fZAn9hEKNe05w9bk
https://github.com/KnowOne134/NPC-MOB-Logger/blob/master/npclogger/Tables/Rolanberry%20Fields%20%5BS%5D.lua
https://drive.google.com/file/d/1omh8g27_5Rb9ZVsvBhq5sjcbMWyWQMSv/view

tested !cs 27 was wrong before the change to npc_list and is now showing correctly


<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
