### PR TITLE
[Mission] Stop Magicite mission from appearing in gate guard list

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -719,9 +719,9 @@ end
 local missionType =
 {
     -- Required Rank             :   1  1  1  2  2  2  2  2  2  2  3  3  3  4  5  5  6  6  7  7  8  8  9  9
-    [xi.mission.log_id.SANDORIA] = { 1, 1, 1, 0, 1, 0, 2, 2, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-    [xi.mission.log_id.BASTOK]   = { 2, 0, 1, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-    [xi.mission.log_id.WINDURST] = { 2, 0, 0, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    [xi.mission.log_id.SANDORIA] = { 1, 1, 1, 0, 1, 0, 2, 2, 2, 2, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    [xi.mission.log_id.BASTOK]   = { 2, 0, 1, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    [xi.mission.log_id.WINDURST] = { 2, 0, 0, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 }
 
 local function getRequiredRank(missionId)


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Magicite mission (Any-Nation 4-1) is always given by the consulate of the proper nation and never from a nation gate guard.