### PR TITLE
Augment Discovery 2022-05-10

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -272,7 +272,7 @@ INSERT INTO `augments` VALUES (213,0,0,0,0,0); -- 213 currently unused. Leave at
 INSERT INTO `augments` VALUES (214,0,0,0,0,0); -- 214 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (215,0,308,1,0,0); -- Ninja tool expertise+1
 
--- 216 to 232 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
+-- 216 to 231 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (216,0,0,0,0,0);
 INSERT INTO `augments` VALUES (217,0,0,0,0,0);
 INSERT INTO `augments` VALUES (218,0,0,0,0,0);
@@ -289,7 +289,7 @@ INSERT INTO `augments` VALUES (228,0,0,0,0,0);
 INSERT INTO `augments` VALUES (229,0,0,0,0,0);
 INSERT INTO `augments` VALUES (230,0,0,0,0,0);
 INSERT INTO `augments` VALUES (231,0,0,0,0,0);
-INSERT INTO `augments` VALUES (232,0,0,0,0,0);
+INSERT INTO `augments` VALUES (232,0,0,0,0,0); -- True Shot +1
 -- End unused block
 
 INSERT INTO `augments` VALUES (233,0,913,1,0,0); -- Blood Boon+1
@@ -302,7 +302,7 @@ INSERT INTO `augments` VALUES (236,0,0,0,0,0);
 
 INSERT INTO `augments` VALUES (237,0,902,1,0,0); -- Occult Acumen+1
 
--- 238 to 256 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
+-- 238 to 250 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (238,0,0,0,0,0);
 INSERT INTO `augments` VALUES (239,0,0,0,0,0);
 INSERT INTO `augments` VALUES (240,0,0,0,0,0);
@@ -316,7 +316,11 @@ INSERT INTO `augments` VALUES (247,0,0,0,0,0);
 INSERT INTO `augments` VALUES (248,0,0,0,0,0);
 INSERT INTO `augments` VALUES (249,0,0,0,0,0);
 INSERT INTO `augments` VALUES (250,0,0,0,0,0);
-INSERT INTO `augments` VALUES (251,0,0,0,0,0);
+-- End unused block
+
+INSERT INTO `augments` VALUES (251,1,911,0,0,0); -- Daken +1
+
+-- 252 to 256 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (252,0,0,0,0,0);
 INSERT INTO `augments` VALUES (253,0,0,0,0,0);
 INSERT INTO `augments` VALUES (254,0,0,0,0,0);
@@ -358,7 +362,7 @@ INSERT INTO `augments` VALUES (283,0,106,1,0,0); -- Throwing skill+1
 INSERT INTO `augments` VALUES (284,0,0,0,0,0); -- 284 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (285,0,0,0,0,0); -- 285 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (286,0,109,1,0,0); -- Shield skill+1
-INSERT INTO `augments` VALUES (287,0,0,0,0,0); -- 287 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
+INSERT INTO `augments` VALUES (287,1,110,1,0,0); -- Parrying Skill +1
 INSERT INTO `augments` VALUES (288,0,111,1,0,0); -- Divine magic skill+1
 INSERT INTO `augments` VALUES (289,0,112,1,0,0); -- Healing magic skill+1
 INSERT INTO `augments` VALUES (290,0,113,1,0,0); -- Enha.mag. skill+1
@@ -420,21 +424,21 @@ INSERT INTO `augments` VALUES (341,0,854,1,0,0); -- Repair potency+1%
 INSERT INTO `augments` VALUES (342,0,0,0,0,0); -- Waltz TP cost -1
 INSERT INTO `augments` VALUES (343,0,315,1,0,0); -- "Drain" and "Aspir" Potency +1
 
--- 344 to 349 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
+-- 344 to 346 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (344,0,0,0,0,0);
 INSERT INTO `augments` VALUES (345,0,0,0,0,0);
 INSERT INTO `augments` VALUES (346,0,0,0,0,0);
-INSERT INTO `augments` VALUES (347,0,0,0,0,0);
-INSERT INTO `augments` VALUES (348,0,0,0,0,0);
-INSERT INTO `augments` VALUES (349,0,0,0,0,0);
 -- End unused block
 
