### PR TITLE
Update menu_merit, break out monipulator packets

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -138,6 +138,8 @@
 #include "../packets/message_standard.h"
 #include "../packets/message_system.h"
 #include "../packets/message_text.h"
+#include "../packets/monipulator1.h"
+#include "../packets/monipulator2.h"
 #include "../packets/position.h"
 #include "../packets/quest_mission_log.h"
 #include "../packets/release.h"
@@ -5284,6 +5286,8 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
     PChar->pushPacket(new CCharAbilitiesPacket(PChar));
     PChar->pushPacket(new CCharUpdatePacket(PChar));
     PChar->pushPacket(new CMenuMeritPacket(PChar));
+    PChar->pushPacket(new CMonipulatorPacket1(PChar));
+    PChar->pushPacket(new CMonipulatorPacket2(PChar));
     PChar->pushPacket(new CCharSyncPacket(PChar));
 }
 
@@ -5453,6 +5457,8 @@ void CLuaBaseEntity::setLevel(uint8 level)
         PChar->pushPacket(new CCharAbilitiesPacket(PChar));
         PChar->pushPacket(new CCharUpdatePacket(PChar));
         PChar->pushPacket(new CMenuMeritPacket(PChar));
+        PChar->pushPacket(new CMonipulatorPacket1(PChar));
+        PChar->pushPacket(new CMonipulatorPacket2(PChar));
         PChar->pushPacket(new CCharSyncPacket(PChar));
     }
 }
@@ -5499,6 +5505,8 @@ void CLuaBaseEntity::setsLevel(uint8 slevel)
     PChar->pushPacket(new CCharAbilitiesPacket(PChar));
     PChar->pushPacket(new CCharUpdatePacket(PChar));
     PChar->pushPacket(new CMenuMeritPacket(PChar));
+    PChar->pushPacket(new CMonipulatorPacket1(PChar));
+    PChar->pushPacket(new CMonipulatorPacket2(PChar));
     PChar->pushPacket(new CCharSyncPacket(PChar));
 }
 
@@ -6994,6 +7002,8 @@ void CLuaBaseEntity::setMerits(uint8 numPoints)
 
     PChar->PMeritPoints->SetMeritPoints(numPoints);
     PChar->pushPacket(new CMenuMeritPacket(PChar));
+    PChar->pushPacket(new CMonipulatorPacket1(PChar));
+    PChar->pushPacket(new CMonipulatorPacket2(PChar));
 
     charutils::SaveCharExp(PChar, PChar->GetMJob());
 }
@@ -9665,6 +9675,8 @@ void CLuaBaseEntity::recalculateStats()
         PChar->pushPacket(new CCharAbilitiesPacket(PChar));
         PChar->pushPacket(new CCharUpdatePacket(PChar));
         PChar->pushPacket(new CMenuMeritPacket(PChar));
+        PChar->pushPacket(new CMonipulatorPacket1(PChar));
+        PChar->pushPacket(new CMonipulatorPacket2(PChar));
         PChar->pushPacket(new CCharSyncPacket(PChar));
     }
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -142,6 +142,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "packets/message_combat.h"
 #include "packets/message_standard.h"
 #include "packets/message_system.h"
+#include "packets/monipulator1.h"
+#include "packets/monipulator2.h"
 #include "packets/party_define.h"
 #include "packets/party_invite.h"
 #include "packets/party_map.h"
@@ -3797,6 +3799,8 @@ void SmallPacket0x061(map_session_data_t* const PSession, CCharEntity* const PCh
     PChar->pushPacket(new CCharSkillsPacket(PChar));
     PChar->pushPacket(new CCharRecastPacket(PChar));
     PChar->pushPacket(new CMenuMeritPacket(PChar));
+    PChar->pushPacket(new CMonipulatorPacket1(PChar));
+    PChar->pushPacket(new CMonipulatorPacket2(PChar));
 
     if (charutils::hasKeyItem(PChar, 2544))
     {
@@ -5218,6 +5222,8 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->MeritMode = operation;
                 PChar->pushPacket(new CMenuMeritPacket(PChar));
+                PChar->pushPacket(new CMonipulatorPacket1(PChar));
+                PChar->pushPacket(new CMonipulatorPacket2(PChar));
             }
         }
         break;
