### PR TITLE
Attach campaign global functions to xi.campaign

### DIFF
--- a/scripts/globals/campaign.lua
+++ b/scripts/globals/campaign.lua
@@ -83,7 +83,7 @@ PAST_WINDURST = 7
 -- Returns the numerical Campaign Medal of the player.
 -- -------------------------------------------------------------------
 
-function getMedalRank(player)
+xi.campaign.getMedalRank = function(player)
     local rank = 0
     local medals =
     {
@@ -106,7 +106,7 @@ end
 -- ListName_AN_price[optionID] = cost -- ItemName
 -- -------------------------------------------------------------------
 
-function getSandOriaNotesItem(i)
+xi.campaign.getSandOriaNotesItem = function(i)
     local SandOria_AN =
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
@@ -151,7 +151,7 @@ function getSandOriaNotesItem(i)
     return item.id, item.price, item.adj
 end
 
-function getBastokNotesItem(i)
+xi.campaign.getBastokNotesItem = function(i)
     local Bastok_AN =
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
@@ -196,7 +196,7 @@ function getBastokNotesItem(i)
     return item.id, item.price, item.adj
 end
 
-function getWindurstNotesItem(i)
+xi.campaign.getWindurstNotesItem = function(i)
     local Windurst_AN =
     {
         [2] = {id = 15754, price = 980}, -- Sprinter's Shoes
@@ -251,7 +251,7 @@ end
 -- effect will last until, NOT the actual status effect duration.
 -- -------------------------------------------------------------------
 
-function getSigilTimeStamp(player)
+xi.campaign.getSigilTimeStamp = function(player)
     local timeStamp = 0 -- zero'd till math is done.
 
     -- TODO: calculate time stamp for menu display of when it wears off

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Millard_IM.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Millard_IM.lua
@@ -22,9 +22,9 @@ entity.onTrigger = function(player, npc)
     -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
     -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
     -- 12 to display both
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
-    local timeStamp = 0 -- getSigilTimeStamp(player)
+    local timeStamp = 0 -- xi.campaign.getSigilTimeStamp(player)
     local allegiance = player:getCampaignAllegiance()
 
     -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
@@ -56,11 +56,11 @@ local optionList =
 }
 
 entity.onEventFinish = function(player, csid, option)
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     if csid == 13 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
         if option >= 2 and option <= 2306 then -- player bought item
-            local item, price, adj = getBastokNotesItem(option)
+            local item, price, adj = xi.campaign.getBastokNotesItem(option)
             --if player is allied with Bastok, they get adjusted price on most items
             if player:getCampaignAllegiance() == 2 and adj ~= nil then
                 price = adj

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Fiaudie.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Fiaudie.lua
@@ -14,7 +14,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local allegiance =  player:getCampaignAllegiance()
-    local rank = getMedalRank(player)
+    local rank = xi.campaign.getMedalRank(player)
 
     player:startEvent(312, allegiance, rank, 0, 0, 0, 0, 0)
 end

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Miliart_TK.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Miliart_TK.lua
@@ -22,9 +22,9 @@ entity.onTrigger = function(player, npc)
     -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
     -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
     -- 12 to display both
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
-    local timeStamp = 0 -- getSigilTimeStamp(player)
+    local timeStamp = 0 -- xi.campaign.getSigilTimeStamp(player)
     local allegiance = player:getCampaignAllegiance()
 
     -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
@@ -56,11 +56,11 @@ local optionList =
 }
 
 entity.onEventFinish = function(player, csid, option)
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     if csid == 110 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
         if (option >= 2 and option <= 2306) then -- player bought item
-            local item, price, adj = getSandOriaNotesItem(option)
+            local item, price, adj = xi.campaign.getSandOriaNotesItem(option)
             --if player is allied with Sandy, they get adjusted price on most items
             if player:getCampaignAllegiance() == 1 and adj ~= nil then
                 price = adj

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Mindala-Andola_CC.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Mindala-Andola_CC.lua
@@ -22,9 +22,9 @@ entity.onTrigger = function(player, npc)
     -- 4 for Valaneiral (New Year's & Summer Alter Ego Extravaganzas)
     -- 8 for Adelheid (Spring & Autumn Alter Ego Extravaganzas)
     -- 12 to display both
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     local bonusEffects = 0 -- 1 = regen, 2 = refresh, 4 = meal duration, 8 = exp loss reduction, 15 = all
-    local timeStamp = 0 -- getSigilTimeStamp(player)
+    local timeStamp = 0 -- xi.campaign.getSigilTimeStamp(player)
     local allegiance = player:getCampaignAllegiance()
 
     -- if ( medal_rank > 25 and nation controls Throne_Room_S ) then
@@ -56,11 +56,11 @@ local optionList =
 }
 
 entity.onEventFinish = function(player, csid, option)
-    local medalRank = getMedalRank(player)
+    local medalRank = xi.campaign.getMedalRank(player)
     if csid == 13 then
         -- Note: the event itself already verifies the player has enough AN, so no check needed here.
         if option >= 2 and option <= 2050 then -- player bought item
-            local item, price, adj = getWindurstNotesItem(option)
+            local item, price, adj = xi.campaign.getWindurstNotesItem(option)
             --if player is allied with Windurst, they get adjusted price on most items
             if player:getCampaignAllegiance() == 3 and adj ~= nil then
                 price = adj

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -265,12 +265,6 @@ global_objects=(
     MOBSKILL_MAGICAL
     MOBSKILL_PHYSICAL
 
-    getMedalRank
-    getBastokNotesItem
-    getSandOriaNotesItem
-    getWindurstNotesItem
-    getSigilTimeStamp
-
     TPMOD_NONE
     TPMOD_CHANCE
     TPMOD_CRITICAL


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
