### PR TITLE
[luacheck] Simplify caskets global to satisfy CI

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -365,17 +365,6 @@ local function removeHint(npc, hintNum)
 end
 
 -----------------------------------
--- Desc: Checks number to see if they are even or not for the locked minigame.
------------------------------------
-local function isEven(number)
-    if number % 2 == 0 then
-        return true
-    else
-        return false
-    end
-end
-
------------------------------------
 -- Desc: Sets the items id in a local variable for the casket.
 -----------------------------------
 local function setItems(npc, item1, item2, item3, item4)
@@ -621,7 +610,7 @@ local function giveItem(player, npc, itemNum)
                     if player:addItem(itemID) then
                         messageChest(player, "PLAYER_OBTAINS_ITEM", itemID, 0, 0, 0)
                         npc:setLocalVar(itemQuery, 0)
-                         checkItemChestIsEmpty(npc)
+                        checkItemChestIsEmpty(npc)
                     end
                 end
             end
@@ -805,7 +794,6 @@ xi.caskets.onEventFinish = function(player, csid, option, npc)
     -----------------------------------
     -- Minigame
     -----------------------------------
-
     local splitNumbers   = {}
     local hintsVar       = chestObj:getLocalVar("[caskets]HINTS_TABLE")
     local availableHints = {}
@@ -824,6 +812,7 @@ xi.caskets.onEventFinish = function(player, csid, option, npc)
         if option > 0 and spawnStatus ~= casketInfo.spawnStatus.SPAWNED_CLOSED then -- prevent minigame from working if chest is opened.
             return
         end
+
         -----------------------------------
         -- Hints
         -----------------------------------
@@ -834,68 +823,43 @@ xi.caskets.onEventFinish = function(player, csid, option, npc)
                 if randText == 0 or randText == nil then
                     player:messageSpecial(baseMessage + casketInfo.messageOffset.UNABLE_TO_GET_HINT, 0, 0, 0, 0)
                     return
-                end
+                elseif randText <= 2 then
+                    local oddEventParam = splitNumbers[randText] % 2
+                    local messageId     = baseMessage + casketInfo.messageOffset.HUNCH_SECOND_EVEN_ODD - (randText - 2)
 
-                if randText == 1 then
-                    if isEven(splitNumbers[1]) then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_FIRST_EVEN_ODD, 0, 0, 0, 0)
-                        chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
+                    player:messageSpecial(messageId, oddEventParam, 0, 0, 0)
+                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts + 1)
+                elseif randText <= 4 then
+                    -- NOTE: Second digit ID is one lower than First Digit ID, but our randText is opposite that.  If randText == 3, then
+                    -- we expect it to be the FIRST_DIGIT_IS message.  Therefore, the below function intends to add 1 to second digit
+                    -- if it is the first.
+
+                    local splitIndex = randText - 2
+                    local messageId = baseMessage + casketInfo.messageOffset.SECOND_DIGIT_IS - (splitIndex - 2)
+
+                    if splitNumbers[splitIndex] <= 6 then
+                        player:messageSpecial(messageId,
+                            splitNumbers[splitIndex],
+                            splitNumbers[splitIndex] + 1,
+                            splitNumbers[splitIndex] + 2, 0)
+                    elseif splitNumbers[splitIndex] == 9 then
+                        player:messageSpecial(messageId,
+                            splitNumbers[splitIndex] - 2,
+                            splitNumbers[splitIndex] - 1,
+                            splitNumbers[splitIndex], 0)
                     else
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_FIRST_EVEN_ODD, 1, 0, 0, 0)
-                        chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
+                        player:messageSpecial(messageId,
+                            splitNumbers[splitIndex] - 1,
+                            splitNumbers[splitIndex],
+                            splitNumbers[splitIndex] + 1, 0)
                     end
