### PR TITLE
Add Storm and Helix Plumbing to Trust Adelheid

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -47,6 +47,7 @@ ai.condition =
     CASTING_MA         = 17,
     RANDOM             = 18,
     NO_SAMBA           = 19,
+    NO_STORM           = 20,
 }
 ai.c = ai.condition
 
@@ -77,6 +78,8 @@ ai.select =
     HIGHEST_WALTZ       = 8,
     ENTRUSTED           = 9,
     BEST_INDI           = 10,
+    STORM_DAY           = 11,
+    HELIX_DAY           = 12,
 }
 ai.s = ai.select
 

--- a/scripts/globals/spells/trust/adelheid.lua
+++ b/scripts/globals/spells/trust/adelheid.lua
@@ -28,18 +28,23 @@ end
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
 
+    -- TODO: Add Dark Arts, Addendum: Black (requires plumbing updates to work with Trusts)
+
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_MS, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_JA, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.CASTING_MA, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)
 
-    -- TODO: Storms
+    -- TODO: Choose Storms based on Mob Weakness before falling back to matching day
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NO_STORM, 0, ai.r.MA, ai.s.STORM_DAY, 0, 0)
 
-    -- TODO: Helices
+    -- TODO: Choose Helix based on Mob Weakness before falling back to matching day
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_STATUS, xi.effect.HELIX, ai.r.MA, ai.s.HELIX_DAY, 0, 0)
 
     mob:addSimpleGambit(ai.t.TANK, ai.c.HPP_LT, 50, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
     mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 33, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
 
+    -- TODO: Add Magic Burst Logic to Gambits to MB with Helix corresponding to SC
     mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_SC_AVAILABLE, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.NONE, 75)
 end
 

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -368,6 +368,22 @@ namespace gambits
                             controller->Cast(target->targid, spell_id.value());
                         }
                     }
+                    else if (action.select == G_SELECT::STORM_DAY)
+                    {
+                        auto spell_id = POwner->SpellContainer->GetStormDay();
+                        if (spell_id.has_value())
+                        {
+                            controller->Cast(target->targid, spell_id.value());
+                        }
+                    }
+                    else if (action.select == G_SELECT::HELIX_DAY)
+                    {
+                        auto spell_id = POwner->SpellContainer->GetHelixDay();
+                        if (spell_id.has_value())
+                        {
+                            controller->Cast(target->targid, spell_id.value());
+                        }
+                    }
                     else if (action.select == G_SELECT::RANDOM)
                     {
                         auto spell_id = POwner->SpellContainer->GetSpell();
@@ -610,6 +626,34 @@ namespace gambits
                     noSamba = false;
                 }
                 return noSamba;
+                break;
+            }
+            case G_CONDITION::NO_STORM:
+            {
+                bool noStorm = true;
+                if (trigger_target->StatusEffectContainer->HasStatusEffect(
+                {
+                    EFFECT_FIRESTORM,
+                    EFFECT_HAILSTORM,
+                    EFFECT_WINDSTORM,
+                    EFFECT_SANDSTORM,
+                    EFFECT_THUNDERSTORM,
+                    EFFECT_RAINSTORM,
+                    EFFECT_AURORASTORM,
+                    EFFECT_VOIDSTORM,
+                    EFFECT_FIRESTORM_II,
+                    EFFECT_HAILSTORM_II,
+                    EFFECT_WINDSTORM_II,
+                    EFFECT_SANDSTORM_II,
+                    EFFECT_THUNDERSTORM_II,
+                    EFFECT_RAINSTORM_II,
+                    EFFECT_AURORASTORM_II,
+                    EFFECT_VOIDSTORM_II,
+                }))
+                {
+                    noStorm = false;
+                }
+                return noStorm;
                 break;
             }
             case G_CONDITION::STATUS_FLAG:

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -50,6 +50,7 @@ namespace gambits
         CASTING_MA         = 17,
         RANDOM             = 18,
         NO_SAMBA           = 19,
+        NO_STORM           = 20,
     };
 
     enum class G_REACTION : uint16
@@ -76,6 +77,8 @@ namespace gambits
         HIGHEST_WALTZ       = 8,
         ENTRUSTED           = 9,
         BEST_INDI           = 10,
+        STORM_DAY           = 11,
+        HELIX_DAY           = 12,
     };
 
     enum class G_TP_TRIGGER : uint16

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -389,6 +389,106 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
     return !choice ? GetBestAvailable(SPELLFAMILY_NONE) : choice;
 }
 
+std::optional<SpellID> CMobSpellContainer::GetStormDay()
+{
+    std::optional<SpellID> choice = std::nullopt;
+    std::size_t dotwIndex = battleutils::GetDayElement();
+    switch (dotwIndex)
+    {
+        case ELEMENT_FIRE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_FIRESTORM);
+            break;
+        }
+        case ELEMENT_ICE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_HAILSTORM);
+            break;
+        }
+        case ELEMENT_WIND:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_WINDSTORM);
+            break;
+        }
+        case ELEMENT_EARTH:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_SANDSTORM);
+            break;
+        }
+        case ELEMENT_THUNDER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_THUNDERSTORM);
+            break;
+        }
+        case ELEMENT_WATER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_RAINSTORM);
+            break;
+        }
+        case ELEMENT_LIGHT:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_AURORASTORM);
+            break;
+        }
+        case ELEMENT_DARK:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_VOIDSTORM);
+            break;
+        }
+    }
+    return choice;
+}
+
+std::optional<SpellID> CMobSpellContainer::GetHelixDay()
+{
+    std::optional<SpellID> choice = std::nullopt;
+    std::size_t dotwIndex = battleutils::GetDayElement();
+    switch (dotwIndex)
+    {
+        case ELEMENT_FIRE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_PYROHELIX);
+            break;
+        }
+        case ELEMENT_ICE:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_CRYOHELIX);
+            break;
+        }
+        case ELEMENT_WIND:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_ANEMOHELIX);
+            break;
+        }
+        case ELEMENT_EARTH:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_GEOHELIX);
+            break;
+        }
+        case ELEMENT_THUNDER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_IONOHELIX);
+            break;
+        }
+        case ELEMENT_WATER:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_HYDROHELIX);
+            break;
+        }
+        case ELEMENT_LIGHT:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_LUMINOHELIX);
+            break;
+        }
+        case ELEMENT_DARK:
+        {
+            choice = GetBestAvailable(SPELLFAMILY_NOCTOHELIX);
+            break;
+        }
+    }
+    return choice;
+}
+
 bool CMobSpellContainer::HasSpells() const
 {
     return m_hasSpells;

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -67,6 +67,8 @@ public:
     std::optional<SpellID> GetBestIndiSpell(CBattleEntity* PMaster);
     std::optional<SpellID> GetBestEntrustedSpell(CBattleEntity* PMaster);
     std::optional<SpellID> GetBestAgainstTargetWeakness(CBattleEntity* PTarget);
+    std::optional<SpellID> GetStormDay();
+    std::optional<SpellID> GetHelixDay();
 
     std::vector<SpellID> m_gaList;
     std::vector<SpellID> m_damageList;


### PR DESCRIPTION
Adds Gambits and related pieces to allow Adelheid to leverage Storms and Helix.
Currently both are only based on the day of week instead of mob weakness.
Left TODO: notes for remaining missing pieces.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Creates Gambits for Storms and Helix based on Day of the Week.
Adds Gambits to Adelheid to cast Storms and Helices with checks to only cast when they are missing.

## Steps to test these changes

Cast Adelheid Trust
Note the Day of the Week
Engage a mob
Adelheid will cast Storm/Helix spells corresponding to the day and replace them when they wear off.