### PR TITLE
[login] Add limit per IP

### DIFF
--- a/conf/default/login.conf
+++ b/conf/default/login.conf
@@ -64,8 +64,8 @@ servername: Nameless
 msg_server_port: 54003
 msg_server_ip: 127.0.0.1
 
-#Number of simultaneous game sessions per IP
-login_limit: 1
+#Number of simultaneous game sessions per IP (0 for no limit)
+login_limit: 0
 
 #Logging of user IP address to database (true/false)
 log_user_ip: false

--- a/conf/default/login.conf
+++ b/conf/default/login.conf
@@ -64,6 +64,9 @@ servername: Nameless
 msg_server_port: 54003
 msg_server_ip: 127.0.0.1
 
+#Number of simultaneous game sessions per IP
+login_limit: 1
+
 #Logging of user IP address to database (true/false)
 log_user_ip: false
 

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -352,10 +352,13 @@ int32 lobbydata_parse(int32 fd)
                     {
                         sql->NextRow();
                         SessionCount = sql->GetIntData(0);
-                        ShowInfo("Number of sessions for %u = %u (Limit is %u)", sd->client_addr, SessionCount, login_config.login_limit);
+                        if (SessionCount >= login_config.login_limit)
+                        {
+                            ShowWarning("Already %u active sessions for %u (Limit is %u)", SessionCount, sd->client_addr, login_config.login_limit);
+                        }
                     }
 
-                    if (maint_config.maint_mode == 0 && SessionCount < login_config.login_limit || gmlevel > 0)
+                    if (maint_config.maint_mode == 0 && (login_config.login_limit == 0 || SessionCount < login_config.login_limit) || gmlevel > 0)
                     {
                         if (PrevZone == 0)
                         {

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -353,7 +353,7 @@ int32 lobbydata_parse(int32 fd)
                     {
                         sql->NextRow();
                         SessionCount = (uint16)sql->GetIntData(0);
-                        if (SessionCount >= login_config.login_limit)
+                        if (login_config.login_limit != 0 && SessionCount >= login_config.login_limit)
                         {
                             ShowWarning("Already %u active sessions for %u (Limit is %u)", SessionCount, sd->client_addr, login_config.login_limit);
                         }

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -313,7 +313,6 @@ int32 lobbydata_parse(int32 fd)
                 uint16 ZoneID   = 0;
                 uint16 PrevZone = 0;
                 uint16 gmlevel  = 0;
-                uint16 SessionCount = 0;
 
                 if (sql->Query(fmtQuery, charid, sd->accid) != SQL_ERROR && sql->NumRows() != 0)
                 {
@@ -345,13 +344,15 @@ int32 lobbydata_parse(int32 fd)
                     ShowInfo("lobbydata_parse: zoneid:(%u),zoneip:(%s),zoneport:(%u) for char:(%u)", ZoneID, ip2str(ntohl(ZoneIP)), ZonePort, charid);
 
                     // Check the number of sessions
+                    uint16 SessionCount = 0;
+
                     fmtQuery = "SELECT COUNT(client_addr) \
                                 FROM accounts_sessions \
                                 WHERE client_addr = %u;";
                     if (sql->Query(fmtQuery, sd->client_addr) != SQL_ERROR && sql->NumRows() != 0)
                     {
                         sql->NextRow();
-                        SessionCount = sql->GetIntData(0);
+                        SessionCount = (uint16)sql->GetIntData(0);
                         if (SessionCount >= login_config.login_limit)
                         {
                             ShowWarning("Already %u active sessions for %u (Limit is %u)", SessionCount, sd->client_addr, login_config.login_limit);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -362,6 +362,10 @@ void login_config_read(const char* key, const char* value)
     {
         login_config.msg_server_ip = std::string(value);
     }
+    else if (strcmp(key, "login_limit") == 0)
+    {
+        login_config.login_limit = atoi(value);
+    }
     else if (strcmp(key, "log_user_ip") == 0)
     {
         login_config.log_user_ip = config_switch(value);
@@ -423,6 +427,7 @@ void login_config_default()
     login_config.msg_server_port    = 54003;
     login_config.msg_server_ip      = "127.0.0.1";
 
+    login_config.login_limit        = 0;
     login_config.log_user_ip        = "false";
     login_config.account_creation   = "true";
     login_config.character_deletion = "true";

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -57,10 +57,10 @@ struct login_config_t
 
     uint16      msg_server_port;    // chat server port
     std::string msg_server_ip;      // chat server IP
+    uint16      login_limit;        // maximum allowed sessions -> default 0 (off)
     bool        log_user_ip;        // log user ip -> default false
     bool        account_creation;   // allow new accounts to be created -> default true
     bool        character_deletion; // allows characters to be deleted -> default true
-    uint16      login_limit;        // maximum allowed sessions
 };
 
 struct version_info_t

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -60,6 +60,7 @@ struct login_config_t
     bool        log_user_ip;        // log user ip -> default false
     bool        account_creation;   // allow new accounts to be created -> default true
     bool        character_deletion; // allows characters to be deleted -> default true
+    uint16      login_limit;        // maximum allowed sessions
 };
 
 struct version_info_t


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Purpose here is to add a `login_limit` setting to control the number of sessions per IP (multiboxing limit) permitted on your server in login.conf

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
adjust the `login_limit` setting in login.conf. 
0 is defaulted for no limit. 
2 sets the server to a dual box limit. 
etc.