### PR TITLE
Fix magic damage references from spell_damage to damage

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -384,7 +384,7 @@ function BlueFinalAdjustments(caster, target, spell, dmg, params)
     -- handle One For All, Liement
     if attackType == xi.attackType.MAGICAL then
 
-        local targetMagicDamageAdjustment = xi.spells.spell_damage.calculateTMDA(caster, target, damageType) -- Apply checks for Liement, MDT/MDTII/DT
+        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(caster, target, damageType) -- Apply checks for Liement, MDT/MDTII/DT
         dmg = math.floor(dmg * targetMagicDamageAdjustment)
         if dmg < 0 then
             target:takeSpellDamage(caster, spell, dmg, attackType, damageType)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -484,16 +484,16 @@ end
 local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc) -- get these multipliers once and store them
     local multipliers = {}
 
-    multipliers.eleStaffBonus        = xi.spells.spell_damage.calculateEleStaffBonus(player, nil, element)
-    multipliers.magianAffinity       = xi.spells.spell_damage.calculateMagianAffinity(player, nil)         -- presumed but untested
-    multipliers.SDT                  = xi.spells.spell_damage.calculateSDT(player, target, nil, element)
-    multipliers.resist               = xi.spells.spell_damage.calculateResist(player, target,  nil, 0, element, 0, bonusMacc)
-    multipliers.magicBurst           = xi.spells.spell_damage.calculateIfMagicBurst(player, target,  0, element)
-    multipliers.magicBurstBonus      = xi.spells.spell_damage.calculateIfMagicBurstBonus(player, target, nil, 0, element)
-    multipliers.dayAndWeather        = xi.spells.spell_damage.calculateDayAndWeather(player, target, nil, 0, element)
-    multipliers.magicBonusDiff       = xi.spells.spell_damage.calculateMagicBonusDiff(player, target, nil, 0, 0, element)
-    multipliers.TMDA                 = xi.spells.spell_damage.calculateTMDA(player, target, xi.damageType.ELEMENTAL + element)
-    multipliers.nukeAbsorbOrNullify  = xi.spells.spell_damage.calculateNukeAbsorbOrNullify(player, target, nil, element)
+    multipliers.eleStaffBonus        = xi.spells.damage.calculateEleStaffBonus(player, nil, element)
+    multipliers.magianAffinity       = xi.spells.damage.calculateMagianAffinity(player, nil)         -- presumed but untested
+    multipliers.SDT                  = xi.spells.damage.calculateSDT(player, target, nil, element)
+    multipliers.resist               = xi.spells.damage.calculateResist(player, target,  nil, 0, element, 0, bonusMacc)
+    multipliers.magicBurst           = xi.spells.damage.calculateIfMagicBurst(player, target,  0, element)
+    multipliers.magicBurstBonus      = xi.spells.damage.calculateIfMagicBurstBonus(player, target, nil, 0, element)
+    multipliers.dayAndWeather        = xi.spells.damage.calculateDayAndWeather(player, target, nil, 0, element)
+    multipliers.magicBonusDiff       = xi.spells.damage.calculateMagicBonusDiff(player, target, nil, 0, 0, element)
+    multipliers.TMDA                 = xi.spells.damage.calculateTMDA(player, target, xi.damageType.ELEMENTAL + element)
+    multipliers.nukeAbsorbOrNullify  = xi.spells.damage.calculateNukeAbsorbOrNullify(player, target, nil, element)
 
     return multipliers
 end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -402,7 +402,7 @@ function AvatarFinalAdjustments(dmg, mob, skill, target, skilltype, damagetype, 
 
     -- handle One For All, Liement
     if skilltype == xi.attackType.MAGICAL then
-        local targetMagicDamageAdjustment = xi.spells.spell_damage.calculateTMDA(mob, target, damagetype) -- Apply checks for Liement, MDT/MDTII/DT
+        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(mob, target, damagetype) -- Apply checks for Liement, MDT/MDTII/DT
 
         dmg = math.floor(dmg * targetMagicDamageAdjustment)
         if dmg < 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes some scripts to reference the new damage vs spell_damage table
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
