### PR TITLE
[mobskills] add 1.0 to breath attacks combinedDamageTaken

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -502,7 +502,7 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
 
     local globalDamageTaken   = target:getMod(xi.mod.DMG) / 10000          -- Mod is base 10000
     local breathDamageTaken   = target:getMod(xi.mod.DMGBREATH) / 10000    -- Mod is base 10000
-    local combinedDamageTaken = utils.clamp(breathDamageTaken + globalDamageTaken, -0.5, 0.5) -- The combination of regular "Damage Taken" and "Breath Damage Taken" caps at 50%. There is no BDTII known as of yet.
+    local combinedDamageTaken = 1.0 +  utils.clamp(breathDamageTaken + globalDamageTaken, -0.5, 0.5) -- The combination of regular "Damage Taken" and "Breath Damage Taken" caps at 50%. There is no BDTII known as of yet.
 
     damage = math.floor(damage * combinedDamageTaken)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This fixes Breath attacks doing 0 damage most of the time. IE, the
damage line that uses combinedDamageTaken pretty much just mutliplies
by zero all the time. In fact, if you have breath damage taken, you
get healed! Fun, but not accurate.
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Force Greater Manticore to only use Heat Breath
2. Go to Cape Terrigan and fight, watch 0 dmg Heat Breaths
