### PR TITLE
[Fix] Weather Reporter events locking players

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Shashan-Mishan.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Shashan-Mishan.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534300, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10012, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Jeuno/npcs/Leffquen.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Leffquen.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534310, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10022, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Port_Windurst/npcs/Eya_Bhithroh.lua
+++ b/scripts/zones/Port_Windurst/npcs/Eya_Bhithroh.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534294, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10006, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Upper_Jeuno/npcs/Appollonia.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Appollonia.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534296, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10008, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Windurst_Waters/npcs/Furan-Furin.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Furan-Furin.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534290, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10002, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Windurst_Woods/npcs/Mushuhi-Metahi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Mushuhi-Metahi.lua
@@ -9,7 +9,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(534296, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
+    player:startEvent(10008, 0, 0, 0, 0, 0, 0, 0, VanadielTime())
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Weather reporter events were set to an insanely high and overflowing value. The returning event was correct but any firther interaction with any other npc in the zone would lock the player, needing a GM warp or a force disconnection to fix.

<!-- Clear and detailed steps to test your changes here -->

1. Talk to a weather reporter
2. Talk to another (or the same) npc in the zone
3. Watch yourself not get locked in place.