### PR TITLE
Retail Accuracy for Brigandish Blade

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -120,10 +120,11 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
         ABSORB_STATUS = 10,
         SELF_BUFF = 11,
         DEATH = 12,
+        DAMAGE_SPECIFIC_MOB = 13,
     }
 
     -- If we're not going to proc, lets not execute all those checks!
-    if chance < math.random(100) then
+    if chance < math.random(100) or (addType == procType.DAMAGE_SPECIFIC_MOB and defender:getTargID() ~= power) then -- power is the targID for type DAMAGE_SPECIFIC_MOB
         return 0,0,0
     end
 
@@ -137,7 +138,7 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
     end
     --------------------------------------
 
-    if addType == procType.DAMAGE then
+    if addType == procType.DAMAGE or addType == procType.DAMAGE_SPECIFIC_MOB then
         damage = xi.additionalEffect.calcDamage(attacker, element, defender, damage)
         msgID = xi.msg.basic.ADD_EFFECT_DMG
         if damage < 0 then

--- a/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
@@ -11,6 +11,43 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
+local BB_physical_SDTs =
+{
+    xi.mod.SLASH_SDT, xi.mod.PIERCE_SDT, xi.mod.IMPACT_SDT, xi.mod.HTH_SDT,
+}
+local BB_elemental_SDTs =
+{
+    xi.mod.FIRE_SDT, xi.mod.ICE_SDT, xi.mod.WIND_SDT, xi.mod.EARTH_SDT,
+    xi.mod.THUNDER_SDT, xi.mod.WATER_SDT, xi.mod.LIGHT_SDT, xi.mod.DARK_SDT,
+}
+
+entity.onMobSpawn = function(mob)
+    mob:setUnkillable(true)
+    mob:addListener("TAKE_DAMAGE", "BRIGANDISH_AT_ONE_PERCENT", function(defender, amount, attacker, attackType, damageType)
+        if defender:getHP() == 1 then
+            for _, SDT in ipairs(BB_physical_SDTs) do
+                defender:setMod(SDT, 0)
+            end
+            for _, SDT in ipairs(BB_elemental_SDTs) do
+                defender:setMod(SDT, 10000)
+            end
+            defender:setLocalVar("STDAPPLIED", 1)
+            defender:removeListener("BRIGANDISH_AT_ONCE_PERCENT")
+        end
+    end)
+    mob:addListener("TAKE_DAMAGE", "BRIGANDISH_POTENTIAL_DEATH_DAMAGE", function(defender, amount, attacker, attackType, damageType)
+        if
+            defender:getLocalVar("STDAPPLIED") == 1 and
+            attackType == xi.attackType.PHYSICAL and
+            attacker:getObjType() == xi.objType.PC and
+            attacker:getEquipID(xi.slot.MAIN) == xi.items.BUCCANEERS_KNIFE
+        then
+            defender:setUnkillable(false)
+            defender:setMod(xi.mod.WATER_SDT, 0)
+        end
+    end)
+end
+
 entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TERROR, {chance = 30})
 end

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -21741,6 +21741,12 @@ INSERT INTO `item_mods` VALUES (17621,9,3);
 INSERT INTO `item_mods` VALUES (17621,10,3);
 INSERT INTO `item_mods` VALUES (17621,20,9); -- WATER_RES
 INSERT INTO `item_mods` VALUES (17622,20,7); -- WATER_RES
+INSERT INTO `item_mods` VALUES (17622,431,13);   -- Buccaneer's Knife against Brigandish Blade (Additional effect: water Damage)
+INSERT INTO `item_mods` VALUES (17622,499,6);   -- Additional effect animation (subEffect)
+INSERT INTO `item_mods` VALUES (17622,500,30);  -- Additional effect damage
+INSERT INTO `item_mods` VALUES (17622,501,100);   -- Additional effect Chance 100%
+INSERT INTO `item_mods` VALUES (17622,950,6);   -- Additional effect element water (xi.magic.element)
+INSERT INTO `item_mods` VALUES (17622,952,360);   -- Power is Brigandish Blade's TargID (it's full ID is too big for data type)
 INSERT INTO `item_mods` VALUES (17623,11,2);
 INSERT INTO `item_mods` VALUES (17623,20,8); -- WATER_RES
 INSERT INTO `item_mods` VALUES (17623,298,2);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Many have tried, many have failed but... this should make Brigandish Blade retail accurate.

Behaviour matches: https://youtu.be/LaXD0oh307A?t=371

## Steps to test these changes

1. Load it up
2. Fight Brigandish
3. Use Buccaneer's Knife (notice the add effect works)
4. Swap to some other weapon
5. Notice how he takes zero damage from everything once he's at 1 HP
6. Swap to Buccaneer's Knife, hit does "0" damage still, but the water add effect kills him.
