### PR TITLE
[lua] Use utils function for Avatar shadow calculation, attach summon global to xi.summon

### DIFF
--- a/scripts/globals/abilities/pets/aerial_blast.lua
+++ b/scripts/globals/abilities/pets/aerial_blast.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/magic")
 require("scripts/globals/mobskills")
-
 -----------------------------------
 local ability_object = {}
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)

--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/axe_kick.lua
+++ b/scripts/globals/abilities/pets/axe_kick.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/barracuda_dive.lua
+++ b/scripts/globals/abilities/pets/barracuda_dive.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHINGING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHINGING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/burning_strike.lua
+++ b/scripts/globals/abilities/pets/burning_strike.lua
@@ -6,7 +6,6 @@ require("scripts/globals/status")
 require("scripts/globals/summon")
 require("scripts/globals/magic")
 require("scripts/globals/mobskills")
-
 -----------------------------------
 local ability_object = {}
 
@@ -20,14 +19,14 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 6
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
     --get resist multiplier (1x if no resist)
     local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.magic.ele.FIRE)
     --get the resisted damage
     damage.dmg = damage.dmg*resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/camisado.lua
+++ b/scripts/globals/abilities/pets/camisado.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/chaotic_strike.lua
+++ b/scripts/globals/abilities/pets/chaotic_strike.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 9
     local dmgmodsubsequent = 2
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.STUN, 1, 0, 2)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/claw.lua
+++ b/scripts/globals/abilities/pets/claw.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 6
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
     if (damage.hitslanded > 0) then
         target:addStatusEffect(xi.effect.PARALYSIS, 22.5, 0, 90)

--- a/scripts/globals/abilities/pets/diamond_dust.lua
+++ b/scripts/globals/abilities/pets/diamond_dust.lua
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)

--- a/scripts/globals/abilities/pets/double_punch.lua
+++ b/scripts/globals/abilities/pets/double_punch.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -20,8 +19,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmodsubsequent = 2
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/double_slap.lua
+++ b/scripts/globals/abilities/pets/double_slap.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -20,8 +19,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmodsubsequent = 2
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.H2H)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/earthen_fury.lua
+++ b/scripts/globals/abilities/pets/earthen_fury.lua
@@ -27,7 +27,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)

--- a/scripts/globals/abilities/pets/eclipse_bite.lua
+++ b/scripts/globals/abilities/pets/eclipse_bite.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 8
     local dmgmodsubsequent = 2
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASH)
     target:updateEnmityFromDamage(pet, totaldamage)
     return totaldamage

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -21,7 +21,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -21,7 +21,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/flaming_crush.lua
+++ b/scripts/globals/abilities/pets/flaming_crush.lua
@@ -6,7 +6,6 @@ require("scripts/globals/status")
 require("scripts/globals/summon")
 require("scripts/globals/magic")
 require("scripts/globals/mobskills")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,14 +20,14 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmodsubsequent = 1
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
     --get resist multiplier (1x if no resist)
     local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.magic.ele.FIRE)
     --get the resisted damage
     damage.dmg = damage.dmg*resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.FIRE, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -14,17 +13,16 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.GEOCRUSH)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
@@ -33,12 +31,12 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
     target:updateEnmityFromDamage(pet, damage)
 
-    if (target:hasStatusEffect(xi.effect.STUN) == false) then
+    if not target:hasStatusEffect(xi.effect.STUN) then
         target:addStatusEffect(xi.effect.STUN, 3, 3, 3)
     end
 

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -14,17 +13,16 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.GRANDFALL)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
@@ -33,7 +31,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -14,17 +13,16 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.HEAVENLY_STRIKE)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
@@ -33,7 +31,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.ICE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/howling_moon.lua
+++ b/scripts/globals/abilities/pets/howling_moon.lua
@@ -5,14 +5,13 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
     local level = player:getMainLvl() * 2
 
-    if(player:getMP()<level) then
+    if player:getMP() < level then
        return 87, 0
     end
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)

--- a/scripts/globals/abilities/pets/inferno.lua
+++ b/scripts/globals/abilities/pets/inferno.lua
@@ -5,14 +5,13 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
     local level = player:getMainLvl() * 2
 
