### PR TITLE
[modules] Add more logging when a nil function is overridden

### DIFF
--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -5,11 +5,11 @@ require("scripts/globals/utils")
 -----------------------------------
 
 -- Global, for use in C++
-function applyOverride(base_table, name, func)
+function applyOverride(base_table, func, name, fullname, filename)
     local old = base_table[name]
 
     if old == nil then
-        print("Inserting empty function to override for: " .. name)
+        print(string.format("Inserting empty function to override for: %s (%s)"), fullname, filename)
         old = function() end -- Insert empty function
     end
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -119,6 +119,12 @@ namespace luautils
         // Globally require bit library
         lua.do_string("if not bit then bit = require('bit') end");
 
+        lua.do_string(
+            "function __FILE__() return debug.getinfo(2, 'S').source end\n"
+            "function __LINE__() return debug.getinfo(2, 'l').currentline end\n"
+            "function __FUNC__() return debug.getinfo(2, 'n').name end\n"
+        );
+
         // Bind print(...) globally
         lua.set_function("print", &luautils::print);
 

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -210,7 +210,7 @@ namespace moduleutils
                     {
                         ShowScript(fmt::format("Applying override: {}", override.overrideName));
 
-                        lua["applyOverride"](table, lastElem, override.func);
+                        lua["applyOverride"](table, override.func, lastElem, override.overrideName, override.filename);
 
                         override.applied = true;
 
@@ -227,7 +227,7 @@ namespace moduleutils
         {
             if (!override.applied)
             {
-                ShowWarning(fmt::format("Override not applied: {} ({})", override.overrideName, override.filename));
+                ShowError(fmt::format("Override not applied: {} ({})", override.overrideName, override.filename));
             }
         }
     }

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -46,7 +46,7 @@ public:
         moduleutils::RegisterCPPModule(this);
     }
 
-    virtual ~CPPModule(){};
+    virtual ~CPPModule() = default;
 
     // Required
     virtual void OnInit() = 0;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞 ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add more logging to applyModules when a nil function is populated

## Steps to test these changes

Apply an override to a function that an entity doesn't already have, it'll log more information now.

Also adds some cool Lua funcs I found online.