+INSERT INTO `augments` VALUES (347,0,0,0,0,0); -- Healing Magic Recast Delay -1
+INSERT INTO `augments` VALUES (348,0,0,0,0,0); -- Elemental Magic Recast Delay -1
+INSERT INTO `augments` VALUES (349,0,0,0,0,0); -- Enfeebling Magic Recast Delay -1
 INSERT INTO `augments` VALUES (350,0,0,0,0,0); -- Occ. maximizes magic accuracy+1%
 INSERT INTO `augments` VALUES (351,0,909,1,0,0); -- Occ. quickens spellcasting+1%
 INSERT INTO `augments` VALUES (352,0,0,0,0,0); -- Occ. grants dmg. bonus based on TP+1%
 INSERT INTO `augments` VALUES (353,0,345,50,0,0); -- TP Bonus +50
 INSERT INTO `augments` VALUES (354,0,430,1,0,0);  -- Quadruple Attack+1%
-INSERT INTO `augments` VALUES (355,0,0,0,0,0); -- 355 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
+INSERT INTO `augments` VALUES (355,0,0,0,0,0); -- Enhancing Magic Recast Delay -1
 INSERT INTO `augments` VALUES (356,0,375,1,0,0); -- Potency of Cure received+1%
 
 -- 354 to 362 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
@@ -457,15 +461,16 @@ INSERT INTO `augments` VALUES (370,0,836,1,0,0); -- Reverse Flourish+1
 INSERT INTO `augments` VALUES (371,0,989,1,0,0); -- Regen Potency+1
 INSERT INTO `augments` VALUES (372,0,0,0,0,0); -- Embolden+1: Mod undefined as of yet so leaving blank.
 
--- 373 to 511 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (373,0,0,0,0,0);
-INSERT INTO `augments` VALUES (374,0,0,0,0,0);
+INSERT INTO `augments` VALUES (374,0,0,0,0,0); -- Enhancing Magic Duration +1
 INSERT INTO `augments` VALUES (375,0,0,0,0,0);
 INSERT INTO `augments` VALUES (376,0,0,0,0,0);
 INSERT INTO `augments` VALUES (377,0,0,0,0,0);
 INSERT INTO `augments` VALUES (378,0,0,0,0,0);
-INSERT INTO `augments` VALUES (379,0,0,0,0,0);
-INSERT INTO `augments` VALUES (380,0,0,0,0,0);
+INSERT INTO `augments` VALUES (379,0,0,0,0,0); -- Enmity +1 for each Utsusemi
+INSERT INTO `augments` VALUES (380,0,0,0,0,0); -- Physical Damage Limit +1%
+
+-- 381 to 511 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (381,0,0,0,0,0);
 INSERT INTO `augments` VALUES (382,0,0,0,0,0);
 INSERT INTO `augments` VALUES (383,0,0,0,0,0);
@@ -788,7 +793,7 @@ INSERT INTO `augments` VALUES (636,0,0,0,0,0);
 INSERT INTO `augments` VALUES (637,0,0,0,0,0);
 INSERT INTO `augments` VALUES (638,0,0,0,0,0);
 INSERT INTO `augments` VALUES (639,0,0,0,0,0);
-INSERT INTO `augments` VALUES (640,0,0,0,0,0);
+INSERT INTO `augments` VALUES (640,2,291,2,0,0); -- Counter +2 (increases by 2)
 INSERT INTO `augments` VALUES (641,0,0,0,0,0);
 INSERT INTO `augments` VALUES (642,0,0,0,0,0);
 INSERT INTO `augments` VALUES (643,0,0,0,0,0);
@@ -1094,7 +1099,7 @@ INSERT INTO `augments` VALUES (895,0,0,0,0,0);
 INSERT INTO `augments` VALUES (896,0,432,1,0,0); -- Sword Enhancement Spell Damage +1
 INSERT INTO `augments` VALUES (897,0,96,1,0,0); -- Enhances Souleater Effect +1%
 INSERT INTO `augments` VALUES (898,0,0,0,0,0);
-INSERT INTO `augments` VALUES (899,0,0,0,0,0);
+INSERT INTO `augments` VALUES (899,0,0,0,0,0); --  Sword Enhancement spell damage +1% (Percent Damage)
 INSERT INTO `augments` VALUES (900,0,0,0,0,0);
 INSERT INTO `augments` VALUES (901,0,0,0,0,0);
 INSERT INTO `augments` VALUES (902,0,0,0,0,0);
@@ -1343,68 +1348,68 @@ INSERT INTO `augments` VALUES (1077,5,779,1,0,0); -- Split Shot:DMG+5% (increase
 INSERT INTO `augments` VALUES (1078,5,780,1,0,0); -- Sniper Shot:DMG+5% (increases by 5)
 INSERT INTO `augments` VALUES (1079,5,785,1,0,0); -- Detonator:DMG+5% (increases by 5)
 INSERT INTO `augments` VALUES (1080,5,840,1,0,0); -- Weapon Skill:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1081,5,580,1,0,0); -- Final Heaven:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1082,5,581,1,0,0); -- Ascetics Fury:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1083,5,582,1,0,0); -- Stringing Pummel:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1084,5,584,1,0,0); -- Victory Smite:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1085,5,596,1,0,0); -- Mercy Stroke:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1086,5,599,1,0,0); -- Pyric Kleos:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1087,5,597,1,0,0); -- Mandalic Stab:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1088,5,598,1,0,0); -- Mordant Rime:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1089,5,601,1,0,0); -- Rudra's Storm:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1090,5,613,1,0,0); -- Knights of Round:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1091,5,614,1,0,0); -- Death Blossom:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1092,5,616,1,0,0); -- Expiacion:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1093,5,795,1,0,0); -- Chant du Cygne:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1094,5,740,1,0,0); -- Randgrith:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1095,5,741,1,0,0); -- Mystic Boon:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1096,5,627,1,0,0); -- Scourge:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1097,5,629,1,0,0); -- Torcleaver:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1098,5,643,1,0,0); -- Onslaught:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1099,5,644,1,0,0); -- Primal Rend:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1100,5,646,1,0,0); -- Cloudsplitter:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1101,5,659,1,0,0); -- Metatron Torment:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1102,5,660,1,0,0); -- King's Justice:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1103,5,662,1,0,0); -- Ukko's Fury:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1104,5,675,1,0,0); -- Catastrophe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1105,5,676,1,0,0); -- Insurgency:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1106,5,678,1,0,0); -- Quietus:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1107,5,691,1,0,0); -- Geirskogul:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1108,5,692,1,0,0); -- Drakesbane:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1109,5,694,1,0,0); -- Camlann's Torment:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1110,5,707,1,0,0); -- Blade: Metsu:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1111,5,708,1,0,0); -- Blade: Kamu:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1112,5,710,1,0,0); -- Blade: Hi:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1113,5,723,1,0,0); -- Tachi: Kaiten:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1114,5,724,1,0,0); -- Tachi: Rana:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1115,5,726,1,0,0); -- Tachi: Fudo:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1116,5,755,1,0,0); -- Gate of Tartarus:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1117,5,758,1,0,0); -- Omniscience:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1118,5,756,1,0,0); -- Vidohunir:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1119,5,757,1,0,0); -- Garland of Bliss:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1120,5,770,1,0,0); -- Namas Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1121,5,702,1,0,0); -- Jishnu's Radiance:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1122,5,787,1,0,0); -- Trueflight:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1123,5,786,1,0,0); -- Coronach:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1124,5,788,1,0,0); -- Leaden Salute:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1125,5,790,1,0,0); -- Wildfire:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1126,5,631,1,0,0); -- Dimidiation:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1127,5,0,1,0,0); -- Exudation:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1128,5,585,1,0,0); -- Shijin Spiral:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1129,5,794,1,0,0); -- Exenterator:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1130,5,796,1,0,0); -- Requiescat:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1131,5,663,1,0,0); -- Upheaval:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1132,5,679,1,0,0); -- Entropy:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1133,5,695,1,0,0); -- Stardiver:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1134,5,711,1,0,0); -- Blade: Shun:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1135,5,727,1,0,0); -- Tachi: Shoha:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1136,5,744,1,0,0); -- Realmrazer:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1137,5,761,1,0,0); -- Shattersoul:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1138,5,630,1,0,0); -- Resolution:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1139,5,647,1,0,0); -- Ruinator:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1140,5,791,1,0,0); -- Last Stand:DMG+5% (increases by 5)
 
