### PR TITLE
Added a target to CEntityAnimationPacket

### DIFF
--- a/scripts/zones/Beadeaux/IDs.lua
+++ b/scripts/zones/Beadeaux/IDs.lua
@@ -62,6 +62,7 @@ zones[xi.zone.BEADEAUX] =
         QM1             = 17379800,
         TREASURE_CHEST  = 17379842,
         TREASURE_COFFER = 17379843,
+        AFFLICTOR_BASE  = 17379801,
     },
 }
 

--- a/scripts/zones/Beadeaux/Zone.lua
+++ b/scripts/zones/Beadeaux/Zone.lua
@@ -75,13 +75,13 @@ zone_object.onRegionEnter = function(player, region)
     then
         if not player:hasStatusEffect(xi.effect.CURSE_I) then
             if not player:hasStatusEffect(xi.effect.SILENCE) then
-                -- TODO: Add animation
+                GetNPCByID(ID.npc.AFFLICTOR_BASE + (region:GetRegionID() -1)):entityAnimationPacket("main", player)
                 player:setLocalVar("inRegion", time + 11) -- Start timer. We set it here to prevent double message.
                 player:addStatusEffect(xi.effect.CURSE_I, 75, 0, 120)
                 player:messageSpecial(ID.text.FEEL_NUMB)
 
                 -- TODO: Convert to interaction
-                if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_CURSE_COLLECTOR) == xi.quest.status.ACCEPTED and player:getCharVar("cCollectCurse") == 0 then
+                if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.THE_CURSE_COLLECTOR) == QUEST_ACCEPTED and player:getCharVar("cCollectCurse") == 0 then
                     player:setCharVar("cCollectCurse", 1)
                 end
             elseif player:getLocalVar("inRegion1") <= time then

--- a/scripts/zones/Beadeaux/npcs/The_Mute.lua
+++ b/scripts/zones/Beadeaux/npcs/The_Mute.lua
@@ -18,6 +18,7 @@ entity.onTrigger = function(player, npc)
         player:setCharVar("cCollectSilence", 1)
     end
 
+    npc:entityAnimationPacket("sils", player)
     player:addStatusEffect(xi.effect.SILENCE, 0, 0, duration)
 
 end

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -31,7 +31,7 @@ CDespawnState::CDespawnState(CBaseEntity* _PEntity, duration spawnTime)
 {
     if (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behaviour & BEHAVIOUR_NO_DESPAWN))
     {
-        _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, new CEntityAnimationPacket(_PEntity, CEntityAnimationPacket::Fade_Out));
+        _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, new CEntityAnimationPacket(_PEntity, _PEntity, CEntityAnimationPacket::Fade_Out));
     }
 }
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -561,7 +561,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 m_AdditionalEnemyList.erase(std::remove_if(m_AdditionalEnemyList.begin(), m_AdditionalEnemyList.end(), check), m_AdditionalEnemyList.end());
             }
         }
-        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, new CEntityAnimationPacket(PEntity, CEntityAnimationPacket::Fade_Out));
+        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, new CEntityAnimationPacket(PEntity, PEntity, CEntityAnimationPacket::Fade_Out));
     }
 
     // Remove enmity from valid battle entities

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -820,15 +820,28 @@ void CLuaBaseEntity::entityVisualPacket(std::string const& command, sol::object 
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::entityAnimationPacket(const char* command)
+void CLuaBaseEntity::entityAnimationPacket(const char* command, sol::object const& target)
 {
-    if (m_PBaseEntity->objtype == TYPE_PC)
+    CBaseEntity* PTarget = nullptr;
+    if (target != sol::lua_nil)
     {
-        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEntityAnimationPacket(m_PBaseEntity, command));
+        // If we have a target then set PTarget to that
+        CLuaBaseEntity* PLuaBaseEntity = target.as<CLuaBaseEntity*>();
+        PTarget                        = PLuaBaseEntity->GetBaseEntity();
     }
     else
     {
-        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CEntityAnimationPacket(m_PBaseEntity, command));
+        // If no target PTarget defaults to m_PBaseEntity
+        PTarget = m_PBaseEntity;
+    }
+
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CEntityAnimationPacket(m_PBaseEntity, PTarget, command));
+    }
+    else
+    {
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CEntityAnimationPacket(m_PBaseEntity, PTarget, command));
     }
 }
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -79,7 +79,7 @@ public:
     void injectPacket(std::string const& filename); // Send the character a packet kept in a file
     void injectActionPacket(uint16 action, uint16 anim, uint16 spec, uint16 react, uint16 message);
     void entityVisualPacket(std::string const& command, sol::object const& entity);
-    void entityAnimationPacket(const char* command);
+    void entityAnimationPacket(const char* command, sol::object const& target);
 
     void       StartEventHelper(int32 EventID, sol::variadic_args va, EVENT_TYPE eventType);
     EventInfo* ParseEvent(int32 EventID, sol::variadic_args va, EventPrep* eventPreparation, EVENT_TYPE eventType);

--- a/src/map/packets/entity_animation.cpp
+++ b/src/map/packets/entity_animation.cpp
@@ -27,16 +27,16 @@
 
 const char* CEntityAnimationPacket::Fade_Out = "kesu";
 
-CEntityAnimationPacket::CEntityAnimationPacket(CBaseEntity* PEntity, const char type[4])
+CEntityAnimationPacket::CEntityAnimationPacket(CBaseEntity* PEntity, CBaseEntity* PTarget, const char type[4])
 {
     this->setType(0x38);
     this->setSize(0x14);
 
     ref<uint32>(0x04) = PEntity->id;
-    ref<uint32>(0x08) = PEntity->id;
+    ref<uint32>(0x08) = PTarget->id;
 
     memcpy(data + ((0x0C)), type, 4);
 
     ref<uint16>(0x10) = PEntity->targid;
-    ref<uint16>(0x12) = PEntity->targid;
+    ref<uint16>(0x12) = PTarget->targid;
 }

--- a/src/map/packets/entity_animation.h
+++ b/src/map/packets/entity_animation.h
@@ -37,7 +37,7 @@ class CEntityAnimationPacket : public CBasicPacket
 {
 public:
     static const char* Fade_Out;
-    CEntityAnimationPacket(CBaseEntity* PEntity, const char type[4]);
+    CEntityAnimationPacket(CBaseEntity* PEntity, CBaseEntity* PTarget, const char type[4]);
 };
 
 #endif


### PR DESCRIPTION
Can now pass a target to entityAnimationPacket,
will default to the baseenity in no target passed.

Added animations to the Afflictor for the curse effect and animations to the mute on receiving silence in Beadeaux.

Took the opertunity to fix a quest error in zones/Beadeaux/Zone.lua

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
