### PR TITLE
[Interaction] Bastok 2-3 W->S Additions and fixes.

### DIFF
--- a/scripts/missions/bastok/2_3_0_The_Emissary.lua
+++ b/scripts/missions/bastok/2_3_0_The_Emissary.lua
@@ -21,11 +21,10 @@ require('scripts/globals/titles')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
-local bastokMarketsID    = require('scripts/zones/Bastok_Markets/IDs')
-local bastokMinesID      = require('scripts/zones/Bastok_Mines/IDs')
-local metalworksID       = require('scripts/zones/Metalworks/IDs')
-local portBastokID       = require('scripts/zones/Port_Bastok/IDs')
-local portWindurstID     = require('scripts/zones/Port_Windurst/IDs')
+local bastokMarketsID = require('scripts/zones/Bastok_Markets/IDs')
+local bastokMinesID   = require('scripts/zones/Bastok_Mines/IDs')
+local metalworksID    = require('scripts/zones/Metalworks/IDs')
+local portBastokID    = require('scripts/zones/Port_Bastok/IDs')
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY)
@@ -114,7 +113,13 @@ mission.sections =
                         not player:hasKeyItem(xi.ki.LETTER_TO_THE_CONSULS_BASTOK) and
                         player:getMissionStatus(mission.areaId) == 0
                     then
-                        return mission:progressEvent(713)
+                        local isFirst2_3 =
+                        (
+                            not player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_ABROAD) and
+                            not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS)
+                        ) and 1 or 0
+
+                        return mission:progressEvent(713, 0, 0, 0, 0, 0, 0, 0, isFirst2_3) -- Contains variation for Lion mention.
                     else
                         return mission:messageText(metalworksID.text.GOOD_LUCK)
                     end
@@ -201,7 +206,6 @@ mission.sections =
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_SANDORIA)
                     player:setMissionStatus(mission.areaId, 2)
-                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_BASTOK)
                 end,
             },
         },
@@ -211,8 +215,12 @@ mission.sections =
             ['Ada'] =
             {
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem(xi.ki.KINDRED_REPORT) then
-                        return mission:progressEvent(69)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                        return mission:event(58)
+                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                        return mission:event(69)
                     end
                 end,
             },
@@ -220,8 +228,14 @@ mission.sections =
             ['Gold_Skull'] =
             {
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem(xi.ki.KINDRED_REPORT) then
-                        return mission:progressEvent(68)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 1 then -- Before Talking to Melek the first time.
+                        return mission:event(43)
+                    elseif missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                        return mission:event(57)
+                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                        return mission:event(68)
                     end
                 end,
             },
@@ -229,8 +243,12 @@ mission.sections =
             ['Josef'] =
             {
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem(xi.ki.KINDRED_REPORT) then
-                        return mission:progressEvent(70)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                        return mission:event(59)
+                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                        return mission:event(70)
                     end
                 end,
             },
@@ -241,12 +259,12 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 1 then
-                        return mission:progressEvent(48)
+                        return mission:progressEvent(48) -- Start Windurst path first.
                     elseif missionStatus == 6 then
                         return mission:progressEvent(61)
-                    elseif missionStatus == 7 then
-                        return mission:messageText(portWindurstID.text.MELEK_DIALOG_C)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then
+                    elseif missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                        return mission:event(56)
+                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
                         return mission:progressEvent(67)
                     end
                 end,
@@ -258,7 +276,6 @@ mission.sections =
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST)
                     player:setMissionStatus(mission.areaId, 2)
-                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_BASTOK)
                 end,
 
                 [61] = function(player, csid, option, npc)

