### PR TITLE
[Mission] CoP 2-3 Oil Lamp Location Fixes

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rn.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Water (West)
+--  NPC: Oil Lamp - Darkness (West)
 -- !pos -63 -26 77
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,20 +12,19 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+2) -- water lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+7) -- Dark lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.WATERSDAY) then
-        if (GetNPCByID(DoorOffset+7):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rk
-        end
-    elseif (day == xi.day.LIGHTNINGDAY) then
-        if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-2):openDoor(15) -- Open Door _0rk
+    if
+        day == xi.day.LIGHTSDAY or
+        day == xi.day.DARKSDAY
+    then
+        if GetNPCByID(doorOffset+1):getAnimation() == 8 then -- Is the Light lamp open?
+            GetNPCByID(doorOffset-2):openDoor(15) -- Opens Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ro.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Ice (West)
+--  NPC: Oil Lamp - Light (West)
 -- !pos -63 -26 73
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,20 +12,19 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+4) -- ice lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+6) -- Light lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.FIRESDAY) then
-        if (GetNPCByID(DoorOffset+6):getAnimation() == 8) then -- lamp fire open?
-            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rk
-        end
-    elseif (day == xi.day.ICEDAY) then -- iceday
-        if (GetNPCByID(DoorOffset+5):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-3):openDoor(15) -- Open Door _0rk
+    if
+        day == xi.day.LIGHTSDAY or
+        day == xi.day.DARKSDAY
+    then
+        if GetNPCByID(doorOffset-1):getAnimation() == 8 then -- Is the Dark lamp open?
+            GetNPCByID(doorOffset-3):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rp.lua
@@ -12,20 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+5) -- lighting lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+5) -- Thunder lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.LIGHTNINGDAY) then
-        if (GetNPCByID(DoorOffset-2):getAnimation() == 8) then -- lamp water open ?
-            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rk
+    if day == xi.day.LIGHTNINGDAY then
+        if GetNPCByID(doorOffset+3):getAnimation() == 8 then -- Is the Water lamp open?
+            GetNPCByID(doorOffset-4):openDoor(15) -- Open Door _0rk
         end
-    elseif (day == xi.day.EARTHSDAY) then
-        if (GetNPCByID(DoorOffset+2):getAnimation() == 8) then -- lamp earth open ?
-            GetNPCByID(DoorOffset-4):openDoor(15) -- Open Door _0rk
+    elseif day == xi.day.EARTHSDAY then
+        if GetNPCByID(doorOffset+4):getAnimation() == 8 then -- Is the Earth lamp open?
+            GetNPCByID(doorOffset-4):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rq.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Light (West)
+--  NPC: Oil Lamp - Ice (West)
 -- !pos -63 -26 63
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,16 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+6) -- light lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+4) -- Ice lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.LIGHTSDAY or day == xi.day.DARKSDAY) then
-        if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp dark open?
-            GetNPCByID(DoorOffset-5):openDoor(15) -- Open Door _0rk
+    if day == xi.day.FIRESDAY then
+        if GetNPCByID(doorOffset+4):getAnimation() == 8 then -- Is the Fire lamp open?
+            GetNPCByID(doorOffset-5):openDoor(15) -- Open Door _0rk
+        end
+    elseif day == xi.day.ICEDAY then
+        if GetNPCByID(doorOffset+1):getAnimation() == 8 then -- Is the Wind lamp open?
+            GetNPCByID(doorOffset-5):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rr.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Darkness (West)
+--  NPC: Oil Lamp - Wind (West)
 -- !pos -63 -26 57
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,16 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+7) -- dark lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+3) -- Wind lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.LIGHTSDAY or day == xi.day.DARKSDAY) then
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp light open ?
-            GetNPCByID(DoorOffset-6):openDoor(15) -- Open Door _0rk
+    if day == xi.day.WINDSDAY then
+        if GetNPCByID(doorOffset+2):getAnimation() == 8 then -- Is the Earth lamp open?
+            GetNPCByID(doorOffset-6):openDoor(15) -- Open Door _0rk
+        end
+    elseif day == xi.day.ICEDAY then
+        if GetNPCByID(doorOffset-1):getAnimation() == 8 then -- Is the Ice lamp open?
+            GetNPCByID(doorOffset-6):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rs.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Earth (West)
+--  NPC: Oil Lamp - Water (West)
 -- !pos -63 -26 53
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,20 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+1) -- earth lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+2) -- Water lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.WINDSDAY) then
-        if (GetNPCByID(DoorOffset+1):getAnimation() == 8) then -- lamp wind open?
-            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rk
+    if day == xi.day.WATERSDAY then
+        if GetNPCByID(doorOffset+2):getAnimation() == 8 then -- Is the Fire lamp open?
+            GetNPCByID(doorOffset-7):openDoor(15) -- Open Door _0rk
         end
