### PR TITLE
Fix applyOverride by properly using string.format, fix Async db strangeness

### DIFF
--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -5,7 +5,7 @@ require("scripts/globals/utils")
 -----------------------------------
 
 -- Global, for use in C++
-function applyOverride(base_table, func, name, fullname, filename)
+function applyOverride(base_table, name, func, fullname, filename)
     local old = base_table[name]
 
     if old == nil then

--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -9,7 +9,7 @@ function applyOverride(base_table, func, name, fullname, filename)
     local old = base_table[name]
 
     if old == nil then
-        print(string.format("Inserting empty function to override for: %s (%s)"), fullname, filename)
+        print(string.format("Inserting empty function to override for: %s (%s)", fullname, filename))
         old = function() end -- Insert empty function
     end
 

--- a/scripts/zones/Dynamis-Bastok/Zone.lua
+++ b/scripts/zones/Dynamis-Bastok/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Beaucedine/Zone.lua
+++ b/scripts/zones/Dynamis-Beaucedine/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Buburimu/Zone.lua
+++ b/scripts/zones/Dynamis-Buburimu/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Jeuno/Zone.lua
+++ b/scripts/zones/Dynamis-Jeuno/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Qufim/Zone.lua
+++ b/scripts/zones/Dynamis-Qufim/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-San_dOria/Zone.lua
+++ b/scripts/zones/Dynamis-San_dOria/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Tavnazia/Zone.lua
+++ b/scripts/zones/Dynamis-Tavnazia/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Valkurm/Zone.lua
+++ b/scripts/zones/Dynamis-Valkurm/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Windurst/Zone.lua
+++ b/scripts/zones/Dynamis-Windurst/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/scripts/zones/Dynamis-Xarcabard/Zone.lua
+++ b/scripts/zones/Dynamis-Xarcabard/Zone.lua
@@ -19,9 +19,6 @@ zone_object.onZoneIn = function(player, prevZone)
     return xi.dynamis.zoneOnZoneIn(player, prevZone)
 end
 
-zone_object.onZoneTick = function(zone)
-end
-
 zone_object.onRegionEnter = function(player, region)
 end
 

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -62,9 +62,9 @@ void SqlConnection::Async(std::string const& query)
     TracyZoneString(query);
 
     // clang-format off
