### PR TITLE
Re-adds Shami's Seal Count Dialog

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -94,7 +94,17 @@ entity.onTrade = function(player, npc, trade)
         local storedSeals = player:getSeals(sealOption)
         local itemCount = trade:getItemCount()
 
-        player:startEvent(321, sealOption, storedSeals + itemCount)
+        if sealOption == 0 then
+            player:startEvent(321, (storedSeals + itemCount) * 65536)
+        elseif sealOption == 1 then
+            player:startEvent(321, 0, (storedSeals + itemCount) * 65536)
+        elseif sealOption == 2 then
+            player:startEvent(321, 0, 0, (storedSeals + itemCount) * 65536)
+        elseif sealOption == 3 then
+            player:startEvent(321, 0, 0, 0, (storedSeals + itemCount) * 65536)
+        else
+            player:startEvent(321, 0, 0, 0, 0, (storedSeals + itemCount) * 65536)
+        end
         player:addSeals(itemCount, sealOption)
         player:confirmTrade()
     end


### PR DESCRIPTION
Re-adds logic to Shami's CS to tell the player their seal count after trading.

params: (bs * 65536), (ks * 65536), (kc * 65536), (hkc * 65536), (skc * 65536), 0, 0, 0

<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
