### PR TITLE
Add Mhaura quest Recycling Rods

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -268,6 +268,7 @@ xi.items =
     CORAL_CREST_KEY                 = 1659,
     BRONZE_KEY                      = 1660,
     CATHEDRAL_TAPESTRY              = 1662,
+    CLEAN_SNAP_ROD                  = 1668,
     INGOT_OF_ROYAL_TREASURY_GOLD    = 1682,
     PIECE_OF_ATTOHWA_GINSENG        = 1683,
     SOILED_LETTER                   = 1686,

--- a/scripts/quests/otherAreas/Recycling_Rods.lua
+++ b/scripts/quests/otherAreas/Recycling_Rods.lua
@@ -1,0 +1,88 @@
+-----------------------------------
+-- Recycling Rods
+-----------------------------------
+-- Log ID: 4, Quest ID: 30
+-- Keshab-Menjab : !pos -15.6 -8 52 249
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.RECYCLING_RODS)
+
+quest.reward =
+{
+    gil = 1500,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.MHAURA] =
+        {
+            ['Keshab-Menjab'] = quest:progressEvent(313),
+
+            onEventFinish =
+            {
+                [313] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.MHAURA] =
+        {
+            ['Keshab-Menjab'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(315)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeHasExactly(trade, xi.items.CLEAN_SNAP_ROD) then
+                        return quest:progressEvent(317)
+                    else
+                        return quest:event(316)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [317] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                    end
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED
+        end,
+
+        [xi.zone.MHAURA] =
+        {
+            ['Keshab-Menjab'] = quest:event(314),
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Mhaura/npcs/Keshab-Menjab.lua
+++ b/scripts/zones/Mhaura/npcs/Keshab-Menjab.lua
@@ -12,7 +12,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(313)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
Verified from retail capture and tested. The item Cleanly Snapped Rod is already on the Jagils from a prior contributor, so if fishing is enabled this quest can be fully completed.

BGWiki: https://www.bg-wiki.com/ffxi/Recycling_Rods
Capture: https://www.youtube.com/watch?v=wS1Itmt3SVk

I did supplemental checks I forgot to do in video afterwards with another character.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
