### PR TITLE
[core] Add option to reuse dynamic Ids from dynamic mobs after they die

### DIFF
--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -41,6 +41,10 @@ function onTrigger(player)
         onMobDeath = function(mob, playerArg, isKiller)
             -- Do stuff
         end,
+
+        -- If set to true, the internal id assigned to this mob will be released for other dynamic entities to use
+        -- after this mob has died. Defaults to false.
+        releaseIdOnDeath = true,
     })
 
     -- Use the mob object as you normally would

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -260,6 +260,8 @@ public:
 
     bool m_IsClaimable;
 
+    bool m_bReleaseTargIDOnDeath = false;
+
     static constexpr float sound_range{ 8.f };
     static constexpr float sight_range{ 15.f };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4826,6 +4826,7 @@ uint8 CLuaBaseEntity::getAllegiance()
 void CLuaBaseEntity::setAllegiance(uint8 allegiance)
 {
     m_PBaseEntity->allegiance = static_cast<ALLEGIANCE_TYPE>(allegiance);
+    m_PBaseEntity->updatemask |= UPDATE_HP | UPDATE_NAME;
 }
 
 /************************************************************************

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1508,17 +1508,6 @@ Usage:
 
                 // must be here first to define mobmods
                 mobutils::InitializeMob(PMob, zoneutils::GetZone(targetZoneId));
-
-                zoneutils::GetZone(targetZoneId)->InsertMOB(PMob);
-
-                luautils::OnEntityLoad(PMob);
-
-                luautils::OnMobInitialize(PMob);
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
-
-                PMob->saveModifiers();
-                PMob->saveMobModifiers();
             }
         }
         return PMob;

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -85,7 +85,8 @@ public:
     EntityList_t m_npcList;  // список всех NPCs в зоне
     EntityList_t m_charList; // список всех PCs  в зоне
 
-    std::set<uint16> charTargIds; // Sorted set of targids for characters
+    std::set<uint16> charTargIds;    // Sorted set of targids for characters
+    std::set<uint16> dynamicTargIds; // Sorted set of targids for dynamic entities
 
     CZoneEntities(CZone*);
     ~CZoneEntities();
@@ -97,8 +98,6 @@ private:
 
     time_point computeTime { server_clock::now() };
     uint16 lastCharComputeTargId;
-
-    uint16 m_DynamicTargIDCount;
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add an optional option to reuse dynamic entity's ids when they die. 

## Steps to test these changes

1. !fafnir
2. observe fafnir's id
3. !hp 0 on fafnir
4. wait for him to fully despawn
5. !fafnir again
6. observe the same id as before, instead of it incrementing forever
