### PR TITLE
Fix CI warnings for trailing whitespace in globals/settings.lua

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -5,12 +5,11 @@
 -- require('scripts/globals/settings')
 --
 -- As a visual indication that "settings are being used in this file somewhere".
--- 
+--
 -- Settings are loaded during executable startup, and then published into the
 -- Lua state.
 --
 -- Settings files in <root>/settings/default/ are loaded first.
--- Then if any files exist in <root>/settings/, they are read and their values 
+-- Then if any files exist in <root>/settings/, they are read and their values
 -- are used to overwrite the values from the defaults folder (if there are any
 -- values).
- 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Removes trailing whitespace from 3 lines in settings.lua to satisfy CI
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
