### PR TITLE
[core] Encode strings and names fixes, packet offset update to item trade

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -27,11 +27,11 @@
 #include "../common/mmo.h"
 #include <math.h>
 
-constexpr size_t PacketNameLength = 15;
+constexpr size_t PacketNameLength = 16;      // 15 + null terminator
 
 constexpr size_t DecodeStringLength    = 21; // used for size of decoded strings of signature/linkshells
-constexpr size_t SignatureStringLength = 12; // encoded signature string size
-constexpr size_t LinkshellStringLength = 16; // encoded linkshell string size
+constexpr size_t SignatureStringLength = 16; // encoded signature string size // 15 characters + null terminator
+constexpr size_t LinkshellStringLength = 20; // encoded linkshell string size // 19 characters + null terminator
 
 int32 checksum(uint8* buf, uint32 buflen, char checkhash[16]);
 int   config_switch(const char* str);

--- a/src/map/packets/trade_update.cpp
+++ b/src/map/packets/trade_update.cpp
@@ -59,6 +59,6 @@ CTradeUpdatePacket::CTradeUpdatePacket(CItem* PItem, uint8 SlotID)
     }
     else
     {
-        memcpy(data + (0x15), PItem->getSignature(), std::min<size_t>(strlen((const char*)PItem->getSignature()), 12));
+        memcpy(data + (0x1A), PItem->getSignature(), std::min<size_t>(strlen((const char*)PItem->getSignature()), 12));
     }
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -957,13 +957,13 @@ namespace charutils
                         {
                             static_cast<CItemLinkshell*>(PItem)->SetLSType((LSTYPE)(PItem->getID() - 0x200));
                         }
-                        int8 EncodedString[16];
+                        int8 EncodedString[LinkshellStringLength];
                         EncodeStringLinkshell(sql->GetData(5), EncodedString);
                         PItem->setSignature(EncodedString);
                     }
                     else if (PItem->getFlag() & (ITEM_FLAG_INSCRIBABLE))
                     {
-                        int8 EncodedString[13];
+                        int8 EncodedString[SignatureStringLength];
                         EncodeStringSignature(sql->GetData(5), EncodedString);
                         PItem->setSignature(EncodedString);
                     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Properly support max length characters, linkshell names, signatures.

Fixes #2182

## Steps to test these changes

Make a max length character, login/logout and don't crash your client + see no garbage in character name past 15th char on your client
Make a max length linkshell name and not have it truncate
Sign an item with a max character length name and have it show up properly, or `!exec player:addItem({id=18110,signature="0123456789ABCDEF"})` and have it add an Mezraq that cuts off past character "E", which is the 15th character.

Trade an item with a signature to another account, have the signature not show up as garbage on the other client 