### PR TITLE
[sql] Fixes typo in ItemID for Leathercraft guild points item Leather Shield.

### DIFF
--- a/sql/guild_item_points.sql
+++ b/sql/guild_item_points.sql
@@ -917,7 +917,7 @@ INSERT INTO `guild_item_points` VALUES (5, 12828, 5, 2160, 17280, 5); -- Raptor 
 INSERT INTO `guild_item_points` VALUES (5, 12919, 5, 2320, 17280, 5); -- Dino Trousers (2320 / 17280)
 INSERT INTO `guild_item_points` VALUES (5, 12995, 5, 1700, 16320, 6); -- Moccasins (1700 / 16320)
 INSERT INTO `guild_item_points` VALUES (5, 13050, 5, 1785, 16320, 6); -- Moccasins +1 (1785 / 16320)
-INSERT INTO `guild_item_points` VALUES (5, 12295, 5, 1280, 15120, 7); -- Leather Shield (1280 / 15120)
+INSERT INTO `guild_item_points` VALUES (5, 12294, 5, 1280, 15120, 7); -- Leather Shield (1280 / 15120)
 INSERT INTO `guild_item_points` VALUES (5, 12329, 5, 1360, 15120, 7); -- Leather Shield +1 (1360 / 15120)
 
 -- Leathercraft / Craftsman


### PR DESCRIPTION
*`guild_item_points.sql` currently lists 12295 as the ItemID for Leather Shield.
*ItemID 12295 actually is the Round Shield (a Woodworking item).

Credit goes to Metal on xiweb for discovering this typo!

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Changes ItemID to be 12294, the correct ItemID for Leather Shield.

## Steps to test these changes

Load a private server built **before** this PR.
Wait for Leathercraft guild to cycle thru requested guild point item until they oddly ask for a Round Shield, which is a Woodworking item.
You are oddly still able to turn the Round Shield in for the same amount of guild points as a Leather Shield.
Go home Leathercraft guild, you're drunk!

Load a private server built **after** this PR.
Wait for the Leathercraft guild to cycle thru needed requested guild point item until they correctly ask for the Leather Shield and never again ask for the Round Shield.
Congratulate the Leathercraft guild on passing the sobriety test!