### PR TITLE
Add item check for Forge Your Destiny Zi'Tah NM Spawn

### DIFF
--- a/scripts/quests/outlands/Forge_Your_Destiny.lua
+++ b/scripts/quests/outlands/Forge_Your_Destiny.lua
@@ -239,7 +239,10 @@ quest.sections =
             ['qm2'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.items.HATCHET) then
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.items.HATCHET) and
+                        player:hasItem(xi.items.SACRED_SPRIG)
+                    then
                         if
                             GetMobByID(zitahID.mob.GUARDIAN_TREANT):isSpawned() or
                             npc:getLocalVar('treantNextPopAllowedTime') > os.time()
@@ -269,7 +272,7 @@ quest.sections =
                     then
                         quest:setVar(player, 'Prog', 2)
                         player:confirmTrade()
-                        return quest:messageSpecial(zitahID.text.STRANGE_FORCE_VANISHED, xi.items.SACRED_SPRIG)
+                        return quest:messageSpecial(zitahID.text.STRANGE_FORCE_VANISHED, xi.items.SACRED_BRANCH)
                     end
                 end,
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This NM cannot be spawned if the player does not have the Sacred Sprig item.  Adds check to ensure this is the case.