### PR TITLE
Fixed Phairet portion of The_Trader_In_The_wood.lua

### DIFF
--- a/scripts/quests/sandoria/The_Trader_in_the_Forest.lua
+++ b/scripts/quests/sandoria/The_Trader_in_the_Forest.lua
@@ -140,19 +140,19 @@ quest.sections =
                         return quest:progressEvent(127, xi.items.CLUMP_OF_BATAGREENS)
                     end
                 end,
+            },
 
-                onEventFinish =
-                {
-                    [124] = function(player, csid, option, npc)
-                        if npcUtil.giveItem(player, xi.items.CLUMP_OF_BATAGREENS) then
-                            player:confirmTrade()
+            onEventFinish =
+            {
+                [124] = function(player, csid, option, npc)
+                    if npcUtil.giveItem(player, xi.items.CLUMP_OF_BATAGREENS) then
+                        player:confirmTrade()
 
-                            if player:getQuestStatus(quest.areaId, quest.questId) == QUEST_ACCEPTED then
-                                quest:setVar(player, 'Prog', 2)
-                            end
+                        if player:getQuestStatus(quest.areaId, quest.questId) == QUEST_ACCEPTED then
+                            quest:setVar(player, 'Prog', 2)
                         end
-                    end,
-                },
+                    end
+                end,
             },
         },
     },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Correctly groups the functions in the Phairet portion of The_Trader_In_The_Forest.lua quest script. Previously the event finish would not work for this NPCs portion of the quest. 

## Steps to test these changes

Trade Supplies Order item to Phairet after flagging the quest. Previously you would receive the event message but no batagreens as onEventFinish was not firing.