### PR TITLE
[Event] Correct Nyzul Isle South Staging point gate

### DIFF
--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -40 then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(114)
+            player:startEvent(115)
         elseif not player:hasKeyItem(xi.ki.NYZUL_ISLE_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(115)
+            player:startEvent(114)
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.NYZUL_ISLE_ASSAULT_ORDERS)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes the Southern door in Nyzul Isle Staging Point to work as it should. Currently trying to exit the staging point makes you enter it and vice versa.

## Steps to test these changes

1. !zone alzadaal undersea ruins (use autotranslate because I definitely spelled that wrong)
2. try to exit staging point via southern door (you will "enter" instead)