-    if(player:getMP()<level) then
+    if player:getMP() < level then
        return 87, 0
     end
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)

--- a/scripts/globals/abilities/pets/judgment_bolt.lua
+++ b/scripts/globals/abilities/pets/judgment_bolt.lua
@@ -5,14 +5,13 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
     local level = player:getMainLvl() * 2
 
-    if(player:getMP()<level) then
+    if player:getMP() < level then
        return 87, 0
     end
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)

--- a/scripts/globals/abilities/pets/megalith_throw.lua
+++ b/scripts/globals/abilities/pets/megalith_throw.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 5.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
     return totaldamage

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -14,17 +13,16 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.METEOR_STRIKE)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
@@ -33,7 +31,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.FIRE)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/moonlit_charge.lua
+++ b/scripts/globals/abilities/pets/moonlit_charge.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 4
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.BLINDNESS, 20, 0, 30)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/mountain_buster.lua
+++ b/scripts/globals/abilities/pets/mountain_buster.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 12
     local dmgmodsubsequent = 0
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -15,10 +14,10 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local level = pet:getMainLvl()
-    local damage = (5 * level +  10)
+    local damage = 5 * level + 10
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/poison_nails.lua
+++ b/scripts/globals/abilities/pets/poison_nails.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,14 +17,17 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 2.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
 
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     target:updateEnmityFromDamage(pet, totaldamage)
 
-    if (AvatarPhysicalHit(skill, totaldamage) and target:hasStatusEffect(xi.effect.POISON) == false) then
+    if
+        xi.summon.avatarPhysicalHit(skill, totaldamage) and
+        not target:hasStatusEffect(xi.effect.POISON)
+    then
         target:addStatusEffect(xi.effect.POISON, 1, 3, 60)
     end
 

--- a/scripts/globals/abilities/pets/predator_claws.lua
+++ b/scripts/globals/abilities/pets/predator_claws.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,8 +17,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 10
     local dmgmodsubsequent = 2
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
     return totaldamage

--- a/scripts/globals/abilities/pets/punch.lua
+++ b/scripts/globals/abilities/pets/punch.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/rock_buster.lua
+++ b/scripts/globals/abilities/pets/rock_buster.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,9 +17,9 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 4
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
 
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/rock_throw.lua
+++ b/scripts/globals/abilities/pets/rock_throw.lua
@@ -4,7 +4,6 @@
 require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -18,9 +17,9 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
 
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/rush.lua
+++ b/scripts/globals/abilities/pets/rush.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -20,8 +19,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmodsubsequent = 2
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/searing_light.lua
+++ b/scripts/globals/abilities/pets/searing_light.lua
@@ -5,14 +5,13 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
     local level = player:getMainLvl() * 2
 
-    if(player:getMP()<level) then
+    if player:getMP() < level then
        return 87, 0
     end
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHT)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/shock_strike.lua
+++ b/scripts/globals/abilities/pets/shock_strike.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 3.5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:addStatusEffect(xi.effect.STUN, 1, 0, 2)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/sleepga.lua
+++ b/scripts/globals/abilities/pets/sleepga.lua
@@ -17,7 +17,7 @@ end
 ability_object.onPetAbility = function(target, pet, skill)
     local duration = 90
     local dINT = pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    local bonus = getSummoningSkillOverCap(pet)
+    local bonus = xi.summon.getSummoningSkillOverCap(pet)
     local resm = xi.mobskills.applyPlayerResistance(pet, -1, target, dINT, bonus, xi.magic.element.ICE)
     if (resm < 0.5) then
         skill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message

--- a/scripts/globals/abilities/pets/spinning_dive.lua
+++ b/scripts/globals/abilities/pets/spinning_dive.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 12
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, numhits)
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -17,11 +16,11 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
 
-    local damage = math.floor(325 + 0.025*(tp))
+    local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.EARTH)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/tail_whip.lua
+++ b/scripts/globals/abilities/pets/tail_whip.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/summon")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,8 +18,8 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmod = 5
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, 0, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, numhits)
 
     local duration = 120
     local resm = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, 5)
@@ -29,9 +28,13 @@ ability_object.onPetAbility = function(target, pet, skill)
     end
     duration = duration * resm
 
