### PR TITLE
add npc command to scripts

### DIFF
--- a/scripts/commands/npc.lua
+++ b/scripts/commands/npc.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- func: !npc
--- desc: Summon a NPC
+-- desc: Test dynamic entity before its placed into a module for testing.
 -- note: Will spawn after you move from your current position
 -----------------------------------
 
@@ -10,7 +10,7 @@ cmdprops =
     parameters = ""
 }
 
-function onTrigger(player, npc)
+function onTrigger(player)
     local zone = player:getZone()
 
     local npc = zone:insertDynamicEntity({
@@ -23,13 +23,13 @@ function onTrigger(player, npc)
         --     : You can then hide the name with entity:hideName(true)
         -- NOTE: This name CAN include spaces and underscores.
         name = "Test",
-       
+
         -- You can use regular model ids (See documentation/model_ids.txt, or play around with !costume)
         look = 2430,
 
         -- You can also use the raw packet look information (as a string), as seen in npc_list and mob_pools
         -- look = "0x0100020500101120003000400050006000700000",
-       
+
         -- Set the NPC at your current position, can set the position using in-game x, y and z if desired.
         x = player:getXPos(),
         y = player:getYPos(),
@@ -38,18 +38,19 @@ function onTrigger(player, npc)
 
         -- onTrade and onTrigger can be hooked up to your dynamic entity,
         -- just like with regular entities. You can also omit these.
-        onTrade = function(player, npc, trade)
+        onTrade = function(playerArg, npcArg, trade)
             -- NOTE: We have to use getPacketName, because the regular name is modified and being used
             --     : for internal lookups
-            player:PrintToPlayer("No, thanks!", 0, npc:getPacketName())
+            player:PrintToPlayer("No, thanks!", 0, npcArg:getPacketName())
         end,
 
         -- The entity will not be "triggerable" unless you populate onTrigger
-        onTrigger = function(player, npc)
+        onTrigger = function(playerArg, npcArg)
             -- NOTE: We have to use getPacketName, because the regular name is modified and being used
             --     : for internal lookups
-            player:PrintToPlayer("Thank you I am free now!", 0, npc:getPacketName())
+            player:PrintToPlayer("Thank you I am free now!", 0, npcArg:getPacketName())
         end,
     })
     player:PrintToPlayer(string.format("Please move to spawn (%s)", npc:getPacketName()))
 end
+

--- a/scripts/commands/npc.lua
+++ b/scripts/commands/npc.lua
@@ -1,0 +1,55 @@
+-----------------------------------
+-- func: !npc
+-- desc: Summon a NPC
+-- note: Will spawn after you move from your current position
+-----------------------------------
+
+cmdprops =
+{
+    permission = 4,
+    parameters = ""
+}
+
+function onTrigger(player, npc)
+    local zone = player:getZone()
+
+    local npc = zone:insertDynamicEntity({
+        -- NPC or MOB
+        objtype = xi.objType.NPC,
+        
+        -- The name visible to players
+        -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
+        --     : So populate it with something unique-ish even if you aren't going to use it.
+        --     : You can then hide the name with entity:hideName(true)
+        -- NOTE: This name CAN include spaces and underscores.
+        name = "Test",
+       
+        -- You can use regular model ids (See documentation/model_ids.txt, or play around with !costume)
+        look = 2430,
+
+        -- You can also use the raw packet look information (as a string), as seen in npc_list and mob_pools
+        -- look = "0x0100020500101120003000400050006000700000",
+       
+        -- Set the NPC at your current position, can set the position using in-game x, y and z if desired.
+        x = player:getXPos(),
+        y = player:getYPos(),
+        z = player:getZPos(),
+        rotation = player:getRotPos(),
+
+        -- onTrade and onTrigger can be hooked up to your dynamic entity,
+        -- just like with regular entities. You can also omit these.
+        onTrade = function(player, npc, trade)
+            -- NOTE: We have to use getPacketName, because the regular name is modified and being used
+            --     : for internal lookups
+            player:PrintToPlayer("No, thanks!", 0, npc:getPacketName())
+        end,
+
+        -- The entity will not be "triggerable" unless you populate onTrigger
+        onTrigger = function(player, npc)
+            -- NOTE: We have to use getPacketName, because the regular name is modified and being used
+            --     : for internal lookups
+            player:PrintToPlayer("Thank you I am free now!", 0, npc:getPacketName())
+        end,
+    })
+    player:PrintToPlayer(string.format("Please move to spawn (%s)", npc:getPacketName()))
+end

--- a/scripts/commands/npc.lua
+++ b/scripts/commands/npc.lua
@@ -16,7 +16,7 @@ function onTrigger(player, npc)
     local npc = zone:insertDynamicEntity({
         -- NPC or MOB
         objtype = xi.objType.NPC,
-        
+
         -- The name visible to players
         -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
         --     : So populate it with something unique-ish even if you aren't going to use it.


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Submitting this on behalf of Demetrie (Omicron). 

Under normal circumstances dynamic entities would have to be loaded in a module which requires a server restart. This command allows the operator to test code changes (and experiment with different model ids [including hex values]) to a custom entity by simply resummoning with the command. 