### PR TITLE
Quest: Know One's Onions scroll reward change

### DIFF
--- a/scripts/quests/windurst/SOB2_Know_Ones_Onions.lua
+++ b/scripts/quests/windurst/SOB2_Know_Ones_Onions.lua
@@ -16,7 +16,6 @@ quest.reward =
 {
     fame     = 10,
     fameArea = xi.quest.fame_area.WINDURST,
-    item     = xi.items.SCROLL_OF_BLAZE_SPIKES,
     title    = xi.title.SOB_SUPER_HERO,
 }
 
@@ -106,8 +105,10 @@ quest.sections =
             onEventFinish =
             {
                 [398] = function(player, csid, option, npc)
-                    player:confirmTrade()
-                    quest:setVar(player, 'Prog', 2)
+                    if npcUtil.giveItem(player, xi.items.SCROLL_OF_BLAZE_SPIKES) then
+                        player:confirmTrade()
+                        quest:setVar(player, 'Prog', 2)
+                    end
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

The Blaze Spikes scroll will be awarded immediately after you turn in the wild onions instead of when the quest completes. Source https://ffxiclopedia.fandom.com/wiki/Know_One%27s_Onions

## Steps to test these changes

!setplayerlevel 5
!completequest 2 36
!pos -26.8 -6 190 240 testplayer
!giveitem testplayer 4387 4
