### PR TITLE
[core] Fishing Heal Fix and Spelling Corrections

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -376,14 +376,14 @@ namespace fishingutils
     {
         uint8 bonusAdd = (legendary) ? rod->lgdBonusAtk : 0;
 
-        return (uint16)std::floor(difficulty * ((rod->fishAttack + bonusAdd) / 100)) * 20;
+        return (uint16)std::floor(difficulty * (((static_cast<float>(rod->fishAttack) + bonusAdd) / 100.0f)) * 20.0f);
     }
 
-    uint16 CaculateHeal(bool legendary, uint8 difficulty, rod_t* rod)
+    uint16 CalculateHeal(bool legendary, uint8 difficulty, rod_t* rod)
     {
         uint16 attack = CalculateAttack(legendary, difficulty, rod);
 
-        return (uint16)std::floor((attack / 20) * (rod->fishRecovery / 100)) * 10;
+        return (uint16)std::floor((static_cast<float>(attack) / 20.0f) * (static_cast<float>(rod->fishRecovery) / 100.0f)) * 10.0f;
     }
 
     uint8 CalculateRegen(uint8 fishingSkill, rod_t* rod, FISHINGCATCHTYPE catchType, uint8 sizeType, uint8 catchSkill, bool legendaryCatch, bool NM)
@@ -2461,7 +2461,7 @@ namespace fishingutils
             response->regen     = CalculateRegen(fishingSkill, rod, (FISHINGCATCHTYPE)response->catchtype, FishSelection->sizeType, FishSelection->maxSkill, FishSelection->legendary, false);
             response->response  = CalculateMovement(PChar, FishSelection->baseMove, FishSelection->sizeType, rod, response->count);
             response->attackdmg = CalculateAttack(FishSelection->legendary, FishSelection->difficulty, rod);
-            response->heal      = CaculateHeal(FishSelection->legendary, FishSelection->difficulty, rod);
+            response->heal      = CalculateHeal(FishSelection->legendary, FishSelection->difficulty, rod);
             response->timelimit = CalculateHookTime(PChar, FishSelection->legendary, FishSelection->legendary_flags, FishSelection->sizeType, rod, bait);
             response->sense     = CalculateFishSense(PChar, response, fishingSkill, (FISHINGCATCHTYPE)response->catchtype, FishSelection->sizeType, FishSelection->maxSkill,
                                                      FishSelection->legendary, FishSelection->minLength, FishSelection->maxLength, FishSelection->ranking, rod);
@@ -2511,7 +2511,7 @@ namespace fishingutils
             response->regen           = CalculateRegen(fishingSkill, rod, (FISHINGCATCHTYPE)response->catchtype, ItemSelection->sizeType, ItemSelection->maxSkill, false, false);
             response->response        = CalculateMovement(PChar, ItemSelection->baseMove, ItemSelection->sizeType, rod, 1);
             response->attackdmg       = CalculateAttack(ItemSelection->legendary, ItemSelection->difficulty, rod);
-            response->heal            = CaculateHeal(ItemSelection->legendary, ItemSelection->difficulty, rod);
+            response->heal            = CalculateHeal(ItemSelection->legendary, ItemSelection->difficulty, rod);
             response->timelimit       = CalculateHookTime(PChar, ItemSelection->legendary, ItemSelection->legendary_flags, ItemSelection->sizeType, rod, bait);
             response->sense           = CalculateFishSense(PChar, response, fishingSkill, (FISHINGCATCHTYPE)response->catchtype, ItemSelection->sizeType,
                                                            ItemSelection->maxSkill, false, ItemSelection->minLength, ItemSelection->maxLength, ItemSelection->ranking, rod);
@@ -2540,7 +2540,7 @@ namespace fishingutils
                 response->regen               = CalculateRegen(fishingSkill, rod, (FISHINGCATCHTYPE)response->catchtype, response->catchsizeType, MobSelection->level, false, MobSelection->nm);
                 response->response            = CalculateMovement(PChar, MobSelection->baseMove, response->catchsizeType, rod, 1);
                 response->attackdmg           = CalculateAttack(false, MobSelection->difficulty, rod);
-                response->heal                = CaculateHeal(false, MobSelection->difficulty, rod);
+                response->heal                = CalculateHeal(false, MobSelection->difficulty, rod);
                 response->timelimit           = CalculateHookTime(PChar, 0, 0, response->catchsizeType, rod, bait);
                 response->sense               = CalculateFishSense(PChar, response, fishingSkill, FISHINGCATCHTYPE_MOB, FISHINGSIZETYPE_LARGE, MobSelection->level, false,
                                                                    MobSelection->minLength, MobSelection->maxLength, MobSelection->ranking, rod);
@@ -2574,7 +2574,7 @@ namespace fishingutils
             response->regen           = CalculateRegen(fishingSkill, rod, (FISHINGCATCHTYPE)response->catchtype, response->catchsizeType, 1, false, false);
             response->response        = CalculateMovement(PChar, 15, response->catchsizeType, rod, 1);
             response->attackdmg       = CalculateAttack(false, 16, rod);
-            response->heal            = CaculateHeal(false, 16, rod);
+            response->heal            = CalculateHeal(false, 16, rod);
             response->timelimit       = CalculateHookTime(PChar, 0, 0, response->catchsizeType, rod, bait);
             response->sense           = CalculateFishSense(PChar, response, fishingSkill, FISHINGCATCHTYPE_CHEST, FISHINGSIZETYPE_LARGE, 1, false, 1, 1, 1, rod);
             response->angle           = ChestAngle;

--- a/src/map/utils/fishingutils.h
+++ b/src/map/utils/fishingutils.h
@@ -942,7 +942,7 @@ namespace fishingutils
     float               GetWeatherModifier(CCharEntity* PChar);
     uint16              CalculateStamina(int skill, uint8 count);
     uint16              CalculateAttack(bool legendary, uint8 difficulty, rod_t* rod);
-    uint16              CaculateHeal(bool legendary, uint8 difficulty, rod_t* rod);
+    uint16              CalculateHeal(bool legendary, uint8 difficulty, rod_t* rod);
     uint8               CalculateRegen(uint8 fishingSkill, rod_t* rod, FISHINGCATCHTYPE catchType,
                                        uint8 sizeType, uint8 catchSkill, bool legendaryCatch, bool NM);
     uint8               CalculateHookTime(CCharEntity* PChar, bool legendary,


### PR DESCRIPTION
Co-Authored-By: Setzor <setzor@gmail.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes the CalculateHeal function to properly calculate how much a fish heals on player mistake during the fishing minigame. 
(Fixes Spellings of that function as well)

## Steps to test these changes

Fish 
reduce fish stamina some 
purposely mess up the minigame
see fish heal