-    if (duration > 0 and AvatarPhysicalHit(skill, totaldamage) and target:hasStatusEffect(xi.effect.WEIGHT) == false) then
+    if duration > 0 and
+        xi.summon.avatarPhysicalHit(skill, totaldamage) and
+        not target:hasStatusEffect(xi.effect.WEIGHT)
+    then
         target:addStatusEffect(xi.effect.WEIGHT, 50, 0, duration)
     end
+
     target:takeDamage(totaldamage, pet, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     target:updateEnmityFromDamage(pet, totaldamage)
 

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -17,11 +16,11 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
 
-    local damage = math.floor(45 + 0.025*(tp))
+    local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -17,11 +16,11 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP()
 
-    local damage = math.floor(325 + 0.025*(tp))
+    local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -6,7 +6,6 @@ require("scripts/globals/status")
 require("scripts/globals/summon")
 require("scripts/globals/magic")
 require("scripts/globals/mobskills")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,19 +20,21 @@ ability_object.onPetAbility = function(target, pet, skill)
     local dmgmodsubsequent = 1 -- ??
 
     local totaldamage = 0
-    local damage = AvatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
+    local damage = xi.summon.avatarPhysicalMove(pet, target, skill, numhits, accmod, dmgmod, dmgmodsubsequent, xi.mobskills.magicalTpBonus.NO_EFFECT, 1, 2, 3)
     --get resist multiplier (1x if no resist)
     local resist = xi.mobskills.applyPlayerResistance(pet, -1, target, pet:getStat(xi.mod.INT)-target:getStat(xi.mod.INT), xi.skill.ELEMENTAL_MAGIC, xi.magic.ele.THUNDER)
     --get the resisted damage
-    damage.dmg = damage.dmg*resist
+    damage.dmg = damage.dmg * resist
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
+
     local tp = skill:getTP()
     if tp < 1000 then
         tp = 1000
     end
+
     damage.dmg = damage.dmg * tp / 1000
-    totaldamage = AvatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, numhits)
+    totaldamage = xi.summon.avatarFinalAdjustments(damage.dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, numhits)
     target:addStatusEffect(xi.effect.PARALYSIS, 15, 0, 60)
     target:takeDamage(totaldamage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
     target:updateEnmityFromDamage(pet, totaldamage)

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -14,26 +13,26 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.THUNDERSTORM)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
-    local damage = math.floor(512 + 1.72*(tp+1))
+    local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.LIGHTNING)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/tidal_wave.lua
+++ b/scripts/globals/abilities/pets/tidal_wave.lua
@@ -5,14 +5,13 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
     local level = player:getMainLvl() * 2
 
-    if(player:getMP()<level) then
+    if player:getMP() < level then
        return 87, 0
     end
 
@@ -27,7 +26,7 @@ ability_object.onPetAbility = function(target, pet, skill, master)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     master:setMP(0)
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -21,7 +20,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WATER)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/magic")
-
 -----------------------------------
 local ability_object = {}
 
@@ -19,12 +18,12 @@ ability_object.onPetAbility = function(target, pet, skill)
     local tp = skill:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
-    if (master ~= nil and master:isPC()) then
+    if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.WIND_BLADE)
     end
 
     tp = tp + (merits - 40)
-    if (tp > 300) then
+    if tp > 300 then
         tp = 300
     end
 
@@ -33,7 +32,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
-    damage = AvatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
+    damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 
     target:takeDamage(damage, pet, xi.attackType.MAGICAL, xi.damageType.WIND)
     target:updateEnmityFromDamage(pet, damage)

--- a/scripts/globals/abilities/pets/zantetsuken.lua
+++ b/scripts/globals/abilities/pets/zantetsuken.lua
@@ -19,12 +19,12 @@ ability_object.onPetAbility = function(target, pet, skill, master)
 
     if (target:isNM()) then
         local dmg = 0.1 * target:getHP() + 0.1 * target:getHP() * power
-        if (dmg > 9999) then
+        if dmg > 9999 then
             dmg = 9999
         end
         dmg = xi.mobskills.mobMagicalMove(pet, target, skill, dmg, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
         dmg = xi.mobskills.mobAddBonuses(pet, target, dmg.dmg, xi.magic.ele.DARK)
-        dmg = AvatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
+        dmg = xi.summon.avatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
         target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.DARK)
         target:updateEnmityFromDamage(pet, dmg)
         return dmg

