### PR TITLE
Fix mission:setLocalVar call in Three Paths

### DIFF
--- a/scripts/missions/cop/5_3_Three_Paths.lua
+++ b/scripts/missions/cop/5_3_Three_Paths.lua
@@ -274,7 +274,7 @@ mission.sections =
             onEventFinish =
             {
                 [852] = function(player, csid, option, npc)
-                    mission:setLocalVar('cidOption', 0)
+                    mission:setLocalVar(player, 'cidOption', 0)
                     player:setMissionStatus(mission.areaId, 11, xi.mission.status.COP.LOUVERANCE)
                 end,
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
