### PR TITLE
[core] Add flag to load all lua files for sanity testing

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -234,6 +234,17 @@ namespace luautils
         CacheLuaObjectFromFile("./scripts/globals/pets/luopan.lua");
         CacheLuaObjectFromFile("./scripts/globals/pets/wyvern.lua");
 
+        if (gLoadAllLua) // Load and cache _all_ lua files (for sanity testing, no need for during regular use)
+        {
+            for (auto entry : std::filesystem::recursive_directory_iterator("./scripts"))
+            {
+                if (entry.path().extension() == ".lua")
+                {
+                    CacheLuaObjectFromFile(entry.path().relative_path().generic_string());
+                }
+            }
+        }
+
         // Handle settings
         contentRestrictionEnabled = GetSettingsVariable("RESTRICT_CONTENT") != 0;
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -533,7 +533,7 @@ namespace luautils
         // Handle Commands then return
         if (parts.size() == 2 && parts[0] == "commands")
         {
-            auto file_result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+            auto result = lua.safe_script_file(filename, &sol::script_pass_on_error);
             if (!result.valid())
             {
                 sol::error err = result;
@@ -541,7 +541,7 @@ namespace luautils
                 return;
             }
 
-            ShowInfo("[FileWatcher] COMMAND %s -> \"%s\"", filename, requireName);
+            ShowInfo("[FileWatcher] COMMAND %s", filename);
             return;
         }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -234,13 +234,18 @@ namespace luautils
         CacheLuaObjectFromFile("./scripts/globals/pets/luopan.lua");
         CacheLuaObjectFromFile("./scripts/globals/pets/wyvern.lua");
 
-        if (gLoadAllLua) // Load and cache _all_ lua files (for sanity testing, no need for during regular use)
+        if (gLoadAllLua) // Load all lua files (for sanity testing, no need for during regular use)
         {
             for (auto entry : std::filesystem::recursive_directory_iterator("./scripts"))
             {
                 if (entry.path().extension() == ".lua")
                 {
-                    CacheLuaObjectFromFile(entry.path().relative_path().generic_string());
+                    auto result = lua.safe_script_file(entry.path().relative_path().generic_string(), &sol::script_pass_on_error);
+                    if (!result.valid())
+                    {
+                        sol::error err = result;
+                        ShowError(err.what());
+                    }
                 }
             }
         }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -530,6 +530,21 @@ namespace luautils
             return;
         }
 
+        // Handle Commands then return
+        if (parts.size() == 2 && parts[0] == "commands")
+        {
+            auto file_result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+            if (!result.valid())
+            {
+                sol::error err = result;
+                ShowError("luautils::CacheLuaObjectFromFile: Load command error: %s: %s", filename, err.what());
+                return;
+            }
+
+            ShowInfo("[FileWatcher] COMMAND %s -> \"%s\"", filename, requireName);
+            return;
+        }
+
         // Handle Quests and Missions then return
         if (parts.size() == 3 &&
             (parts[0] == "quests" || parts[0] == "missions"))

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -102,6 +102,8 @@ std::unique_ptr<SqlConnection> sql;
 
 extern std::map<uint16, CZone*> g_PZoneList; // Global array of pointers for zones
 
+bool gLoadAllLua = false;
+
 namespace
 {
     uint32 MAX_BUFFER_SIZE             = 2500U;
@@ -192,6 +194,10 @@ int32 do_init(int32 argc, char** argv)
         else if (strcmp(argv[i], "--port") == 0)
         {
             map_port = std::stoi(argv[i + 1]);
+        }
+        else if (strcmp(argv[i], "--load_all") == 0)
+        {
+            gLoadAllLua = true;
         }
     }
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -78,6 +78,8 @@ extern inline map_session_data_t* mapsession_createsession(uint32 ip, uint16 por
 
 extern std::unique_ptr<SqlConnection> sql;
 
+extern bool gLoadAllLua;
+
 //=======================================================================
 
 int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*); // main function to parse recv packets

--- a/tools/ci/startup_checks.py
+++ b/tools/ci/startup_checks.py
@@ -10,7 +10,7 @@ def main():
 
     p0 = subprocess.Popen(["xi_connect","--log","connect-server.log"], stdout=subprocess.PIPE)
     p1 = subprocess.Popen(["xi_search","--log","search-server.log"], stdout=subprocess.PIPE)
-    p2 = subprocess.Popen(["xi_map","--log","game-server.log"], stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(["xi_map","--log","game-server.log", "--load_all"], stdout=subprocess.PIPE)
 
     print("Sleeping for 2 minutes...")
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds flag to load all lua files for sanity testing

The idea is to catch mistakes like https://github.com/LandSandBoat/server/pull/2126 in CI, hopefully filling in for anything luacheck might miss

NOTE: I'll rip out all of these horrible global extern things in a later PR

## Steps to test these changes

Look at the Windows CI run job
