### PR TITLE
[core] Fix Linkshell and item signature encode/decode

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -498,7 +498,7 @@ uint64 unpackBitsLE(const uint8* target, int32 byteOffset, int32 bitOffset, uint
 
 void EncodeStringLinkshell(int8* signature, int8* target)
 {
-    uint8 encodedSignature[16];
+    uint8 encodedSignature[LinkshellStringLength];
     memset(encodedSignature, 0, sizeof encodedSignature);
     uint8 chars    = 0;
     uint8 leftover = 0;
@@ -527,8 +527,7 @@ void EncodeStringLinkshell(int8* signature, int8* target)
     leftover = (leftover == 8 || leftover == 2 ? 6 : leftover);
     packBitsLE(encodedSignature, 0xFF, 6 * chars, leftover);
 
-    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
-    strncpy((char*)target, (const char*)encodedSignature, sizeof target);
+    strncpy((char*)target, (const char*)encodedSignature, LinkshellStringLength);
 }
 
 void DecodeStringLinkshell(int8* signature, int8* target)
@@ -569,13 +568,13 @@ void DecodeStringLinkshell(int8* signature, int8* target)
             decodedSignature[currChar] = tempChar;
         }
     }
-    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
-    strncpy((char*)target, (const char*)decodedSignature, sizeof target);
+
+    strncpy((char*)target, (const char*)decodedSignature, LinkshellStringLength);
 }
 
 int8* EncodeStringSignature(int8* signature, int8* target)
 {
-    uint8 encodedSignature[12];
+    uint8 encodedSignature[SignatureStringLength];
     memset(encodedSignature, 0, sizeof encodedSignature);
     uint8 chars = 0;
     // uint8 leftover = 0;
@@ -604,8 +603,7 @@ int8* EncodeStringSignature(int8* signature, int8* target)
     // leftover = (leftover == 8 ? 6 : leftover);
     // packBitsLE(encodedSignature,0xFF,6*chars, leftover);
 
-    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
-    return (int8*)strncpy((char*)target, (const char*)encodedSignature, sizeof target);
+    return (int8*)strncpy((char*)target, (const char*)encodedSignature, SignatureStringLength);
 }
 
 void DecodeStringSignature(int8* signature, int8* target)
@@ -629,8 +627,7 @@ void DecodeStringSignature(int8* signature, int8* target)
 
         decodedSignature[currChar] = tempChar;
     }
-    // TODO: -Wno-sizeof-pointer-memaccess - sizeof references source not destination
-    strncpy((char*)target, (const char*)decodedSignature, sizeof target);
+    strncpy((char*)target, (const char*)decodedSignature, SignatureStringLength);
 }
 
 // Take a regular string of 8-bit wide chars and packs it down into an

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -29,6 +29,10 @@
 
 constexpr size_t PacketNameLength = 15;
 
+constexpr size_t DecodeStringLength    = 21; // used for size of decoded strings of signature/linkshells
+constexpr size_t SignatureStringLength = 12; // encoded linkshell string size
+constexpr size_t LinkshellStringLength = 16; // encoded signature string size
+
 int32 checksum(uint8* buf, uint32 buflen, char checkhash[16]);
 int   config_switch(const char* str);
 bool  bin2hex(char* output, unsigned char* input, size_t count);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -30,8 +30,8 @@
 constexpr size_t PacketNameLength = 15;
 
 constexpr size_t DecodeStringLength    = 21; // used for size of decoded strings of signature/linkshells
