### PR TITLE
Limit ID range that can be passed into `addSpell()` to be 1-1023

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3201,7 +3201,8 @@ namespace charutils
 
     int32 addSpell(CCharEntity* PChar, uint16 SpellID)
     {
-        if (!hasSpell(PChar, SpellID))
+        // Todo: come up with a good way to validate that the SpellID exists in the database also.
+        if (SpellID > 0 && SpellID < 1024 && !hasSpell(PChar, SpellID))
         {
             PChar->m_SpellList[SpellID] = true;
             return 1;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [:crossed_fingers:] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Limits spell IDs the core will try to set on a player to the legit range that exists in the client dat file.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Try and `!addspell` spell ID of 0 or 1024 or higher.
<!-- Clear and detailed steps to test your changes here -->

If anyone has a quick suggestion on how to check if the spell ID being passed also exists in our database, I'd like to add that as well - not all 1023 slots are used at present. I tried it and it didn't seem to crash me at least, but it did bug out my clients list display till I zoned. Wasn't super thorough with this.
