### PR TITLE
 hook up super family to actually use it and add latent effect trigger for it

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1751,8 +1751,9 @@ xi.latent =
     WEAPON_DRAWN_MP_OVER     = 56, -- while weapon is drawn and mp greater than # - PARAM: MP #
     ELEVEN_ROLL_ACTIVE       = 57, -- corsair roll of 11 active
     IN_ASSAULT               = 58, -- is in an Instance battle in a TOAU zone
-    VS_ECOSYSTEM             = 59, -- Vs. Specific Ecosystem ID (e.g. Vs. Birds: Accuracy+3)
-    VS_FAMILY                = 60, -- Vs. Specific Family ID (e.g. Vs. Apkallu: Accuracy+3)
+    VS_ECOSYSTEM             = 59, -- Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
+    VS_FAMILY                = 60, -- Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
+    VS_SUPERFAMILY           = 61, -- Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
 }
 
 -----------------------------------

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -49,7 +49,7 @@ CREATE TABLE `mob_family_system` (
 -- Dumping data for table `mob_family_system`
 --
 
--- "family, superFamily, ecosystem" relationship: Korrigan, Madragora, Plantoid
+-- "family, superFamily, ecosystem" relationship: Korrigan, Mandragora, Plantoid
 -- Nothing is enforced so it is possible to use completely unrelated values
 LOCK TABLES `mob_family_system` WRITE;
 /*!40000 ALTER TABLE `mob_family_system` DISABLE KEYS */;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -83,6 +83,7 @@ CMobEntity::CMobEntity()
     m_AllowRespawn = false;
     m_DropItemTime = 0;
     m_Family       = 0;
+    m_SuperFamily  = 0;
     m_Type         = MOBTYPE_NORMAL;
     m_Behaviour    = BEHAVIOUR_NONE;
     m_SpawnType    = SPAWNTYPE_NORMAL;

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -239,6 +239,7 @@ public:
     int16  m_THLvl;       // Highest Level of Treasure Hunter that apply to drops
     bool   m_ItemStolen;  // if true, mob has already been robbed. reset on respawn. also used for thf maat fight
     uint16 m_Family;
+    uint16 m_SuperFamily;
     uint16 m_MobSkillList; // Mob skill list defined from mob_pools
     uint32 m_Pool;         // pool the mob came from
 

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -86,7 +86,7 @@ enum class LATENT : uint16
     WEAPON_DRAWN_MP_OVER = 56, // while weapon is drawn and mp greater than # - PARAM: MP #
     ELEVEN_ROLL_ACTIVE   = 57, // corsair roll of 11 active
     IN_ASSAULT           = 58, // is in an Instance battle in a TOAU zone
-    VS_ECOSYSTEM         = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Birds: Accuracy+3)
+    VS_ECOSYSTEM         = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
     VS_FAMILY            = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
     VS_SUPERFAMILY       = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
 };

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -94,13 +94,13 @@ enum class LATENT : uint16
 #define MAX_LATENTEFFECTID 61
 
 /************************************************************************
- *																		*
- *  Нерешенные задачи:													*
- *																		*
- *  - сохранение ID сущности, добавившей эффект							*
- *  - обновление эффекта (например перезапись protect 1 на protect 2)    *
- *																		*
- ************************************************************************/
+*                                                                       *
+* Unsolved problems:                                                    *
+*                                                                       *
+* - saving the ID of the entity that added the effect                   *
+* - updating effect (for example, overwriting protect 1 with protect 2) *
+*                                                                       *
+************************************************************************/
 
 class CBattleEntity;
 

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -87,7 +87,8 @@ enum class LATENT : uint16
     ELEVEN_ROLL_ACTIVE   = 57, // corsair roll of 11 active
     IN_ASSAULT           = 58, // is in an Instance battle in a TOAU zone
     VS_ECOSYSTEM         = 59, // Vs. Specific Ecosystem ID (e.g. Vs. Birds: Accuracy+3)
-    VS_FAMILY            = 60, // Vs. Specific Family ID (e.g. Vs. Apkallu: Accuracy+3)
+    VS_FAMILY            = 60, // Vs. Specific Family ID (e.g. Vs. Korrigan: Accuracy+3)
+    VS_SUPERFAMILY       = 61, // Vs. Specific SuperFamily ID (e.g. Vs. Mandragora: Accuracy+3)
 };
 
 #define MAX_LATENTEFFECTID 61

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -637,6 +637,7 @@ void CLatentEffectContainer::CheckLatentsTargetChange()
             case LATENT::SIGNET_BONUS:
             case LATENT::VS_ECOSYSTEM:
             case LATENT::VS_FAMILY:
+            case LATENT::VS_SUPERFAMILY:
                 return ProcessLatentEffect(latentEffect);
             default:
                 break;
