### PR TITLE
[core] Set TrustEntity and PetEntity to be unclaimable

### DIFF
--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -46,6 +46,7 @@ CPetEntity::CPetEntity(PET_TYPE petType)
     allegiance     = ALLEGIANCE_TYPE::PLAYER;
     m_MobSkillList = 0;
     m_PetID        = 0;
+    m_IsClaimable  = false;
 
     PAI            = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CPetController>(this), std::make_unique<CTargetFind>(this));
 }

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -51,6 +51,7 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
     m_MobSkillList = 0;
     PMaster        = PChar;
     m_MovementType = MELEE_RANGE;
+    m_IsClaimable  = false;
 
     PAI            = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CTrustController>(PChar, this),
                                          std::make_unique<CTargetFind>(this));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This will prevent assignment of CharEntity's PClaimedMob when it should never be set to a pet or a mob

## Steps to test these changes

1. Summon a trust
2. Cure the trust
3. Dismiss the trust
4. Zone (preferably immediately)
5. Don't crash

