### PR TITLE
[core] fix -Werror=format-truncation

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -183,28 +183,27 @@ std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket)>
 
 void PrintPacket(CBasicPacket data)
 {
-    char message[50];
-    memset(&message, 0, 50);
+    std::string message;
+    char buffer[5];
 
     for (size_t y = 0; y < data.getSize(); y++)
     {
-        // TODO: -Wno-restrict - undefined behavior to print and write src into dest
-        // TODO: -Wno-format-overflow - writing between 4 and 53 bytes into destination of 50
-        // TODO: FIXME
-        // cppcheck-suppress sprintfOverlappingData
-        snprintf(message, sizeof(message), "%s %02hhx", message, *((uint8*)data[(int)y]));
+        std::memset(buffer, 0, sizeof(buffer));                               // TODO: Replace these three lines with std::format when/if we move to C++ 20.
+        snprintf(buffer, sizeof(buffer), "%02hhx ", *((uint8*)data[(int)y])); //
+        message.append(buffer);                                               //
+
         if (((y + 1) % 16) == 0)
         {
-            message[48] = '\n';
-            ShowDebug(message);
-            memset(&message, 0, 50);
+            message += "\n";
+            ShowDebug(message.c_str());
+            message.clear();
         }
     }
 
-    if (strlen(message) > 0)
+    if (message.length() > 0)
     {
-        message[strlen(message)] = '\n';
-        ShowDebug(message);
+        message += "\n";
+        ShowDebug(message.c_str());
     }
 }
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -115,28 +115,15 @@ extern std::unique_ptr<ConsoleService> gConsoleService;
 
 void PrintPacket(char* data, int size)
 {
-    char message[50];
-    memset(&message, 0, 50);
-
-    printf("\n");
+    std::printf("\n");
 
     for (int32 y = 0; y < size; y++)
     {
-        char msgtmp[50];
-        memset(&msgtmp, 0, 50);
-        std::snprintf(msgtmp, sizeof(msgtmp), "%s %02x", message, (uint8)data[y]);
-        strncpy(message, msgtmp, 50);
+        std::printf("%02x ", (uint8)data[y]);
         if (((y + 1) % 16) == 0)
         {
-            message[48] = '\n';
-            fputs(message, stdout);
-            memset(&message, 0, 50);
+            printf("\n");
         }
-    }
-    if (strlen(message) > 0)
-    {
-        message[strlen(message)] = '\n';
-        fputs(message, stdout);
     }
     printf("\n");
 }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes Linux debug mode build, removes possible memory corruption from error:
```
note: ‘snprintf’ output between 4 and 53 bytes into a destination of size 50
```

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
open delivery box, observe packet messages in xi_map output, such as

```
[map][info][action] DeliveryBox Action (0d) (SmallPacket0x04D:2213)
[map][debug][debug] 4d 10 10 00 0d ff ff ff ff ff ff ff 00 00 00 00
 (PrintPacket:198)
][map][debug][debug] 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 (PrintPacket:198)
```

list linkshell members, observe packet messages in xi_search, such as :
```
[search][info][message] SEARCH::LinkshellIDs = 1, 0 (HandleGroupListRequest:579)

 00 00 00 00 00 00 00 00 4a 00 80 82 00 00 01 00
 00 00 00 00 00 00 00 00 31 02 c3 c3 cf 2f 90 9d
 42 47 61 91 8c c4 a3 00 13 00 00 20 00 00 5a 02
 00 00 00 00 00 02 00 00 00 00 00 00 00 00 e0 00
 00 00 0b 00 00 00 00 5c 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
