### PR TITLE
Fix RoV Progression for Inescapable Binds

### DIFF
--- a/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
+++ b/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
@@ -97,7 +97,7 @@ local function handleSelectionEventFinish(player, csid, option, npc)
     then
         if quest:complete(player) then
             npcUtil.giveKeyItem(player, xi.ki.BOARDING_PERMIT)
-            npcUtil.completeMission(player, xi.mission.log_id.ROV, xi.mission.id.rov.INESCAPABLE_BINDS, { nextMission = xi.mission.id.rov.DESERT_WINDS, })
+            npcUtil.completeMission(player, xi.mission.log_id.ROV, xi.mission.id.rov.INESCAPABLE_BINDS, { nextMission = { xi.mission.log_id.ROV, xi.mission.id.rov.DESERT_WINDS } })
         end
     -- Let me think about it.
     elseif option == 2 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes nextMission parameter for Inescapable Binds when interacting with Faursel

Closes #1891 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Select the "Where's Tenzen" option from Faursel for obtaining your boarding permit
<!-- Clear and detailed steps to test your changes here -->
