### PR TITLE
Simplify Shami onTrade seal event options

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -91,22 +91,15 @@ entity.onTrade = function(player, npc, trade)
     -- Trading Seals/Crests
     local sealOption = getSealTradeOption(trade)
     if sealOption ~= nil then
+        local eventParams = { 321, 0, 0, 0, 0, 0 }
         local storedSeals = player:getSeals(sealOption)
         local itemCount = trade:getItemCount()
 
-        if sealOption == 0 then
-            player:startEvent(321, (storedSeals + itemCount) * 65536)
-        elseif sealOption == 1 then
-            player:startEvent(321, 0, (storedSeals + itemCount) * 65536)
-        elseif sealOption == 2 then
-            player:startEvent(321, 0, 0, (storedSeals + itemCount) * 65536)
-        elseif sealOption == 3 then
-            player:startEvent(321, 0, 0, 0, (storedSeals + itemCount) * 65536)
-        else
-            player:startEvent(321, 0, 0, 0, 0, (storedSeals + itemCount) * 65536)
-        end
+        eventParams[sealOption + 2] = bit.lshift(storedSeals + itemCount, 16)
+        player:startEvent(unpack(eventParams))
         player:addSeals(itemCount, sealOption)
         player:confirmTrade()
+        return
     end
 
     -- Trading Orbs


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [🤞] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits
