### PR TITLE
[core] Adds "too far" for player and trust WS, fix 0 delay TP moves generating an empty action packet, add some more safety

### DIFF
--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -65,7 +65,10 @@ bool CAttackState::Update(time_point tick)
             action_t action;
             if (m_PEntity->OnAttack(*this, action))
             {
-                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                if (action.actiontype != ACTION_NONE) // CMobEntity::OnAttack(...) generates it's own action and sends it there, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
+                {
+                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+                }
             }
         }
         else if (m_PEntity->OnAttackError(*this))

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -65,7 +65,8 @@ bool CAttackState::Update(time_point tick)
             action_t action;
             if (m_PEntity->OnAttack(*this, action))
             {
-                if (action.actiontype != ACTION_NONE) // CMobEntity::OnAttack(...) generates it's own action and sends it there, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
+                // CMobEntity::OnAttack(...) generates it's own action and sends it there, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
+                if (action.actiontype != ACTION_NONE)
                 {
                     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
                 }

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -113,17 +113,22 @@ bool CWeaponSkillState::Update(time_point tick)
         action_t action;
         m_PEntity->OnWeaponSkillFinished(*this, action);
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
         auto* PTarget{ GetTarget() };
 
-        m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), m_PSkill->getID(), m_spent, &action);
-        PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), m_PSkill->getID(), m_spent, &action);
-
-        if (m_PEntity->objtype == TYPE_PC)
+        if (action.actiontype == ACTION_WEAPONSKILL_FINISH) // category changes upon being out of range. This does not count for RoE and delay is not increased beyond the normal delay.
         {
-            roeutils::event(ROE_EVENT::ROE_WSKILL_USE, static_cast<CCharEntity*>(m_PEntity), RoeDatagram("skillType", m_PSkill->getType()));
+            // only send lua the WS events if we are in range
+            m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", CLuaBaseEntity(m_PEntity), CLuaBaseEntity(PTarget), m_PSkill->getID(), m_spent, &action);
+            PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(m_PEntity), m_PSkill->getID(), m_spent, &action);
+
+            if(m_PEntity->objtype == TYPE_PC)
+            {
+                roeutils::event(ROE_EVENT::ROE_WSKILL_USE, static_cast<CCharEntity*>(m_PEntity), RoeDatagram("skillType", m_PSkill->getType()));
+            }
         }
 
-        auto delay   = m_PSkill->getAnimationTime();
+        auto delay   = m_PSkill->getAnimationTime(); // TODO: Is delay time a fixed number if the weaponskill is used out of range?
         m_finishTime = tick + delay;
         Complete();
     }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1094,7 +1094,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
         actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY;
 
         // While it doesn't seem that speceffect is actually used at all in this "do nothing" animation, this is here for accuracy.
-        if (isRangedWS) //Ranged WS seem to stay 0 on Reaction
+        if (isRangedWS) // Ranged WS seem to stay 0 on Reaction
         {
             actionTarget.speceffect = SPECEFFECT::NONE;
         }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -964,6 +964,8 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
     PLatentEffectContainer->CheckLatentsTP();
 
     SLOTTYPE damslot = SLOT_MAIN;
+    bool isRangedWS = (PWeaponSkill->getID() >= 192 && PWeaponSkill->getID() <= 218);
+
     if (distance(loc.p, PBattleTarget->loc.p) - PBattleTarget->m_ModelRadius <= PWeaponSkill->getRange())
     {
         if (PWeaponSkill->getID() >= 192 && PWeaponSkill->getID() <= 221)
@@ -1018,7 +1020,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
 
             if (primary)
             {
-                if (PWeaponSkill->getID() >= 192 && PWeaponSkill->getID() <= 218)
+                if (isRangedWS)
                 {
                     uint16 recycleChance = getMod(Mod::RECYCLE) + PMeritPoints->GetMeritValue(MERIT_RECYCLE, this) + this->PJobPoints->GetJobPointValue(JP_AMMO_CONSUMPTION);
 
@@ -1083,7 +1085,23 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
     }
     else
     {
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_TOO_FAR_AWAY));
+        actionList_t& actionList     = action.getNewActionList();
+        actionList.ActionTargetID    = PBattleTarget->id;
+        action.actiontype            = ACTION_MAGIC_FINISH; // all "Too Far" messages use cat 4
+
+        actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.animation       = 0x1FC; // Seems hardcoded, two bits away from 0x1FF
+        actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY;
+
+        // While it doesn't seem that speceffect is actually used at all in this "do nothing" animation, this is here for accuracy.
+        if (isRangedWS) //Ranged WS seem to stay 0 on Reaction
+        {
+            actionTarget.speceffect = SPECEFFECT::NONE;
+        }
+        else // Always 2 observed on various melee weapons
+        {
+            actionTarget.speceffect = SPECEFFECT::BLOOD;
+        }
     }
 }
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -296,7 +296,6 @@ void CMobEntity::TapDeaggroTime()
     }
 }
 
