### PR TITLE
[core] [RUN] Add "modifier" to action, add MB message to Swipe/Lunge, fixup reaction bits

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -677,11 +677,21 @@ xi.reaction =
 {
     NONE     = 0x00,
     MISS     = 0x01,
+    GUARDED  = 0x02,
     PARRY    = 0x03,
     BLOCK    = 0x04,
     HIT      = 0x08,
     EVADE    = 0x09,
-    GUARD    = 0x14,
+    ABILITY  = 0x10,
+}
+
+xi.actionModifier =
+{
+    NONE        = 0x00,
+    COVER       = 0x01,
+    RESIST      = 0x02,
+    MAGIC_BURST = 0x04, -- Currently known to be used for Swipe/Lunge only
+    IMMUNOBREAK = 0x08,
 }
 
 xi.specEffect =

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -585,7 +585,8 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
 
             -- Handle Magic Absorb
             if damage < 0 then
-                damage = -target:addHP(-damage)
+                local totalHealedHP = target:addHP(math.abs(damage)) -- Heal target, get total HP healed (addHP accounts for re-capping to get the actual value healed)
+                damage = -totalHealedHP                              -- Keep track of damage to determine later if we need to use heal or damage message
             else
                 -- We dealt damage. Check if we are going to kill it, and if we can kill it with less rune strength if rune strength > 1.
                 if numHits > 1 and runesUsed ~= numHits and target:getHP()-damage <= 0 and runeStrength > 1 then -- try less duplicate rune count if not on final duplicate rune

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -585,7 +585,7 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
 
             -- Handle Magic Absorb
             if damage < 0 then
-                damage = target:addHP(-damage)
+                damage = -target:addHP(-damage)
             else
                 -- We dealt damage. Check if we are going to kill it, and if we can kill it with less rune strength if rune strength > 1.
                 if numHits > 1 and runesUsed ~= numHits and target:getHP()-damage <= 0 and runeStrength > 1 then -- try less duplicate rune count if not on final duplicate rune
@@ -625,20 +625,24 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
 
     if shadowsHit == numHits and cumulativeDamage == 0 then
         action:messageID(target:getID(), xi.msg.basic.SHADOW_ABSORB) -- set message to blinked hit(s)
+        action:reaction(target:getID(), xi.reaction.EVADE + xi.reaction.ABILITY) -- TODO: confirm these bit flags for reaction
+
         return shadowsHit
     end
 
     action:setAnimation(target:getID(), getAnimationEffusion(weaponSkillType, 0)) -- set animation for currently equipped weapon
 
-    if cumulativeDamage < 0 or cumulativeDamage == 0 and absorbed then -- TODO: figre out how to set "unknown" bit in message 102
-                                                                       -- "unknown" = 4 on message 102 for healed MB
+    action:reaction(target:getID(), xi.reaction.HIT + xi.reaction.ABILITY)
+
+    if cumulativeDamage < 0 or (cumulativeDamage == 0 and absorbed) then
         action:messageID(target:getID(), xi.msg.basic.JA_RECOVERS_HP)
     end
 
-    if magicBursted then -- TODO: set MB message somehow by setting "unknown" = 4 on message 110 for MB
+    if magicBursted then -- Note: the vanilla client does not report a healed magic burst, but this bit is set.
+        action:modifier(target:getID(), xi.actionModifier.MAGIC_BURST)
     end
 
-    return cumulativeDamage
+    return math.abs(cumulativeDamage)
 end
 
 -- see http://wiki.ffo.jp/html/1720.html, the effects resisted are against the strong element.

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -59,7 +59,7 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
         auto& list             = action.getNewActionList();
         list.ActionTargetID    = PTarget->id;
         auto& actionTarget     = list.getNewActionTarget();
-        actionTarget.reaction  = (REACTION)24;
+        actionTarget.reaction  = REACTION::HIT | REACTION::ABILITY; // TODO: not all abilities are HIT + Ability (provoke/chi blast has been observed as only REACTION:ABILITY)
         actionTarget.animation = 121;
         actionTarget.messageID = 326;
         actionTarget.param     = PAbility->getID();

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1905,7 +1905,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             battleutils::HandleSpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());
         }
 
