### PR TITLE
reduce potential future confusion regarding speed values

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -114,13 +114,14 @@ ws_points_skillchain: 1
 #Enable/disable jobs other than BST and RNG having widescan
 all_jobs_widescan: 1
 
-#Modifier to apply to player speed. 0 means default speed of 50, where 20 would mean speed 70 or -10 would mean speed 40.
+#Modifier to apply to player speed. 0 is the retail accurate default. Negative numbers will reduce it.
 speed_mod: 0
 
-#Modifier to apply to mount speed. 0 means default speed of 80, where 20 would mean speed 100 or -20 would mean speed 60.
+#Modifier to apply to mount speed. 0 is the retail accurate default. Negative numbers will reduce it.
+#Note retail treats the mounted speed as double what it actually is.
 mount_speed_mod: 0
 
-#Modifier to apply to agro'd monster speed. 0 means default speed, where 20 would mean default speed + 20 or -10 would mean default speed - 10.
+#Modifier to apply to agro'd monster speed. 0 is the retail accurate default. Negative numbers will reduce it.
 mob_speed_mod: 0
 
 #Allows you to manipulate the constant multiplier in the skill-up rate formulas, having a potent effect on skill-up rates.

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -222,6 +222,7 @@ int32 CBattleEntity::GetMaxMP() const
 
 uint8 CBattleEntity::GetSpeed()
 {
+    // Note: retail treats mounted speed as double what it actually is! 40 is in fact retail accurate!
     int16 startingSpeed = isMounted() ? 40 + map_config.mount_speed_mod : speed;
     // Mod::MOVE (169)
     // Mod::MOUNT_MOVE (972)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

No functional changes, only code comments.

@m241dan I'm sorry again again again. I was a jerk there.