### PR TITLE
[core] Add safety and additional logging to replace debug breaks

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -306,9 +306,9 @@ void CTargetFind::addAllInRange(CBattleEntity* PTarget, float radius, ALLEGIANCE
     m_radius        = radius;
     m_PRadiusAround = &(m_PBattleEntity->loc.p);
 
-    if (allegiance == ALLEGIANCE_TYPE::PLAYER)
+    if (PTarget && allegiance == ALLEGIANCE_TYPE::PLAYER)
     {
-        if (PTarget && PTarget->objtype == TYPE_PC)
+        if (PTarget->objtype == TYPE_PC)
         {
             CCharEntity* PChar = static_cast<CCharEntity*>(PTarget);
             for (const auto& list : { PChar->SpawnPCList, PChar->SpawnPETList })

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -207,6 +207,12 @@ void CAlliance::delParty(CParty* party)
     {
         auto* PChar = dynamic_cast<CCharEntity*>(party->members.at(0));
 
+        if (!PChar)
+        {
+            ShowWarning("CAlliance::delParty - Party Member at Position 0 is not of type CCharEntity.");
+            return;
+        }
+
         PChar->PTreasurePool = new CTreasurePool(TREASUREPOOL_PARTY);
         PChar->PTreasurePool->AddMember(PChar);
         PChar->PTreasurePool->UpdatePool(PChar);
@@ -214,7 +220,7 @@ void CAlliance::delParty(CParty* party)
         for (auto& member : party->members)
         {
             auto* PMember = dynamic_cast<CCharEntity*>(member);
-            if (PChar != PMember)
+            if (PMember && (PChar != PMember))
             {
                 PMember->PTreasurePool = PChar->PTreasurePool;
                 PChar->PTreasurePool->AddMember(PMember);

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -279,7 +279,11 @@ bool CBattlefield::IsOccupied() const
 
 bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOBCONDITION conditions, bool ally)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
+    if (PEntity == nullptr)
+    {
+        ShowWarning("CBattlefield::InsertEntity() - PEntity is null.");
+        return false;
+    }
 
     if (PEntity->PBattlefield)
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1614,7 +1614,12 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(PBattleTarget == nullptr);
+
+    if (PBattleTarget == nullptr)
+    {
+        ShowWarning("CCharEntity::IsMobOwner() - PBattleTarget was null.")
+        return false;
+    }
 
     if (PBattleTarget->m_OwnerID.id == 0 || PBattleTarget->m_OwnerID.id == this->id || PBattleTarget->objtype == TYPE_PC)
     {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -773,26 +773,24 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             target.knockback  = PSkill->getKnockback();
             if (first && (PSkill->getPrimarySkillchain() != 0))
             {
-                if (PSkill->getPrimarySkillchain())
+                SUBEFFECT effect = battleutils::GetSkillChainEffect(PTarget, PSkill->getPrimarySkillchain(), PSkill->getSecondarySkillchain(),
+                                                                    PSkill->getTertiarySkillchain());
+                if (effect != SUBEFFECT_NONE)
                 {
-                    SUBEFFECT effect = battleutils::GetSkillChainEffect(PTarget, PSkill->getPrimarySkillchain(), PSkill->getSecondarySkillchain(),
-                                                                        PSkill->getTertiarySkillchain());
-                    if (effect != SUBEFFECT_NONE)
+                    int32 skillChainDamage = battleutils::TakeSkillchainDamage(this, PTarget, target.param, nullptr);
+                    if (skillChainDamage < 0)
                     {
-                        int32 skillChainDamage = battleutils::TakeSkillchainDamage(this, PTarget, target.param, nullptr);
-                        if (skillChainDamage < 0)
-                        {
-                            target.addEffectParam   = -skillChainDamage;
-                            target.addEffectMessage = 384 + effect;
-                        }
-                        else
-                        {
-                            target.addEffectParam   = skillChainDamage;
-                            target.addEffectMessage = 287 + effect;
-                        }
-                        target.additionalEffect = effect;
+                        target.addEffectParam   = -skillChainDamage;
+                        target.addEffectMessage = 384 + effect;
                     }
+                    else
+                    {
+                        target.addEffectParam   = skillChainDamage;
+                        target.addEffectMessage = 287 + effect;
+                    }
+                    target.additionalEffect = effect;
                 }
+
                 first = false;
             }
         }
@@ -803,6 +801,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         }
         battleutils::DirtyExp(PTarget, this);
     }
+
     PTarget = static_cast<CBattleEntity*>(state.GetTarget());
     if (PTarget->objtype == TYPE_MOB && (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR)))
     {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5384,7 +5384,7 @@ void CLuaBaseEntity::unlockJob(uint8 JobID)
 
 bool CLuaBaseEntity::hasJob(uint8 job)
 {
-    if (m_PBaseEntity->objtype != TYPE_PC || job >= MAX_JOBTYPE || job < 0)
+    if (m_PBaseEntity->objtype != TYPE_PC || job >= MAX_JOBTYPE)
     {
         ShowWarning("CLuaBaseEntity::unlockJob() - Non-PC calling function or invalid JOBTYPE");
         return false;
@@ -5430,7 +5430,7 @@ uint8 CLuaBaseEntity::getSubLvl()
 
 uint8 CLuaBaseEntity::getJobLevel(uint8 JobID)
 {
-    if (m_PBaseEntity->objtype != TYPE_PC || JobID >= MAX_JOBTYPE || JobID < 0)
+    if (m_PBaseEntity->objtype != TYPE_PC || JobID >= MAX_JOBTYPE)
     {
         ShowWarning("CLuaBaseEntity::getJobLevel() - Non-PC or Invalid JobID passed to function.");
         return 0;
@@ -9214,7 +9214,11 @@ uint8 CLuaBaseEntity::registerBattlefield(sol::object const& arg0, sol::object c
     uint32 initiator   = (arg2 != sol::lua_nil) ? arg2.as<uint32>() : 0;
 
     // TODO: Verify what happens if -1 makes it to the cast below
-    XI_DEBUG_BREAK_IF(battlefield < 0);
+    if (battlefield < 0)
+    {
+        ShowError("CLuaBaseEntity::registerBattlefield() - Battlefield State was < 0.  Investigate!");
+        return 6; // For safety, if we hit this condition, return battlefield full.
+    }
 
     return PZone->m_BattlefieldHandler->RegisterBattlefield(PChar, static_cast<uint16>(battlefield), area, initiator);
 }
@@ -9251,8 +9255,11 @@ bool CLuaBaseEntity::battlefieldAtCapacity(int battlefieldID)
 
 bool CLuaBaseEntity::enterBattlefield(sol::object const& area)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC || m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
+    {
+        ShowWarning("CLuaBaseEntity::enterBattlefield() - Non-PC calling function, or Battlefield Handler is null.");
+        return false;
+    }
 
     CBattlefield* PBattlefield = nullptr;
     if (area == sol::lua_nil)
@@ -9276,8 +9283,11 @@ bool CLuaBaseEntity::enterBattlefield(sol::object const& area)
 
 bool CLuaBaseEntity::leaveBattlefield(uint8 leavecode)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr || m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC || m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
+    {
+        ShowWarning("CLuaBaseEntity::leaveBattlefield() - NPC calling function, or Battlefield Handler is null.");
+        return false;
+    }
 
     return m_PBaseEntity->loc.zone->m_BattlefieldHandler->RemoveFromBattlefield(m_PBaseEntity, m_PBaseEntity->PBattlefield, leavecode);
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4248,6 +4248,12 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
 
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
+    if (!PChar)
+    {
+        ShowWarning("CLuaBaseEntity::addGearSetMod() - m_pBaseEntity is not of type Char.");
+        return;
+    }
+
     for (auto& exsistingMod : PChar->m_GearSetMods)
     {
         if (gearSetMod.modNameId == exsistingMod.modNameId)
@@ -4964,9 +4970,13 @@ bool CLuaBaseEntity::getNewPlayer()
 
 void CLuaBaseEntity::setNewPlayer(bool newplayer)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
     auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (!PChar)
+    {
+        ShowWarning("CLuaBaseEntity::setNewPlayer() - m_pBaseEntity is not of type Char.");
+        return;
+    }
 
     if (newplayer == true)
     {
@@ -5231,9 +5241,14 @@ uint8 CLuaBaseEntity::getSubJob()
 
 void CLuaBaseEntity::changeJob(uint8 newJob)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
-    auto*   PChar   = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+    if (!PChar)
+    {
+        ShowWarning("CLuaBaseEntity::changeJob() - m_pBaseEntity is not of type Char.");
+        return;
+    }
+
     JOBTYPE prevjob = PChar->GetMJob();
 
     PChar->resetPetZoningInfo();
@@ -6801,7 +6816,7 @@ void CLuaBaseEntity::addKeyItem(uint16 keyItemID)
     if (table >= MAX_KEYS_TABLE)
     {
         // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::addKeyItem - Attempting to add invalid key item: %d", keyItemID);
+        ShowWarning("CLuaBaseEntity::addKeyItem() - Attempting to add invalid key item: %d", keyItemID);
         return;
     }
 
@@ -6847,7 +6862,7 @@ void CLuaBaseEntity::delKeyItem(uint16 keyItemID)
     if (table >= MAX_KEYS_TABLE)
     {
         // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::delKeyItem - Attempting to delete invalid key item: %d", keyItemID);
+        ShowWarning("CLuaBaseEntity::delKeyItem() - Attempting to delete invalid key item: %d", keyItemID);
         return;
     }
 
@@ -6888,7 +6903,7 @@ void CLuaBaseEntity::unseenKeyItem(uint16 keyItemID)
     if (table >= MAX_KEYS_TABLE)
     {
         // Bail out if an invalid keyitem is being added
-        ShowWarning("CLuaBaseEntity::unseenKeyItem - Attempting to unsee invalid key item: %d", keyItemID);
+        ShowWarning("CLuaBaseEntity::unseenKeyItem() - Attempting to unsee invalid key item: %d", keyItemID);
         return;
     }
 
@@ -7096,7 +7111,7 @@ uint32 CLuaBaseEntity::getGil()
     if (m_PBaseEntity->objtype == TYPE_MOB)
     {
         auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
-        if (PMob->CanStealGil())
+        if (PMob && PMob->CanStealGil())
         {
             return PMob->GetRandomGil();
         }
@@ -7691,6 +7706,12 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
 
     CBattleEntity* PDefender = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
 
+    if (!PDefender)
+    {
+        ShowWarning("CLuaBaseEntity::takeDamage() - Attempt to use non-BattleEntity as PDefender.");
+        return;
+    }
+
     // Check for special flags which may prevent damage from waking up the target
     bool wakeUp        = true;
     bool breakBind     = true;
@@ -7974,11 +7995,16 @@ uint8 CLuaBaseEntity::getAverageItemLevel()
 
 void CLuaBaseEntity::capSkill(uint8 skill)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
     if (skill < MAX_SKILLTYPE)
     {
         auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+        if (!PChar)
+        {
+            ShowWarning("CLuaBaseEntity::capSkill() - m_PBaseEntity is not a player.");
+            return;
+        }
+
         // CItemWeapon* PItem = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN];
         /* let's just ignore this part for the moment
         //remove modifiers if valid
@@ -9010,11 +9036,12 @@ void CLuaBaseEntity::setInstance(CLuaInstance* PLuaInstance)
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
     CInstance* PInstance     = PLuaInstance->GetInstance();
+    CCharEntity* PChar       = dynamic_cast<CCharEntity*>(m_PBaseEntity);
     m_PBaseEntity->PInstance = PInstance;
 
-    if (PInstance)
+    if (PInstance && PChar)
     {
-        PInstance->RegisterChar(dynamic_cast<CCharEntity*>(m_PBaseEntity));
+        PInstance->RegisterChar(PChar);
     }
 }
 
@@ -10703,10 +10730,14 @@ bool CLuaBaseEntity::delLatent(uint16 condID, uint16 conditionValue, uint16 mID,
 
 int16 CLuaBaseEntity::getMaxGearMod(Mod modId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
     CCharEntity* PChar       = dynamic_cast<CCharEntity*>(m_PBaseEntity);
     uint16       maxModValue = 0;
+
+    if (!PChar)
+    {
+        ShowWarning("CLuaBaseEntity::getMaxGearMod() - m_PBaseEntity is not a player.")
+        return 0;
+    }
 
     for (uint8 i = 0; i < SLOT_BACK; ++i)
     {
@@ -12092,7 +12123,7 @@ void CLuaBaseEntity::petAttack(CLuaBaseEntity* PEntity)
 
 void CLuaBaseEntity::petAbility(uint16 abilityID)
 {
-    ShowWarning("CLuaBaseEntity::petAbility: Non-implemented function called with parameter %d", abilityID);
+    ShowWarning("CLuaBaseEntity::petAbility() - Non-implemented function called with parameter %d", abilityID);
 }
 
 /************************************************************************
@@ -12488,7 +12519,12 @@ uint8 CLuaBaseEntity::getSystem()
 uint16 CLuaBaseEntity::getSuperFamily()
 {
     auto* entity = dynamic_cast<CMobEntity*>(m_PBaseEntity);
-    XI_DEBUG_BREAK_IF(!entity);
+
+    if (!entity)
+    {
+        ShowWarning("CLuaBaseEntity::getSuperFamily() -  m_pBaseEntity is not a Mob.");
+        return 0;
+    }
 
     return entity->m_SuperFamily;
 }
@@ -12503,7 +12539,12 @@ uint16 CLuaBaseEntity::getSuperFamily()
 uint16 CLuaBaseEntity::getFamily()
 {
     auto* entity = dynamic_cast<CMobEntity*>(m_PBaseEntity);
-    XI_DEBUG_BREAK_IF(!entity);
+
+    if (!entity)
+    {
+        ShowWarning("CLuaBaseEntity::getFamily() -  m_pBaseEntity is not a Mob.");
+        return 0;
+    }
 
     return entity->m_Family;
 }
@@ -12873,9 +12914,10 @@ void CLuaBaseEntity::setTrueDetection(bool truedetection)
 
 void CLuaBaseEntity::setUnkillable(bool unkillable)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
-
-    dynamic_cast<CBattleEntity*>(m_PBaseEntity)->m_unkillable = unkillable;
+    if (auto* PBattle = dynamic_cast<CBattleEntity*>(m_PBaseEntity))
+    {
+        PBattle->m_unkillable = unkillable;
+    }
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4337,7 +4337,7 @@ uint8 CLuaBaseEntity::storeWithPorterMoogle(uint16 slipId, sol::table const& ext
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
         ShowWarning("CLuaBaseEntity::storeWithPorterMoogle() - Non_PC passed to function.");
-        return;
+        return 0;
     }
 
     auto* PChar      = (CCharEntity*)m_PBaseEntity;
@@ -5350,7 +5350,11 @@ void CLuaBaseEntity::changesJob(uint8 subJob)
 
 void CLuaBaseEntity::unlockJob(uint8 JobID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::unlockJob() - Non-PC calling function.");
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5380,13 +5384,14 @@ void CLuaBaseEntity::unlockJob(uint8 JobID)
 
 bool CLuaBaseEntity::hasJob(uint8 job)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC || job >= MAX_JOBTYPE || job < 0)
+    {
+        ShowWarning("CLuaBaseEntity::unlockJob() - Non-PC calling function or invalid JOBTYPE");
+        return false;
+    }
 
     JOBTYPE JobID = static_cast<JOBTYPE>(job);
-
-    XI_DEBUG_BREAK_IF(JobID > MAX_JOBTYPE || JobID < 0);
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    auto*   PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
     return (PChar->jobs.unlocked >> JobID) & 1;
 }
@@ -5425,7 +5430,7 @@ uint8 CLuaBaseEntity::getSubLvl()
 
 uint8 CLuaBaseEntity::getJobLevel(uint8 JobID)
 {
-    if (m_PBaseEntity->objtype != TYPE_PC || JobID > MAX_JOBTYPE || JobID < 0)
+    if (m_PBaseEntity->objtype != TYPE_PC || JobID >= MAX_JOBTYPE || JobID < 0)
     {
         ShowWarning("CLuaBaseEntity::getJobLevel() - Non-PC or Invalid JobID passed to function.");
         return 0;
@@ -5575,8 +5580,11 @@ void CLuaBaseEntity::setLevelCap(uint8 cap)
 
 uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity == nullptr || m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::levelRestriction() - Entity is null, or not PC.");
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7706,8 +7714,11 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
     {
         CLuaBaseEntity* PLuaAttacker = attacker.as<CLuaBaseEntity*>();
 
-        XI_DEBUG_BREAK_IF(PLuaAttacker == nullptr);
-        XI_DEBUG_BREAK_IF(PLuaAttacker->m_PBaseEntity->objtype == TYPE_NPC);
+        if (PLuaAttacker == nullptr || PLuaAttacker->m_PBaseEntity->objtype == TYPE_NPC)
+        {
+            ShowWarning("CLuaBaseEntity::takeDamage() - PLuaAttacker was null, or was NPC.");
+            return;
+        }
 
         PAttacker = dynamic_cast<CBattleEntity*>(PLuaAttacker->m_PBaseEntity);
     }
@@ -8621,7 +8632,11 @@ bool CLuaBaseEntity::hasPartyJob(uint8 job)
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::getPartyMember(uint8 member, uint8 allianceparty)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::getPartyMember() - Non-PC calling function.");
+        return std::nullopt;
+    }
 
     CBattleEntity* PBattle     = static_cast<CBattleEntity*>(m_PBaseEntity);
     CBattleEntity* PTargetChar = nullptr;
@@ -8632,7 +8647,7 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::getPartyMember(uint8 member, uint8
     }
     else if (PBattle->PParty != nullptr)
     {
-        if (allianceparty == 0 && member <= PBattle->PParty->members.size())
+        if (allianceparty == 0 && member < PBattle->PParty->members.size())
         {
             PTargetChar = PBattle->PParty->members[member];
         }
@@ -8661,8 +8676,11 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::getPartyMember(uint8 member, uint8
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::getPartyLeader()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::getPartyLeader() - Non-PC called function.");
+        return std::nullopt;
+    }
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     if (PChar->PParty)
@@ -8708,7 +8726,11 @@ void CLuaBaseEntity::forMembersInRange(float range, sol::function function)
 
 void CLuaBaseEntity::addPartyEffect(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::addPartyEffect() - Non-PC called function.");
+        return;
+    }
 
     std::vector<uint16> args(7, 0);
 
@@ -8740,7 +8762,11 @@ void CLuaBaseEntity::addPartyEffect(sol::variadic_args va)
 
 bool CLuaBaseEntity::hasPartyEffect(uint16 effectid)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::hasPartyEffect() - Non-PC called function.");
+        return false;
+    }
 
     CCharEntity* PChar = ((CCharEntity*)m_PBaseEntity);
 
@@ -8770,7 +8796,11 @@ bool CLuaBaseEntity::hasPartyEffect(uint16 effectid)
 
 void CLuaBaseEntity::removePartyEffect(uint16 effectid)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::removePartyEffect() - Non-PC called function.");
+        return;
+    }
 
     CCharEntity* PChar = ((CCharEntity*)m_PBaseEntity);
 
@@ -8792,7 +8822,11 @@ void CLuaBaseEntity::removePartyEffect(uint16 effectid)
 
 sol::table CLuaBaseEntity::getAlliance()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("CLuaBaseEntity::getAlliance() - NPC passed to function.");
+        return luautils::lua.create_table();
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8986,10 +9020,11 @@ uint8 CLuaBaseEntity::checkSoloPartyAlliance()
 
 bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    XI_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PLuaBaseEntity->GetBaseEntity()->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_PC || PLuaBaseEntity->GetBaseEntity()->objtype != TYPE_MOB)
+    {
+        ShowWarning("CLuaBaseEntity::checkKillCredit() - Non-PC type calling function, or PLuaBaseEntity is not a MOB.");
+        return false;
+    }
 
     CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     CMobEntity*  PMob  = static_cast<CMobEntity*>(PLuaBaseEntity->GetBaseEntity());
@@ -9192,11 +9227,14 @@ bool CLuaBaseEntity::battlefieldAtCapacity(int battlefieldID)
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     auto* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
 
-    XI_DEBUG_BREAK_IF(PZone->m_BattlefieldHandler == nullptr);
+    if (!PZone || PZone->m_BattlefieldHandler == nullptr)
+    {
+        ShowWarning("CLuaBaseEntity::battlefieldAtCapacity() - Battlefield Handler is null.");
+        return true; // NOTE: We were previously breaking here, so return full in this case.
+    }
 
     bool full = false;
-
-    if (PZone != nullptr && PZone->m_BattlefieldHandler != nullptr && PZone->m_BattlefieldHandler->ReachedMaxCapacity(battlefieldID))
+    if (PZone->m_BattlefieldHandler->ReachedMaxCapacity(battlefieldID))
     {
         full = true;
     }
@@ -9421,10 +9459,7 @@ void CLuaBaseEntity::enableEntities(sol::object const& obj)
  ************************************************************************/
 void CLuaBaseEntity::independentAnimation(CLuaBaseEntity* PTarget, uint16 animId, uint8 mode)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-
-    CBaseEntity* PActor = (CCharEntity*)m_PBaseEntity;
-    PActor->loc.zone->PushPacket(PActor, CHAR_INRANGE_SELF, new CIndependentAnimationPacket(PActor, PTarget->GetBaseEntity(), animId, mode));
+    m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE_SELF, new CIndependentAnimationPacket(m_PBaseEntity, PTarget->GetBaseEntity(), animId, mode));
 }
 
 /************************************************************************
@@ -10986,8 +11021,6 @@ uint8 CLuaBaseEntity::getOverloadChance(uint8 element)
 
 void CLuaBaseEntity::setStatDebilitation(uint16 statDebil)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
         auto* PChar{ static_cast<CCharEntity*>(m_PBaseEntity) };
@@ -11634,8 +11667,11 @@ int32 CLuaBaseEntity::takeSwipeLungeDamage(CLuaBaseEntity* caster, int32 damage,
 
 void CLuaBaseEntity::spawnPet(sol::object const& arg0)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("CLuaBaseEntity::spawnPet() - NPC calling function.");
+        return;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1827,8 +1827,11 @@ void CLuaBaseEntity::openDoor(sol::object const& seconds)
 
 void CLuaBaseEntity::closeDoor(sol::object const& seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("CLuaBaseEntity::closeDoor() - Non-NPC passed to function.");
+        return;
+    }
 
     if (m_PBaseEntity->animation == ANIMATION_OPEN_DOOR)
     {
@@ -4331,8 +4334,11 @@ std::optional<CLuaItem> CLuaBaseEntity::getStorageItem(uint8 container, uint8 sl
 
 uint8 CLuaBaseEntity::storeWithPorterMoogle(uint16 slipId, sol::table const& extraTable, sol::table const& storableItemIdsTable)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("CLuaBaseEntity::storeWithPorterMoogle() - Non_PC passed to function.");
+        return;
+    }
 
     auto* PChar      = (CCharEntity*)m_PBaseEntity;
     auto  slipSlotId = PChar->getStorage(LOC_INVENTORY)->SearchItem(slipId);
@@ -5419,9 +5425,11 @@ uint8 CLuaBaseEntity::getSubLvl()
 
 uint8 CLuaBaseEntity::getJobLevel(uint8 JobID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    XI_DEBUG_BREAK_IF(JobID > MAX_JOBTYPE || JobID < 0);
+    if (m_PBaseEntity->objtype != TYPE_PC || JobID > MAX_JOBTYPE || JobID < 0)
+    {
+        ShowWarning("CLuaBaseEntity::getJobLevel() - Non-PC or Invalid JobID passed to function.");
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->jobs.job[JobID];
@@ -8089,9 +8097,11 @@ uint16 CLuaBaseEntity::getSkillLevel(uint16 skillId)
 
 void CLuaBaseEntity::setSkillLevel(uint8 SkillID, uint16 SkillAmount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    XI_DEBUG_BREAK_IF(SkillID >= MAX_SKILLTYPE);
+    if (m_PBaseEntity->objtype != TYPE_PC || SkillID >= MAX_SKILLTYPE)
+    {
+        ShowWarning("CLuaBaseEntity::setSkillLevel() - Non-PC or Invalid SkillID passed to function.");
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -12252,7 +12262,11 @@ auto CLuaBaseEntity::getAutomatonName() -> const char*
 
 uint8 CLuaBaseEntity::getAutomatonFrame()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON);
+    if (m_PBaseEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON)
+    {
+        ShowWarning("CLuaBaseEntity::getAutomatonFrame() - No automaton passed to function, or master does not have an automaton.");
+        return 0;
+    }
 
     auto* PAutomaton = static_cast<CAutomatonEntity*>(m_PBaseEntity);
     return static_cast<uint8>(PAutomaton->getFrame());
@@ -12267,7 +12281,11 @@ uint8 CLuaBaseEntity::getAutomatonFrame()
 
 uint8 CLuaBaseEntity::getAutomatonHead()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON);
+    if (m_PBaseEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() != PET_TYPE::AUTOMATON)
+    {
+        ShowWarning("CLuaBaseEntity::getAutomatonFrame() - No automaton passed to function, or master does not have an automaton.");
+        return 0;
+    }
 
     auto* PAutomaton = static_cast<CAutomatonEntity*>(m_PBaseEntity);
     return static_cast<uint8>(PAutomaton->getHead());

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -85,7 +85,11 @@ uint16 CLuaItem::getTrialNumber()
 
 auto CLuaItem::getMatchingTrials() -> sol::table
 {
-    XI_DEBUG_BREAK_IF(m_PLuaItem == nullptr);
+    if (m_PLuaItem == nullptr)
+    {
+        ShowWarning("CLuaItem::getMatchingTrials() - m_PLuaItem is null.");
+        return;
+    }
 
     auto PItem = static_cast<CItemEquipment*>(m_PLuaItem);
 

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -88,7 +88,7 @@ auto CLuaItem::getMatchingTrials() -> sol::table
     if (m_PLuaItem == nullptr)
     {
         ShowWarning("CLuaItem::getMatchingTrials() - m_PLuaItem is null.");
-        return;
+        return luautils::lua.create_table();
     }
 
     auto PItem = static_cast<CItemEquipment*>(m_PLuaItem);

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -206,7 +206,7 @@ void CMeritPoints::LoadMeritPoints(uint32 charid)
 
     for (uint16 i = 0; i < MERITS_COUNT; ++i)
     {
-        if ((catNumber <= maxCatCount && i == meritNameSpace::groupOffset[catNumber]) || (catNumber > 27 && catNumber < 31) || catNumber == 51) // Increment category number if known (or known unknown)
+        if ((catNumber < maxCatCount && i == meritNameSpace::groupOffset[catNumber]) || (catNumber > 27 && catNumber < 31) || catNumber == 51) // Increment category number if known (or known unknown)
         {
             if ((catNumber > 27 && catNumber < 31) || catNumber == 51) // 28-30 and 51 are UNK.
             {

--- a/src/map/packets/guild_menu_buy.cpp
+++ b/src/map/packets/guild_menu_buy.cpp
@@ -35,8 +35,11 @@ CGuildMenuBuyPacket::CGuildMenuBuyPacket(CCharEntity* PChar, CItemContainer* PGu
     this->setType(0x83);
     this->setSize(0xF8);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PGuild == nullptr);
+    if (PChar == nullptr || PGuild == nullptr)
+    {
+        ShowError("CGuildMenuBuyPacket::CGuildMenuBuyPacket() - PChar or PGuild was null.");
+        return;
+    }
 
     uint8 ItemCount   = 0;
     uint8 PacketCount = 0;

--- a/src/map/packets/guild_menu_sell.cpp
+++ b/src/map/packets/guild_menu_sell.cpp
@@ -35,8 +35,11 @@ CGuildMenuSellPacket::CGuildMenuSellPacket(CCharEntity* PChar, CItemContainer* P
     this->setType(0x85);
     this->setSize(0xF8);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PGuild == nullptr);
+    if (PChar == nullptr || PGuild == nullptr)
+    {
+        ShowError("CGuildMenuSellPacket::CGuildMenuSellPacket() - PChar or PGuild was null.");
+        return;
+    }
 
     uint8 ItemCount   = 0;
     uint8 PacketCount = 0;

--- a/src/map/packets/jobpoint_details.cpp
+++ b/src/map/packets/jobpoint_details.cpp
@@ -54,7 +54,10 @@ CJobPointDetailsPacket::CJobPointDetailsPacket(CCharEntity* PChar)
         if (i % 2 == 1)
         {
             PChar->pushPacket(new CBasicPacket(*this));
-            memset(data + 4, 0, sizeof(JP_DETAIL_DATA_SIZE * 20));
+
+            // Reset Data
+            uint8 jpPacketSize = JP_DETAIL_DATA_SIZE * 20;
+            std::memset(data + 4, 0, sizeof(jpPacketSize));
         }
     }
 }

--- a/src/map/packets/message_standard.cpp
+++ b/src/map/packets/message_standard.cpp
@@ -52,7 +52,7 @@ CMessageStandardPacket::CMessageStandardPacket(uint32 param0, uint32 param1, uin
 
     ref<uint16>(0x0A) = MessageID;
 
-    snprintf((char*)data + (0x0D), 24, "Para0 %d Para1 %d", param0, param1);
+    snprintf((char*)data + (0x0D), 24, "Para0 %u Para1 %u", param0, param1);
 }
 
 CMessageStandardPacket::CMessageStandardPacket(CCharEntity* PChar, uint32 param0, uint32 param1, MsgStd MessageID)

--- a/src/map/packets/party_map.cpp
+++ b/src/map/packets/party_map.cpp
@@ -30,7 +30,11 @@ CPartyMapPacket::CPartyMapPacket(CCharEntity* PChar)
     this->setType(0xA0);
     this->setSize(0x18);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
+    if (PChar == nullptr)
+    {
+        ShowError("CPartyMapPacket::CPartyMapPacket() - PChar was null.");
+        return;
+    }
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->getZone();

--- a/src/map/packets/party_member_update.cpp
+++ b/src/map/packets/party_member_update.cpp
@@ -40,7 +40,11 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CCharEntity* PChar, uint8 Mem
     // Modify with caution for the below functions!
     this->setSize(0x40);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
+    if (PChar == nullptr)
+    {
+        ShowError("CPartyMemberUpdatePacket::CPartyMemberUpdatePacket() - PChar was null.");
+        return;
+    }
 
     ref<uint32>(0x04) = PChar->id;
 
@@ -77,7 +81,11 @@ CPartyMemberUpdatePacket::CPartyMemberUpdatePacket(CTrustEntity* PTrust, uint8 M
     this->setType(0xDD);
     this->setSize(0x40);
 
-    XI_DEBUG_BREAK_IF(PTrust == nullptr);
+    if (PTrust == nullptr)
+    {
+        ShowError("CPartyMemberUpdatePacket::CPartyMemberUpdatePacket() - PTrust was null.");
+        return;
+    }
 
     ref<uint32>(0x04) = PTrust->id;
 

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -60,29 +60,30 @@ struct CParty::partyInfo_t
     uint16      prev_zone;
 };
 
-/************************************************************************
- *                                                                      *
- *  Конструктор                                                         *
- *                                                                      *
- ************************************************************************/
-
+// Constructor
 CParty::CParty(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != nullptr);
-
-    m_PartyID     = PEntity->id;
-    m_PartyType   = PEntity->objtype == TYPE_PC ? PARTY_PCS : PARTY_MOBS;
-    m_PartyNumber = 0;
-
-    m_PLeader       = nullptr;
-    m_PAlliance     = nullptr;
-    m_PSyncTarget   = nullptr;
-    m_PQuaterMaster = nullptr;
-
+    m_PLeader        = nullptr;
+    m_PAlliance      = nullptr;
+    m_PSyncTarget    = nullptr;
+    m_PQuaterMaster  = nullptr;
     m_EffectsChanged = false;
-    AddMember(PEntity);
-    SetLeader((char*)PEntity->name.c_str());
+    m_PartyID        = 0;
+    m_PartyType      = PARTY_MOBS;
+    m_PartyNumber    = 0;
+
+    if (PEntity != nullptr && PEntity->PParty == nullptr)
+    {
+        m_PartyID     = PEntity->id;
+        m_PartyType   = PEntity->objtype == TYPE_PC ? PARTY_PCS : PARTY_MOBS;
+
+        AddMember(PEntity);
+        SetLeader((char*)PEntity->name.c_str());
+    }
+    else
+    {
+        ShowWarning("CParty::CParty() - PEntity was null, or party was not null.")
+    }
 }
 
 CParty::CParty(uint32 id)

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -261,8 +261,11 @@ CBattleEntity* CParty::GetMemberByName(const int8* MemberName)
 
 void CParty::RemoveMember(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != this);
+    if (PEntity == nullptr || PEntity->PParty != this)
+    {
+        ShowWarning("CParty::RemoveMember() - PEntity was null, or PParty mismatch.");
+        return;
+    }
 
     if (m_PLeader == PEntity)
     {
@@ -342,8 +345,11 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
 
 void CParty::DelMember(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != this);
+    if (PEntity == nullptr || PEntity->PParty != this)
+    {
+        ShowWarning("CParty::DelMember() - PEntity was null, or PParty mismatch.");
+        return;
+    }
 
     if (m_PLeader == PEntity)
     {
@@ -500,8 +506,11 @@ std::vector<CParty::partyInfo_t> CParty::GetPartyInfo() const
 
 void CParty::AddMember(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != nullptr);
+    if (PEntity == nullptr || PEntity->PParty != nullptr)
+    {
+        ShowWarning("CParty::AddMember() - PEntity was null, or PParty not null.");
+        return;
+    }
 
     PEntity->PParty = this;
     members.push_back(PEntity);
@@ -610,8 +619,11 @@ void CParty::AddMember(uint32 id)
 
 void CParty::PushMember(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != nullptr);
+    if (PEntity == nullptr || PEntity->PParty != nullptr)
+    {
+        ShowWarning("CParty::PushMember() - PEntity was null, or PParty not null.");
+        return;
+    }
 
     PEntity->PParty = this;
     members.push_back(PEntity);
@@ -697,8 +709,11 @@ CBattleEntity* CParty::GetQuaterMaster()
 
 uint16 CParty::GetMemberFlags(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->PParty != this);
+    if (PEntity == nullptr || PEntity->PParty != this)
+    {
+        ShowWarning("CParty::GetMemberFlags() - PEntity was null, or PParty mismatch.");
+        return 0;
+    }
 
     uint16 Flags = 0;
 
@@ -878,7 +893,11 @@ void CParty::ReloadPartyMembers(CCharEntity* PChar)
 
 void CParty::ReloadTreasurePool(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
+    if (PChar == nullptr)
+    {
+        ShowWarning("CParty::ReloadTreasurePool() - PChar was null.");
+        return;
+    }
 
     if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() == TREASUREPOOL_ZONE)
     {

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1815,7 +1815,12 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
 void CStatusEffectContainer::TickEffects(time_point tick)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(m_POwner == nullptr);
+
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("CStatusEffectContainer::TickRegen() - m_POwner is null.");
+        return;
+    }
 
     if (!m_POwner->isDead())
     {
@@ -1847,7 +1852,12 @@ void CStatusEffectContainer::TickEffects(time_point tick)
 void CStatusEffectContainer::TickRegen(time_point tick)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(m_POwner == nullptr);
+
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("CStatusEffectContainer::TickRegen() - m_POwner is null.");
+        return;
+    }
 
     if (!m_POwner->isDead())
     {

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -996,9 +996,12 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
 
 bool CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, uint8 maxRolls, uint8 bustDuration)
 {
-    // break if not a COR roll.
-    XI_DEBUG_BREAK_IF(!((PStatusEffect->GetStatusID() >= EFFECT_FIGHTERS_ROLL && PStatusEffect->GetStatusID() <= EFFECT_NATURALISTS_ROLL) ||
-                        (PStatusEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL)));
+    // Don't process if not a COR roll.
+    if (!((PStatusEffect->GetStatusID() >= EFFECT_FIGHTERS_ROLL && PStatusEffect->GetStatusID() <= EFFECT_NATURALISTS_ROLL) ||
+                        (PStatusEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL)))
+    {
+        return false;
+    }
 
     // if all match tier/id/effect then overwrite
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -73,8 +73,11 @@ TREASUREPOOLTYPE CTreasurePool::GetPoolType()
 
 void CTreasurePool::AddMember(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != this);
+    if (PChar == nullptr || PChar->PTreasurePool != this)
+    {
+        ShowWarning("CTreasurePool::AddMember() - PChar was null, or PTreasurePool mismatched.");
+        return;
+    }
 
     members.push_back(PChar);
 
@@ -96,8 +99,11 @@ void CTreasurePool::AddMember(CCharEntity* PChar)
 
 void CTreasurePool::DelMember(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != this);
+    if (PChar == nullptr || PChar->PTreasurePool != this)
+    {
+        ShowWarning("CTreasurePool::DelMember() - PChar was null, or PTreasurePool mismatched.");
+        return;
+    }
 
     // if(m_TreasurePoolType != TREASUREPOOL_ZONE){
     // Zone drops e.g. Dynamis DO NOT remove previous lot info. Everything else does.
@@ -245,8 +251,11 @@ uint8 CTreasurePool::AddItem(uint16 ItemID, CBaseEntity* PEntity)
 
 void CTreasurePool::UpdatePool(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != this);
+    if (PChar == nullptr || PChar->PTreasurePool != this)
+    {
+        ShowWarning("CTreasurePool::UpdatePool() - PChar was null, or PTreasurePool mismatched.");
+        return;
+    }
 
     if (PChar->status != STATUS_TYPE::DISAPPEAR)
     {
@@ -265,8 +274,11 @@ void CTreasurePool::UpdatePool(CCharEntity* PChar)
 
 void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != this);
+    if (PChar == nullptr || PChar->PTreasurePool != this)
+    {
+        ShowWarning("CTreasurePool::LotItem() - PChar was null, or PTreasurePool mismatched.");
+        return;
+    }
 
     if (SlotID >= TREASUREPOOL_SIZE)
     {
@@ -306,8 +318,11 @@ void CTreasurePool::LotItem(CCharEntity* PChar, uint8 SlotID, uint16 Lot)
 
 void CTreasurePool::PassItem(CCharEntity* PChar, uint8 SlotID)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != this);
+    if (PChar == nullptr || PChar->PTreasurePool != this)
+    {
+        ShowWarning("CTreasurePool::PassItem() - PChar was null, or PTreasurePool mismatched.");
+        return;
+    }
 
     if (SlotID >= TREASUREPOOL_SIZE)
     {
@@ -517,9 +532,11 @@ void CTreasurePool::CheckTreasureItem(time_point tick, uint8 SlotID)
 
 void CTreasurePool::TreasureWon(CCharEntity* winner, uint8 SlotID)
 {
-    XI_DEBUG_BREAK_IF(winner == nullptr);
-    XI_DEBUG_BREAK_IF(winner->PTreasurePool != this);
-    XI_DEBUG_BREAK_IF(m_PoolItems[SlotID].ID == 0);
+    if (winner == nullptr || winner->PTreasurePool != this || m_PoolItems[SlotID].ID == 0)
+    {
+        ShowWarning("CTreasurePool::TreasureError() - Winner, or Winner Treasure Pool mismatch, or Pool ID = 0.");
+        return;
+    }
 
     m_PoolItems[SlotID].TimeStamp = get_server_start_time();
 
@@ -543,9 +560,11 @@ void CTreasurePool::TreasureWon(CCharEntity* winner, uint8 SlotID)
 
 void CTreasurePool::TreasureError(CCharEntity* winner, uint8 SlotID)
 {
-    XI_DEBUG_BREAK_IF(winner == nullptr);
-    XI_DEBUG_BREAK_IF(winner->PTreasurePool != this);
-    XI_DEBUG_BREAK_IF(m_PoolItems[SlotID].ID == 0);
+    if (winner == nullptr || winner->PTreasurePool != this || m_PoolItems[SlotID].ID == 0)
+    {
+        ShowWarning("CTreasurePool::TreasureError() - Winner, or Winner Treasure Pool mismatch, or Pool ID = 0.");
+        return;
+    }
 
     m_PoolItems[SlotID].TimeStamp = get_server_start_time();
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2300,7 +2300,7 @@ namespace battleutils
 
                 float ratio = 1.0f;
 
-                if (weapon->getSkillType() == SKILL_HAND_TO_HAND)
+                if (weapon && weapon->getSkillType() == SKILL_HAND_TO_HAND)
                 {
                     ratio = 2.0f;
                 }
@@ -2646,7 +2646,7 @@ namespace battleutils
                 if (isPet)
                 {
                     CPetEntity* petEntity = dynamic_cast<CPetEntity*>(PAttacker);
-                    isAvatar              = petEntity->getPetType() == PET_TYPE::AVATAR;
+                    isAvatar              = petEntity ? petEntity->getPetType() == PET_TYPE::AVATAR : false;
                 }
 
                 if (isAvatar)
@@ -2677,7 +2677,7 @@ namespace battleutils
             // Broth
 
             int32 maxHitRate  = 99;
-            auto* targ_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]);
+            auto* targ_weapon = PAttacker ? dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]) : nullptr;
 
             // As far as I can tell kick attacks fall under Hand-to-Hand so ignoring them and letting them go to 99
             bool isOffhand   = attackNumber == 1;
@@ -4089,7 +4089,12 @@ namespace battleutils
 
     CItemWeapon* GetEntityWeapon(CBattleEntity* PEntity, SLOTTYPE Slot)
     {
-        XI_DEBUG_BREAK_IF(Slot < SLOT_MAIN || Slot > SLOT_AMMO);
+        if (Slot < SLOT_MAIN || Slot > SLOT_AMMO)
+        {
+            ShowWarning("battleutils::GetEntityWeapon() - Received invalid slot type.");
+            return nullptr;
+        }
+
         return dynamic_cast<CItemWeapon*>(((CMobEntity*)PEntity)->m_Weapons[Slot]);
     }
 
@@ -4373,8 +4378,11 @@ namespace battleutils
 
     void GenerateCureEnmity(CBattleEntity* PSource, CBattleEntity* PTarget, int32 amount)
     {
-        XI_DEBUG_BREAK_IF(PSource == nullptr);
-        XI_DEBUG_BREAK_IF(PTarget == nullptr);
+        if (!PSource || !PTarget)
+        {
+            ShowWarning("battleutils::GenerateCureEnmity - PSource or PTarget was null.")
+            return;
+        }
 
         for (auto* entity : *PTarget->PNotorietyContainer)
         {
@@ -6691,6 +6699,12 @@ namespace battleutils
 
     int32 GetScaledItemModifier(CBattleEntity* PEntity, CItemEquipment* PItem, Mod mod)
     {
+        if (!PEntity || !PItem)
+        {
+            ShowWarning("battleutils::GetScaledItemModifier() - PEntity or PItem received as null.");
+            return 0;
+        }
+
         if (PEntity->GetMLevel() < PItem->getReqLvl())
         {
             auto modAmount = PItem->getModifier(mod);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3646,7 +3646,11 @@ namespace battleutils
 
     uint8 GetSkillchainSubeffect(SKILLCHAIN_ELEMENT skillchain)
     {
-        XI_DEBUG_BREAK_IF(skillchain < SC_NONE || skillchain > SC_DARKNESS_II);
+        if (skillchain < SC_NONE || skillchain > SC_DARKNESS_II)
+        {
+            ShowWarning("battleutils::GetSkillchainSubeffect() - Invalid Element passed to function.");
+            return 0;
+        }
 
         static const uint8 effects[] = {
             SUBEFFECT_NONE,          // SC_NONE
@@ -3673,7 +3677,11 @@ namespace battleutils
 
     uint8 GetSkillchainTier(SKILLCHAIN_ELEMENT skillchain)
     {
-        XI_DEBUG_BREAK_IF(skillchain < SC_NONE || skillchain > SC_DARKNESS_II);
+        if (skillchain < SC_NONE || skillchain > SC_DARKNESS_II)
+        {
+            ShowWarning("battleutils::GetSkillchainTier() - Invalid Element passed to function.");
+            return 0;
+        }
 
         static const uint8 tiers[] = {
             0, // SC_NONE
@@ -4001,8 +4009,11 @@ namespace battleutils
 
     int32 TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar)
     {
-        XI_DEBUG_BREAK_IF(PAttacker == nullptr);
-        XI_DEBUG_BREAK_IF(PDefender == nullptr);
+        if (PAttacker == nullptr || PDefender == nullptr)
+        {
+            ShowWarning("battleutils::TakeSkillchainDamage() - PAttacker or PDefender was null.");
+            return 0;
+        }
 
         CStatusEffect* PEffect = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SKILLCHAIN, 0);
 
@@ -4100,7 +4111,11 @@ namespace battleutils
 
     void MakeEntityStandUp(CBattleEntity* PEntity)
     {
-        XI_DEBUG_BREAK_IF(PEntity == nullptr);
+        if (PEntity == nullptr)
+        {
+            ShowWarning("battleutils::MakeEntityStandUp() - PEntity was null.");
+            return;
+        }
 
         if (PEntity->objtype == TYPE_PC)
         {
@@ -4122,7 +4137,11 @@ namespace battleutils
 
     bool HasNinjaTool(CBattleEntity* PEntity, CSpell* PSpell, bool ConsumeTool)
     {
-        XI_DEBUG_BREAK_IF(PEntity == nullptr || PSpell == nullptr);
+        if (PEntity == nullptr || PSpell == nullptr)
+        {
+            ShowWarning("battleutils::HasNinjaTool() - PEntity or PSpell was null.");
+            return false;
+        }
 
         if (PEntity->objtype == TYPE_PC)
         {
@@ -4399,7 +4418,11 @@ namespace battleutils
     // Generate enmity for all targets in range
     void GenerateInRangeEnmity(CBattleEntity* PSource, int16 CE, int16 VE)
     {
-        XI_DEBUG_BREAK_IF(PSource == nullptr);
+        if (PSource == nullptr)
+        {
+            ShowWarning("battleutils::GenerateInRangeEnmity() - PSource received as null.");
+            return;
+        }
 
         CCharEntity* PIterSource = nullptr;
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2645,6 +2645,12 @@ namespace charutils
     {
         std::vector<CAbility*> AbilitiesList;
 
+        if (PChar == nullptr)
+        {
+            ShowWarning("charutils::BuildingCharAbilityTable() - PChar was null.");
+            return;
+        }
+
         memset(&PChar->m_Abilities, 0, sizeof(PChar->m_Abilities));
 
         AbilitiesList = ability::GetAbilities(PChar->GetMJob());

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5205,7 +5205,11 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        XI_DEBUG_BREAK_IF(SkillID >= MAX_SKILLTYPE);
+        if (SkillID >= MAX_SKILLTYPE)
+        {
+            ShowWarning("charutils::SaveCharSkills() - SkillID is greated than MAX_SKILLTYPE.");
+            return;
+        }
 
         const char* Query = "INSERT INTO char_skills "
                             "SET "

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -179,40 +179,52 @@ namespace itemutils
 
     CItem* GetItem(CItem* PItem)
     {
-        XI_DEBUG_BREAK_IF(PItem == nullptr);
+        if (PItem == nullptr)
+        {
+            ShowWarning("CItem::GetItem() - PItem is null.");
+            return nullptr;
+        }
 
         if (PItem->isType(ITEM_WEAPON))
         {
             return new CItemWeapon(*((CItemWeapon*)PItem));
         }
+
         if (PItem->isType(ITEM_EQUIPMENT))
         {
             return new CItemEquipment(*((CItemEquipment*)PItem));
         }
+
         if (PItem->isType(ITEM_USABLE))
         {
             return new CItemUsable(*((CItemUsable*)PItem));
         }
+
         if (PItem->isType(ITEM_LINKSHELL))
         {
             return new CItemLinkshell(*((CItemLinkshell*)PItem));
         }
+
         if (PItem->isType(ITEM_FURNISHING))
         {
             return new CItemFurnishing(*((CItemFurnishing*)PItem));
         }
+
         if (PItem->isType(ITEM_PUPPET))
         {
             return new CItemPuppet(*((CItemPuppet*)PItem));
         }
+
         if (PItem->isType(ITEM_GENERAL))
         {
             return new CItemGeneral(*((CItemGeneral*)PItem));
         }
+
         if (PItem->isType(ITEM_CURRENCY))
         {
             return new CItemCurrency(*((CItemCurrency*)PItem));
         }
+
         return nullptr;
     }
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -332,7 +332,11 @@ namespace petutils
 
     void AttackTarget(CBattleEntity* PMaster, CBattleEntity* PTarget)
     {
-        XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
+        if (PMaster == nullptr || PMaster->PPet == nullptr || PTarget == nullptr)
+        {
+            ShowWarning("petutils::AttackTarget() - Null master, pet, or target passed to function.");
+            return;
+        }
 
         CBattleEntity* PPet = PMaster->PPet;
 
@@ -344,7 +348,11 @@ namespace petutils
 
     void RetreatToMaster(CBattleEntity* PMaster)
     {
-        XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
+        if (PMaster == nullptr || PMaster->PPet == nullptr)
+        {
+            ShowWarning("petutils::RetreatToMaster() - Null master or pet passed to function.");
+            return;
+        }
 
         CBattleEntity* PPet = PMaster->PPet;
 

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -549,6 +549,12 @@ namespace puppetutils
 
     uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill)
     {
+        if (PChar == nullptr)
+        {
+            ShowWarning("puppetutils::getSkillCap() - Null PChar passed to function.");
+            return 0;
+        }
+
         return getSkillCap(PChar, skill, PChar->PAutomaton->GetMLevel());
     }
 
@@ -577,7 +583,11 @@ namespace puppetutils
 
     void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
     {
-        XI_DEBUG_BREAK_IF(!PAutomaton->PMaster || PAutomaton->PMaster->objtype != TYPE_PC);
+        if (!PAutomaton->PMaster || PAutomaton->PMaster->objtype != TYPE_PC)
+        {
+            ShowWarning("puppetutils::TrySkillUP() - PMaster was null, or was not a player.");
+            return;
+        }
 
         CCharEntity* PChar = (CCharEntity*)PAutomaton->PMaster;
         if (getSkillCap(PChar, SkillID) != 0 && !(PAutomaton->WorkingSkills.skill[SkillID] & 0x8000))

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -408,20 +408,31 @@ namespace trustutils
         auto baseDamage       = mobStyleDamage * 0.5f;
         auto damageMultiplier = static_cast<float>(trustData->cmbDmgMult) / 100.0f;
         auto adjustedDamage   = baseDamage * damageMultiplier;
-        auto finalDamage      = std::max(adjustedDamage, 1.0f);
+        auto finalDamage      = static_cast<uint16>(std::max(adjustedDamage, 1.0f));
 
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_MAIN]))->setDamage(static_cast<uint16>(finalDamage));
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_RANGED]))->setDamage(static_cast<uint16>(finalDamage));
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_AMMO]))->setDamage(static_cast<uint16>(finalDamage));
+        auto mainWeapon   = dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_MAIN]);
+        auto rangedWeapon = dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_RANGED]);
+        auto ammoWeapon   = dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_AMMO]);
 
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_MAIN]))->setDelay((trustData->cmbDelay * 1000) / 60);
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_MAIN]))->setBaseDelay((trustData->cmbDelay * 1000) / 60);
+        if (mainWeapon && rangedWeapon && ammoWeapon)
+        {
+            mainWeapon->setDamage(finalDamage);
+            rangedWeapon->setDamage(finalDamage);
+            ammoWeapon->setDamage(finalDamage);
 
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_RANGED]))->setDelay((trustData->cmbDelay * 1000) / 60);
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_RANGED]))->setBaseDelay((trustData->cmbDelay * 1000) / 60);
+            mainWeapon->setDelay((trustData->cmbDelay * 1000) / 60);
+            mainWeapon->setBaseDelay((trustData->cmbDelay * 1000) / 60);
 
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_AMMO]))->setDelay((trustData->cmbDelay * 1000) / 60);
-        (dynamic_cast<CItemWeapon*>(PTrust->m_Weapons[SLOT_AMMO]))->setBaseDelay((trustData->cmbDelay * 1000) / 60);
+            rangedWeapon->setDelay((trustData->cmbDelay * 1000) / 60);
+            rangedWeapon->setBaseDelay((trustData->cmbDelay * 1000) / 60);
+
+            ammoWeapon->setDelay((trustData->cmbDelay * 1000) / 60);
+            ammoWeapon->setBaseDelay((trustData->cmbDelay * 1000) / 60);
+        }
+        else
+        {
+            ShowError("trustutils::LoadTrust() - Unable to set Weapon parameters.")
+        }
 
         // Spell lists
         auto* spellList = mobSpellList::GetMobSpellList(trustData->spellList);
