### PR TITLE
[core] replace delete with assign of nullptr in CCharEntity destructor

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -266,7 +266,7 @@ CCharEntity::~CCharEntity()
     delete CraftContainer;
     delete PMeritPoints;
     delete PJobPoints;
-    delete PGuildShop;
+    PGuildShop = nullptr;
     delete eventPreparation;
     delete currentEvent;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fix crash from UpdateGuildsStock after a character that has used the shop gets destructed

## Steps to test these changes

Check out a guildshop, logout, wait for guild stock to update, xi_map doesn't crash
