### PR TITLE
Fix weekly logic for Unity Leader objectives

### DIFF
--- a/src/map/packets/roe_questlog.cpp
+++ b/src/map/packets/roe_questlog.cpp
@@ -28,7 +28,7 @@
 CRoeQuestLogPacket::CRoeQuestLogPacket(CCharEntity* PChar, uint8 order)
 {
     this->setType(0x112);
-    this->setSize(0x88);
+    this->setSize(0x136);
 
     ref<uint32>(0x84) = order;
 

--- a/src/map/packets/roe_sparkupdate.cpp
+++ b/src/map/packets/roe_sparkupdate.cpp
@@ -30,13 +30,13 @@
 CRoeSparkUpdatePacket::CRoeSparkUpdatePacket(CCharEntity* PChar)
 {
     this->setType(0x110);
-    this->setSize(0x14);
+    this->setSize(0x20);
 
     const char* query = "SELECT spark_of_eminence FROM char_points WHERE charid = %d";
 
     uint32 vanaTime        = CVanaTime::getInstance()->getVanaTime();
     uint32 daysSinceEpoch  = vanaTime / (60 * 60 * 24);
-    uint32 weeksSinceEpoch = (vanaTime + 86400) / 7;
+    uint32 weeksSinceEpoch = daysSinceEpoch / 7;
 
     int ret = sql->Query(query, PChar->id);
     if (ret != SQL_ERROR && sql->NextRow() == SQL_SUCCESS)

--- a/src/map/packets/roe_update.cpp
+++ b/src/map/packets/roe_update.cpp
@@ -28,7 +28,7 @@
 CRoeUpdatePacket::CRoeUpdatePacket(CCharEntity* PChar)
 {
     this->setType(0x111);
-    this->setSize(0x104);
+    this->setSize(0x260);
 
     /*  Each 4-bit nibble in the 4-byte chunk is labeled here. The second number is it's position.
                     (0 is the lowest order. IE the right-most bits)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes #2013 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Repeatedly exit and enter Quest menu and select unity objectives for leader.  Should not change until next JP week
<!-- Clear and detailed steps to test your changes here -->
