### PR TITLE
[Fix] Windows x86 and x64 release builds

### DIFF
--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -287,7 +287,5 @@ int main(int argc, char** argv)
     gConsoleService = nullptr;
 
     do_final(EXIT_SUCCESS);
-
-    return 0;
 }
 #endif // DEFINE_OWN_MAIN


### PR DESCRIPTION
Co-authored-by: WinterSolstice8 <60417494+WinterSolstice8@users.noreply.github.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes unreachable code error when building in x86 and x64 release.

Closes #1868 