### PR TITLE
Correct setting names to correct crafting skill ups 

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -23,7 +23,7 @@ xi.settings.map =
 
     --  PacketGuard will block and report any packets that aren't in the allow-list for a
     --  player's current state.
-    PACKETGUARD_ENABLED = 1,
+    PACKETGUARD_ENABLED = true,
 
     -- Minimal number of 0x3A packets which uses for detect lightluggage (set 0 for disable)
     LIGHTLUGGAGE_BLOCK = 4,
@@ -43,7 +43,7 @@ xi.settings.map =
     -- Misc EXP related settings
     EXP_RATE                = 1.0,
     EXP_LOSS_RATE           = 1.0,
-    EXP_PARTY_GAP_PENALTIES = 1,
+    EXP_PARTY_GAP_PENALTIES = true,
 
     --  Capacity Point Settings
     CAPACITY_RATE = 1.0,
@@ -64,10 +64,10 @@ xi.settings.map =
     EXP_LOSS_LEVEL = 31,
 
     -- Enable/disable Level Sync
-    LEVEL_SYNC_ENABLE = 1,
+    LEVEL_SYNC_ENABLE = true,
 
     -- Disables ability to equip higher level gear when level cap/sync effect is on player.
-    DISABLE_GEAR_SCALING = 0,
+    DISABLE_GEAR_SCALING = false,
 
     -- Weaponskill point base (before skillchain) for breaking latent - whole numbers only. retail is 1.
     WS_POINTS_BASE = 1,
@@ -77,7 +77,7 @@ xi.settings.map =
     WS_POINTS_SKILLCHAIN = 1,
 
     -- Enable/disable jobs other than BST and RNG having widescan
-    ALL_JOBS_WIDESCAN = 1,
+    ALL_JOBS_WIDESCAN = true,
 
     -- Modifier to apply to player speed. 0 is the retail accurate default. Negative numbers will reduce it.
     SPEED_MOD = 0,
@@ -97,14 +97,14 @@ xi.settings.map =
     SKILLUP_AMOUNT_MULTIPLIER = 1,
     CRAFT_AMOUNT_MULTIPLIER   = 1,
 
-    -- Gardening Factors        = DO NOT change defaults without verifiable proof that your change IS how retail does it. Myths need to be optional.
-    GARDEN_DAY_MATTERS       = 0,
-    GARDEN_MOONPHASE_MATTERS = 0,
-    GARDEN_POT_MATTERS       = 0,
-    GARDEN_MH_AURA_MATTERS   = 0,
+    -- Gardening Factors. DO NOT change defaults without verifiable proof that your change IS how retail does it. Myths need to be optional.
+    GARDEN_DAY_MATTERS       = false,
+    GARDEN_MOONPHASE_MATTERS = false,
+    GARDEN_POT_MATTERS       = false,
+    GARDEN_MH_AURA_MATTERS   = false,
 
     -- Use current retail skill up rates and margins (Retail = High Skill-Up rate; Skill-Up when at or under 10 levels above synth recipe level.)
-    CRAFT_MODERN_SYSTEM = 1,
+    CRAFT_MODERN_SYSTEM = true,
 
     -- Craft level limit from witch specialization points beging to count. (Retail = 700; Level 75 era:600)
     CRAFT_COMMON_CAP = 700,
@@ -113,13 +113,13 @@ xi.settings.map =
     CRAFT_SPECIALIZATION_POINTS = 400,
 
     -- Enables fishing. 0 = Disbaled. 1 = Enable. ENABLE AT YOUR OWN RISK.
-    FISHING_ENABLE     = 0,
+    FISHING_ENABLE = false,
 
     -- Multipler for fishing skill-up chance. Default = 1.0, very hard.
     FISHING_SKILL_MULTIPLIER = 1.0,
 
     -- Enable/disable skill-ups from bloodpacts
-    SKILLUP_BLOODPACT = 1,
+    SKILLUP_BLOODPACT = true,
 
     -- Adjust rate of TP gain for mobs, and players. Acts as a multiplier, so default is 1.
     MOB_TP_MULTIPLIER    = 1.0,
@@ -163,7 +163,7 @@ xi.settings.map =
     ABILITY_RECAST_MULTIPLIER = 1.0,
 
     -- Enable/disable shared blood pact timer
-    BLOOD_PACT_SHARED_TIMER = 0,
+    BLOOD_PACT_SHARED_TIMER = false,
 
     -- Adjust mob drop rate. Acts as a multiplier, so default is 1.
     DROP_RATE_MULTIPLIER = 1.0,
