### PR TITLE
Change chars table home_zone to smallint(5)

### DIFF
--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -16,7 +16,7 @@ CREATE TABLE `chars` (
   `pos_z` float(7,3) NOT NULL DEFAULT '0.000',
   `moghouse` int(10) unsigned NOT NULL DEFAULT '0',
   `boundary` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `home_zone` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `home_zone` smallint(5) unsigned NOT NULL DEFAULT '0',
   `home_rot` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `home_x` float(7,3) NOT NULL DEFAULT '0.000',
   `home_y` float(7,3) NOT NULL DEFAULT '0.000',

--- a/tools/migrations/home_zone_size.py
+++ b/tools/migrations/home_zone_size.py
@@ -1,0 +1,22 @@
+import array
+import mysql.connector
+
+def migration_name():
+	return "Adjusting home_zone size to smallint."
+
+def check_preconditions(cur):
+	return
+
+def needs_to_run(cur):
+	# Ensure home_zone is currently tinyint
+	cur.execute("SHOW COLUMNS FROM chars WHERE FIELD = 'home_zone' AND TYPE = 'tinyint(3) unsigned';")
+	if cur.fetchone():
+		return True
+	return False
+
+def migrate(cur, db):
+	try:
+		cur.execute("ALTER TABLE chars MODIFY home_zone smallint(5) unsigned NOT NULL DEFAULT '0';")
+		db.commit()
+	except mysql.connector.Error as err:
+		print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Changes home_zone in the chars table from tinyint(3) to smallint(5) to allow for homepoints to be set in zones > 255

## Steps to test these changes
1. Attempt to set Homepoint in Western or Eastern Adoulin
2. Confirm homepoint is set

<!-- Clear and detailed steps to test your changes here -->