-                elseif randText == 2 then
-                    if isEven(splitNumbers[2]) then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_SECOND_EVEN_ODD, 0, 0, 0, 0)
-                        chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                    else
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_SECOND_EVEN_ODD, 1, 0, 0, 0)
-                        chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                    end
-                elseif randText == 3 then
-                    if splitNumbers[1] <= 6 then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.FIRST_DIGIT_IS,
-                            splitNumbers[1],
-                            splitNumbers[1] +1,
-                            splitNumbers[1] +2, 0)
-                    elseif splitNumbers[1] == 9 then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.FIRST_DIGIT_IS,
-                            splitNumbers[1] -2,
-                            splitNumbers[1] -1,
-                            splitNumbers[1], 0)
-                    else
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.FIRST_DIGIT_IS,
-                            splitNumbers[1] -1,
-                            splitNumbers[1],
-                            splitNumbers[1] +1, 0)
-                    end
-                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                elseif randText == 4 then
-                    if splitNumbers[2] <= 6 then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.SECOND_DIGIT_IS,
-                            splitNumbers[2],
-                            splitNumbers[2] +1,
-                            splitNumbers[2] +2, 0)
-                    elseif splitNumbers[2] == 9 then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.SECOND_DIGIT_IS,
-                            splitNumbers[2] -2,
-                            splitNumbers[2] -1,
-                            splitNumbers[2], 0)
-                    else
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.SECOND_DIGIT_IS,
-                            splitNumbers[2] -1,
-                            splitNumbers[2],
-                            splitNumbers[2] +1, 0)
-                    end
-                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                elseif randText == 5 then
-                    player:messageSpecial(baseMessage + casketInfo.messageOffset.ONE_OF_TWO_DIGITS_IS,
-                        splitNumbers[1], 0, 0, 0)
-                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                elseif randText == 6 then
-                    player:messageSpecial(baseMessage + casketInfo.messageOffset.ONE_OF_TWO_DIGITS_IS,
-                        splitNumbers[2], 0, 0, 0)
-                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
+
+                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts + 1)
+                elseif randText <= 6 then
+                    local splitIndex = randText - 4
+
+                    player:messageSpecial(baseMessage + casketInfo.messageOffset.ONE_OF_TWO_DIGITS_IS, splitNumbers[splitIndex], 0, 0, 0)
+                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts + 1)
                 elseif randText == 7 then
                     local highNum = 0
                     local lowNum  = 0
@@ -903,12 +867,12 @@ xi.caskets.onEventFinish = function(player, csid, option, npc)
                     if splitNumbers[1] == 1 then
                         lowNum  = 10
                         highNum = 20 + math.random(1, 9)
-                    elseif splitNumbers[1] > 1 and splitNumbers[1] < 9 then
-                        lowNum  = splitNumbers[1] * 10 - 10 + math.random(1, 9)
-                        highNum = splitNumbers[1] * 10 + 10 + math.random(1, 9)
                     elseif splitNumbers[1] == 9 then
                         lowNum  = 80 + math.random(1, 9)
                         highNum = 99
+                    else
+                        lowNum  = splitNumbers[1] * 10 - 10 + math.random(1, 9)
+                        highNum = splitNumbers[1] * 10 + 10 + math.random(1, 9)
                     end
 
                     player:messageSpecial(baseMessage + casketInfo.messageOffset.COMBINATION_GREATER_LESS, lowNum, highNum, 0, 0)
@@ -916,70 +880,46 @@ xi.caskets.onEventFinish = function(player, csid, option, npc)
                 else
                     player:messageSpecial(baseMessage + casketInfo.messageOffset.UNABLE_TO_GET_HINT, 0, 0, 0, 0)
                 end
+
                 checkRemainingAttempts(player, chestObj, remainingAttempts, correctNumber)
                 removeHint(chestObj, randText)
             end
+
         -----------------------------------
         -- Inputs
         -----------------------------------
         elseif lockedChoice == 1 then -- Input a number
             if inputNumber > 9 and inputNumber < 100 then
