### PR TITLE
[core] Allow dynamic mobs to use mixins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,13 @@
 {
+    "C_Cpp.default.cppStandard": "c++17",
+    "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": true,
+    "C_Cpp.intelliSenseEngine": "Tag Parser",
+
+    "editor.bracketPairColorization.enabled": true,
+    "editor.renderWhitespace": "all",
+    "editor.renderControlCharacters": true,
+    "editor.trimAutoWhitespace": true,
+
     "Lua.workspace.maxPreload": 20000,
     "Lua.diagnostics.globals": [
         "xi",
@@ -441,7 +450,6 @@
     "Lua.hint.setType": true,
     "Lua.runtime.version": "LuaJIT",
     "Lua.workspace.preloadFileSize": 10000,
-    "editor.renderWhitespace": "all",
     "files.associations": {
         "algorithm": "cpp",
         "any": "cpp",
@@ -536,5 +544,5 @@
         "coroutine": "cpp",
         "resumable": "cpp",
         "typeindex": "cpp"
-    }
+    },
 }

--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -45,6 +45,13 @@ function onTrigger(player)
         -- If set to true, the internal id assigned to this mob will be released for other dynamic entities to use
         -- after this mob has died. Defaults to false.
         releaseIdOnDeath = true,
+
+        -- You can apply mixins like you would with regular mobs. mixinOptions aren't supported yet.
+        mixins =
+        {
+            require("scripts/mixins/rage"),
+            require("scripts/mixins/job_special"),
+        }
     })
 
     -- Use the mob object as you normally would

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -266,6 +266,18 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     }
     else if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
     {
+        auto mixins = table["mixins"].get_or<sol::table>(sol::lua_nil);
+        if (mixins.valid())
+        {
+            // Use the global function "applyMixins"
+            auto result = lua["applyMixins"](CLuaBaseEntity(PMob), mixins);
+            if (!result.valid())
+            {
+                sol::error err = result;
+                ShowError("applyMixins: %s: %s", PMob->name.c_str(), err.what());
+            }
+        }
+
         luautils::OnEntityLoad(PMob);
 
         luautils::OnMobInitialize(PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Allow dynamic mobs to use mixins, with the same format as regular mobs. Set up fafnir as an example.

## Steps to test these changes

Put a print in `rage.lua`, give `!fafnir` rage, use `!fafnir`, see print