@@ -664,6 +675,12 @@ namespace trustutils
         // Skills
         using namespace gambits;
         auto* controller = dynamic_cast<CTrustController*>(PTrust->PAI->GetController());
+
+        if (!controller)
+        {
+            ShowWarning("trustutils::LoadTrustStatsAndSkills() - Trust Controller was null.");
+            return;
+        }
 
         // Default TP selectors
         controller->m_GambitsContainer->tp_trigger = G_TP_TRIGGER::ASAP;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -995,7 +995,11 @@ namespace zoneutils
 
     int GetWeatherElement(WEATHER weather)
     {
-        XI_DEBUG_BREAK_IF(weather >= MAX_WEATHER_ID);
+        if (weather >= MAX_WEATHER_ID)
+        {
+            ShowWarning("zoneutils::GetWeatherElement() - Invalid weather passed to function.");
+            return 0;
+        }
 
         // TODO: Fix weather ordering; at the moment, this current fire, water, earth, wind, snow, thunder
         // order MUST be preserved due to the weather enums going in this order. Those enums will

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -650,9 +650,12 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 void CZone::IncreaseZoneCounter(CCharEntity* PChar)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->loc.zone != nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != nullptr);
+
+    if (PChar == nullptr || PChar->loc.zone != nullptr || PChar->PTreasurePool != nullptr)
+    {
+        ShowWarning("CZone::IncreaseZoneCounter() - PChar is null, or Player zone or Treasure Pools is not null.");
+        return;
+    }
 
     PChar->targid = m_zoneEntities->GetNewCharTargID();
 

