### PR TITLE
[core] Add some basic warnings for SQL query latency after startup

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -64,6 +64,10 @@ using server_clock = std::chrono::system_clock;
 using time_point   = server_clock::time_point;
 using duration     = server_clock::duration;
 
+using hires_clock      = std::chrono::high_resolution_clock;
+using hires_time_point = server_clock::time_point;
+using hires_duration   = server_clock::duration;
+
 #include <queue>
 
 template <class T>

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -193,6 +193,8 @@ public:
 
     void HandleAsync();
 
+    void SetLatencyWarning(bool _LatencyWarning);
+
 private:
     Sql_t*      self;
     const char* m_User;
@@ -203,6 +205,7 @@ private:
 
     uint32 m_PingInterval;
     uint32 m_LastPing;
+    bool   m_LatencyWarning;
 
     void InitPreparedStatements();
     std::unordered_map<std::string, std::shared_ptr<SqlPreparedStatement>> m_PreparedStatements;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds some optional additional logging to track when SQL queries run long. Will be helpful in identifying when db's need to be cleared out. 

## Steps to test these changes

Run an artificially long query, or set `m_LatencyWarning` to true during startup, to see those long queries generate warnings.
