### PR TITLE
[Quest] Limit Break 1 and 2 KI cleanup and other fixes

### DIFF
--- a/scripts/quests/jeuno/LB01_In_Defiant_Challenge.lua
+++ b/scripts/quests/jeuno/LB01_In_Defiant_Challenge.lua
@@ -31,6 +31,25 @@ local garlaigeID = require('scripts/zones/Garlaige_Citadel/IDs')
 
 local quest = Quest:new(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.IN_DEFIANT_CHALLENGE)
 
+-- Key Item removals
+local function cleanKIMold(player)
+    player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB1)
+    player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB2)
+    player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB3)
+end
+
+local function cleanKICoal(player)
+    player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT1)
+    player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT2)
+    player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT3)
+end
+
+local function cleanKIPapyrus(player)
+    player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED1)
+    player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED2)
+    player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED3)
+end
+
 -- NOTE: This is handled in such an unconventional manner just so the text appears in the same order as in retail.
 local function handleExorayMold(player)
     if
@@ -39,9 +58,7 @@ local function handleExorayMold(player)
         player:hasKeyItem(xi.ki.EXORAY_MOLD_CRUMB3)
     then
         if player:getFreeSlotsCount() > 0 then
-            player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB1)
-            player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB2)
-            player:delKeyItem(xi.ki.EXORAY_MOLD_CRUMB3)
+            cleanKIMold(player)
             player:messageSpecial(crawlersID.text.COMBINE_INTO_A_CLUMP, xi.ki.EXORAY_MOLD_CRUMB1)
             npcUtil.giveItem(player, xi.items.CLUMP_OF_EXORAY_MOLD)
         else
@@ -57,9 +74,7 @@ local function handleBombCoal(player)
         player:hasKeyItem(xi.ki.BOMB_COAL_FRAGMENT3)
     then
         if player:getFreeSlotsCount() > 0 then
-            player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT1)
-            player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT2)
-            player:delKeyItem(xi.ki.BOMB_COAL_FRAGMENT3)
+            cleanKICoal(player)
             player:messageSpecial(garlaigeID.text.COMBINE_INTO_A_CHUNK, xi.ki.BOMB_COAL_FRAGMENT1)
             npcUtil.giveItem(player, xi.items.CHUNK_OF_BOMB_COAL)
         else
@@ -75,9 +90,7 @@ local function handleAncientPapyrus(player)
         player:hasKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED3)
     then
         if player:getFreeSlotsCount() > 0 then
-            player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED1)
-            player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED2)
-            player:delKeyItem(xi.ki.ANCIENT_PAPYRUS_SHRED3)
+            cleanKIPapyrus(player)
             player:messageSpecial(eldiemeID.text.PUT_TOGUETHER_TO_COMPLETE, xi.ki.ANCIENT_PAPYRUS_SHRED1)
             npcUtil.giveItem(player, xi.items.PIECE_OF_ANCIENT_PAPYRUS)
         else
@@ -149,6 +162,9 @@ quest.sections =
             {
                 [81] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        cleanKIMold(player)
+                        cleanKICoal(player)
+                        cleanKIPapyrus(player)
                         player:confirmTrade()
                         player:setLevelCap(55)
                         -- Leaving this here for historic purposes. Unneeded. The event now returns this message on its own.

--- a/scripts/quests/jeuno/LB02_Atop_the_Highest_Mountains.lua
+++ b/scripts/quests/jeuno/LB02_Atop_the_Highest_Mountains.lua
@@ -34,7 +34,6 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
-                player:getMainLvl() >= 51 and
                 player:getLevelCap() == 55 and
                 xi.settings.MAX_LEVEL >= 60
         end,
@@ -44,7 +43,11 @@ quest.sections =
             ['Maat'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(82)
+                    if player:getMainLvl() >= 51 then
+                        return quest:progressEvent(82)
+                    else
+                        return quest:messageText(npc, 10387)
+                    end
                 end,
             },
 

--- a/scripts/quests/jeuno/LB03_Whence_Blows_the_wind.lua
+++ b/scripts/quests/jeuno/LB03_Whence_Blows_the_wind.lua
@@ -32,7 +32,6 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
-                player:getMainLvl() >= 56 and
                 player:getLevelCap() == 60 and
                 xi.settings.MAX_LEVEL >= 65
         end,
@@ -42,7 +41,11 @@ quest.sections =
             ['Maat'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(85)
+                    if player:getMainLvl() >= 56 then
+                        return quest:progressEvent(85)
+                    else
+                        return quest:messageText(npc, 10399)
+                    end
                 end,
             },
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Changes:
- Add missing message after LB1 quest completion (But before next quest is available)
- Add missing message after LB2 quest completion (But before next quest is available)
- Add cleanup method on quest complete