### PR TITLE
Rework Gearsets - Implement BLU AF3 Sets and Calcs

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -239,6 +239,15 @@ function BluePhysicalSpell(caster, target, spell, params)
 
     local multiplier = params.multiplier
 
+    -- Process chance for Bonus WSC from AF3 Set. BLU AF3 set triples the base
+    -- WSC when it procs and can stack with Chain Affinity. See Final bonus WSC
+    -- calculation below.
+
+    local bonusWSC = 0
+    if caster:getMod(xi.mod.AUGMENT_BLU_MAGIC) > math.random(0,99) then
+       bonusWSC = 2
+    end
+
     -- If under CA, replace multiplier with fTP(multiplier, tp150, tp300)
     local chainAffinity = caster:getStatusEffect(xi.effect.CHAIN_AFFINITY)
     if chainAffinity ~= nil then
@@ -249,7 +258,18 @@ function BluePhysicalSpell(caster, target, spell, params)
         end
 
         multiplier = BluefTP(tp, multiplier, params.tp150, params.tp300)
+        bonusWSC = bonusWSC + 1 -- Chain Affinity Doubles the Base WSC.
     end
+
+    -- Calculate final WSC bonuses
+    -- print("pre-calc wsc value is ".. wsc)
+    -- print("bonusWSC value is ".. bonusWSC)
+    wsc = wsc + (wsc * bonusWSC)
+    -- print("post-calc wsc value is ".. wsc)
+
+    -- See BG Wiki for reference. Chain Affinity will double the WSC. BLU AF3 set will
+    -- Triple the WSC when the set bonus procs. The AF3 set bonus stacks with Chain
+    -- Affinity for a maximum total of 4x WSC.
 
     -- TODO: Modify multiplier to account for family bonus/penalty
     local finalD = math.floor(D + fStr + wsc) * multiplier

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -262,10 +262,7 @@ function BluePhysicalSpell(caster, target, spell, params)
     end
 
     -- Calculate final WSC bonuses
-    -- print("pre-calc wsc value is ".. wsc)
-    -- print("bonusWSC value is ".. bonusWSC)
     wsc = wsc + (wsc * bonusWSC)
-    -- print("post-calc wsc value is ".. wsc)
 
     -- See BG Wiki for reference. Chain Affinity will double the WSC. BLU AF3 set will
     -- Triple the WSC when the set bonus procs. The AF3 set bonus stacks with Chain

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -33,6 +33,9 @@ local absorbDamageBaseRate = 2
 local absorbDamagePieceBonus = 1
 local instantCastBaseRate = 2
 local instantCastPieceBonus = 1
+local baseRate = 2
+local pieceBonus = 1
+--TODO: Migrate remaining AF3 variables to baseRate/pieceBonus and update comment.
 
 --              {id, {item, ids, in, no, particular, order}, minimum matches required, match type, mods{id, value, modvalue for each additional match, additional whole set bonus}
 local gearSets =
@@ -177,7 +180,9 @@ local gearSets =
              {id = 214, items = {26673, 26849, 27025, 27201, 27377}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.DOUBLE_ATTACK, 4, 2, 0}} }, -- Argosy +1
              {id = 215, items = {25616, 25689, 27120, 27305, 27476}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.MATT, 20, 10, 0}} }, -- Amalric +1
              {id = 216, items = {18947, 15818}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.ACC, 5, 0, 0}, {xi.mod.SOULEATER_EFFECT, 2, 0, 0}} }, -- Moliones's Sickle/Ring
-             -- next id = 218
+             {id = 218, items = {11079, 11099, 11119, 11139, 11159}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0}} }, -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+             {id = 219, items = {26770, 26771, 26928, 26929, 27082, 27083, 27267, 27268, 27441, 27442}, matches = 2, matchType = matchtype.any, mods = {{xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0}} },  -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+             -- next id = 220
         }
 
              -- increment id by the number of mods in previous gearset (e.g. id 199 has 3 mods, 199 + 3 = 202)
@@ -416,16 +421,6 @@ Empyrean +2
 11147 -- Goetia Sabots+2
 -- Set Bonus: Augments "Conserve MP"
 -- Occasionally increases damage of elemental spells when Conserve MP is triggered. Increased amount is proportional to twice the ratio of MP conserved.
-
---Mavi Attire +2 Set
------------------------------------
-11079 -- Mavi Kavuk+2
-11099 -- Mavi Mintan+2
-11119 -- Mavi Bazubands+2
-11139 -- Mavi Tayt+2
-11159 -- Mavi Basmak+2
--- Set Bonus: Occ. augments blue magic spells.
--- no clue!
 
 --Bale Armor +2 Set
 -----------------------------------


### PR DESCRIPTION
Continued rework of #726 into smaller chunks for easier review/ingestion.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Updates the `bluemagic` script to apply bonus WSC for chain affinity and the AF3 set (when it 
procs) 
Adds the associated BLU AF3 sets to `gear_sets`.

References: 
<https://www.bg-wiki.com/ffxi/Hashishin_Attire_Set>
<https://www.bg-wiki.com/ffxi/Chain_Affinity>

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
**Testing Gear Set MOD Values**

Login a test character
`!changejob BLU 99`
Remove all currently equipped gear
`!getmod AUGMENT_BLU_MAGIC` should return 0

Add the following test items: `!additem <itemid>`
```
11079 \
11099 /  Set 218 samples
27082 \
27268  > Set 219 samples
27442 /
```
Mix and Match equipped items, check results with `!getmod AUGMENT_BLU_MAGIC`.
Sets 218 and 219 should activate independently of one another, but behave with the same logic, two items from the set minimum, with a bonus of 1 for each additional piece (2, 3, 4, 5).

Mix and match gear, and test for expected resulting value of `!getmod AUGMENT_BLU_MAGIC`. Combing at least 2 items of either set will activate the bonus:

1. AF3 85 Head + AF3 109 Hands will not activate bonus 
2. AF3 85 Head + AF3 89 Body will activate bonus (2) (Set 218 is active)
3. AF3 109 hands + AF3 119 Legs will activate bonus (2) (Set 219 is active)
4. AF3 85 Head + AF3 89 Body + AF3 109 hands + AF3 119 Legs will activate bonus (4) (Set 218 AND Set 219 are active)
5. Equipping all 5 example test items will replicate having set 218 active (2) and set 219 active (3) for a total of 5.
6. Bonus testing: Add all 15 item IDs referenced in the PR and mix and match to confirm expected values.

**Testing WSC Calculations**

Login a test character
`!changejob BLU 99`
`!addallspells`
`!capallskills`
Set `Foot Kick` as an available blu spell
Head to any starter zone (e.g. West Ron.)
Remove all currently equipped gear
Select a specific Test Mob for consistency (e.g. Tunnel Worm or Wild Rabbit)
Use `Foot Kick` against the mob and note the damage. (1x WSC)
Use `Chain Affinity` then use `Foot Kick` again, noting the increased damage output. (2x WSC)
Target the character and `!setmod AUGMENT_BLU_MAGIC 100`
Use `Foot Kick` against the mob and note the increased damage output. (3x WSC)
Use `Chain Affinity` then use `Foot Kick` again, noting the increased damage output. (4x WSC)

~~Note: Testers may un-comment lines 272, 273 and 275 in the updated `bluemagic.lua` to see pre- and post- values in the map server logs to help evaluate the changes.~~ Removed commented debug prints.