-        // if we parried, run battuta check if applicablle
+        // if we parried, run battuta check if applicable
         if ((actionTarget.reaction & REACTION::PARRY) == REACTION::PARRY && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_BATTUTA))
         {
             battleutils::HandleParrySpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1715,7 +1715,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             else if (attack.IsParried())
             {
                 actionTarget.messageID  = 70;
-                actionTarget.reaction   = REACTION::PARRY;
+                actionTarget.reaction   = REACTION::PARRY | REACTION::HIT;
                 actionTarget.speceffect = SPECEFFECT::NONE;
                 battleutils::HandleTacticalParry(PTarget);
                 battleutils::HandleIssekiganEnmityBonus(PTarget, this);
@@ -1790,10 +1790,11 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 // Set this attack's critical flag.
                 attack.SetCritical(xirand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing()));
 
+                actionTarget.reaction   = REACTION::HIT;
+
                 // Critical hit.
                 if (attack.IsCritical())
                 {
-                    actionTarget.reaction   = REACTION::HIT;
                     actionTarget.speceffect = SPECEFFECT::CRITICAL_HIT;
                     actionTarget.messageID  = attack.GetAttackType() == PHYSICAL_ATTACK_TYPE::DAKEN ? 353 : 67;
 
@@ -1809,7 +1810,6 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 // Not critical hit.
                 else
                 {
-                    actionTarget.reaction   = REACTION::HIT;
                     actionTarget.speceffect = SPECEFFECT::HIT;
                     actionTarget.messageID  = attack.GetAttackType() == PHYSICAL_ATTACK_TYPE::DAKEN ? 352 : 1;
                 }
@@ -1817,7 +1817,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 // Guarded. TODO: Stuff guards that shouldn't.
                 if (attack.IsGuarded())
                 {
-                    actionTarget.reaction = REACTION::GUARD;
+                    actionTarget.reaction |= REACTION::GUARDED;
                     battleutils::HandleTacticalGuard(PTarget);
                 }
 
@@ -1835,7 +1835,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 // Try shield block
                 if (attack.IsBlocked())
                 {
-                    actionTarget.reaction = REACTION::BLOCK;
+                    actionTarget.reaction |= REACTION::BLOCK;
                 }
 
                 actionTarget.param =
@@ -1891,23 +1891,27 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             battleutils::HandleAfflatusMiseryAccuracyBonus(this);
         }
 
-        if (actionTarget.reaction != REACTION::HIT && actionTarget.reaction != REACTION::BLOCK && actionTarget.reaction != REACTION::GUARD && actionTarget.messageID != MSGBASIC_SHADOW_ABSORB)
+        // If we didn't hit at all, set param to 0 if we didn't blink any shadows.
+        if ((actionTarget.reaction & REACTION::HIT) == REACTION::NONE && actionTarget.messageID != MSGBASIC_SHADOW_ABSORB)
         {
             actionTarget.param = 0;
         }
 
-        if (actionTarget.reaction != REACTION::EVADE && actionTarget.reaction != REACTION::PARRY && attack.GetAttackType() != PHYSICAL_ATTACK_TYPE::DAKEN)
+        // if we did hit, run enspell/spike routines as long as this isn't a Daken swing
+        if ((actionTarget.reaction & REACTION::MISS) == REACTION::NONE && attack.GetAttackType() != PHYSICAL_ATTACK_TYPE::DAKEN)
         {
             battleutils::HandleEnspell(this, PTarget, &actionTarget, attack.IsFirstSwing(), (CItemWeapon*)this->m_Weapons[attack.GetWeaponSlot()],
                                        attack.GetDamage());
             battleutils::HandleSpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());
         }
 
-        if (actionTarget.reaction == REACTION::PARRY && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_BATTUTA))
+        // if we parried, run battuta check if applicablle
+        if ((actionTarget.reaction & REACTION::PARRY) == REACTION::PARRY && PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_BATTUTA))
         {
             battleutils::HandleParrySpikesDamage(this, PTarget, &actionTarget, attack.GetDamage());
         }
 
