### PR TITLE
Fix syntax in quest - A Journey Begins

### DIFF
--- a/scripts/quests/abyssea/A_Journey_Begins.lua
+++ b/scripts/quests/abyssea/A_Journey_Begins.lua
@@ -26,44 +26,44 @@ quest.sections =
         check = function(player, status, vars)
             return status == QUEST_ACCEPTED and player:getMainLvl() >= 30
         end,
-    },
 
-    [xi.zone.PORT_JEUNO] =
-    {
-        ['Joachim'] =
+        [xi.zone.PORT_JEUNO] =
         {
-            onTrigger = function(player, npc)
-                if quest:getVar(player, 'Prog') == 1 then
-                    return quest:progressEvent(325)
-                end
-            end,
-        },
+            ['Joachim'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(325)
+                    end
+                end,
+            },
 
-        onZoneIn =
-        {
-            function(player, prevZone)
-                if quest:getVar(player, 'Prog') == 0 then
-                    return 324
-                end
-            end,
-        },
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return 324
+                    end
+                end,
+            },
 
-        onEventFinish =
-        {
-            [324] = function(player, csid, option, npc)
-                quest:setVar(player, 'Prog', 1)
-            end,
+            onEventFinish =
+            {
+                [324] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
 
-            [325] = function(player, csid, option, npc)
-                if quest:complete(player) then
+                [325] = function(player, csid, option, npc)
+                    if quest:complete(player) then
 
-                    -- Traverser Stone epoch begins when 'The Truth Beckons' is flagged, and is
-                    -- retail behavior.  This can be confirmed by checking the currency tab on
-                    -- retail servers.
-                    player:setTraverserEpoch()
-                    player:addQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.THE_TRUTH_BECKONS)
-                end
-            end,
+                        -- Traverser Stone epoch begins when 'The Truth Beckons' is flagged, and is
+                        -- retail behavior.  This can be confirmed by checking the currency tab on
+                        -- retail servers.
+                        player:setTraverserEpoch()
+                        player:addQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.THE_TRUTH_BECKONS)
+                    end
+                end,
+            },
         },
     },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes #1734 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Zone into Port Jeuno with Quest added
<!-- Clear and detailed steps to test your changes here -->
