### PR TITLE
Move buildNpcTable to onConquestUpdate

### DIFF
--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -400,6 +400,7 @@ xi.garrison.onTrade = function(player, npc, trade, guardNation)
     -- TODO: Check to see if party has a fellow
     -- Offset 42 A party member has an NPC called up. You cannot take part in this event.
     local zoneId = npc:getZoneID()
+    local zone = player:getZone()
     local garrisonZoneData = xi.garrison.data[zoneId]
     local text = zones[zoneId].text
     local lockout = xi.settings.GARRISON_LOCKOUT
@@ -445,7 +446,12 @@ xi.garrison.onTrade = function(player, npc, trade, guardNation)
             ( xi.settings.GARRISON_ONCE_PER_WEEK == 1 or player:getCharVar("GARRISON_CONQUEST_WAIT") < os.time() ) and
             ( player:getNation() == guardNation or xi.settings.GARRISON_NATION_BYPASS == 1 )
         then
-            xi.garrison.start(player, npc, party)
+            if xi.garrison.npcTableEmpty(zone) == true then
+                xi.garrison.buildNpcTable(zone)
+            end
+            npc:timer(1000, function(npcArg)
+                xi.garrison.start(player, npc, party)
+            end)
             player:confirmTrade()
             player:setCharVar("GARRISON_CONQUEST_WAIT", getConquestTally())
             npc:getZone():setLocalVar(string.format("[GARRISON]EndTime_%s", zoneId), os.time() + timeLimit)
@@ -519,10 +525,7 @@ xi.garrison.buildNpcTable = function(zone)
     local zoneId = zone:getID()
     local garrisonZoneData = xi.garrison.data[zoneId]
     local garrisonRunning = zone:getLocalVar(string.format("[GARRISON]EndTime_%s", zoneId))
-    if
-        xi.garrison.npcTableEmpty(zone) == true and
-        owner < 3
-    then
+    if owner < 3 then
         local npcs = garrisonZoneData.npcs
         local xPos = garrisonZoneData.xPos
         local yPos = garrisonZoneData.yPos
@@ -541,8 +544,8 @@ xi.garrison.buildNpcTable = function(zone)
                 y = yPos,
                 z = zPos,
                 rotation = rot,
-                groupId = 74,
-                groupZoneId = 103,
+                groupId = 100,
+                groupZoneId = 63,
                 onMobRoam = function(mob) xi.garrison.returnHome(mob) end,
                 onMobDeath = function(mob, playerArg, isKiller) end,
                 releaseIdOnDeath = false,

--- a/scripts/globals/garrison_data.lua
+++ b/scripts/globals/garrison_data.lua
@@ -74,8 +74,8 @@ xi.garrison.names =
             npcName = "Patriarch"
         },
     },
