### PR TITLE
[core] Revert and replace entity_update packet changes

### DIFF
--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -1,21 +1,16 @@
 ﻿/*
 ===========================================================================
-
   Copyright (c) 2010-2015 Darkstar Dev Teams
-
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see http://www.gnu.org/licenses/
-
 ===========================================================================
 */
 
@@ -39,7 +34,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
     this->setSize(0x58);
 
     ref<uint32>(0x04) = PEntity->id;
-    ref<uint16>(0x08) = PEntity->targid; // 0x0E entity updates are valid for 0 to 1023 and 1792 to 2303
+    ref<uint16>(0x08) = PEntity->targid;
     ref<uint8>(0x0A)  = updatemask;
 
     switch (type)
@@ -59,7 +54,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             }
             if (PEntity->objtype == TYPE_TRUST)
             {
-                //ref<uint8>(0x28) = 0x45;
+                // ref<uint8>(0x28) = 0x45;
             }
             if (PEntity->look.size == MODEL_EQUIPPED || PEntity->look.size == MODEL_CHOCOBO)
             {
@@ -99,7 +94,6 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         ref<uint8>(0x20) = static_cast<uint8>(PEntity->status);
     }
 
-    // General flags and data
     switch (PEntity->objtype)
     {
         case TYPE_NPC:
@@ -108,7 +102,8 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
 
             if (updatemask & UPDATE_HP)
             {
-                ref<uint8>(0x1E) = 0x64; // HPP: 100
+                // HPP
+                ref<uint8>(0x1E) = 0x64; // 100
                 ref<uint8>(0x1F) = PEntity->animation;
                 ref<uint8>(0x2A) |= PEntity->animationsub;
 
@@ -123,6 +118,14 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
                 ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);
                 ref<uint8>(0x2B) = PEntity->namevis;
             }
+
+            // TODO: Unify name logic
+            if (updatemask & UPDATE_NAME)
+            {
+                // depending on size of name, this can be 0x20, 0x22, or 0x24
+                this->setSize(0x48);
+                memcpy(data + (0x34), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
+            }
         }
         break;
         case TYPE_MOB:
@@ -130,28 +133,42 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         case TYPE_TRUST:
         {
             CMobEntity* PMob = static_cast<CMobEntity*>(PEntity);
-            {
-                if (updatemask & UPDATE_HP)
-                {
-                    ref<uint8>(0x1E) = PMob->GetHPP();
-                    ref<uint8>(0x1F) = PEntity->animation;
-                    ref<uint8>(0x2A) |= PEntity->animationsub;
 
-                    ref<uint32>(0x21) = PMob->m_flags;
-                    ref<uint8>(0x25)  = PMob->health.hp > 0 ? 0x08 : 0;
-                    ref<uint8>(0x27)  = PMob->m_name_prefix;
-                    if (PMob->PMaster != nullptr && PMob->PMaster->objtype == TYPE_PC)
-                    {
-                        ref<uint8>(0x27) |= 0x08;
-                    }
-                    ref<uint8>(0x28) |= (PMob->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR) ? 0x10 : 0x00);
-                    ref<uint8>(0x28) |= PMob->health.hp > 0 && PMob->animation == ANIMATION_DEATH ? 0x08 : 0;
-                    ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);
-                    ref<uint8>(0x2B) = PEntity->namevis;
-                }
-                if (updatemask & UPDATE_STATUS)
+            if (updatemask & UPDATE_HP)
+            {
+                ref<uint8>(0x1E) = PMob->GetHPP();
+                ref<uint8>(0x1F) = PEntity->animation;
+                ref<uint8>(0x2A) |= PEntity->animationsub;
+
+                ref<uint32>(0x21) = PMob->m_flags;
+                ref<uint8>(0x25)  = PMob->health.hp > 0 ? 0x08 : 0;
+                ref<uint8>(0x27)  = PMob->m_name_prefix;
+                if (PMob->PMaster != nullptr && PMob->PMaster->objtype == TYPE_PC)
                 {
-                    ref<uint32>(0x2C) = PMob->m_OwnerID.id;
+                    ref<uint8>(0x27) |= 0x08;
+                }
+                ref<uint8>(0x28) |= (PMob->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR) ? 0x10 : 0x00);
+                ref<uint8>(0x28) |= PMob->health.hp > 0 && PMob->animation == ANIMATION_DEATH ? 0x08 : 0;
+                ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);
+                ref<uint8>(0x2B) = PEntity->namevis;
+            }
+
+            if (updatemask & UPDATE_STATUS)
+            {
+                ref<uint32>(0x2C) = PMob->m_OwnerID.id;
+            }
+
+            if (updatemask & UPDATE_NAME)
+            {
+                // depending on size of name, this can be 0x20, 0x22, or 0x24
+                this->setSize(0x48);
+                if (PMob->packetName.empty())
+                {
+                    memcpy(data + (0x34), PEntity->GetName(), std::min<size_t>(PEntity->name.size(), PacketNameLength));
+                }
+                else
+                {
+                    memcpy(data + (0x34), PMob->packetName.c_str(), std::min<size_t>(PMob->packetName.size(), PacketNameLength));
                 }
             }
         }
