### PR TITLE
Additional functionality for Allied Notes NPCs

### DIFF
--- a/scripts/globals/campaign.lua
+++ b/scripts/globals/campaign.lua
@@ -111,42 +111,44 @@ function getSandOriaNotesItem(i)
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
         [258] = {id = 5428, price = 10}, -- Scroll of Instant Retrace
-        [514] = {id = 14584, price = 1500}, -- Iron Ram jack coat
-        [770] = {id = 14587, price = 1500}, -- Pilgrim Tunica
-        [1026] = {id = 16172, price = 4500}, -- Iron Ram Shield
-        [1282] = {id = 15841, price = 5000}, -- Recall Ring: Jugner
-        [1538] = {id = 15842, price = 5000}, -- Recall Ring: Pashhow
-        [1794] = {id = 15843, price = 5000}, -- Recall Ring: Meriphataud
+        [514] = {id = 14584, price = 1500, adj = 1000}, -- Iron Ram jack coat
+        [770] = {id = 14587, price = 1500, adj = 1000}, -- Pilgrim Tunica
+        [1026] = {id = 16172, price = 4500, adj = 3000}, -- Iron Ram Shield
+        [1282] = {id = 15841, price = 5000, adj = 5000}, -- Recall Ring: Jugner
+        [1538] = {id = 15842, price = 5000, adj = 5000}, -- Recall Ring: Pashow
+        [1794] = {id = 15843, price = 5000, adj = 5000}, -- Recall Ring: Meriphataud
         [2050] = {id = 10116, price = 2000}, -- Cipher: Valaineral
+        [2306] = {id = 10153, price = 2000}, -- Cipher: Adelheid
         -- Stars Service
-        [18] = {id = 14581, price = 15000}, -- Iron Ram Chainmain
-        [274] = {id = 15005, price = 10500}, -- Iron Ram Mufflers
-        [530] = {id = 15749, price = 10500}, -- Iron Ram Sollerets
-        [786] = {id = 16141, price = 10500}, -- Iron Ram Helm
-        [1042] = {id = 16312, price = 10500}, -- Iron Ram Breeches
+        [18] = {id = 14581, price = 15000, adj = 10000}, -- Iron Ram Chainmain
+        [274] = {id = 15005, price = 10500, adj = 7000}, -- Iron Ram Mufflers
+        [530] = {id = 15749, price = 10500, adj = 7000}, -- Iron Ram Sollerets
+        [786] = {id = 16141, price = 10500, adj = 7000}, -- Iron Ram Helm
+        [1042] = {id = 16312, price = 10500, adj = 7000}, -- Iron Ram Breeches
         -- Emblems Service
-        [34] = {id = 16312, price = 30000}, -- Iron Ram Horn
-        [290] = {id = 16312, price = 30000}, -- Iron Ram Lance
-        [546] = {id = 16312, price = 30000}, -- Iron Ram Pick
-        [802] = {id = 16312, price = 60000}, -- Iron Ram Sallet
-        [1058] = {id = 16312, price = 60000}, -- Iron Ram Dastanas
+        [34] = {id = 17853, price = 30000, adj = 20000}, -- Iron Ram Horn
+        [290] = {id = 18074, price = 30000, adj = 20000}, -- Iron Ram Lance
+        [546] = {id = 17958, price = 30000, adj = 20000}, -- Iron Ram Pick
+        [802] = {id = 16146, price = 60000, adj = 40000}, -- Iron Ram Sallet
+        [1058] = {id = 15009, price = 60000, adj = 40000}, -- Iron Ram Dastanas
         -- Wings Service
-        [50] = {id = 15755, price = 75000}, -- Iron Ram Greaves
-        [306] = {id = 16315, price = 75000}, -- Iron Ram Hose
+        [50] = {id = 15755, price = 75000, adj = 50000}, -- Iron Ram Greaves
+        [306] = {id = 16315, price = 75000, adj = 50000}, -- Iron Ram Hose
         -- Medals Service
