### PR TITLE
Various improvements after stress testing

### DIFF
--- a/cmake/Tracy.cmake
+++ b/cmake/Tracy.cmake
@@ -36,7 +36,14 @@ if(TRACY_ENABLE)
 
     add_library(tracy_client ${CMAKE_SOURCE_DIR}/ext/tracy/tracy-0.8.1/TracyClient.cpp)
     target_include_directories(tracy_client PUBLIC ${CMAKE_SOURCE_DIR}/ext/tracy/tracy-0.8.1/)
-    target_compile_definitions(tracy_client PUBLIC TRACY_ENABLE TRACY_ON_DEMAND TRACY_NO_EXIT TRACY_NO_BROADCAST TRACY_TIMER_QPC)
+    target_compile_definitions(tracy_client
+        PUBLIC
+            TRACY_ENABLE
+            TRACY_ON_DEMAND
+            TRACY_NO_EXIT
+            TRACY_NO_BROADCAST
+            TRACY_NO_SYSTEM_TRACING
+            TRACY_TIMER_QPC)
 
     if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")

--- a/sql/zone_settings.sql
+++ b/sql/zone_settings.sql
@@ -28,7 +28,7 @@ CREATE TABLE `zone_settings` (
   `battlemulti` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `restriction` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `tax` float(5,2) unsigned NOT NULL DEFAULT '0.00',
-  `misc` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `misc` smallint(5) unsigned NOT NULL DEFAULT '0', -- ZONEMISC in zone.h
   PRIMARY KEY (`zoneid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AVG_ROW_LENGTH=20 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -249,7 +249,7 @@ INSERT INTO `zone_settings` VALUES (206,4,'127.0.0.1',54230,'QuBia_Arena',0,0,12
 INSERT INTO `zone_settings` VALUES (207,4,'127.0.0.1',54230,'Cloister_of_Flames',0,0,0,0,0,0.00,2201);
 INSERT INTO `zone_settings` VALUES (208,3,'127.0.0.1',54230,'Quicksand_Caves',0,0,115,192,0,0.00,2201);
 INSERT INTO `zone_settings` VALUES (209,4,'127.0.0.1',54230,'Cloister_of_Tremors',0,0,0,0,0,0.00,2201);
-INSERT INTO `zone_settings` VALUES (210,0,'127.0.0.1',54230,'GM_Home',0,0,0,0,0,0.00,0); -- NPC debug zone, where GMs idle on retail.
+INSERT INTO `zone_settings` VALUES (210,0,'127.0.0.1',54230,'GM_Home',0,0,0,0,0,0.00,4095); -- NPC debug zone, where GMs idle on retail.
 INSERT INTO `zone_settings` VALUES (211,4,'127.0.0.1',54230,'Cloister_of_Tides',0,0,0,0,0,0.00,2201);
 INSERT INTO `zone_settings` VALUES (212,3,'127.0.0.1',54230,'Gustav_Tunnel',0,0,115,192,0,0.00,2201);
 INSERT INTO `zone_settings` VALUES (213,3,'127.0.0.1',54230,'Labyrinth_of_Onzozo',0,0,115,192,0,0.00,2201);

--- a/src/common/filewatcher.cpp
+++ b/src/common/filewatcher.cpp
@@ -1,5 +1,7 @@
 ﻿#include "filewatcher.h"
 
+#include "tracy.h"
+
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -22,6 +24,7 @@ Filewatcher::Filewatcher(std::string const& path)
 // cppcheck-suppress passedByValue
 void Filewatcher::handleFileAction(efsw::WatchID watchid, const std::string& dir, const std::string& filename, efsw::Action action, std::string oldFilename)
 {
+    TracyZoneScoped;
     std::filesystem::path fullPath = dir + "/" + filename;
     switch (action)
     {

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -62,6 +62,7 @@ int    sock_arr_len = 0;
 /// @return Fd or -1
 int sock2fd(SOCKET s)
 {
+    TracyZoneScoped;
     int fd;
 
     // search for the socket
@@ -83,6 +84,7 @@ int sock2fd(SOCKET s)
 /// @return New fd or -1
 int sock2newfd(SOCKET s)
 {
+    TracyZoneScoped;
     int fd;
 
     // find an empty position
@@ -104,6 +106,7 @@ int sock2newfd(SOCKET s)
 
 int sAccept(int fd, struct sockaddr* addr, int* addrlen)
 {
+    TracyZoneScoped;
     SOCKET s;
 
     // accept connection
@@ -115,6 +118,7 @@ int sAccept(int fd, struct sockaddr* addr, int* addrlen)
 
 int sClose(int fd)
 {
+    TracyZoneScoped;
     int ret     = closesocket(fd2sock(fd));
     fd2sock(fd) = INVALID_SOCKET;
     return ret;
@@ -122,6 +126,7 @@ int sClose(int fd)
 
 int sSocket(int af, int type, int protocol)
 {
+    TracyZoneScoped;
     SOCKET s;
 
     // create socket
@@ -154,6 +159,7 @@ time_t stall_time = 60;
 
 int32 makeConnection(uint32 ip, uint16 port, int32 type)
 {
+    TracyZoneScoped;
     struct sockaddr_in remote_address;
     int32              fd;
     int32              result;
@@ -220,6 +226,7 @@ int32 makeConnection(uint32 ip, uint16 port, int32 type)
 
 void do_close(int32 fd)
 {
+    TracyZoneScoped;
     sFD_CLR(fd, &readfds);    // this needs to be done before closing the socket
     sShutdown(fd, SHUT_RDWR); // Disallow further reads/writes
     sClose(fd);               // We don't really care if these closing functions return an error, we are just shutting down and not reusing this socket.
@@ -227,6 +234,7 @@ void do_close(int32 fd)
 
 bool _vsocket_init()
 {
+    TracyZoneScoped;
 #ifdef WIN32
     { // Start up windows networking
         WSADATA wsaData;
@@ -361,6 +369,7 @@ static int connect_check_(uint32 ip);
 /// @see connect_check_()
 static int connect_check(uint32 ip)
 {
+    TracyZoneScoped;
     int result = connect_check_(ip);
     if (access_debug)
     {
@@ -374,6 +383,7 @@ static int connect_check(uint32 ip)
 ///  1 or 2 : Connection Accepted
 static int connect_check_(uint32 ip)
 {
+    TracyZoneScoped;
     ConnectHistory* hist = connect_history[ip & 0xFFFF];
     size_t          i;
     int             is_allowip = 0;
@@ -496,6 +506,7 @@ static int connect_check_(uint32 ip)
 /// Deletes old connection history records.
 static int connect_check_clear(time_point tick, CTaskMgr::CTask* PTask)
 {
+    TracyZoneScoped;
     int             i;
     int             clear = 0;
     int             list  = 0;
@@ -536,6 +547,7 @@ static int connect_check_clear(time_point tick, CTaskMgr::CTask* PTask)
 /// Returns 1 is successful, 0 otherwise.
 int access_ipmask(const char* str, AccessControl* acc)
 {
+    TracyZoneScoped;
     uint32       ip;
     uint32       mask;
     unsigned int a[4];
@@ -594,6 +606,7 @@ int access_ipmask(const char* str, AccessControl* acc)
 //////////////////////////////
 int recv_to_fifo(int fd)
 {
+    TracyZoneScoped;
     int len;
 
     if (!session_isActive(fd))
@@ -628,6 +641,7 @@ int recv_to_fifo(int fd)
 
 int send_from_fifo(int fd)
 {
+    TracyZoneScoped;
     int len;
 
     if (!session_isValid(fd))
@@ -692,15 +706,18 @@ std::array<std::unique_ptr<socket_data>, FD_SETSIZE> session;
 
 bool session_isValid(int fd)
 {
+    TracyZoneScoped;
     return (fd > 0 && fd < FD_SETSIZE && session[fd] != nullptr);
 }
 bool session_isActive(int fd)
 {
+    TracyZoneScoped;
     return (session_isValid(fd) && !session[fd]->flag.eof);
 }
 
 int32 makeConnection_tcp(uint32 ip, uint16 port)
 {
+    TracyZoneScoped;
     int fd = makeConnection(ip, port, SOCK_STREAM);
     if (fd > 0)
     {
@@ -714,6 +731,7 @@ int32 makeConnection_tcp(uint32 ip, uint16 port)
  *--------------------------------------*/
 int connect_client(int listen_fd, sockaddr_in& client_address)
 {
+    TracyZoneScoped;
     int fd;
     // struct sockaddr_in client_address;
     socklen_t len;
@@ -765,6 +783,7 @@ int connect_client(int listen_fd, sockaddr_in& client_address)
 
 int32 makeListenBind_tcp(const char* ip, uint16 port, RecvFunc connect_client)
 {
+    TracyZoneScoped;
     struct sockaddr_in server_address;
     int                fd;
     int                result;
@@ -825,6 +844,7 @@ int32 makeListenBind_tcp(const char* ip, uint16 port, RecvFunc connect_client)
 
 int32 RFIFOSKIP(int32 fd, size_t len)
 {
+    TracyZoneScoped;
     struct socket_data* s;
 
     if (!session_isActive(fd))
@@ -846,6 +866,7 @@ int32 RFIFOSKIP(int32 fd, size_t len)
 
 void do_close_tcp(int32 fd)
 {
+    TracyZoneScoped;
     flush_fifo(fd);
     do_close(fd);
     if (session[fd])
@@ -856,6 +877,7 @@ void do_close_tcp(int32 fd)
 
 int socket_config_read(const char* cfgName)
 {
+    TracyZoneScoped;
     char  line[1024];
     char  w1[1024];
     char  w2[1024];
@@ -956,6 +978,7 @@ int socket_config_read(const char* cfgName)
 
 void socket_init_tcp()
 {
+    TracyZoneScoped;
     if (!_vsocket_init())
     {
         return;
@@ -977,6 +1000,7 @@ void socket_init_tcp()
 
 void socket_final_tcp()
 {
+    TracyZoneScoped;
     if (!_vsocket_final())
     {
         return;
@@ -1009,6 +1033,7 @@ void socket_final_tcp()
 
 void flush_fifo(int32 fd)
 {
+    TracyZoneScoped;
     if (session[fd] != nullptr)
     {
         session[fd]->func_send(fd);
@@ -1017,8 +1042,8 @@ void flush_fifo(int32 fd)
 
 void flush_fifos()
 {
-    int i;
-    for (i = 1; i < fd_max; i++)
+    TracyZoneScoped;
+    for (int i = 1; i < fd_max; i++)
     {
         flush_fifo(i);
     }
@@ -1026,11 +1051,13 @@ void flush_fifos()
 
 void set_defaultparse(ParseFunc defaultparse)
 {
+    TracyZoneScoped;
     default_func_parse = defaultparse;
 }
 
 void set_eof(int32 fd)
 {
+    TracyZoneScoped;
     if (session_isActive(fd))
     {
         session[fd]->flag.eof = 1;
@@ -1039,6 +1066,7 @@ void set_eof(int32 fd)
 
 int create_session(int fd, RecvFunc func_recv, SendFunc func_send, ParseFunc func_parse)
 {
+    TracyZoneScoped;
     session[fd] = std::make_unique<socket_data>();
     session[fd]->rdata.reserve(RFIFO_SIZE);
     session[fd]->wdata.reserve(WFIFO_SIZE);
@@ -1052,6 +1080,7 @@ int create_session(int fd, RecvFunc func_recv, SendFunc func_send, ParseFunc fun
 
 int delete_session(int fd)
 {
+    TracyZoneScoped;
     if (fd <= 0 || fd >= FD_SETSIZE)
     {
         return -1;
@@ -1064,6 +1093,7 @@ int delete_session(int fd)
  *--------------------------------------*/
 void set_nonblocking(int fd, unsigned long yes)
 {
+    TracyZoneScoped;
     // FIONBIO Use with a nonzero argp parameter to enable the nonblocking mode of socket s.
     // The argp parameter is zero if nonblocking is to be disabled.
     if (sIoctl(fd, FIONBIO, &yes) != 0)
@@ -1079,6 +1109,7 @@ void set_nonblocking(int fd, unsigned long yes)
  */
 int32 makeBind_udp(uint32 ip, uint16 port)
 {
+    TracyZoneScoped;
     struct sockaddr_in server_address;
     int                fd;
     int                result;
@@ -1125,6 +1156,7 @@ int32 makeBind_udp(uint32 ip, uint16 port)
 
 void socket_init_udp()
 {
+    TracyZoneScoped;
     if (!_vsocket_init())
     {
         return;
@@ -1135,11 +1167,13 @@ void socket_init_udp()
 
 void do_close_udp(int32 fd)
 {
+    TracyZoneScoped;
     do_close(fd);
 }
 
 void socket_final_udp()
 {
+    TracyZoneScoped;
     if (!_vsocket_final())
     {
         return;
@@ -1149,16 +1183,19 @@ void socket_final_udp()
 
 int32 recvudp(int32 fd, void* buff, size_t nbytes, int32 flags, struct sockaddr* from, socklen_t* addrlen)
 {
+    TracyZoneScoped;
     return sRecvfrom(fd, (char*)buff, (int)nbytes, flags, from, addrlen);
 }
 
 int32 sendudp(int32 fd, void* buff, size_t nbytes, int32 flags, const struct sockaddr* from, socklen_t addrlen)
 {
+    TracyZoneScoped;
     return sSendto(fd, (const char*)buff, (int)nbytes, flags, from, addrlen);
 }
 
 void socket_init()
 {
+    TracyZoneScoped;
     switch (SOCKET_TYPE)
     {
         case socket_type::TCP:
@@ -1174,6 +1211,7 @@ void socket_init()
 
 void socket_final()
 {
+    TracyZoneScoped;
     switch (SOCKET_TYPE)
     {
         case socket_type::TCP:

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -34,6 +34,7 @@
 
 SqlConnection::SqlConnection(const char* user, const char* passwd, const char* host, uint16 port, const char* db)
 {
+    TracyZoneScoped;
     self = new Sql_t{};
     mysql_init(&self->handle);
     if (self == nullptr)
@@ -72,6 +73,7 @@ SqlConnection::SqlConnection(const char* user, const char* passwd, const char* h
 
 SqlConnection::~SqlConnection()
 {
+    TracyZoneScoped;
     if (self)
     {
         mysql_close(&self->handle);
@@ -88,6 +90,7 @@ SqlConnection::~SqlConnection()
 
 int32 SqlConnection::GetTimeout(uint32* out_timeout)
 {
+    TracyZoneScoped;
     if (out_timeout && SQL_SUCCESS == Query("SHOW VARIABLES LIKE 'wait_timeout'"))
     {
         char*  data;
@@ -112,6 +115,7 @@ int32 SqlConnection::GetTimeout(uint32* out_timeout)
 
 int32 SqlConnection::GetColumnNames(const char* table, char* out_buf, size_t buf_len, char sep)
 {
+    TracyZoneScoped;
     char*  data;
     size_t len;
     size_t off = 0;
@@ -148,6 +152,7 @@ int32 SqlConnection::GetColumnNames(const char* table, char* out_buf, size_t buf
 
 int32 SqlConnection::SetEncoding(const char* encoding)
 {
+    TracyZoneScoped;
     if (mysql_set_character_set(&self->handle, encoding) == 0)
     {
         return SQL_SUCCESS;
@@ -157,6 +162,7 @@ int32 SqlConnection::SetEncoding(const char* encoding)
 
 void SqlConnection::SetupKeepalive()
 {
+    TracyZoneScoped;
     auto now        = std::chrono::system_clock::now().time_since_epoch();
     auto nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(now).count();
     m_LastPing      = nowSeconds;
@@ -185,6 +191,7 @@ void SqlConnection::SetupKeepalive()
 
 int32 SqlConnection::TryPing()
 {
+    TracyZoneScoped;
     auto now        = std::chrono::system_clock::now().time_since_epoch();
     auto nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(now).count();
 
@@ -229,6 +236,7 @@ int32 SqlConnection::TryPing()
 
 size_t SqlConnection::EscapeStringLen(char* out_to, const char* from, size_t from_len)
 {
+    TracyZoneScoped;
     if (self)
     {
         return (size_t)mysql_real_escape_string(&self->handle, out_to, from, (uint32)from_len);
@@ -244,6 +252,7 @@ size_t SqlConnection::EscapeStringLen(char* out_to, const char* from, size_t fro
 
 size_t SqlConnection::EscapeString(char* out_to, const char* from)
 {
+    TracyZoneScoped;
     return EscapeStringLen(out_to, from, strlen(from));
 }
 
@@ -291,6 +300,7 @@ int32 SqlConnection::QueryStr(const char* query)
 
 uint64 SqlConnection::AffectedRows()
 {
+    TracyZoneScoped;
     if (self)
     {
         return (uint64)mysql_affected_rows(&self->handle);
@@ -307,6 +317,7 @@ uint64 SqlConnection::AffectedRows()
 
 uint64 SqlConnection::LastInsertId()
 {
+    TracyZoneScoped;
     if (self)
     {
         return (uint64)mysql_insert_id(&self->handle);
@@ -322,6 +333,7 @@ uint64 SqlConnection::LastInsertId()
 
 uint32 SqlConnection::NumColumns()
 {
+    TracyZoneScoped;
     if (self && self->result)
     {
         return (uint32)mysql_num_fields(self->result);
@@ -337,6 +349,7 @@ uint32 SqlConnection::NumColumns()
 
 uint64 SqlConnection::NumRows()
 {
+    TracyZoneScoped;
     if (self && self->result)
     {
         return (uint64)mysql_num_rows(self->result);
@@ -352,6 +365,7 @@ uint64 SqlConnection::NumRows()
 
 int32 SqlConnection::NextRow()
 {
+    TracyZoneScoped;
     if (self && self->result)
     {
         self->row = mysql_fetch_row(self->result);
@@ -379,6 +393,7 @@ int32 SqlConnection::NextRow()
 
 int32 SqlConnection::GetData(size_t col, char** out_buf, size_t* out_len)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -418,6 +433,7 @@ int32 SqlConnection::GetData(size_t col, char** out_buf, size_t* out_len)
 
 int8* SqlConnection::GetData(size_t col)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -438,6 +454,7 @@ int8* SqlConnection::GetData(size_t col)
 
 int32 SqlConnection::GetIntData(size_t col)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -458,6 +475,7 @@ int32 SqlConnection::GetIntData(size_t col)
 
 uint32 SqlConnection::GetUIntData(size_t col)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -478,6 +496,7 @@ uint32 SqlConnection::GetUIntData(size_t col)
 
 uint64 SqlConnection::GetUInt64Data(size_t col)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -498,6 +517,7 @@ uint64 SqlConnection::GetUInt64Data(size_t col)
 
 float SqlConnection::GetFloatData(size_t col)
 {
+    TracyZoneScoped;
     if (self && self->row)
     {
         if (col < NumColumns())
@@ -518,6 +538,7 @@ float SqlConnection::GetFloatData(size_t col)
 
 void SqlConnection::FreeResult()
 {
+    TracyZoneScoped;
     if (self && self->result)
     {
         mysql_free_result(self->result);
@@ -535,6 +556,7 @@ void SqlConnection::FreeResult()
 
 bool SqlConnection::SetAutoCommit(bool value)
 {
+    TracyZoneScoped;
     uint8 val = (value) ? 1 : 0;
 
     // if( self && mysql_autocommit(&self->handle, val) == 0)
@@ -556,6 +578,7 @@ bool SqlConnection::SetAutoCommit(bool value)
 
 bool SqlConnection::GetAutoCommit()
 {
+    TracyZoneScoped;
     if (self)
     {
         int32 ret = Query("SELECT @@autocommit;");
@@ -579,6 +602,7 @@ bool SqlConnection::GetAutoCommit()
 
 bool SqlConnection::TransactionStart()
 {
+    TracyZoneScoped;
     if (self && Query("START TRANSACTION;") != SQL_ERROR)
     {
         return true;
@@ -597,6 +621,7 @@ bool SqlConnection::TransactionStart()
 
 bool SqlConnection::TransactionCommit()
 {
+    TracyZoneScoped;
     if (self && mysql_commit(&self->handle) == 0)
     {
         return true;
@@ -615,6 +640,7 @@ bool SqlConnection::TransactionCommit()
 
 bool SqlConnection::TransactionRollback()
 {
+    TracyZoneScoped;
     if (self && Query("ROLLBACK;") != SQL_ERROR)
     {
         return true;
@@ -627,6 +653,7 @@ bool SqlConnection::TransactionRollback()
 
 void SqlConnection::InitPreparedStatements()
 {
+    TracyZoneScoped;
     auto add = [&](std::string const& name, std::string const& query)
     {
         auto st                    = std::make_shared<SqlPreparedStatement>(&self->handle, query);
@@ -638,5 +665,6 @@ void SqlConnection::InitPreparedStatements()
 
 std::shared_ptr<SqlPreparedStatement> SqlConnection::GetPreparedStatement(std::string const& name)
 {
+    TracyZoneScoped;
     return m_PreparedStatements[name];
 }

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -181,6 +181,10 @@ public:
     bool TransactionRollback();
 
     std::shared_ptr<SqlPreparedStatement> GetPreparedStatement(std::string const& name);
+
+    void Async(std::function<void(SqlConnection*)>&& func);
+    void HandleAsync();
+
 private:
     Sql_t*      self;
     const char* m_User;

--- a/src/common/taskmgr.cpp
+++ b/src/common/taskmgr.cpp
@@ -31,6 +31,7 @@ CTaskMgr* CTaskMgr::_instance = nullptr;
 
 CTaskMgr* CTaskMgr::getInstance()
 {
+    TracyZoneScoped;
     if (_instance == nullptr)
     {
         _instance = new CTaskMgr();
@@ -62,6 +63,7 @@ CTaskMgr::CTask* CTaskMgr::AddTask(CTask* PTask)
 
 void CTaskMgr::RemoveTask(const std::string& TaskName)
 {
+    TracyZoneScoped;
     // m_TaskList is a priority_queue, so we can't directly pull members out of it.
     //
     // Tasks are compared using their m_tick values, so we can safely remove all the tasks
@@ -101,10 +103,10 @@ duration CTaskMgr::DoTimer(time_point tick)
 
     while (!m_TaskList.empty())
     {
-        TracyZoneScoped;
         CTask* PTask = m_TaskList.top();
-        diff         = PTask->m_tick - tick;
+        TracyZoneString(PTask->m_name);
 
+        diff = PTask->m_tick - tick;
         if (diff > 0s)
         {
             break; // no more expired timers to process

--- a/src/common/tracy.h
+++ b/src/common/tracy.h
@@ -11,11 +11,14 @@
 #define TracyFrameMark         FrameMark
 #define TracyZoneScoped        ZoneScoped
 #define TracyZoneScopedN(n)    ZoneScopedN(n)
+#define TracyNamed(name)       ZoneNamed(name, true)
 #define TracyZoneText(n, l)    ZoneText(n, l)
 #define TracyZoneScopedC(c)    ZoneScopedC(c)
 #define TracyZoneString(str)   ZoneText(str.c_str(), str.size())
 #define TracyZoneCString(cstr) ZoneText(cstr, std::strlen(cstr))
 #define TracyZoneIString(istr) TracyZoneCString(reinterpret_cast<const char*>(istr))
+#define TracyLuaRegister(lua)  tracy::LuaRegister(lua)
+#define TracyMessageStr(str)   TracyMessage(str.c_str(), str.size())
 
 inline std::string Hex8ToString(uint8 hex)
 {
@@ -54,6 +57,7 @@ inline std::string Hex16ToString(uint16 hex)
 #define TracyFrameMark
 #define TracyZoneScoped
 #define TracyZoneScopedN(n)
+#define TracyNamed(var, name)
 #define TracyZoneText(n, l)
 #define TracyZoneScopedC(c)
 #define TracyZoneString(str)
@@ -65,6 +69,8 @@ inline std::string Hex16ToString(uint16 hex)
 #define TracyReportGraphNumber(name, num)
 #define TracyReportGraphBytes(name, num)
 #define TracyReportGraphPercent(name, num)
+#define TracyLuaRegister(lua)
+#define TracyMessageStr(str)
 #endif
 
 #endif // _TRACY_H

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -133,6 +133,9 @@ endif()
 set(module_include_dirs "")
 file(STRINGS ${CMAKE_SOURCE_DIR}/modules/init.txt INIT_FILE_ENTRIES REGEX "^[^#\n].*")
 foreach(entry ${INIT_FILE_ENTRIES})
+    if (${entry} STREQUAL "")
+        continue()
+    endif()
     if (IS_DIRECTORY "${CMAKE_SOURCE_DIR}/modules/${entry}")
         file(GLOB_RECURSE module_files
             "${CMAKE_SOURCE_DIR}/modules/${entry}/*.cpp"

--- a/src/map/ai/helpers/event_handler.cpp
+++ b/src/map/ai/helpers/event_handler.cpp
@@ -23,6 +23,9 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 void CAIEventHandler::addListener(const std::string& eventname, sol::function lua_func, const std::string& identifier)
 {
+    TracyZoneScoped;
+    TracyZoneString(eventname);
+    TracyZoneString(identifier);
     // Remove entries with same identifier (if they exist)
     eventListeners[eventname]
         .erase(std::remove_if(eventListeners[eventname].begin(), eventListeners[eventname].end(),
@@ -37,6 +40,8 @@ void CAIEventHandler::addListener(const std::string& eventname, sol::function lu
 
 void CAIEventHandler::removeListener(std::string const& identifier)
 {
+    TracyZoneScoped;
+    TracyZoneString(identifier);
     for (auto&& eventListener : eventListeners)
     {
         auto remove = [&identifier](const ai_event_t& event)

--- a/src/map/ai/helpers/event_handler.h
+++ b/src/map/ai/helpers/event_handler.h
@@ -51,6 +51,8 @@ public:
     template <class... Args>
     void triggerListener(std::string const& eventname, Args&&... args)
     {
+        TracyZoneScoped;
+        TracyZoneString(eventname);
         if (auto eventListener = eventListeners.find(eventname); eventListener != eventListeners.end())
         {
             for (auto&& event : eventListener->second)

--- a/src/map/commandhandler.cpp
+++ b/src/map/commandhandler.cpp
@@ -176,6 +176,9 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const int8* com
         return -1;
     }
 
+    TracyZoneString(PChar->name);
+    TracyZoneIString(commandline);
+
     auto filename   = fmt::format("./scripts/commands/{}.lua", cmdname.c_str());
     auto loadResult = lua.safe_script_file(filename);
     if (!loadResult.valid())

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -49,6 +49,7 @@
 
 CBattleEntity::CBattleEntity()
 {
+    TracyZoneScoped;
     m_OwnerID.clean();
     m_ModelRadius = 0;
     m_mlvl        = 0;
@@ -157,6 +158,7 @@ bool CBattleEntity::isSitting()
 
 void CBattleEntity::UpdateHealth()
 {
+    TracyZoneScoped;
     int32 dif = (getMod(Mod::CONVMPTOHP) - getMod(Mod::CONVHPTOMP));
 
     health.modmp = std::max(0, ((health.maxmp) * (100 + getMod(Mod::MPP)) / 100) +
@@ -262,6 +264,7 @@ bool CBattleEntity::Rest(float rate)
 
 int16 CBattleEntity::GetWeaponDelay(bool tp)
 {
+    TracyZoneScoped;
     if (StatusEffectContainer->HasStatusEffect(EFFECT_HUNDRED_FISTS) && !tp)
     {
         return 1700;
@@ -353,6 +356,7 @@ int16 CBattleEntity::GetAmmoDelay()
 
 uint16 CBattleEntity::GetMainWeaponDmg()
 {
+    TracyZoneScoped;
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
         if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
@@ -373,6 +377,7 @@ uint16 CBattleEntity::GetMainWeaponDmg()
 
 uint16 CBattleEntity::GetSubWeaponDmg()
 {
+    TracyZoneScoped;
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]))
     {
         if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
@@ -393,6 +398,7 @@ uint16 CBattleEntity::GetSubWeaponDmg()
 
 uint16 CBattleEntity::GetRangedWeaponDmg()
 {
+    TracyZoneScoped;
     uint16 dmg = 0;
     if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]))
     {
@@ -554,6 +560,7 @@ int32 CBattleEntity::addMP(int32 mp)
 int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullptr*/, ATTACK_TYPE attackType /* = ATTACK_NONE*/,
                                 DAMAGE_TYPE damageType /* = DAMAGE_NONE*/)
 {
+    TracyZoneScoped;
     PLastAttacker                             = attacker;
     this->BattleHistory.lastHitTaken_atkType  = attackType;
     std::optional<CLuaBaseEntity> optAttacker = attacker ? std::optional<CLuaBaseEntity>(CLuaBaseEntity(attacker)) : std::nullopt;
@@ -618,6 +625,7 @@ uint16 CBattleEntity::CHR()
 
 uint16 CBattleEntity::ATT()
 {
+    TracyZoneScoped;
     // TODO: consider which weapon!
     int32 ATT    = 8 + m_modStat[Mod::ATT];
     auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
@@ -672,6 +680,7 @@ uint16 CBattleEntity::RATT(uint8 skill, uint16 bonusSkill)
 
 uint16 CBattleEntity::RACC(uint8 skill, uint16 bonusSkill)
 {
+    TracyZoneScoped;
     auto* PWeakness = StatusEffectContainer->GetStatusEffect(EFFECT_WEAKNESS);
     if (PWeakness && PWeakness->GetPower() >= 2)
     {
@@ -691,6 +700,7 @@ uint16 CBattleEntity::RACC(uint8 skill, uint16 bonusSkill)
 
 uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
 {
+    TracyZoneScoped;
     if (this->objtype & TYPE_PC)
     {
         uint8  skill     = 0;
@@ -835,6 +845,7 @@ void CBattleEntity::SetSJob(uint8 sjob)
 
 void CBattleEntity::SetMLevel(uint8 mlvl)
 {
+    TracyZoneScoped;
     m_modStat[Mod::DEF] -= m_mlvl + std::clamp(m_mlvl - 50, 0, 10);
     m_mlvl = (mlvl == 0 ? 1 : mlvl);
     m_modStat[Mod::DEF] += m_mlvl + std::clamp(m_mlvl - 50, 0, 10);
@@ -847,6 +858,7 @@ void CBattleEntity::SetMLevel(uint8 mlvl)
 
 void CBattleEntity::SetSLevel(uint8 slvl)
 {
+    TracyZoneScoped;
     if (!map_config.include_mob_sj && (this->objtype == TYPE_MOB && this->objtype != TYPE_PET))
     {
         // Technically, we shouldn't be assuming mobs even have a ratio they must adhere to.
@@ -910,6 +922,7 @@ void CBattleEntity::addModifier(Mod type, int16 amount)
 
 void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
 {
+    TracyZoneScoped;
     for (auto modifier : *modList)
     {
         m_modStat[modifier.getModID()] += modifier.getModAmount();
@@ -918,6 +931,7 @@ void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
 
 void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)
 {
+    TracyZoneScoped;
     if (GetMLevel() >= itemLevel)
     {
         for (auto& i : *modList)
@@ -1015,6 +1029,7 @@ void CBattleEntity::setModifier(Mod type, int16 amount)
 
 void CBattleEntity::setModifiers(std::vector<CModifier>* modList)
 {
+    TracyZoneScoped;
     for (auto& i : *modList)
     {
         m_modStat[i.getModID()] = i.getModAmount();
@@ -1050,6 +1065,7 @@ void CBattleEntity::restoreModifiers()
 
 void CBattleEntity::delModifiers(std::vector<CModifier>* modList)
 {
+    TracyZoneScoped;
     for (auto& i : *modList)
     {
         m_modStat[i.getModID()] -= i.getModAmount();
@@ -1058,6 +1074,7 @@ void CBattleEntity::delModifiers(std::vector<CModifier>* modList)
 
 void CBattleEntity::delEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)
 {
+    TracyZoneScoped;
     if (GetMLevel() >= itemLevel)
     {
         for (auto& i : *modList)
@@ -1144,11 +1161,13 @@ void CBattleEntity::delEquipModifiers(std::vector<CModifier>* modList, uint8 ite
 
 int16 CBattleEntity::getMod(Mod modID)
 {
+    TracyZoneScoped;
     return m_modStat[modID];
 }
 
 void CBattleEntity::addPetModifier(Mod type, PetModType petmod, int16 amount)
 {
+    TracyZoneScoped;
     m_petMod[petmod][type] += amount;
 
     if (PPet && petutils::CheckPetModType(PPet, petmod))
@@ -1160,6 +1179,7 @@ void CBattleEntity::addPetModifier(Mod type, PetModType petmod, int16 amount)
 
 void CBattleEntity::setPetModifier(Mod type, PetModType petmod, int16 amount)
 {
+    TracyZoneScoped;
     m_petMod[petmod][type] = amount;
 
     if (PPet && petutils::CheckPetModType(PPet, petmod))
@@ -1171,6 +1191,7 @@ void CBattleEntity::setPetModifier(Mod type, PetModType petmod, int16 amount)
 
 void CBattleEntity::delPetModifier(Mod type, PetModType petmod, int16 amount)
 {
+    TracyZoneScoped;
     m_petMod[petmod][type] -= amount;
 
     if (PPet && petutils::CheckPetModType(PPet, petmod))
@@ -1182,6 +1203,7 @@ void CBattleEntity::delPetModifier(Mod type, PetModType petmod, int16 amount)
 
 void CBattleEntity::addPetModifiers(std::vector<CPetModifier>* modList)
 {
+    TracyZoneScoped;
     for (auto modifier : *modList)
     {
         addPetModifier(modifier.getModID(), modifier.getPetModType(), modifier.getModAmount());
@@ -1190,6 +1212,7 @@ void CBattleEntity::addPetModifiers(std::vector<CPetModifier>* modList)
 
 void CBattleEntity::delPetModifiers(std::vector<CPetModifier>* modList)
 {
+    TracyZoneScoped;
     for (auto modifier : *modList)
     {
         delPetModifier(modifier.getModID(), modifier.getPetModType(), modifier.getModAmount());
@@ -1198,6 +1221,7 @@ void CBattleEntity::delPetModifiers(std::vector<CPetModifier>* modList)
 
 void CBattleEntity::applyPetModifiers(CPetEntity* PPet)
 {
+    TracyZoneScoped;
     for (const auto& modtype : m_petMod)
     {
         if (petutils::CheckPetModType(PPet, modtype.first))
@@ -1213,6 +1237,7 @@ void CBattleEntity::applyPetModifiers(CPetEntity* PPet)
 
 void CBattleEntity::removePetModifiers(CPetEntity* PPet)
 {
+    TracyZoneScoped;
     for (const auto& modtype : m_petMod)
     {
         if (petutils::CheckPetModType(PPet, modtype.first))
@@ -1234,6 +1259,7 @@ void CBattleEntity::removePetModifiers(CPetEntity* PPet)
 
 uint16 CBattleEntity::GetSkill(uint16 SkillID)
 {
+    TracyZoneScoped;
     if (SkillID < MAX_SKILLTYPE)
     {
         return WorkingSkills.skill[SkillID] & 0x7FFF;
@@ -1243,18 +1269,21 @@ uint16 CBattleEntity::GetSkill(uint16 SkillID)
 
 void CBattleEntity::addTrait(CTrait* PTrait)
 {
+    TracyZoneScoped;
     TraitList.push_back(PTrait);
     addModifier(PTrait->getMod(), PTrait->getValue());
 }
 
 void CBattleEntity::delTrait(CTrait* PTrait)
 {
+    TracyZoneScoped;
     delModifier(PTrait->getMod(), PTrait->getValue());
     TraitList.erase(std::remove(TraitList.begin(), TraitList.end(), PTrait), TraitList.end());
 }
 
 bool CBattleEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
+    TracyZoneScoped;
     if (targetFlags & TARGET_ENEMY)
     {
         if (!isDead())
@@ -1289,11 +1318,13 @@ bool CBattleEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 
 bool CBattleEntity::CanUseSpell(CSpell* PSpell)
 {
+    TracyZoneScoped;
     return spell::CanUseSpell(this, PSpell);
 }
 
 void CBattleEntity::Spawn()
 {
+    TracyZoneScoped;
     animation = ANIMATION_NONE;
     HideName(false);
     CBaseEntity::Spawn();
@@ -1302,6 +1333,7 @@ void CBattleEntity::Spawn()
 
 void CBattleEntity::Die()
 {
+    TracyZoneScoped;
     if (CBaseEntity* PKiller = GetEntity(m_OwnerID.targid))
     {
         static_cast<CBattleEntity*>(PKiller)->ForAlliance([this](CBattleEntity* PMember) {
@@ -1322,10 +1354,12 @@ void CBattleEntity::Die()
 
 void CBattleEntity::OnDeathTimer()
 {
+    TracyZoneScoped;
 }
 
 void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto*          PSpell          = state.GetSpell();
     auto*          PActionTarget   = static_cast<CBattleEntity*>(state.GetTarget());
     CBattleEntity* POriginalTarget = PActionTarget;
@@ -1531,6 +1565,7 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 
 void CBattleEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBASIC_ID msg)
 {
+    TracyZoneScoped;
     CSpell* PSpell = state.GetSpell();
     if (PSpell)
     {
@@ -1552,6 +1587,7 @@ void CBattleEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGB
 
 void CBattleEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PWeaponskill = state.GetSkill();
 
     action.id         = id;
@@ -1561,11 +1597,13 @@ void CBattleEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& ac
 
 bool CBattleEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
 {
+    TracyZoneScoped;
     return !((distance(loc.p, PTarget->loc.p) - PTarget->m_ModelRadius) > GetMeleeRange() || !PAI->GetController()->IsAutoAttackEnabled());
 }
 
 void CBattleEntity::OnDisengage(CAttackState& s)
 {
+    TracyZoneScoped;
     m_battleTarget = 0;
     if (animation == ANIMATION_ATTACK)
     {
@@ -1586,6 +1624,7 @@ CBattleEntity* CBattleEntity::GetBattleTarget()
 
 bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
     if (PTarget->objtype == TYPE_PC)
@@ -1893,12 +1932,14 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
 CBattleEntity* CBattleEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg)
 {
+    TracyZoneScoped;
     auto* PTarget = PAI->TargetFind->getValidTarget(targid, validTargetFlags);
     return PTarget;
 }
 
 void CBattleEntity::OnEngage(CAttackState& state)
 {
+    TracyZoneScoped;
     animation = ANIMATION_ATTACK;
     updatemask |= UPDATE_HP;
     PAI->EventHandler.triggerListener("ENGAGE", CLuaBaseEntity(this), CLuaBaseEntity(state.GetTarget()));
@@ -1914,6 +1955,7 @@ void CBattleEntity::TryHitInterrupt(CBattleEntity* PAttacker)
 
 void CBattleEntity::OnDespawn(CDespawnState& /*unused*/)
 {
+    TracyZoneScoped;
     FadeOut();
     //#event despawn
     PAI->EventHandler.triggerListener("DESPAWN", CLuaBaseEntity(this));
@@ -1932,10 +1974,12 @@ duration CBattleEntity::GetBattleTime()
 
 void CBattleEntity::Tick(time_point /*unused*/)
 {
+    TracyZoneScoped;
 }
 
 void CBattleEntity::PostTick()
 {
+    TracyZoneScoped;
     if (health.hp == 0 && PAI->IsSpawned() && !PAI->IsCurrentState<CDeathState>() && !PAI->IsCurrentState<CRaiseState>() &&
         !PAI->IsCurrentState<CDespawnState>())
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -86,6 +86,7 @@
 
 CCharEntity::CCharEntity()
 {
+    TracyZoneScoped;
     objtype     = TYPE_PC;
     m_EcoSystem = ECOSYSTEM::HUMANOID;
 
@@ -241,6 +242,7 @@ CCharEntity::CCharEntity()
 
 CCharEntity::~CCharEntity()
 {
+    TracyZoneScoped;
     clearPacketList();
 
     if (PTreasurePool != nullptr)
@@ -676,6 +678,7 @@ void CCharEntity::delTrait(CTrait* PTrait)
 
 bool CCharEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
+    TracyZoneScoped;
     if (StatusEffectContainer->GetConfrontationEffect() != PInitiator->StatusEffectContainer->GetConfrontationEffect())
     {
         return false;
@@ -719,12 +722,14 @@ bool CCharEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 
 bool CCharEntity::CanUseSpell(CSpell* PSpell)
 {
+    TracyZoneScoped;
     return charutils::hasSpell(this, static_cast<uint16>(PSpell->getID())) && CBattleEntity::CanUseSpell(PSpell) &&
            !PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(PSpell->getID()));
 }
 
 void CCharEntity::OnChangeTarget(CBattleEntity* PNewTarget)
 {
+    TracyZoneScoped;
     battleutils::RelinquishClaim(this);
     pushPacket(new CLockOnPacket(this, PNewTarget));
     PLatentEffectContainer->CheckLatentsTargetChange();
@@ -732,6 +737,7 @@ void CCharEntity::OnChangeTarget(CBattleEntity* PNewTarget)
 
 void CCharEntity::OnEngage(CAttackState& state)
 {
+    TracyZoneScoped;
     CBattleEntity::OnEngage(state);
     PLatentEffectContainer->CheckLatentsTargetChange();
     this->m_charHistory.battlesFought++;
@@ -739,6 +745,7 @@ void CCharEntity::OnEngage(CAttackState& state)
 
 void CCharEntity::OnDisengage(CAttackState& state)
 {
+    TracyZoneScoped;
     battleutils::RelinquishClaim(this);
     CBattleEntity::OnDisengage(state);
     if (state.HasErrorMsg())
@@ -750,6 +757,7 @@ void CCharEntity::OnDisengage(CAttackState& state)
 
 bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
 {
+    TracyZoneScoped;
     float dist = distance(loc.p, PTarget->loc.p);
 
     if (!IsMobOwner(PTarget))
@@ -780,6 +788,7 @@ bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket
 
 bool CCharEntity::OnAttack(CAttackState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* controller{ static_cast<CPlayerController*>(PAI->GetController()) };
     controller->setLastAttackTime(server_clock::now());
     auto ret = CBattleEntity::OnAttack(state, action);
@@ -791,6 +800,7 @@ bool CCharEntity::OnAttack(CAttackState& state, action_t& action)
 
 void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
+    TracyZoneScoped;
     CBattleEntity::OnCastFinished(state, action);
 
     auto* PSpell  = state.GetSpell();
@@ -862,6 +872,7 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
 
 void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBASIC_ID msg)
 {
+    TracyZoneScoped;
     CBattleEntity::OnCastInterrupted(state, action, msg);
 
     auto* message = state.GetErrorMsg();
@@ -874,6 +885,7 @@ void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBAS
 
 void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
+    TracyZoneScoped;
     CBattleEntity::OnWeaponSkillFinished(state, action);
 
     auto* PWeaponSkill  = state.GetSkill();
@@ -1010,6 +1022,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
 
 void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PAbility = state.GetAbility();
     if (this->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
     {
@@ -1286,6 +1299,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
 void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
     int32 damage      = 0;
@@ -1520,6 +1534,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
 bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
 {
+    TracyZoneScoped;
     XI_DEBUG_BREAK_IF(PBattleTarget == nullptr);
 
     if (PBattleTarget->m_OwnerID.id == 0 || PBattleTarget->m_OwnerID.id == this->id || PBattleTarget->objtype == TYPE_PC)
@@ -1541,6 +1556,7 @@ bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
 
 void CCharEntity::HandleErrorMessage(std::unique_ptr<CBasicPacket>& msg)
 {
+    TracyZoneScoped;
     if (msg && !isCharmed)
     {
         pushPacket(msg.release());
@@ -1549,11 +1565,13 @@ void CCharEntity::HandleErrorMessage(std::unique_ptr<CBasicPacket>& msg)
 
 void CCharEntity::OnDeathTimer()
 {
+    TracyZoneScoped;
     charutils::HomePoint(this);
 }
 
 void CCharEntity::OnRaise()
 {
+    TracyZoneScoped;
     // TODO: Moghancement Experience needs to be factored in here somewhere.
     if (m_hasRaise > 0)
     {
@@ -1659,6 +1677,7 @@ void CCharEntity::OnRaise()
 
 void CCharEntity::OnItemFinish(CItemState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
     auto* PItem   = static_cast<CItemUsable*>(state.GetItem());
 
@@ -1720,6 +1739,7 @@ void CCharEntity::OnItemFinish(CItemState& state, action_t& action)
 
 CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg)
 {
+    TracyZoneScoped;
     auto* PTarget = CBattleEntity::IsValidTarget(targid, validTargetFlags, errMsg);
     if (PTarget)
     {
@@ -1755,6 +1775,7 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
 
 void CCharEntity::Die()
 {
+    TracyZoneScoped;
     if (PLastAttacker)
     {
         loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PLastAttacker, this, 0, 0, MSGBASIC_PLAYER_DEFEATED_BY));
@@ -1784,6 +1805,7 @@ void CCharEntity::Die()
 
 void CCharEntity::Die(duration _duration)
 {
+    TracyZoneScoped;
     this->ClearTrusts();
 
     if (StatusEffectContainer->HasStatusEffect(EFFECT_WEAKNESS))
@@ -1834,6 +1856,7 @@ void CCharEntity::Die(duration _duration)
 
 void CCharEntity::Raise()
 {
+    TracyZoneScoped;
     PAI->Internal_Raise();
     SetDeathTimestamp(0);
 }
@@ -1859,6 +1882,7 @@ int32 CCharEntity::GetTimeRemainingUntilDeathHomepoint() const
 
 int32 CCharEntity::GetTimeCreated()
 {
+    TracyZoneScoped;
     const char* fmtQuery = "SELECT UNIX_TIMESTAMP(timecreated) FROM chars WHERE charid = %u;";
 
     int32 ret = sql->Query(fmtQuery, id);
@@ -1878,6 +1902,7 @@ bool CCharEntity::hasMoghancement(uint16 moghancementID) const
 
 void CCharEntity::UpdateMoghancement()
 {
+    TracyZoneScoped;
     // Add up all of the installed furniture auras
     std::array<uint16, 8> elements = { 0 };
     for (auto containerID : { LOC_MOGSAFE, LOC_MOGSAFE2 })
@@ -1991,6 +2016,7 @@ void CCharEntity::UpdateMoghancement()
 
 void CCharEntity::SetMoghancement(uint16 moghancementID)
 {
+    TracyZoneScoped;
     m_moghancementID = moghancementID;
 
     // Apply the moghancement
@@ -2204,6 +2230,7 @@ void CCharEntity::SetMoghancement(uint16 moghancementID)
 
 void CCharEntity::TrackArrowUsageForScavenge(CItemWeapon* PAmmo)
 {
+    TracyZoneScoped;
     // Check if local has been set yet
     if (this->GetLocalVar("ArrowsUsed") == 0)
     {
@@ -2232,6 +2259,7 @@ void CCharEntity::TrackArrowUsageForScavenge(CItemWeapon* PAmmo)
 
 bool CCharEntity::OnAttackError(CAttackState& state)
 {
+    TracyZoneScoped;
     auto* controller{ static_cast<CPlayerController*>(PAI->GetController()) };
     if (controller->getLastErrMsgTime() + std::chrono::milliseconds(this->GetWeaponDelay(false)) < PAI->getTick())
     {
@@ -2269,6 +2297,7 @@ void CCharEntity::queueEvent(EventInfo* eventToQueue)
 
 void CCharEntity::tryStartNextEvent()
 {
+    TracyZoneScoped;
     if (isInEvent() || eventQueue.empty())
         return;
 
@@ -2316,6 +2345,7 @@ void CCharEntity::tryStartNextEvent()
 
 void CCharEntity::skipEvent()
 {
+    TracyZoneScoped;
     if (!m_Locked && !isInEvent() && (!currentEvent->cutsceneOptions.empty() || currentEvent->interruptText != 0))
     {
         pushPacket(new CMessageSystemPacket(0, 0, 117));
@@ -2333,6 +2363,7 @@ void CCharEntity::skipEvent()
 
 void CCharEntity::setLocked(bool locked)
 {
+    TracyZoneScoped;
     m_Locked = locked;
     if (locked)
     {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -54,6 +54,7 @@
 
 CMobEntity::CMobEntity()
 {
+    TracyZoneScoped;
     objtype = TYPE_MOB;
 
     m_DropID = 0;
@@ -282,6 +283,7 @@ bool CMobEntity::CanRoam()
 
 bool CMobEntity::CanLink(position_t* pos, int16 superLink)
 {
+    TracyZoneScoped;
     // handle super linking
     if (superLink && getMobMod(MOBMOD_SUPERLINK) == superLink)
     {
@@ -470,6 +472,7 @@ bool CMobEntity::IsUntargetable() const
 
 void CMobEntity::PostTick()
 {
+    TracyZoneScoped;
     CBattleEntity::PostTick();
     if (loc.zone && updatemask)
     {
@@ -497,6 +500,7 @@ float CMobEntity::GetRoamRate()
 
 bool CMobEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 {
+    TracyZoneScoped;
     if (StatusEffectContainer->GetConfrontationEffect() != PInitiator->StatusEffectContainer->GetConfrontationEffect())
     {
         return false;
@@ -528,6 +532,7 @@ bool CMobEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 
 void CMobEntity::Spawn()
 {
+    TracyZoneScoped;
     CBattleEntity::Spawn();
     m_giveExp      = true;
     m_HiPCLvl      = 0;
@@ -583,6 +588,7 @@ void CMobEntity::Spawn()
 
 void CMobEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
+    TracyZoneScoped;
     CBattleEntity::OnWeaponSkillFinished(state, action);
 
     static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
@@ -590,6 +596,7 @@ void CMobEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& actio
 
 void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 {
+    TracyZoneScoped;
     auto* PSkill  = state.GetSkill();
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
 
@@ -790,6 +797,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 
 void CMobEntity::DistributeRewards()
 {
+    TracyZoneScoped;
     CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.targid, TYPE_PC);
 
     if (PChar != nullptr && PChar->id == m_OwnerID.id)
@@ -841,6 +849,7 @@ void CMobEntity::DistributeRewards()
 
 void CMobEntity::DropItems(CCharEntity* PChar)
 {
+    TracyZoneScoped;
     // Adds an item to the treasure pool and returns true if the pool has been filled
     auto AddItemToPool = [this, PChar](uint16 ItemID, uint8 dropCount)
     {
@@ -1252,6 +1261,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
 bool CMobEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
 {
+    TracyZoneScoped;
     auto skill_list_id{ getMobMod(MOBMOD_ATTACK_SKILL_LIST) };
     if (skill_list_id)
     {
@@ -1275,6 +1285,7 @@ bool CMobEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>
 
 void CMobEntity::OnEngage(CAttackState& state)
 {
+    TracyZoneScoped;
     CBattleEntity::OnEngage(state);
     luautils::OnMobEngaged(this, state.GetTarget());
     unsigned int range = this->getMobMod(MOBMOD_ALLI_HATE);
@@ -1305,12 +1316,14 @@ void CMobEntity::OnEngage(CAttackState& state)
 
 void CMobEntity::FadeOut()
 {
+    TracyZoneScoped;
     CBaseEntity::FadeOut();
     PEnmityContainer->Clear();
 }
 
 void CMobEntity::OnDeathTimer()
 {
+    TracyZoneScoped;
     if (!(m_Behaviour & BEHAVIOUR_RAISABLE))
     {
         PAI->Despawn();
@@ -1319,6 +1332,7 @@ void CMobEntity::OnDeathTimer()
 
 void CMobEntity::OnDespawn(CDespawnState& /*unused*/)
 {
+    TracyZoneScoped;
     FadeOut();
     PAI->Internal_Respawn(std::chrono::milliseconds(m_RespawnTime));
     luautils::OnMobDespawn(this);
@@ -1328,6 +1342,7 @@ void CMobEntity::OnDespawn(CDespawnState& /*unused*/)
 
 void CMobEntity::Die()
 {
+    TracyZoneScoped;
     m_THLvl = PEnmityContainer->GetHighestTH();
     PEnmityContainer->Clear();
     PAI->ClearStateStack();
@@ -1337,7 +1352,10 @@ void CMobEntity::Die()
     }
     PAI->Internal_Die(15s);
     CBattleEntity::Die();
-    PAI->QueueAction(queueAction_t(std::chrono::milliseconds(m_DropItemTime), false, [this](CBaseEntity* PEntity) {
+
+    // clang-format off
+    PAI->QueueAction(queueAction_t(std::chrono::milliseconds(m_DropItemTime), false, [this](CBaseEntity* PEntity)
+    {
         if (static_cast<CMobEntity*>(PEntity)->isDead())
         {
             if (PLastAttacker)
@@ -1353,6 +1371,8 @@ void CMobEntity::Die()
             m_OwnerID.clean();
         }
     }));
+    // clang-format on
+
     if (PMaster && PMaster->PPet == this && PMaster->objtype == TYPE_PC)
     {
         petutils::DetachPet(PMaster);
@@ -1361,6 +1381,7 @@ void CMobEntity::Die()
 
 void CMobEntity::OnDisengage(CAttackState& state)
 {
+    TracyZoneScoped;
     PAI->PathFind->Clear();
     PEnmityContainer->Clear();
 
@@ -1380,6 +1401,7 @@ void CMobEntity::OnDisengage(CAttackState& state)
 
 void CMobEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
+    TracyZoneScoped;
     CBattleEntity::OnCastFinished(state, action);
 
     static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
@@ -1387,6 +1409,7 @@ void CMobEntity::OnCastFinished(CMagicState& state, action_t& action)
 
 bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
 {
+    TracyZoneScoped;
     static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
 
     if (getMobMod(MOBMOD_ATTACK_SKILL_LIST))

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -113,6 +113,7 @@ namespace luautils
         ShowStatus("luautils::init:lua initializing");
 
         lua = sol::state();
+        TracyLuaRegister(lua.lua_state());
         lua.open_libraries();
 
         // Globally require bit library
@@ -1544,6 +1545,7 @@ namespace luautils
     uint8 GetSettingsVariable(const char* variable)
     {
         TracyZoneScoped;
+        TracyZoneCString(variable);
         return lua["xi"]["settings"][variable].valid() ? lua["xi"]["settings"][variable].get<uint8>() : 0;
     }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -29,7 +29,9 @@
 
 #include "lua.hpp"
 
+#ifdef TRACY_ENABLE
 #include "TracyLua.hpp"
+#endif
 
 // Sol compilation definitions are in the base CMakeLists file
 // SOL_ALL_SAFETIES_ON = 1

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -29,6 +29,8 @@
 
 #include "lua.hpp"
 
+#include "TracyLua.hpp"
+
 // Sol compilation definitions are in the base CMakeLists file
 // SOL_ALL_SAFETIES_ON = 1
 // SOL_NO_CHECK_NUMBER_PRECISION = 1

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -211,9 +211,14 @@ int32 do_init(int32 argc, char** argv)
                                           map_config.mysql_port,
                                           map_config.mysql_database.c_str());
 
-    // We clear the session table at server start (temporary solution)
-    sql->Query("DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);", map_ip.s_addr, map_port,
-                map_ip.s_addr, map_port);
+    // clang-format off
+    sql->Async([&](SqlConnection* sql)
+    {
+        // We clear the session table at server start (temporary solution)
+        sql->Query("DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);", map_ip.s_addr, map_port,
+                    map_ip.s_addr, map_port);
+    });
+    // clang-format on
 
     ShowStatus("do_init: zlib is reading");
     zlib_init();

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -42,10 +42,13 @@ void CNotorietyContainer::add(CBattleEntity* entity)
 void CNotorietyContainer::remove(CBattleEntity* entity)
 {
     TracyZoneScoped;
-    auto entity_itr = m_Lookup.find(entity);
-    if (entity_itr != m_Lookup.end())
+    if (entity)
     {
-        m_Lookup.erase(*entity_itr);
+        auto entity_itr = m_Lookup.find(entity);
+        if (entity_itr != m_Lookup.end())
+        {
+            m_Lookup.erase(*entity_itr);
+        }
     }
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3406,10 +3406,12 @@ void SmallPacket0x059(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x05A(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    CampaignState state = campaign::GetCampaignState();
     PChar->pushPacket(new CConquestPacket(PChar));
-    PChar->pushPacket(new CCampaignPacket(PChar, state, 0));
-    PChar->pushPacket(new CCampaignPacket(PChar, state, 1));
+
+    // TODO: This is unstable across multiple processes. Fix me.
+    // CampaignState state = campaign::GetCampaignState();
+    // PChar->pushPacket(new CCampaignPacket(PChar, state, 0));
+    // PChar->pushPacket(new CCampaignPacket(PChar, state, 1));
 }
 
 /************************************************************************

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5940,15 +5940,24 @@ namespace charutils
             return;
         }
 
+        // clang-format off
+        auto id = PChar->id;
         if (value == 0)
         {
-            sql->Query("DELETE FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;", PChar->id, var);
+            sql->Async([=](SqlConnection* sql)
+            {
+                sql->Query("DELETE FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;", id, var);
+            });
         }
         else
         {
             const char* fmtQuery = "INSERT INTO char_vars SET charid = %u, varname = '%s', value = %i ON DUPLICATE KEY UPDATE value = %i;";
-            sql->Query(fmtQuery, PChar->id, var, value, value);
+            sql->Async([=](SqlConnection* sql)
+            {
+                sql->Query(fmtQuery, id, var, value, value);
+            });
         }
+        // clang-format on
     }
 
     void ClearCharVarsWithPrefix(CCharEntity* PChar, std::string prefix)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5904,6 +5904,8 @@ namespace charutils
     int32 GetCharVar(CCharEntity* PChar, const char* var)
     {
         TracyZoneScoped;
+        TracyZoneString(PChar->name);
+        TracyZoneCString(var);
 
         if (PChar == nullptr)
         {
@@ -5929,6 +5931,8 @@ namespace charutils
     void SetCharVar(CCharEntity* PChar, const char* var, int32 value)
     {
         TracyZoneScoped;
+        TracyZoneString(PChar->name);
+        TracyZoneString(fmt::format("{} -> {}", var, value));
         
         if (PChar == nullptr)
         {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -112,11 +112,11 @@ namespace zoneutils
 
     CZone* GetZone(uint16 ZoneID)
     {
-        XI_DEBUG_BREAK_IF(ZoneID >= MAX_ZONEID);
         if (auto PZone = g_PZoneList.find(ZoneID); PZone != g_PZoneList.end())
         {
             return PZone->second;
         }
+        ShowWarning(fmt::format("Invalid zone requested: {}", ZoneID));
         return nullptr;
     }
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Thanks Wings 3.0 for the stress  testing, we learned a bunch of things.

This is a mixed bag of things, split into sane commits.

- More things for tracy
- Comment out the campaign map packet logic - it isn't safe across processes!
- Add sql->Async. I thought this would make the command handler faster, but it seems like it's slow because of `stringstream` and friends :(