### PR TITLE
[core] Replace setName/PacketName with renameEntity

### DIFF
--- a/modules/custom/replace_trust_with_cornelia.lua
+++ b/modules/custom/replace_trust_with_cornelia.lua
@@ -28,7 +28,7 @@ m:addOverride(string.format("xi.globals.spells.trust.%s.onSpellCast", trustToRep
     -- New logic below
     -----------------------------------
     trust:setModelId(3119) -- Trust: Cornelia
-    trust:setPacketName("Cornelia")
+    trust:renameEntity("Cornelia")
 
     local boostAmount = math.ceil((30 / 99) * caster:getMainLvl())
     trust:addStatusEffectEx(xi.effect.GEO_HASTE, xi.effect.GEO_HASTE, 6, 3, 0, xi.effect.GEO_HASTE, boostAmount, xi.auraTarget.ALLIES, xi.effectFlag.AURA)

--- a/scripts/globals/abilities/ventriloquy.lua
+++ b/scripts/globals/abilities/ventriloquy.lua
@@ -28,9 +28,9 @@ ability_object.onUseAbility = function(player, target, ability)
         local enmitylist = target:getEnmityList()
         local playerfound, petfound = false, false
         for k, v in pairs(enmitylist) do
-            if v.entity:getShortID() == player:getShortID() then
+            if v.entity:getTargID() == player:getTargID() then
                 playerfound = true
-            elseif v.entity:getShortID() == pet:getShortID() then
+            elseif v.entity:getTargID() == pet:getTargID() then
                 petfound = true
             end
         end
@@ -45,7 +45,7 @@ ability_object.onUseAbility = function(player, target, ability)
 
             local playerEnmityBonus = 1
             local petEnmityBonus = 1
-            if target:getTarget():getShortID() == player:getShortID() or ((playerCE + playerVE) >= (petCE + petVE) and target:getTarget():getShortID() ~= pet:getShortID()) then
+            if target:getTarget():getTargID() == player:getTargID() or ((playerCE + playerVE) >= (petCE + petVE) and target:getTarget():getTargID() ~= pet:getTargID()) then
                 playerEnmityBonus = playerEnmityBonus + bonus
                 petEnmityBonus = petEnmityBonus - bonus
             else

--- a/scripts/globals/allyassist.lua
+++ b/scripts/globals/allyassist.lua
@@ -45,7 +45,7 @@ xi.ally =
             for i, player in pairs(players) do
                 local battleTarget = player:getTarget()
                 if battleTarget ~= nil then
-                    assistTarget = battleTarget:getShortID()
+                    assistTarget = battleTarget:getTargID()
                     break
                 end
             end
@@ -75,7 +75,7 @@ xi.ally =
         end
 
         for _, ally in ipairs(allies) do
-            ally:engage(target:getShortID())
+            ally:engage(target:getTargID())
         end
     end
 }

--- a/scripts/zones/Apollyon/mobs/Carnagechief_Jackbodokk.lua
+++ b/scripts/zones/Apollyon/mobs/Carnagechief_Jackbodokk.lua
@@ -8,7 +8,7 @@ mixins = {require("scripts/mixins/job_special")}
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 end
 
 entity.onMobEngaged = function(mob, target)
@@ -18,9 +18,9 @@ entity.onMobEngaged = function(mob, target)
         battlefield:setLocalVar("startTime", battlefield:getRemainingTime())
     end
 
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
     mob:setLocalVar("wave", 1)
 end
 
@@ -44,15 +44,15 @@ entity.onMobFight = function(mob, target)
             mob:setLocalVar("wave", 2)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 4):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 4):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 5):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 5):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 6):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 6):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
         elseif
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 4):isDead() and
@@ -63,15 +63,15 @@ entity.onMobFight = function(mob, target)
             mob:setLocalVar("wave", 1)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 1):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 1):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 2):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 2):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 3):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[1] + 3):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[1] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
         end
 
         if remainingTime <= startTime * 0.66 then

