### PR TITLE
Add csid check to Event Update for Unity global

### DIFF
--- a/scripts/globals/unity.lua
+++ b/scripts/globals/unity.lua
@@ -149,40 +149,42 @@ function xi.unity.onEventUpdate(player, csid, option)
     local category  = bit.band(option, 0xF)
     local selection = bit.band(bit.rshift(option, 5), 0xFF)
 
-    if option == 10 then
-        player:updateEvent(0, 0, 0, remainingLimit, 0, 0, 0, 0)
+    if csid == zoneEventIds[zoneId][4] then
+        if option == 10 then
+            player:updateEvent(0, 0, 0, remainingLimit, 0, 0, 0, 0)
 
-    -- Item Selected, enter amount/confirm
-    elseif category == 3 then
-        player:updateEvent(unityOptions[4][selection][2], unityOptions[4][selection][3], 0, 0, 0, 0, 0, player:getUnityLeader())
+        -- Item Selected, enter amount/confirm
+        elseif category == 3 then
+            player:updateEvent(unityOptions[4][selection][2], unityOptions[4][selection][3], 0, 0, 0, 0, 0, player:getUnityLeader())
 
-    -- Attempt to grant the Item selected
-    elseif category == 4 then
-        local qty = bit.rshift(option, 13)
-        local itemId = unityOptions[category][selection][1]
-        local cost = unityOptions[category][selection][4] * qty
+        -- Attempt to grant the Item selected
+        elseif category == 4 then
+            local qty = bit.rshift(option, 13)
+            local itemId = unityOptions[category][selection][1]
+            local cost = unityOptions[category][selection][4] * qty
 
-        if npcUtil.giveItem(player, { {itemId, qty} }) then
-            accolades = accolades - cost
-            player:delCurrency("unity_accolades", cost)
-            if xi.settings.ENABLE_EXCHANGE_LIMIT == 1 then
-                remainingLimit = remainingLimit - cost
-                player:setCharVar("weekly_accolades_spent", weeklyAccoladesSpent + cost)
+            if npcUtil.giveItem(player, { {itemId, qty} }) then
+                accolades = accolades - cost
+                player:delCurrency("unity_accolades", cost)
+                if xi.settings.ENABLE_EXCHANGE_LIMIT == 1 then
+                    remainingLimit = remainingLimit - cost
+                    player:setCharVar("weekly_accolades_spent", weeklyAccoladesSpent + cost)
+                end
+
+                player:updateEvent(itemId, qty, accolades, remainingLimit, 0, 0, 0, player:getUnityLeader())
+            else
+                player:updateEvent(utils.MAX_UINT32)
             end
 
-            player:updateEvent(itemId, qty, accolades, remainingLimit, 0, 0, 0, player:getUnityLeader())
-        else
-            player:updateEvent(utils.MAX_UINT32)
-        end
-
-    -- Change Unity
-    elseif category == 5 then
-        if player:getCharVar("unity_changed") == 1 then
-            player:updateEvent(utils.MAX_UINT32)
-            player:messageSpecial(ID.text.HAVE_ALREADY_CHANGED_UNITY, option)
-        else
-            local changeUnityCost = getChangeUnityCost(player, selection)
-            player:updateEvent(changeUnityCost, changeUnityCost)
+        -- Change Unity
+        elseif category == 5 then
+            if player:getCharVar("unity_changed") == 1 then
+                player:updateEvent(utils.MAX_UINT32)
+                player:messageSpecial(ID.text.HAVE_ALREADY_CHANGED_UNITY, option)
+            else
+                local changeUnityCost = getChangeUnityCost(player, selection)
+                player:updateEvent(changeUnityCost, changeUnityCost)
+            end
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Removes errant event update when progressing through 'All for One' involving a refractive crystal by adding csid check to event update.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Progress through 'All for One' event
2. Progress through Unity NPC menu and either warp or purchase item to verify function
<!-- Clear and detailed steps to test your changes here -->
