### PR TITLE
[core] Update zoneutils::GetEntity to match dynamic entity index change

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1859,7 +1859,7 @@ void CLuaBaseEntity::setElevator(uint8 id, uint32 lowerDoor, uint32 upperDoor, u
     // If giving the elevator ANIMATION_ELEVATOR_UP makes it go down, set this bool to true
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
 
-    Elevator_t elevator;
+    Elevator_t elevator         = {};
 
     elevator.id                 = id;
     elevator.LowerDoor          = static_cast<CNpcEntity*>(zoneutils::GetEntity(lowerDoor, TYPE_NPC));
@@ -4244,10 +4244,10 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    GearSetMod_t gearSetMod;
-    gearSetMod.modNameId = modNameId;
-    gearSetMod.modId     = modId;
-    gearSetMod.modValue  = modValue;
+    GearSetMod_t gearSetMod = {};
+    gearSetMod.modNameId    = modNameId;
+    gearSetMod.modId        = modId;
+    gearSetMod.modValue     = modValue;
 
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -12801,9 +12801,17 @@ void CLuaBaseEntity::spawn(sol::object const& despawnSec, sol::object const& res
 
 bool CLuaBaseEntity::isSpawned()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    CMobEntity* PMobEntity = dynamic_cast<CMobEntity*>(m_PBaseEntity);
 
-    return static_cast<CMobEntity*>(m_PBaseEntity)->PAI->IsSpawned();
+    if (PMobEntity)
+    {
+        return static_cast<CMobEntity*>(m_PBaseEntity)->PAI->IsSpawned();
+    }
+    else
+    {
+        ShowError("CLuaBaseEntity::isSpawned() called on entity that is not a PMobEntity.");
+    }
+    return false;
 }
 
 /************************************************************************

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -125,11 +125,12 @@ namespace zoneutils
 
     CBaseEntity* GetEntity(uint32 ID, uint8 filter)
     {
-        uint16 zoneID = (ID >> 12) & 0x0FFF;
-        CZone* PZone  = GetZone(zoneID);
+        const uint16 DynamicEntityStart  = 0x700;
+        uint16 zoneID                    = (ID >> 12) & 0x0FFF;
+        CZone* PZone                     = GetZone(zoneID);
         if (PZone)
         {
-            return PZone->GetEntity((uint16)(ID & 0x0FFF), filter);
+            return PZone->GetEntity((uint16)(ID & 0x00000800 ? (ID & 0x7FF) + DynamicEntityStart : ID & 0xFFF), filter);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Updates zoneutils::GetEntity to match the ID change logic for Dynamic Entities
Fixes relating to !gotoid causing a debug break on pet IDs
Removes 2 warnings about no initializers in lua_baseentity.cpp
Closes #2047

## Steps to test these changes

Before PR:
Use !fafnir in a zone, use targetinfo to try to !gotoid to the new fafnir, the command will silently fail.

After PR
Use !fafnir in a zone, use targetinfo to try to !gotoid to it, the command will work.

- [x]     spawn fafnir
- [x]     still be able to target and punch him in the face
- [x]     cast spells on him
- [x]     Same with other regular mobs
- [x]     make sure instances still work
- [x]     make sure bcnms still work
