### PR TITLE
[core] Reduce spam from mob pets trying to follow their masters

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -25,6 +25,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../entities/mobentity.h"
 #include "../../zone.h"
 
+namespace
+{
+    bool arePositionsClose(const position_t& a, const position_t& b)
+    {
+        return distance(a, b) < 1.0f;
+    }
+} // namespace
+
 CPathFind::CPathFind(CBaseEntity* PTarget)
 : m_POwner(PTarget)
 , m_pathFlags(0)
@@ -212,7 +220,9 @@ void CPathFind::PrunePathWithin(float within)
     TracyZoneScoped;
 
     if (!IsFollowingPath())
+    {
         return;
+    }
 
     position_t* targetPoint     = &m_points.back();
     position_t* secondLastPoint = nullptr;
@@ -343,6 +353,11 @@ bool CPathFind::FindPath(const position_t& start, const position_t& end)
 {
     TracyZoneScoped;
 
+    if (arePositionsClose(start, end))
+    {
+        return false;
+    }
+
     if (!isNavMeshEnabled())
     {
         return false;
@@ -397,6 +412,11 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
 bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
 {
     TracyZoneScoped;
+
+    if (arePositionsClose(start, end))
+    {
+        return false;
+    }
 
     if (!isNavMeshEnabled())
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Gigas' Leech and other mob pets are constantly trying to follow their masters around. But if the distance they're trying to travel is too small (as it often is), navmesh won't return any points, so PathFind will complain, a lot, loudly.

```
[06/13/22 22:40:10:414][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293553) could not find path (FindPath:362)
[06/13/22 22:40:12:813][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293379) could not find path (FindPath:362)
[06/13/22 22:40:18:814][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293499) could not find path (FindPath:362)
[06/13/22 22:40:21:614][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293344) could not find path (FindPath:362)
[06/13/22 22:40:24:814][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293499) could not find path (FindPath:362)
[06/13/22 22:40:26:414][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293384) could not find path (FindPath:362)
[06/13/22 22:40:28:413][map][error][navmesh] CPathFind::FindPath Entity (Gigass_Leech - 17293384) could not find path (FindPath:362)
```

So we put in a small check to bail out early if they're trying to nav to what is essentially the same spot. If mobs/trusts/whatever is trying to nav between two spots that are so close, they should be sliding without a navmesh anyway.

## Steps to test these changes

Go to Qufim, enjoy your log silence.

`!togglegm` and follow Gigas' Leech around, and see that their movement isn't broken.