@@ -5239,6 +5245,8 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
                             break;
                     }
                     PChar->pushPacket(new CMenuMeritPacket(PChar));
+                    PChar->pushPacket(new CMonipulatorPacket1(PChar));
+                    PChar->pushPacket(new CMonipulatorPacket2(PChar));
                     PChar->pushPacket(new CMeritPointsCategoriesPacket(PChar, merit));
 
                     charutils::SaveCharExp(PChar, PChar->GetMJob());
@@ -6807,6 +6815,8 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
         PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
         PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
         PChar->pushPacket(new CMenuMeritPacket(PChar));
+        PChar->pushPacket(new CMonipulatorPacket1(PChar));
+        PChar->pushPacket(new CMonipulatorPacket2(PChar));
         PChar->pushPacket(new CCharSyncPacket(PChar));
     }
 }

--- a/src/map/packets/CMakeLists.txt
+++ b/src/map/packets/CMakeLists.txt
@@ -168,6 +168,10 @@ set(PACKET_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/message_system.h
     ${CMAKE_CURRENT_SOURCE_DIR}/message_text.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/message_text.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/monipulator1.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/monipulator1.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/monipulator2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/monipulator2.h
     ${CMAKE_CURRENT_SOURCE_DIR}/party_define.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/party_define.h
     ${CMAKE_CURRENT_SOURCE_DIR}/party_effects.cpp

--- a/src/map/packets/menu_merit.cpp
+++ b/src/map/packets/menu_merit.cpp
@@ -22,6 +22,7 @@
 #include "common/socket.h"
 
 #include "menu_merit.h"
+#include "job_points.h"
 
 #include "../entities/charentity.h"
 #include "../utils/charutils.h"
@@ -31,56 +32,40 @@ CMenuMeritPacket::CMenuMeritPacket(CCharEntity* PChar)
     this->setType(0x63);
     this->setSize(0x10);
 
-    ref<uint8>(0x04) = 0x02;
-    ref<uint8>(0x06) = 0x0C;
+    ref<uint8>(0x04) = 0x02; // Update Type
+    ref<uint8>(0x06) = 0x0C; // Variable Data Size
 
     ref<uint16>(0x08) = PChar->PMeritPoints->GetLimitPoints();
+    ref<uint16>(0x0A) = PChar->PMeritPoints->GetMeritPoints();
 
-    uint16 bits = 0;
-    bits += PChar->PMeritPoints->GetMeritPoints() & 0b0000000001111111; // first seven bits are merit points
-    if (PChar->GetMJob() == JOB_BLU && PChar->GetMLevel() > 74)
+    // 0x0A
+    if (PChar->GetMJob() == JOB_BLU)
     {
-        bits += (PChar->PMeritPoints->GetMeritValue(MERIT_ASSIMILATION, PChar) << 7) &
-                0b0001111110000000; // next six bits are assimilation points. the last three bits are the three flags below:
-    }
-    bits += (PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606)) << 13; // is 75 and has limit breaker KI
-    bits += ((PChar->jobs.job[PChar->GetMJob()] >= PChar->jobs.genkai &&
-              PChar->jobs.exp[PChar->GetMJob()] == charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1) ||
-             PChar->MeritMode)
-            << 14;                                        // my exp is capped
-    bits += (bits & (1 << 13) && PChar->MeritMode) << 15; // flag 13 is set and merit mode is on
+        uint8 bluePointBonus = 0;
 