-        [66] = {id = 15844, price = 45000}, -- Patronus Ring
-        [322] = {id = 15966, price = 45000}, -- Fox Earring
-        [578] = {id = 15961, price = 45000}, -- Temple Earring
-        [834] = {id = 15934, price = 45000}, -- Crimson Belt
-        [1090] = {id = 19041, price = 45000}, -- Rose Strap
-        [1346] = {id = 15488, price = 112500}, -- Iron Ram Hauberk
-        [1602] = {id = 11356, price = 15000}, -- Royal Guard Livery
+        [66] = {id = 15844, price = 45000, adj = 30000}, -- Patronus Ring
+        [322] = {id = 15966, price = 45000, adj = 30000}, -- Fox Earring
+        [578] = {id = 15961, price = 45000, adj = 30000}, -- Temple Earring
+        [834] = {id = 15934, price = 45000, adj = 30000}, -- Crimson Belt
+        [1090] = {id = 19041, price = 45000, adj = 30000}, -- Rose Strap
+        [1346] = {id = 14588, price = 112500, adj = 75000}, -- Iron Ram Hauberk
+        [1602] = {id = 11356, price = 15000, adj = 10000}, -- Royal Guard Livery
+        [1858] = {id = 14671, price = 22500, adj = 15000}, -- Alied ring
         -- Medal of Altana
-        [82] = {id = 17684, price = 150000}, -- Griffinclaw
-        [338] = {id = 11636, price = 75000} -- Royal Knight Sigil Ring
+        [82] = {id = 17684, price = 150000, adj = 100000}, -- Griffinclaw
+        [338] = {id = 11636, price = 75000, adj = 50000} -- Royal Knight Sigil Ring
     }
     local item = SandOria_AN[i]
-    return item.id, item.price
+    return item.id, item.price, item.adj
 end
 
 function getBastokNotesItem(i)
@@ -154,42 +156,44 @@ function getBastokNotesItem(i)
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
         [258] = {id = 5428, price = 10}, -- Scroll of Instant Retrace
-        [514] = {id = 14585, price = 1500}, -- Fourth Tunica
-        [770] = {id = 14587, price = 1500}, -- Pilgrim Tunica
-        [1026] = {id = 18727, price = 4500}, -- Fourth Gun
+        [514] = {id = 14585, price = 1500, adj = 1000}, -- Fourth Tunica
+        [770] = {id = 14587, price = 1500, adj = 1000}, -- Pilgrim Tunica
+        [1026] = {id = 18727, price = 4500, adj = 3000}, -- Fourth Gun
         [1282] = {id = 15841, price = 5000}, -- Recall Ring: Jugner
-        [1538] = {id = 15842, price = 5000}, -- Recall Ring: Pashhow
+        [1538] = {id = 15842, price = 5000}, -- Recall Ring: Pashow
         [1794] = {id = 15843, price = 5000}, -- Recall Ring: Meriphataud
         [2050] = {id = 10116, price = 2000}, -- Cipher: Valaineral
+        [2306] = {id = 10153, price = 2000}, -- Cipher: Adelheid
         -- Stars Service
-        [18] = {id = 14582, price = 15000}, -- Fourth Cuirass
-        [274] = {id = 15006, price = 10500}, -- Fourth Gauntlets
-        [530] = {id = 15750, price = 10500}, -- Fourth Sabatons
-        [786] = {id = 16142, price = 10500}, -- Fourth Armet
-        [1042] = {id = 16313, price = 10500}, -- Fourth Cuisses
+        [18] = {id = 14582, price = 15000, adj = 10000}, -- Fourth Cuirass
+        [274] = {id = 15006, price = 10500, adj = 7000}, -- Fourth Gauntlets
+        [530] = {id = 15750, price = 10500, adj = 7000}, -- Fourth Sabatons
+        [786] = {id = 16142, price = 10500, adj = 7000}, -- Fourth Armet
+        [1042] = {id = 16313, price = 10500, adj = 7000}, -- Fourth Cuisses
         -- Emblems Service
