### PR TITLE
[search] Add expire_all command, fix delete order in listing expiry

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -22,7 +22,6 @@ BEGIN
     END IF;
 END $$
 
-
 DROP TRIGGER IF EXISTS account_delete $$
 CREATE TRIGGER account_delete
     BEFORE DELETE ON accounts

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -93,7 +93,7 @@ public:
     std::list<SearchEntity*> GetPlayersList(search_req sr, int* count);
     std::string              GetSearchComment(uint32 playerId);
     std::vector<ahItem*>     GetAHItemsToCategory(uint8 AHCategoryID, int8* OrderByString);
-    void                     ExpireAHItems();
+    void                     ExpireAHItems(uint16 expireAgeInDays);
 
 private:
     std::unique_ptr<SqlConnection> sql;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -280,6 +280,13 @@ int32 main(int32 argc, char** argv)
     {
         ah_cleanup(server_clock::now(), nullptr);
     });
+    gConsoleService->RegisterCommand(
+    "expire_all", "Force-expire all items on the AH, returning to sender.",
+    [](std::vector<std::string> inputs)
+    {
+        CDataLoader data;
+        data.ExpireAHItems(0);
+    });
     // clang-format on
 
     while (true)
@@ -1013,7 +1020,7 @@ void TaskManagerThread()
 int32 ah_cleanup(time_point tick, CTaskMgr::CTask* PTask)
 {
     CDataLoader data;
-    data.ExpireAHItems();
+    data.ExpireAHItems(search_config.expire_days);
 
     return 0;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds `expire_all` command to search server, and jiggles things around, so you can specify the age of things you want to expire on the expiry job. `expire_all` is just "anything over 0 days old".

Also, the order of operations in `CDataLoader::ExpireAHItems()` was kinda funky. Since our SQL code doesn't keep any more than a single query's worth of state, multiple things need to be broken out to be safe.

Closes https://github.com/LandSandBoat/server/issues/2060

## Steps to test these changes

- Fire the server up
- List something on the AH
- Verify its in the db
- Use `expire_all` from the search console
- See that the ah listing is gone, and is now in the lister's delivery box
- Also, no errors.