### PR TITLE
Add missing fields to char_check, health, and jobs, Fix max merit poi…

### DIFF
--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -35,7 +35,7 @@
 
 // массив больше на одно значение, заполняемое нулем
 
-static uint8 upgrade[10][16] = {
+static uint8 upgrade[10][45] = {
     { 1, 2, 3, 4, 5, 5, 5, 5, 5, 7, 7, 7, 9, 9, 9 },           // HP-MP
     { 3, 6, 9, 9, 9, 12, 12, 12, 12, 15, 15, 15, 15, 18, 18 }, // Attributes
     { 1, 2, 3, 3, 3, 3, 3, 3 },                                // Combat Skills
@@ -45,8 +45,12 @@ static uint8 upgrade[10][16] = {
     { 1, 2, 3, 4, 5 },                                         // Job Group 1
     { 3, 4, 5, 5, 5 },                                         // Job Group 2
     { 20, 22, 24, 27, 30 },                                    // Weapon Skills
-    { 1, 3, 5, 7, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39 }  // Max merits
+    { 1, 3, 5, 7, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39,
+      42, 45, 45, 45, 45, 45, 45, 45, 45, 45, 45, 48, 48, 48,
+      48, 48, 48, 48, 48, 48, 48, 51, 51, 51, 51, 51, 51, 51,
+      51, 51 } // Max merits
 };
+
 #define MAX_LIMIT_POINTS 10000 // количество опыта для получения одного merit
 
 // TODO: скорее всего придется все это перенести в базу
@@ -489,7 +493,7 @@ int32 CMeritPoints::GetMeritValue(MERIT_TYPE merit, CCharEntity* PChar)
     {
         if (PMerit->catid < 5 || (PMerit->jobs & (1 << (PChar->GetMJob() - 1)) && PChar->GetMLevel() >= 75))
         {
-            meritValue = std::min(PMerit->count, cap[PChar->GetMLevel()]);
+            meritValue = merit == MERIT_MAX_MERIT ? PMerit->count : std::min(PMerit->count, cap[PChar->GetMLevel()]);
         }
 
         if (PMerit->catid == 25 && PChar->GetMLevel() < 96)

--- a/src/map/packets/char_check.cpp
+++ b/src/map/packets/char_check.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -124,8 +124,8 @@ CCheckPacket::CCheckPacket(CCharEntity* PChar, CCharEntity* PTarget)
         ref<uint8>(0x24) = PTarget->GetMLevel();
         ref<uint8>(0x25) = PTarget->GetSLevel();
         ref<uint8>(0x26) = PTarget->GetMJob();
-        // 0x27: master level
-        // 0x28: bitflags, bit 0 = master breaker
+        ref<uint8>(0x27) = 0; // Master Level
+        ref<uint8>(0x28) = 0; // bitflags, bit 0 = Master Breaker
     }
 
     // Chevron 32 bit Big Endean, starting at 0x2B

--- a/src/map/packets/char_health.cpp
+++ b/src/map/packets/char_health.cpp
@@ -48,8 +48,8 @@ CCharHealthPacket::CCharHealthPacket(CCharEntity* PChar)
         ref<uint8>(0x21) = PChar->GetMLevel();
         ref<uint8>(0x22) = PChar->GetSJob();
         ref<uint8>(0x23) = PChar->GetSLevel();
-        // 0x24: master level
-        // 0x25: bitflags, bit 0 = master breaker
+        ref<uint8>(0x24) = 0; // Master Level
+        ref<uint8>(0x25) = 0; // Master Breaker
     }
 }
 

--- a/src/map/packets/char_jobs.cpp
+++ b/src/map/packets/char_jobs.cpp
@@ -29,7 +29,7 @@
 CCharJobsPacket::CCharJobsPacket(CCharEntity* PChar)
 {
     this->setType(0x1B);
-    this->setSize(0x68);
+    this->setSize(0x84);
 
     ref<uint8>(0x04) = PChar->look.race;
 
@@ -51,5 +51,9 @@ CCharJobsPacket::CCharJobsPacket(CCharEntity* PChar)
         PChar->m_StatsDebilitation; // Bit field. Underestimation of physical characteristics, the characteristic turns red and a red arrlow appears next to it.
 
     ref<uint8>(0x64) = 0x01; // Unknown, set due to Retail reference; suspicion around mentor unlock
+    ref<uint8>(0x65) = 0;    // Mentor Icon
     ref<uint8>(0x66) = 0x01; // Mastery Rank (In Profile Menu)
+
+    ref<uint8>(0x68) = 0; // Is job mastered, and has Master Breaker KI
+    ref<uint8>(0x6D) = 0; // Master Level
 }


### PR DESCRIPTION
…nt cap

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Adds Exemplar/Master Level/Master Breaker to several packets that were missing this data, and updates size (0xDD still needs these values added)
* Fixes error in capping Max merits value, and allows for all 45 to be obtained
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* Cap Max Merits value in merit points menu
<!-- Clear and detailed steps to test your changes here -->