-        [34] = {id = 18494, price = 30000}, -- Fourth Toporok
-        [290] = {id = 18854, price = 30000}, -- Fourth Mace
-        [546] = {id = 18946, price = 30000}, -- Fourth Zaghnal
-        [802] = {id = 16147, price = 60000}, -- Fourth Haube
-        [1058] = {id = 15010, price = 60000}, -- Fourth Hentzes
+        [34] = {id = 18494, price = 30000, adj = 20000}, -- Fourth Toporok
+        [290] = {id = 18854, price = 30000, adj = 20000}, -- Fourth Mace
+        [546] = {id = 18946, price = 30000, adj = 20000}, -- Fourth Zaghnal
+        [802] = {id = 16147, price = 60000, adj = 40000}, -- Fourth Haube
+        [1058] = {id = 15010, price = 60000, adj = 40000}, -- Fourth Hentzes
         -- Wings Service
-        [50] = {id = 15756, price = 75000}, -- Fourth Schuhs
-        [306] = {id = 16316, price = 75000}, -- Fourth Schoss
+        [50] = {id = 15756, price = 75000, adj = 50000}, -- Fourth Schuhs
+        [306] = {id = 16316, price = 75000, adj = 50000}, -- Fourth Schoss
         -- Medals Service
-        [66] = {id = 16291, price = 45000}, -- Shield Collar
-        [322] = {id = 18734, price = 45000}, -- Sturm's Report
-        [578] = {id = 18735, price = 45000}, -- Sonia's Plectrum
-        [834] = {id = 16292, price = 45000}, -- Bull Necklace
-        [1090] = {id = 16258, price = 45000}, -- Arrestor Mantle
-        [1346] = {id = 14589, price = 112500}, -- Fourth Division Brunne
-        [1602] = {id = 11357, price = 15000}, -- Mythril Musketeer Livery
+        [66] = {id = 16291, price = 45000, adj = 30000}, -- Shield Collar
+        [322] = {id = 18734, price = 45000, adj = 30000}, -- Sturm's Report
+        [578] = {id = 18735, price = 45000, adj = 30000}, -- Sonia's Plectrum
+        [834] = {id = 16292, price = 45000, adj = 30000}, -- Bull Necklace
+        [1090] = {id = 16258, price = 45000, adj = 30000}, -- Arrestor Mantle
+        [1346] = {id = 14589, price = 112500, adj = 75000}, -- Fourth Division Brunne
+        [1602] = {id = 11357, price = 15000, adj = 10000}, -- Mythril Musketeer Livery
+        [1858] = {id = 14671, price = 22500, adj = 15000}, -- Alied ring
         -- Medal of Altana
-        [82] = {id = 17685, price = 150000}, -- Lex Talionis
-        [338] = {id = 11545, price = 75000} -- Fourth Mantle
+        [82] = {id = 17685, price = 150000, adj = 100000}, -- Lex Talionis
+        [338] = {id = 11545, price = 75000, adj = 50000} -- Fourth Mantle
     }
     local item = Bastok_AN[i]
-    return item.id, item.price
+    return item.id, item.price, item.adj
 end
 
 function getWindurstNotesItem(i)
@@ -197,44 +201,48 @@ function getWindurstNotesItem(i)
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
         [258] = {id = 5428, price = 10}, -- Scroll of Instant Retrace
-        [514] = {id = 14586, price = 1500}, -- Cobra Tunica
-        [770] = {id = 14587, price = 1500}, -- Pilgrim Tunica
-        [1026] = {id = 19150, price = 4500}, -- Cobra CLaymore
+        [514] = {id = 14586, price = 1500, adj = 1000}, -- Cobra Tunica
+        [770] = {id = 14587, price = 1500, adj = 1000}, -- Pilgrim Tunica
+        [1026] = {id = 19150, price = 4500, adj = 3000}, -- Cobra CLaymore
         [1282] = {id = 15841, price = 5000}, -- Recall Ring: Jugner
-        [1538] = {id = 15842, price = 5000}, -- Recall Ring: Pashhow
+        [1538] = {id = 15842, price = 5000}, -- Recall Ring: Pashow
         [1794] = {id = 15843, price = 5000}, -- Recall Ring: Meriphataud
         [2050] = {id = 10116, price = 2000}, -- Cipher: Valaineral
+        [2306] = {id = 10153, price = 2000}, -- Cipher: Adelheid
         -- Stars Service
