### PR TITLE
[core] Allow commands to be specified from modules

### DIFF
--- a/modules/custom/commands/test.lua
+++ b/modules/custom/commands/test.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- func: test
+-- desc: A test command module
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+local function double_print(player, str)
+    print(str)
+    player:PrintToPlayer(str, xi.msg.channel.SYSTEM_3, "")
+end
+
+function onTrigger(player)
+    double_print("Test print")
+end

--- a/modules/init.txt
+++ b/modules/init.txt
@@ -36,4 +36,5 @@
 #
 # Live example:
 
+custom/commands/
 custom/lua/test_npcs_in_gm_home.lua

--- a/src/common/filewatcher.cpp
+++ b/src/common/filewatcher.cpp
@@ -7,15 +7,18 @@
 #include <memory>
 #include <string>
 
-Filewatcher::Filewatcher(std::string const& path)
+Filewatcher::Filewatcher(std::vector<std::string> paths)
 #ifdef USE_GENERIC_FILEWATCHER
 : fileWatcher(std::make_unique<efsw::FileWatcher>(true))
 #else
 : fileWatcher(std::make_unique<efsw::FileWatcher>(false))
 #endif
-, basePath(path)
+, basePaths(paths)
 {
-    fileWatcher->addWatch(path, this, true);
+    for (auto& path : paths)
+    {
+        fileWatcher->addWatch(path, this, true);
+    }
     fileWatcher->watch();
 }
 

--- a/src/common/filewatcher.h
+++ b/src/common/filewatcher.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <concurrentqueue.h>
 #include <efsw/efsw.hpp>
@@ -11,12 +12,12 @@
 class Filewatcher : public efsw::FileWatchListener
 {
 public:
-    Filewatcher(std::string const& path);
+    Filewatcher(std::vector<std::string> paths);
     void handleFileAction(efsw::WatchID watchid, const std::string& dir, const std::string& filename, efsw::Action action, std::string oldFilename) override;
 
     moodycamel::ConcurrentQueue<std::filesystem::path> modifiedQueue;
 
 private:
     std::unique_ptr<efsw::FileWatcher> fileWatcher;
-    std::string                        basePath;
+    std::vector<std::string>           basePaths;
 };

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -31,11 +31,17 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
 // NOTE: Auto-translate blocks are dealt with as a string of bytes
 using CommandArg = std::variant<bool, int, double, std::string>;
+
+namespace
+{
+    std::unordered_map<std::string, std::string> registeredCommands;
+}
 
 // The below section is a proposed rewrite of commandhandler.
 // It can automatically deduce the types of strings that are passed to it.
@@ -182,7 +188,13 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const int8* com
     TracyZoneString(PChar->name);
     TracyZoneIString(commandline);
 
-    auto filename   = fmt::format("./scripts/commands/{}.lua", cmdname.c_str());
+    auto filename = fmt::format("./scripts/commands/{}.lua", cmdname.c_str());
+    if (auto maybeRegisteredCommand = registeredCommands.find(cmdname);
+        maybeRegisteredCommand != registeredCommands.end())
+    {
+        filename = (*maybeRegisteredCommand).second;
+    }
+
     auto loadResult = lua.safe_script_file(filename, &sol::script_pass_on_error);
     if (!loadResult.valid())
     {
@@ -311,4 +323,9 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const int8* com
     }
 
     return 0;
+}
+
+void CCommandHandler::registerCommand(std::string const& commandName, std::string const& path)
+{
+    registeredCommands[commandName] = path;
 }

--- a/src/map/command_handler.h
+++ b/src/map/command_handler.h
@@ -38,6 +38,7 @@ class CCommandHandler
 {
 public:
     static int32 call(sol::state& lua, CCharEntity* PChar, const int8* commandline);
+    static void  registerCommand(std::string const& commandName, std::string const& path);
 };
 
 #endif // _COMMAND_HANDLER_H

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -21,6 +21,7 @@
 
 #include "moduleutils.h"
 
+#include "../command_handler.h"
 #include "../lua/luautils.h"
 #include "common/cbasetypes.h"
 #include "common/utils.h"
@@ -176,8 +177,18 @@ namespace moduleutils
                     continue;
                 }
 
+                // Check the file is a valid command
+                if (lua["cmdprops"].valid() && lua["onTrigger"].valid())
+                {
+                    auto commandName = path.filename().replace_extension("").generic_string();
+                    ShowScript(fmt::format("Registering module command: !{}", commandName));
+                    CCommandHandler::registerCommand(commandName, relPath);
+                    continue;
+                }
+
+                // Check the file is a valid module
                 sol::table table = res;
-                if (table["overrides"].valid()) // Check the file is a valid module
+                if (table["overrides"].valid())
                 {
                     auto moduleName = table.get_or("name", std::string());
                     ShowScript(fmt::format("=== Module: {} ===", moduleName));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Lets you specify new commands in the modules folder.

It also adds basic reloading of module Lua files. I fully expect people will misinterpret how this works, and how modules work in general. So let's prepare for that.

## Steps to test these changes

Use the new test command, or make your own.
