### PR TITLE
mini patch to fix chocobo digging fatigue

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -808,7 +808,7 @@ local function updatePlayerDigCount(player, increment)
         player:setCharVar('[DIG]DigCount', player:getCharVar('[DIG]DigCount') + increment)
     end
 
-    player:setLocalVar('[DIG]LastDigTime', os.time())
+    player:setCharVar('[DIG]LastDigTime', os.time())
 end
 
 --[[ Not Implemented
@@ -826,7 +826,7 @@ end
 
 local function canDig(player)
     local digCount = player:getCharVar('[DIG]DigCount')
-    local lastDigTime = player:getLocalVar('[DIG]LastDigTime')
+    local lastDigTime = player:getCharVar('[DIG]LastDigTime')
     local zoneItemsDug = GetServerVariable('[DIG]ZONE'..player:getZoneID()..'_ITEMS')
     local zoneInTime = player:getLocalVar('ZoneInTime')
     local currentTime = os.time()


### PR DESCRIPTION
This should fix zoning resetting the players dig fatigue.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Changes digging fatigue to use char var instead of local var

## Steps to test these changes

1. Dig one zone out to your max.
2. Zone and remax yourself, repeat. Notice digging fatigue never gets reset, get upset, frown, and merge this pull request to fix.