--- a/scripts/missions/bastok/2_3_0_The_Emissary.lua
+++ b/scripts/missions/bastok/2_3_0_The_Emissary.lua
@@ -31,10 +31,10 @@ local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_E
 
 mission.reward =
 {
-    gil = 3000,
+    gil     = 3000,
     keyItem = xi.ki.ADVENTURERS_CERTIFICATE,
-    rank = 3,
-    title = xi.title.CERTIFIED_ADVENTURER,
+    rank    = 3,
+    title   = xi.title.CERTIFIED_ADVENTURER,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)
@@ -151,11 +151,7 @@ mission.sections =
             ['Baraka'] =
             {
                 onTrigger = function(player, npc)
-                    local missionStatus = player:getMissionStatus(mission.areaId)
-
-                    if missionStatus == 1 then
-                        -- This cs should only play if you visit San d'Oria first
-                        -- If you visit Windurst first you will encounter Lion in Heaven's Tower instead
+                    if player:getMissionStatus(mission.areaId) == 1 then -- Start Sandoria path first.
                         return mission:progressEvent(581)
                     end
                 end,
@@ -166,13 +162,14 @@ mission.sections =
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
-                    -- Bastok Mission 2-3 Part I - San d'Oria > Windurst
-                    if missionStatus == 1 then
+                    if missionStatus == 1 then -- Placeholder before starting first path.
                         return mission:progressEvent(676)
-                    -- Bastok Mission 2-3 Part II - Windurst > San d'Oria
-                    elseif missionStatus == 7 then
+                    elseif missionStatus == 7 then -- Start Sandoria path second.
                         return mission:progressEvent(537)
-                    elseif missionStatus == 11 then
+                    elseif
+                        missionStatus == 11 and
+                        player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_SANDORIA2)
+                    then -- Both paths completed, with Sandoria last.
                         return mission:progressEvent(557)
                     end
                 end,
@@ -186,8 +183,8 @@ mission.sections =
                     if
                         missionStatus == 1 or
                         missionStatus == 7
-                    then
-                        return mission:progressEvent(556)
+                    then -- TODO: Default dialog and status 1 need confirmation.
+                        return mission:event(556)
                     end
                 end,
             },
@@ -198,6 +195,7 @@ mission.sections =
                     if option == 0 then
                         player:delMission(mission.areaId, mission.missionId)
                         player:addMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_SANDORIA2)
+                        player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_BASTOK) -- Key item deleted when starting second path.
                         player:setMissionStatus(mission.areaId, 8)
                     end
                 end,
@@ -219,7 +217,10 @@ mission.sections =
 
                     if missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
                         return mission:event(58)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                    elseif
+                        player:hasKeyItem(xi.ki.KINDRED_REPORT) and
+                        player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST2)
+                    then -- Both paths completed, with Windurst last.
                         return mission:event(69)
                     end
                 end,
@@ -228,13 +229,12 @@ mission.sections =
             ['Gold_Skull'] =
             {
                 onTrigger = function(player, npc)
-                    local missionStatus = player:getMissionStatus(mission.areaId)
-
-                    if missionStatus == 1 then -- Before Talking to Melek the first time.
-                        return mission:event(43)
-                    elseif missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                    if player:getMissionStatus(mission.areaId) == 7 then -- Windurst path completed. Sandoria path not started.
                         return mission:event(57)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                    elseif
+                        player:hasKeyItem(xi.ki.KINDRED_REPORT) and
+                        player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST2)
+                    then -- Both paths completed, with Windurst last.
                         return mission:event(68)
                     end
                 end,
@@ -243,11 +243,12 @@ mission.sections =
             ['Josef'] =
             {
                 onTrigger = function(player, npc)
-                    local missionStatus = player:getMissionStatus(mission.areaId)
-
-                    if missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
+                    if player:getMissionStatus(mission.areaId) == 7 then -- Windurst path completed. Sandoria path not started.
                         return mission:event(59)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                    elseif
+                        player:hasKeyItem(xi.ki.KINDRED_REPORT) and
+                        player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST2)
+                    then -- Both paths completed, with Windurst last.
                         return mission:event(70)
                     end
                 end,
@@ -258,13 +259,16 @@ mission.sections =
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
-                    if missionStatus == 1 then
-                        return mission:progressEvent(48) -- Start Windurst path first.
-                    elseif missionStatus == 6 then
+                    if missionStatus == 1 then -- Start Windurst path first.
+                        return mission:progressEvent(48)
+                    elseif missionStatus == 6 then -- Start Windurst path second.
                         return mission:progressEvent(61)
                     elseif missionStatus == 7 then -- Windurst path completed. Sandoria path not started.
                         return mission:event(56)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_REPORT) then -- Both paths Completed
+                    elseif
+                        player:hasKeyItem(xi.ki.KINDRED_REPORT) and
+                        player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST2)
+                    then -- Both paths completed, with Windurst last.
                         return mission:progressEvent(67)
                     end
                 end,
