### PR TITLE
[core] Replace RoeSystem.RoeEnabled with new settings system

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -7257,7 +7257,7 @@ void SmallPacket0x10B(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x10C(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    if (roeutils::RoeSystem.RoeEnabled)
+    if (settings::get<bool>("main.ENABLE_ROE"))
     {
         uint16 recordID = data.ref<uint32>(0x04);
         roeutils::AddEminenceRecord(PChar, recordID);
@@ -7275,7 +7275,7 @@ void SmallPacket0x10C(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x10D(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    if (roeutils::RoeSystem.RoeEnabled)
+    if (settings::get<bool>("main.ENABLE_ROE"))
     {
         roeutils::DelEminenceRecord(PChar, data.ref<uint32>(0x04));
         PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
@@ -7291,7 +7291,7 @@ void SmallPacket0x10D(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x10E(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    if (roeutils::RoeSystem.RoeEnabled)
+    if (settings::get<bool>("main.ENABLE_ROE"))
     {
         uint16 recordID = data.ref<uint16>(0x04);
         roeutils::onRecordClaim(PChar, recordID);
@@ -7354,7 +7354,7 @@ void SmallPacket0x112(map_session_data_t* const PSession, CCharEntity* const PCh
     // Send spark updates
     PChar->pushPacket(new CRoeSparkUpdatePacket(PChar));
 
-    if (roeutils::RoeSystem.RoeEnabled)
+    if (settings::get<bool>("main.ENABLE_ROE"))
     {
         // Current RoE quests
         PChar->pushPacket(new CRoeUpdatePacket(PChar));

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -99,7 +99,6 @@ namespace roeutils
     void init()
     {
         TracyZoneScoped;
-        roeutils::RoeSystem.RoeEnabled   = lua["xi"]["settings"]["ENABLE_ROE"].get_or(0);
         lua["RoeParseRecords"] = &roeutils::ParseRecords;
         lua["RoeParseTimed"]   = &roeutils::ParseTimedSchedule;
         RoeHandlers.fill(RoeCheckHandler());
@@ -219,7 +218,7 @@ namespace roeutils
     bool event(ROE_EVENT eventID, CCharEntity* PChar, const RoeDatagramList& payload)
     {
         TracyZoneScoped;
-        if (!RoeSystem.RoeEnabled || !PChar || PChar->objtype != TYPE_PC)
+        if (!settings::get<bool>("main.ENABLE_ROE") || !PChar || PChar->objtype != TYPE_PC)
         {
             return false;
         }
@@ -443,7 +442,7 @@ namespace roeutils
     void onCharLoad(CCharEntity* PChar)
     {
         TracyZoneScoped;
-        if (!RoeSystem.RoeEnabled)
+        if (!settings::get<bool>("main.ENABLE_ROE"))
         {
             return;
         }
@@ -589,7 +588,7 @@ namespace roeutils
     void CycleTimedRecords()
     {
         TracyZoneScoped;
-        if (!RoeSystem.RoeEnabled)
+        if (!settings::get<bool>("main.ENABLE_ROE"))
         {
             return;
         }
@@ -611,7 +610,7 @@ namespace roeutils
     void CycleDailyRecords()
     {
         TracyZoneScoped;
-        if (!RoeSystem.RoeEnabled)
+        if (!settings::get<bool>("main.ENABLE_ROE"))
         {
             return;
         }
@@ -668,7 +667,7 @@ namespace roeutils
     void CycleWeeklyRecords()
     {
         TracyZoneScoped;
-        if (!RoeSystem.RoeEnabled)
+        if (!settings::get<bool>("main.ENABLE_ROE"))
         {
             return;
         }

--- a/src/map/roe.h
+++ b/src/map/roe.h
@@ -80,7 +80,6 @@ typedef std::array<uint16, 6>            RecordTimetable_D;
 typedef std::array<RecordTimetable_D, 7> RecordTimetable_W;
 struct RoeSystemData
 {
-    bool                     RoeEnabled = true;
     RecordTimetable_W        TimedRecordTable;
     std::bitset<4096>        ImplementedRecords;
     std::bitset<4096>        RepeatableRecords;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4696,7 +4696,7 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        if (!roeutils::RoeSystem.RoeEnabled)
+        if (!settings::get<bool>("main.ENABLE_ROE"))
         {
             return;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

ROE didn't use the global settings that everything else uses, so it got missed in the refactor and defaulted to off. This replaces the custom flag it was using with a proper settings lookup and fixes https://github.com/LandSandBoat/server/issues/2134

## Steps to test these changes

You can get to the ROE menus

![image](https://user-images.githubusercontent.com/1389729/176205669-e601a0be-9020-4a65-abd8-ec7cd690f953.png)

