### PR TITLE
Remove direct references to specific settings lua files

### DIFF
--- a/scripts/globals/mobskills/cosmic_elucidation.lua
+++ b/scripts/globals/mobskills/cosmic_elucidation.lua
@@ -6,7 +6,6 @@
 --  Range:
 --  Notes: Ejects all combatants from the battlefield, resulting in a failure.
 ---------------------------------------------------
-require("settings/main")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/msg")
@@ -19,12 +18,12 @@ end
 
 mobskill_object.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg()*21, xi.magic.ele.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.DMG_BONUS, 1)
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 21, xi.magic.ele.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.DMG_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 0)
 
     dmg = math.min(0, dmg) -- Cosmic Elucidation does not have an absorb message
 
-    target:takeDamage(dmg, mob, xi.attackType.SPECIAL, xi.damageType.ELEMENTA)
+    target:takeDamage(dmg, mob, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
     skill:setMsg(302)
 
     return dmg

--- a/scripts/globals/mobskills/oisoya.lua
+++ b/scripts/globals/mobskills/oisoya.lua
@@ -6,7 +6,6 @@
 --  Range: Ranged Attack
 --  Notes: Unique ranged weaponskill used by Tenzen during The Warrior's Path. Also used by Trust: Tenzen II.
 ---------------------------------------------------
-require("settings/main")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 ---------------------------------------------------

--- a/scripts/globals/mobskills/riceball.lua
+++ b/scripts/globals/mobskills/riceball.lua
@@ -2,7 +2,6 @@
 -- Riceball
 -- Dummy ability used for Tenzen using riceball.
 ---------------------------------------------
-require("settings/main")
 require("scripts/globals/msg")
 require("scripts/globals/mobskills")
 ---------------------------------------------

--- a/scripts/globals/mobskills/tenzen_ranged_alt.lua
+++ b/scripts/globals/mobskills/tenzen_ranged_alt.lua
@@ -3,7 +3,6 @@
 -- Only Used when in Bow Mode
 -- Deals a ranged attack to a single target.
 ---------------------------------------------------
-require("settings/main")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 ---------------------------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Removes direct references in requires to various settings files which are loaded on runtime for either the modified or default value.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Start server with only network.lua outside of defaults, observe no errors.
<!-- Clear and detailed steps to test your changes here -->
