### PR TITLE
Add utils::UnpackSoultrapperName, improve utils::split, add "!up" command

### DIFF
--- a/scripts/commands/up.lua
+++ b/scripts/commands/up.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- func: up
+-- desc: Add 10 to the player's y position
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+function onTrigger(player)
+    -- validate target
+    local targ
+    local cursorTarget = player:getCursorTarget()
+    if cursorTarget and not cursorTarget:isNPC() then
+        targ = cursorTarget
+    else
+        targ = player
+    end
+
+    targ:setPos(targ:getXPos(), targ:getYPos() - 10, targ:getZPos(), targ:getRotPos())
+end

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -635,7 +635,7 @@ void DecodeStringSignature(int8* signature, int8* target)
 
 // Take a regular string of 8-bit wide chars and packs it down into an
 // array of 7-bit wide chars.
-void PackSoultrapperName(std::string name, uint8 output[], uint8 size)
+void PackSoultrapperName(std::string name, uint8 output[])
 {
     // Before anything else, sanitize the name string
     // If contains underscore character
@@ -657,7 +657,7 @@ void PackSoultrapperName(std::string name, uint8 output[], uint8 size)
     uint8 shift   = 1;
     uint8 loops   = 0;
     uint8 total   = (uint8)name.length();
-    uint8 maxSize = std::max((uint8)20, size);
+    uint8 maxSize = 13; // capped at 13 based on examples like GoblinBountyH
 
     // Pack and shift 8-bit to 7-bit
     for (uint8 i = 0; i <= maxSize; ++i)
@@ -689,6 +689,50 @@ void PackSoultrapperName(std::string name, uint8 output[], uint8 size)
             shift++;
         }
     }
+}
+
+std::string UnpackSoultrapperName(uint8 input[])
+{
+    uint8 current = 0;
+    uint8 remainder = 0;
+    uint8 shift = 1;
+    uint8 maxSize = 13; // capped at 13 based on examples like GoblinBountyH
+    std::string output = "";
+
+     // Unpack and shift 7-bit to 8-bit
+    for (uint8 i = 0; i <= maxSize; ++i)
+    {
+        current = input[i];
+        uint8 tempLeft = current;
+        uint8 tempRight = current;
+
+        for (int j = 0; j < shift; ++j)
+        {
+            tempLeft = tempLeft >> 1;
+        }
+
+        // uint8 orvalue = tempLeft | remainder;
+        output = output + (char)(tempLeft | remainder);
+
+        remainder = tempRight << (7 - shift);
+        if (remainder & 128)
+        {
+            remainder = remainder ^ 128;
+        }
+
+        if (shift == 7)
+        {
+            output = output + char(remainder);
+            remainder = 0;
+            shift = 1;
+        }
+        else
+        {
+            shift++;
+        }
+    }
+
+    return output;
 }
 
 std::string escape(std::string const& s)

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -751,16 +751,22 @@ std::string escape(std::string const& s)
     return escaped;
 }
 
-std::vector<std::string> split(const std::string& s, char delim)
+std::vector<std::string> split(std::string const& s, std::string const& delimiter)
 {
-    std::stringstream        ss(s);
-    std::string              item;
-    std::vector<std::string> elems;
-    while (std::getline(ss, item, delim))
+    std::size_t pos_start = 0;
+    std::size_t pos_end, delim_len = delimiter.length();
+    std::string token;
+    std::vector<std::string> res;
+
+    while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos)
     {
-        elems.push_back(item);
+        token = s.substr(pos_start, pos_end - pos_start);
+        pos_start = pos_end + delim_len;
+        res.push_back(token);
     }
-    return elems;
+
+    res.push_back(s.substr(pos_start));
+    return res;
 }
 
 // https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -74,7 +74,9 @@ void        EncodeStringLinkshell(int8* signature, int8* target);
 void        DecodeStringLinkshell(int8* signature, int8* target);
 int8*       EncodeStringSignature(int8* signature, int8* target);
 void        DecodeStringSignature(int8* signature, int8* target);
-void        PackSoultrapperName(std::string name, uint8 output[], uint8 size);
+void        PackSoultrapperName(std::string name, uint8 output[]);
+std::string UnpackSoultrapperName(uint8 input[]);
+
 std::string escape(std::string const& s);
 
 std::vector<std::string> split(const std::string& s, char delim);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -63,6 +63,7 @@ uint32 packBitsBE(uint8* target, uint64 value, int32 byteOffset, int32 bitOffset
 uint32 packBitsBE(uint8* target, uint64 value, int32 bitOffset, uint8 lengthInBit);
 uint64 unpackBitsBE(uint8* target, int32 byteOffset, int32 bitOffset, uint8 lengthInBit);
 uint64 unpackBitsBE(uint8* target, int32 bitOffset, uint8 lengthInBit);
+
 //(un)pack functions for Little Endian(LE) targets
 uint32 packBitsLE(uint8* target, uint64 value, int32 byteOffset, int32 bitOffset, uint8 lengthInBit);
 uint32 packBitsLE(uint8* target, uint64 value, int32 bitOffset, uint8 lengthInBit);
@@ -79,8 +80,7 @@ std::string UnpackSoultrapperName(uint8 input[]);
 
 std::string escape(std::string const& s);
 
-std::vector<std::string> split(const std::string& s, char delim);
-// https://stackoverflow.com/questions/313970/how-to-convert-an-instance-of-stdstring-to-lower-case
+std::vector<std::string> split(std::string const& s, std::string const& delimiter);
 std::string trim(const std::string& str, const std::string& whitespace = " \t");
 look_t stringToLook(std::string str);
 

--- a/src/map/items/item.cpp
+++ b/src/map/items/item.cpp
@@ -379,7 +379,7 @@ bool CItem::isSoultrapper() const
 
 void CItem::setSoulPlateData(std::string const& name, uint16 mobFamily, uint8 zeni, uint16 skillIndex, uint8 fp)
 {
-    PackSoultrapperName(name, m_extra, static_cast<uint8>(name.size()));
+    PackSoultrapperName(name, m_extra);
 
     // Hack: Artificially chop off extremely long names, so we can pack the mobFamily info into m_extra
     m_extra[17] = (mobFamily & 0xFF00) >> 8;

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -178,7 +178,7 @@ namespace moduleutils
 
                         ShowScript(fmt::format("Preparing override: {}", name));
 
-                        auto parts = split(name, '.');
+                        auto parts = split(name, ".");
                         overrides.emplace_back(Override{ filename, name, parts, func, false });
                     }
                 }

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -230,6 +230,9 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
     }
     else
     {
+        ShowWarning(fmt::format("Failed to place {} in {} ({}). Placing them in that zone's instance exit area.",
+            PChar->name, this->GetName(), this->GetID()).c_str());
+
         // instance no longer exists: put them outside (at exit)
         PChar->loc.prevzone = GetID();
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