-    elseif (day == xi.day.EARTHSDAY) then
-        if (GetNPCByID(DoorOffset-3):getAnimation() == 8) then -- lamp lightning open?
-            GetNPCByID(DoorOffset-7):openDoor(15) -- Open Door _0rk
+    elseif day == xi.day.LIGHTNINGDAY then
+        if GetNPCByID(doorOffset-3):getAnimation() == 8 then -- Is the Thunder lamp open?
+            GetNPCByID(doorOffset-7):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0rt.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: Oil Lamp - Wind (West)
+--  NPC: Oil Lamp - Earth (West)
 -- !pos -63 -26 47
 -----------------------------------
 local ID = require("scripts/zones/Phomiuna_Aqueducts/IDs")
@@ -12,20 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET+3) -- wind lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET+1) -- Earth lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.WINDSDAY) then
-        if (GetNPCByID(DoorOffset-1):getAnimation() == 8) then -- lamp earth open?
-            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rk
+    if day == xi.day.WINDSDAY then
+        if GetNPCByID(doorOffset-2):getAnimation() == 8 then -- Is the Wind lamp open?
+            GetNPCByID(doorOffset-8):openDoor(15) -- Open Door _0rk
         end
-    elseif (day == xi.day.ICEDAY) then
-        if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- lamp ice open?
-            GetNPCByID(DoorOffset-8):openDoor(15) -- Open Door _0rk
+    elseif day == xi.day.EARTHSDAY then
+        if GetNPCByID(doorOffset-4):getAnimation() == 8 then -- Is the Thunder lamp open?
+            GetNPCByID(doorOffset-8):openDoor(15) -- Open Door _0rk
         end
     end
 

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_0ru.lua
@@ -12,20 +12,20 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    local DoorOffset = npc:getID()
+    local doorOffset = npc:getID()
 
-    player:messageSpecial(ID.text.LAMP_OFFSET) -- fire lamp
-    npc:openDoor(7) -- lamp animation
+    player:messageSpecial(ID.text.LAMP_OFFSET) -- Fire lamp
+    npc:openDoor(7) -- Lamp animation
 
     local day = VanadielDayOfTheWeek()
 
-    if (day == xi.day.FIRESDAY) then
-        if (GetNPCByID(DoorOffset-6):getAnimation() == 8) then -- ice lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rk
+    if day == xi.day.FIRESDAY then
+        if GetNPCByID(doorOffset-4):getAnimation() == 8 then -- Is the Ice lamp open?
+            GetNPCByID(doorOffset-9):openDoor(15) -- Door _0rk
         end
-    elseif (day == xi.day.WATERSDAY) then
-        if (GetNPCByID(DoorOffset-5):getAnimation() == 8) then -- water lamp open?
-            GetNPCByID(DoorOffset-9):openDoor(15) -- Door _0rk
+    elseif day == xi.day.WATERSDAY then
+        if GetNPCByID(doorOffset-2):getAnimation() == 8 then -- Is the Water lamp open?
+            GetNPCByID(doorOffset-9):openDoor(15) -- Door _0rk
         end
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes Oil Lamp locations from South to North in Phomiuna Aqueducts.

## Steps to test these changes

1) Type: !pos -63 -26 43
2) Click Oil Lamps in order from South to North to get the corresponding messages. During a specific day a set of two lamps should open the next door.

**Order:**
Opens door to south room.
Fire
Earth
Water
Wind
Ice
Thunder (Lightning)
Light
Darkness
Opens door to north room.

**Solutions for door**
Firesday: Fire and Ice
Iceday: Ice and Wind
Windsday: Wind and Earth
Earthsday: Earth and Thunder
Lightningsday: Thunder and Water
Watersday: Water and Fire
Lightsday: Light and Dark
Darksday: Dark and Light