--- 1081 to 1151 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
-INSERT INTO `augments` VALUES (1081,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1082,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1083,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1084,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1085,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1086,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1087,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1088,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1089,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1090,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1091,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1092,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1093,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1094,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1095,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1096,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1097,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1098,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1099,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1100,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1101,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1102,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1103,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1104,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1105,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1106,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1107,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1108,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1109,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1110,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1111,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1112,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1113,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1114,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1115,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1116,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1117,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1118,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1119,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1120,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1121,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1122,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1123,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1124,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1125,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1126,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1127,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1128,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1129,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1130,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1131,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1132,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1133,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1134,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1135,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1136,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1137,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1138,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1139,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1140,0,0,0,0,0);
+-- 1141 to 1151 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (1141,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1142,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1143,0,0,0,0,0);
@@ -1521,9 +1526,9 @@ INSERT INTO `augments` VALUES (1247,0,163,-2,1,0); -- Pet: Magic Dmg. Taken -2%
 INSERT INTO `augments` VALUES (1248,0,890,1,0,0); -- Enhancing Magic Effect Duration +1
 INSERT INTO `augments` VALUES (1249,0,477,1,0,0); -- Helix Effect Duration+1
 INSERT INTO `augments` VALUES (1250,0,960,1,0,0); -- Indi Effect Duration+1
+INSERT INTO `augments` VALUES (1251,0,0,0,0,0); -- Enfeebling Magic Duration +1
 