-
 bool CMobEntity::CanLink(position_t* pos, int16 superLink)
 {
     TracyZoneScoped;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -286,6 +286,17 @@ bool CMobEntity::CanRoam()
     return !(m_roamFlags & ROAMFLAG_EVENT) && PMaster == nullptr && (speed > 0 || (m_roamFlags & ROAMFLAG_WORM)) && getMobMod(MOBMOD_NO_MOVE) == 0;
 }
 
+void CMobEntity::TapDeaggroTime()
+{
+    CMobController* mobController = dynamic_cast<CMobController*>(PAI->GetController());
+
+    if (mobController)
+    {
+        mobController->TapDeaggroTime();
+    }
+}
+
+
 bool CMobEntity::CanLink(position_t* pos, int16 superLink)
 {
     TracyZoneScoped;
@@ -597,16 +608,22 @@ void CMobEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& actio
     TracyZoneScoped;
     CBattleEntity::OnWeaponSkillFinished(state, action);
 
-    static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    TapDeaggroTime();
 }
 
 void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 {
     TracyZoneScoped;
     auto* PSkill  = state.GetSkill();
-    auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
+    auto* PTarget = dynamic_cast<CBattleEntity*>(state.GetTarget());
 
-    static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    if (PTarget == nullptr)
+    {
+        ShowWarning("CMobEntity::OnMobSkillFinished: PTarget is null");
+        return;
+    }
+
+    TapDeaggroTime();
 
     // store the skill used
     m_UsedSkillIds[PSkill->getID()] = GetMLevel();
@@ -641,7 +658,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     }
     action.actionid = PSkill->getID();
 
-    if (PTarget && PAI->TargetFind->isWithinRange(&PTarget->loc.p, distance))
+    if (PAI->TargetFind->isWithinRange(&PTarget->loc.p, distance))
     {
         if (PSkill->isAoE())
         {
@@ -669,7 +686,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 
     uint16 targets = (uint16)PAI->TargetFind->m_targets.size();
 
-    if (!PTarget || targets == 0)
+    if (targets == 0)
     {
         action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
         actionList_t& actionList  = action.getNewActionList();
@@ -802,12 +819,16 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         battleutils::DirtyExp(PTarget, this);
     }
 
-    PTarget = static_cast<CBattleEntity*>(state.GetTarget());
-    if (PTarget->objtype == TYPE_MOB && (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR)))
+    PTarget = dynamic_cast<CBattleEntity*>(state.GetTarget()); // TODO: why is this recast here? can state change between now and the original cast?
+
+    if(PTarget)
     {
-        battleutils::ClaimMob(PTarget, this);
+        if (PTarget->objtype == TYPE_MOB && (PTarget->isDead() || (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AVATAR)))
+        {
+            battleutils::ClaimMob(PTarget, this);
+        }
+        battleutils::DirtyExp(PTarget, this);
     }
-    battleutils::DirtyExp(PTarget, this);
 }
 
 void CMobEntity::DistributeRewards()
@@ -1336,8 +1357,7 @@ void CMobEntity::OnEngage(CAttackState& state)
             this->PEnmityContainer->UpdateEnmity((PPet ? (CBattleEntity*)PPet : (CBattleEntity*)PTarget), 0, 1); // Set VE so target doesn't change
         }
     }
-
-    static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    TapDeaggroTime();
 }
 
 void CMobEntity::FadeOut()
@@ -1430,13 +1450,13 @@ void CMobEntity::OnCastFinished(CMagicState& state, action_t& action)
     TracyZoneScoped;
     CBattleEntity::OnCastFinished(state, action);
 
