### PR TITLE
[abyssea] Implement Abyssea-specific status effects

### DIFF
--- a/scripts/globals/effects/atma.lua
+++ b/scripts/globals/effects/atma.lua
@@ -1,7 +1,8 @@
 -----------------------------------
 -- xi.effect.ATMA
 -----------------------------------
-require("scripts/globals/atma")
+require("scripts/globals/abyssea/atma")
+require("scripts/globals/abyssea")
 -----------------------------------
 local effect_object = {}
 
@@ -10,6 +11,9 @@ effect_object.onEffectGain = function(target, effect)
 end
 
 effect_object.onEffectTick = function(target, effect)
+	if not xi.abyssea.isInAbysseaZone(target) then
+        target:delStatusEffect(effect)
+    end
 end
 
 effect_object.onEffectLose = function(target, effect)

--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -2,6 +2,7 @@
 -- xi.effect.HEALING
 -- Activated through the /heal command
 -----------------------------------
+require("scripts/globals/abyssea")
 require("scripts/globals/keyitems")
 require("scripts/settings/main")
 require("scripts/globals/quests")
@@ -14,6 +15,19 @@ local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
     target:setAnimation(33)
+
+    -- Abyssea Lights and time remaining check
+    if
+        target:isPC() and
+        xi.abyssea.isInAbysseaZone(target)
+    then
+        local visitantEffect = target:getStatusEffect(xi.effect.VISITANT)
+
+        if visitantEffect and visitantEffect:getIcon() == xi.effect.VISITANT then
+            xi.abyssea.displayTimeRemaining(target)
+            xi.abyssea.displayAbysseaLights(target)
+        end
+    end
 
     -- Dances with Luopans
     if target:getLocalVar("GEO_DWL_Locus_Area") == 1 and target:getCharVar("GEO_DWL_Luopan") == 0 then

--- a/scripts/globals/effects/visitant.lua
+++ b/scripts/globals/effects/visitant.lua
@@ -1,22 +1,157 @@
 -----------------------------------
 -- xi.effect.VISITANT
 -----------------------------------
+require("scripts/globals/abyssea")
+require("scripts/globals/zone")
+-----------------------------------
 local effect_object = {}
 
+local exitPositions =
+{
+    [xi.zone.ABYSSEA_KONSCHTAT]  = {   88.4, -68.09, -579.97, 128, 108 },
+    [xi.zone.ABYSSEA_TAHRONGI]   = {  -28.6,  46.17,  -680.3, 192, 117 },
+    [xi.zone.ABYSSEA_LA_THEINE]  = {   -562,      0,     640, 158, 102 },
+    [xi.zone.ABYSSEA_ATTOHWA]    = {   -340, -23.36,   48.49,  31, 118 },
+    [xi.zone.ABYSSEA_MISAREAUX]  = { 363.47,      0, -119.72, 129, 103 },
+    [xi.zone.ABYSSEA_VUNKERL]    = { 242.98,   0.24,    8.72, 157, 104 },
+    [xi.zone.ABYSSEA_ALTEPA]     = {    340,  -0.52,    -668, 192, 107 },
+    [xi.zone.ABYSSEA_ULEGUERAND] = {    270,   -7.8,     -82,  64, 112 },
+    [xi.zone.ABYSSEA_GRAUBERG]   = {    -64,      0,     600,   0, 106 },
+}
+
+local remainingTimeLimits =
+{
+    300,
+    120,
+     60,
+     30,
+     10,
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2,
+      1,
+}
+
+-- NOTE: Update the last
+local reportTimeRemaining
+reportTimeRemaining = function(player, effect)
+    local ID = zones[player:getZoneID()]
+    local lastTimeUpdate = player:getLocalVar('lastTimeUpdate')
+    local currentTime = effect:getTimeRemaining() / 1000 - 4
+    local messageParam = 0
+    local nextTimeReport = 0
+
+    -- All possible forms of TE will reset out of the final two minute warning,
+    -- reset this here.
+    if
+        currentTime > lastTimeUpdate
+    then
+        lastTimeUpdate = currentTime
+        player:setLocalVar('finalCountdown', 0)
+        return
+    end
+
+    for i = 1, #remainingTimeLimits do
+        if
+            lastTimeUpdate > remainingTimeLimits[i] and
+            currentTime <= remainingTimeLimits[i]
+        then
+            messageParam = remainingTimeLimits[i]
+            nextTimeReport = remainingTimeLimits[i] ~= 1 and remainingTimeLimits[i + 1] or 0
+            player:setLocalVar('lastTimeUpdate', messageParam)
+
+            if messageParam <= 30 then
+                player:setLocalVar('finalCountdown', 1)
+            end
+            break
+        end
+    end
+
+    if messageParam > 0 then
+        if messageParam >= 60 then
+            player:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 4, messageParam / 60)
+        elseif messageParam > 1 then
+            player:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 7, messageParam)
+        else
+            player:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 6, messageParam)
+        end
+    end
+
+    -- Handle the more granular countdown, as effect ticks are only every
+    -- three seconds.
+    if player:getLocalVar('finalCountdown') == 1 then
+        if messageParam > 0 then
+            local timerVal = (messageParam - nextTimeReport) * 1000
+
+            player:timer(timerVal, function() reportTimeRemaining(player, effect) end)
+        else
+            -- There's 4s of buffer time built in, so that the full countdown is displayed.
+            -- If we reached the end, delete the status effect so that the player is ejected.
+            player:delStatusEffectSilent(xi.effect.VISITANT)
+        end
+    end
+end
+
 effect_object.onEffectGain = function(target, effect)
