### PR TITLE
Fixes Pirate Ship Client Crashes

### DIFF
--- a/sql/transport.sql
+++ b/sql/transport.sql
@@ -53,4 +53,6 @@ INSERT INTO `transport` VALUES(14, 'Nashmau-Whitegate_Boat', 16994327, 16994326,
 INSERT INTO `transport` VALUES(15, 'Manaclip_Bibiki-Tours', 16793913, 16793914, 491.500, 0.000, 687.400, 128, 0, 18, 19, 710,720, 20, 40, 20, 3);
 INSERT INTO `transport` VALUES(16, 'Manaclip_Bibiki-Purgonorgo', 16793913, 16793914, 491.500, 0.000, 687.400, 128, 0, 18, 19, 270, 720, 20, 40, 20, 3);
 INSERT INTO `transport` VALUES(17, 'Manaclip_Purgonorgo-Bibiki', 16793913, 16793915, -392.000, 0.000, -364.000, 128, 0, 20, 21, 500, 720, 20, 40, 20, 3);
+INSERT INTO `transport` VALUES(18, 'Selbina-Mhaura_Boat_Pirates', 17793088, 17793087, 9.294, 0.000, -69.775, 0, 485, 18, 19, 382, 480, 18, 80, 17, 227);
+INSERT INTO `transport` VALUES(19, 'Mhaura-Selbina_Boat_Pirates', 17797182, 17797181, -0.516, 0.026, -8.409, 0, 493, 18, 19, 382, 480, 18, 80, 17, 228);
 


### PR DESCRIPTION
Co-Authored-By: Mattyg <mattygs@gmail.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes a Client Crash causes by a 'bad' NPC on the pirate ship instances.
Implements the transport.sql lines for the two ships. Provided by Mattyg

Fixes #2000 

## Steps to test these changes
!zone 227 or 228
Not crash!

![image](https://user-images.githubusercontent.com/6257062/176275689-d46dfc7c-f929-4dca-95ff-db3e7e0b4d8d.png)