### PR TITLE
[Fix] Apollyon NW movement and 3rd floor portal

### DIFF
--- a/scripts/zones/Apollyon/mobs/Apollyon_Scavenger.lua
+++ b/scripts/zones/Apollyon/mobs/Apollyon_Scavenger.lua
@@ -2,6 +2,7 @@
 -- Area: Apollyon NW, Floor 3
 --  Mob: Apollyon Scavenger
 -----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/zones/Apollyon/bcnms/nw_apollyon_helper")
 require("scripts/globals/pathfind")
 -----------------------------------

--- a/scripts/zones/Apollyon/mobs/Bardha.lua
+++ b/scripts/zones/Apollyon/mobs/Bardha.lua
@@ -2,6 +2,7 @@
 -- Area: Apollyon NW, Floor 1
 --  Mob: Bardha
 -----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/zones/Apollyon/bcnms/nw_apollyon_helper")
 require("scripts/globals/pathfind")
 -----------------------------------

--- a/scripts/zones/Apollyon/mobs/Gorynich.lua
+++ b/scripts/zones/Apollyon/mobs/Gorynich.lua
@@ -2,6 +2,7 @@
 -- Area: Apollyon NW, Floor 4
 --  Mob: Gorynich
 -----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/zones/Apollyon/bcnms/nw_apollyon_helper")
 require("scripts/globals/pathfind")
 -----------------------------------

--- a/scripts/zones/Apollyon/mobs/Mountain_Buffalo.lua
+++ b/scripts/zones/Apollyon/mobs/Mountain_Buffalo.lua
@@ -2,6 +2,7 @@
 -- Area: Apollyon NW, Floor 2
 --  Mob: Mountain Buffalo
 -----------------------------------
+local ID = require("scripts/zones/Apollyon/IDs")
 require("scripts/zones/Apollyon/bcnms/nw_apollyon_helper")
 require("scripts/globals/pathfind")
 -----------------------------------


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes mob movement caused by missing requires and floor 3 portal not opening sometimes because the mob selected weren't defined in the database.