-constexpr size_t SignatureStringLength = 12; // encoded linkshell string size
-constexpr size_t LinkshellStringLength = 16; // encoded signature string size
+constexpr size_t SignatureStringLength = 12; // encoded signature string size
+constexpr size_t LinkshellStringLength = 16; // encoded linkshell string size
 
 int32 checksum(uint8* buf, uint32 buflen, char checkhash[16]);
 int   config_switch(const char* str);

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -329,7 +329,7 @@ void CLinkshell::RemoveMemberByName(int8* MemberName, uint8 kickerRank, bool bre
 void CLinkshell::BreakLinkshell(int8* lsname, bool gm)
 {
     uint32 lsid = m_id;
-    int8   signature[21];
+    int8   signature[DecodeStringLength];
     DecodeStringLinkshell(lsname, signature);
 
     // break logged in and equipped members
@@ -407,7 +407,10 @@ namespace linkshell
             auto PLinkshell = std::make_unique<CLinkshell>(sql->GetUIntData(0));
 
             PLinkshell->setColor(sql->GetIntData(1));
-            int8 EncodedName[16];
+            int8 EncodedName[LinkshellStringLength];
+
+            memset(EncodedName, 0, sizeof(EncodedName));
+
             EncodeStringLinkshell(sql->GetData(2), EncodedName);
             PLinkshell->setName(EncodedName);
             if (sql->GetUIntData(3) < LSTYPE_LINKSHELL || sql->GetUIntData(3) > LSTYPE_LINKPEARL)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3314,7 +3314,9 @@ bool CLuaBaseEntity::addItem(sol::variadic_args va)
 
                 if (!signature.empty())
                 {
-                    int8 encoded[12];
+                    int8 encoded[SignatureStringLength];
+
+                    memset(encoded, 0, sizeof(encoded));
                     PItem->setSignature(EncodeStringSignature((int8*)signature.c_str(), encoded));
                 }
 
@@ -3774,7 +3776,9 @@ bool CLuaBaseEntity::breakLinkshell(std::string const& lsname)
             PLinkshell = linkshell::LoadLinkshell(lsid);
         }
 
-        int8 EncodedName[16];
+        int8 EncodedName[LinkshellStringLength];
+
+        memset(EncodedName, 0, sizeof(EncodedName));
         EncodeStringLinkshell((int8*)lsname.c_str(), EncodedName);
         PLinkshell->BreakLinkshell(EncodedName, true);
         linkshell::UnloadLinkshell(lsid);
@@ -3803,7 +3807,9 @@ bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
         if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
         {
             // build linkpearl
-            int8 EncodedString[16];
+            int8 EncodedString[LinkshellStringLength];
+
+            memset(EncodedString, 0, sizeof(EncodedString));
             EncodeStringLinkshell((int8*)lsname.c_str(), EncodedString);
             ((CItem*)PItemLinkPearl)->setSignature(EncodedString);
             PItemLinkPearl->SetLSID(sql->GetUIntData(0));

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -266,7 +266,9 @@ bool CLuaItem::isShield()
 
 auto CLuaItem::getSignature() -> std::string
 {
-    int8 signature[21];
+    int8 signature[DecodeStringLength];
+
+    memset(signature, 0, sizeof(signature));
     if (m_PLuaItem->isType(ITEM_LINKSHELL))
     {
         DecodeStringLinkshell((int8*)m_PLuaItem->getSignature(), signature);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5360,8 +5360,12 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             uint32 LinkshellID    = 0;
             uint16 LinkshellColor = data.ref<uint16>(0x04);
-            int8   DecodedName[21];
-            int8   EncodedName[16];
+
+            int8   DecodedName[DecodeStringLength];
+            int8   EncodedName[LinkshellStringLength];
+
+            memset(DecodedName, 0, sizeof(DecodedName));
+            memset(EncodedName, 0, sizeof(EncodedName));
 
             DecodeStringLinkshell(data[12], DecodedName);
             EncodeStringLinkshell(DecodedName, EncodedName);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1301,7 +1301,7 @@ namespace charutils
                                 "extra) "
                                 "VALUES(%u,%u,%u,%u,%u,'%s','%s')";
 
-            int8 signature[21];
+            int8 signature[DecodeStringLength];
             if (PItem->isType(ITEM_LINKSHELL))
             {
                 DecodeStringLinkshell((int8*)PItem->getSignature(), signature);

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -932,7 +932,9 @@ namespace synthutils
             {
                 if ((PItem->getFlag() & ITEM_FLAG_INSCRIBABLE) && (PChar->CraftContainer->getItemID(0) > 0x1080))
                 {
-                    int8 encodedSignature[12];
+                    int8 encodedSignature[SignatureStringLength];
+
+                    memset(encodedSignature, 0, sizeof(encodedSignature));
                     PItem->setSignature(EncodeStringSignature((int8*)PChar->name.c_str(), encodedSignature));
 
                     char signature_esc[31]; // max charname: 15 chars * 2 + 1


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Add constexpr for encode/decode string sizes, adds safety with memsetting new empty buffers.
Fixes #1742

## Steps to test these changes

Buy a new linkshell from vendor, type in as many characters as possible when you make the new linkshell.  Long names were broken on creation/readback due to bad sizeof calls acting upon pointers and not real sizes. If you can create the linkshell, the fix worked. This same fix is also applied the same way to signatures. A long character name >8 chars signing an item would likely produce the same result.