### PR TITLE
[core] added the actual fmt::format() around the output for modules report

### DIFF
--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -202,7 +202,7 @@ namespace moduleutils
         {
             if (!override.applied)
             {
-                ShowWarning("Override not applied: {} ({})", override.overrideName, override.filename);
+                ShowWarning(fmt::format("Override not applied: {} ({})", override.overrideName, override.filename));
             }
         }
     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
