### PR TITLE
Fix errant negation in Ghatsad

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
@@ -120,7 +120,7 @@ end
 
 local function hasRequiredMats(trade, headFrameKey)
     for _, v in ipairs(headAndFrameItems[headFrameKey]) do
-        if not trade:getItemQty(v) == 1 then
+        if trade:getItemQty(v) ~= 1 then
             return false
         end
     end


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Looks like Luacheck got an upgrade and caught another issue.  Fixes negation for Ghatsad function.