@@ -281,6 +285,7 @@ mission.sections =
                 [61] = function(player, csid, option, npc)
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST2)
+                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_BASTOK) -- Key item deleted when starting second path.
                     player:setMissionStatus(mission.areaId, 7)
                 end,
             },

--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -130,7 +130,7 @@ mission.sections =
 
         [xi.zone.NORTHERN_SAN_DORIA] =
         {
-            ['Helaku'] = mission:messageSpecial(northSandoriaID.text.THE_EMISSARY_PLACEHOLDER),
+            ['Helaku'] = mission:messageText(northSandoriaID.text.THE_EMISSARY_PLACEHOLDER),
         },
 
         [xi.zone.PORT_WINDURST] =

--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -14,7 +14,7 @@ require('scripts/globals/npc_util')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
-local portWindurstID = require('scripts/zones/Port_Windurst/IDs')
+local northSandoriaID = require('scripts/zones/Northern_San_dOria/IDs')
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_WINDURST)
@@ -39,11 +39,13 @@ mission.sections =
                 end,
 
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem(xi.ki.DULL_SWORD) then
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 4 then -- Reject Sword and request Aspir Knife.
                         return mission:progressEvent(40)
-                    elseif player:getMissionStatus(player:getNation()) == 5 then
+                    elseif missionStatus == 5 then -- Waiting for Aspir Knife.
                         return mission:progressEvent(43)
-                    else
+                    elseif missionStatus >= 6 then -- After trading Aspir Knife.
                         return mission:progressEvent(44)
                     end
                 end,
@@ -53,11 +55,11 @@ mission.sections =
             {
                 [40] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 5)
-                    player:delKeyItem(xi.ki.DULL_SWORD)
                 end,
 
                 [41] = function(player, csid, option, npc)
                     player:confirmTrade()
+                    player:delKeyItem(xi.ki.DULL_SWORD)
                     player:setMissionStatus(mission.areaId, 6)
                 end,
             },
@@ -71,9 +73,15 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsSemihTrust = (not player:hasSpell(940) and not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        local needsSemihTrust = (not player:hasSpell(940) and not player:hasItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        local hasTrustQuest =
+                        (
+                            player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) or
+                            player:hasKeyItem(xi.ki.BASTOK_TRUST_PERMIT) or
+                            player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
+                        ) and 0 or 1
 
-                        return mission:progressEvent(238, 1, 1, 1, 1, xi.nation.BASTOK, 0, 0, needsSemihTrust)
+                        return mission:progressEvent(239, 0, 0, 0, xi.nation.BASTOK, 0, hasTrustQuest, needsSemihTrust)
                     elseif missionStatus == 5 then
                         return mission:event(240)
                     elseif missionStatus == 6 then
@@ -102,17 +110,17 @@ mission.sections =
 
             onEventFinish =
             {
-                [ 42] = function(player, csid, option, npc)
+                [42] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 3)
                 end,
 
-                [238] = function(player, csid, option, npc)
+                [239] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 4)
                     npcUtil.giveKeyItem(player, xi.ki.SWORD_OFFERING)
 
                     if
                         not player:hasSpell(940) and
-                        not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
+                        not player:hasItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
                     end
