### PR TITLE
[core] Extract client language ID during login

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -580,6 +580,9 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
         if (map_session_data->PChar == nullptr)
         {
             uint32 CharID = ref<uint32>(buff, FFXI_HEADER_SIZE + 0x0C);
+            uint16 LangID = ref<uint16>(buff, FFXI_HEADER_SIZE + 0x58);
+
+            std::ignore = LangID;
 
             const char* fmtQuery = "SELECT charid FROM chars WHERE charid = %u LIMIT 1;";
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add Lang ID capture during login. All credits to atom0s.

## Steps to test these changes

N/A, not used yet but valuable.