-    ref<uint16>(0x0A) = bits;
+        if (PChar->GetMLevel() >= 75)
+        {
+            bluePointBonus += PChar->PMeritPoints->GetMeritValue(MERIT_ASSIMILATION, PChar);
+        }
+
+        if (PChar->GetMLevel() >= 99)
+        {
+            bluePointBonus += PChar->PJobPoints->GetJobPointValue(JP_BLUE_MAGIC_POINT_BONUS);
+        }
+
+        ref<uint16>(0x0A) |= bluePointBonus << 7;
+    }
+
+    bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
+
+    ref<uint16>(0x0A) |= canUseMeritMode << 13; // Level >= 75 and has Limit Break KI
+
+    bool atMaxLevelLimit = PChar->jobs.job[PChar->GetMJob()] >= PChar->jobs.genkai;
+    bool hasCappedXp     = PChar->jobs.exp[PChar->GetMJob()] == (charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1);
+
+    ref<uint16>(0x0A) |= ((atMaxLevelLimit && hasCappedXp) || PChar->MeritMode) << 14; // XP is capped, or player is in Merit Mode
+    ref<uint16>(0x0A) |= (canUseMeritMode && PChar->MeritMode) << 15;                  // Merit Mode Enabled, and Current Job is eligible
 
     ref<uint8>(0x0C) = map_config.max_merit_points + PChar->PMeritPoints->GetMeritValue(MERIT_MAX_MERIT, PChar);
-
-    PChar->pushPacket(new CBasicPacket(*this));
-
-    // Update Type 3 : Monstrosity 1 (Possible to move these packets out of here?)
-    // --------------------------------------------
-
-    this->setSize(0xDC);
-
-    memset(data + 4, 0, PACKET_SIZE - 4);
-
-    uint8 packet[] = { 0x03, 0x00, 0xD8 };
-
-    memcpy(data + (0x04), &packet, sizeof(packet));
-
-    // This is a hack.  We really should clear all non-relevant bytes in memset
-    ref<uint8>(0x0C) = 0x00; // Temporary fix for Monstrosity Gladiator Rank.  This applies to next packet as well.
-
-    PChar->pushPacket(new CBasicPacket(*this));
-
-    // Update Type 4 : Monstrosity 2
-    // --------------------------------------------
-
-    this->setSize(0xB4);
-
-    memset(data + 4, 0, PACKET_SIZE - 4);
-
-    uint8 packet2[] = { 0x04, 0x00, 0xB0 };
-    memcpy(data + (0x04), &packet2, sizeof(packet2));
 }
 
-// 0x63, 0x06, 0x88, 0x41, 0x02, 0x00, 0x08, 0x00, 0xD3, 0x03, 0x03, 0x60

--- a/src/map/packets/monipulator1.cpp
+++ b/src/map/packets/monipulator1.cpp
@@ -1,0 +1,42 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "common/socket.h"
+
+#include "monipulator1.h"
+
+CMonipulatorPacket1::CMonipulatorPacket1(CCharEntity* PChar)
+{
+    this->setType(0x63);
+    this->setSize(0xDC);
+
+    ref<uint8>(0x04) = 0x03; // Update Type
+    ref<uint8>(0x06) = 0xD8; // Variable Data Size
+
+    ref<uint8>(0x08)  = 0; // Species
+    ref<uint16>(0x0A) = 0; // Flags?
+    ref<uint8>(0x0C)  = 0; // Monstrosity Rank (0 = Mon, 1 = NM, 2 = HNM)
+
+    ref<uint16>(0x12) = 0; // Infamy
+
+    std::memset(data + 0x1C, 0, 64);  // Instinct Battlefield 1
+    std::memset(data + 0x5C, 0, 128); // Monster Level Char Field
+}

--- a/src/map/packets/monipulator1.h
+++ b/src/map/packets/monipulator1.h
@@ -1,0 +1,37 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _CMONIPULATORPACKET_H
+#define _CMONIPULATORPACKET_H
+
+#include "common/cbasetypes.h"
+
+#include "basic.h"
+
+class CCharEntity;
+
+class CMonipulatorPacket1 : public CBasicPacket
+{
+public:
+    CMonipulatorPacket1(CCharEntity* PChar);
+};
+
+#endif

