### PR TITLE
Disable Abyssea QMs which call deprecated implementation

### DIFF
--- a/scripts/zones/Abyssea-Altepa/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Altepa/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm23.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm23.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm24.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm24.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm25.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm25.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Attohwa/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Grauberg/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Konschtat/npcs/qm_bloodeye_vileberry.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/qm_bloodeye_vileberry.lua
@@ -12,7 +12,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-Konschtat/npcs/qm_eccentric_eve.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/qm_eccentric_eve.lua
@@ -10,7 +10,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-Konschtat/npcs/qm_kukulkan.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/qm_kukulkan.lua
@@ -12,7 +12,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-La_Theine/npcs/qm_briareus.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/qm_briareus.lua
@@ -10,7 +10,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-La_Theine/npcs/qm_carabosse.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/qm_carabosse.lua
@@ -10,7 +10,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-La_Theine/npcs/qm_hadhayosh.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/qm_hadhayosh.lua
@@ -10,7 +10,7 @@ require('scripts/globals/keyitems')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm23.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm23.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm24.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm24.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Misareaux/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Tahrongi/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Uleguerand/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm1.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm1.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm10.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm10.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm11.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm11.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm12.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm12.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm13.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm13.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm14.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm14.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm15.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm15.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm16.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm16.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm17.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm17.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm18.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm18.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm19.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm19.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm2.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm2.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm20.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm20.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm21.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm21.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm22.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm22.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm23.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm23.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm24.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm24.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm3.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm3.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm4.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm4.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm5.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm5.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm6.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm6.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm7.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm7.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm8.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm8.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Abyssea-Vunkerl/npcs/qm9.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/qm9.lua
@@ -9,11 +9,11 @@ require("scripts/globals/abyssea")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.abyssea.qmOnTrade(player, npc, trade)
+    -- xi.abyssea.qmOnTrade(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.abyssea.qmOnTrigger(player, npc)
+    -- xi.abyssea.qmOnTrigger(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Comments out global calls to Abyssea QMs that have not been updated to the new implementation
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