@@ -1127,6 +1128,16 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                 if (PMob)
                 {
                     expression = PMob->m_Family == latentEffect.GetConditionsValue();
+                }
+            }
+            break;
+        case LATENT::VS_SUPERFAMILY:
+            if (CBattleEntity* PTarget = m_POwner->GetBattleTarget())
+            {
+                CMobEntity* PMob = dynamic_cast<CMobEntity*>(PTarget);
+                if (PMob)
+                {
+                    expression = PMob->m_SuperFamily == latentEffect.GetConditionsValue();
                 }
             }
             break;

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -41,9 +41,9 @@ CLatentEffectContainer::CLatentEffectContainer(CCharEntity* PEntity)
 }
 
 /************************************************************************
- *																		*
- *  Adds new latent effect to the character.								*
- *																		*
+*                                                                       *
+* Adds new latent effect to the character.                              *
+*                                                                       *
  ************************************************************************/
 
 void CLatentEffectContainer::AddLatentEffects(std::vector<CItemEquipment::itemLatent>& latentList, uint8 reqLvl, uint8 slot)
@@ -65,9 +65,9 @@ void CLatentEffectContainer::AddLatentEffects(std::vector<CItemEquipment::itemLa
 }
 
 /************************************************************************
- *																		*
- *  Removes all latent effects associated with a specified slot			*
- *																		*
+*                                                                       *
+* Removes all latent effects associated with a specified slot           *
+*                                                                       *
  ************************************************************************/
 
 void CLatentEffectContainer::DelLatentEffects(uint8 reqLvl, uint8 slot)
