### PR TITLE
[sql] changed Boreas Cesti to match proc rates

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -22916,7 +22916,7 @@ INSERT INTO `item_mods` VALUES (18357,953,60);  -- Additional effect Status Dura
 INSERT INTO `item_mods` VALUES (18359,431,1);   -- Boreas Cesti (Additional effect: Wind Damage)
 INSERT INTO `item_mods` VALUES (18359,499,3);   -- Additional effect animation (subEffect)
 INSERT INTO `item_mods` VALUES (18359,500,15);  -- Additional effect damage
-INSERT INTO `item_mods` VALUES (18359,501,5);   -- Additional effect Chance 5%
+INSERT INTO `item_mods` VALUES (18359,501,100); -- Additional effect Chance 100%
 INSERT INTO `item_mods` VALUES (18359,950,3);   -- Additional effect element Wind (xi.magic.element)
 INSERT INTO `item_mods` VALUES (18360,13,7);
 INSERT INTO `item_mods` VALUES (18360,826,2);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

https://ffxiclopedia.fandom.com/wiki/Boreas_Cesti
https://www.ffxiah.com/item/18359/boreas-cesti
