### PR TITLE
Fix BCNM Icon display for Level Sync and Campaign status

### DIFF
--- a/src/map/packets/char_sync.cpp
+++ b/src/map/packets/char_sync.cpp
@@ -39,15 +39,15 @@ CCharSyncPacket::CCharSyncPacket(CCharEntity* PChar)
 
     ref<uint8>(0x10) = PChar->StatusEffectContainer->HasStatusEffect(EFFECT_ALLIED_TAGS) ? 2 : 0; // 0x02 - Campaign Battle, 0x04 - Level Sync
 
-    if (PChar->m_LevelRestriction)
+    if (PChar->m_LevelRestriction && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
     {
-        ref<uint8>(0x10) |= 6;
-
-        if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
+        if (PChar->PBattlefield == nullptr)
         {
+            // Only display the level sync icon outside of BCNMs
             ref<uint8>(0x10) |= 4;
-            ref<uint8>(0x26) = PChar->m_LevelRestriction;
         }
+
+        ref<uint8>(0x26) = PChar->m_LevelRestriction;
     }
 
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_MOUNTED))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Removes Campaign icon being added inside of BCNMs
* Removes Level Sync Icon being displayed if inside of BCNM

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Enter a BCNM, and ensure neither icon is displayed
2. Level Sync outside of BCNM to ensure icon is displayed
<!-- Clear and detailed steps to test your changes here -->
