### PR TITLE
[lua] Make "Full Speed Ahead!" resistant to ID shifts

### DIFF
--- a/scripts/quests/full_speed_ahead.lua
+++ b/scripts/quests/full_speed_ahead.lua
@@ -136,3 +136,5 @@ xi.full_speed_ahead.completeGame = function(player)
 end
 
 xi.fsa = xi.full_speed_ahead
+
+return xi.full_speed_ahead -- NOTE: This return does nothing apart from silence the hot-reloader

--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -104,10 +104,7 @@ zones[xi.zone.BATALLIA_DOWNS] =
 
     npc =
     {
-        CASKET_BASE      = 17207794,
-        SYRILLIA         = 17207972,
-        BLUE_BEAM_BASE   = 17207973, -- NPC[2a4] in npc_list
-        RAPTOR_FOOD_BASE = 17207981,
+        CASKET_BASE = 17207794,
     },
 }
 

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -31,10 +31,19 @@ zone_object.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.AHTU);
     GetMobByID(ID.mob.AHTU):setRespawnTime(math.random(900, 10800));
 
+    -- Prepare everything for Full Speed Ahead!
+    local syrillia   = zone:queryEntitiesByName("Syrillia")[1]
+    local syrilliaID = syrillia:getID()
+
+    ID.npc.SYRILLIA         = syrilliaID
+    ID.npc.BLUE_BEAM_BASE   = syrilliaID + 1
+    ID.npc.RAPTOR_FOOD_BASE = syrilliaID + 9
+
     for i = 0, 7 do
         registerRegionAroundNPC(zone, ID.npc.RAPTOR_FOOD_BASE + i, i + 1)
     end
     registerRegionAroundNPC(zone, ID.npc.SYRILLIA, 9)
+
     xi.voidwalker.zoneOnInit(zone)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removes the hard-coded IDs needed to complete FSA and replaces them with a by-name lookup of the main NPC, and then uses offsets from there to work out everything else.

## Steps to test these changes

Play, _and complete_ FSA, either naturally, or through `!minigame` menu
