### PR TITLE
Set cutscene bits for Promathia Mission 7-1

### DIFF
--- a/scripts/missions/cop/7_1_Chains_and_Bonds.lua
+++ b/scripts/missions/cop/7_1_Chains_and_Bonds.lua
@@ -93,13 +93,17 @@ mission.sections =
                 end,
 
                 [115] = function(player, csid, option, npc)
-                    if mission:getVar(player, 'Option') == 6 then
+                    mission:setVarBit(player, 'Option', 0)
+
+                    if mission:getVar(player, 'Option') == 7 then
                         mission:complete(player)
                     end
                 end,
 
                 [116] = function(player, csid, option, npc)
-                    if mission:getVar(player, 'Option') == 5 then
+                    mission:setVarBit(player, 'Option', 1)
+
+                    if mission:getVar(player, 'Option') == 7 then
                         mission:complete(player)
                     end
                 end,
@@ -120,7 +124,9 @@ mission.sections =
             onEventFinish =
             {
                 [14] = function(player, csid, option, npc)
-                    if mission:getVar(player, 'Option') == 3 then
+                    mission:setVarBit(player, 'Option', 2)
+
+                    if mission:getVar(player, 'Option') == 7 then
                         mission:complete(player)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Closes #1860
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Trigger the remaining 3 cutscenes for CoP M7-1.  Cutscenes should not be repeatable, and mission should be completed following watching all three.