### PR TITLE
[Fix] Update message when interrupting item usage

### DIFF
--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -240,10 +240,11 @@ void CItemState::TryInterrupt(CBattleEntity* PTarget)
         UpdateTarget(m_PEntity->IsValidTarget(m_targid, m_PItem->getValidTarget(), m_errorMsg));
     }
 
-    uint16 msg = 62; // the item fails to activate
+    uint16 msg = 445; // you cannot use items at this time
 
     if (HasMoved() || m_PEntity->StatusEffectContainer->HasPreventActionEffect())
     {
+        msg           = MSGBASIC_ITEM_FAILS_TO_ACTIVATE;
         m_interrupted = true;
     }
     else if (battleutils::IsParalyzed(m_PEntity))

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -240,7 +240,7 @@ void CItemState::TryInterrupt(CBattleEntity* PTarget)
         UpdateTarget(m_PEntity->IsValidTarget(m_targid, m_PItem->getValidTarget(), m_errorMsg));
     }
 
-    uint16 msg = 445; // you cannot use items at this time
+    uint16 msg = 62; // the item fails to activate
 
     if (HasMoved() || m_PEntity->StatusEffectContainer->HasPreventActionEffect())
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Addresses issue #835 where incorrect message is displayed when interrupting an item use.

## Steps to test these changes

1. Attempt to use an item while moving