### PR TITLE
Homepoint the player instead of setting a specific zone

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -274,9 +274,10 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (destination >= MAX_ZONEID)
         {
+            // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
             ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone out of range: %d", destination);
-            ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to a valid zone!", PChar->GetName());
-            PChar->loc.destination = destination = (uint16)ZONE_SELBINA;
+            ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->GetName());
+            charutils::HomePoint(PChar);
         }
 
         zoneutils::GetZone(destination)->IncreaseZoneCounter(PChar);
@@ -320,12 +321,9 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         ShowWarning("Client cannot receive packet or key is invalid: %s, Zone: %s (%i)",
                     PChar->GetName(), PChar->loc.zone->GetName(), PChar->loc.zone->GetID());
 
-        // Write a sane location for them
         // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
-        ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to a valid zone!", PChar->GetName());
-        auto prevZone          = PChar->loc.prevzone ? PChar->loc.prevzone : (uint16)ZONE_VALKURM_DUNES;
-        PChar->loc.destination = prevZone;
-        sql->Query("UPDATE chars SET pos_zone = %u WHERE charid = %u", prevZone, PChar->id);
+        ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->GetName());
+        charutils::HomePoint(PChar);
     }
 
     charutils::SaveCharPosition(PChar);


### PR DESCRIPTION
Closes #2122 but this is really more of a band-aid.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Since homepointing also takes care of coordinates in the zone I don;' have to set those. Alternatively, I could zero the pos and let the default from the zones lua script move the player to a valid position. I tried to ask before opening the PR but didn't see an answer/ Its a rel;atively trivial change, but I feel homepoiting is actually less of a problem than was thought when the choice of "prevzone or valkurm" was decided. A scroll of instant warp is a mere 7cp, or free daily at the satchel moogle. Not much of an exploit and the repeated log warnings should tip off a server operator.

Honestly, I could not even get myself transported to valkurm on purpose (I tried) without cheating it by editing database to make prevzone invalid, and zooming back to previous zone can be pretty exploitable on servers that don't give everyone the `!return` command. While if you actually land in valkurm at too low a lv your only choice is to die and get homepointed anyway.

**Still, let me know if you'd prefer I just zero the pos.**

Note: while testing this, I discovered _another_ bug which I will open another issue for. It involved new characters only and does not happen once your new character has zoned. This PR does not cause the bug, but it did expose it.

## Steps to test these changes
Build, and try to trigger and invalid key message, watch map server move player to homepoint.

Zone normally without tripping it, see player zone as normal.