### PR TITLE
adds missing settings files for docker_compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN mkdir docker_build && cd docker_build && cmake .. && make -j $(nproc)  && cd
 # Copy the docker config files to the conf folder instead of the default config
 COPY /conf/default/* conf/
 
+# Copy the docker settings files to the settings folder instead of the default settings
+COPY /scripts/settings/default/* scripts/settings/
+
 # Ensure wait_for_db_then_launch.sh is executable
 RUN chmod +x ./tools/wait_for_db_then_launch.sh
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Docker compose fails as it is missing moving the main.lua inside the settings folder. This PR fixes that

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
