### PR TITLE
[QC] Audit and Update WotG missions through Purple, the New Black

### DIFF
--- a/scripts/missions/wotg/03_Cait_Sith.lua
+++ b/scripts/missions/wotg/03_Cait_Sith.lua
@@ -9,11 +9,7 @@
 -- EAST_RONFAURE_S      : !zone 81
 -- SOUTHERN_SAN_DORIA_S : !zone 80
 -----------------------------------
-require('scripts/globals/keyitems')
-require('scripts/globals/maws')
 require('scripts/globals/missions')
-require('scripts/globals/quests')
-require('scripts/globals/settings')
 require('scripts/globals/titles')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
@@ -24,8 +20,8 @@ local mission = Mission:new(xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH
 
 mission.reward =
 {
+    title       = xi.title.CAIT_SITHS_ASSISTANT,
     nextMission = { xi.mission.log_id.WOTG, xi.mission.id.wotg.THE_QUEEN_OF_THE_DANCE },
-    title = xi.title.CAIT_SITHS_ASSISTANT,
 }
 
 mission.sections =

--- a/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
+++ b/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
@@ -36,12 +36,12 @@ mission.sections =
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =
         {
-            ['Lion_Springs'] = mission:progressEvent(68),
+            ['Lion_Springs'] = mission:progressEvent(68, 80, 4224267, 1756, utils.MAX_UINT32 - 1540096, utils.MAX_UINT32 - 1239549952, 427798150, 3, 4095),
 
             onEventFinish =
             {
                 [68] = function(player, csid, option, npc)
-                    player:setMissionStatus(xi.mission.log_id.WOTG, 1)
+                    player:setMissionStatus(mission.areaId, 1)
                 end,
             },
         },
@@ -53,6 +53,11 @@ mission.sections =
             return currentMission == mission.missionId and missionStatus == 1
         end,
 
+        [xi.zone.SOUTHERN_SAN_DORIA_S] =
+        {
+            ['Lion_Springs'] = mission:event(69),
+        },
+
         [xi.zone.UPPER_JEUNO] =
         {
             ['Turlough'] = mission:progressEvent(10172),
@@ -61,7 +66,7 @@ mission.sections =
             {
                 [10172] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.MAYAKOV_SHOW_TICKET)
-                    player:setMissionStatus(xi.mission.log_id.WOTG, 2)
+                    player:setMissionStatus(mission.areaId, 2)
                 end,
             },
         },
@@ -75,16 +80,46 @@ mission.sections =
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =
         {
-            ['Lion_Springs'] = mission:progressEvent(70),
+            ['Lion_Springs'] = mission:progressEvent(70, 1, 0, 2964, 0, 66453367, 8366690, 4095, 131140),
+
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 3 then
+                        return mission:progressEvent(152)
+                    elseif missionStatus == 4 then
+                        return mission:progressEvent(153)
+                    end
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [152] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:updateEvent(1, 0, 1756, 0, 66453367, 8366690, 4095, 131140)
+                    end
+                end,
+
+                [153] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:updateEvent(1, 0, 1756, 0, 66451386, 11124900, 4095, 131140)
+                    end
+                end,
+            },
 
             onEventFinish =
             {
                 [70] = function(player, csid, option, npc)
-                    return mission:event(152)
+                    player:setMissionStatus(mission.areaId, 3)
+                    player:setPos(100.801, 1, 103.211, 31, xi.zone.SOUTHERN_SAN_DORIA_S)
                 end,
 
                 [152] = function(player, csid, option, npc)
-                    return mission:event(153)
+                    player:setMissionStatus(mission.areaId, 4)
+                    player:setPos(100.801, 1, 103.211, 31, xi.zone.SOUTHERN_SAN_DORIA_S)
                 end,
 
                 [153] = function(player, csid, option, npc)

--- a/scripts/missions/wotg/05_While_the_Cat_is_Away.lua
+++ b/scripts/missions/wotg/05_While_the_Cat_is_Away.lua
@@ -6,12 +6,8 @@
 -- SOUTHERN_SAN_DORIA_S : !zone 80
 -- EAST_RONFAURE_S      : !zone 81
 -----------------------------------
-require('scripts/globals/keyitems')
-require('scripts/globals/maws')
 require('scripts/globals/missions')
 require('scripts/globals/quests')
-require('scripts/globals/settings')
-require('scripts/globals/titles')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
@@ -44,12 +40,15 @@ mission.sections =
             onEventUpdate =
             {
                 [7] = function(player, csid, option, npc)
-                    local sandyFlag = player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.BURDEN_OF_SUSPICION) == QUEST_COMPLETED and 1 or 0
-                    local bastokFlag = player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) == QUEST_COMPLETED and 1 or 0
-                    local windyFlag = player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.A_MANIFEST_PROBLEM) == QUEST_COMPLETED and 1 or 0
-                    local rovFlag = player:getMissionStatus(xi.mission.log_id.ROV, xi.mission.id.rov.GANGED_UP_ON) == QUEST_ACCEPTED and 1 or 0
+                    if option == 0 then
+                        local sandyFlag = player:hasCompletedQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.BURDEN_OF_SUSPICION) and 1 or 0
+                        local bastokFlag = player:hasCompletedQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.WRATH_OF_THE_GRIFFON) and 1 or 0
+                        local windyFlag = player:hasCompletedQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.A_MANIFEST_PROBLEM) and 1 or 0
 