-    Async([query](SqlConnection* sql)
+    Async([query = std::move(query)](SqlConnection* sql)
     {
-        // Executed on worker thread with a copy of query
+        // Executed on worker thread
         if (sql->QueryStr(query.c_str()) == SQL_ERROR)
         {
             ShowFatalError("Asyc Query Error");

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -191,17 +191,6 @@ public:
     void Async(std::function<void(SqlConnection*)>&& func);
     void Async(std::string const& query);
 
-    template <typename... Args>
-    void Async(const char* query, Args... args)
-    {
-        TracyZoneScoped;
-
-        auto queryStr = fmt::sprintf(query, args...);
-        TracyZoneString(queryStr);
-
-        Async(queryStr);
-    }
-
     void HandleAsync();
 
 private:

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -100,7 +100,7 @@ namespace conquest
 
         influences[nation] += lost;
 
-        sql->Async(
+        sql->Query(
             "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
             "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u;",
             influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region));
@@ -374,7 +374,7 @@ namespace conquest
                             IF(windurst_influence > bastok_influence AND windurst_influence > sandoria_influence AND \
                             windurst_influence > beastmen_influence, 2, 3)));";
 
-        sql->Async(Query);
+        sql->Query(Query);
 
         // update conquest overseers
         for (uint8 i = 0; i <= 18; i++)

--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -98,7 +98,7 @@ std::pair<uint8, int16> CGuild::addGuildPoints(CCharEntity* PChar, CItem* PItem)
 
                     charutils::AddPoints(PChar, pointsName.c_str(), points);
 
-                    sql->Async("REPLACE INTO char_vars VALUES (%d, '[GUILD]daily_points', %u);", PChar->id, curPoints + points);
+                    sql->Query("REPLACE INTO char_vars VALUES (%d, '[GUILD]daily_points', %u);", PChar->id, curPoints + points);
 
                     return {
                         std::clamp<uint8>(quantity, 0, std::numeric_limits<uint8>::max()), points

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -222,9 +222,8 @@ int32 do_init(int32 argc, char** argv)
                                           map_config.mysql_port,
                                           map_config.mysql_database.c_str());
 
-    auto query = fmt::sprintf("DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);",
+    sql->Query("DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);",
         map_ip.s_addr, map_port, map_ip.s_addr, map_port);
-    sql->Async(std::move(query));
 
     ShowStatus("do_init: zlib is reading");
     zlib_init();
@@ -886,7 +885,7 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
         // clear accounts_sessions if character is logging out (not when zoning)
         if (map_session_data->shuttingDown == 1)
         {
-            sql->Async("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
+            sql->Query("DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
         }
 
         uint64 port64 = map_session_data->client_port;
@@ -977,7 +976,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     else
                     {
                         map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
-                        sql->Async("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
+                        sql->Query("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
 
                         delete[] map_session_data->server_packet_data;
                         delete map_session_data->PChar;
@@ -993,7 +992,7 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     ShowWarning("map_cleanup: WHITHOUT CHAR timed out, session closed");
 
                     const char* Query = "DELETE FROM accounts_sessions WHERE client_addr = %u AND client_port = %u";
-                    sql->Async(Query, map_session_data->client_addr, map_session_data->client_port);
+                    sql->Query(Query, map_session_data->client_addr, map_session_data->client_port);
 
                     delete[] map_session_data->server_packet_data;
                     map_session_list.erase(it++);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -290,7 +290,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         // Current zone could either be current zone or destination
         CZone* currentZone = zoneutils::GetZone(PChar->getZone());
 
-        sql->Async(fmtQuery, PChar->targid, session_key, currentZone->GetIP(), PSession->client_port, PChar->id);
+        sql->Query(fmtQuery, PChar->targid, session_key, currentZone->GetIP(), PSession->client_port, PChar->id);
 
         fmtQuery  = "SELECT death FROM char_stats WHERE charid = %u;";
         int32 ret = sql->Query(fmtQuery, PChar->id);
@@ -327,7 +327,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to a valid zone!", PChar->GetName());
         auto prevZone = PChar->loc.prevzone ? PChar->loc.prevzone : (uint16)ZONE_VALKURM_DUNES;
         PChar->loc.destination = prevZone;
-        sql->Async("UPDATE chars SET pos_zone = %u WHERE charid = %u", prevZone, PChar->id);
+        sql->Query("UPDATE chars SET pos_zone = %u WHERE charid = %u", prevZone, PChar->id);
     }
 
     charutils::SaveCharPosition(PChar);
@@ -518,12 +518,12 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
         }
 
         PSession->shuttingDown = 1;
-        sql->Async("UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
+        sql->Query("UPDATE char_stats SET zoning = 0 WHERE charid = %u", PChar->id);
     }
     else
     {
         PSession->shuttingDown = 2;
-        sql->Async("UPDATE char_stats SET zoning = 1 WHERE charid = %u", PChar->id);
+        sql->Query("UPDATE char_stats SET zoning = 1 WHERE charid = %u", PChar->id);
         charutils::CheckEquipLogic(PChar, SCRIPT_CHANGEZONE, PChar->getZone());
 
         if (PChar->CraftContainer->getItemsCount() > 0 && PChar->animation == ANIMATION_SYNTH)
@@ -5440,7 +5440,7 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
                         char extra[sizeof(PItemLinkshell->m_extra) * 2 + 1];
                         sql->EscapeStringLen(extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
                         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
-                        sql->Async(Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+                        sql->Query(Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
                         PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID()));
                         PChar->pushPacket(new CInventoryFinishPacket());
                         PChar->pushPacket(new CMessageStandardPacket(MsgStd::LinkshellNoLongerExists));
@@ -5904,7 +5904,7 @@ void SmallPacket0x0DE(map_session_data_t* const PSession, CCharEntity* const PCh
     char message[256];
     sql->EscapeString(message, PChar->bazaar.message.c_str());
 
-    sql->Async("UPDATE char_stats SET bazaar_message = '%s' WHERE charid = %u;", message, PChar->id);
+    sql->Query("UPDATE char_stats SET bazaar_message = '%s' WHERE charid = %u;", message, PChar->id);
 }
 
 /************************************************************************
@@ -6507,7 +6507,7 @@ void SmallPacket0x0FC(map_session_data_t* const PSession, CCharEntity* const PCh
     char extra[sizeof(PPotItem->m_extra) * 2 + 1];
     sql->EscapeStringLen(extra, (const char*)PPotItem->m_extra, sizeof(PPotItem->m_extra));
     const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
-    sql->Async(Query, extra, PChar->id, PPotItem->getLocationID(), PPotItem->getSlotID());
+    sql->Query(Query, extra, PChar->id, PPotItem->getLocationID(), PPotItem->getSlotID());
 
     PChar->pushPacket(new CFurnitureInteractPacket(PPotItem, potContainerID, potSlotID));
 
@@ -6583,7 +6583,7 @@ void SmallPacket0x0FD(map_session_data_t* const PSession, CCharEntity* const PCh
             char extra[sizeof(PItem->m_extra) * 2 + 1];
             sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
             const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
-            sql->Async(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
+            sql->Query(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
         }
     }
 
@@ -6656,7 +6656,7 @@ void SmallPacket0x0FE(map_session_data_t* const PSession, CCharEntity* const PCh
         char extra[sizeof(PItem->m_extra) * 2 + 1];
         sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
-        sql->Async(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
+        sql->Query(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
 
         PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
         PChar->pushPacket(new CInventoryFinishPacket());
@@ -6697,7 +6697,7 @@ void SmallPacket0x0FF(map_session_data_t* const PSession, CCharEntity* const PCh
         char extra[sizeof(PItem->m_extra) * 2 + 1];
         sql->EscapeStringLen(extra, (const char*)PItem->m_extra, sizeof(PItem->m_extra));
         const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u";
-        sql->Async(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
+        sql->Query(Query, extra, PChar->id, PItem->getLocationID(), PItem->getSlotID());
 
         PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
         PChar->pushPacket(new CInventoryFinishPacket());
@@ -7195,7 +7195,7 @@ void SmallPacket0x10A(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if ((PItem != nullptr) && !(PItem->getFlag() & ITEM_FLAG_EX) && (!PItem->isSubType(ITEM_LOCKED) || PItem->getCharPrice() != 0))
     {
-        sql->Async("UPDATE char_inventory SET bazaar = %u WHERE charid = %u AND location = 0 AND slot = %u;", price, PChar->id, slotID);
+        sql->Query("UPDATE char_inventory SET bazaar = %u WHERE charid = %u AND location = 0 AND slot = %u;", price, PChar->id, slotID);
 
         PItem->setCharPrice(price);
         PItem->setSubType((price == 0 ? ITEM_UNLOCKED : ITEM_LOCKED));

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6059,15 +6059,13 @@ namespace charutils
 
         if (value == 0)
         {
-            auto query = fmt::sprintf("DELETE FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;",
-                PChar->id, var);
-            sql->Query(query.c_str());
+            sql->Async(fmt::format("DELETE FROM char_vars WHERE charid = {} AND varname = '{}' LIMIT 1;",
+                PChar->id, var));
         }
         else
         {
-            auto query = fmt::sprintf("INSERT INTO char_vars SET charid = %u, varname = '%s', value = %i ON DUPLICATE KEY UPDATE value = %i;",
-                PChar->id, var.c_str(), value, value);
-            sql->Query(query.c_str());
+            sql->Async(fmt::format("INSERT INTO char_vars SET charid = {}, varname = '{}', value = {} ON DUPLICATE KEY UPDATE value = {};",
+                PChar->id, var.c_str(), value, value));
         }
     }
 

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -210,7 +210,7 @@ namespace moduleutils
                     {
                         ShowScript(fmt::format("Applying override: {}", override.overrideName));
 
-                        lua["applyOverride"](table, override.func, lastElem, override.overrideName, override.filename);
+                        lua["applyOverride"](table, lastElem, override.func, override.overrideName, override.filename);
 
                         override.applied = true;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes https://github.com/LandSandBoat/server/issues/1756
Is also the real fix for https://github.com/LandSandBoat/server/issues/1706

Thats what I get for making a change I couldn't test properly on the train home

## Steps to test these changes

Use this module, see that the overrides are applied, and that the printing happens while you're in the relevant zone
```lua
-----------------------------------
-- Test overrides
-----------------------------------
require("modules/module_utils")
require("scripts/globals/zone")
-----------------------------------
local m = Module:new("test")

m:addOverride("xi.zones.Dynamis-Buburimu.Zone.onZoneTick", function(zone)
    print("xi.zones.Dynamis-Buburimu.Zone.onZoneTick")
end)

m:addOverride("xi.zones.Windurst_Woods.Zone.onZoneTick", function(zone)
    print("xi.zones.Windurst_Woods.Zone.onZoneTick")
end)

return m
```
