### PR TITLE
[module] Add claim_shield module

### DIFF
--- a/modules/custom/claim_shield.lua
+++ b/modules/custom/claim_shield.lua
@@ -1,0 +1,93 @@
+-----------------------------------
+-- Claim Shield
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/msg")
+require("scripts/globals/utils")
+-----------------------------------
+local m = Module:new("claim_shield")
+m:setEnabled(false)
+
+local claimshieldTime = 7500
+
+-- NOTE: These names are as they are as filenames.
+-- Example: Behemoth's Dominion => Behemoths_Dominion
+-- Example: King Behemoth       => King_Behemoth
+-- { zone name, mob name }
+-- Format:
+local nmsToShield =
+{
+    { "Attohwa_Chasm", "Citipati" },
+    { "Attohwa_Chasm", "Tiamat" },
+    { "Attohwa_Chasm", "Xolotl" },
+    { "Caedarva_Mire", "Khimaira" },
+    { "Castle_Oztroja", "Mee_Deggi_the_Punisher" },
+    { "Castle_Oztroja", "Quu_Domi_the_Gallant" },
+    { "FeiYin", "Capricious_Cassie" },
+    { "FeiYin", "Eastern_Shadow" },
+    { "FeiYin", "Northern_Shadow" },
+    { "FeiYin", "Southern_Shadow" },
+    { "FeiYin", "Western_Shadow" },
+    { "Garlaige_Citadel", "Serket" },
+    { "Giddeus", "Hoo_Mjuu_the_Torrent" },
+    { "Gustav_Tunnel", "Bune" },
+    { "Jugner_Forest", "King_Arthro" },
+    { "King_Ranperres_Tomb", "Vrtra" },
+    { "Labyrinth_of_Onzozo", "Lord_of_Onzozo" },
+    { "Lufaise_Meadows", "Padfoot" },
+    { "Maze_of_Shakhrami", "Argus" },
+    { "Maze_of_Shakhrami", "Leech_King" },
+    { "Mount_Zhayolm", "Cerberus" },
+    { "Rolanberry_Fields", "Eldritch_Edge" },
+    { "Rolanberry_Fields", "Simurgh" },
+    { "Rolanberry_Fields_[S]", "Lamina" },
+    { "Sauromugue_Champaign", "Blighting_Brand" },
+    { "Sauromugue_Champaign", "Roc" },
+    { "Sauromugue_Champaign_[S]", "Hyakinthos" },
+    { "Sea_Serpent_Grotto", "Charybdis" },
+    { "South_Gustaberg", "Leaping_Lizzy" },
+    { "Uleguerand_Range", "Jormungand" },
+    { "Valkurm_Dunes", "Valkurm_Emperor" },
+    { "Wajaom_Woodlands", "Hydra" },
+    { "Western_Altepa_Desert", "King_Vinegarroon" },
+    { "South_Gustaberg", "Leaping_Lizzy" },
+    { "Valkurm_Dunes", "Valkurm_Emperor" },
+    { "Maze_of_Shakhrami", "Argus" },
+    { "Sea_Serpent_Grotto", "Charybdis" },
+}
+
+-- NOTE: At the time we iterate over these entries, the Lua zone and mob objects won't be ready,
+--     : so we deal with everything as strings for now.
+for _, entry in pairs(nmsToShield) do
+    local zoneName = entry[1]
+    local mobName = entry[2]
+
+    m:addOverride(string.format("xi.zones.%s.mobs.%s.onMobSpawn", zoneName, mobName),
+    function(mob)
+        print(string.format("Applying Claimshield to %s for %ims", mob:getName(), claimshieldTime))
+        mob:setClaimable(false)
+        mob:setUnkillable(true)
+        mob:stun(claimshieldTime)
+
+        mob:timer(claimshieldTime, function(mobArg)
+            local enmityList = mobArg:getEnmityList()
+            local numEntries = #enmityList
+
+            mobArg:setClaimable(true)
+            mobArg:setUnkillable(false)
+
+            mobArg:resetAI()
+            mobArg:setHP(mobArg:getMaxHP())
+
+            local claimWinner = utils.randomEntry(enmityList)["entity"]
+            if claimWinner then
+                mobArg:updateClaim(claimWinner)
+                print(string.format("Claimshield Winner: %s - %s, out of %i entries", mobArg:getName(), claimWinner:getName(), numEntries))
+            end
+
+            super(mobArg)
+        end)
+    end)
+end
+
+return m

