### PR TITLE
[bcnm] added phaseChange to Apollyon SW

### DIFF
--- a/scripts/zones/Apollyon/bcnms/sw_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/sw_apollyon.lua
@@ -20,6 +20,11 @@ battlefield_object.onBattlefieldInitialise = function(battlefield)
     battlefield:setLocalVar("restorePH", ID.npc.APOLLYON_SW_CRATE[3] + random + 1)
     battlefield:setLocalVar("itemPH", ID.npc.APOLLYON_SW_CRATE[3] + random + 2)
 
+    -- Since this BC does not have a default "kill to win" mob set in the database like the other Apollyons
+    -- We have to manage it with this phaseChange variable. This allows the "kill to win" mobs to be the
+    -- elementals that correspond with the day you enter
+    battlefield:setLocalVar("phaseChange", 1)
+
     xi.limbus.setupArmouryCrates(battlefield:getID())
 end
 

--- a/scripts/zones/Apollyon/bcnms/sw_apollyon_helper.lua
+++ b/scripts/zones/Apollyon/bcnms/sw_apollyon_helper.lua
@@ -170,6 +170,10 @@ xi.apollyon_sw.handleMobDeathFloorFour = function(mob, player, isKiller, noKille
                 GetMobByID(ID.mob.APOLLYON_SW_MOB[4] + table[3]):isDead()
             then
                 GetNPCByID(ID.npc.APOLLYON_SW_CRATE[4]):setStatus(xi.status.NORMAL)
+                -- Once the elementals that correspond with the day you entered are killed, you can move
+                -- to phase 0, and that will set the scenario to a 'win' since there are no default
+                -- "kill to win" mobs
+                battlefield:setLocalVar("phaseChange", 0)
             end
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

Apollyon - SW is set to "WON" shortly after the first player enters. This creates a weird situation where whoever follows gets a weird "you cannot enter, you need to wait" message. However, it still lets them enter. And then, when the original person casts on one of the people who entered after them, it will crash that client. When the caster fully DC / exits, the BCNM will clean up and everything will despawn, but the other party members will have the battlefield effect flag stuck on them (needs to be manually removed).

## What does this pull request do?

This PR adds a "phaseChange" to the Apollyon - SW BCNM since it has no "kill this specific mob" to win mechanic (ie, the "kill to win" changes based on day you enter). This leads to the malarkey described above. 

## Steps to test these changes

1. Bring two characters, (one rdm, one anything).
2. Enter on RDM.
3. Enter on other.
4. Notice weird message on "other".
5. RDM cast haste on "other", client will crash.
6. Profit from insanity.