--- a/scripts/globals/spells/summoning/air_spirit.lua
+++ b/scripts/globals/spells/summoning/air_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/alexander.lua
+++ b/scripts/globals/spells/summoning/alexander.lua
@@ -11,21 +11,20 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW)) then
+    elseif not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
         return xi.msg.basic.MAGIC_MUST_ASTRAL_FLOW
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
     caster:spawnPet(xi.pet.id.ALEXANDER)
-
     return 0
 end
 

--- a/scripts/globals/spells/summoning/dark_spirit.lua
+++ b/scripts/globals/spells/summoning/dark_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/diabolos.lua
+++ b/scripts/globals/spells/summoning/diabolos.lua
@@ -11,12 +11,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/earth_spirit.lua
+++ b/scripts/globals/spells/summoning/earth_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/fenrir.lua
+++ b/scripts/globals/spells/summoning/fenrir.lua
@@ -11,19 +11,18 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
     caster:spawnPet(xi.pet.id.FENRIR)
-
     return 0
 end
 

--- a/scripts/globals/spells/summoning/fire_spirit.lua
+++ b/scripts/globals/spells/summoning/fire_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/garuda.lua
+++ b/scripts/globals/spells/summoning/garuda.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/ice_spirit.lua
+++ b/scripts/globals/spells/summoning/ice_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/ifrit.lua
+++ b/scripts/globals/spells/summoning/ifrit.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/leviathan.lua
+++ b/scripts/globals/spells/summoning/leviathan.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/light_spirit.lua
+++ b/scripts/globals/spells/summoning/light_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/odin.lua
+++ b/scripts/globals/spells/summoning/odin.lua
@@ -11,14 +11,14 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW)) then
+    elseif not caster:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
         return 581
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/ramuh.lua
+++ b/scripts/globals/spells/summoning/ramuh.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/shiva.lua
+++ b/scripts/globals/spells/summoning/shiva.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/thunder_spirit.lua
+++ b/scripts/globals/spells/summoning/thunder_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/spells/summoning/titan.lua
+++ b/scripts/globals/spells/summoning/titan.lua
@@ -10,12 +10,12 @@ require("scripts/globals/status")
 local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
-    if (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    if not caster:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:hasPet()) then
+    elseif caster:hasPet() then
         return xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (caster:getObjType() == xi.objType.PC) then
-        return avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        return xi.summon.avatarMiniFightCheck(caster)
     end
     return 0
 end

--- a/scripts/globals/spells/summoning/water_spirit.lua
+++ b/scripts/globals/spells/summoning/water_spirit.lua
@@ -12,12 +12,12 @@ local spell_object = {}
 
 spell_object.onMagicCastingCheck = function(caster, target, spell)
     local result = 0
-    if (caster:hasPet()) then
+    if caster:hasPet() then
         result = xi.msg.basic.ALREADY_HAS_A_PET
-    elseif (not caster:canUseMisc(xi.zoneMisc.PET)) then
+    elseif not caster:canUseMisc(xi.zoneMisc.PET) then
         result = xi.msg.basic.CANT_BE_USED_IN_AREA
-    elseif (caster:getObjType() == xi.objType.PC) then
-        result = avatarMiniFightCheck(caster)
+    elseif caster:getObjType() == xi.objType.PC then
+        result = xi.summon.avatarMiniFightCheck(caster)
     end
     return result
 end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -300,7 +300,6 @@ local attackTypeShields =
 }
 
 function AvatarFinalAdjustments(dmg, mob, skill, target, skilltype, damagetype, shadowbehav)
-
     -- physical attack missed, skip rest
     if skilltype == xi.attackType.PHYSICAL and dmg == 0 then
         return 0
