### PR TITLE
[core] Only allow mobs to gain enmity

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -148,6 +148,12 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
 void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster, bool tameable)
 {
     TracyZoneScoped;
+
+    if (m_EnmityHolder->objtype != ENTITYTYPE::TYPE_MOB) // pets and trusts dont have enmity.
+    {
+        return;
+    }
+
     // you're too far away so i'm ignoring you
     if (!IsWithinEnmityRange(PEntity))
     {

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -40,6 +40,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../status_effect_container.h"
 #include "../utils/battleutils.h"
 #include "../utils/trustutils.h"
+#include "../enmity_container.h"
 
 CTrustEntity::CTrustEntity(CCharEntity* PChar)
 : CMobEntity()
@@ -89,9 +90,11 @@ void CTrustEntity::FadeOut()
 void CTrustEntity::Die()
 {
     luautils::OnMobDeath(this, nullptr);
+    PEnmityContainer->Clear();
     PAI->ClearStateStack();
     PAI->Internal_Die(0s);
     ((CCharEntity*)PMaster)->RemoveTrust(this);
+    m_OwnerID.clean();
 
     // NOTE: This is purposefully calling CBattleEntity's impl.
     // TODO: Calling a grand-parent's impl. of an overridden function is bad


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Bandaid fixes a crash, only mobs should have enmity containers. Essentially, you can cure a trust to get on it's enmity list, and when you zone you destruct before the trust. Then the CEnmityContainer contains a garbage pointer to your player, which crashes. Forcing cleanup of CEnmityContainer exposed this and created a reliable crash method.

## Steps to test these changes

1. Summon a trust you can target
2. Cure them
3. !zone somewhere else
4. don't crash from cleanup of enmity containers