### PR TITLE
[core] changed how loading group items works

### DIFF
--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -564,11 +564,12 @@ namespace itemutils
                 {
                     uint8  GroupId   = (uint8)sql->GetIntData(4);
                     uint16 GroupRate = (uint16)sql->GetIntData(5);
-                    while (GroupId >= dropList->Groups.size())
+                    while (GroupId > dropList->Groups.size())
                     {
                         dropList->Groups.emplace_back(GroupRate);
                     }
-                    dropList->Groups[GroupId].Items.emplace_back(DropType, ItemID, DropRate);
+                    dropList->Groups[GroupId - 1].GroupRate = GroupRate; // a bit redundant but it prevents any ordering issues.
+                    dropList->Groups[GroupId - 1].Items.emplace_back(DropType, ItemID, DropRate);
                 }
                 else
                 {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This could screw up people who have dropType=1 and dropId=0 type stuff, but LSB as a project does not have any and seems to want dropId's for groups to start at 1 (a sane number for an Id).

First, this fixes it so that unless you start with groupId 0,
which we don't do, you don't get an extra group (empty)

Second, this fixes it so that if SQL loads a groupId 2 first,
groupId 1 doesn't get groupId 2's droprate.
