### PR TITLE
[lua]Fix returning to Promyvion Vahzl

### DIFF
--- a/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
+++ b/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
@@ -300,6 +300,11 @@ mission.sections =
         [xi.zone.PSOXJA] =
         {
             ['_i99'] = mission:event(112),
+
+            onEventFinish =
+            {
+                [112] = setPromyvionVahzlPos,
+            },
         },
     },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
    Adds the onEventFinish listener to the stone door in Pso'Xja so players trying to re enter Promyvion Vahzl get teleported in instead of getting stuck on a black screen after the cs
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
   Touch the stone door in Pso'Xja select a option and get teleported into Promyvion Vahzl 
<!-- Clear and detailed steps to test your changes here -->
