### PR TITLE
Fix NW Apollyon Floor 4

### DIFF
--- a/scripts/zones/Apollyon/bcnms/nw_apollyon_helper.lua
+++ b/scripts/zones/Apollyon/bcnms/nw_apollyon_helper.lua
@@ -89,7 +89,7 @@ xi.apollyon_nw.handleMobDeathFloorThreePortal = function(mob, player, isKiller, 
 
         if mobID == randomF3 then
             -- Select witch of the 7 Goryniches will open portal to floor 4.
-            battlefield:setLocalVar("randomF4", ID.mob.APOLLYON_NW_MOB[4] + math.random(1, 7))
+            battlefield:setLocalVar("randomF4", ID.mob.APOLLYON_NW_MOB[4] + math.random(1, 5))
 
             -- Open portal to floor 4.
             xi.limbus.handleDoors(battlefield, true, ID.npc.APOLLYON_NW_PORTAL[3])
@@ -111,9 +111,9 @@ end
 -----------------------------------
 -- Floor 4
 -----------------------------------
--- Mobs in floor 4: Cynoprosopi x1, Gorynich x7
+-- Mobs in floor 4: Cynoprosopi x1, Gorynich x5
 
--- Killing 1 of the 7 Goryniches opens the portal.
+-- Killing 1 of the 5 Goryniches opens the portal.
 xi.apollyon_nw.handleMobDeathFloorFourPortal = function(mob, player, isKiller, noKiller)
     if isKiller or noKiller then
         local mobID       = mob:getID()


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Re-Checked captures and turns out Floor 4 only has 5 regular mobs, not 7.

I wrongly added this 2 mobs in #1539