--- a/modules/custom/test_npcs_in_gm_home.lua
+++ b/modules/custom/test_npcs_in_gm_home.lua
@@ -5,7 +5,7 @@ require("modules/module_utils")
 require("scripts/zones/GM_Home/Zone")
 -----------------------------------
 local m = Module:new("test_npcs_in_gm_home")
-m:setEnabled(true)
+m:setEnabled(false)
 
 m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
 

--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -7,6 +7,12 @@ require("scripts/globals/utils")
 -- Global, for use in C++
 function applyOverride(base_table, name, func)
     local old = base_table[name]
+
+    if old == nil then
+        print("Inserting empty function to override for: " .. name)
+        old = function() end -- Insert empty function
+    end
+
     local thisenv = getfenv(old)
 
     local env = { super = old }

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -127,6 +127,8 @@ CMobEntity::CMobEntity()
     // For Dyna Stats
     m_StatPoppedMobs = false;
 
+    m_IsClaimable = true;
+
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CMobController>(this), std::make_unique<CTargetFind>(this));
 }
 

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -252,6 +252,8 @@ public:
 
     CMobSpellContainer* SpellContainer;   // retrieves spells for the mob
 
+    bool m_IsClaimable;
+
     static constexpr float sound_range{ 8.f };
     static constexpr float sight_range{ 15.f };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9715,7 +9715,9 @@ void CLuaBaseEntity::updateEnmityFromCure(CLuaBaseEntity* PEntity, int32 amount)
 {
     XI_DEBUG_BREAK_IF(amount < 0);
 
-    auto* PCurer = [&]() -> CBattleEntity* {
+    // clang-format off
+    auto* PCurer = [&]() -> CBattleEntity*
+    {
         if (m_PBaseEntity->objtype == TYPE_PC || m_PBaseEntity->objtype == TYPE_TRUST)
         {
             return static_cast<CBattleEntity*>(m_PBaseEntity);
@@ -9730,6 +9732,7 @@ void CLuaBaseEntity::updateEnmityFromCure(CLuaBaseEntity* PEntity, int32 amount)
         }
         return nullptr;
     }();
+    // clang-format on
 
     if (PEntity != nullptr && PCurer)
     {
@@ -9819,23 +9822,38 @@ sol::table CLuaBaseEntity::getNotorietyList()
     return table;
 }
 
+/************************************************************************
+ *  Function: setClaimable(...)
+ *  Purpose : sets m_IsClaimable for a mob
+ *  Example : mob:setClaimable(false)
+ *  Notes   :
+ ************************************************************************/
+
 void CLuaBaseEntity::setClaimable(bool claimable)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
     if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
     {
         PMob->m_IsClaimable = claimable;
+        return;
     }
+    ShowError("lua::setClaimable called on invalid entity");
 }
+
+/************************************************************************
+ *  Function: getClaimable(...)
+ *  Purpose : Returns whether or not a mob is claimable
+ *  Example : local claimable = mob:getClaimable()
+ *  Notes   : Defaults to true, as in the CMobEntity constructor
+ ************************************************************************/
 
 bool CLuaBaseEntity::getClaimable()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
     if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
     {
         return PMob->m_IsClaimable;
     }
-    return false;
+    ShowError("lua::getClaimable called on invalid entity");
+    return true;
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9819,6 +9819,25 @@ sol::table CLuaBaseEntity::getNotorietyList()
     return table;
 }
 