-        [18] = {id = 14583, price = 15000}, -- Cobra Coat
-        [274] = {id = 15007, price = 10500}, -- Cobra Cuffs
-        [530] = {id = 15751, price = 10500}, -- Cobra Pigaches
-        [786] = {id = 16143, price = 10500}, -- Cobra Hat
-        [1042] = {id = 16314, price = 10500}, -- Cobra Slops
+        [18] = {id = 14583, price = 15000, adj = 10000}, -- Cobra Coat
+        [274] = {id = 15007, price = 10500, adj = 7000}, -- Cobra Cuffs
+        [530] = {id = 15751, price = 10500, adj = 7000}, -- Cobra Pigaches
+        [786] = {id = 16143, price = 10500, adj = 7000}, -- Cobra Hat
+        [1042] = {id = 16314, price = 10500, adj = 7000}, -- Cobra Slops
         -- Emblems Service
-        [34] = {id = 18756, price = 30000}, -- Cobra Unit Baghnakhs
-        [290] = {id = 19100, price = 30000}, -- Cobra Unit Knife
-        [546] = {id = 18728, price = 30000}, -- Cobra Unit Bow
-        [802] = {id = 16149, price = 60000}, -- Cobra Unit Cloche
-        [1058] = {id = 15011, price = 60000}, -- Cobra Unit Mittens
+        [34] = {id = 18756, price = 30000, adj = 20000}, -- Cobra Unit Baghnakhs
+        [290] = {id = 19100, price = 30000, adj = 20000}, -- Cobra Unit Knife
+        [546] = {id = 18728, price = 30000, adj = 20000}, -- Cobra Unit Bow
+        [802] = {id = 16148, price = 60000, adj = 40000}, -- Cobra Unit Cap
+        [1058] = {id = 15011, price = 60000, adj = 40000}, -- Cobra Unit Mittens
+        [1314] = {id = 16149, price = 60000, adj = 40000}, -- Cobra Unit Cloche
+        [1570] = {id = 15012, price = 60000, adj = 40000}, -- Cobra Unit Gloves
         -- Wings Service
-        [50] = {id = 15757, price = 75000}, -- Cobra Unit Leggings
-        [306] = {id = 16317, price = 75000}, -- Cobra Unit Subligar
-        [580] = {id = 15758, price = 75000}, -- Cobra Unit Crackows
-        [1001] = {id = 16318, price = 75000}, -- Cobra Unit Trews
+        [50] = {id = 15757, price = 75000, adj = 50000}, -- Cobra Unit Leggings
+        [306] = {id = 16317, price = 75000, adj = 50000}, -- Cobra Unit Subligar
+        [562] = {id = 15758, price = 75000, adj = 50000}, -- Cobra Unit Crackows
+        [818] = {id = 16318, price = 75000, adj = 50000}, -- Cobra Unit Trews
         -- Medals Service
-        [66] = {id = 15935, price = 45000}, -- Capricornian Rope
-        [322] = {id = 15936, price = 45000}, -- Earthly Belt
-        [578] = {id = 16293, price = 45000}, -- Cougar Pendant
-        [834] = {id = 16294, price = 45000}, -- Crocodile Collar
-        [1090] = {id = 19041, price = 45000}, -- Ariesian Grip
-        [1346] = {id = 19042, price = 112500}, -- Cobra Unit Harness
-        [1602] = {id = 11358, price = 15000}, -- Patriarch Protector Livery
+        [66] = {id = 15935, price = 45000, adj = 30000}, -- Capricornian Rope
+        [322] = {id = 15936, price = 45000, adj = 30000}, -- Earthly Belt
+        [578] = {id = 16293, price = 45000, adj = 30000}, -- Cougar Pendant
+        [834] = {id = 16294, price = 45000, adj = 30000}, -- Crocodile Collar
+        [1090] = {id = 19042, price = 45000, adj = 30000}, -- Ariesian Grip
+        [1346] = {id = 14590, price = 112500, adj = 75000}, -- Cobra Unit Harness
+        [1602] = {id = 14591, price = 15000, adj = 75000}, -- Cobra Unit Robe
+        [1858] = {id = 14671, price = 22500, adj = 15000}, -- Alied ring
         -- Medal of Altana
-        [82] = {id = 17684, price = 150000}, -- Samudra
-        [338] = {id = 11636, price = 75000} -- Mercenary Major Charm
+        [82] = {id = 17684, price = 150000, adj = 10000}, -- Samudra
+        [338] = {id = 11636, price = 75000, adj = 50000} -- Mercenary Major Charm
     }
     local item = Windurst_AN[i]
