### PR TITLE
Uragnite mixin adjustments

### DIFF
--- a/scripts/mixins/families/uragnite.lua
+++ b/scripts/mixins/families/uragnite.lua
@@ -56,15 +56,30 @@ local function exitShell(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
 end
 
+local function shellTimer(mob)
+    -- Uragnites go into their shell every 40-60 seconds
+    local timeToShell = mob:getLocalVar("[uragnite]shellTimer")
+
+    -- mob:isMobType check due to Shell We Dance ENM. Those uragnites do not enter their shell except through damage
+    if os.time() > timeToShell and mob:getAnimationSub() == 0 and not mob:isFollowingPath() and not mob:isMobType(xi.mobskills.mobType.BATTLEFIELD) then
+        enterShell(mob)
+
+        local timeInShell = math.random(mob:getLocalVar("[uragnite]timeInShellMin"), mob:getLocalVar("[uragnite]timeInShellMax"))
+        local shellRandom = timeInShell + (os.time() + math.random(40,60))
+        mob:setLocalVar("[uragnite]shellTimer", shellRandom)
+
+        mob:timer(timeInShell * 1000, function(uragnite)
+            exitShell(uragnite)
+        end)
+    end
+end
+
 xi.mix.uragnite.config = function(mob, params)
     if params.inShellSkillList and type(params.inShellSkillList) == "number" then
         mob:setLocalVar("[uragnite]inShellSkillList", params.inShellSkillList)
     end
     if params.noShellSkillList and type(params.noShellSkillList) == "number" then
         mob:setLocalVar("[uragnite]noShellSkillList", params.noShellSkillList)
-    end
-    if params.chanceToShell and type(params.chanceToShell) == "number" then
-        mob:setLocalVar("[uragnite]chanceToShell", params.chanceToShell)
     end
     if params.timeInShellMin and type(params.timeInShellMin) == "number" then
         mob:setLocalVar("[uragnite]timeInShellMin", params.timeInShellMin)
@@ -75,6 +90,9 @@ xi.mix.uragnite.config = function(mob, params)
     if params.inShellRegen and type(params.inShellRegen) == "number" then
         mob:setLocalVar("[uragnite]inShellRegen", params.inShellRegen)
     end
+    if params.shellChange and type(params.shellChange) == "number" then
+        mob:setLocalVar("[uragnite]shellChange", params.shellChange)
+    end
 end
 
 g_mixins.families.uragnite = function(uragniteMob)
@@ -84,22 +102,44 @@ g_mixins.families.uragnite = function(uragniteMob)
     uragniteMob:addListener("SPAWN", "URAGNITE_SPAWN", function(mob)
         mob:setLocalVar("[uragnite]noShellSkillList", 251)
         mob:setLocalVar("[uragnite]inShellSkillList", 250)
-        mob:setLocalVar("[uragnite]chanceToShell", 20)
         mob:setLocalVar("[uragnite]timeInShellMin", 30)
         mob:setLocalVar("[uragnite]timeInShellMax", 45)
-        mob:setLocalVar("[uragnite]inShellRegen", 50)
+        mob:setLocalVar("[uragnite]inShellRegen", 22)
+        mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(7,10))
     end)
 
     uragniteMob:addListener("TAKE_DAMAGE", "URAGNITE_TAKE_DAMAGE", function(mob, amount, attacker, attackType, damageType)
-        if attackType == xi.attackType.PHYSICAL then
-            if math.random(100) <= mob:getLocalVar("[uragnite]chanceToShell") and bit.band(mob:getAnimationSub(), 1) == 0 then
+        local damageTaken = mob:getLocalVar("damageTaken") + amount
+
+        -- Uragnites are triggered into and out of their shell by damage every 10-15% of health
+        if damageTaken > mob:getLocalVar("[uragnite]shellChange") then
+            if mob:getAnimationSub() == 1 then
+                exitShell(mob)
+                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5,10))
+            else
                 enterShell(mob)
+                mob:useMobAbility(1572) -- Going into shell caused by damage always triggers venom shell
+                mob:setLocalVar("[uragnite]shellChange", mob:getMaxHP() / math.random(5,10))
+
                 local timeInShell = math.random(mob:getLocalVar("[uragnite]timeInShellMin"), mob:getLocalVar("[uragnite]timeInShellMax"))
-                mob:timer(timeInShell * 1000, function(mobArg)
-                    exitShell(mobArg)
+                mob:timer(timeInShell * 1000, function(uragnite)
+                    if mob:getAnimationSub() == 1 then
+                        exitShell(uragnite)
+                    end
                 end)
             end
+            mob:setLocalVar("damageTaken", 0)
+        else
+            mob:setLocalVar("damageTaken", damageTaken)
         end
+    end)
+
+    uragniteMob:addListener("ROAM_TICK", "URAGNITE_ROAM_TIMER", function(mob)
+        shellTimer(mob)
+    end)
+
+    uragniteMob:addListener("COMBAT_TICK", "URAGNITE_COMBAT_TIMER",  function(mob)
+        shellTimer(mob)
     end)
 end
 

--- a/scripts/zones/Manaclipper/mobs/uragnite.lua
+++ b/scripts/zones/Manaclipper/mobs/uragnite.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Manaclipper
+--  Mob: Uragnite
+-----------------------------------
+mixins = {require("scripts/mixins/families/uragnite")}
+-----------------------------------
+local entity = {}
+
+entity.onMobDeath = function(mob, player, isKiller)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjustments to the Uragnite mixin:
- They will now always use venom shell when forced into their shell with damage.
- Uragnites are forced into their shell by doing a certain % of their HP of damage rather than being a random chance
- They now also can go into and out of their shell on a timer, even when roaming.

All adjustments are from my own time spent poking uragnites on retail.

## Steps to test these changes

Watch a uragnite in game to see that they now go into their shell randomly even when out of combat.