### PR TITLE
[core] Remove manual Lua management from commandhandler

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -719,6 +719,21 @@ std::vector<std::string> split(const std::string& s, char delim)
     return elems;
 }
 
+// https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case
+std::string trim(const std::string& str, const std::string& whitespace)
+{
+    const auto strBegin = str.find_first_not_of(whitespace);
+    if (strBegin == std::string::npos)
+    {
+        return ""; // no content
+    }
+
+    const auto strEnd = str.find_last_not_of(whitespace);
+    const auto strRange = strEnd - strBegin + 1;
+
+    return str.substr(strBegin, strRange);
+}
+
 look_t stringToLook(std::string str)
 {
     // Remove "0x" if found

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -78,6 +78,8 @@ void        PackSoultrapperName(std::string name, uint8 output[], uint8 size);
 std::string escape(std::string const& s);
 
 std::vector<std::string> split(const std::string& s, char delim);
+// https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case
+std::string trim(const std::string& str, const std::string& whitespace = " \t");
 look_t stringToLook(std::string str);
 
 // Float tools
@@ -88,5 +90,22 @@ bool definitelyGreaterThan(float a, float b);
 bool definitelyLessThan(float a, float b);
 
 void crash();
+
+class ScopeGuard
+{
+public:
+    ScopeGuard(std::function<void()> func)
+    : func(func)
+    {
+    }
+
+    ~ScopeGuard()
+    {
+        func();
+    }
+
+private:
+    std::function<void()> func;
+};
 
 #endif


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Closes https://github.com/LandSandBoat/server/issues/1516 (I hope)