### PR TITLE
[core] Add special spawn animation to non-trust entities

### DIFF
--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -51,7 +51,10 @@ function onTrigger(player)
         {
             require("scripts/mixins/rage"),
             require("scripts/mixins/job_special"),
-        }
+        },
+
+        -- The "whooshy" special animation that plays when Trusts or Dynamis mobs spawn
+        specialSpawnAnimation = true,
     })
 
     -- Use the mob object as you normally would

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -31,6 +31,7 @@ CBaseEntity::CBaseEntity()
 : objtype(ENTITYTYPE::TYPE_NONE)
 , status(STATUS_TYPE::DISAPPEAR)
 , allegiance(ALLEGIANCE_TYPE::MOB)
+, spawnAnimation(SPAWN_ANIMATION::NORMAL)
 , PAI(nullptr)
 , m_nextUpdateTimer(std::chrono::steady_clock::now())
 {

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -194,6 +194,13 @@ enum NAMEVIS : uint8
     VIS_GHOST_PHASE = 0x80,
 };
 
+
+enum class SPAWN_ANIMATION : uint8
+{
+    NORMAL  = 0,
+    SPECIAL = 1,
+};
+
 // TODO:it is possible to make this structure part of the class, instead of the current ID and Targid, but without the Clean method
 
 struct EntityID_t
@@ -301,6 +308,8 @@ public:
     uint8           updatemask; // what to update next server tick to players nearby
 
     bool isRenamed; // tracks if the entity's name has been overidden. Defaults to false.
+
+    SPAWN_ANIMATION spawnAnimation;
 
     std::unique_ptr<CAIContainer> PAI;          // AI container
     CBattlefield*                 PBattlefield; // pointer to battlefield (if in one)

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -314,6 +314,8 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
 
         PMob->m_bReleaseTargIDOnDeath = table["releaseIdOnDeath"].get_or(false);
 
+        PMob->spawnAnimation = static_cast<SPAWN_ANIMATION>(table["specialSpawnAnimation"].get_or(false) ? 1 : 0);
+
         // Ensure mobs get a function for onMobDeath
         auto onMobDeath = table["onMobDeath"].get_or<sol::function>(sol::lua_nil);
         if (!onMobDeath.valid())

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -80,6 +80,10 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
             {
                 ref<uint8>(0x2A) = 4;
             }
+            if (PEntity->spawnAnimation == SPAWN_ANIMATION::SPECIAL)
+            {
+                ref<uint8>(0x28) |= 0x45;
+            }
             ref<uint8>(0x0A) = updatemask;
         }
         break;
@@ -195,15 +199,11 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         }
     }
 
-    // TODO: Read from the trust model itself
     if (PEntity->objtype == TYPE_TRUST)
     {
-        // ref<uint32>(0x21) = 0x21b;
-        // ref<uint8>(0x2B) = 0x06;
-        // ref<uint8>(0x2A) = 0x08;
-        // ref<uint8>(0x25) = 0x0f;
-        // ref<uint8>(0x27) = 0x28;
-        ref<uint8>(0x28) = 0x45; // This allows trusts to be despawned
+        // Special spawn animation
+        // This also allows trusts to be despawned
+        ref<uint8>(0x28) |= 0x45;
     }
 
     // Send look data


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds an enum that can turn on/off the whooshy spawn animation for non-Trust entities. For trust, this is always on for spawn and despawn. We'll eventually need this for Dyna-D, and possibly also for zoning with Avatars or Wyverns.

## Steps to test these changes

Test `!fafnir` with the new flag true and false, see the animation:
```
        -- The "whooshy" special animation that plays when Trusts or Dynamis mobs spawn
        specialSpawnAnimation = true,
```