+    local visEffect = target:getStatusEffect(xi.effect.VISITANT)
+
+    visEffect:setFlag(xi.effectFlag.OFFLINE_TICK)
+    visEffect:setFlag(xi.effectFlag.NO_CANCEL)
+    visEffect:setFlag(xi.effectFlag.ON_ZONE)
+    visEffect:setFlag(xi.effectFlag.HIDE_TIMER)
+
+    target:setLocalVar('lastTimeUpdate', effect:getTimeRemaining() / 1000 + 1)
 end
 
 effect_object.onEffectTick = function(target, effect)
-    --[[
-    local duration = effect:getDuration()
-    if (target:getCharVar("Abyssea_Time") >= 3) then
-        target:setCharVar("Abyssea_Time", duration)
+	if not xi.abyssea.isInAbysseaZone(target) then
+        target:delStatusEffect(effect)
     end
-    Some messages about remaining time.will need to handled outside of this effect (zone ejection warnings after visitant is gone).
-    ]]
+
+    -- Searing Ward Tether is set and reset in zone onRegionLeave and
+    -- onRegionEnter.
+    if target:getLocalVar('tetherTimer') == 11 then
+        xi.abyssea.searingWardTimer(target)
+    end
+
+    -- Handle Time Remaining Messages. This will no longer be called if the time
+    -- remaining is less that 30s, as then we move to timers set on the player to
+    -- ensure that they're displayed at the appropriate timings.
+    if
+        target:getLocalVar('finalCountdown') == 0
+    then
+        reportTimeRemaining(target, effect)
+    end
 end
 
 effect_object.onEffectLose = function(target, effect)
+    local zoneID = target:getZoneID()
+    local ID = zones[zoneID]
+
+    if xi.abyssea.isInAbysseaZone(target) then
+        target:setLocalVar('finalCountdown', 0)
+        target:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 8)
+        target:setPos(unpack(exitPositions[zoneID]))
+    elseif effect:getIcon() == xi.effect.VISITANT then
+        -- Player exited willingly, set their time stored as seconds remaining.  Cap at 120 minutes,
+        -- and remove the 4 seconds that was granted as a buffer time.
+        local timeRemaining = math.min(effect:getTimeRemaining() / 1000 - 4, 7200)
+
+        if timeRemaining < 0 then
+            timeRemaining = 0
+        end
+
+        target:setCharVar('abysseaTimeStored', timeRemaining)
+    end
+
+    -- Reset Abyssea Lights
+    target:setCharVar('abysseaLights1', 0)
+    target:setCharVar('abysseaLights2', 0)
 end
 
 return effect_object


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
