### PR TITLE
[SQL/Lua] Add mods for rarab cap and make usable

### DIFF
--- a/scripts/globals/items/white_rarab_cap_+1.lua
+++ b/scripts/globals/items/white_rarab_cap_+1.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- ID: 25679
+-- White Rarab Cap +1
+--  This Hairpin functions in the same way as the spell Reraise.
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/msg")
+-----------------------------------
+local item_object = {}
+
+item_object.onItemCheck = function(target)
+    return 0
+end
+
+item_object.onItemUse = function(target)
+    local duration = 7200
+    target:delStatusEffect(xi.effect.RERAISE)
+    target:addStatusEffect(xi.effect.RERAISE, 1, 0, duration)
+    target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.RERAISE)
+end
+
+return item_object

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -53587,11 +53587,18 @@ INSERT INTO `item_mods` VALUES (25668,384,300); -- HASTE_GEAR: 300
 -- Crab Cap +1
 INSERT INTO `item_mods` VALUES (25669,1,2); -- DEF: 2
 
+-- White Rarab Cap
+INSERT INTO `item_mods` VALUES (25675,1,1); -- DEF: 1
+
 -- Arthros Cap
 INSERT INTO `item_mods` VALUES (25677,1,1); -- DEF: 1
 
 -- Arthros Cap +1
 INSERT INTO `item_mods` VALUES (25678,1,2); -- DEF: 2
+
+-- White Rarab Cap +1
+INSERT INTO `item_mods` VALUES (25679,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (25679,303,1); -- TREASURE_HUNTER: 1
 
 -- Emicho Haubert (Checked)
 INSERT INTO `item_mods` VALUES (25682,1,147);   -- DEF: 147

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -2343,6 +2343,7 @@ INSERT INTO `item_usable` VALUES (25585,'black_chocobo_cap',1,8,79,0,1,30,72000,
 INSERT INTO `item_usable` VALUES (26271,'hi-elixir_tank',1,2,55,0,3,30,60,0);
 INSERT INTO `item_usable` VALUES (26272,'super_reraiser_tank',1,2,55,0,5,30,60,0);
 INSERT INTO `item_usable` VALUES (26517,'shadow_lord_shirt',1,8,79,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (25679,'white_rarab_cap_+1',1,8,33,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (26720,'sheep_cap_+1',1,2,55,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (26955,'behemoth_suit_+1',1,2,55,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (27556,'echad_ring',1,3,76,0,1,5,7200,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Add mods for NQ/HQ White Rarab Caps, make usable, and add corresponding lua for reraise enchantment.

## Steps to test these changes

!additem 25679
equip item
use

NOTE: Normal acquisition of this item requires Synergy.