+void CLuaBaseEntity::setClaimable(bool claimable)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
+    {
+        PMob->m_IsClaimable = claimable;
+    }
+}
+
+bool CLuaBaseEntity::getClaimable()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
+    {
+        return PMob->m_IsClaimable;
+    }
+    return false;
+}
+
 /************************************************************************
  *  Function: addStatusEffect(effect, power, tick, duration)
  *  Purpose : Adds a specified Status Effect to the Entity
@@ -14100,6 +14119,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("updateClaim", CLuaBaseEntity::updateClaim);
     SOL_REGISTER("hasEnmity", CLuaBaseEntity::hasEnmity);
     SOL_REGISTER("getNotorietyList", CLuaBaseEntity::getNotorietyList);
+    SOL_REGISTER("setClaimable", CLuaBaseEntity::setClaimable);
+    SOL_REGISTER("getClaimable", CLuaBaseEntity::getClaimable);
 
     // Status Effects
     SOL_REGISTER("addStatusEffect", CLuaBaseEntity::addStatusEffect);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -572,6 +572,8 @@ public:
     void  updateClaim(sol::object const& entity); // Adds Enmity to player for specified mob and claims
     bool  hasEnmity();                            // Does the player have any enmity at all from any source
     auto  getNotorietyList() -> sol::table;       // Returns a table with all of the entities on a chars notoriety list
+    void  setClaimable(bool claimable);
+    bool  getClaimable();
 
     // Status Effects
     bool   addStatusEffect(sol::variadic_args va);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5003,8 +5003,13 @@ namespace battleutils
     void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
     {
         TracyZoneScoped;
-        if (PDefender->objtype == TYPE_MOB)
+        if (auto* mob = dynamic_cast<CMobEntity*>(PDefender))
         {
+            if (!mob->m_IsClaimable)
+            {
+                return;
+            }
+
             CBattleEntity* original = PAttacker;
             if (PAttacker->objtype != TYPE_PC)
             {
@@ -5018,7 +5023,6 @@ namespace battleutils
                 }
             }
             CBattleEntity* battleTarget = original->GetBattleTarget();
-            CMobEntity*    mob          = static_cast<CMobEntity*>(PDefender);
             if (!passing)
             {
                 mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true, true);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5005,11 +5005,6 @@ namespace battleutils
         TracyZoneScoped;
         if (auto* mob = dynamic_cast<CMobEntity*>(PDefender))
         {
-            if (!mob->m_IsClaimable)
-            {
-                return;
-            }
-
             CBattleEntity* original = PAttacker;
             if (PAttacker->objtype != TYPE_PC)
             {
@@ -5027,6 +5022,12 @@ namespace battleutils
             {
                 mob->PEnmityContainer->UpdateEnmity(original, 0, 0, true, true);
             }
+
+            if (!mob->m_IsClaimable)
+            {
+                return;
+            }
+
             if (PAttacker)
             {
                 CCharEntity* attacker = static_cast<CCharEntity*>(PAttacker);
@@ -6101,12 +6102,15 @@ namespace battleutils
 
         bool found = false;
 
-        PMaster->ForAlliance([&PTarget, &found](CBattleEntity* PChar) {
+        // clang-format off
+        PMaster->ForAlliance([&PTarget, &found](CBattleEntity* PChar)
+        {
             if (PChar->id == PTarget->m_OwnerID.id)
             {
                 found = true;
             }
         });
+        // clang-format on
 
         return found;
     }

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -146,6 +146,8 @@ namespace moduleutils
                 sol::table table = lua.require_file(pathNoExt, relPath);
                 if (table["enabled"])
                 {
+                    auto moduleName = table.get<std::string>("name");
+                    ShowScript(fmt::format("=== Module: {} ===", moduleName));
                     for (auto& override : table.get<std::vector<sol::table>>("overrides"))
                     {
                         std::string name = override["name"];


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

We'll need `m_IsClaimable` later down the line for things like DI etc., this just adds it and uses it for a lua module claimshield. Seems to work nicely. Avoids any core changes