### PR TITLE
Fix naming and default value issues for Abyssea Lights

### DIFF
--- a/scripts/globals/abyssea/lights.lua
+++ b/scripts/globals/abyssea/lights.lua
@@ -566,9 +566,9 @@ xi.abyssea.AddDeathListeners = function(mob)
 		if deathType == xi.abyssea.deathType.NONE then
 			deathType = xi.abyssea.deathType.PHYSICAL
 		end
-        xi.abyssea.lights.DropLights(player, mobArg:getName(), deathType, mobArg)
+        xi.abyssea.DropLights(player, mobArg:getName(), deathType, mobArg)
 
-		xi.abyssea.lights.RemoveDeathListeners(mobArg)
+		xi.abyssea.RemoveDeathListeners(mobArg)
     end)
 end
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes #1603