### PR TITLE
[core] Rename trust sync packet

### DIFF
--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -34,8 +34,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../mob_spell_container.h"
 #include "../mob_spell_list.h"
 #include "../packets/char_health.h"
+#include "../packets/entity_set_name.h"
 #include "../packets/entity_update.h"
-#include "../packets/trust_sync.h"
 #include "../recast_container.h"
 #include "../status_effect_container.h"
 #include "../utils/battleutils.h"
@@ -105,7 +105,7 @@ void CTrustEntity::Spawn()
     // we need to skip CMobEntity's spawn because it calculates stats (and our stats are already calculated)
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
-    ((CCharEntity*)PMaster)->pushPacket(new CTrustSyncPacket((CCharEntity*)PMaster, this));
+    ((CCharEntity*)PMaster)->pushPacket(new CEntitySetNamePacket(this));
 }
 
 void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)

--- a/src/map/packets/CMakeLists.txt
+++ b/src/map/packets/CMakeLists.txt
@@ -80,6 +80,8 @@ set(PACKET_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_animation.h
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_enable_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_enable_list.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity_set_name.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity_set_name.h
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_update.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_update.h
     ${CMAKE_CURRENT_SOURCE_DIR}/entity_visual.cpp
@@ -232,8 +234,6 @@ set(PACKET_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/treasure_find_item.h
     ${CMAKE_CURRENT_SOURCE_DIR}/treasure_lot_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/treasure_lot_item.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/trust_sync.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/trust_sync.h
     ${CMAKE_CURRENT_SOURCE_DIR}/weather.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/weather.h
     ${CMAKE_CURRENT_SOURCE_DIR}/wide_scan.cpp

--- a/src/map/packets/entity_set_name.h
+++ b/src/map/packets/entity_set_name.h
@@ -19,20 +19,19 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 ===========================================================================
 */
 
-#ifndef _CTRUSTSYNCPACKET_H
-#define _CTRUSTSYNCPACKET_H
+#ifndef _CENTITYSETNAMEPACKET_H
+#define _CENTITYSETNAMEPACKET_H
 
 #include "common/cbasetypes.h"
 
 #include "basic.h"
 
-class CCharEntity;
-class CTrustEntity;
+class CBaseEntity;
 
-class CTrustSyncPacket : public CBasicPacket
+class CEntitySetNamePacket : public CBasicPacket
 {
 public:
-    CTrustSyncPacket(CCharEntity* PChar, CTrustEntity* PTrust);
+    CEntitySetNamePacket(CBaseEntity* PEntity);
 };
 
-#endif
+#endif // _CENTITYSETNAMEPACKET_H

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -28,7 +28,6 @@
 #include "../packets/char_sync.h"
 #include "../packets/entity_update.h"
 #include "../packets/message_standard.h"
-#include "../packets/trust_sync.h"
 #include "../status_effect_container.h"
 #include "../weapon_skill.h"
 #include "../zone_instance.h"

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -41,9 +41,9 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "packets/change_music.h"
 #include "packets/char.h"
 #include "packets/char_sync.h"
+#include "packets/entity_set_name.h"
 #include "packets/entity_update.h"
 #include "packets/entity_visual.h"
-#include "packets/trust_sync.h"
 #include "packets/wide_scan.h"
 
 #include "lua/luautils.h"
@@ -641,7 +641,7 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
                     PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     if (PMaster)
                     {
-                        PChar->pushPacket(new CTrustSyncPacket(PMaster, PCurrentTrust));
+                        PChar->pushPacket(new CEntitySetNamePacket(PCurrentTrust));
                     }
                 }
             }


### PR DESCRIPTION
Now that we know it works on other mobs, and is used in pankration, and for fellows

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Internally renames the CTrustSync packet, now that we have a better idea of what it is used for

## Steps to test these changes

Make sure Trusts and dynamic entities all still work as expected