-    return item.id, item.price
+    return item.id, item.price, item.adj
 end
 
 -- -------------------------------------------------------------------

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Millard_IM.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Millard_IM.lua
@@ -2,6 +2,7 @@
 -- Area: Bastok Markets [S]
 --  NPC: Millard IM
 -- Type: Sigil NPC
+-- !pos -248.5 0 81.2 87
 -----------------------------------
 local ID = require("scripts/zones/Bastok_Markets_[S]/IDs")
 require("scripts/globals/campaign")
@@ -16,30 +17,33 @@ end
 entity.onTrigger = function(player, npc)
     local notes = player:getCurrency("allied_notes")
     local freelances = 99 -- Faking it for now
-    local unknown = 12 -- Faking it for now
+    local ciphers = 0
+    -- 0 for not displaying ciphers
+    -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
+    -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
+    -- 12 to display both
     local medalRank = getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
     local timeStamp = 0 -- getSigilTimeStamp(player)
-    -- todo add in Throne Room controls
+    local allegiance = player:getCampaignAllegiance()
 
     -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
         -- medal_rank = 32
         -- this decides if allied ring is in the Allied Notes item list.
     -- end
 
-    if (medalRank == 0) then
+    if medalRank == 0 then
         player:startEvent(14)
     else
-        player:startEvent(13, 0, notes, freelances, unknown, medalRank, bonusEffects, timeStamp, 0)
+        player:startEvent(13, allegiance, notes, freelances, ciphers, medalRank, bonusEffects, timeStamp, 0)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
     -- local itemid = 0
     local canEquip = 2 -- Faking it for now.
     -- 0 = Wrong job, 1 = wrong level, 2 = Everything is in order, 3 or greater = menu exits...
-    if (csid == 13 and option >= 2 and option <= 2050) then
+    if csid == 13 and option >= 2 and option <= 2306 then
         -- itemid = getBastokNotesItem(option)
         player:updateEvent(0, 0, 0, 0, 0, 0, 0, canEquip) -- canEquip(player, itemid));  <- works for sanction NPC, wtf?
     end
@@ -53,12 +57,15 @@ local optionList =
 
 entity.onEventFinish = function(player, csid, option)
     local medalRank = getMedalRank(player)
-    if (csid == 13) then
+    if csid == 13 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
-        if (option >= 2 and option <= 2050) then -- player bought item
-        -- currently only "ribbons" rank coded.
-            local item, price = getBastokNotesItem(option)
-            if (player:getFreeSlotsCount() >= 1) then
+        if option >= 2 and option <= 2306 then -- player bought item
+            local item, price, adj = getBastokNotesItem(option)
+            --if player is allied with Bastok, they get adjusted price on most items
+            if player:getCampaignAllegiance() == 2 and adj ~= nil then
+                price = adj
+            end
+            if player:getFreeSlotsCount() >= 1 then
                 player:delCurrency("allied_notes", price)
                 player:addItem(item)
                 player:messageSpecial(ID.text.ITEM_OBTAINED, item)
@@ -73,19 +80,19 @@ entity.onEventFinish = function(player, csid, option)
             local duration = 10800+((15*medalRank)*60) -- 3hrs +15 min per medal (minimum 3hr 15 min with 1st medal)
             local subPower = 35 -- Sets % trigger for regen/refresh. Static at minimum value (35%) for now.
 
-            if (power == 1 or power == 2 or power == 4) then
+            if power == 1 or power == 2 or power == 4 then
             -- 1: Regen,  2: Refresh,  4: Meal Duration
                 cost = 50
-            elseif (power == 3 or power == 5 or power == 6 or power == 8 or power == 12) then
+            elseif power == 3 or power == 5 or power == 6 or power == 8 or power == 12 then
             -- 3: Regen + Refresh,  5: Regen + Meal Duration,  6: Refresh + Meal Duration,
             -- 8: Reduced EXP loss,  12: Meal Duration + Reduced EXP loss
                 cost = 100
