### PR TITLE
Implement Shikaree Z Trust Acquisition

### DIFF
--- a/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
+++ b/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Trust: Shikaree Z
 -----------------------------------
--- Perih Vashai !gotoid 17764470 / !pos 117.5 -3.7 90.453 241
------------------------------------
 require('scripts/globals/magic')
 require('scripts/globals/trust')
 require('scripts/globals/quests')
@@ -28,7 +26,7 @@ quest.sections =
                 --      https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Shikaree_Z
                 not (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.FLAMES_IN_THE_DARKNESS and
                 player:getCurrentMission(xi.mission.log_id.COP) <= xi.mission.id.cop.FIRE_IN_THE_EYES_OF_MEN) and
-                not (player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.A_FATE_DECIDED) and
+                player:getCurrentMission(xi.mission.log_id.COP) ~= xi.mission.id.cop.A_FATE_DECIDED and
                 player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
         end,
 

--- a/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
+++ b/scripts/quests/hiddenQuests/Trust_ShikareeZ.lua
@@ -1,0 +1,57 @@
+-----------------------------------
+-- Trust: Shikaree Z
+-----------------------------------
+-- Perih Vashai !gotoid 17764470 / !pos 117.5 -3.7 90.453 241
+-----------------------------------
+require('scripts/globals/magic')
+require('scripts/globals/trust')
+require('scripts/globals/quests')
+require('scripts/globals/keyitems')
+require('scripts/globals/missions')
+require('scripts/globals/interaction/hidden_quest')
+-----------------------------------
+local woodsID = require('scripts/zones/Windurst_Woods/IDs')
+-----------------------------------
+
+local quest = HiddenQuest:new("TrustShikareeZ")
+
+quest.sections =
+{
+    {
+        check = function(player, questVars, vars)
+            return not player:hasSpell(xi.magic.spell.SHIKAREE_Z) and
+                player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THREE_PATHS) and
+                -- TODO BG WIKI States acquisition can be blocked while Shikaree Z is "out of town".
+                --      Verify which Missions this comment refers to, though likely the following:
+                --      FLAMES_IN_THE_DARKNESS, FIRE_IN_THE_EYES_OF_MEN, A_FATE_DECIDED
+                --      https://www.bg-wiki.com/ffxi/Promathia_Mission_5-3
+                --      https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Shikaree_Z
+                not (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.FLAMES_IN_THE_DARKNESS and
+                player:getCurrentMission(xi.mission.log_id.COP) <= xi.mission.id.cop.FIRE_IN_THE_EYES_OF_MEN) and
+                not (player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.A_FATE_DECIDED) and
+                player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
+        end,
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Perih_Vashai'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(869)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [869] = function(player, csid, option, npc)
+                    if xi.trust.hasPermit(player) then
+                        player:addSpell(xi.magic.spell.SHIKAREE_Z, true, true)
+                        player:messageSpecial(woodsID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.SHIKAREE_Z)
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest


### PR DESCRIPTION
Adds Interaction Quest to Obtain Trust Shikaree Z

Based on Retail Capture - https://www.youtube.com/watch?v=L1GaEBML6_o

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds Interaction Quest to Obtain Trust Shikaree Z
See TODO Comments in script

## Steps to test these changes

Login Test Character
`!changejob WAR 75`
`!addkeyitem WINDURST_TRUST_PERMIT`

Add One of the missions listed below.

Working examples:
6_1_For_Whom_the_Verse_is_Sung.lua:-- `!addmission 6 578`
6_2_A_Place_to_Return.lua:-- `!addmission 6 618`
6_3_More_Questions_than_Answers.lua:-- `!addmission 6 628`
6_4_One_to_be_Feared.lua:-- `!addmission 6 638`
7_1_Chains_and_Bonds.lua:-- `!addmission 6 648`

Blocked examples:
5_3_Three_Paths.lua:-- `!addmission 6 530`
7_2_Flames_in_the_Darkness.lua:-- `!addmission 6 718`
7_3_Fire_in_the_Eyes_of_Men.lua:-- `!addmission 6 728`
8_2: -- `!addmission 6 818`