-                if inputNumber == correctNumber then
-                    if locked == 0 then
-                        player:messageSpecial(baseMessage + casketInfo.messageOffset.NO_COMBINATION, 0, 0, 0, 0)
-                    else
-                        messageChest(player, "OPENED_LOCK", 0 , 0, 0, 0, chestObj)
-                        chestObj:setLocalVar("[caskets]LOCKED", 0)
+                if locked == 0 then
+                    player:messageSpecial(baseMessage + casketInfo.messageOffset.NO_COMBINATION, 0, 0, 0, 0)
+                elseif inputNumber == correctNumber then
+                    messageChest(player, "OPENED_LOCK", 0 , 0, 0, 0, chestObj)
+                    chestObj:setLocalVar("[caskets]LOCKED", 0)
 
-                        if chestObj:getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.SPAWNED_CLOSED then  -- is the chest shut?, then open it.
-                           chestObj:setAnimationSub(1)
-                           chestObj:setLocalVar("[caskets]SPAWNSTATUS", casketInfo.spawnStatus.SPAWNED_OPEN)
-                           -- RoE Timed Record #4019 - Crack Tresure Caskets
-                           if player:getEminenceProgress(4019) then
-                               xi.roe.onRecordTrigger(player, 4019)
-                           end
-                        end
+                    if chestObj:getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.SPAWNED_CLOSED then  -- is the chest shut?, then open it.
+                        chestObj:setAnimationSub(1)
+                        chestObj:setLocalVar("[caskets]SPAWNSTATUS", casketInfo.spawnStatus.SPAWNED_OPEN)
+
+                        -- RoE Timed Record #4019 - Crack Tresure Caskets (Progress is verified in onRecordTrigger function)
+                        xi.roe.onRecordTrigger(player, 4019)
                     end
                 else
-                    if inputNumber < correctNumber then
-                        if locked == 0 then
-                            player:messageSpecial(baseMessage + casketInfo.messageOffset.NO_COMBINATION, 0, 0, 0, 0)
-                        else
-                            player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_GREATER_LESS, inputNumber, 0, 0, 0, 0)
-                            chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                            checkRemainingAttempts(player, chestObj, remainingAttempts, correctNumber)
-                        end
-                    elseif inputNumber > correctNumber then
-                        if locked == 0 then
-                            player:messageSpecial(baseMessage + casketInfo.messageOffset.NO_COMBINATION, 0, 0, 0, 0)
-                        else
-                            player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_GREATER_LESS, inputNumber, 1, 0, 0, 0)
-                            chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts +1)
-                            checkRemainingAttempts(player, chestObj, remainingAttempts, correctNumber)
-                        end
-                    end
+                    local isGreater = inputNumber > correctNumber and 1 or 0
+
+                    player:messageSpecial(baseMessage + casketInfo.messageOffset.HUNCH_GREATER_LESS, inputNumber, isGreater, 0, 0, 0)
+                    chestObj:setLocalVar("[caskets]FAILED_ATEMPTS", failedAtempts + 1)
+                    checkRemainingAttempts(player, chestObj, remainingAttempts, correctNumber)
                 end
             end
         end
+
     elseif locked == 0 then
+        local itemPos = bit.band(option, 0x7)
+
         if lootType == 1 then
-            if option == 65537 then
-                giveTempItem(player, chestObj, 1)
-            elseif option == 65538 then
-                giveTempItem(player, chestObj, 2)
-            elseif option == 65539 then
-                giveTempItem(player, chestObj, 3)
-            end
+            giveTempItem(player, chestObj, itemPos)
         elseif lootType == 2 then
-            if option == 65537 then
-                giveItem(player, chestObj, 1)
-            elseif option == 65538 then
-                giveItem(player, chestObj, 2)
-            elseif option == 65539 then
-                giveItem(player, chestObj, 3)
-            elseif option == 65540 then
-                giveItem(player, chestObj, 4)
-            end
+            giveItem(player, chestObj, itemPos)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Simplifies caskets.lua global to satisfy CI checks
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Nothing should change for Treasure Casket interactions
<!-- Clear and detailed steps to test your changes here -->
