### PR TITLE
Adds Trust Gambit Conditions for Tank in Party

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -48,6 +48,8 @@ ai.condition =
     RANDOM             = 18,
     NO_SAMBA           = 19,
     NO_STORM           = 20,
+    PT_HAS_TANK        = 21,
+    NOT_PT_HAS_TANK    = 22,
 }
 ai.c = ai.condition
 

--- a/scripts/globals/spells/trust/volker.lua
+++ b/scripts/globals/spells/trust/volker.lua
@@ -1,5 +1,9 @@
 -----------------------------------
 -- Trust: Volker
+-- If there is a NIN, PLD, or RUN in the party, behaves as a damage dealer: Uses Aggressor, Berserk.
+-- If there are no other tanks in the party, behaves as a tank: Uses Defender, Retaliation.
+-- Uses Provoke in either role to maintain enmity as a tank or off-tank.
+-- Uses weapon skills at 2000 TP with Warrior's Charge if it's available; does not try to skillchain. (TODO)
 -----------------------------------
 require("scripts/globals/ability")
 require("scripts/globals/gambits")
@@ -25,8 +29,19 @@ spell_object.onMobSpawn = function(mob)
         [xi.magic.spell.KLARA] = xi.trust.message_offset.TEAMWORK_3,
     })
 
-    mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50,
-                        ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE)
+    -- DD Mode
+    mob:addSimpleGambit(ai.t.SELF, ai.c.PT_HAS_TANK, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.BERSERK)
+    mob:addSimpleGambit(ai.t.SELF, ai.c.PT_HAS_TANK, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.AGGRESSOR)
+    mob:addSimpleGambit(ai.t.TANK, ai.c.HPP_LT, 50, ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE)
+
+    -- Tank Mode
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.NOT_PT_HAS_TANK, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE)
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_PT_HAS_TANK, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.DEFENDER)
+    mob:addSimpleGambit(ai.t.SELF, ai.c.NOT_PT_HAS_TANK, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.RETALIATION)
+
+    mob:addSimpleGambit(ai.t.MASTER, ai.c.HPP_LT, 50, ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE)
+
+    -- TODO: Add Warriors Charge + WS Logic
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -663,7 +663,7 @@ namespace gambits
             }
             case G_CONDITION::NOT_PT_HAS_TANK:
             {
-                return (!PartyHasTank());
+                return !PartyHasTank();
                 break;
             }
             case G_CONDITION::STATUS_FLAG:
@@ -926,7 +926,9 @@ namespace gambits
     bool CGambitsContainer::PartyHasTank()
     {
         bool hasTank = false;
-        static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember) {
+        // clang-format off
+        static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
+        {
             auto jobType = PMember->GetMJob();
 
             if (jobType == JOB_NIN || jobType == JOB_PLD || jobType == JOB_RUN)
@@ -934,6 +936,7 @@ namespace gambits
                 hasTank = true;
             }
         });
+        // clang-format on
         return hasTank;
     }
 } // namespace gambits

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -656,6 +656,16 @@ namespace gambits
                 return noStorm;
                 break;
             }
+            case G_CONDITION::PT_HAS_TANK:
+            {
+                return PartyHasTank();
+                break;
+            }
+            case G_CONDITION::NOT_PT_HAS_TANK:
+            {
+                return (!PartyHasTank());
+                break;
+            }
             case G_CONDITION::STATUS_FLAG:
             {
                 return trigger_target->StatusEffectContainer->HasStatusEffectByFlag(static_cast<EFFECTFLAG>(predicate.condition_arg));
@@ -911,5 +921,19 @@ namespace gambits
             }
         });
         return hasHealer;
+    }
+    // used to check for tanks in party (Volker, AA Hume)
+    bool CGambitsContainer::PartyHasTank()
+    {
+        bool hasTank = false;
+        static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember) {
+            auto jobType = PMember->GetMJob();
+
+            if (jobType == JOB_NIN || jobType == JOB_PLD || jobType == JOB_RUN)
+            {
+                hasTank = true;
+            }
+        });
+        return hasTank;
     }
 } // namespace gambits

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -51,6 +51,8 @@ namespace gambits
         RANDOM             = 18,
         NO_SAMBA           = 19,
         NO_STORM           = 20,
+        PT_HAS_TANK        = 21,
+        NOT_PT_HAS_TANK    = 22,
     };
 
     enum class G_REACTION : uint16
@@ -232,6 +234,7 @@ namespace gambits
         bool CheckTrigger(CBattleEntity* trigger_target, Predicate_t& predicate);
         bool TryTrustSkill();
         bool PartyHasHealer();
+        bool PartyHasTank();
 
         CTrustEntity*         POwner;
         time_point            m_lastAction;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds Trust Gambit Conditions `PT_HAS_TANK` and `NOT_PT_HAS_TANK`
Adds Conditional Gambits for Volker to either DD or Tank depending on results

## Steps to test these changes

Log in a GM Test Char
`!changejob WAR 99`
`!addspell 903` -- Volker
`!addspell 910` -- Valaineral
Summon only Volker, Engage a mob
Volker will use Provoke, Defender, and Retaliation
Despawn or Defeat Mob
Summon Valaineral alongside of Volker, Engage a mob
Volker will use Berserk and Aggressor. Will use Provoke if Tank is < 50% Health
