### PR TITLE
[WS] Add multihit FTP to Katana, Polearm, Scythe, and Sword weaponskills

### DIFF
--- a/scripts/globals/weaponskills/blade_jin.lua
+++ b/scripts/globals/weaponskills/blade_jin.lua
@@ -31,7 +31,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
-        params.multiHitfTP = true
+        params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Blade:_Jin
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/blade_jin.lua
+++ b/scripts/globals/weaponskills/blade_jin.lua
@@ -18,23 +18,25 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 3
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.multiHitfTP = true -- http://wiki.ffo.jp/html/722.html
+        params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -23,27 +23,29 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 5
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.1 params.dex_wsc = 0.1 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
+    params.str_wsc = 0.1 params.dex_wsc = 0.1 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.9 params.acc200= 1 params.acc300= 1.1
-    --  the TP bonus for TP 1,000 and above has been raised, which has substantially raised the hit rate http://wiki.ffo.jp/html/732.html
-    -- data on ws accuracy are difficult to come by, would need to decide on sane value for the accuracy boost stated in JPWiki for now I'm only adding 0.1 per tier
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1,000 TP
+    -- http://wiki.ffo.jp/html/732.html does not list ACC Bonus
+    -- https://www.bg-wiki.com/ffxi/Blade:_Ku does not list ACC Bonus
+    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.multiHitfTP = true -- http://wiki.ffo.jp/html/732.html
         params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
         params.str_wsc = 0.3 params.dex_wsc = 0.3
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/blade_shun.lua
+++ b/scripts/globals/weaponskills/blade_shun.lua
@@ -21,26 +21,27 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 5
     params.ftp100 = 0.6875 params.ftp200 = 0.6875 params.ftp300 = 0.6875
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 + (player:getMerit(xi.merit.BLADE_SHUN) * 0.17) params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.0 params.dex_wsc = player:getMerit(xi.merit.BLADE_SHUN) * 0.17 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
+        params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
         params.dex_wsc = 0.7 + (player:getMerit(xi.merit.BLADE_SHUN) * 0.03)
-        params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Blade:_Shun
-        params.atk100 = 1; params.atk200 = 2; params.atk300 = 3 -- http://wiki.ffo.jp/html/25610.html
+        params.atk100 = 1.0 params.atk200 = 2.0 params.atk300 = 3.0
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/blade_shun.lua
+++ b/scripts/globals/weaponskills/blade_shun.lua
@@ -35,8 +35,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
         params.dex_wsc = 0.7 + (player:getMerit(xi.merit.BLADE_SHUN) * 0.03)
-        params.atk100 = 1.0 params.atk200 = 2.0 params.atk300 = 3.0
-        params.multiHitfTP = true
+        params.atk100 = 1.0 params.atk200 = 2.0 params.atk300 = 3.0 -- http://wiki.ffo.jp/html/25610.html
+        params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Blade:_Shun
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/chant_du_cygne.lua
+++ b/scripts/globals/weaponskills/chant_du_cygne.lua
@@ -20,14 +20,17 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     local params = {}
     params.numHits = 3
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.8
+        params.multiHitfTP = true
     end
 
     -- Apply aftermath

--- a/scripts/globals/weaponskills/chant_du_cygne.lua
+++ b/scripts/globals/weaponskills/chant_du_cygne.lua
@@ -23,7 +23,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0
     params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
+    params.crit100 = 0.15 params.crit200 = 0.25 params.crit300 = 0.4
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
@@ -31,7 +31,6 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.6328 params.ftp200 = 1.6328 params.ftp300 = 1.6328
         params.dex_wsc = 0.8
-        params.crit100 = 0.15 params.crit200 = 0.25 params.crit300 = 0.4
         params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Chant_du_Cygne
     end
 

--- a/scripts/globals/weaponskills/chant_du_cygne.lua
+++ b/scripts/globals/weaponskills/chant_du_cygne.lua
@@ -29,8 +29,10 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
+        params.ftp100 = 1.6328 params.ftp200 = 1.6328 params.ftp300 = 1.6328
         params.dex_wsc = 0.8
-        params.multiHitfTP = true
+        params.crit100 = 0.15 params.crit200 = 0.25 params.crit300 = 0.4
+        params.multiHitfTP = true -- https://www.bg-wiki.com/ffxi/Chant_du_Cygne
     end
 
     -- Apply aftermath

