### PR TITLE
[cmake] Force download and build LuaJIT on Unix

### DIFF
--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -22,10 +22,31 @@
 #
 # TEST AND MAKE SURE THAT EVERYTHING STILL WORKS!
 
+if (UNIX)
+    message(STATUS "Downloading LuaJIT src")
+    CPMAddPackage(
+        NAME LuaJIT
+        GITHUB_REPOSITORY LuaJIT/LuaJIT
+        GIT_TAG e3bae12fc0461cfa7e4bef3dfed2dad372e5da8d
+        DOWNLOAD_ONLY YES
+    )
+    if (LuaJIT_ADDED)
+        message(STATUS "Modifying LuaJIT build flags (adding -DLUAJIT_NO_UNWIND=1)")
+        file(READ "${LuaJIT_SOURCE_DIR}/src/Makefile" FILE_CONTENTS)
+        string(REPLACE "CCOPT= -O2 -fomit-frame-pointer\n" "CCOPT= -O2 -fomit-frame-pointer -DLUAJIT_NO_UNWIND=1\n" FILE_CONTENTS "${FILE_CONTENTS}")
+        file(WRITE "${LuaJIT_SOURCE_DIR}/src/Makefile" "${FILE_CONTENTS}")
+
+        # LuaJIT has no CMake support, so we break out to using make on it's own
+        message(STATUS "Building LuaJIT from src")
+        execute_process(COMMAND make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR})
+    endif()
+endif()
+
 find_library(LuaJIT_LIBRARY
     NAMES
         luajit luajit_64 luajit-5.1 libluajit libluajit_64
     PATHS
+        ${LuaJIT_SOURCE_DIR}/src/
         ${PROJECT_SOURCE_DIR}/ext/luajit/${libpath}
         /usr/
         /usr/bin/

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -44,7 +44,7 @@ endif()
 
 find_library(LuaJIT_LIBRARY
     NAMES
-        luajit luajit_64 luajit-5.1 libluajit libluajit_64
+        libluajit.a luajit luajit_64 luajit-5.1 libluajit libluajit_64
     PATHS
         ${LuaJIT_SOURCE_DIR}/src/
         ${PROJECT_SOURCE_DIR}/ext/luajit/${libpath}

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -38,7 +38,13 @@ if (UNIX)
 
         # LuaJIT has no CMake support, so we break out to using make on it's own
         message(STATUS "Building LuaJIT from src")
-        execute_process(COMMAND make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR})
+
+        if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            execute_process(COMMAND export MACOSX_DEPLOYMENT_TARGET=11.6 ; make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR}) # TODO don't hardcode MACOSX_DEPLOYMENT_TARGET
+        else()
+            execute_process(COMMAND make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR})
+        endif()
+
     endif()
 endif()
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes https://github.com/LandSandBoat/server/issues/2238
(I hope)

## Steps to test these changes

Build on Linux, you should see LuaJIT get downloaded and built (doesn't take long)
Everything should start as normal, that crash should be gone.
