### PR TITLE
[PUP] changed newAttachmentStatus to support giving Spirit Reaver

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
@@ -192,7 +192,7 @@ entity.onTrade = function(player, npc, trade)
                 elseif trade:getItemQty(xi.items.BLACK_PUPPET_TURBAN) == 1 and not player:hasAttachment(xi.items.SPIRITREAVER_HEAD) then
                     local range = getWaitRange(xi.items.BLACK_PUPPET_TURBAN, trade)
 
-                    play_event902(player, 12, math.random(range[1], range[2]))
+                    play_event902(player, 13, math.random(range[1], range[2]))
                 end
             end
         end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #1525 and #1300