-                    player:updateEvent(sandyFlag, bastokFlag, windyFlag, rovFlag)
+                        local rovFlag = player:getCurrentMission(xi.mission.log_id.ROV) >= xi.mission.id.rov.GANGED_UP_ON and 1 or 0
+
+                        player:updateEvent(sandyFlag, bastokFlag, windyFlag, rovFlag, 0, 7733257, 0, 0)
+                    end
                 end,
             },
 

--- a/scripts/missions/wotg/06_A_Timeswept_Butterfly.lua
+++ b/scripts/missions/wotg/06_A_Timeswept_Butterfly.lua
@@ -6,12 +6,7 @@
 -- JUGNER_FOREST_S : !zone 82
 -- LA_VAULE_S       : !zone 85
 -----------------------------------
-require('scripts/globals/keyitems')
-require('scripts/globals/maws')
 require('scripts/globals/missions')
-require('scripts/globals/quests')
-require('scripts/globals/settings')
-require('scripts/globals/titles')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------

--- a/scripts/missions/wotg/07_Purple_The_New_Black.lua
+++ b/scripts/missions/wotg/07_Purple_The_New_Black.lua
@@ -34,12 +34,12 @@ mission.sections =
 
         [xi.zone.LA_VAULE_S] =
         {
-            ['_2d1'] = mission:progressEvent(2, 85),
+            ['_2d1'] = mission:progressEvent(2, 85, 3456, utils.MAX_UINT32 - 207616, 1525, 0, 19550816, 0, 0),
 
             onEventFinish =
             {
                 [2] = function(player, csid, option, npc)
-                    player:setMissionStatus(xi.mission.log_id.WOTG, 1)
+                    player:setMissionStatus(mission.areaId, 1)
                 end,
             },
         },
@@ -53,24 +53,27 @@ mission.sections =
 
         [xi.zone.LA_VAULE_S] =
         {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    if player:getMissionStatus(mission.areaId) == 2 then
+                        return 6
+                    end
+                end,
+            },
+
             onEventFinish =
             {
                 -- Completed BCNM
                 [32001] = function(player, csid, option, npc)
                     if player:getLocalVar('battlefieldWin') == 2721 then
-                        if option == 5 then -- Didn't skip CS
-                            return mission:event(6)
-                        else -- Skipped CS
-                            mission:complete(player)
-                            player:setPos(-260, 0, -156, 192, 85)
-                        end
+                        player:setMissionStatus(mission.areaId, 2)
+                        player:setPos(-260.44, 0.134, -156.652, 192, xi.zone.LA_VAULE_S)
                     end
                 end,
 
                 [6] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        player:setPos(-260, 0, -156, 192, 85)
-                    end
+                    mission:complete(player)
                 end,
             },
         },

--- a/scripts/zones/Jugner_Forest_[S]/npcs/_2a5.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/_2a5.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Jugner Forest (S)
+--  NPC: Wooden Gate
+-- !pos -200 -10.965 -511.129 82
+-----------------------------------
+require('scripts/globals/zone')
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(104)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    if option == 1 then
+        player:setPos(231.029, -0.083, 19.975, 128, xi.zone.LA_VAULE_S)
+    end
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds additional dialogue, NPC DB entries, and minor cleanup to WotG missions through Purple, the new Black
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Follow BG Wiki mission steps
<!-- Clear and detailed steps to test your changes here -->