--- 1251 to 1263 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
-INSERT INTO `augments` VALUES (1251,0,0,0,0,0);
+-- 1252 to 1263 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (1252,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1253,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1254,0,0,0,0,0);
@@ -1824,123 +1829,123 @@ INSERT INTO `augments` VALUES (1532,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1533,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1534,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1535,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1536,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1537,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1538,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1539,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1540,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1541,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1542,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1543,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1544,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1545,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1546,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1547,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1548,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1549,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1550,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1551,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1552,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1553,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1554,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1555,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1556,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1557,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1558,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1559,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1560,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1561,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1562,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1563,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1564,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1565,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1566,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1567,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1568,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1569,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1570,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1571,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1572,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1573,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1574,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1575,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1576,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1577,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1578,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1579,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1580,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1581,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1582,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1583,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1584,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1585,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1586,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1587,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1588,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1589,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1590,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1591,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1592,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1593,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1594,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1595,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1596,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1597,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1598,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1599,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1600,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1601,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1602,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1603,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1604,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1605,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1606,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1607,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1608,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1609,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1610,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1611,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1612,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1613,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1614,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1615,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1616,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1617,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1618,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1619,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1620,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1621,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1622,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1623,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1624,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1625,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1626,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1627,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1628,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1629,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1630,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1631,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1632,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1633,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1634,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1635,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1636,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1637,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1638,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1639,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1640,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1641,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1642,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1643,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1644,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1645,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1646,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1647,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1648,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1649,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1650,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1651,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1652,0,0,0,0,0);
+INSERT INTO `augments` VALUES (1536,5,574,1,0,0); -- Backhand Blow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1537,5,576,1,0,0); -- Spinning Attack:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1538,5,577,1,0,0); -- Howling Fist:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1539,5,578,1,0,0); -- Dragon Kick:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1540,5,587,1,0,0); -- Viper Bite:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1541,5,588,1,0,0); -- Shadowstitch:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1542,5,590,1,0,0); -- Cyclone:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1543,5,595,1,0,0); -- Evisceration:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1544,5,603,1,0,0); -- Burning Blade:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1545,5,606,1,0,0); -- Shining Blade:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1546,5,608,1,0,0); -- Circle Blade:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1547,5,612,1,0,0); -- Savage Blade:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1548,5,621,1,0,0); -- Freezebite:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1549,5,622,1,0,0); -- Shockwave:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1550,5,626,1,0,0); -- Ground Strike:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1551,5,624,1,0,0); -- Sickle Moon:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1552,5,636,1,0,0); -- Gale Axe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1553,5,638,1,0,0); -- Spinning Axe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1554,5,640,1,0,0); -- Calamity:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1555,5,642,1,0,0); -- Decimation:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1556,5,651,1,0,0); -- Iron Tempest:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1557,5,652,1,0,0); -- Sturmwind:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1558,5,654,1,0,0); -- Keen Edge:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1559,5,658,1,0,0); -- Steel Cyclone:DMG+5% (increase by 5)
+INSERT INTO `augments` VALUES (1560,5,669,1,0,0); -- Nightmare Scythe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1561,5,670,1,0,0); -- Spinning Scythe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1562,5,671,1,0,0); -- Vorpal Scythe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1563,5,674,1,0,0); -- Spiral Hell:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1564,5,685,1,0,0); -- Leg Sweep:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1565,5,687,1,0,0); -- Vorpal Thrust:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1566,5,688,1,0,0); -- Skewer:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1567,5,690,1,0,0); -- Impulse Drive:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1568,5,701,1,0,0); -- Blade: To:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1569,5,702,1,0,0); -- Blade: Chi:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1570,5,705,1,0,0); -- Blade: Ten:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1571,5,706,1,0,0); -- Blade: Ku:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1572,5,716,1,0,0); -- Tachi: Goten:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1573,5,718,1,0,0); -- Tachi: Jinpu:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1574,5,719,1,0,0); -- Tachi: Koki:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1575,5,722,1,0,0); -- Tachi: Kasha:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1576,5,732,1,0,0); -- Brainshaker:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1577,5,735,1,0,0); -- Skullbreaker:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1578,5,737,1,0,0); -- Judgment:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1579,5,739,1,0,0); -- Black Halo:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1580,5,747,1,0,0); -- Rock Crusher:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1581,5,751,1,0,0); -- Shell Crusher:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1582,5,752,1,0,0); -- Full Swing:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1583,5,754,1,0,0); -- Retribution:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1584,5,764,1,0,0); -- Dulling Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1585,5,767,1,0,0); -- Blast Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1586,5,768,1,0,0); -- Arching Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1587,5,769,1,0,0); -- Empyreal Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1588,5,779,1,0,0); -- Split Shot:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1589,5,778,1,0,0); -- Hot Shot:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1590,5,780,1,0,0); -- Sniper Shot:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1591,5,785,1,0,0); -- Detonator:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1592,5,840,1,0,0); -- Weapon Skill:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1593,5,580,1,0,0); -- Final Heaven:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1594,5,581,1,0,0); -- Ascetics Fury:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1595,5,582,1,0,0); -- Stringing Pummel:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1596,5,584,1,0,0); -- Victory Smite:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1597,5,596,1,0,0); -- Mercy Stroke:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1598,5,599,1,0,0); -- Pyric Kleos:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1599,5,597,1,0,0); -- Mandalic Stab:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1600,5,598,1,0,0); -- Mordant Rime:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1601,5,601,1,0,0); -- Rudra's Storm:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1602,5,613,1,0,0); -- Knights of Round:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1603,5,614,1,0,0); -- Death Blossom:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1604,5,616,1,0,0); -- Expiacion:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1605,5,795,1,0,0); -- Chant du Cygne:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1606,5,740,1,0,0); -- Randgrith:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1607,5,741,1,0,0); -- Mystic Boon:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1608,5,627,1,0,0); -- Scourge:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1609,5,629,1,0,0); -- Torcleaver:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1610,5,643,1,0,0); -- Onslaught:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1611,5,644,1,0,0); -- Primal Rend:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1612,5,646,1,0,0); -- Cloudsplitter:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1613,5,659,1,0,0); -- Metatron Torment:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1614,5,660,1,0,0); -- King's Justice:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1615,5,662,1,0,0); -- Ukko's Fury:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1616,5,675,1,0,0); -- Catastrophe:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1617,5,676,1,0,0); -- Insurgency:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1618,5,678,1,0,0); -- Quietus:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1619,5,691,1,0,0); -- Geirskogul:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1620,5,692,1,0,0); -- Drakesbane:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1621,5,694,1,0,0); -- Camlann's Torment:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1622,5,707,1,0,0); -- Blade: Metsu:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1623,5,708,1,0,0); -- Blade: Kamu:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1624,5,710,1,0,0); -- Blade: Hi:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1625,5,723,1,0,0); -- Tachi: Kaiten:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1626,5,724,1,0,0); -- Tachi: Rana:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1627,5,726,1,0,0); -- Tachi: Fudo:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1628,5,755,1,0,0); -- Gate of Tartarus:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1629,5,758,1,0,0); -- Omniscience:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1630,5,756,1,0,0); -- Vidohunir:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1631,5,757,1,0,0); -- Garland of Bliss:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1632,5,770,1,0,0); -- Namas Arrow:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1633,5,702,1,0,0); -- Jishnu's Radiance:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1634,5,787,1,0,0); -- Trueflight:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1635,5,786,1,0,0); -- Coronach:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1636,5,788,1,0,0); -- Leaden Salute:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1637,5,790,1,0,0); -- Wildfire:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1638,5,631,1,0,0); -- Dimidiation:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1639,5,0,1,0,0); -- Exudation:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1640,5,585,1,0,0); -- Shijin Spiral:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1641,5,794,1,0,0); -- Exenterator:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1642,5,796,1,0,0); -- Requiescat:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1643,5,663,1,0,0); -- Upheaval:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1644,5,679,1,0,0); -- Entropy:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1645,5,695,1,0,0); -- Stardiver:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1646,5,711,1,0,0); -- Blade: Shun:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1647,5,727,1,0,0); -- Tachi: Shoha:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1648,5,744,1,0,0); -- Realmrazer:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1649,5,761,1,0,0); -- Shattersoul:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1650,5,630,1,0,0); -- Resolution:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1651,5,647,1,0,0); -- Ruinator:DMG+5% (increases by 5)
+INSERT INTO `augments` VALUES (1652,5,791,1,0,0); -- Last Stand:DMG+5% (increases by 5)
 INSERT INTO `augments` VALUES (1653,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1654,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1655,0,0,0,0,0);