@@ -98,10 +98,10 @@ bool CLatentEffectContainer::DelLatentEffect(LATENT conditionID, uint16 conditio
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by HP and activates them if  	*
- *  the conditions are met.												*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by HP and activates them if      *
+* the conditions are met.                                               *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsHP()
 {
@@ -126,10 +126,10 @@ void CLatentEffectContainer::CheckLatentsHP()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by TP and activates them if  	*
- *  the conditions are met.												*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by TP and activates them if      *
+* the conditions are met.                                               *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsTP()
 {
@@ -152,10 +152,10 @@ void CLatentEffectContainer::CheckLatentsTP()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by MP and activates them if  	*
- *  the conditions are met.												*
- *																		*
+*                                                                       *
+ * Checks all latents that are affected by MP and activates them if     *
+ * the conditions are met.                                              *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsMP()
 {
@@ -178,9 +178,9 @@ void CLatentEffectContainer::CheckLatentsMP()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents for a given slot (ie. on equip)					*
- *																		*
+*                                                                       *
+ * Checks all latents for a given slot (ie. on equip)                   *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
 {
@@ -194,10 +194,10 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by drawn weapon and activates  	*
- *  them if the conditions are met.										*
- *																		*
+*                                                                       *
+ * Checks all latents that are affected by drawn weapon and activates   *
+ * them if the conditions are met.                                      *
+*                                                                       *
  ************************************************************************/
 
 // easy: when animationType changes to ANIMATION_ATTACK or to something else
@@ -259,10 +259,10 @@ void CLatentEffectContainer::CheckLatentsWeaponDraw(bool drawn)
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by status effects and activates	*
- *  them if the conditions are met.										*
- *																		*
+*                                                                       *
+ * Checks all latents that are affected by status effects and activates *
+ * them if the conditions are met.                                      *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsStatusEffect()
 {
@@ -282,11 +282,11 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
 }
 
 /************************************************************************
- *																		*
- *  Checks latents that are affected by food effects. Usage:				*
- *  LATENT_FOOD_ACTIVE: (49,foodItemId)									*
- *  LATENT_NO_FOOD_ACTIVE: (14,0)										*
- *																		*
+*                                                                       *
+ * Checks latents that are affected by food effects. Usage:             *
+ * LATENT_FOOD_ACTIVE: (49,foodItemId)                                  *
+ * LATENT_NO_FOOD_ACTIVE: (14,0)                                        *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsFoodEffect()
 {
@@ -305,10 +305,10 @@ void CLatentEffectContainer::CheckLatentsFoodEffect()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by rolls or songs and activates *
- *  them if the conditions are met.										*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by rolls or songs and activates  *
+* them if the conditions are met.                                       *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsRollSong()
 {
@@ -327,10 +327,10 @@ void CLatentEffectContainer::CheckLatentsRollSong()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by day or moon and activates	*
- *  them if the conditions are met.										*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by day or moon and activates     *
+* them if the conditions are met.                                       *
+*                                                                       *
  ************************************************************************/
 
 // probably call this at 00:00 vana time only
@@ -350,9 +350,9 @@ void CLatentEffectContainer::CheckLatentsDay()
 }
 
 /************************************************************************
- *																		*
- *  Checks latents affected by the moon phase and activates them			*
- *																		*
+*                                                                       *
+* Checks latents affected by the moon phase and activates them          *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsMoonPhase()
 {
@@ -371,10 +371,10 @@ void CLatentEffectContainer::CheckLatentsMoonPhase()
 }
 
 /************************************************************************
- *																		*
- *  Checks latents that are affected by the day of the week and			*
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks latents that are affected by the day of the week and           *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsWeekDay()
 {
@@ -399,10 +399,10 @@ void CLatentEffectContainer::CheckLatentsWeekDay()
 }
 
 /************************************************************************
- *																		*
- *  Checks latents that are affected the hour and activates them			*
- *  if the conditions are met.											*
- *																		*
+*                                                                       *
+* Checks latents that are affected the hour and activates them          *
+* if the conditions are met.                                            *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsHours()
 {
@@ -421,10 +421,10 @@ void CLatentEffectContainer::CheckLatentsHours()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by party members and			*
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by party members and             *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsPartyMembers(size_t members)
 {
@@ -490,10 +490,10 @@ void CLatentEffectContainer::CheckLatentsPartyJobs()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by an avatar in party and		*
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by an avatar in party and        *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsPartyAvatar()
 {
@@ -511,10 +511,10 @@ void CLatentEffectContainer::CheckLatentsPartyAvatar()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by job level and			    *
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by job level and                 *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsJobLevel()
 {
@@ -533,10 +533,10 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by players pet type and			*
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by players pet type and          *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsPetType()
 {
@@ -554,10 +554,10 @@ void CLatentEffectContainer::CheckLatentsPetType()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by time of vana day and			*
- *  activates them if the conditions are met.							*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by time of vana day and          *
+* activates them if the conditions are met.                             *
+*                                                                       *
  ************************************************************************/
 
 // will probably only call this at transition points in the day
@@ -567,9 +567,9 @@ void CLatentEffectContainer::CheckLatentsTime()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents that are affected by weapon skill points			*
- *																		*
+*                                                                       *
+* Checks all latents that are affected by weapon skill points           *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 {
@@ -583,9 +583,9 @@ void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents regarding current zone							*
- *																		*
+*                                                                       *
+* Checks all latents regarding current zone                             *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsZone()
 {
@@ -608,9 +608,9 @@ void CLatentEffectContainer::CheckLatentsZone()
 }
 
 /************************************************************************
- *																		*
- *  Checks all latents regarding current weather							*
- *																		*
+*                                                                       *
+* Checks all latents regarding current weather                          *
+*                                                                       *
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsWeather()
 {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12439,6 +12439,21 @@ uint8 CLuaBaseEntity::getSystem()
 }
 
 /************************************************************************
+ *  Function: getSuperFamily()
+ *  Purpose : Returns the integer value of the associated Mob SuperFamily
+ *  Example : if mob:getSuperFamily() == 123 then
+ *  Notes   : To Do: Enumerate Mob Families in global script
+ ************************************************************************/
+
+uint16 CLuaBaseEntity::getSuperFamily()
+{
+    auto* entity = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    XI_DEBUG_BREAK_IF(!entity);
+
+    return entity->m_SuperFamily;
+}
+
+/************************************************************************
  *  Function: getFamily()
  *  Purpose : Returns the integer value of the associated Mob Family
  *  Example : if mob:getFamily() == 123 then
@@ -14522,7 +14537,8 @@ void CLuaBaseEntity::Register()
 
     // Mob Entity-Specific
     SOL_REGISTER("setMobLevel", CLuaBaseEntity::setMobLevel);
-    SOL_REGISTER("getSystem", CLuaBaseEntity::getSystem);
+    SOL_REGISTER("getSystem", CLuaBaseEntity::getSystem); // TODO: rename to getEcoSystem()
+    SOL_REGISTER("getSuperFamily", CLuaBaseEntity::getSuperFamily);
     SOL_REGISTER("getFamily", CLuaBaseEntity::getFamily);
     SOL_REGISTER("isMobType", CLuaBaseEntity::isMobType);
     SOL_REGISTER("isUndead", CLuaBaseEntity::isUndead);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -727,7 +727,8 @@ public:
 
     // Mob Entity-Specific
     void   setMobLevel(uint8 level);
-    uint8  getSystem();
+    uint8  getSystem(); // TODO: rename this to getEcosystem()
+    uint16 getSuperFamily();
     uint16 getFamily();
     bool   isMobType(uint8 mobType); // True if mob is of type passed to function
     bool   isUndead();               // True if mob is undead

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -355,7 +355,7 @@ namespace zoneutils
             slash_sdt, pierce_sdt, h2h_sdt, impact_sdt, \
             fire_sdt, ice_sdt, wind_sdt, earth_sdt, lightning_sdt, water_sdt, light_sdt, dark_sdt, \
             fire_res, ice_res, wind_res, earth_res, lightning_res, water_res, light_res, dark_res, \
-            Element, mob_pools.familyid, name_prefix, entityFlags, animationsub, \
+            Element, mob_pools.familyid, mob_family_system.superFamilyID, name_prefix, entityFlags, animationsub, \
             (mob_family_system.HP / 100), (mob_family_system.MP / 100), hasSpellScript, spellList, mob_groups.poolid, \
             allegiance, namevis, aggro, roamflag, mob_pools.skill_list_id, mob_pools.true_detection, mob_family_system.detects, \
             mob_family_system.charmable \
@@ -460,8 +460,9 @@ namespace zoneutils
 
                     PMob->m_Element     = (uint8)sql->GetIntData(58);
                     PMob->m_Family      = (uint16)sql->GetIntData(59);
-                    PMob->m_name_prefix = (uint8)sql->GetIntData(60);
-                    PMob->m_flags       = (uint32)sql->GetIntData(61);
+                    PMob->m_SuperFamily = (uint16)sql->GetIntData(60);
+                    PMob->m_name_prefix = (uint8)sql->GetIntData(61);
+                    PMob->m_flags       = (uint32)sql->GetIntData(62);
 
                     // Cap Level if Necessary (Don't Cap NMs)
                     if (normalLevelRangeMin > 0 && !(PMob->m_Type & MOBTYPE_NOTORIOUS) && PMob->m_minLevel > normalLevelRangeMin)
@@ -477,7 +478,7 @@ namespace zoneutils
                     // Special sub animation for Mob (yovra, jailer of love, phuabo)
                     // yovra 1: On top/in the sky, 2: , 3: On top/in the sky
                     // phuabo 1: Underwater, 2: Out of the water, 3: Goes back underwater
-                    PMob->animationsub = (uint32)sql->GetIntData(62);
+                    PMob->animationsub = (uint32)sql->GetIntData(63);
 
                     if (PMob->animationsub != 0)
                     {
@@ -485,28 +486,28 @@ namespace zoneutils
                     }
 
                     // Setup HP / MP Stat Percentage Boost
-                    PMob->HPscale = sql->GetFloatData(63);
-                    PMob->MPscale = sql->GetFloatData(64);
+                    PMob->HPscale = sql->GetFloatData(64);
+                    PMob->MPscale = sql->GetFloatData(65);
 
                     // TODO: Remove me
                     // Check if we should be looking up scripts for this mob
-                    //PMob->m_HasSpellScript = (uint8)sql->GetIntData(65);
+                    //PMob->m_HasSpellScript = (uint8)sql->GetIntData(66);
 
-                    PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(sql->GetIntData(66));
+                    PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(sql->GetIntData(67));
 
-                    PMob->m_Pool = sql->GetUIntData(67);
+                    PMob->m_Pool = sql->GetUIntData(68);
 
-                    PMob->allegiance = static_cast<ALLEGIANCE_TYPE>(sql->GetUIntData(68));
-                    PMob->namevis    = sql->GetUIntData(69);
-                    PMob->m_Aggro    = sql->GetUIntData(70);
+                    PMob->allegiance = static_cast<ALLEGIANCE_TYPE>(sql->GetUIntData(69));
+                    PMob->namevis    = sql->GetUIntData(70);
+                    PMob->m_Aggro    = sql->GetUIntData(71);
 
-                    PMob->m_roamFlags    = (uint16)sql->GetUIntData(71);
-                    PMob->m_MobSkillList = sql->GetUIntData(72);
+                    PMob->m_roamFlags    = (uint16)sql->GetUIntData(72);
+                    PMob->m_MobSkillList = sql->GetUIntData(73);
 
-                    PMob->m_TrueDetection = sql->GetUIntData(73);
-                    PMob->m_Detects       = sql->GetUIntData(74);
+                    PMob->m_TrueDetection = sql->GetUIntData(74);
+                    PMob->m_Detects       = sql->GetUIntData(75);
 
-                    PMob->setMobMod(MOBMOD_CHARMABLE, sql->GetUIntData(75));
+                    PMob->setMobMod(MOBMOD_CHARMABLE, sql->GetUIntData(76));
 
                     // Overwrite base family charmables depending on mob type. Disallowed mobs which should be charmable
                     // can be set in mob_spawn_mods or in their onInitialize


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Awhile back i added super families to the mob sql table in prep for some things. This PR continues with it and makes use of super families in the mob_family_system sql table so that we can't check against those for example with the latent this PR also adds.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
while targeting a mob:
`!exec player:PrintToPlayer(tostring(target:getSuperfamily()))`

A follow up PR will be using the latent this PR adds. Latent was only as far as ensuring some prints happened and nothing else got broken.

<!-- Clear and detailed steps to test your changes here -->
