### PR TITLE
[sql] Corrected AH category for Hajduk Ring/+1

### DIFF
--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -8395,8 +8395,8 @@ INSERT INTO `item_basic` VALUES (11054,0,'pensee_earring','pensee_earring',1,635
 INSERT INTO `item_basic` VALUES (11055,0,'aredan_earring','aredan_earring',1,34820,24,0,7315);
 INSERT INTO `item_basic` VALUES (11056,0,'ghillie_earring','ghillie_earring',1,2084,24,0,0);
 INSERT INTO `item_basic` VALUES (11057,0,'ghillie_earring_+1','ghillie_earring_+1',1,2080,24,0,6930);
-INSERT INTO `item_basic` VALUES (11058,0,'hajduk_ring','hajduk_ring',1,2084,24,0,0);
-INSERT INTO `item_basic` VALUES (11059,0,'hajduk_ring_+1','hajduk_ring_+1',1,2080,24,0,0);
+INSERT INTO `item_basic` VALUES (11058,0,'hajduk_ring','hajduk_ring',1,2084,25,0,0);
+INSERT INTO `item_basic` VALUES (11059,0,'hajduk_ring_+1','hajduk_ring_+1',1,2080,25,0,0);
 INSERT INTO `item_basic` VALUES (11060,0,'evader_earring','evader_earring',1,2084,24,0,0);
 INSERT INTO `item_basic` VALUES (11061,0,'evader_earring_+1','evader_earring_+1',1,2080,24,0,0);
 INSERT INTO `item_basic` VALUES (11062,0,'fountain_ring','fountain_ring',1,38916,25,0,0);


### PR DESCRIPTION
Two rings, alone in a sea of earrings, now they can be reunited with their brethren!

No concrete resale values for either version of the ring so I left those values blank.

Also quickly scanned the other rings/earrings to see if any were also lost, didn't look like no one else wanders like Hajduk does!

Fixes #1998.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Corrects AH category for Hajduk Ring/+1, was listed in item_basic.sql as AH category 24 (earrings), changes that to be AH category 25 (rings).

## Steps to test these changes

Check listings on the AH for these rings **before** this PR, see 2 rings....lost and confused in a sea of earrings.

Check listings on the AH for these rings **after** this PR, see 2 rings, no longer lost, back with their companion rings.