@@ -120,8 +128,15 @@ mission.sections =
             },
         },
 
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Helaku'] = mission:messageSpecial(northSandoriaID.text.THE_EMISSARY_PLACEHOLDER),
+        },
+
         [xi.zone.PORT_WINDURST] =
         {
+            ['Ada'] = mission:event(51),
+
             ['Gold_Skull'] =
             {
                 onTrigger = function(player, npc)
@@ -131,28 +146,24 @@ mission.sections =
                         player:hasKeyItem(xi.ki.SWORD_OFFERING) and
                         not player:hasKeyItem(xi.ki.DULL_SWORD)
                     then
-                        return mission:progressEvent(53)
-                    elseif missionStatus == 2 then
-                        return mission:progressEvent(50)
-                    elseif missionStatus == 12 then -- TODO: Find out what the below does, this is dead code
+                        return mission:progressEvent(53) -- Trade Sword with fake.
+                    elseif missionStatus <= 3 then -- After getting instructions and before getting Magic Sword.
+                        return mission:event(50)
+                    elseif missionStatus <= 6 then -- After trading Sword with fake and before reporting to Melek.
                         return mission:progressEvent(54)
-                    elseif missionStatus == 14 then
-                        return mission:messageText(npc, portWindurstID.text.GOLD_SKULL_DIALOG)
-                    elseif missionStatus == 15 then
-                        return mission:progressEvent(57)
                     end
                 end,
             },
+
+            ['Josef'] = mission:event(52),
 
             ['Melek'] =
             {
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
-                    if missionStatus == 2 then
+                    if missionStatus <= 5 then
                         return mission:progressEvent(49)
-                    elseif missionStatus <= 5 then
-                        return mission:messageText(portWindurstID.text.MELEK_DIALOG_B)
                     elseif missionStatus == 6 then
                         return mission:progressEvent(55)
                     end
@@ -168,7 +179,6 @@ mission.sections =
 
                 [55] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
                         player:addMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY)
                         player:setMissionStatus(mission.areaId, 7)
                     end

--- a/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
+++ b/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
@@ -16,7 +16,8 @@ require('scripts/globals/titles')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
-local chateauID = require('scripts/zones/Chateau_dOraguille/IDs')
+local chateauID       = require('scripts/zones/Chateau_dOraguille/IDs')
+local northSandoriaID = require('scripts/zones/Northern_San_dOria/IDs')
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_EMISSARY_SANDORIA2)
@@ -72,7 +73,6 @@ mission.sections =
                         player:getLocalVar('battlefieldWin') == 999
                     then
                         npcUtil.giveKeyItem(player, xi.ki.KINDRED_CREST)
-                        player:delKeyItem(xi.ki.DARK_KEY)
                         player:setMissionStatus(mission.areaId, 10)
                     end
                 end,
@@ -84,24 +84,15 @@ mission.sections =
             ['Helaku'] =
             {
                 onTrigger = function(player, npc)
-                    local missionStatus = player:getMissionStatus(mission.areaId)
-
-                    if missionStatus == 9 then
-                        return mission:progressEvent(542)
-                    elseif player:hasKeyItem(xi.ki.KINDRED_CREST) then
+                    if player:hasKeyItem(xi.ki.KINDRED_CREST) then
                         return mission:progressEvent(545)
+                    else
+                        return mission:messageText(northSandoriaID.text.HELAKU_DIALOG + 16)
                     end
                 end,
             },
 
-            ['Shakir'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 9 then
-                        return mission:progressEvent(556)
-                    end
-                end,
-            },
+            ['Shakir'] = mission:event(538),
 
             onEventFinish =
             {

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -79,6 +79,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         DOGGOMEHR_SHOP_DIALOG    = 11552, -- Welcome to the Blacksmiths' Guild shop.
         LUCRETIA_SHOP_DIALOG     = 11553, -- Blacksmiths' Guild shop, at your service!
         CAUZERISTE_SHOP_DIALOG   = 11620, -- Welcome! San d'Oria Carpenters' Guild shop, at your service.
+        THE_EMISSARY_PLACEHOLDER = 11627, -- I'm glad you brought a letter of introduction, but you haven't finished your duty to Consul Melek yet. You'll need to come back once that's out of the way.
         ANTONIAN_OPEN_DIALOG     = 11635, -- Interested in goods from Aragoneu?
         BONCORT_SHOP_DIALOG      = 11636, -- Welcome to the Phoenix Perch!
         PIRVIDIAUCE_SHOP_DIALOG  = 11637, -- Care to see what I have?


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Additions:
- Helaku placeholder text in Northern San'doria during Windurst branch.
- Ada and Josef text messages during Windurst Path and after windurst path (But before Sandoria. After that, they revert to default)
- Additional parameters to Starting Event and to Kupipi's Event during Windurst Path.

Fixes:
- Letter to consuls KI being removed when starting first path, instead of second.
- Incorrect events for Melek, Kupipi and Gold Skull in windurst (1st) path.
- Uu_Zhoumo event triggering before it should.
- Dull Sword being removed before it should.
- Incorrect events for Helaku and Shakir in Sandoria (2nd) path.
- Dead, superfluous or incorrect code.