### PR TITLE
Adjust Trust Adelheid Cure Thresholds

### DIFF
--- a/scripts/globals/spells/trust/adelheid.lua
+++ b/scripts/globals/spells/trust/adelheid.lua
@@ -37,7 +37,8 @@ spell_object.onMobSpawn = function(mob)
 
     -- TODO: Helices
 
-    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+    mob:addSimpleGambit(ai.t.TANK, ai.c.HPP_LT, 50, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 33, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.NONE, 75)
 end


### PR DESCRIPTION
per BG Wiki: "Casts Cure spells on party members under 33% (red) hp,
with a higher threshold and priority for the tank."

source: https://www.bg-wiki.com/ffxi/Cipher:_Adelheid

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds a TANK specific Gambit for Cures
Adjusts the PARTY specific Gambit for Cures

## Steps to test these changes

Use `!hp` to adjust the HP of various party members and tank, observe that Adelheid follows the rules defined in the gambit (50% or below for Tank, 33% or below for other Party Members).
