### PR TITLE
Add textTable support to onZoneIn packet

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1653,7 +1653,7 @@ namespace luautils
      *                                                                       *
      ************************************************************************/
 
-    int32 OnZoneIn(CCharEntity* PChar)
+    void OnZoneIn(CCharEntity* PChar)
     {
         TracyZoneScoped;
 
@@ -1667,10 +1667,20 @@ namespace luautils
         {
             sol::error err = result;
             ShowError("luautils::onZoneIn: %s", err.what());
-            return -1;
+            return;
         }
 
-        return result.get_type() == sol::type::number ? result : -1;
+        if (result.get_type() == sol::type::table)
+        {
+            auto resultTable = result.get<sol::table>();
+
+            PChar->currentEvent->eventId   = resultTable.get_or(1, -1);
+            PChar->currentEvent->textTable = resultTable.get_or(2, -1);
+        }
+        else if (result.get_type() == sol::type::number)
+        {
+            PChar->currentEvent->eventId = result.get<int32>();
+        }
     }
 
     void AfterZoneIn(CBaseEntity* PChar)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -191,7 +191,7 @@ namespace luautils
     int32 OnTOTDChange(uint16 ZoneID, uint8 TOTD);
 
     int32 OnGameIn(CCharEntity* PChar, bool zoning);
-    int32 OnZoneIn(CCharEntity* PChar);                        // triggers when a player zones into a zone
+    void  OnZoneIn(CCharEntity* PChar);                        // triggers when a player zones into a zone
     void  OnZoneOut(CCharEntity* PChar);                       // triggers when a player leaves a zone
     void  AfterZoneIn(CBaseEntity* PChar);                     // triggers after a player has finished zoning in
     int32 OnZoneInitialise(uint16 ZoneID);                     // triggers when zone is loaded

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -179,7 +179,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
         // ref<uint8>(data,(0x1F)) = 4;                             // предположительно animation
         // ref<uint8>(data,(0x20)) = 2;
 
-        ref<uint16>(0x40) = PChar->getZone();
+        ref<uint16>(0x40) = PChar->currentEvent->textTable == -1 ? PChar->getZone() : PChar->currentEvent->textTable;
         ref<uint16>(0x62) = PChar->getZone();
         ref<uint16>(0x64) = csid;
     }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -842,7 +842,8 @@ namespace charutils
         PChar->health.hp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxHP() : HP;
         PChar->health.mp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxMP() : MP;
         PChar->UpdateHealth();
-        PChar->currentEvent->eventId = luautils::OnZoneIn(PChar);
+
+        luautils::OnZoneIn(PChar);
         luautils::OnGameIn(PChar, zoning == 1);
     }
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

* Adjusts byte 40 in 0x0A (zone_in) packet to allow for text table swapping
* Converts luautils::OnZoneIn to void function, and sets event data directly
* Allows for table input to OnZoneIn to allow for a second parameter to change text table.  This was the simpler solution, since multiple returns from interaction functions would require significant refactors.