-            elseif (power == 7 or power == 9 or power == 10 or power == 11 or power == 13 or power == 14) then
+            elseif power == 7 or power == 9 or power == 10 or power == 11 or power == 13 or power == 14 then
             -- 7: Regen + Refresh + Meal Duration,  9: Regen + Reduced EXP loss,
             -- 10: Refresh + Reduced EXP loss,  11: Regen + Refresh + Reduced EXP loss,
             -- 13: Regen + Meal Duration + Reduced EXP loss,  14: Refresh + Meal Duration + Reduced EXP loss
                 cost = 150
-            elseif (power == 15) then
+            elseif power == 15 then
             -- 15: Everything
                 cost = 200
             end
@@ -94,7 +101,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addStatusEffect(xi.effect.SIGIL, power, 0, duration, 0, subPower, 0)
             player:messageSpecial(ID.text.ALLIED_SIGIL)
 
-            if (cost > 0) then
+            if cost > 0 then
                 player:delCurrency("allied_notes", cost)
             end
         end

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Miliart_TK.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Miliart_TK.lua
@@ -17,29 +17,33 @@ end
 entity.onTrigger = function(player, npc)
     local notes = player:getCurrency("allied_notes")
     local freelances = 99 -- Faking it for now
-    local unknown = 12 -- Faking it for now
+    local ciphers = 0
+    -- 0 for not displaying ciphers
+    -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
+    -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
+    -- 12 to display both
     local medalRank = getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
     local timeStamp = 0 -- getSigilTimeStamp(player)
+    local allegiance = player:getCampaignAllegiance()
 
     -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
         -- medal_rank = 32
         -- this decides if allied ring is in the Allied Notes item list.
     -- end
 
-    if (medalRank == 0) then
+    if medalRank == 0 then
         player:startEvent(111)
     else
-        player:startEvent(110, 0, notes, freelances, unknown, medalRank, bonusEffects, timeStamp, 0)
+        player:startEvent(110, allegiance, notes, freelances, ciphers, medalRank, bonusEffects, timeStamp, 0)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
     -- local itemid = 0
     local canEquip = 2 -- Faking it for now.
     -- 0 = Wrong job, 1 = wrong level, 2 = Everything is in order, 3 or greater = menu exits...
-    if (csid == 110 and option >= 2 and option <= 2050) then
+    if csid == 110 and option >= 2 and option <= 2306 then
         -- itemid = getSandOriaNotesItem(option)
         player:updateEvent(0, 0, 0, 0, 0, 0, 0, canEquip) -- canEquip(player, itemid));  <- works for sanction NPC, wtf?
     end
@@ -53,12 +57,15 @@ local optionList =
 
 entity.onEventFinish = function(player, csid, option)
     local medalRank = getMedalRank(player)
-    if (csid == 110) then
+    if csid == 110 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
-        if (option >= 2 and option <= 2050) then -- player bought item
-        -- currently only "ribbons" rank coded.
-            local item, price = getSandOriaNotesItem(option)
-            if (player:getFreeSlotsCount() >= 1) then
+        if (option >= 2 and option <= 2306) then -- player bought item
+            local item, price, adj = getSandOriaNotesItem(option)
+            --if player is allied with Sandy, they get adjusted price on most items
+            if player:getCampaignAllegiance() == 1 and adj ~= nil then
+                price = adj
+            end
+            if player:getFreeSlotsCount() >= 1 then
                 player:delCurrency("allied_notes", price)
                 player:addItem(item)
                 player:messageSpecial(ID.text.ITEM_OBTAINED, item)
@@ -73,19 +80,19 @@ entity.onEventFinish = function(player, csid, option)
             local duration = 10800+((15*medalRank)*60) -- 3hrs +15 min per medal (minimum 3hr 15 min with 1st medal)
             local subPower = 35 -- Sets % trigger for regen/refresh. Static at minimum value (35%) for now.
 
-            if (power == 1 or power == 2 or power == 4) then
+            if power == 1 or power == 2 or power == 4 then
             -- 1: Regen,  2: Refresh,  4: Meal Duration
                 cost = 50
