### PR TITLE
Implement Rala Sluice Gate 2 as example for manually opened gates

### DIFF
--- a/scripts/zones/Rala_Waterways/npcs/Sluice_Gate_2.lua
+++ b/scripts/zones/Rala_Waterways/npcs/Sluice_Gate_2.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Area: Rala Waterways (258)
+--  NPC: Sluice Gate #2
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    local zone = npc:getZone()
+    local resultTable = zone:queryEntitiesByName('_76r')
+
+    resultTable[1]:openDoor(15)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Rala_Waterways/npcs/_76r.lua
+++ b/scripts/zones/Rala_Waterways/npcs/_76r.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Area: Rala Waterways (258)
+--  NPC: _76r - Sluice Gate 2 Controller
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Implements Sluice Gate 2 in Rala Waterways (manually opened gate)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to Sluice Gate 2, trigger NPC (door should open)
<!-- Clear and detailed steps to test your changes here -->