@@ -173,21 +190,20 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
         ref<uint8>(0x28) = 0x45; // This allows trusts to be despawned
     }
 
-    // Send look data
     switch (PEntity->look.size)
     {
         case MODEL_STANDARD:
         case MODEL_UNK_5:
         case MODEL_AUTOMATON:
         {
-            this->setSize(0x48);
             ref<uint32>(0x30) = ::ref<uint32>(&PEntity->look, 0);
         }
         break;
         case MODEL_EQUIPPED:
         case MODEL_CHOCOBO:
         {
-            std::memcpy(data + 0x30, &PEntity->look, sizeof(PEntity->look));
+            this->setSize(0x48);
+            memcpy(data + (0x30), &(PEntity->look), 20);
         }
         break;
         case MODEL_DOOR:
@@ -199,52 +215,5 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             memcpy(data + (0x34), PEntity->GetName(), (PEntity->name.size() > 12 ? 12 : PEntity->name.size()));
         }
         break;
-    }
-
-    // If the entity has been renamed, we have to re-send the name during every update.
-    // Otherwise it will revert to it's default name (if applicable).
-    if (PEntity->isRenamed)
-    {
-        updatemask       |= UPDATE_NAME;
-        ref<uint8>(0x0A) |= updatemask;
-    }
-
-    // Send name data
-    if (updatemask & UPDATE_NAME)
-    {
-        this->setSize(0x48);
-
-        auto name       = PEntity->name;
-        auto nameOffset = (PEntity->look.size == MODEL_EQUIPPED) ? 0x44 : 0x34;
-
-        // Mobs and NPC's targid's live in the range 0-1023
-        if (PEntity->targid < 1024 && PEntity->isRenamed)
-        {
-            ref<uint16>(0x34) = 0x01;
-            nameOffset        = 0x35;
-        }
-
-        if (PEntity->isRenamed ||
-            PEntity->objtype == TYPE_TRUST ||
-            PEntity->IsDynamicEntity())
-        {
-            name = PEntity->packetName;
-        }
-
-        auto maxLength = std::min<size_t>(name.size(), PacketNameLength);
-
-        if (PEntity->look.size == MODEL_DOOR ||
-            PEntity->look.size == MODEL_ELEVATOR ||
-            PEntity->look.size == MODEL_SHIP)
-        {
-            maxLength = 12;
-        }
-
-        std::memcpy(data + nameOffset, name.c_str(), maxLength);
-
-        // Make sure the rest of the packet is empty (or garbage might appear)
-        auto start = data + nameOffset + maxLength;
-        auto size = static_cast<std::size_t>(this->getSize());
-        std::memset(start, 0U, size);
     }
 }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

(should)
Fixes https://github.com/LandSandBoat/server/issues/1592
Fixes https://github.com/LandSandBoat/server/issues/1607

Tested on Kazham Mithras, custom NPCs and Mobs in GM Home, Renaming existing mobs and NPCs.

This is the original entity_update layout, with a block added at the bottom for renaming. So if it was stable before, it'll be stable again now.