### PR TITLE
[Interaction] Bastok 4-1 additions and fixes

### DIFF
--- a/scripts/missions/bastok/4_1_Magicite.lua
+++ b/scripts/missions/bastok/4_1_Magicite.lua
@@ -22,6 +22,8 @@ require('scripts/settings/main')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
+local ruludeID = require('scripts/zones/RuLude_Gardens/IDs')
+-----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.MAGICITE)
 
@@ -38,8 +40,8 @@ end
 
 mission.reward =
 {
-    rank = 5,
-    gil = 10000,
+    rank    = 5,
+    gil     = 10000,
     keyItem = xi.ki.MESSAGE_TO_JEUNO_BASTOK,
 }
 
@@ -55,6 +57,16 @@ mission.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
+            ['_6r2'] =
+            {
+                onTrigger = function(player, npc)
+                    if xi.mission.getMissionRankPoints(player, xi.mission.id.bastok.MAGICITE) then
+                        local hasKIParam = player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and 1 or 0
+                        return mission:progressEvent(129, hasKIParam) -- This event starts the mission.
+                    end
+                end,
+            },
+
             ['Goggehn'] =
             {
                 onTrigger = function(player, npc)
@@ -68,8 +80,9 @@ mission.sections =
 
             onEventFinish =
             {
-                [0] = function(player, csid, option, npc)
+                [129] = function(player, csid, option, npc)
                     mission:begin(player)
+                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,
             },
         },
@@ -84,21 +97,13 @@ mission.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            ['_6r2'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        local hasKIParam = player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and 1 or 0
-                        return mission:progressEvent(129, hasKIParam)
-                    end
-                end,
-            },
-
             ['_6r9'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
+                    if player:getMissionStatus(mission.areaId) == 0 then
                         return mission:progressEvent(128)
+                    else
+                        return mission:progressEvent(138, 1)
                     end
                 end,
             },
@@ -106,7 +111,7 @@ mission.sections =
             ['Goggehn'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
+                    if player:getMissionStatus(mission.areaId) == 0 then
                         return mission:progressEvent(132)
                     else
                         return mission:progressEvent(135)
@@ -117,13 +122,8 @@ mission.sections =
             onEventFinish =
             {
                 [128] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 2)
-                    npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ALDO)
-                end,
-
-                [129] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 1)
-                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+                    npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ALDO)
                 end,
             },
         },
@@ -133,11 +133,11 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 2 then
+                    if player:getMissionStatus(mission.areaId) == 1 then
                         if player:hasKeyItem(xi.ki.SILVER_BELL) then
-                            return mission:progressEvent(152, 1)
+                            return mission:progressEvent(152, 1) -- CS without Verena nor Fickblix
                         else
-                            return mission:progressEvent(152)
+                            return mission:progressEvent(152) -- Regular CS with Verena and Fickblix
                         end
                     end
                 end,
@@ -146,7 +146,7 @@ mission.sections =
             onEventFinish =
             {
                 [152] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 3)
+                    player:setMissionStatus(mission.areaId, 2)
                     player:delKeyItem(xi.ki.LETTER_TO_ALDO)
 
                     if not player:hasKeyItem(xi.ki.SILVER_BELL) then
@@ -161,7 +161,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
-                player:getMissionStatus(mission.areaId) == 3
+                player:getMissionStatus(mission.areaId) == 2
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -175,6 +175,8 @@ mission.sections =
                         else
                             return mission:progressEvent(60)
                         end
+                    else
+                        return mission:progressEvent(138, 1)
                     end
                 end,
             },
@@ -200,7 +202,7 @@ mission.sections =
                     end
 
                     player:addTitle(xi.title.HAVE_WINGS_WILL_FLY)
-                    player:setMissionStatus(mission.areaId, 4)
+                    player:setMissionStatus(mission.areaId, 3)
                 end,
             },
         },
@@ -358,17 +360,22 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
-                player:getMissionStatus(mission.areaId) == 4
+                player:getMissionStatus(mission.areaId) == 3
         end,
 
         [xi.zone.RULUDE_GARDENS] =
         {
+            ['_6r2'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:messageSpecial(ruludeID.text.THE_CONSULATE_IS_AWAY)
+                end,
+            },
+
             ['Goggehn'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 4 then
-                        return mission:progressEvent(35)
-                    end
+                    return mission:progressEvent(35)
                 end,
             },
 

--- a/scripts/missions/bastok/4_1_Magicite.lua
+++ b/scripts/missions/bastok/4_1_Magicite.lua
@@ -71,9 +71,9 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if xi.mission.getMissionRankPoints(player, xi.mission.id.bastok.MAGICITE) then
-                        return mission:progressEvent(0)
+                        return mission:event(0)
                     else
-                        return mission:progressEvent(4)
+                        return mission:event(4)
                     end
                 end,
             },
@@ -103,7 +103,7 @@ mission.sections =
                     if player:getMissionStatus(mission.areaId) == 0 then
                         return mission:progressEvent(128)
                     else
-                        return mission:progressEvent(138, 1)
+                        return mission:event(138, 1)
                     end
                 end,
             },
@@ -112,9 +112,9 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 0 then
-                        return mission:progressEvent(132)
+                        return mission:event(132)
                     else
-                        return mission:progressEvent(135)
+                        return mission:event(135)
                     end
                 end,
             },
@@ -176,7 +176,7 @@ mission.sections =
                             return mission:progressEvent(60)
                         end
                     else
-                        return mission:progressEvent(138, 1)
+                        return mission:event(138, 1)
                     end
                 end,
             },
@@ -184,7 +184,7 @@ mission.sections =
             ['Goggehn'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(135)
+                    return mission:event(135)
                 end,
             },
 
@@ -213,9 +213,9 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if magiciteCounter(player) == 0 then
-                        return mission:progressEvent(161)
+                        return mission:event(161)
                     else
-                        return mission:progressEvent(183)
+                        return mission:event(183)
                     end
                 end,
             },
@@ -227,13 +227,13 @@ mission.sections =
                         if mission:getVar(player, 'Option') == 1 then
                             return mission:progressEvent(184)
                         else
-                            return mission:progressEvent(80)
+                            return mission:event(80)
                         end
                     else
                         if mission:getVar(player, 'Option') == 2 then
-                            return mission:progressEvent(81)
+                            return mission:event(81)
                         else
-                            return mission:progressEvent(79)
+                            return mission:event(79)
                         end
                     end
                 end,
@@ -392,7 +392,7 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(183)
+                    return mission:event(183)
                 end,
             },
         },

--- a/scripts/zones/RuLude_Gardens/IDs.lua
+++ b/scripts/zones/RuLude_Gardens/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.RULUDE_GARDENS] =
         OBTAIN_SCYLDS                    = 6896,  -- You obtain <number> [scyld/scylds]! Current balance: <number> [scyld/scylds].
         HUNT_CANCELED                    = 6900,  -- Hunt canceled.
         RESTRICTED                       = 10107, -- It reads, Restricted Area.
+        THE_CONSULATE_IS_AWAY            = 10109, -- The consulate is away.
         SOVEREIGN_WITHOUT_AN_APPOINTMENT = 10180, -- Nobody sees the sovereign without an appointment!
         ITEM_DELIVERY_DIALOG             = 10271, -- Now offering quick and easy delivery of packages to homes everywhere!
         HOMEPOINT_SET                    = 10284, -- Home point set!


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Changes:
- Correct starting event. The missionis started by the consulate door, not Goggehn.
- This change has the effect of reducing the mission status variable by 1.
- Add aditional message to consulate door after recieving Airship pass.
- Remove unneeded check in Goggehn final event.