### PR TITLE
[WS] Add multihit FTP to Club weaponskills

### DIFF
--- a/scripts/globals/weaponskills/hexa_strike.lua
+++ b/scripts/globals/weaponskills/hexa_strike.lua
@@ -18,24 +18,26 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 6
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
+    params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+	params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2
+	params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.125 params.ftp200 = 1.125 params.ftp300 = 1.125
         params.str_wsc = 0.3 params.mnd_wsc = 0.3
+		params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/hexa_strike.lua
+++ b/scripts/globals/weaponskills/hexa_strike.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.numHits = 6
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-	params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2
-	params.chr_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2
+    params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
@@ -32,7 +32,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.125 params.ftp200 = 1.125 params.ftp300 = 1.125
         params.str_wsc = 0.3 params.mnd_wsc = 0.3
-		params.multiHitfTP = true
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/realmrazer.lua
+++ b/scripts/globals/weaponskills/realmrazer.lua
@@ -18,23 +18,25 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 7
     params.ftp100 = 0.88 params.ftp200 = 0.88 params.ftp300 = 0.88
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 + (player:getMerit(xi.merit.REALMRAZER) * 0.17) params.chr_wsc = 0.0
+    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+	params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
+	params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.mnd_wsc = 0.7 + (player:getMerit(xi.merit.REALMRAZER) * 0.03)
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/realmrazer.lua
+++ b/scripts/globals/weaponskills/realmrazer.lua
@@ -22,8 +22,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.numHits = 7
     params.ftp100 = 0.88 params.ftp200 = 0.88 params.ftp300 = 0.88
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-	params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
-	params.chr_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds missing params.multiHitfTP to Club weaponskills Hexa Strike and Realmrazer.
Adjusts formatting of the associated Club weaponskill lua's to conform to LSB standards.

Reference:
https://www.bg-wiki.com/ffxi/Category:FTP_Replicating_WS

Issue https://github.com/LandSandBoat/server/issues/1357 lists the weaponskills found to be missing the multiHitfTP code.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Load the adjusted weaponskill LUA into your server.
Pick your favorite mob to test against and use the weaponskills.
fTP adjusting items like the Fotia Gorget and Belt should make significant differences in the output of these weaponskills.

Useful commands:
!tp 1000-3000 charName

<!-- Clear and detailed steps to test your changes here -->
