### PR TITLE
Fix variable spelling errors in "The Wayward Automaton" quest

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Iruki-Waraki.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Iruki-Waraki.lua
@@ -32,13 +32,13 @@ entity.onTrigger = function(player, npc)
     local playerLvl = player:getMainLvl()
     local playerJob = player:getMainJob()
 
-    --Quest: The Wayward Automation
+    --Quest: The Wayward Automaton
     if playerJob == xi.job.PUP and playerLvl >= xi.settings.AF1_QUEST_LEVEL and noStringsAttached == QUEST_COMPLETED and theWaywardAutomaton == QUEST_AVAILABLE then
         player:startEvent(774) -- he tells you to help find his auto
     elseif theWaywardAutomaton == QUEST_ACCEPTED and theWaywardAutomatonProgress == 1 then
         player:startEvent(775) -- reminder about to head to Nashmau
     elseif theWaywardAutomaton == QUEST_ACCEPTED and theWaywardAutomatonProgress == 3 then
-        player:startEvent(776) -- tell him you found automation
+        player:startEvent(776) -- tell him you found Automaton
     elseif playerJob == xi.job.PUP and playerLvl < xi.settings.AF2_QUEST_LEVEL and theWaywardAutomaton == QUEST_COMPLETED then
         player:startEvent(777)
     elseif playerJob ~= xi.job.PUP and theWaywardAutomaton == QUEST_COMPLETED then

--- a/scripts/zones/Caedarva_Mire/npcs/qm9.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/qm9.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: Caedarva Mire
 --  NPC: qm9
--- Involved in quest: The Wayward Automation
+-- Involved in quest: The Wayward Automaton
 -- !pos  129 1.396 -631 79
 -----------------------------------
 local ID = require("scripts/zones/Caedarva_Mire/IDs")
@@ -13,11 +13,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local theWaywardAutomation = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
-    local theWaywardAutomationProgress = player:getCharVar("TheWaywardAutomationProgress")
+    local theWaywardAutomaton = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
+    local theWaywardAutomatonProgress = player:getCharVar("TheWaywardAutomatonProgress")
 
-    if (theWaywardAutomation == QUEST_ACCEPTED and theWaywardAutomationProgress == 2) then
-        if (player:getCharVar("TheWaywardAutomationNM") >= 1) then
+    if (theWaywardAutomaton == QUEST_ACCEPTED and theWaywardAutomatonProgress == 2) then
+        if (player:getCharVar("TheWaywardAutomatonNM") >= 1) then
             player:startEvent(14)-- Event ID 14 for CS after toad
         elseif (not GetMobByID(ID.mob.CAEDARVA_TOAD):isSpawned()) then
             SpawnMob(ID.mob.CAEDARVA_TOAD):updateClaim(player) --Caedarva toad
@@ -33,8 +33,8 @@ end
 entity.onEventFinish = function(player, csid, option)
 
     if (csid == 14) then
-        player:setCharVar("TheWaywardAutomationProgress", 3)
-        player:setCharVar("TheWaywardAutomationNM", 0)
+        player:setCharVar("TheWaywardAutomatonProgress", 3)
+        player:setCharVar("TheWaywardAutomatonNM", 0)
     end
 end
 

--- a/scripts/zones/Nashmau/npcs/Dnegan.lua
+++ b/scripts/zones/Nashmau/npcs/Dnegan.lua
@@ -2,7 +2,7 @@
 -- Area: Nashmau
 --  NPC: Dnegan
 -- Standard Info NPC
--- Involved in quest: Wayward Automation
+-- Involved in quest: Wayward Automaton
 -- !pos 29.89 -6 55.83 53
 -----------------------------------
 require("scripts/globals/quests")
@@ -13,14 +13,14 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local theWaywardAutomation = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
-    local theWaywardAutomationProgress = player:getCharVar("TheWaywardAutomationProgress")
+    local theWaywardAutomaton = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
+    local theWaywardAutomatonProgress = player:getCharVar("TheWaywardAutomatonProgress")
     local operationTeatimeProgress = player:getCharVar("OperationTeatimeProgress")
 
-    -- Quest: The WayWard Automation
-    if (theWaywardAutomation == QUEST_ACCEPTED and theWaywardAutomationProgress == 1) then
+    -- Quest: The WayWard Automaton
+    if (theWaywardAutomaton == QUEST_ACCEPTED and theWaywardAutomatonProgress == 1) then
         player:startEvent(289) -- he tells u to go Caedarva Mire
-    elseif (theWaywardAutomationProgress == 2) then
+    elseif (theWaywardAutomatonProgress == 2) then
         player:startEvent(289) -- Hint to go to Caedarva Mire
 
     -- Quest: Operation Teatime
@@ -37,7 +37,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 289) then
-        player:setCharVar("TheWaywardAutomationProgress", 2)
+        player:setCharVar("TheWaywardAutomatonProgress", 2)
     elseif (csid == 290 and option == 0) then
         player:setCharVar("OTT_DayWait", VanadielDayOfTheYear())
     elseif (csid == 290 and option == 1) then


### PR DESCRIPTION
fixes spelling errors among a common variable "theWaywardAutomatonProgress" that prevents player progression

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
