### PR TITLE
[core] Add resetLocalVars to CLuaZone

### DIFF
--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -66,6 +66,11 @@ void CLuaZone::setLocalVar(const char* key, uint32 val)
     m_pLuaZone->SetLocalVar(key, val);
 }
 
+void CLuaZone::resetLocalVars()
+{
+    m_pLuaZone->ResetLocalVars();
+}
+
 /************************************************************************
  *                                                                       *
  * Registering the active area in the zone                               *
@@ -397,6 +402,7 @@ void CLuaZone::Register()
 
     SOL_REGISTER("getLocalVar", CLuaZone::getLocalVar);
     SOL_REGISTER("setLocalVar", CLuaZone::setLocalVar);
+    SOL_REGISTER("resetLocalVars", CLuaZone::resetLocalVars);
 
     SOL_REGISTER("registerRegion", CLuaZone::registerRegion);
     SOL_REGISTER("levelRestriction", CLuaZone::levelRestriction);

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -42,6 +42,7 @@ public:
 
     auto getLocalVar(const char* key);
     void setLocalVar(const char* key, uint32 value);
+    void resetLocalVars();
 
     void        registerRegion(uint32 RegionID, float x1, float y1, float z1, float x2, float y2, float z2);
     sol::object levelRestriction();

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -270,6 +270,11 @@ void CZone::SetLocalVar(const char* var, uint32 val)
     m_LocalVars[var] = val;
 }
 
+void CZone::ResetLocalVars()
+{
+    m_LocalVars.clear();
+}
+
 bool CZone::CanUseMisc(uint16 misc) const
 {
     return (m_miscMask & misc) == misc;

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -557,7 +557,8 @@ public:
     void SetBackgroundMusicNight(uint8 music);
 
     uint32 GetLocalVar(const char* var);
-    void SetLocalVar(const char* var, uint32 val);
+    void   SetLocalVar(const char* var, uint32 val);
+    void   ResetLocalVars();
 
     virtual CCharEntity* GetCharByName(int8* name); // finds the player if exists in zone
     virtual CCharEntity* GetCharByID(uint32 id);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add resetLocalVars binding to CLuaZone

## Steps to test these changes

Use like you would the same binding on entities
