### PR TITLE
[Mission] CoP 5-2 - Desires of Emptiness - Promy Vahzl Balancing

### DIFF
--- a/scripts/zones/Promyvion-Vahzl/mobs/Craver.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Craver.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Craver
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Deviator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Deviator.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--   NM: Deviator
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Gorger.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Gorger.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Gorger
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Ponderer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Ponderer.lua
@@ -1,10 +1,34 @@
 -----------------------------------
 -- Area: Promyvion - Vahzl
 --   NM: Ponderer
+-- TODO: Verify cmbDelay
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 -----------------------------------
 local entity = {}
 
-entity.onMobDeath = function(mob, player, isKiller)
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local roll = math.random()
+    if mob:getHPP() <= 25 then
+        if roll <= 0.25 then
+            return 1252 -- Shadow_spread
+        else
+            return 1248 -- Trinary_absorption
+        end
+    end
+end
+
+entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
+    if mob:getHPP() <= 35 then
+       mob:setMod(xi.mod.STORETP, 250)
+    end
 end
 
 return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
@@ -1,16 +1,42 @@
 -----------------------------------
 -- Area: Promyvion - Vahzl
---   NM: Propagator
+-- NM  : Propagator
+-- TODO: Verify cmbDelay
 -----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("maxBabies", 2)
+    mob:addMod(xi.mod.TRIPLE_ATTACK, 10)
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local fission = 755
+    local random = math.random()
+    if mob:getHPP() <= 50 then
+        if random < 0.6 then
+            return fission
+        else
+            return 0
+        end
+    end
+end
+
+entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
+
+    if mob:getHPP() <= 35 then
+       mob:setMod(xi.mod.STORETP, 250)
+    end
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
     local momma = mob:getID()
-
     for i = momma + 1, momma + mob:getLocalVar("maxBabies") do
         local baby = GetMobByID(i)
         if baby:isSpawned() then

--- a/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
@@ -2,6 +2,7 @@
 -- Area: Promyvion - Vahzl
 --   NM: Provoker
 -----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 require("scripts/globals/status")
 require("scripts/globals/magic")
 -----------------------------------

--- a/scripts/zones/Promyvion-Vahzl/mobs/Seether.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Seether.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Seether
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Solicitor.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Solicitor.lua
@@ -1,10 +1,34 @@
 -----------------------------------
 -- Area: Promyvion - Vahzl
 --   NM: Solicitor
+-- TODO: Verify cmbDelay
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 -----------------------------------
 local entity = {}
 
-entity.onMobDeath = function(mob, player, isKiller)
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
+end
+
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local roll = math.random()
+    if mob:getHPP() <= 35 then
+        if roll <= 0.7 then
+            return 1234 -- Carousel
+        else
+            return 1274 -- Impalement
+        end
+    end
+end
+
+entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
+    if mob:getHPP() <= 35 then
+       mob:setMod(xi.mod.STORETP, 250)
+    end
 end
 
 return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Thinker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Thinker.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Thinker
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--   NM: Wailer
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wanderer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wanderer.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Wanderer
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Promyvion-Vahzl/mobs/Weeper.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Weeper.lua
@@ -1,0 +1,9 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  Mob: Weeper
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
+-----------------------------------
+local entity = {}
+
+return entity

--- a/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
@@ -1,23 +1,32 @@
 -----------------------------------
 -- Area: Spire of Vahzl
 --  Mob: Agonizer
+-- TODO: Verify cmbDelay
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.LINK_RADIUS, 50)
-end
-
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
 end
 
-entity.onMobEngaged = function(mob, target)
-end
-
-entity.onMobWeaponSkill = function(target, mob, skill)
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local roll = math.random()
+    if mob:getHPP() <= 25 then
+        if roll <= 0.25 then
+            return 1252 -- Shadow_spread
+        else
+            return 1248 -- Trinary_absorption
+        end
+    end
 end
 
 entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
     if mob:getHPP() < 20 then
         local nextMob = GetMobByID(mob:getID() + 6) --Cumulator aggros at <20%
         if not nextMob:isEngaged() then

--- a/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
@@ -1,23 +1,32 @@
 -----------------------------------
 -- Area: Spire of Vahzl
 --  Mob: Cumulator
+-- TODO: Verify cmbDelay
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.LINK_RADIUS, 50)
-end
-
 entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 20)
 end
 
-entity.onMobEngaged = function(mob, target)
-end
-
-entity.onMobWeaponSkill = function(target, mob, skill)
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local roll = math.random()
+    if mob:getHPP() <= 35 then
+        if roll <= 0.7 then
+            return 1234 -- Carousel
+        else
+            return 1274 -- Impalement
+        end
+    end
 end
 
 entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
     if mob:getHPP() < 20 then
         local nextMob = GetMobByID(mob:getID() - 5) --Procreator aggros at <20%
         if not nextMob:isEngaged() then

--- a/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
@@ -1,24 +1,34 @@
 -----------------------------------
 -- Area: Spire of Vahzl
 --  Mob: Procreator
+-- TODO: Verify cmbDelay
+-----------------------------------
+mixins = {require("scripts/mixins/families/empty_terroanima")}
 -----------------------------------
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.LINK_RADIUS, 50)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setLocalVar("maxBabies", 4)
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMod(xi.mod.TRIPLE_ATTACK, 10)
 end
 
-entity.onMobEngaged = function(mob, target)
-end
-
-entity.onMobWeaponSkill = function(target, mob, skill)
+entity.onMobWeaponSkillPrepare = function(mob, target)
+    local fission = 755
+    local random = math.random()
+    if mob:getHPP() <= 50 then
+        if random < 0.6 then
+            return fission
+        else
+            return 0
+        end
+    end
 end
 
 entity.onMobFight = function(mob, target)
+    if mob:getTP() >= 2000 then
+        mob:useMobAbility()
+    end
     if mob:getHPP() < 20 then
         local nextMob = GetMobByID(mob:getID() - 1) --Agonizer aggros at <20%
         if not nextMob:isEngaged() then


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Created missing mob luas and applied terroanima mixins
- All Promy Vahzl and and Spire of Vahzl bosses have been scripted towards retail accuracy

**References:**

-- https://ffxiclopedia.fandom.com/wiki/Desires_of_Emptiness
-- https://ffxiclopedia.fandom.com/wiki/Propagator
-- https://ffxiclopedia.fandom.com/wiki/Solicitor
-- https://ffxiclopedia.fandom.com/wiki/Ponderer
-- https://ffxiclopedia.fandom.com/wiki/Cumulator
-- https://ffxiclopedia.fandom.com/wiki/Agonizer
-- https://ffxiclopedia.fandom.com/wiki/Procreator
-- https://www.youtube.com/watch?v=gVWzFDHf5v8&feature=youtu.be&ab_channel=WiggoCaptures

## Steps to test these changes

-- !addmission 6 518
-- Stone Door    : !pos -380 46.074 330.5 9
-- _0mc (Flux 1) : !pos 180 -2.5 -60 22 - Click on Flux and fight boss
-- _0md (Flux 2) : !pos 420 -2.5 140 22 - Click on Flux and fight boss
-- _0m0 (Flux 3) : !pos -340 -2.5 140 22 - Click on Flux and fight boss
-- Enter Spire of Vahzl
-- Enter Desires off Emptiness BCNM
-- Fight the things
