### PR TITLE
Fix the northern most blue monolith to work in VeLugannon

### DIFF
--- a/scripts/zones/VeLugannon_Palace/npcs/Monolith.lua
+++ b/scripts/zones/VeLugannon_Palace/npcs/Monolith.lua
@@ -13,8 +13,8 @@ end
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.Y_LITH_OFFSET
     if (offset >= 0 and offset <= 20) then
-        local y = (offset <= 11) and xi.anim.OPEN_DOOR or xi.anim.CLOSE_DOOR
-        local b = (offset <= 11) and xi.anim.CLOSE_DOOR or xi.anim.OPEN_DOOR
+        local y = (offset <= 8) and xi.anim.OPEN_DOOR or xi.anim.CLOSE_DOOR
+        local b = (offset <= 8) and xi.anim.CLOSE_DOOR or xi.anim.OPEN_DOOR
         for i = ID.npc.Y_DOOR_OFFSET,    ID.npc.Y_DOOR_OFFSET + 7, 1 do GetNPCByID(i):setAnimation(y); end  -- yellow doors
         for i = ID.npc.B_DOOR_OFFSET,    ID.npc.B_DOOR_OFFSET + 6, 1 do GetNPCByID(i):setAnimation(b); end  -- blue doors
         for i = ID.npc.Y_LITH_OFFSET -1, ID.npc.Y_LITH_OFFSET + 9, 2 do GetNPCByID(i):setAnimation(y); end  -- yellow monoliths


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes the northern most blue monolith near Zipacna in VeLugannon

## Steps to test these changes

1. Go to NW VeLugannon entrance (Zip western entrance)
2. Wallhack to the Blue Monolith
3. Click blue monolith, nothing happens, frown to yourself and think, "that's not right."