--- a/scripts/globals/weaponskills/entropy.lua
+++ b/scripts/globals/weaponskills/entropy.lua
@@ -19,24 +19,27 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 2.0
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 + (player:getMerit(xi.merit.ENTROPY) * 0.17) params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = player:getMerit(xi.merit.ENTROPY) * 0.17 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.int_wsc = 0.7 + (player:getMerit(xi.merit.ENTROPY) * 0.03)
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    player:addMP(damage * 0.2)
-    return tpHits, extraHits, criticalHit, damage
 
+    player:addMP(damage * 0.2)
+
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -15,39 +15,21 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 5
-
-    params.ftp100 = 1
-    params.ftp200 = 1
-    params.ftp300 = 1
-
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 + (player:getMerit(xi.merit.REQUIESCAT) * 0.17)
+    params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
+    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REQUIESCAT) * 0.17
     params.chr_wsc = 0.0
-
+    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.crit100 = 0.0
-    params.crit200 = 0.0
-    params.crit300 = 0.0
-
-    params.acc100 = 0.0
-    params.acc200 = 0.0
-    params.acc300 = 0.0
-
-    params.atk100 = 0.8
-    params.atk200 = 0.9
-    params.atk300 = 1.0
-
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 0.8 params.atk200 = 0.9 params.atk300 = 1.0
     params.formless = true
 
-    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.mnd_wsc = 0.7 + (player:getMerit(xi.merit.REQUIESCAT) * 0.03)
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -25,6 +25,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 0.8 params.atk200 = 0.9 params.atk300 = 1.0
+    -- TODO: Verify the params.formless check
     params.formless = true
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/stardiver.lua
+++ b/scripts/globals/weaponskills/stardiver.lua
@@ -16,18 +16,20 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 1.75
-    params.str_wsc = 0.0 + (player:getMerit(xi.merit.STARDIVER) * 0.17) params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = player:getMerit(xi.merit.STARDIVER) * 0.17 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.7 + (player:getMerit(xi.merit.STARDIVER) * 0.03)
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
@@ -35,8 +37,8 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     if (damage > 0 and target:hasStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN) == false) then
         target:addStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN, 5, 0, 60)
     end
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/swift_blade.lua
+++ b/scripts/globals/weaponskills/swift_blade.lua
@@ -18,23 +18,28 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.5 params.ftp200 = 1.5 params.ftp300 = 1.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3
+    params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1,000 TP
+    -- http://wiki.ffo.jp/html/382.html does not list ACC Bonus
+    -- https://www.bg-wiki.com/ffxi/Swift_Blade does not list ACC Bonus
+    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.5 params.mnd_wsc = 0.5
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object

--- a/scripts/globals/weaponskills/vorpal_blade.lua
+++ b/scripts/globals/weaponskills/vorpal_blade.lua
@@ -18,24 +18,26 @@ require("scripts/globals/weaponskills")
 local weaponskill_object = {}
 
 weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-
     local params = {}
     params.numHits = 4
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0
+    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
-    params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
+    params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
+    params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
-    if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+    if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
         params.str_wsc = 0.6
+        params.multiHitfTP = true
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    return tpHits, extraHits, criticalHit, damage
 
+    return tpHits, extraHits, criticalHit, damage
 end
 
 return weaponskill_object


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Adds missing params.multiHitfTP to Katana weaponskills Blade: Jin, Blade: Ku, and Blade: Shun.
- Adds missing params.multiHitfTP to Polearm weaponskill Stardiver.
- Adds missing params.multiHitfTP to Scythe weaponskill Entropy.
- Adds missing params.multiHitfTP to Sword weaponskills Chant du Cygne, Requiescat, Swift Blade, and Vorpal Blade.
- Adjusts formatting of the associated weaponskill lua's to conform to LSB standards.

**Reference:**
https://www.bg-wiki.com/ffxi/Category:FTP_Replicating_WS

Issue https://github.com/LandSandBoat/server/issues/1357 lists the weaponskills found to be missing the multiHitfTP code.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Load the adjusted weaponskill LUA into your server.
Pick your favorite mob to test against and use the weaponskills.
fTP adjusting items like the Fotia Gorget and Belt should make significant differences in the output of these weaponskills.

Useful commands:
!tp 1000-3000 charName

<!-- Clear and detailed steps to test your changes here -->
