### PR TITLE
[core] added code to prevent modules for re-caching

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -674,7 +674,15 @@ namespace luautils
         {
             if (part == parts.back())
             {
-                table[sol::override_value][part] = file_result;
+                // if this isn't checked, you will re-load the same thing many times
+                // this generally isn't a problem unless you have applied on override
+                // from a module already, in this situation, the override gets overwritten.
+                bool not_cached_already = !table[part].valid();
+
+                if (not_cached_already)
+                {
+                    table[sol::override_value][part] = file_result;
+                }
             }
             else
             {


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This is seen when loading mobs. For example, loadMOBList() loops through all its mobs, each time it luautils::OnEntityLoad(PMob) once the Mobs stats are set. This in turn called CacheLuaObjectFromFile()
on the mob even if it has already loaded it.
    
Ultimately, this creates a bug for people who load modules something say the "Peryton" in Valley Of
Sorrows. When it loads the Peryton for the first time, it applies the override, and then marks that as
applied. However, once the second Peryton is loaded, it pulls directly from the file and overwrites its
cache value (which had been previously overwritten by the module, essentially undoing that). However,
when the "TryApplyLuaModules" goes to run that override again, the applied flag is already set to true
so it does not try to load it again. Bother...
