### PR TITLE
[search] Further simplify the logic in ExpireAHItems

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -289,6 +289,8 @@ int32 main(int32 argc, char** argv)
     });
     // clang-format on
 
+    ShowMessage("========================================================");
+
     while (true)
     {
         // Accept a client socket


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

In my last PR I only fixed the search expiry for a single listing, after that the original errors popped up again.

Fixed it, and tested it properly too.

## Steps to test these changes

Using the search console:
```
[06/22/22 00:59:54:381][search][info][message] ======================================================== (main:263)
[06/22/22 00:59:54:381][search][info][message] search and auction server (main:264)
[06/22/22 00:59:54:381][search][info][message] ======================================================== (main:265)
[06/22/22 00:59:54:381][search][info][message] AH task to return items older than 3 days is running (main:268)
[06/22/22 00:59:54:381][search][info][status] Console input thread is ready... (ConsoleService::ConsoleService:55)
[06/22/22 00:59:54:381][search][info][status] Type 'help' for a list of available commands. (ConsoleService::ConsoleService:56)
[06/22/22 00:59:54:389][search][info][info] Expiring auction house listings over 3 days old (CDataLoader::ExpireAHItems:592)
[06/22/22 00:59:54:401][search][info][message] Sent 0 expired auction house listings back to sellers (CDataLoader::ExpireAHItems:646)
Currently one item on AH
> Unknown command.
ah_cleanup
[06/22/22 01:05:02:475][search][info][info] Expiring auction house listings over 3 days old (CDataLoader::ExpireAHItems:592)
[06/22/22 01:05:02:476][search][info][message] Sent 0 expired auction house listings back to sellers (CDataLoader::ExpireAHItems:646)
help
> Available commands:
> expire_all : Force-expire all items on the AH, returning to sender.
> help : Print a list of available console commands.
> exit : Terminate the program.
> tasks : Show the current amount of tasks registered to the application task manager.
> ah_cleanup : AH task to return items older than 3 days.
expire_all
[06/22/22 01:05:10:684][search][info][info] Expiring auction house listings over 0 days old (CDataLoader::ExpireAHItems:592)
[06/22/22 01:05:10:692][search][info][message] Sent 1 expired auction house listings back to sellers (CDataLoader::ExpireAHItems:646)
That item is now in the deliv. box, and the AH is empty in the DB
> Unknown command.
Listing multiple items
> Unknown command.
[06/22/22 01:05:58:016][search][info][message] = = = = = = = Type: 5 Size: 268  (TCPComm:529)
[06/22/22 01:06:04:874][search][info][message] = = = = = = = Type: 5 Size: 268  (TCPComm:529)
[06/22/22 01:06:12:013][search][info][message] = = = = = = = Type: 5 Size: 268  (TCPComm:529)
[06/22/22 01:06:17:708][search][info][message] = = = = = = = Type: 5 Size: 268  (TCPComm:529)
4 items now listed
> Unknown command.
expire_all
[06/22/22 01:06:43:175][search][info][info] Expiring auction house listings over 0 days old (CDataLoader::ExpireAHItems:592)
[06/22/22 01:06:43:188][search][info][message] Sent 4 expired auction house listings back to sellers (CDataLoader::ExpireAHItems:646)
Nothing on the AH, 5 items in the deliv. box
> Unknown command.
```
