### PR TITLE
[RUN] Implement Foil; [lua] fix accuracy calculation for mob TP moves

### DIFF
--- a/scripts/globals/effects/foil.lua
+++ b/scripts/globals/effects/foil.lua
@@ -6,14 +6,26 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    effect:addMod(xi.mod.SPECIAL_ATTACK_EVASION, effect:getPower())
+    target:addMod(xi.mod.SPECIAL_ATTACK_EVASION, effect:getPower())
 end
 
-effect_object.onEffectTick = function(target, effect) -- TODO: Determine how Foil ticks down? It's description indicates this.
+-- https://www.ffxiah.com/forum/topic/56696/foil-potency-and-decay-testing/#3625559
+effect_object.onEffectTick = function(target, effect)
+
+    local power = effect:getPower()
+
+    -- TODO: Verify Foil evasion floor when more enhancing magic duration+ gear is available or RDM can cast foil from Master Levels.
+    if power > 0 then -- don't go negative. but we don't know what the floor of Foil is currently.
+
+        local powerDecay = 3
+
+        effect:setPower(power-powerDecay)
+        target:delMod(xi.mod.SPECIAL_ATTACK_EVASION, powerDecay)
+    end
 end
 
 effect_object.onEffectLose = function(target, effect)
-    -- intentionally blank. mod removes itself in C++ due to being added to the effect.
+    target:delMod(xi.mod.SPECIAL_ATTACK_EVASION, effect:getPower())
 end
 
 return effect_object

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -158,7 +158,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     local lvluser = mob:getMainLvl()
     local lvltarget = target:getMainLvl()
     local acc = mob:getACC()
-    local eva = target:getEVA() + target:getMod(SPECIAL_ATTACK_EVASION)
+    local eva = target:getEVA() + target:getMod(xi.mod.SPECIAL_ATTACK_EVASION)
 
     if target:hasStatusEffect(xi.effect.YONIN) and mob:isFacing(target, 23) then -- Yonin evasion boost if mob is facing target
         eva = eva + target:getStatusEffect(xi.effect.YONIN):getPower()

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -158,7 +158,7 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     local lvluser = mob:getMainLvl()
     local lvltarget = target:getMainLvl()
     local acc = mob:getACC()
-    local eva = target:getEVA()
+    local eva = target:getEVA() + target:getMod(SPECIAL_ATTACK_EVASION)
 
     if target:hasStatusEffect(xi.effect.YONIN) and mob:isFacing(target, 23) then -- Yonin evasion boost if mob is facing target
         eva = eva + target:getStatusEffect(xi.effect.YONIN):getPower()
@@ -184,8 +184,8 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numberofhits, accmod
     ratio = ratio + lvldiff * 0.05
     ratio = utils.clamp(ratio, 0, 4)
 
-    --work out hit rate for mobs (bias towards them)
-    local hitrate = (acc * accmod) - eva + (lvldiff * 2) + 75
+    --work out hit rate for mobs
+    local hitrate = ( (acc * accmod) - eva) / 2 + (lvldiff * 2) + 75
 
     hitrate = utils.clamp(hitrate, 20, 95)
 

--- a/scripts/globals/spells/white/foil.lua
+++ b/scripts/globals/spells/white/foil.lua
@@ -11,12 +11,10 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
     return 0
 end
 
--- TODO: determine mechanics of how Foil's "Special Attack" evasion works.
--- Martel has a post about it here: https://www.bluegartr.com/threads/115399-Rune-Fencer-Findings?p=5665305&viewfull=1#post5665305
--- More testing is required (such as determining accuracy of the target used for testing)
+-- https://www.ffxiah.com/forum/topic/56696/foil-potency-and-decay-testing/#3625542
 spell_object.onSpellCast = function(caster, target, spell)
 
-    if target:addStatusEffect(xi.effect.FOIL, 0, 0, 30) then -- power set to 0 because true mechanics are unknown as of now. The primary use of Foil is for enmity anyway.
+    if target:addStatusEffect(xi.effect.FOIL, 150, 3, 30) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)


### PR DESCRIPTION

After a truly herculean amount of testing, nerding with some other more qualified math nerds...

**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Implement Foil's Special Attack evasion for mob TP moves only.
Fix accuracy calculation for mob TP moves.


## Steps to test these changes

Foil potency:
1. !changejob RUN 99
2. cast foil
3. !getmod SPECIAL_ATTACK_EVASION, it should be 150 on first tick
4. re-issue !getmod to verify it ticks down by 3 every tick
5. verify mod is 0 when foil wears off naturally
6. verify mod is 0 when foil is cancelled manually

Verify Special Attack Evasion:
find a mob that has good accuracy against you on _physical_ TP moves

1. target yourself, !setmod SPECIAL_ATTACK_EVASION 9999
2. target mob, !tp 3000 repeatedly for TP moves
3. note mob constantly misses 
4. target yourself, !setmod SPECIAL_ATTACK_EVASION 0
7. reissue !tp 3000 on mob, note it can hit you well enough again