@@ -178,7 +178,7 @@ xi.settings.map =
     MAX_GIL_BONUS = 9999,
 
     --  Allow mobs to walk back home instead of despawning
-    MOB_NO_DESPAWN = 0,
+    MOB_NO_DESPAWN = false,
 
     -- Allows parry, block, and guard to skill up regardless of the action occuring.
     -- This did not happen in previous eras
@@ -202,28 +202,28 @@ xi.settings.map =
 
     -- Command Audit [logging] commands with lower permission than this will not be logged.
     -- Zero for no logging at all. Commands given to non GMs are not logged.
-    AUDIT_GM_CMD = 0,
+    AUDIT_GM_CMD = false,
 
     -- Todo = other logging including anti-cheat messages
 
     -- Chat Audit[logging] settings
-    AUDIT_CHAT      = 0,
-    AUDIT_SAY       = 0,
-    AUDIT_SHOUT     = 0,
-    AUDIT_TELL      = 0,
-    AUDIT_YELL      = 0,
-    AUDIT_LINKSHELL = 0,
-    AUDIT_UNITY     = 0,
-    AUDIT_PARTY     = 0,
+    AUDIT_CHAT      = false,
+    AUDIT_SAY       = false,
+    AUDIT_SHOUT     = false,
+    AUDIT_TELL      = false,
+    AUDIT_YELL      = false,
+    AUDIT_LINKSHELL = false,
+    AUDIT_UNITY     = false,
+    AUDIT_PARTY     = false,
 
     -- Seconds between healing ticks. Default is 10
     HEALING_TICK_DELAY = 10,
 
     -- Set to 1 to enable server side anti-cheating measurements
-    ANTICHEAT_ENABLED = 1,
+    ANTICHEAT_ENABLED = true,
 
     -- Set to 1 to completely disable auto-jailing offenders
-    ANTICHEAT_JAIL_DISABLE = 0,
+    ANTICHEAT_JAIL_DISABLE = false,
 
 
     --  Gobbie Mystery Box settings

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -458,22 +458,22 @@ namespace synthutils
             // Section 2: Skill up equations and penalties
             double skillUpChance = 0;
 
-            double craftChanceMultipler = settings::get<double>("map.CRAFT_AMOUNT_MULTIPLER");
+            double craftChanceMultiplier = settings::get<double>("map.CRAFT_CHANCE_MULTIPLIER");
 
             if (settings::get<bool>("map.CRAFT_MODERN_SYSTEM"))
             {
                 if (baseDiff > 0)
                 {
-                    skillUpChance = (double)baseDiff * craftChanceMultipler * (3 - (log(1.2 + charSkill / 100))) / 5; // Original skill up equation with "x2 chance" applied.
+                    skillUpChance = (double)baseDiff * craftChanceMultiplier * (3 - (log(1.2 + charSkill / 100))) / 5; // Original skill up equation with "x2 chance" applied.
                 }
                 else
                 {
-                    skillUpChance = craftChanceMultipler * (3 - (log(1.2 + charSkill / 100))) / (6 - baseDiff); // Equation used when over cap.
+                    skillUpChance = craftChanceMultiplier * (3 - (log(1.2 + charSkill / 100))) / (6 - baseDiff); // Equation used when over cap.
                 }
             }
             else
             {
-                skillUpChance = (double)baseDiff * craftChanceMultipler * (3 - (log(1.2 + charSkill / 100))) / 10; // Original skill up equation
+                skillUpChance = (double)baseDiff * craftChanceMultiplier * (3 - (log(1.2 + charSkill / 100))) / 10; // Original skill up equation
             }
 
             // Apply synthesis skill gain rate modifier before synthesis fail modifier
@@ -566,9 +566,9 @@ namespace synthutils
                 }
 
                 // Do skill amount multiplier
-                if (settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLER") > 1)
+                if (settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLIER") > 1)
                 {
-                    skillUpAmount += skillUpAmount * settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLER");
+                    skillUpAmount += skillUpAmount * settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLIER");
                     if (skillUpAmount > 9)
                     {
                         skillUpAmount = 9;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Fix crafting skill ups.
- Fix incorrect cafting setting (amount instead of chance)
- Change several setting values from 0/1 to false/true

Closes #2154 

## Steps to test these changes

With craft skill not caped, perform crafting with a recipe apropiate to your level.