-    static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    TapDeaggroTime();
 }
 
 bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
 {
     TracyZoneScoped;
-    static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
+    TapDeaggroTime();
 
     if (getMobMod(MOBMOD_ATTACK_SKILL_LIST))
     {

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -129,6 +129,7 @@ public:
     uint32     GetRandomGil(); // returns a random amount of gil
     bool       CanRoamHome();  // is it possible for me to walk back?
     bool       CanRoam();      // check if mob can walk around
+    void       TapDeaggroTime(); // call TapDeaggroTime if PAI->GetController is a CMobController
 
     bool CanLink(position_t* pos, int16 superLink = 0);
 

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -129,7 +129,7 @@ public:
     uint32     GetRandomGil(); // returns a random amount of gil
     bool       CanRoamHome();  // is it possible for me to walk back?
     bool       CanRoam();      // check if mob can walk around
-    void       TapDeaggroTime(); // call TapDeaggroTime if PAI->GetController is a CMobController
+    void       TapDeaggroTime(); // call CMobController->TapDeaggroTime if PAI->GetController() is a CMobController, otherwise do nothing.
 
     bool CanLink(position_t* pos, int16 superLink = 0);
 

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -58,7 +58,7 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
 void CTrustEntity::PostTick()
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overidden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::PostTick();
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     if (loc.zone && updatemask && status != STATUS_TYPE::DISAPPEAR && now > m_nextUpdateTimer)
@@ -94,14 +94,14 @@ void CTrustEntity::Die()
     ((CCharEntity*)PMaster)->RemoveTrust(this);
 
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overidden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::Die();
 }
 
 void CTrustEntity::Spawn()
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overidden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     // we need to skip CMobEntity's spawn because it calculates stats (and our stats are already calculated)
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
@@ -486,7 +486,7 @@ void CTrustEntity::OnDespawn(CDespawnState& /*unused*/)
 void CTrustEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overidden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::OnCastFinished(state, action);
 
     auto* PSpell = state.GetSpell();
@@ -502,7 +502,7 @@ void CTrustEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overidden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::OnWeaponSkillFinished(state, action);
 
     auto* PWeaponSkill  = state.GetSkill();

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -58,7 +58,7 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
 void CTrustEntity::PostTick()
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overidden function is bad
     CBattleEntity::PostTick();
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     if (loc.zone && updatemask && status != STATUS_TYPE::DISAPPEAR && now > m_nextUpdateTimer)
@@ -94,14 +94,14 @@ void CTrustEntity::Die()
     ((CCharEntity*)PMaster)->RemoveTrust(this);
 
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overidden function is bad
     CBattleEntity::Die();
 }
 
 void CTrustEntity::Spawn()
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overidden function is bad
     // we need to skip CMobEntity's spawn because it calculates stats (and our stats are already calculated)
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
@@ -486,7 +486,7 @@ void CTrustEntity::OnDespawn(CDespawnState& /*unused*/)
 void CTrustEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overidden function is bad
     CBattleEntity::OnCastFinished(state, action);
 
     auto* PSpell = state.GetSpell();
@@ -502,7 +502,7 @@ void CTrustEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
 void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)
 {
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overidden function is bad
     CBattleEntity::OnWeaponSkillFinished(state, action);
 
     auto* PWeaponSkill  = state.GetSkill();
@@ -582,5 +582,18 @@ void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& act
                 }
             }
         }
+    }
+    else
+    {
+        actionList_t& actionList     = action.getNewActionList();
+        actionList.ActionTargetID    = PBattleTarget->id;
+        action.actiontype            = ACTION_MAGIC_FINISH; // all "too far" messages use cat 4
+
+        actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.animation       = 0x1FC; // seems hardcoded, 2 bits away from 0x1FF.
+        actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY;
+
+        actionTarget.speceffect      = SPECEFFECT::NONE; // It seems most mobs use NONE, but player-like models use BLOOD for their weaponskills
+                                                         // TODO: figure out a good way to differentiate between the two. There does not seem to be a functional difference.
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add "too far" messages for players/trusts that become out of range after readying a WS.
Fix 0 delay mob TP move such as Shantotto II generating an empty action packet.
Add some safety to mobentity

Fixes #1877
## Steps to test these changes

Too far:

- !tp 1000
- use WS when out of range
- receive "too far" message

repeat the same except for a trust like Ayame, and give yourself and her 1k tp, engage a raptor/tiger and run backwards to try to force her to use a WS, she should trigger out of range if you're lucky.

empty action packet fix:

- load battlemod on windower
- summon Shantotto II, have her melee something
- don't get "nil" warnings in log
