### PR TITLE
Update Trust Adelheid to use Dark Arts / Addendum: Black

### DIFF
--- a/scripts/globals/effects/addendum_black.lua
+++ b/scripts/globals/effects/addendum_black.lua
@@ -6,7 +6,9 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    target:recalculateAbilitiesTable()
+    if target:getObjType() ~= xi.objType.TRUST then -- account for trusts
+        target:recalculateAbilitiesTable()
+    end
     local bonus = effect:getPower()
     local helix = effect:getSubPower()
 
@@ -24,14 +26,26 @@ effect_object.onEffectGain = function(target, effect)
         target:addMod(xi.mod.HELIX_EFFECT, helix)
         target:addMod(xi.mod.HELIX_DURATION, 72)
     end
-    target:recalculateSkillsTable()
+    if target:getObjType() ~= xi.objType.TRUST then
+        target:recalculateSkillsTable()
+    else -- account for trusts
+        local rankD = target:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
+        local artsRank = target:getMaxSkillLevel(target:getMainLvl(), xi.job.RDM, xi.skill.ENHANCING_MAGIC)
+        local trustArts = artsRank - rankD
+
+        -- TODO: update charutils to work with Trusts
+        target:addMod(xi.mod.MACC, trustArts)
+        -- cheats in MACC since Skill MODs aren't processed outside of charutils
+    end
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:recalculateAbilitiesTable()
+    if target:getObjType() ~= xi.objType.TRUST then -- account for trusts
+        target:recalculateAbilitiesTable()
+    end
     local bonus = effect:getPower()
     local helix = effect:getSubPower()
 
@@ -49,7 +63,17 @@ effect_object.onEffectLose = function(target, effect)
         target:delMod(xi.mod.HELIX_EFFECT, helix)
         target:delMod(xi.mod.HELIX_DURATION, 72)
     end
-    target:recalculateSkillsTable()
+    if target:getObjType() ~= xi.objType.TRUST then
+        target:recalculateSkillsTable()
+    else -- account for trusts
+        local rankD = target:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
+        local artsRank = target:getMaxSkillLevel(target:getMainLvl(), xi.job.RDM, xi.skill.ENHANCING_MAGIC)
+        local trustArts = artsRank - rankD
+
+        -- TODO: update charutils to work with Trusts
+        target:delMod(xi.mod.MACC, trustArts)
+        -- cheats out MACC since Skill MODs aren't processed outside of charutils
+    end
 end
 
 return effect_object

--- a/scripts/globals/effects/dark_arts.lua
+++ b/scripts/globals/effects/dark_arts.lua
@@ -6,7 +6,9 @@ require("scripts/globals/status")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    target:recalculateAbilitiesTable()
+    if target:getObjType() ~= xi.objType.TRUST then -- account for trusts
+        target:recalculateAbilitiesTable()
+    end
     local bonus = effect:getPower()
     local helix = effect:getSubPower()
 
@@ -24,14 +26,26 @@ effect_object.onEffectGain = function(target, effect)
         target:addMod(xi.mod.HELIX_EFFECT, helix)
         target:addMod(xi.mod.HELIX_DURATION, 72)
     end
-    target:recalculateSkillsTable()
+    if target:getObjType() ~= xi.objType.TRUST then
+        target:recalculateSkillsTable()
+    else -- account for trusts
+        local rankD = target:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
+        local artsRank = target:getMaxSkillLevel(target:getMainLvl(), xi.job.RDM, xi.skill.ENHANCING_MAGIC)
+        local trustArts = artsRank - rankD
+
+        -- TODO: update charutils to work with Trusts
+        target:addMod(xi.mod.MACC, trustArts)
+        -- cheats in MACC since Skill MODs aren't processed outside of charutils
+    end
 end
 
 effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:recalculateAbilitiesTable()
+    if target:getObjType() ~= xi.objType.TRUST then -- account for trusts
+        target:recalculateAbilitiesTable()
+    end
     local bonus = effect:getPower()
     local helix = effect:getSubPower()
 
@@ -49,7 +63,17 @@ effect_object.onEffectLose = function(target, effect)
         target:delMod(xi.mod.HELIX_EFFECT, helix)
         target:delMod(xi.mod.HELIX_DURATION, 72)
     end
-    target:recalculateSkillsTable()
+    if target:getObjType() ~= xi.objType.TRUST then -- account for trusts
+        target:recalculateSkillsTable()
+    else
+        local rankD = target:getSkillLevel(xi.skill.ENFEEBLING_MAGIC)
+        local artsRank = target:getMaxSkillLevel(target:getMainLvl(), xi.job.RDM, xi.skill.ENHANCING_MAGIC)
+        local trustArts = artsRank - rankD
+
+        -- TODO: update charutils to work with Trusts
+        target:delMod(xi.mod.MACC, trustArts)
+        -- cheats out MACC since Skill MODs aren't processed outside of charutils
+    end
 end
 
 return effect_object

--- a/scripts/globals/spells/trust/adelheid.lua
+++ b/scripts/globals/spells/trust/adelheid.lua
@@ -28,7 +28,9 @@ end
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
 
-    -- TODO: Add Dark Arts, Addendum: Black (requires plumbing updates to work with Trusts)
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.ADDENDUM_BLACK, ai.r.JA, ai.s.SPECIFIC, xi.ja.DARK_ARTS)
+    -- TODO: Restrict Addendum Black to Level 30+
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_STATUS, xi.effect.ADDENDUM_BLACK, ai.r.JA, ai.s.SPECIFIC, xi.ja.ADDENDUM_BLACK)
 
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_MS, 0, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)


### PR DESCRIPTION
Adds Gambits to Adelheid to use Dark Arts and Addendum: Black.
Updates Effects for Dark Arts and Addendum: Black to account for Trusts.

Notes:

* charutils (called by Dark Arts and Addendum: Black), does not work with Trusts and will cause a server crash when called by a Trust currently.
* This change creates checks to bypass `recalculateAbilitiesTable()` and `recalculateSkillsTable()` when called by a Trust in the above mentioned scripts.
* Instead of applying skill via MODs, applies an amount of MACC equal to (Skill B+ - Skill D) since * Skill MODs are also applied via `charutils` and not a viable workaround.
* Dark Arts Gambit checks for Addendum: Black so as to not re-apply Dark Arts and create a repeating loop.

* Left comments and TODOs.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds Gambits to Adelheid to use Dark Arts and Addendum: Black.
Updates Effects for Dark Arts and Addendum: Black to account for Trusts.

## Steps to test these changes

Testing : Player use of Dark Arts / Addendum: Black

1. Change your test player to SCH 75
2. `!capallskills`
3. Check that your Enfeebling/Dark/Elemental skills are all 210
4. Use Dark Arts
5. Check that your Enfeebling/Dark/Elemental skills are all 256
6. Use Addendum: Black
7. Check that your Enfeebling/Dark/Elemental skills are all 256
8. Target your test player
9. `!deleffect addendum_black`
10. Check that your Enfeebling/Dark/Elemental skills are all 210

Testing: Adelheid use of Dark Arts / Addendum: Black

1. Set your Test player to any job level 75
2. Summon Adelheid
3. Engage a mob
4. Observe that Adelheid will now use Dark Arts and Addendum: Black.
5. Check MODs on Adelheid using `!getmod`:

MACC (should return 46)
BLACK_MAGIC_COST (should return -10)
BLACK_MAGIC_CAST (should return -10)
etc