### PR TITLE
Remove setHP(0) from Mijin when mob:isInDynamis()

### DIFF
--- a/scripts/globals/mobskills/mijin_gakure.lua
+++ b/scripts/globals/mobskills/mijin_gakure.lua
@@ -19,10 +19,6 @@ mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, baseDmg, xi.magic.ele.NONE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
-    if mob:isInDynamis() then -- dynamis mobs will kill themselves, other mobs might not
-        mob:setHP(0)
-    end
-
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)
 
     return dmg


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+Removes the global mob:setHP(0) which kills mobs in dynamis upon using Mijin Gakure.

This was tested in multiple zones for Dynamis in retail. Tested all cities, tested Beaucedine and could not find the behavior of killing the mob once it used Mijin Gakure in either normal mobs or NMs within these zones. Thus a global mob:setHP(0) should not be used to potentially fix an issue with a handful of instances which I was unable to prove existed. Without documentation of what these instances were and the lack of additional data located on BG-Wiki, Ffxiclopedia, or other major resources for finding information on the game, I was unable to find any indication that this should happen in current retail. 

If such an instance does crop up, it is suggested to add an additional function to the bg-code for the job_special mixin in order to take care of this rather than have a global solution which is not accurate to every mob. This bg-code should be taken care of in the mob's specific lua as an additional job_special param. Additional methods of adding this in specifically would be to have gates in place for specific mob parameters such as families or IDs in the future, however at this point with the lack of information this global change should be removed. 

## Steps to test these changes
+ Bring a normal NIN mob in Dynamis (Vanguard Backstabber or the like) to < 60% and the mob will use Mijin. Prior to the change the mob would immediately have its HP set to 0, now the mob continues living. 