--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -22,7 +22,7 @@ target=${1:-src}
 # https://quick-bench.com/q/13EX97WSfj9-rY_98opaAwgDOQc
 
 cppcheck -v -j 4 --force --quiet --inconclusive --std=c++17 \
---enable=information,performance,portability --inline-suppr \
+--enable=information,performance,portability,warning --inline-suppr \
 --suppress=passedByValue:src/map/packet_system.cpp \
 -DSA_INTERRUPT -DZMQ_DEPRECATED -DZMQ_EVENT_MONITOR_STOPPED -DTRACY_ENABLE \
 ${target}

--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -22,7 +22,7 @@ target=${1:-src}
 # https://quick-bench.com/q/13EX97WSfj9-rY_98opaAwgDOQc
 
 cppcheck -v -j 4 --force --quiet --inconclusive --std=c++17 \
---enable=information,performance,portability,warning --inline-suppr \
+--enable=information,performance,portability --inline-suppr \
 --suppress=passedByValue:src/map/packet_system.cpp \
 -DSA_INTERRUPT -DZMQ_DEPRECATED -DZMQ_EVENT_MONITOR_STOPPED -DTRACY_ENABLE \
 ${target}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds some additional checks and logging around dynamic_cast, and converts some debug break macros to logging to sanely exit function.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Nothing should change, unless additional checks catch an issue.
<!-- Clear and detailed steps to test your changes here -->
