### PR TITLE
[sql] ModID 370 (Regen) with a negative power value changed to ModID 404 (Regen Down) with positive power value

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1462,8 +1462,9 @@ INSERT INTO `item_latents` VALUES (15162,68,2,29,0);
 INSERT INTO `item_latents` VALUES (15164,68,2,29,0);
 INSERT INTO `item_latents` VALUES (15168,68,2,29,0);
 INSERT INTO `item_latents` VALUES (15168,68,2,31,0);
+
 INSERT INTO `item_latents` VALUES (15174,25,12,10,0);
-INSERT INTO `item_latents` VALUES (15174,370,-100,10,0);
+INSERT INTO `item_latents` VALUES (15174,404,100,10,0);
 INSERT INTO `item_latents` VALUES (15174,384,400,10,0);
 
 -- -------------------------------------------------------
@@ -1644,7 +1645,7 @@ INSERT INTO `item_latents` VALUES (15520,68,7,58,0);     -- storm torque eva +7
 -- Berserker's Torque
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (15530,368,10,10,0);   -- HP-50/Tick of TP while weapon drawn
-INSERT INTO `item_latents` VALUES (15530,370,-50,10,0);
+INSERT INTO `item_latents` VALUES (15530,404,50,10,0);
 
 -- -------------------------------------------------------
 -- Shark Necklace


### PR DESCRIPTION
This adjustment is only in item_latents.sql.  
-This is so that items that have a latent effect of draining HP wake the player up if the player has sleep status effect.

Also checked and verified no above uses in item_mods.sql/item_mods_pet.sql.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
