### PR TITLE
[lua] Add TODO to verify "accuracy varies with TP" on retail to various weaponskills

### DIFF
--- a/scripts/globals/weaponskills/asuran_fists.lua
+++ b/scripts/globals/weaponskills/asuran_fists.lua
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.1 params.dex_wsc = 0.0 params.vit_wsc = 0.1 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -34,7 +34,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1,000 TP
     -- http://wiki.ffo.jp/html/732.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Blade:_Ku does not list ACC Bonus
-    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2
+    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/blast_arrow.lua
+++ b/scripts/globals/weaponskills/blast_arrow.lua
@@ -24,7 +24,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/blast_shot.lua
+++ b/scripts/globals/weaponskills/blast_shot.lua
@@ -24,7 +24,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/dancing_edge.lua
+++ b/scripts/globals/weaponskills/dancing_edge.lua
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/decimation.lua
+++ b/scripts/globals/weaponskills/decimation.lua
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0
+    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/penta_thrust.lua
+++ b/scripts/globals/weaponskills/penta_thrust.lua
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 0.875; params.atk200 = 0.875; params.atk300 = 0.875
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/realmrazer.lua
+++ b/scripts/globals/weaponskills/realmrazer.lua
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0
+    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/ruinator.lua
+++ b/scripts/globals/weaponskills/ruinator.lua
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0
+    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.1 params.atk200 = 1.1 params.atk300 = 1.1
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/sidewinder.lua
+++ b/scripts/globals/weaponskills/sidewinder.lua
@@ -24,7 +24,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/slug_shot.lua
+++ b/scripts/globals/weaponskills/slug_shot.lua
@@ -25,7 +25,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
+    params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/swift_blade.lua
+++ b/scripts/globals/weaponskills/swift_blade.lua
@@ -29,7 +29,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1,000 TP
     -- http://wiki.ffo.jp/html/382.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Swift_Blade does not list ACC Bonus
-    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2
+    params.acc100 = 1.0 params.acc200 = 1.1 params.acc300 = 1.2 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/tachi_rana.lua
+++ b/scripts/globals/weaponskills/tachi_rana.lua
@@ -27,7 +27,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
-    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1
+    params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/true_strike.lua
+++ b/scripts/globals/weaponskills/true_strike.lua
@@ -26,7 +26,7 @@ weaponskill_object.onUseWeaponSkill = function(player, target, wsID, tp, primary
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 1.0 params.crit200 = 1.0 params.crit300 = 1.0
     params.canCrit = true
-    params.acc100 = 0.5 params.acc200= 0.7 params.acc300= 1
+    params.acc100 = 0.5 params.acc200= 0.7 params.acc300= 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 2; params.atk200 = 2; params.atk300 = 2
 
     if (xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add TODOs to various weaponskills to verify accuracy being static vs percentage on retail

## Steps to test these changes

N/A