### PR TITLE
[ZM/Quest] Divine Might Bugfix + Small Adjustments

### DIFF
--- a/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
@@ -25,9 +25,6 @@ battlefield_object.onBattlefieldRegister = function(player, battlefield)
 end
 
 battlefield_object.onBattlefieldEnter = function(player, battlefield)
-    local _, clearTime, partySize = battlefield:getRecord()
-
-    player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
 end
 
 battlefield_object.onBattlefieldLeave = function(player, battlefield, leavecode)

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
@@ -31,7 +31,20 @@ entity.onMobEngaged = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    -- TODO: AA GK actively seeks to skillchain to Light off of his own WSs under MS, or other AA's WSs.
+    if mob:hasStatusEffect(xi.effect.MEIKYO_SHISUI) then
+        mob:setTP(0)
+        if mob:getLocalVar("order") == 0 then
+            mob:useMobAbility(946)
+            mob:setLocalVar("order", 1)
+        elseif mob:getLocalVar("order") == 1 then
+            mob:useMobAbility(947)
+            mob:setLocalVar("order", 2)
+        else
+            mob:useMobAbility(948)
+            mob:setLocalVar("order", 0)
+            mob:delStatusEffect(xi.effect.MEIKYO_SHISUI)
+        end
+    end
 end
 
 entity.onMobDeath = function(mob, player, isKiller)

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
@@ -15,7 +15,7 @@ entity.onMobSpawn = function(mob)
         specials =
         {
             {id = xi.jsa.CALL_WYVERN, hpp = 100, cooldown = 60}, -- "Call Wyvern is used at the time of monster engage. Call Wyvern is used ~1 minute subsequent to Wyvern's death."
-            {id = xi.jsa.MEIKYO_SHISUI, hpp = math.random(90, 95), cooldown = 90}, -- "Meikyo Shisui is used very frequently."
+            {id = xi.jsa.MEIKYO_SHISUI, begCode = function(mobArg) mobArg:setLocalVar('order', 0) end, hpp = math.random(90, 95), cooldown = 90}, -- "Meikyo Shisui is used very frequently."
         },
     })
 end
@@ -31,19 +31,22 @@ entity.onMobEngaged = function(mob, target)
     end
 end
 
+
+
 entity.onMobFight = function(mob, target)
     if mob:hasStatusEffect(xi.effect.MEIKYO_SHISUI) then
-        mob:setTP(0)
         if mob:getLocalVar("order") == 0 then
-            mob:useMobAbility(946)
+            mob:useMobAbility(946) -- Tachi - Yukikaze
             mob:setLocalVar("order", 1)
+            mob:setTP(2000)
         elseif mob:getLocalVar("order") == 1 then
-            mob:useMobAbility(947)
+            mob:useMobAbility(947) -- Tachi - Gekko
             mob:setLocalVar("order", 2)
-        else
-            mob:useMobAbility(948)
-            mob:setLocalVar("order", 0)
-            mob:delStatusEffect(xi.effect.MEIKYO_SHISUI)
+            mob:setTP(1000)
+        elseif mob:getLocalVar("order") == 2 then
+            mob:useMobAbility(948) -- Tachi - Kasha
+            mob:setLocalVar("order", 3)
+            mob:setTP(0)
         end
     end
 end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_GK.lua
@@ -8,6 +8,7 @@ require("scripts/globals/status")
 local entity = {}
 
 -- TODO: Allegedly has a 12 hp/sec regen.  Determine if true, and add to onMobInitialize if so.
+-- TODO: Create listener for SCing with other AAs during DM
 
 entity.onMobSpawn = function(mob)
     xi.mix.jobSpecial.config(mob, {
@@ -31,7 +32,20 @@ entity.onMobEngaged = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    -- TODO: AA GK actively seeks to skillchain to Light off of his own WSs under MS, or other AA's WSs.
+    if mob:hasStatusEffect(xi.effect.MEIKYO_SHISUI) then
+        mob:setTP(0)
+        if mob:getLocalVar("order") == 0 then
+            mob:useMobAbility(946)
+            mob:setLocalVar("order", 1)
+        elseif mob:getLocalVar("order") == 1 then
+            mob:useMobAbility(947)
+            mob:setLocalVar("order", 2)
+        else
+            mob:useMobAbility(948)
+            mob:setLocalVar("order", 0)
+            mob:delStatusEffect(xi.effect.MEIKYO_SHISUI)
+        end
+    end
 end
 
 entity.onMobDeath = function(mob, player, isKiller)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes a BCNM startup issue with the Divine Might BCNM. (Starting event on bcnm start that ends bcnm)
Takes control of AA GK during Meikyo to attempt to perform a Light SC on Players
Fixes positions of mobs based on capture data for arena 1. (Adjusted like positions for Arena 2/3 based on position differences in arena 1)

Capture in question from FFXICaptures discord:
https://drive.google.com/file/d/1R9-99fUf_ssEJYlnFyTlyFLbt5QaVR7F/view

## Steps to test these changes
Divine might or AA GK fight and watch him 2hr~
Divine might BCNM for new positions and successful BCNM
