### PR TITLE
[core] Make sure all public navmesh functions check for a valid navmesh

### DIFF
--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -227,6 +227,12 @@ void CNavMesh::outputError(uint32 status)
 std::vector<position_t> CNavMesh::findPath(const position_t& start, const position_t& end)
 {
     TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return {};
+    }
+
     std::vector<position_t> ret;
     dtStatus                status;
 
@@ -323,6 +329,12 @@ std::vector<position_t> CNavMesh::findPath(const position_t& start, const positi
 std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& start, float maxRadius)
 {
     TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return {};
+    }
+
     dtStatus status;
 
     float spos[3];
@@ -370,6 +382,11 @@ std::pair<int16, position_t> CNavMesh::findRandomPosition(const position_t& star
 
 bool CNavMesh::inWater(const position_t& point)
 {
+    if (!m_navMesh)
+    {
+        return false;
+    }
+
     // TODO:
     return false;
 }
@@ -377,6 +394,12 @@ bool CNavMesh::inWater(const position_t& point)
 bool CNavMesh::validPosition(const position_t& position)
 {
     TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return true;
+    }
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -401,6 +424,12 @@ bool CNavMesh::validPosition(const position_t& position)
 void CNavMesh::snapToValidPosition(position_t& position)
 {
     TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return;
+    }
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -494,6 +523,11 @@ bool CNavMesh::raycast(const position_t& start, const position_t& end, bool look
     TracyZoneScoped;
 
     if (start.x == end.x && start.y == end.y && start.z == end.z)
+    {
+        return true;
+    }
+
+    if (!m_navMesh)
     {
         return true;
     }


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Fixes rare but possible crash when a mob draws-in in a zone that doesn't have a valid navmesh.