+        // set recoil if we hit and dealt non-zero damage
         if (actionTarget.speceffect == SPECEFFECT::HIT && actionTarget.param > 0)
         {
             actionTarget.speceffect = SPECEFFECT::RECOIL;
@@ -1920,7 +1924,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             uint16 zanshinChance = this->getMod(Mod::ZANSHIN) + battleutils::GetMeritValue(this, MERIT_ZASHIN_ATTACK_RATE);
             zanshinChance        = std::clamp<uint16>(zanshinChance, 0, 100);
             // zanshin may only proc on a missed/guarded/countered swing or as SAM main with hasso up (at 25% of the base zanshin rate)
-            if (((actionTarget.reaction == REACTION::EVADE || actionTarget.reaction == REACTION::GUARD || actionTarget.spikesEffect == SUBEFFECT_COUNTER) &&
+            if ((((actionTarget.reaction & REACTION::MISS) != REACTION::NONE || (actionTarget.reaction & REACTION::GUARDED) != REACTION::NONE || actionTarget.spikesEffect == SUBEFFECT_COUNTER) &&
                  xirand::GetRandomNumber(100) < zanshinChance) ||
                 (GetMJob() == JOB_SAM && this->StatusEffectContainer->HasStatusEffect(EFFECT_HASSO) && xirand::GetRandomNumber(100) < (zanshinChance / 4)))
             {

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -271,16 +271,45 @@ enum class DAMAGE_TYPE : uint16
     DARK      = 13
 };
 
-enum class REACTION
+// This enum class is a set of bitfields that modify messages sent to the client.
+// There are helpers (PARRY/EVADE) because it is not inuitive
+// These flag names may not match SE's intent perfectly, but seem to work well.
+
+// For example
+// A guard is HIT + GUARDED
+// A parry is MISS + GUARDED
+// A block is HIT + BLOCK
+// It also seems weaponskills and job abilities set ABILITY in addition to these flags.
+// All of these flags are also seen in weaponskills.
+enum class REACTION : uint8
 {
-    NONE  = 0x00, // No Reaction
-    MISS  = 0x01, // Miss
-    PARRY = 0x03, // Block with weapons (MISS + PARRY)
-    BLOCK = 0x04, // Block with shield
-    HIT   = 0x08, // Hit
-    EVADE = 0x09, // Evasion (MISS + HIT)
-    GUARD = 0x14  // mnk guard (20 dec)
+    NONE         = 0x00, // No Reaction
+    MISS         = 0x01, // Miss
+    GUARDED      = 0x02, // Bit to indicate guard, used individually to indicate guard during WS packet as well
+    PARRY        = 0x03, // Block with weapons (MISS + GUARDED)
+    BLOCK        = 0x04, // Block with shield, bit to indicate blocked during WS packet as well
+    HIT          = 0x08, // Hit
+    EVADE        = 0x09, // Evasion (MISS + HIT)
+    ABILITY      = 0x10, // Observed on JA and WS
 };
+
+// These operators are used to combine bits that may not have a discrete value upon combining.
+inline REACTION operator |(REACTION a, REACTION b)
+{
+    return (REACTION)((uint8)a | (uint8)b);
+}
+
+inline REACTION operator &(REACTION a, REACTION b)
+{
+    return (REACTION)((uint8)a & (uint8)b);
+}
+
+inline REACTION operator |=(REACTION& a, REACTION b)
+{
+    a = a | b;
+
+    return a;
+}
 
 enum class SPECEFFECT
 {
@@ -290,6 +319,15 @@ enum class SPECEFFECT
     RAISE        = 0x11,
     RECOIL       = 0x20,
     CRITICAL_HIT = 0x22
+};
+
+enum class MODIFIER
+{
+    NONE        = 0x00,
+    COVER       = 0x01,
+    RESIST      = 0x02,
+    MAGIC_BURST = 0x04, // Currently known to be used for Swipe/Lunge only
+    IMMUNOBREAK = 0x08,
 };
 
 enum SUBEFFECT

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -483,17 +483,17 @@ struct apAction_t
     uint16         spikesMessage;    // 10 bits
 
     apAction_t()
+    : reaction(REACTION::NONE)
+    , speceffect(SPECEFFECT::NONE)
+    , additionalEffect(SUBEFFECT_NONE)
+    , spikesEffect(SUBEFFECT_NONE)
     {
         ActionTarget     = nullptr;
-        reaction         = REACTION::NONE;
         animation        = 0;
-        speceffect       = SPECEFFECT::NONE;
         param            = 0;
         messageID        = 0;
-        additionalEffect = SUBEFFECT_NONE;
         addEffectParam   = 0;
         addEffectMessage = 0;
-        spikesEffect     = SUBEFFECT_NONE;
         spikesParam      = 0;
         spikesMessage    = 0;
         knockback        = 0;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -277,7 +277,7 @@ enum class DAMAGE_TYPE : uint16
 
 // For example
 // A guard is HIT + GUARDED
-// A parry is MISS + GUARDED
+// A parry is HIT + MISS + GUARDED
 // A block is HIT + BLOCK
 // It also seems weaponskills and job abilities set ABILITY in addition to these flags.
 // All of these flags are also seen in weaponskills.

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1035,7 +1035,8 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
                         battleutils::RemoveAmmo(this);
                     }
                 }
-                if (actionTarget.reaction == REACTION::HIT)
+
+                if ((actionTarget.reaction & REACTION::HIT) != REACTION::NONE)
                 {
                     int wspoints = settings::get<uint8>("map.WS_POINTS_BASE");
                     if (PWeaponSkill->getPrimarySkillchain() != 0)
@@ -1560,8 +1561,8 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
     // if a hit did occur (even without barrage)
     if (hitOccured)
     {
-        // any misses with barrage cause remaing shots to miss, meaning we must check Action.reaction
-        if (actionTarget.reaction == REACTION::EVADE && (this->StatusEffectContainer->HasStatusEffect(EFFECT_BARRAGE) || isSange))
+        // any misses with barrage cause remaining shots to miss, meaning we must check Action.reaction
+        if ((actionTarget.reaction & REACTION::MISS) != REACTION::NONE && (this->StatusEffectContainer->HasStatusEffect(EFFECT_BARRAGE) || isSange))
         {
             actionTarget.messageID  = 352;
             actionTarget.reaction   = REACTION::HIT;

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -371,7 +371,7 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
     if (hitOccured)
     {
         // any misses with barrage cause remaing shots to miss, meaning we must check Action.reaction
-        if (actionTarget.reaction == REACTION::EVADE && (this->StatusEffectContainer->HasStatusEffect(EFFECT_BARRAGE) || isSange))
+        if ((actionTarget.reaction & REACTION::MISS) != REACTION::NONE && (this->StatusEffectContainer->HasStatusEffect(EFFECT_BARRAGE) || isSange))
         {
             actionTarget.messageID  = 352;
             actionTarget.reaction   = REACTION::HIT;

--- a/src/map/lua/lua_action.cpp
+++ b/src/map/lua/lua_action.cpp
@@ -131,6 +131,18 @@ void CLuaAction::reaction(uint32 actionTargetID, uint8 reaction)
     }
 }
 
+void CLuaAction::modifier(uint32 actionTargetID, uint8 modifier)
+{
+    for (auto&& actionList : m_PLuaAction->actionLists)
+    {
+        if (actionList.ActionTargetID == actionTargetID)
+        {
+            actionList.actionTargets[0].modifier = static_cast<MODIFIER>(modifier);
+            return;
+        }
+    }
+}
+
 void CLuaAction::additionalEffect(uint32 actionTargetID, uint16 additionalEffect)
 {
     for (auto&& actionList : m_PLuaAction->actionLists)
@@ -182,6 +194,7 @@ void CLuaAction::Register()
     SOL_REGISTER("setAnimation", CLuaAction::setAnimation);
     SOL_REGISTER("speceffect", CLuaAction::speceffect);
     SOL_REGISTER("reaction", CLuaAction::reaction);
+    SOL_REGISTER("modifier", CLuaAction::modifier);
     SOL_REGISTER("additionalEffect", CLuaAction::additionalEffect);
     SOL_REGISTER("addEffectParam", CLuaAction::addEffectParam);
     SOL_REGISTER("addEffectMessage", CLuaAction::addEffectMessage);

--- a/src/map/lua/lua_action.h
+++ b/src/map/lua/lua_action.h
@@ -51,6 +51,7 @@ public:
     void   setAnimation(uint32 actionTargetID, uint16 animation);
     void   speceffect(uint32 actionTargetID, uint8 speceffect);
     void   reaction(uint32 actionTargetID, uint8 reaction);
+    void   modifier(uint32 actionTargetID, uint8 modifier);
     void   additionalEffect(uint32 actionTargetID, uint16 additionalEffect);
     void   addEffectParam(uint32 actionTargetID, int32 addEffectParam);
     void   addEffectMessage(uint32 actionTargetID, uint16 addEffectMessage);

--- a/src/map/packets/action.cpp
+++ b/src/map/packets/action.cpp
@@ -350,12 +350,13 @@ CActionPacket::CActionPacket(action_t& action)
         for (auto&& target : list.actionTargets)
         {
             bitOffset = packBitsBE(data, static_cast<uint64>(target.reaction), bitOffset, 5);   // Physical reaction to damage
-            bitOffset = packBitsBE(data, target.animation, bitOffset, 12);                      // анимация специальных эффектов (monster TP animations are 1800+)
+            bitOffset = packBitsBE(data, target.animation, bitOffset, 12);                      // animation ID
             bitOffset = packBitsBE(data, static_cast<uint64>(target.speceffect), bitOffset, 7); // specialEffect
             bitOffset = packBitsBE(data, target.knockback, bitOffset, 3);                       // knockback amount (mobskill only)
-            bitOffset = packBitsBE(data, target.param, bitOffset, 17);                          // параметр сообщения (урон)
+            bitOffset = packBitsBE(data, target.param, bitOffset, 17);                          // message parameter (damage/healing)
             bitOffset = packBitsBE(data, target.messageID, bitOffset, 10);                      // message
-            bitOffset += 31;
+            bitOffset = packBitsBE(data, static_cast<uint64>(target.modifier), bitOffset, 31);  // "Resist!", Immunobreak, MB for Swipe/Lunge, Cover message modifiers.
+                                                                                                // 4 bits are currently used, with the other bits unknown
 
             if (target.additionalEffect != SUBEFFECT_NONE)
             {

--- a/src/map/packets/action.h
+++ b/src/map/packets/action.h
@@ -75,6 +75,7 @@ struct actionTarget_t
     SUBEFFECT  spikesEffect;     // 10 bits
     uint16     spikesParam;      // 14 bits
     uint16     spikesMessage;    // 10 bits
+    MODIFIER   modifier;         // 31 bits, but only the first 4 are known to be usable to the client.
 
     actionTarget_t()
     : reaction(REACTION::NONE)
@@ -89,6 +90,7 @@ struct actionTarget_t
     , spikesEffect(SUBEFFECT_NONE)
     , spikesParam(0)
     , spikesMessage(0)
+    , modifier(MODIFIER::NONE)
     {
     }
     actionTarget_t(const actionTarget_t&)            = delete;


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds a "modifier" to Action to allow modifiers such as"Resist!" "Cover!" , "Immunobreak" swipe/lunge MB in messages to work.
Adds Swipe/Lunge MB message
Fixes up Guard reaction bits and related code to be treated more like SE appears to uses them

## Steps to test these changes

New feature:
Switch to SAM/RUN, get 2k tp, use flabra, use sekkanoki, use 2x tachi-jinpu for detonaton, use swipe/lunge and see MB message for swipe/lunge. (does not work on absorb, client is not aware of such a thing but the bit is set)

Regression testing:
Test Zanshin on sam to verify it still works on guard/counter/miss/parry
Test spikes, enspells and verity you only give spike damage when you get hit, and only deal enspell damage when you hit and not get parried
Test parry spikes on RUN with Battuta, verify you only deal parry spikes damage when you parry
Verify Parry/Block/Guard animations still work (mobs don't guard, so test on PLD/MNK yourself)