@@ -2099,25 +2104,25 @@ INSERT INTO `augments` VALUES (1805,0,14,-1,1,0); -- Pet: CHR-1
 INSERT INTO `augments` VALUES (1806,0,8,1,1,0); -- Pet: STR+1 DEX+1 VIT+1
 INSERT INTO `augments` VALUES (1806,0,9,1,1,0); -- Cont.
 INSERT INTO `augments` VALUES (1806,0,10,1,1,0); -- Cont.
+INSERT INTO `augments` VALUES (1807,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1808,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1809,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1810,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1811,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1812,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1813,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1814,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1815,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1816,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1817,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1818,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1819,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1820,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1821,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1822,0,0,0,0,0); -- Pet: <dummy>
+INSERT INTO `augments` VALUES (1823,0,0,0,0,0); -- Pet: <dummy>
 
--- 1807 to 2046 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
-INSERT INTO `augments` VALUES (1807,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1808,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1809,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1810,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1811,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1812,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1813,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1814,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1815,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1816,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1817,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1818,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1819,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1820,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1821,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1822,0,0,0,0,0);
-INSERT INTO `augments` VALUES (1823,0,0,0,0,0);
+-- 1824 to 2046 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (1824,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1825,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1826,0,0,0,0,0);


### PR DESCRIPTION
Cycled through the augment list 1-2047 to look for Augment new IDs.

Used `!additem 27631 1 <augid> 1` to check for augments that weren't
already documented. Wired up augments where possible, and captured
augment text in places where MODs weren't yet present.

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
