### PR TITLE
[Fix] Show warning message when fishing is disabled

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1906,6 +1906,14 @@ namespace fishingutils
 
     void StartFishing(CCharEntity* PChar)
     {
+        if (map_config.fishing_enable == 0)
+        {
+            ShowWarning("Fishing is currently disabled");
+            PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Fishing is currently disabled"));
+            PChar->pushPacket(new CReleasePacket(PChar, RELEASE_TYPE::FISHING));
+            return;
+        }
+
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_INVISIBLE);
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HIDE);
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_CAMOUFLAGE);
@@ -2586,6 +2594,14 @@ namespace fishingutils
 
     void FishingAction(CCharEntity* PChar, FISHACTION action, uint16 stamina, uint32 special)
     {
+        if (map_config.fishing_enable == 0)
+        {
+            ShowWarning("Fishing is currently disabled, but somehow we have someone commencing a fishing action");
+            // Unlikely anyone can get here legit, since we already disabled "startFishing"
+            PChar->animation = ANIMATION_FISHING_STOP;
+            return;
+        }
+
         uint16 MessageOffset = GetMessageOffset(PChar->getZone());
         uint32 vanaTime      = CVanaTime::getInstance()->getVanaTime();
 


### PR DESCRIPTION
Co-authored-by: TeoTwawki <TeoTwawki@users.noreply.github.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

It stops players from being locked in place when attempting to fish when fishing is disabled

## Steps to test these changes

Build and fish without enabling fishing
