### PR TITLE
[geo] Entrust and indi effects on others

### DIFF
--- a/scripts/globals/abilities/entrust.lua
+++ b/scripts/globals/abilities/entrust.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Ability: Entrust
+-- Causes the next indicolure spell cast to be able to target a party member.
+-- Obtained: Geomancer Level 75
+-- Recast Time: 00:10:00
+-- Duration: 00:00:30
+-----------------------------------
+require("scripts/settings/main")
+require("scripts/globals/status")
+-----------------------------------
+local ability_object = {}
+
+ability_object.onAbilityCheck = function(player, target, ability)
+    return 0, 0
+end
+
+ability_object.onUseAbility = function(player, target, ability)
+    player:addStatusEffect(xi.effect.ENTRUST, 1, 0, 60)
+end
+
+return ability_object

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -134,6 +134,12 @@ CCharPacket::CCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask
                 ref<uint8>(0x33) = 0x40;
             }
 
+            // Geomancer (GEO) Indi spell effect on the char.
+            if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_COLURE_ACTIVE))
+            {
+                ref<uint8>(0x42) = 0x50 + PChar->StatusEffectContainer->GetStatusEffect(EFFECT_COLURE_ACTIVE)->GetPower();
+            }
+
             ref<uint8>(0x43)  = 0x04;
 
             if (updatemask & UPDATE_LOOK)


### PR DESCRIPTION
Adds the indi effect to the player so others can see the effect in the CCharPacket

Added Entrust script

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
