### PR TITLE
[core] Fix bindings for Full Speed Ahead

### DIFF
--- a/scripts/commands/minigame.lua
+++ b/scripts/commands/minigame.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- func: minigame
+-- desc: Opens a menu to allow you to quickly test minigames.
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+function onTrigger(player)
+    local menu =
+    {
+        title = "Minigame Test Menu",
+        options =
+        {
+            {
+                "Full Speed Ahead! (Normal)",
+                function(playerArg)
+                    playerArg:setCharVar("[QUEST]FullSpeedAhead", 1)
+                    player:setPos(475, 8.8, -159, 128, xi.zone.BATALLIA_DOWNS)
+                end,
+            },
+            {
+                "Full Speed Ahead! (Easy)",
+                function(playerArg)
+                    playerArg:setCharVar("[QUEST]FullSpeedAhead", 2)
+                    player:setPos(475, 8.8, -159, 128, xi.zone.BATALLIA_DOWNS)
+                end,
+            },
+        },
+    }
+    player:customMenu(menu)
+end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2831,7 +2831,7 @@ xi.anim = xi.animation
 xi.mount =
 {
     CHOCOBO        = 0,
-    QUEST_RAPTOR   = 1,
+    QUEST_RAPTOR   = 1, -- NOTE: This now appears as a plain chocobo
     RAPTOR         = 2,
     TIGER          = 3,
     CRAB           = 4,

--- a/scripts/quests/full_speed_ahead.lua
+++ b/scripts/quests/full_speed_ahead.lua
@@ -40,7 +40,8 @@ xi.full_speed_ahead.onEffectGain = function(player, effect)
     player:setLocalVar("FSA_Pep", 0)
     player:setLocalVar("FSA_Food", 0xFF)
     player:setLocalVar("FSA_FoodCount", 0)
-    player:addStatusEffect(xi.effect.MOUNTED, xi.mount.QUEST_RAPTOR, 3, 0)
+    -- NOTE: This used to be mount id 1: QUEST_RAPTOR, but it appears to have changed
+    player:addStatusEffect(xi.effect.MOUNTED, xi.mount.RAPTOR, 3, 0)
     player:setCharVar("[QUEST]FullSpeedAhead", 3)
 end
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9264,12 +9264,19 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj,
  *  Example : player:enableEntities({ 17207972, 17207973})
  *  Notes   : Default is all off, so sending the ID enables the special entity
  ************************************************************************/
-void CLuaBaseEntity::enableEntities(std::vector<uint32> const& data)
+void CLuaBaseEntity::enableEntities(sol::object const& obj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-    PChar->pushPacket(new CEntityEnableList(data));
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        if (obj.is<std::vector<uint32>>())
+        {
+            PChar->pushPacket(new CEntityEnableList(obj.as<std::vector<uint32>>()));
+        }
+    }
+    else
+    {
+        ShowWarning(fmt::format("enableEntities called on invalid type ({})", m_PBaseEntity->name).c_str());
+    }
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -534,7 +534,7 @@ public:
     void countdown(sol::object const& secondsObj,
                    sol::object const& bar1NameObj, sol::object const& bar1ValObj,
                    sol::object const& bar2NameObj, sol::object const& bar2ValObj);
-    void enableEntities(std::vector<uint32> const& data);
+    void enableEntities(sol::object const& obj);
     void independentAnimation(CLuaBaseEntity* PTarget, uint16 animId, uint8 mode);
 
     void engage(uint16 requestedTarget);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

I'm not sure why this broke, nobody has gone near it in nearly 2 years 👀 . It looks like the new Noble Chocobo mount in retail has caused some issues.

## What does this pull request do?

Fixes https://github.com/LandSandBoat/server/issues/1788

## Steps to test these changes

1. `!minigame`
2. Select 1: Full Speed Ahead
3. Play the game normally, as expected