-    --level 75 garrison names
-    [75] =
+    --level 99 garrison names
+    [99] =
     {
         [0] =
         {
@@ -99,8 +99,6 @@ xi.garrison.looks =
     {
         [0] =
         {
-            802,
-            803,
             804,
             805
             -- "0x01000C030010262000303A403A5008611B700000",
@@ -108,15 +106,11 @@ xi.garrison.looks =
         },
         [1] =
         {
-            802,
-            803,
             804,
             805
         },
         [2] =
         {
-            802,
-            803,
             804,
             805
         },
@@ -126,8 +120,6 @@ xi.garrison.looks =
     {
         [0] =
         {
-            802,
-            803,
             804,
             805
             -- "0x010006030010762076303A400650736000700000",
@@ -137,15 +129,11 @@ xi.garrison.looks =
         },
         [1] =
         {
-            802,
-            803,
             804,
             805
         },
         [2] =
         {
-            802,
-            803,
             804,
             805
         },
@@ -155,8 +143,6 @@ xi.garrison.looks =
     {
         [0] =
         {
-            802,
-            803,
             804,
             805
             -- "0x01000E04191019201930194019506B601C700000",
@@ -164,15 +150,11 @@ xi.garrison.looks =
         },
         [1] =
         {
-            802,
-            803,
             804,
             805
         },
         [2] =
         {
-            802,
-            803,
             804,
             805
         },
@@ -182,22 +164,16 @@ xi.garrison.looks =
     {
         [0] =
         {
-            802,
-            803,
             804,
             805
         },
         [1] =
         {
-            802,
-            803,
             804,
             805
         },
         [2] =
         {
-            802,
-            803,
             804,
             805
             -- "0x0100020600106320633063406350056122700000",
@@ -205,27 +181,22 @@ xi.garrison.looks =
             -- "0x0100080669106B206B306B406B50FE6000700000"
         },
     },
-    --level 75 garrison looks
-    [75] =
+    --level 99 garrison looks
+    [99] =
     {
         [0] =
         {
-            802,
-            803,
             804,
             805
         },
         [1] =
         {
-            802,
-            803,
             804,
             805
+            -- "0x010002071C1070201C301C401C50C46000700000"
         },
         [2] =
         {
-            802,
-            803,
             804,
             805
         },
@@ -283,8 +254,8 @@ xi.garrison.loot =
         {itemId = xi.items.REFRESH_EARRING, dropRate = 350},
         {itemId = xi.items.ACCURATE_EARRING, dropRate = 350},
     },
-    --level 75 garrison loot
-    [75] =
+    --level 99 garrison loot
+    [99] =
     {
         {itemId = xi.items.MIRATETES_MEMOIRS, dropRate = 1000},
         {itemId = xi.items.MIGHTY_BOW, dropRate = 350},
@@ -907,38 +878,37 @@ xi.garrison.data =
         waveOrder =
         {
         -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
             [1] =
             {
-                8,
-                7
+                8, -- Goblin Enchanter
+                7  -- Goblin Enchanter
             },
             [2] =
             {
-                8,
-                7,
-                6,
-                5
+                8, -- Goblin Enchanter
+                7, -- Goblin Enchanter
+                6, -- Goblin Poacher
+                5  -- Goblin Poacher
             },
             [3] =
             {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
+                8, -- Goblin Enchanter
+                7, -- Goblin Enchanter
+                6, -- Goblin Poacher
+                5, -- Goblin Poacher
+                4, -- Goblin Bouncer
+                3  -- Goblin Bouncer
             },
             [4] =
             {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
+                8, -- Goblin Enchanter
+                7, -- Goblin Enchanter
+                6, -- Goblin Poacher
+                5, -- Goblin Poacher
+                4, -- Goblin Bouncer
+                3, -- Goblin Bouncer
+                2, -- Goblin Reaper
+                1  -- Goblin Reaper
             },
         },
     },
@@ -1177,7 +1147,7 @@ xi.garrison.data =
     {
         itemReq = xi.items.BUNNY_FANG_SACK,
         textRegion = 13,
-        levelCap = 75,
+        levelCap = 99, -- Level_Restriction 99
         npcs =
         {
         -- empty filled with dynamic entries
@@ -1196,38 +1166,37 @@ xi.garrison.data =
         waveOrder =
         {
         -- # Represents the negative offset from boss to spawn
-        -- TODO Capture Correct Wave Order
             [1] =
             {
-                8,
-                7
+                8, -- Goblin Pirate
+                7  -- Goblin Pirate
             },
             [2] =
             {
-                8,
-                7,
-                6,
-                5
+                8, -- Goblin Pirate
+                7, -- Goblin Pirate
+                6, -- Goblin Duelist
+                5  -- Goblin Duelist
             },
             [3] =
             {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3
+                8, -- Goblin Pirate
+                7, -- Goblin Pirate
+                6, -- Goblin Duelist
+                5, -- Goblin Duelist
+                4, -- Goblin Doctor
+                3  -- Goblin Doctor
             },
             [4] =
             {
-                8,
-                7,
-                6,
-                5,
-                4,
-                3,
-                2,
-                1
+                8, -- Goblin Pirate
+                7, -- Goblin Pirate
+                6, -- Goblin Duelist
+                5, -- Goblin Duelist
+                4, -- Goblin Doctor
+                3, -- Goblin Doctor
+                2, -- Goblin Professor
+                1  -- Goblin Professor
             },
         },
     },

--- a/scripts/zones/Beaucedine_Glacier/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier/Zone.lua
@@ -18,10 +18,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -42,6 +38,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -28,10 +28,6 @@ zone_object.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helm.type.LOGGING)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -53,6 +49,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Cape_Teriggan/Zone.lua
+++ b/scripts/zones/Cape_Teriggan/Zone.lua
@@ -23,12 +23,9 @@ zone_object.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function( player, prevZone)

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -31,12 +31,9 @@ zone_object.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -36,10 +36,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function( player, prevZone)
     local cs = -1
 
@@ -61,6 +57,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function( player, region)

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -27,10 +27,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -52,6 +48,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -19,10 +19,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -39,6 +35,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -24,10 +24,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -49,6 +45,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Qufim_Island/Zone.lua
+++ b/scripts/zones/Qufim_Island/Zone.lua
@@ -17,12 +17,9 @@ zone_object.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -22,12 +22,9 @@ zone_object.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -20,10 +20,6 @@ zone_object.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -45,6 +41,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -18,10 +18,6 @@ zone_object.onInitialize = function(zone)
     xi.conq.setRegionalConquestOverseers(zone:getRegionID())
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
@@ -38,6 +34,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -23,10 +23,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function( player, prevZone)
     local cs = -1
 
@@ -47,6 +43,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function( player, region)

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -16,10 +16,6 @@ zone_object.onInitialize = function(zone)
     xi.voidwalker.zoneOnInit(zone)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
     local dynamisMask = player:getCharVar("Dynamis_Status")
@@ -52,6 +48,7 @@ end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -42,16 +42,13 @@ zone_object.onInitialize = function(zone)
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onGameDay = function()
     xi.bmt.updatePeddlestox(xi.zone.YHOATOR_JUNGLE, ID.npc.PEDDLESTOX)
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function( player, prevZone)

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -28,16 +28,13 @@ zone_object.onInitialize = function(zone)
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end
 
-zone_object.onZoneTick = function(zone)
-    xi.garrison.buildNpcTable(zone)
-end
-
 zone_object.onGameDay = function()
     xi.bmt.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
     xi.conq.onConquestUpdate(zone, updatetype)
+    xi.garrison.buildNpcTable(zone)
 end
 
 zone_object.onZoneIn = function( player, prevZone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

More garrison Fixes.. moved when the npcs are built,
No longer need the Trader SQL (uses an existing base npc from Black Coffin)
Cape Terrigan is 99 Restricted not 75 on retail

<!-- Clear and detailed steps to test your changes here -->
Just a heads up cannot test these changes with base build until the lua_zone.cpp  PEntity->id = 0x1000100 is fixed or changed back to PEntity->id = 0x1000000