### PR TITLE
Change FollowPath to not use old pathpoints

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -105,7 +105,7 @@ class AHAnnouncementModule : public CPPModule
                                     {
                                         // Sanitize name
                                         std::string name = (const char*)PItem->getName();
-                                        auto parts = split(name, '_');
+                                        auto parts = split(name, "_");
                                         name = "";
                                         name += std::accumulate(std::begin(parts), std::end(parts), std::string(),
                                         [](std::string& ss, std::string& s)

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -238,11 +238,7 @@ void CPathFind::FollowPath()
     }
 
     m_onPoint = false;
-
-    // move mob to next point
     position_t& targetPoint = m_points[m_currentPoint];
-
-    StepTo(targetPoint, m_pathFlags & PATHFLAG_RUN);
 
     if (isNavMeshEnabled() && m_carefulPathing)
     {
@@ -253,20 +249,34 @@ void CPathFind::FollowPath()
     {
         // if I have a max distance, check to stop me
         Clear();
-
         m_onPoint = true;
+        return;
     }
-    else if (AtPoint(targetPoint))
-    {
-        m_currentPoint++;
 
-        if (m_currentPoint >= (int16)m_points.size())
+    // Iterate over points in the current path and find the first point
+    // that we haven't successfully arrived at already.
+    while (m_currentPoint < (int16)m_points.size())
+    {
+        targetPoint = m_points[m_currentPoint];
+
+        if (AtPoint(targetPoint))
         {
-            FinishedPath();
+            m_currentPoint++;
+        }
+        else
+        {
+            break;
         }
 
         m_onPoint = true;
-        //#event onPoint event
+    }
+
+    StepTo(targetPoint, m_pathFlags & PATHFLAG_RUN);
+
+    if (m_currentPoint >= (int16)m_points.size())
+    {
+        FinishedPath();
+        m_onPoint = true;
     }
 }
 


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Downstream reported that this was a good change, will test and see how it goes