### PR TITLE
[core] Make sure equipped dynamic entities have correct names

### DIFF
--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -319,7 +319,12 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     }
     else if (table["look"].get_type() == sol::type::string)
     {
-        auto look = stringToLook(table.get<std::string>("look"));
+        auto lookStr = table.get<std::string>("look");
+        if (lookStr.size() >= 4 && ((lookStr[1] == 'x' && lookStr[3] == '1') || lookStr[1] == '1'))
+        {
+            PEntity->look.size = MODEL_EQUIPPED;
+        }
+        auto look = stringToLook(lookStr);
         std::memcpy(&PEntity->look, &look, sizeof(PEntity->look));
     }
 

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -244,7 +244,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         this->setSize(0x48);
 
         auto name       = PEntity->packetName;
-        auto nameOffset = (PEntity->look.size == MODEL_EQUIPPED) ? 0x44 : 0x34;
+        auto nameOffset = 0x34;
         auto maxLength  = std::min<size_t>(name.size(), PacketNameLength);
 
         // Mobs and NPC's targid's live in the range 0-1023
@@ -260,6 +260,6 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         std::memset(start, 0U, size);
 
         // Copy in name
-        std::memcpy(data + nameOffset, name.c_str(), maxLength);
+        std::memcpy(start, name.c_str(), maxLength);
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

If you pass in a long model look string, it'll set the entity to LOOK_EQUIPPED, also adjusts the offsets so names will work correctly.

## Steps to test these changes

![image](https://user-images.githubusercontent.com/1389729/175766034-af1cf101-4bb1-4112-b0e6-281d9b099764.png)