-            elseif (power == 3 or power == 5 or power == 6 or power == 8 or power == 12) then
+            elseif power == 3 or power == 5 or power == 6 or power == 8 or power == 12 then
             -- 3: Regen + Refresh,  5: Regen + Meal Duration,  6: Refresh + Meal Duration,
             -- 8: Reduced EXP loss,  12: Meal Duration + Reduced EXP loss
                 cost = 100
-            elseif (power == 7 or power == 9 or power == 10 or power == 11 or power == 13 or power == 14) then
+            elseif power == 7 or power == 9 or power == 10 or power == 11 or power == 13 or power == 14 then
             -- 7: Regen + Refresh + Meal Duration,  9: Regen + Reduced EXP loss,
             -- 10: Refresh + Reduced EXP loss,  11: Regen + Refresh + Reduced EXP loss,
             -- 13: Regen + Meal Duration + Reduced EXP loss,  14: Refresh + Meal Duration + Reduced EXP loss
                 cost = 150
-            elseif (power == 15) then
+            elseif power == 15 then
             -- 15: Everything
                 cost = 200
             end
@@ -94,7 +101,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addStatusEffect(xi.effect.SIGIL, power, 0, duration, 0, subPower, 0)
             player:messageSpecial(ID.text.ALLIED_SIGIL)
 
-            if (cost > 0) then
+            if cost > 0 then
                 player:delCurrency("allied_notes", cost)
             end
         end

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Mindala-Andola_CC.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Mindala-Andola_CC.lua
@@ -17,14 +17,17 @@ end
 entity.onTrigger = function(player, npc)
     local notes = player:getCurrency("allied_notes")
     local freelances = 99 -- Faking it for now
-    local unknown = 12 -- Faking it for now
+    local ciphers = 0
+    -- 0 for not displaying ciphers
+    -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
+    -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
+    -- 12 to display both
     local medalRank = getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
     local timeStamp = 0 -- getSigilTimeStamp(player)
+    local allegiance = player:getCampaignAllegiance()
 
-    -- todo if Throne control is active
-
-    -- if medal_rank > 25 and nation controls Throne_Room_S then
+    -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
         -- medal_rank = 32
         -- this decides if allied ring is in the Allied Notes item list.
     -- end
@@ -32,7 +35,7 @@ entity.onTrigger = function(player, npc)
     if medalRank == 0 then
         player:startEvent(14)
     else
-        player:startEvent(13, 0, notes, freelances, unknown, medalRank, bonusEffects, timeStamp, 0)
+        player:startEvent(13, allegiance, notes, freelances, ciphers, medalRank, bonusEffects, timeStamp, 0)
     end
 
 end
@@ -40,7 +43,7 @@ end
 entity.onEventUpdate = function(player, csid, option)
     local canEquip = 2 -- Faking it for now.
     -- 0 = Wrong job, 1 = wrong level, 2 = Everything is in order, 3 or greater = menu exits...
-    if csid == 13 and option >= 2 and option <= 2050 then
+    if csid == 13 and option >= 2 and option <= 2306 then
         -- local itemid = getWindurstNotesItem(option)
         player:updateEvent(0, 0, 0, 0, 0, 0, 0, canEquip) -- canEquip(player, itemid))  <- works for sanction NPC, wtf?
     end
@@ -57,8 +60,11 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 13 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
         if option >= 2 and option <= 2050 then -- player bought item
-        -- currently only "ribbons" rank coded.
-            local item, price = getWindurstNotesItem(option)
+            local item, price, adj = getWindurstNotesItem(option)
+            --if player is allied with Windurst, they get adjusted price on most items
+            if player:getCampaignAllegiance() == 3 and adj ~= nil then
+                price = adj
+            end
             if player:getFreeSlotsCount() >= 1 then
                 player:delCurrency("allied_notes", price)
                 player:addItem(item)


### PR DESCRIPTION
Adds:

- Discount for players of the same allegiance as the nation the NPC represents on most items, as on retail.
- Mapping for ciphers / information on how to enable. These should ultimately depend on an active campaign unless a server wants them both active all of the time.

Fixes incorrect values for Cobra Unit Cloche/Cap.

These NPCs could use a refactor once they're more fully implemented. They still need some aspects sorted, like the Can Equip check in the event update.  Did a little bit of cleanup work on styling for now and left them mostly as-is per side discussion with Teo.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