--- a/src/map/packets/monipulator2.cpp
+++ b/src/map/packets/monipulator2.cpp
@@ -1,0 +1,36 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "common/socket.h"
+
+#include "monipulator2.h"
+
+
+CMonipulatorPacket2::CMonipulatorPacket2(CCharEntity* PChar)
+{
+    this->setType(0x63);
+    this->setSize(0xB4);
+
+    memset(data + 4, 0, PACKET_SIZE - 4);
+
+    std::array<uint8, 3> packet2 = { 0x04, 0x00, 0xB0 };
+    memcpy(data + (0x04), &packet2, sizeof(packet2));
+}

--- a/src/map/packets/monipulator2.h
+++ b/src/map/packets/monipulator2.h
@@ -1,0 +1,37 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _CMONIPULATORPACKET2_H
+#define _CMONIPULATORPACKET2_H
+
+#include "common/cbasetypes.h"
+
+#include "basic.h"
+
+class CCharEntity;
+
+class CMonipulatorPacket2 : public CBasicPacket
+{
+public:
+    CMonipulatorPacket2(CCharEntity* PChar);
+};
+
+#endif

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -63,6 +63,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../packets/message_combat.h"
 #include "../packets/message_special.h"
 #include "../packets/message_standard.h"
+#include "../packets/monipulator1.h"
+#include "../packets/monipulator2.h"
 #include "../packets/quest_mission_log.h"
 
 #include "../packets/roe_sparkupdate.h"
@@ -1382,6 +1384,8 @@ namespace charutils
         PChar->pushPacket(new CCharAbilitiesPacket(PChar));
         PChar->pushPacket(new CCharUpdatePacket(PChar));
         PChar->pushPacket(new CMenuMeritPacket(PChar));
+        PChar->pushPacket(new CMonipulatorPacket1(PChar));
+        PChar->pushPacket(new CMonipulatorPacket2(PChar));
         PChar->pushPacket(new CCharSyncPacket(PChar));
     }
 
@@ -4305,6 +4309,8 @@ namespace charutils
                 PChar->pushPacket(new CCharRecastPacket(PChar));
                 PChar->pushPacket(new CCharAbilitiesPacket(PChar));
                 PChar->pushPacket(new CMenuMeritPacket(PChar));
+                PChar->pushPacket(new CMonipulatorPacket1(PChar));
+                PChar->pushPacket(new CMonipulatorPacket2(PChar));
                 PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
                 PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
                 PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -4536,6 +4542,8 @@ namespace charutils
                 PChar->pushPacket(new CCharRecastPacket(PChar));
                 PChar->pushPacket(new CCharAbilitiesPacket(PChar));
                 PChar->pushPacket(new CMenuMeritPacket(PChar));
+                PChar->pushPacket(new CMonipulatorPacket1(PChar));
+                PChar->pushPacket(new CMonipulatorPacket2(PChar));
                 PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
                 PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
                 PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -4558,6 +4566,8 @@ namespace charutils
         if (onLimitMode)
         {
             PChar->pushPacket(new CMenuMeritPacket(PChar));
+            PChar->pushPacket(new CMonipulatorPacket1(PChar));
+            PChar->pushPacket(new CMonipulatorPacket2(PChar));
         }
 
         if (PMob != PChar) // Only mob kills count for gain EXP records


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Refactors menu_merit packet, and adds support for Blue Mage job points
* Breaks out monipulator packets 1 and 2 into two separate packet types

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* Add Blue Mage job points for points, and observe increase
* All other function should remain

NOTE: Need to verify that we're sending the proper packets for various requests, as we may be over-sending
<!-- Clear and detailed steps to test your changes here -->
