### PR TITLE
[core] More safety checks for Trusts in enmity and notoriety containers

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -67,7 +67,7 @@ void CEnmityContainer::Clear(uint32 EntityID)
             if (const auto& maybeEntityObj = m_EnmityList.find(listEntry.first); maybeEntityObj != m_EnmityList.end())
             {
                 auto entry = maybeEntityObj->second;
-                if (entry.PEnmityOwner && entry.PEnmityOwner->PNotorietyContainer && m_EnmityHolder)
+                if (entry.PEnmityOwner && m_EnmityHolder)
                 {
                     entry.PEnmityOwner->PNotorietyContainer->remove(m_EnmityHolder);
                 }
@@ -81,7 +81,7 @@ void CEnmityContainer::Clear(uint32 EntityID)
         if (const auto& maybeEntityObj = m_EnmityList.find(EntityID); maybeEntityObj != m_EnmityList.end())
         {
             auto entry = maybeEntityObj->second;
-            if (entry.PEnmityOwner && entry.PEnmityOwner->PNotorietyContainer && m_EnmityHolder)
+            if (entry.PEnmityOwner && m_EnmityHolder)
             {
                 entry.PEnmityOwner->PNotorietyContainer->remove(m_EnmityHolder);
             }

--- a/src/map/notoriety_container.cpp
+++ b/src/map/notoriety_container.cpp
@@ -39,7 +39,7 @@ std::set<CBattleEntity*>::iterator CNotorietyContainer::end()
 void CNotorietyContainer::add(CBattleEntity* entity)
 {
     TracyZoneScoped;
-    if (entity)
+    if (m_POwner && entity && entity->allegiance != m_POwner->allegiance)
     {
         m_Lookup.insert(entity);
     }
@@ -48,7 +48,7 @@ void CNotorietyContainer::add(CBattleEntity* entity)
 void CNotorietyContainer::remove(CBattleEntity* entity)
 {
     TracyZoneScoped;
-    if (entity)
+    if (m_POwner && entity)
     {
         auto entity_itr = m_Lookup.find(entity);
         if (entity_itr != m_Lookup.end())


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

Testing:
- Add `mob:addStatusEffect(xi.effect.REGAIN, 300, 0, 0)` to `!fafnir`
- Make a new command: `!killtrusts`:
```lua
function onTrigger(player)
    for i = 910, 920 do
        player:spawnTrust(i)
    end
    player:reloadParty()
end
```
- Be around Lv70
- Spawn your trusts, spawn Fafnir, punch fafnir in the face and wait.
- If all the trusts end up dead, summon them again with your custom command.
- Keep going and wait for crash in `CNotorietyContainer::remove` where `m_Lookup` doesn't exist. Usually happens in under 2 minutes.

After fix:
- Can't trigger crash.

THIS IS JUST A BANDAID. The real answer here is to not track the lifetimes of entities manually. But until I can sit down and refactor _everything to do with entities_, this will have to do.

Should fix (maybe this time?):
https://github.com/LandSandBoat/server/issues/1694
https://github.com/LandSandBoat/server/issues/1724
https://github.com/LandSandBoat/server/issues/1666
https://github.com/LandSandBoat/server/issues/1654