--- a/scripts/zones/Apollyon/mobs/Dee_Wapa_the_Desolator.lua
+++ b/scripts/zones/Apollyon/mobs/Dee_Wapa_the_Desolator.lua
@@ -7,7 +7,7 @@ local ID = require("scripts/zones/Apollyon/IDs")
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 end
 
 entity.onMobEngaged = function(mob, target)
@@ -17,9 +17,9 @@ entity.onMobEngaged = function(mob, target)
         battlefield:setLocalVar("startTime", battlefield:getRemainingTime())
     end
 
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
     mob:setLocalVar("wave", 1)
 end
 
@@ -44,15 +44,15 @@ entity.onMobFight = function(mob, target)
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 6):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 6):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 7):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 7):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 7):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 7):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 8):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 8):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 8):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 8):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
         elseif
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 6):isDead() and
@@ -64,15 +64,15 @@ entity.onMobFight = function(mob, target)
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 3):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 3):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 4):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 4):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 5):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[3] + 5):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[3] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
         end
 
         if remainingTime <= startTime * 0.66 then

--- a/scripts/zones/Apollyon/mobs/NaQba_Chirurgeon.lua
+++ b/scripts/zones/Apollyon/mobs/NaQba_Chirurgeon.lua
@@ -8,7 +8,7 @@ mixins = {require("scripts/mixins/job_special")}
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 end
 
 entity.onMobEngaged = function(mob, target)
@@ -18,9 +18,9 @@ entity.onMobEngaged = function(mob, target)
         battlefield:setLocalVar("startTime", battlefield:getRemainingTime())
     end
 
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
-    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
+    SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
     mob:setLocalVar("wave", 1)
 end
 
@@ -45,15 +45,15 @@ entity.onMobFight = function(mob, target)
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 4):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 4):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 4):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 5):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 5):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 5):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 6):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 6):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 6):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
         elseif
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 4):isDead() and
@@ -64,15 +64,15 @@ entity.onMobFight = function(mob, target)
             mob:setLocalVar("wave", 1)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 1):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 1):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 1):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 2):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 2):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 2):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
 
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 3):setSpawn(mobX, mobY, mobZ)
             GetMobByID(ID.mob.APOLLYON_CS_MOB[2] + 3):setPos(mobX, mobY, mobZ)
-            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+            SpawnMob(ID.mob.APOLLYON_CS_MOB[2] + 3):setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
         end
 
         if remainingTime <= startTime * 0.66 then

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -15,7 +15,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getShortID())
+    mob:setMobMod(xi.mobMod.SUPERLINK, mob:getTargID())
     mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
     mob:setMod(xi.mod.UDMGPHYS, -7500)
     mob:setMod(xi.mod.UDMGRANGE, -7500)

--- a/scripts/zones/Nyzul_Isle/mobs/Raubahn.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Raubahn.lua
@@ -29,7 +29,7 @@ entity.onMobSpawn = function(mob)
             local target = mobArg:getTarget()
             local targetid = 0
 
-            if target then targetid = target:getShortID() end
+            if target then targetid = target:getTargID() end
 
             mobArg:timer(12000, function(mobTimerArg)
                 mobTimerArg:setHP(mobTimerArg:getMaxHP())

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
@@ -22,7 +22,7 @@ entity.onMobInitialize = function(IxAernDrkMob)
             local target = mob:getTarget()
             local targetid = 0
             if target then
-                targetid = target:getShortID()
+                targetid = target:getTargID()
             end
             mob:setMobMod(xi.mobMod.NO_DROPS, 1)
             mob:timer(9000, function(mobArg)

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -29,6 +29,7 @@
 
 CBaseEntity::CBaseEntity()
 : status(STATUS_TYPE::DISAPPEAR)
+, isRenamed(false)
 {
     id       = 0;
     targid   = 0;
@@ -81,6 +82,11 @@ void CBaseEntity::FadeOut()
 const int8* CBaseEntity::GetName()
 {
     return (const int8*)name.c_str();
+}
+
+const int8* CBaseEntity::GetPacketName()
+{
+    return (const int8*)packetName.c_str();
 }
 
 uint16 CBaseEntity::getZone() const

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -215,6 +215,7 @@ public:
     virtual void        Spawn();
     virtual void        FadeOut();
     virtual const int8* GetName();       // имя сущности
+    virtual const int8* GetPacketName();
     uint16              getZone() const; // текущая зона
     float               GetXPos() const; // позиция по координате X
     float               GetYPos() const; // позиция по координате Y
@@ -261,6 +262,7 @@ public:
     ALLEGIANCE_TYPE allegiance; // what types of targets the entity can fight
     uint8           updatemask; // what to update next server tick to players nearby
 
+    bool isRenamed; // tracks if the entity's name has been overidden. Defaults to false.
 
     std::unique_ptr<CAIContainer> PAI;          // AI container
     CBattlefield*                 PBattlefield; // pointer to battlefield (if in one)

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -170,7 +170,7 @@ enum ENTITYFLAGS
     FLAG_UNTARGETABLE  = 0x800,
 };
 
-// TODO: возможо стоит сделать эту структуру частью класса, взамен нынешних id и targid, но уже без метода clean
+// TODO:it is possible to make this structure part of the class, instead of the current ID and Targid, but without the Clean method
 
 struct EntityID_t
 {
@@ -188,12 +188,12 @@ class CZone;
 
 struct location_t
 {
-    position_t p;           // позиция сущности
-    uint16     destination; // текущая зона
-    CZone*     zone;        // текущая зона
-    uint16     prevzone;    // предыдущая зона (для монстров и npc не используется)
-    bool       zoning; // флаг сбрасывается при каждом входе в новую зону. необходим для реализации логики игровых задач ("quests")
-    uint16     boundary; // определенная область в зоне, в которой находится сущность (используется персонажами и транспортом)
+    position_t p;           // Position of entity
+    uint16     destination; // Destination zone while zoning
+    CZone*     zone;        // Current zone
+    uint16     prevzone;    // Previous zone (Not used for monsters and NPCs)
+    bool       zoning;      // The flag is reset at each entrance to the new zone. We are needed to implement the logic of game tasks ("Quests")
+    uint16     boundary;    // A certain area in the zone in which the entity is located (used by characters and transport)
 };
 
 class CAIContainer;
@@ -202,24 +202,24 @@ class CBattlefield;
 
 /************************************************************************
  *                                                                       *
- *  Базовый класс для всех сущностей в игре                              *
+ *  Basic class for all entities in the game                             *
  *                                                                       *
  ************************************************************************/
 
 class CBaseEntity
 {
 public:
-    CBaseEntity();          // конструктор
-    virtual ~CBaseEntity(); // деструктор
+    CBaseEntity();
+    virtual ~CBaseEntity();
 
     virtual void        Spawn();
     virtual void        FadeOut();
-    virtual const int8* GetName();       // имя сущности
-    virtual const int8* GetPacketName();
-    uint16              getZone() const; // текущая зона
-    float               GetXPos() const; // позиция по координате X
-    float               GetYPos() const; // позиция по координате Y
-    float               GetZPos() const; // позиция по координате Z
+    virtual const int8* GetName();       // Internal name of entity
+    virtual const int8* GetPacketName(); // Name of entity sent to the client
+    uint16              getZone() const; // Current zone
+    float               GetXPos() const; // Position of co-ordinate X
+    float               GetYPos() const; // Position of co-ordinate Y
+    float               GetZPos() const; // Position of co-ordinate Z
     uint8               GetRotPos() const;
     void                HideName(bool hide);  // hide / show name
     bool                IsNameHidden() const; // checks if name is hidden
@@ -246,18 +246,18 @@ public:
 
     uint32          id;           // global identifier unique on the server
     uint16          targid;       // local identifier unique to the zone
-    ENTITYTYPE      objtype;      // тип сущности
-    STATUS_TYPE     status;       // статус сущности (разные сущности - разные статусы)
+    ENTITYTYPE      objtype;      // Type of entity
+    STATUS_TYPE     status;       // Entity status (different entities - different statuses)
     uint16          m_TargID;     // the targid of the object the entity is looking at
     string_t        name;         // Entity name
     string_t        packetName;   // Used to override name when being sent to the client
-    look_t          look;         // внешний вид всех сущностей
+    look_t          look;
     look_t          mainlook;     // only used if mob use changeSkin() or player /lockstyle
-    location_t      loc;          // местоположение сущности
-    uint8           animation;    // анимация
-    uint8           animationsub; // дополнительный параметры анимации
-    uint8           speed;        // скорость передвижения
-    uint8           speedsub;     // подолнительный параметр скорости передвижения
+    location_t      loc;          // Location of entity
+    uint8           animation;    // animation
+    uint8           animationsub; // Additional animation parameter
+    uint8           speed;        // speed of movement
+    uint8           speedsub;     // Additional movement speed parameter
     uint8           namevis;
     ALLEGIANCE_TYPE allegiance; // what types of targets the entity can fight
     uint8           updatemask; // what to update next server tick to players nearby

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4402,11 +4402,17 @@ std::string CLuaBaseEntity::getPacketName()
  *  Purpose : Overrides the visible name of the entity.
  *  Example : mob:renameEntity("NewName")
  *  Note    : This will set the packet name of the entity to a name of
- *          : your choosing. This will not work for players.
+ *          : your choosing.
  ************************************************************************/
 
 void CLuaBaseEntity::renameEntity(std::string const& newName)
 {
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        ShowWarning("Renaming player character entities isn't supported.");
+        return;
+    }
+
     auto oldName = m_PBaseEntity->packetName.empty() ? "<empty>" : m_PBaseEntity->packetName;
     m_PBaseEntity->packetName = newName;
     m_PBaseEntity->updatemask |= UPDATE_NAME | UPDATE_HP;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4387,21 +4387,6 @@ std::string CLuaBaseEntity::getName()
 }
 
 /************************************************************************
- *  Function: setName()
- *  Purpose : Sets the name of the entity.
- *  Example : mob:setName("NewName")
- *  Note    : This will only apply to entities whose targid's are in a range
- *          : that will allow their names to be changed: Trusts, Pets,
- *          : Dynamic Entities etc.
- ************************************************************************/
-
-void CLuaBaseEntity::setName(std::string const& name)
-{
-    m_PBaseEntity->name = name;
-    m_PBaseEntity->updatemask |= UPDATE_NAME;
-}
-
-/************************************************************************
  *  Function: getPacketName()
  *  Purpose : Returns the string packet name of the character
  *  Example : mob:getPacketName()
@@ -4413,18 +4398,21 @@ std::string CLuaBaseEntity::getPacketName()
 }
 
 /************************************************************************
- *  Function: setPacketName()
- *  Purpose : Sets the packet name of the entity.
- *  Example : mob:getPacketName("NewName")
- *  Note    : This will only apply to entities whose targid's are in a range
- *          : that will allow their packet names to be changed: Trusts, Pets,
- *          : Dynamic Entities etc.
+ *  Function: renameEntity()
+ *  Purpose : Overrides the visible name of the entity.
+ *  Example : mob:renameEntity("NewName")
+ *  Note    : This will set the packet name of the entity to a name of
+ *          : your choosing. This will not work for players.
  ************************************************************************/
 
-void CLuaBaseEntity::setPacketName(std::string const& name)
+void CLuaBaseEntity::renameEntity(std::string const& newName)
 {
-    m_PBaseEntity->packetName = name;
+    auto oldName = m_PBaseEntity->packetName;
+    m_PBaseEntity->packetName = newName;
     m_PBaseEntity->updatemask |= UPDATE_NAME;
+    m_PBaseEntity->isRenamed = true;
+
+    ShowInfo("Renaming %s: %s -> %s", m_PBaseEntity->name, oldName, newName);
 }
 
 /************************************************************************
@@ -13741,9 +13729,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getRace", CLuaBaseEntity::getRace);
     SOL_REGISTER("getGender", CLuaBaseEntity::getGender);
     SOL_REGISTER("getName", CLuaBaseEntity::getName);
-    SOL_REGISTER("setName", CLuaBaseEntity::setName);
     SOL_REGISTER("getPacketName", CLuaBaseEntity::getPacketName);
-    SOL_REGISTER("setPacketName", CLuaBaseEntity::setPacketName);
+    SOL_REGISTER("renameEntity", CLuaBaseEntity::renameEntity);
     SOL_REGISTER("hideName", CLuaBaseEntity::hideName);
     SOL_REGISTER("checkNameFlags", CLuaBaseEntity::checkNameFlags);
     SOL_REGISTER("getModelId", CLuaBaseEntity::getModelId);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4407,9 +4407,9 @@ std::string CLuaBaseEntity::getPacketName()
 
 void CLuaBaseEntity::renameEntity(std::string const& newName)
 {
-    auto oldName = m_PBaseEntity->packetName;
+    auto oldName = m_PBaseEntity->packetName.empty() ? "<empty>" : m_PBaseEntity->packetName;
     m_PBaseEntity->packetName = newName;
-    m_PBaseEntity->updatemask |= UPDATE_NAME;
+    m_PBaseEntity->updatemask |= UPDATE_NAME | UPDATE_HP;
     m_PBaseEntity->isRenamed = true;
 
     ShowInfo("Renaming %s: %s -> %s", m_PBaseEntity->name, oldName, newName);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1280,13 +1280,13 @@ uint32 CLuaBaseEntity::getID()
 }
 
 /************************************************************************
- *  Function: getShortID()
+ *  Function: getTargID()
  *  Purpose : Gets the ID of a Target
- *  Example : mob:getShortID(); pet:getShortID()
- *  Notes   : To Do: Should be renamed to getTargID
+ *  Example : mob:getTargID(); pet:getTargID()
+ *  Notes   :
  ************************************************************************/
 
-uint16 CLuaBaseEntity::getShortID()
+uint16 CLuaBaseEntity::getTargID()
 {
     return m_PBaseEntity->targid;
 }
@@ -12271,7 +12271,7 @@ uint32 CLuaBaseEntity::getMobFlags()
 *  Function: setNpcFlags()
 *  Purpose : Manually set NPC Entity Flags
 *  Example : npc:setNpcFlags(1)
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 void CLuaBaseEntity::setNpcFlags(uint32 flags)
@@ -13586,7 +13586,7 @@ void CLuaBaseEntity::Register()
 
     // Object Identification
     SOL_REGISTER("getID", CLuaBaseEntity::getID);
-    SOL_REGISTER("getShortID", CLuaBaseEntity::getShortID);
+    SOL_REGISTER("getTargID", CLuaBaseEntity::getTargID);
     SOL_REGISTER("getCursorTarget", CLuaBaseEntity::getCursorTarget);
 
     SOL_REGISTER("getObjType", CLuaBaseEntity::getObjType);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -255,9 +255,8 @@ public:
     uint8  getRace();
     uint8  getGender();              // Returns the player character's gender
     auto   getName() -> std::string; // Gets Entity Name
-    void   setName(std::string const& name);
     auto   getPacketName() -> std::string;
-    void   setPacketName(std::string const& name);
+    void   renameEntity(std::string const& newName);
     void   hideName(bool isHidden);
     bool   checkNameFlags(uint32 flags); // this is check and not get because it tests for a flag, it doesn't return all flags
     uint16 getModelId();

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -104,7 +104,7 @@ public:
 
     // Object Identification
     uint32 getID();
-    uint16 getShortID();
+    uint16 getTargID();
     auto   getCursorTarget() -> std::optional<CLuaBaseEntity>; // Returns the ID any object under players in game cursor.
 
     uint8 getObjType();
@@ -509,7 +509,7 @@ public:
     // int32 isInAssault(lua_Stat*); // If player is in a Instanced Assault Dungeon returns true --- Not Implemented
 
     uint16 getConfrontationEffect();
-    uint16 copyConfrontationEffect(uint16 targetID); // copy confrontation effect, param = targetEntity:getShortID()
+    uint16 copyConfrontationEffect(uint16 targetID); // copy confrontation effect, param = targetEntity:getTargID()
 
     // Battlefields
     auto  getBattlefield() -> std::optional<CLuaBattlefield>;                                             // returns CBattlefield* or nullptr if not available

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -224,6 +224,8 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     PEntity->name = lookupName;
     PEntity->packetName = name;
 
+    PEntity->isRenamed = true;
+
     auto typeKey = (PEntity->objtype == TYPE_NPC) ? "npcs" : "mobs";
     auto cacheEntry = lua[sol::create_if_nil]["xi"]["zones"][(const char*)m_pLuaZone->GetName()][typeKey][lookupName];
 

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -35,7 +35,7 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
     this->setSize(0x74);
 
     ref<uint32>(0x04) = PChar->id;
-    ref<uint16>(0x08) = PChar->targid;
+    ref<uint16>(0x08) = PChar->targid; // 0x0D entity updates are valid for 1024 to 1791
 
     switch (type)
     {

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -159,7 +159,7 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
 
             if (updatemask & UPDATE_NAME)
             {
-                std::string name = PChar->isRenamed ? (const char*)PChar->GetPacketName() : (const char*)PChar->GetName();
+                std::string name = (const char*)PChar->GetName();
                 memcpy(data + (0x5A), name.c_str(), name.size());
             }
         }

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -159,7 +159,8 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
 
             if (updatemask & UPDATE_NAME)
             {
-                memcpy(data + (0x5A), PChar->GetName(), PChar->name.size());
+                std::string name = PChar->isRenamed ? (const char*)PChar->GetPacketName() : (const char*)PChar->GetName();
+                memcpy(data + (0x5A), name.c_str(), name.size());
             }
         }
         break;

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -39,7 +39,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
     this->setSize(0x58);
 
     ref<uint32>(0x04) = PEntity->id;
-    ref<uint16>(0x08) = PEntity->targid;
+    ref<uint16>(0x08) = PEntity->targid; // 0x0E entity updates are valid for 0 to 1023 and 1792 to 2303
     ref<uint8>(0x0A)  = updatemask;
 
     switch (type)

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -209,11 +209,11 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
     {
         this->setSize(0x48);
 
-        bool isNPC      = PEntity->objtype == TYPE_NPC;
         auto name       = PEntity->name;
         auto nameOffset = (PEntity->look.size == MODEL_EQUIPPED) ? 0x44 : 0x34;
 
-        if ((!isNPC && !PEntity->packetName.empty()) ||
+        if (PEntity->isRenamed ||
+            PEntity->objtype == TYPE_TRUST ||
             PEntity->IsDynamicEntity())
         {
             name = PEntity->packetName;


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Finally, we don't have to use the renamer addon anymore!

![image](https://user-images.githubusercontent.com/1389729/163595294-f04ea9b6-a42f-4e6e-98d0-7b963ed0713b.png)
![image](https://user-images.githubusercontent.com/1389729/163595317-3148a057-5ad9-4b96-acd1-98be5dac50b6.png)
