### PR TITLE
[tools] Remove zmq.sugar.constants dependency from announce.py

### DIFF
--- a/tools/announce.py
+++ b/tools/announce.py
@@ -14,8 +14,6 @@ import sys
 import zmq
 import struct
 
-from zmq.sugar.constants import NOBLOCK
-
 # ENUM: Send to every character, in every zone, on every map process
 MSG_CHAT_SERVMES = 6
 
@@ -60,7 +58,7 @@ def send_server_message(msg):
         struct.pack("!B", MSG_CHAT_SERVMES),
         b"\0",
         buffer
-    ], NOBLOCK)
+    ], zmq.NOBLOCK)
 
 def main():
     if len(sys.argv) < 2:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes https://github.com/LandSandBoat/server/issues/1967

## Steps to test these changes

Windows:
```
PS C:\ffxi\server\tools> python .\announce.py hello
Sending 'hello'
```

Linux:
```
zach2good@ZACH-LAPTOP:/mnt/c/ffxi/server/tools$ python3 announce.py hello
Sending 'hello'
```