### PR TITLE
[core] Protect navmesh access in battleutils::DrawIn

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5881,7 +5881,10 @@ namespace battleutils
         position_t  nearEntity = nearPosition(pos, offset, (float)0);
 
         // Snap nearEntity to a guaranteed valid position
-        PMob->loc.zone->m_navMesh->snapToValidPosition(nearEntity);
+        if (PMob->loc.zone->m_navMesh)
+        {
+            PMob->loc.zone->m_navMesh->snapToValidPosition(nearEntity);
+        }
 
         // Move the target a little higher, just in case
         nearEntity.y -= 1.0f;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/1890

So what has been happening here is this:

Regular pathing and fighting in any zone, with any mob, at any distance is fine without navmesh data.

During Draw in:
```cpp
    bool DrawIn(CBattleEntity* PTarget, CMobEntity* PMob, float offset)
    {
        position_t& pos        = PMob->loc.p;
        position_t  nearEntity = nearPosition(pos, offset, (float)0);

        // Snap nearEntity to a guaranteed valid position
        PMob->loc.zone->m_navMesh->snapToValidPosition(nearEntity);
                                          ^---- here
```

We're assuming the navmesh exists, so we try to call snapToValidPosition on a bit of memory that doesn't exist. The stacktrace in the issue is misleading, as its taking you into m_navMesh as if it were there, but it isn't.

## Steps to test these changes

- Rename your `navmeshes` folder to something else
- Fire up the server
- Go fight something that draws in, and run away
- Before fix: You'll hit a crash
- After fix: No crash
