### PR TITLE
[core] Add !build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ memcheck.out.*
 
 # Auto-generated files
 /src/common/version.cpp
+
+# Module init file
+modules/init.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -442,6 +442,7 @@
         "GetQuestAndMissionFilenamesList",
         "GetCachedInstanceScript",
         "ForceCrash",
+        "BuildString",
     ],
     "Lua.diagnostics.disable": [
         "lowercase-global"

--- a/cmake/Git.cmake
+++ b/cmake/Git.cmake
@@ -2,7 +2,7 @@
 find_package(Git)
 
 execute_process(COMMAND
-    "${GIT_EXECUTABLE}" describe --match=NeVeRmAtCh --always --abbrev=40 --dirty
+    "${GIT_EXECUTABLE}" describe --match=NeVeRmAtCh --always --dirty
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_SHA1
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/scripts/commands/build.lua
+++ b/scripts/commands/build.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- func: build
+-- desc: Print the server's current build information
+-----------------------------------
+
+cmdprops =
+{
+    permission = 0,
+    parameters = ""
+}
+
+function onTrigger(player, target)
+    player:PrintToPlayer(BuildString())
+end

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -199,6 +199,17 @@ namespace luautils
         lua.set_function("ForceCrash", []() { crash(); });
         // clang-format on
 
+        // clang-format off
+        lua.set_function("BuildString", []()
+        {
+            return fmt::format("{}-{}\n{}\n{}",
+                version::GetGitBranch(),
+                version::GetGitSha(),
+                version::GetGitCommitSubject(),
+                version::GetGitDate());
+        });
+        // clang-format on
+
         // Register Sol Bindings
         CLuaAbility::Register();
         CLuaAction::Register();

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -215,6 +215,9 @@ global_objects=(
     PERIQIA_ASSAULT_POINT
     ILRUSI_ASSAULT_POINT
     NYZUL_ISLE_ASSAULT_POINT
+
+    ForceCrash
+    BuildString
 )
 
 ignores=(


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds the !build command, available to all players.

https://github.com/LandSandBoat/server/issues/1928

## Steps to test these changes

`!build`

![image](https://user-images.githubusercontent.com/1389729/173011777-fd1d4c77-d22e-4245-93dd-914a0f42d96d.png)
^Taken with long-hash, we use short-hash now

![image](https://user-images.githubusercontent.com/1389729/173013617-cbe84016-1068-4e0b-b4f2-78d4f82a7cf4.png)
