### PR TITLE
Get Item ID By Name

### DIFF
--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -6,7 +6,7 @@
 cmdprops =
 {
     permission = 1,
-    parameters = "iiiiiiiiiii"
+    parameters = "siiiiiiiiii"
 }
 
 function error(player, msg)
@@ -14,27 +14,47 @@ function error(player, msg)
     player:PrintToPlayer("!additem <itemId> {quantity} {aug1} {v1} {aug2} {v2} {aug3} {v3} {aug4} {v4} {trial}")
 end
 
-function onTrigger(player, itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
+function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
     -- Load needed text ids for players current zone..
     local ID = zones[player:getZoneID()]
+    local itemToGet = 0
 
-    -- validate itemId
-    if (itemId == nil or tonumber(itemId) == nil or tonumber(itemId) == 0) then
-        error(player, "Invalid itemId.")
+    -- validate item
+    if item == nil then
+        -- No Item Provided
+        error(player, "No Item ID given.")
         return
-    end
-
-    -- Ensure the GM has room to obtain the item
-    if (player:getFreeSlotsCount() == 0) then
-        player:messageSpecial( ID.text.ITEM_CANNOT_BE_OBTAINED, itemId )
-        return
-    end
-
-    -- Give the GM the item
-    player:addItem( itemId, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId )
-    if quantity and quantity > 1 then
-        player:messageSpecial( ID.text.ITEM_OBTAINED + 9, itemId , quantity )
+    elseif tonumber(item) == nil and item ~= nil then
+        -- Item was provided, but was not a number.  Try text lookup.
+        local retItem = GetItemIDByName(tostring(item))
+        if retItem > 0 then
+            itemToGet = retItem
+        else
+            error(player, string.format("Item %s not found in database.", item))
+            return
+        end
     else
-        player:messageSpecial( ID.text.ITEM_OBTAINED, itemId )
+        -- Number was provided, so just use it
+        itemToGet = tonumber(item)
+    end
+
+    -- At this point, if there's no item found, exit out of the function
+    if itemToGet == 0 then
+        error(player, "Item not found.")
+        return
+    end
+
+    -- Ensure the GM has room to obtain the item...
+    if player:getFreeSlotsCount() == 0 then
+        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
+        return
+    end
+
+    -- Give the GM the item...
+    player:addItem(itemToGet, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
+    if quantity and quantity > 1 then
+        player:messageSpecial(ID.text.ITEM_OBTAINED + 9, itemToGet, quantity)
+    else
+        player:messageSpecial(ID.text.ITEM_OBTAINED, itemToGet)
     end
 end

--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -27,10 +27,13 @@ function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, a
     elseif tonumber(item) == nil and item ~= nil then
         -- Item was provided, but was not a number.  Try text lookup.
         local retItem = GetItemIDByName(tostring(item))
-        if retItem > 0 then
+        if retItem > 0 and retItem < 65000 then
             itemToGet = retItem
+        elseif retItem >= 65000 then
+            player:PrintToPlayer(string.format("Found %s instances matching '%s'.  Use ID or exact name.", 65536 - retItem,  tostring(item)))
+            return
         else
-            error(player, string.format("Item %s not found in database.", item))
+            player:PrintToPlayer(string.format("Item %s not found in database.", item))
             return
         end
     else

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4889,7 +4889,7 @@ namespace luautils
     uint16 GetItemIDByName(std::string const& name)
     {
         uint16      id    = 0;
-        const char* Query = "SELECT itemid FROM item_basic WHERE name = '%s' LIMIT 1;";
+        const char* Query = "SELECT itemid FROM item_basic WHERE name LIKE '%s%%' LIMIT 1;";
         int32       ret   = sql->Query(Query, name);
 
         if (ret != SQL_ERROR && sql->NumRows() != 0)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4889,16 +4889,22 @@ namespace luautils
     uint16 GetItemIDByName(std::string const& name)
     {
         uint16      id    = 0;
-        const char* Query = "SELECT itemid FROM item_basic WHERE name LIKE '%s%%' LIMIT 1;";
+        const char* Query = "SELECT itemid FROM item_basic WHERE name LIKE '%s';";
         int32       ret   = sql->Query(Query, name);
 
-        if (ret != SQL_ERROR && sql->NumRows() != 0)
+        if (ret != SQL_ERROR && sql->NumRows() == 1)  // Found a single result
         {
             while (sql->NextRow() == SQL_SUCCESS)
             {
                 id = sql->GetIntData(0);
             }
         }
+        else if (ret != SQL_ERROR && sql->NumRows() > 1)
+        {
+            // 0xFFFF is gil, so we will always return a value less than that as a warning
+            id = 0xFFFF - sql->NumRows() + 1;
+        }
+        
 
         return id;
     }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -193,6 +193,7 @@ namespace luautils
         lua.set_function("SelectDailyItem", &luautils::SelectDailyItem);
         lua.set_function("GetQuestAndMissionFilenamesList", &luautils::GetQuestAndMissionFilenamesList);
         lua.set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
+        lua.set_function("GetItemIDByName", &luautils::GetItemIDByName);
 
         // This binding specifically exists to forcefully crash the server.
         // clang-format off
@@ -4883,5 +4884,22 @@ namespace luautils
         }
 
         customMenuContext.erase(PChar->id);
+    }
+
+    uint16 GetItemIDByName(std::string const& name)
+    {
+        uint16      id    = 0;
+        const char* Query = "SELECT itemid FROM item_basic WHERE name = '%s' LIMIT 1;";
+        int32       ret   = sql->Query(Query, name);
+
+        if (ret != SQL_ERROR && sql->NumRows() != 0)
+        {
+            while (sql->NextRow() == SQL_SUCCESS)
+            {
+                id = sql->GetIntData(0);
+            }
+        }
+
+        return id;
     }
 }; // namespace luautils

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -325,6 +325,8 @@ namespace luautils
     auto SetCustomMenuContext(CCharEntity* PChar, sol::table table) -> std::string;
     bool HasCustomMenuContext(CCharEntity* PChar);
     void HandleCustomMenu(CCharEntity* PChar, std::string selection);
+
+    uint16 GetItemIDByName(std::string const& name); // Retrive the first itemId that matches a name
 }; // namespace luautils
 
 #endif // _LUAUTILS_H -


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

1.  Added a C++ function that will return the first matching ItemID value from the name of the item in the database. 
2.  Modified the !additem GM Command (additem.lua file) such that it will accept _either_ the item ID or the name of the item as found within the database.

## Steps to test these changes

1. Use !togglegm to ensure GM mode is active
2. Use the !additem command with any item id (eg: !additem 14421)  (This will add a Genie Weskit to the inventory)
3. Use the !additem command with an item name (eg: !additem genie_weskit)

(NOTE: following step added for testing wildcards)
4. Use the !additem command with wildcards (% is wildcard char)  in the item name (eg: !additem genie_wes% )