@@ -311,49 +310,7 @@ function AvatarFinalAdjustments(dmg, mob, skill, target, skilltype, damagetype, 
     skill:setMsg(xi.msg.basic.DAMAGE)
 
     -- Handle shadows depending on shadow behaviour / skilltype
-    if shadowbehav < 5 and shadowbehav ~= xi.mobskills.shadowBehavior.IGNORE_SHADOWS then -- remove 'shadowbehav' shadows.
-        local targShadows = target:getMod(xi.mod.UTSUSEMI)
-        local shadowType = xi.mod.UTSUSEMI
-        if targShadows == 0 then -- try blink, as utsusemi always overwrites blink this is okay
-            targShadows = target:getMod(xi.mod.BLINK)
-            shadowType = xi.mod.BLINK
-        end
-
-        if targShadows > 0 then
-            -- Blink has a VERY high chance of blocking tp moves, so im assuming its 100% because its easier!
-            if targShadows >= shadowbehav then -- no damage, just suck the shadows
-                skill:setMsg(xi.msg.basic.SHADOW_ABSORB)
-                target:setMod(shadowType, targShadows - shadowbehav)
-                if shadowType == xi.mod.UTSUSEMI then -- update icon
-                    local effect = target:getStatusEffect(xi.effect.COPY_IMAGE)
-                    if effect ~= nil then
-                        if targShadows - shadowbehav == 0 then
-                            target:delStatusEffect(xi.effect.COPY_IMAGE)
-                            target:delStatusEffect(xi.effect.BLINK)
-                        elseif targShadows - shadowbehav == 1 then
-                            effect:setIcon(xi.effect.COPY_IMAGE)
-                        elseif targShadows - shadowbehav == 2 then
-                            effect:setIcon(xi.effect.COPY_IMAGE_2)
-                        elseif targShadows - shadowbehav == 3 then
-                            effect:setIcon(xi.effect.COPY_IMAGE_3)
-                        end
-                    end
-                end
-                return shadowbehav
-            else -- less shadows than this move will take, remove all and factor damage down
-                dmg = dmg * (shadowbehav - targShadows) / shadowbehav
-                target:setMod(xi.mod.UTSUSEMI, 0)
-                target:setMod(xi.mod.BLINK, 0)
-                target:delStatusEffect(xi.effect.COPY_IMAGE)
-                target:delStatusEffect(xi.effect.BLINK)
-            end
-        end
-    elseif shadowbehav == xi.mobskills.shadowBehavior.WIPE_SHADOWS then -- take em all!
-        target:setMod(xi.mod.UTSUSEMI, 0)
-        target:setMod(xi.mod.BLINK, 0)
-        target:delStatusEffect(xi.effect.COPY_IMAGE)
-        target:delStatusEffect(xi.effect.BLINK)
-    end
+    dmg = utils.utils.takeShadows(target, dmg, shadowbehav)
 
     -- handle Third Eye using shadowbehav as a guide
     local teye = target:getStatusEffect(xi.effect.THIRD_EYE)

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -147,7 +147,7 @@ function utils.takeShadows(target, dmg, shadowbehav)
                 shadowsLeft = targShadows - shadowbehav
 
                 if shadowsLeft > 0 then
-                    --update icon
+                    -- Update icon
                     local effect = target:getStatusEffect(xi.effect.COPY_IMAGE)
                     if effect ~= nil then
                         if shadowsLeft == 1 then
@@ -156,6 +156,8 @@ function utils.takeShadows(target, dmg, shadowbehav)
                             effect:setIcon(xi.effect.COPY_IMAGE_2)
                         elseif shadowsLeft == 3 then
                             effect:setIcon(xi.effect.COPY_IMAGE_3)
+                        elseif shadowsLeft >= 4 then
+                            effect:setIcon(xi.effect.COPY_IMAGE_4)
                         end
                     end
                 end

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -168,12 +168,6 @@ global_objects=(
 
     AbilityFinalAdjustments
 
-    getSummoningSkillOverCap
-    AvatarFinalAdjustments
-    AvatarPhysicalHit
-    AvatarPhysicalMove
-    avatarMiniFightCheck
-
     MOBSKILL_MAGICAL
     MOBSKILL_PHYSICAL
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Attaches globals/summon.lua to xi.summon
* Removes exceptions for summon global functions in lua CI check
* Replaces duplicate shadow logic with utils function
* General formatting and cleanup of related scripts

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* No observable change should occur with summoned avatars.
<!-- Clear and detailed steps to test your changes here -->
