### PR TITLE
Provides Docker config defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,14 @@ ADD . /server
 # Configure and build
 RUN mkdir docker_build && cd docker_build && cmake .. && make -j $(nproc)  && cd .. && rm -r /server/docker_build
 
-# Copy the docker config files to the conf folder instead of the default config
-COPY /conf/default/* conf/
-
-# Copy the docker settings files to the settings folder instead of the default settings
-COPY /scripts/settings/default/* scripts/settings/
+# Set SQL_HOST in lua settings 
+RUN echo '\
+xi = xi or {}\n\
+xi.settings = xi.settings or {}\n\
+xi.settings.network =\n\
+{\n\
+    SQL_HOST     = "db",\n\
+}' >> settings/network.lua
 
 # Ensure wait_for_db_then_launch.sh is executable
 RUN chmod +x ./tools/wait_for_db_then_launch.sh


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Separates docker config defaults from original defaults and provides different network defaults. Merges environment network settings into the cpp settingsMap

## Steps to test these changes

In the root folder: 
```
docker-compose up
```