### PR TITLE
[ci] Add clang-format checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,25 @@ jobs:
           exit 1
         fi
         exit 0
+    - name: CPP Formatting Checks
+      if: always()
+      run: |
+        touch cpp_formatting_checks.txt
+        for changed_file in ${{ steps.changed-files.outputs.all }}; do
+          if [[ -f $changed_file ]]; then
+            if [[ $changed_file == *.cpp || $changed_file == *.h ]]; then
+              clang-format -style=file -i ${changed_file}
+            fi
+          fi
+        done
+        git diff >> cpp_formatting_checks.txt
+        cat cpp_formatting_checks.txt
+        git reset --hard
+        if [ -s cpp_formatting_checks.txt ]
+        then
+          exit 1
+        fi
+        exit 0
     - name: Lua Checks
       if: always()
       run: |
@@ -122,27 +141,6 @@ jobs:
           exit 1
         fi
         exit 0
-    - name: Clang Format (C++ files)
-      if: 'false' # Don't run until fixed
-      run: |
-        clang-format --version
-        echo "Base Ref: ${{ github.event.pull_request.base.ref }}"
-        echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
-        echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
-        echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-        diff=`git diff -U0 --no-color ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- '*.cpp' '*.h' | clang-format-diff -p1`
-
-        if [ -z "$diff" ]
-        then
-            echo "Diff formatting looks good!"
-        else
-            echo "Problem with formatting!"
-            echo "To fix this locally, run: git diff -U0 --no-color ${{ github.event.pull_request.base.ref }}..HEAD -- '*.cpp' '*.h' | clang-format-diff -p1 -i"
-            echo ""
-            echo "$diff"
-
-            exit -1
-        fi
 
   Linux_Clang11_64bit:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Sanity_Checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
       with:
@@ -21,7 +21,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y software-properties-common clang-format cppcheck luajit-5.1-dev luarocks mariadb-server-10.3 mariadb-client libmariadb-dev-compat
+        sudo apt-get install -y software-properties-common cppcheck luajit-5.1-dev luarocks mariadb-server mariadb-client libmariadb-dev-compat
         pip install -r tools/requirements.txt
         luarocks install luacheck --local
     - id: changed-files
@@ -74,11 +74,12 @@ jobs:
     - name: CPP Formatting Checks
       if: always()
       run: |
+        clang-format-14 -version
         touch cpp_formatting_checks.txt
         for changed_file in ${{ steps.changed-files.outputs.all }}; do
           if [[ -f $changed_file ]]; then
             if [[ $changed_file == *.cpp || $changed_file == *.h ]]; then
-              clang-format -style=file -i ${changed_file}
+              clang-format-14 -style=file -i ${changed_file}
             fi
           fi
         done
@@ -90,6 +91,13 @@ jobs:
           exit 1
         fi
         exit 0
+    - name: Upload CPP Formatting Diff
+      if: hashFiles('cpp_formatting_checks.txt') != ''
+      uses: actions/upload-artifact@v2
+      with:
+        name: clang_format_diff
+        path: |
+          cpp_formatting_checks.txt
     - name: Lua Checks
       if: always()
       run: |
@@ -142,8 +150,8 @@ jobs:
         fi
         exit 0
 
-  Linux_Clang11_64bit:
-    runs-on: ubuntu-latest
+  Linux_Clang14_64bit:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
       with:
@@ -152,15 +160,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y software-properties-common cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev
-    - name: Cache 'build' folder
-      uses: actions/cache@v3
-      with:
-        path: build
-        key: ${{ runner.os }}-clang
+    #- name: Cache 'build' folder
+    #  uses: actions/cache@v3
+    #  with:
+    #    path: build
+    #    key: ${{ runner.os }}-clang
     - name: Configure CMake
       run: |
-        export CC=/usr/bin/clang-11
-        export CXX=/usr/bin/clang++-11
+        export CC=/usr/bin/clang-14
+        export CXX=/usr/bin/clang++-14
         mkdir -p build
         cmake -S . -B build
     - name: Build
@@ -175,8 +183,8 @@ jobs:
           xi_map
           xi_search
 
-  Linux_GCC10_64bit:
-    runs-on: ubuntu-latest
+  Linux_GCC11_64bit:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
       with:
@@ -185,15 +193,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y software-properties-common cmake libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev
-    - name: Cache 'build' folder
-      uses: actions/cache@v3
-      with:
-        path: build
-        key: ${{ runner.os }}-gcc
+    #- name: Cache 'build' folder
+    #  uses: actions/cache@v3
+    #  with:
+    #    path: build
+    #    key: ${{ runner.os }}-gcc
     - name: Configure CMake
       run: |
-        export CC=/usr/bin/gcc-10
-        export CXX=/usr/bin/g++-10
+        export CC=/usr/bin/gcc-11
+        export CXX=/usr/bin/g++-11
         mkdir -p build
         CFLAGS=-m64 CXXFLAGS=-m64 LDFLAGS=-m64 cmake -S . -B build
     - name: Build
@@ -316,8 +324,8 @@ jobs:
           cmake --build build -j4
 
   Full_Startup_Checks_Linux:
-    runs-on: ubuntu-latest
-    needs: Linux_Clang11_64bit
+    runs-on: ubuntu-22.04
+    needs: Linux_Clang14_64bit
     services:
       mysql:
         image: mariadb
@@ -338,7 +346,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y software-properties-common cmake mariadb-server-10.3 mariadb-client-10.3 libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev luarocks
+        sudo apt-get install -y software-properties-common cmake mariadb-server mariadb-client libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev luarocks
     - name: Verify MySQL connection from container
       run: |
         mysql -h 127.0.0.1 -uroot -proot -e "SHOW DATABASES"
@@ -459,8 +467,8 @@ jobs:
         fi
 
   MultiInstance_Startup_Checks_Linux:
-    runs-on: ubuntu-latest
-    needs: Linux_Clang11_64bit
+    runs-on: ubuntu-22.04
+    needs: Linux_Clang14_64bit
     services:
       mysql:
         image: mariadb
@@ -481,7 +489,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y software-properties-common cmake mariadb-server-10.3 mariadb-client-10.3 libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev luarocks
+        sudo apt-get install -y software-properties-common cmake mariadb-server mariadb-client libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev luarocks
     - name: Verify MySQL connection from container
       run: |
         mysql -h 127.0.0.1 -uroot -proot -e "SHOW DATABASES"

--- a/src/common/blowfish.h
+++ b/src/common/blowfish.h
@@ -33,11 +33,11 @@ enum BLOWFISH
 
 struct blowfish_t
 {
-    uint32   key[5] = {};
-    uint8    hash[16] = {};
-    uint32   P[18] = {};
+    uint32   key[5]    = {};
+    uint8    hash[16]  = {};
+    uint32   P[18]     = {};
     uint32   S[4][256] = {};
-    BLOWFISH status = BLOWFISH_WAITING;
+    BLOWFISH status    = BLOWFISH_WAITING;
 };
 
 void blowfish_decipher(uint32* xl, uint32* xr, const uint32* P, uint32* S);

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -50,8 +50,8 @@
 
 std::atomic<bool> gRunFlag = true;
 
-int    arg_c   = 0;
-char** arg_v   = nullptr;
+int    arg_c = 0;
+char** arg_v = nullptr;
 
 char* SERVER_NAME = nullptr;
 char  SERVER_TYPE = XI_SERVER_NONE;
@@ -103,7 +103,7 @@ static void dump_backtrace()
 {
     // gdb
 #if defined(__linux__)
-    int fd[2] = {};
+    int fd[2]  = {};
     int status = pipe(fd);
     if (status == -1)
     {

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -34,10 +34,14 @@
 
 namespace logging
 {
-    const std::vector<std::string> logNames =
-    {
+    const std::vector<std::string> logNames = {
         // Regular loggers
-        "critical", "error", "warn", "info", "debug", "trace",
+        "critical",
+        "error",
+        "warn",
+        "info",
+        "debug",
+        "trace",
 
         // Special loggers
         "lua",

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -42,7 +42,7 @@ namespace settings
 {
     template <typename T>
     T get(std::string);
-} // settings
+} // namespace settings
 
 namespace logging
 {

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -46,8 +46,7 @@ void lua_init()
     lua.do_string(
         "function __FILE__() return debug.getinfo(2, 'S').source end\n"
         "function __LINE__() return debug.getinfo(2, 'l').currentline end\n"
-        "function __FUNC__() return debug.getinfo(2, 'n').name end\n"
-    );
+        "function __FUNC__() return debug.getinfo(2, 'n').name end\n");
 
     // Bind print(...) globally
     lua.set_function("print", &lua_print);
@@ -103,7 +102,7 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
         }
         case sol::type::table:
         {
-            auto table  = obj.as<sol::table>();
+            auto table = obj.as<sol::table>();
 
             // Stringify everything first
             std::vector<std::string> stringVec;
@@ -113,12 +112,14 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
             }
 
             // Accumulate into a pretty string
+            // clang-format off
             std::string outStr = "table{ ";
             outStr += std::accumulate(std::begin(stringVec), std::end(stringVec), std::string(),
             [](std::string& ss, std::string& s)
             {
                 return ss.empty() ? s : ss + ", " + s;
             });
+            // clang-format on
             return outStr + " }";
         }
         default:

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -239,7 +239,7 @@ struct look_t
         ranged  = look[9];
     }
 
-    look_t(std::vector<uint16> &look)
+    look_t(std::vector<uint16>& look)
     {
         if (look.size() == 10)
         {
@@ -259,7 +259,6 @@ struct look_t
             look_t();
         }
     }
-
 };
 
 struct skills_t
@@ -434,7 +433,7 @@ struct eminencelog_t
 
     eminencelog_t()
     {
-        std::memset(&active,   0, sizeof(active));
+        std::memset(&active, 0, sizeof(active));
         std::memset(&progress, 0, sizeof(progress));
         std::memset(&complete, 0, sizeof(complete));
     }
@@ -444,7 +443,8 @@ struct eminencecache_t
 {
     std::bitset<4096> activemap;
     uint32            lastWriteout;
-    bool              notifyTimedRecord;;
+    bool              notifyTimedRecord;
+    ;
 
     eminencecache_t()
     {
@@ -572,8 +572,8 @@ public:
     {
         std::memset(&m_name, 0, sizeof(m_name));
 
-        m_mjob = 0;
-        m_zone = 0;
+        m_mjob   = 0;
+        m_zone   = 0;
         m_nation = 0;
     };
     ~char_mini(){};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -97,7 +97,7 @@ namespace settings
                     }
                     else if constexpr (std::is_same_v<T, std::string>)
                     {
-                        out = arg ? "true" : "false";
+                        out = std::string(arg ? "true" : "false");
                     }
                 },
                 [&](double const& arg)

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -251,10 +251,10 @@ struct socket_data
     , func_send(_func_send)
     , func_parse(_func_parse)
     {
-        client_addr = 0;
-        flag.eof    = '\0';
-        flag.server = '\0';
-        rdata_pos = 0;
+        client_addr  = 0;
+        flag.eof     = '\0';
+        flag.server  = '\0';
+        rdata_pos    = 0;
         ver_mismatch = 0;
         session_data = nullptr;
     }

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -379,7 +379,7 @@ int32 SqlConnection::QueryStr(const char* query)
     }
 
     auto endTime = hires_clock::now();
-    auto dTime = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+    auto dTime   = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
     if (m_LatencyWarning)
     {
         if (dTime > 250ms)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -27,7 +27,7 @@
 #include "../common/mmo.h"
 #include <math.h>
 
-constexpr size_t PacketNameLength = 16;      // 15 + null terminator
+constexpr size_t PacketNameLength = 16; // 15 + null terminator
 
 constexpr size_t DecodeStringLength    = 21; // used for size of decoded strings of signature/linkshells
 constexpr size_t SignatureStringLength = 16; // encoded signature string size // 15 characters + null terminator

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -550,7 +550,7 @@ int32 lobbyview_parse(int32 fd)
 
     if (RFIFOREST(fd) >= 9)
     {
-        auto maintMode  = settings::get<uint8>("login.MAINT_MODE");
+        auto maintMode = settings::get<uint8>("login.MAINT_MODE");
 
         char* buff = &sessions[fd]->rdata[0];
         ShowDebug("lobbyview_parse:Incoming Packet: <%x> from ip:<%s>", ref<uint8>(buff, 8), ip2str(sd->client_addr));

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -43,9 +43,9 @@ enum ACCOUNT_STATUS_CODE : uint8
 
 enum ACCOUNT_PRIVILIGE_CODE : uint8
 {
-   USER  = 0x01,
-   ADMIN = 0x02,
-   ROOT  = 0x04,
+    USER  = 0x01,
+    ADMIN = 0x02,
+    ROOT  = 0x04,
 };
 
 /*

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -250,8 +250,8 @@ void message_server_init()
     zSocket->set(zmq::sockopt::rcvtimeo, 500);
 
     auto server = fmt::format("tcp://{}:{}",
-        settings::get<std::string>("network.ZMQ_IP"),
-        settings::get<std::string>("network.ZMQ_PORT"));
+                              settings::get<std::string>("network.ZMQ_IP"),
+                              settings::get<std::string>("network.ZMQ_PORT"));
 
     try
     {

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -24,22 +24,22 @@
 
 CAbility::CAbility(uint16 id)
 {
-    m_Job = JOB_NON;
-    m_level = 0;
+    m_Job         = JOB_NON;
+    m_level       = 0;
     m_animationID = 0;
-    m_range = 0;
+    m_range       = 0;
     m_validTarget = 0;
-    m_addType = 0;
-    m_message = 0;
-    m_recastTime = 0;
-    m_recastId = 0;
-    m_recastId = 0;
-    m_CE = 0;
-    m_VE = 0;
-    m_aoe = 0;
-    m_meritModID = 0;
-    m_mobskillId = 0;
-    m_ID = id;
+    m_addType     = 0;
+    m_message     = 0;
+    m_recastTime  = 0;
+    m_recastId    = 0;
+    m_recastId    = 0;
+    m_CE          = 0;
+    m_VE          = 0;
+    m_aoe         = 0;
+    m_meritModID  = 0;
+    m_mobskillId  = 0;
+    m_ID          = id;
 }
 
 bool CAbility::isPetAbility() const

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -252,11 +252,11 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
     }
 
     // Checking the players triple, double and quadruple attack
-    int16 tripleAttack = m_attacker->getMod(Mod::TRIPLE_ATTACK);
-    int16 doubleAttack = m_attacker->getMod(Mod::DOUBLE_ATTACK);
-    int16 quadAttack   = m_attacker->getMod(Mod::QUAD_ATTACK);
-    bool multiHitOccurred = false;
-    
+    int16 tripleAttack     = m_attacker->getMod(Mod::TRIPLE_ATTACK);
+    int16 doubleAttack     = m_attacker->getMod(Mod::DOUBLE_ATTACK);
+    int16 quadAttack       = m_attacker->getMod(Mod::QUAD_ATTACK);
+    bool  multiHitOccurred = false;
+
     // Checking for Mythic Weapon Aftermath
     int16 occAttThriceRate = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_THRICE), 0, 100);
     int16 occAttTwiceRate  = std::clamp<int16>(m_attacker->getMod(Mod::MYTHIC_OCC_ATT_TWICE), 0, 100);

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -328,6 +328,6 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const int8* com
 void CCommandHandler::registerCommand(std::string const& commandName, std::string const& path)
 {
     registeredCommands[commandName] = path;
-    lua["cmdprops"]  = sol::lua_nil;
-    lua["onTrigger"] = sol::lua_nil;
+    lua["cmdprops"]                 = sol::lua_nil;
+    lua["onTrigger"]                = sol::lua_nil;
 }

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -150,18 +150,18 @@ CInstance* CInstanceLoader::LoadInstance()
             PMob->setModifier(Mod::HTH_SDT, (uint16)(sql->GetFloatData(39) * 1000));
             PMob->setModifier(Mod::IMPACT_SDT, (uint16)(sql->GetFloatData(40) * 1000));
 
-            PMob->setModifier(Mod::FIRE_SDT, (int16)sql->GetIntData(41));      // Modifier 54, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::ICE_SDT, (int16)sql->GetIntData(42));       // Modifier 55, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::WIND_SDT, (int16)sql->GetIntData(43));      // Modifier 56, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::EARTH_SDT, (int16)sql->GetIntData(44));     // Modifier 57, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::THUNDER_SDT, (int16)sql->GetIntData(45));   // Modifier 58, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::WATER_SDT, (int16)sql->GetIntData(46));     // Modifier 59, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::LIGHT_SDT, (int16)sql->GetIntData(47));     // Modifier 60, base 10000 stored as signed integer. Positives signify less damage.
-            PMob->setModifier(Mod::DARK_SDT, (int16)sql->GetIntData(48));      // Modifier 61, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::FIRE_SDT, (int16)sql->GetIntData(41));    // Modifier 54, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::ICE_SDT, (int16)sql->GetIntData(42));     // Modifier 55, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::WIND_SDT, (int16)sql->GetIntData(43));    // Modifier 56, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::EARTH_SDT, (int16)sql->GetIntData(44));   // Modifier 57, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::THUNDER_SDT, (int16)sql->GetIntData(45)); // Modifier 58, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::WATER_SDT, (int16)sql->GetIntData(46));   // Modifier 59, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::LIGHT_SDT, (int16)sql->GetIntData(47));   // Modifier 60, base 10000 stored as signed integer. Positives signify less damage.
+            PMob->setModifier(Mod::DARK_SDT, (int16)sql->GetIntData(48));    // Modifier 61, base 10000 stored as signed integer. Positives signify less damage.
 
-            PMob->setModifier(Mod::FIRE_MEVA, (int16)(sql->GetIntData(49)));   // These are stored as signed integers which
-            PMob->setModifier(Mod::ICE_MEVA, (int16)(sql->GetIntData(50)));    // is directly the modifier starting value.
-            PMob->setModifier(Mod::WIND_MEVA, (int16)(sql->GetIntData(51)));   // Positives signify increased resist chance.
+            PMob->setModifier(Mod::FIRE_MEVA, (int16)(sql->GetIntData(49))); // These are stored as signed integers which
+            PMob->setModifier(Mod::ICE_MEVA, (int16)(sql->GetIntData(50)));  // is directly the modifier starting value.
+            PMob->setModifier(Mod::WIND_MEVA, (int16)(sql->GetIntData(51))); // Positives signify increased resist chance.
             PMob->setModifier(Mod::EARTH_MEVA, (int16)(sql->GetIntData(52)));
             PMob->setModifier(Mod::THUNDER_MEVA, (int16)(sql->GetIntData(53)));
             PMob->setModifier(Mod::WATER_MEVA, (int16)(sql->GetIntData(54)));

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -94,13 +94,13 @@ enum class LATENT : uint16
 #define MAX_LATENTEFFECTID 61
 
 /************************************************************************
-*                                                                       *
-* Unsolved problems:                                                    *
-*                                                                       *
-* - saving the ID of the entity that added the effect                   *
-* - updating effect (for example, overwriting protect 1 with protect 2) *
-*                                                                       *
-************************************************************************/
+ *                                                                       *
+ * Unsolved problems:                                                    *
+ *                                                                       *
+ * - saving the ID of the entity that added the effect                   *
+ * - updating effect (for example, overwriting protect 1 with protect 2) *
+ *                                                                       *
+ ************************************************************************/
 
 class CBattleEntity;
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -703,7 +703,7 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
             if (SmallPD_Type != 0x15)
             {
                 DebugPackets("parse: %03hX | %04hX %04hX %02hX from user: %s",
-                    SmallPD_Type, ref<uint16>(SmallPD_ptr, 2), ref<uint16>(buff, 2), SmallPD_Size, PChar->GetName());
+                             SmallPD_Type, ref<uint16>(SmallPD_ptr, 2), ref<uint16>(buff, 2), SmallPD_Size, PChar->GetName());
             }
 
             if (settings::get<bool>("map.PACKETGUARD_ENABLED") && PacketGuard::IsRateLimitedPacket(PChar, SmallPD_Type))

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -58,8 +58,8 @@ struct map_session_data_t
     uint8        shuttingDown       = 0;       // prevents double session closing
 };
 
-extern uint32       map_amntplayers;
-extern int32        map_fd;
+extern uint32 map_amntplayers;
+extern int32  map_fd;
 
 // 2.5 updates per second
 static constexpr float server_tick_rate = 2.5f;

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -550,7 +550,7 @@ namespace message
             }
             case MSG_LUA_FUNCTION:
             {
-                auto str = std::string((const char*)extra.data() + 4);
+                auto str    = std::string((const char*)extra.data() + 4);
                 auto result = lua.safe_script(str);
                 if (!result.valid())
                 {

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -306,7 +306,7 @@ std::optional<SpellID> CMobSpellContainer::GetBestEntrustedSpell(CBattleEntity* 
         case JOB_SCH:
         case JOB_PLD:
         case JOB_RUN:
-           choice = SpellID::Indi_Refresh;
+            choice = SpellID::Indi_Refresh;
             break;
         case JOB_NIN:
             choice = SpellID::Indi_Regen;
@@ -391,8 +391,8 @@ std::optional<SpellID> CMobSpellContainer::GetBestAgainstTargetWeakness(CBattleE
 
 std::optional<SpellID> CMobSpellContainer::GetStormDay()
 {
-    std::optional<SpellID> choice = std::nullopt;
-    std::size_t dotwIndex = battleutils::GetDayElement();
+    std::optional<SpellID> choice    = std::nullopt;
+    std::size_t            dotwIndex = battleutils::GetDayElement();
     switch (dotwIndex)
     {
         case ELEMENT_FIRE:
@@ -441,8 +441,8 @@ std::optional<SpellID> CMobSpellContainer::GetStormDay()
 
 std::optional<SpellID> CMobSpellContainer::GetHelixDay()
 {
-    std::optional<SpellID> choice = std::nullopt;
-    std::size_t dotwIndex = battleutils::GetDayElement();
+    std::optional<SpellID> choice    = std::nullopt;
+    std::size_t            dotwIndex = battleutils::GetDayElement();
     switch (dotwIndex)
     {
         case ELEMENT_FIRE:

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -153,18 +153,18 @@ enum class Mod
     PARRY             = 110, // Parry Skill
 
     // Magic Skills
-    DIVINE    = 111,  // Divine Magic Skill
-    HEALING   = 112,  // Healing Magic Skill
-    ENHANCE   = 113,  // Enhancing Magic Skill
-    ENFEEBLE  = 114,  // Enfeebling Magic Skill
-    ELEM      = 115,  // Elemental Magic Skill
-    DARK      = 116,  // Dark Magic Skill
-    SUMMONING = 117,  // Summoning Magic Skill
-    NINJUTSU  = 118,  // Ninjutsu Magic Skill
-    SINGING   = 119,  // Singing Magic Skill
-    STRING    = 120,  // String Magic Skill
-    WIND      = 121,  // Wind Magic Skill
-    BLUE      = 122,  // Blue Magic Skill
+    DIVINE    = 111, // Divine Magic Skill
+    HEALING   = 112, // Healing Magic Skill
+    ENHANCE   = 113, // Enhancing Magic Skill
+    ENFEEBLE  = 114, // Enfeebling Magic Skill
+    ELEM      = 115, // Elemental Magic Skill
+    DARK      = 116, // Dark Magic Skill
+    SUMMONING = 117, // Summoning Magic Skill
+    NINJUTSU  = 118, // Ninjutsu Magic Skill
+    SINGING   = 119, // Singing Magic Skill
+    STRING    = 120, // String Magic Skill
+    WIND      = 121, // Wind Magic Skill
+    BLUE      = 122, // Blue Magic Skill
     GEOMANCY  = 123, // Geomancy Magic Skill
     HANDBELL  = 124, // Handbell Magic SKill
 
@@ -308,13 +308,13 @@ enum class Mod
     DUAL_WIELD    = 259, // Percent reduction in dual wield delay.
 
     // Warrior
-    DOUBLE_ATTACK      = 288, // Percent chance to proc
+    DOUBLE_ATTACK      = 288,  // Percent chance to proc
     DOUBLE_ATTACK_DMG  = 1038, // Increases "Double Attack" damage/"Double Attack" damage + (in percents, e.g. +20 = +20% damage)
-    WARCRY_DURATION    = 483, // Warcy duration bonus from gear
-    BERSERK_EFFECT     = 948, // Conqueror Berserk Effect
-    BERSERK_DURATION   = 954, // Berserk Duration
-    AGGRESSOR_DURATION = 955, // Aggressor Duration
-    DEFENDER_DURATION  = 956, // Defender Duration
+    WARCRY_DURATION    = 483,  // Warcy duration bonus from gear
+    BERSERK_EFFECT     = 948,  // Conqueror Berserk Effect
+    BERSERK_DURATION   = 954,  // Berserk Duration
+    AGGRESSOR_DURATION = 955,  // Aggressor Duration
+    DEFENDER_DURATION  = 956,  // Defender Duration
 
     // Monk
     BOOST_EFFECT        = 97,   // Boost power in tenths
@@ -352,19 +352,19 @@ enum class Mod
     ENHANCES_SABOTEUR = 297, // Increases Saboteur Potency %
 
     // Thief
-    FLEE_DURATION     = 93,  // Flee duration in seconds
-    STEAL             = 298, // Increase/Decrease THF Steal chance
-    DESPOIL           = 896, // Increases THF Despoil chance
-    PERFECT_DODGE     = 883, // Increases Perfect Dodge duration in seconds
-    TRIPLE_ATTACK     = 302, // Percent chance
+    FLEE_DURATION     = 93,   // Flee duration in seconds
+    STEAL             = 298,  // Increase/Decrease THF Steal chance
+    DESPOIL           = 896,  // Increases THF Despoil chance
+    PERFECT_DODGE     = 883,  // Increases Perfect Dodge duration in seconds
+    TRIPLE_ATTACK     = 302,  // Percent chance
     TRIPLE_ATTACK_DMG = 1039, // Increases "Triple Attack" damage/"Triple Attack" damage + (in percents, e.g. +20 = +20% damage)
-    TREASURE_HUNTER   = 303, // Percent chance
-    SNEAK_ATK_DEX     = 830, // % DEX boost to Sneak Attack (if gear mod, needs to be equipped on hit)
-    TRICK_ATK_AGI     = 520, // % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
-    MUG_EFFECT        = 835, // Mug effect as multiplier
-    ACC_COLLAB_EFFECT = 884, // Increases amount of enmity transferred for Accomplice/Collaborator
-    HIDE_DURATION     = 885, // Hide duration increase (percentage based)
-    GILFINDER         = 897, // Gilfinder, duh
+    TREASURE_HUNTER   = 303,  // Percent chance
+    SNEAK_ATK_DEX     = 830,  // % DEX boost to Sneak Attack (if gear mod, needs to be equipped on hit)
+    TRICK_ATK_AGI     = 520,  // % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
+    MUG_EFFECT        = 835,  // Mug effect as multiplier
+    ACC_COLLAB_EFFECT = 884,  // Increases amount of enmity transferred for Accomplice/Collaborator
+    HIDE_DURATION     = 885,  // Hide duration increase (percentage based)
+    GILFINDER         = 897,  // Gilfinder, duh
 
     // Paladin
     HOLY_CIRCLE_DURATION   = 857, // Holy Circle extended duration in seconds

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -183,7 +183,7 @@ std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket)>
 void PrintPacket(CBasicPacket data)
 {
     std::string message;
-    char buffer[5];
+    char        buffer[5];
 
     for (size_t y = 0; y < data.getSize(); y++)
     {
@@ -1662,7 +1662,7 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
                     else
                     {
                         ShowInfo("%s->%s trade updating trade slot id %d with item %s, quantity %d", PChar->GetName(), PTarget->GetName(),
-                                   tradeSlotID, PItem->getName(), quantity);
+                                 tradeSlotID, PItem->getName(), quantity);
                         PItem->setReserve(quantity + PItem->getReserve());
                         PChar->UContainer->SetItem(tradeSlotID, PItem);
                     }
@@ -1670,7 +1670,7 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
                 else
                 {
                     ShowInfo("%s->%s trade updating trade slot id %d with item %s, quantity %d", PChar->GetName(), PTarget->GetName(),
-                               tradeSlotID, PItem->getName(), quantity);
+                             tradeSlotID, PItem->getName(), quantity);
                     PItem->setReserve(quantity + PItem->getReserve());
                     PChar->UContainer->SetItem(tradeSlotID, PItem);
                 }
@@ -1678,7 +1678,7 @@ void SmallPacket0x034(map_session_data_t* const PSession, CCharEntity* const PCh
             else
             {
                 ShowInfo("%s->%s trade updating trade slot id %d with item %s, quantity 0", PChar->GetName(), PTarget->GetName(),
-                           tradeSlotID, PItem->getName());
+                         tradeSlotID, PItem->getName());
                 PItem->setReserve(0);
                 PChar->UContainer->SetItem(tradeSlotID, nullptr);
             }
@@ -3693,7 +3693,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 PChar->m_moghouseID    = 0;
                 PChar->loc.destination = destinationZone;
-                PChar->loc.p = {};
+                PChar->loc.p           = {};
             }
             else
             {
@@ -4761,8 +4761,8 @@ void SmallPacket0x096(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x0AA(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    uint16     itemID     = data.ref<uint16>(0x04);
-    uint8      quantity   = data.ref<uint8>(0x07);
+    uint16 itemID   = data.ref<uint16>(0x04);
+    uint8  quantity = data.ref<uint8>(0x07);
 
     if (!PChar->PGuildShop)
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -625,8 +625,14 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
         uint16 newTargID   = data.ref<uint16>(0x16);
         uint8  newRotation = data.ref<uint8>(0x14);
 
-        bool   moved       = (PChar->loc.p.x != newX || PChar->loc.p.y != newY || PChar->loc.p.z != newZ || PChar->m_TargID != newTargID
-                           || PChar->loc.p.rotation != newRotation);
+        // clang-format off
+        bool moved =
+            PChar->loc.p.x != newX ||
+            PChar->loc.p.y != newY ||
+            PChar->loc.p.z != newZ ||
+            PChar->m_TargID != newTargID ||
+            PChar->loc.p.rotation != newRotation;
+        // clang-format on
 
         // Cache previous location
         PChar->m_previousLocation = PChar->loc;
@@ -656,11 +662,11 @@ void SmallPacket0x015(map_session_data_t* const PSession, CCharEntity* const PCh
         }
 
         // Request updates for all entity types
-        PChar->loc.zone->SpawnNPCs(PChar);   // Some NPCs can move, some rotate when other players talk to them, always request NPC updates.
+        PChar->loc.zone->SpawnNPCs(PChar); // Some NPCs can move, some rotate when other players talk to them, always request NPC updates.
         PChar->loc.zone->SpawnMOBs(PChar);
         PChar->loc.zone->SpawnPETs(PChar);
         PChar->loc.zone->SpawnTRUSTs(PChar);
-        PChar->requestedInfoSync = true;     // Ask to update PCs during CZoneEntities::ZoneServer
+        PChar->requestedInfoSync = true; // Ask to update PCs during CZoneEntities::ZoneServer
 
         if (PChar->PWideScanTarget != nullptr)
         {

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -74,8 +74,8 @@ CParty::CParty(CBattleEntity* PEntity)
 
     if (PEntity != nullptr && PEntity->PParty == nullptr)
     {
-        m_PartyID     = PEntity->id;
-        m_PartyType   = PEntity->objtype == TYPE_PC ? PARTY_PCS : PARTY_MOBS;
+        m_PartyID   = PEntity->id;
+        m_PartyType = PEntity->objtype == TYPE_PC ? PARTY_PCS : PARTY_MOBS;
 
         AddMember(PEntity);
         SetLeader((char*)PEntity->name.c_str());
@@ -490,11 +490,11 @@ void CParty::RemovePartyLeader(CBattleEntity* PEntity)
         SetLeader(newLeader.c_str());
     }
 
-    if (m_PartyType == PARTYTYPE::PARTY_MOBS)  // mob party, mob destructor being called and is leader of a party
+    if (m_PartyType == PARTYTYPE::PARTY_MOBS) // mob party, mob destructor being called and is leader of a party
     {
-        for (auto member: members)
+        for (auto member : members)
         {
-            if (member != PEntity)             // assign leader to next party member
+            if (member != PEntity) // assign leader to next party member
             {
                 m_PLeader = member;
                 DelMember(PEntity);

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -998,7 +998,7 @@ bool CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
 {
     // Don't process if not a COR roll.
     if (!((PStatusEffect->GetStatusID() >= EFFECT_FIGHTERS_ROLL && PStatusEffect->GetStatusID() <= EFFECT_NATURALISTS_ROLL) ||
-                        (PStatusEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL)))
+          (PStatusEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL)))
     {
         return false;
     }
@@ -1784,7 +1784,7 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
                 }
             });
-             // clang-format on
+            // clang-format on
         }
         else if (auraTarget == AURA_TARGET::ENEMIES)
         {

--- a/src/map/treasure_pool.h
+++ b/src/map/treasure_pool.h
@@ -47,7 +47,7 @@ struct LotInfo
 
     LotInfo()
     {
-        lot = 0;
+        lot    = 0;
         member = nullptr;
     }
 };
@@ -62,7 +62,7 @@ struct TreasurePoolItem
 
     TreasurePoolItem()
     {
-        ID = 0;
+        ID     = 0;
         SlotID = 0;
     }
 };

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -624,8 +624,8 @@ void CDataLoader::ExpireAHItems(uint16 expireAgeInDays)
             }
 
             qStr = fmt::format("INSERT INTO delivery_box (charid, charname, box, itemid, itemsubid, quantity, senderid, sender) VALUES "
-                "({}, '{}', 1, {}, 0, {}, 0, 'AH-Jeuno');",
-                listing.sellerID, listing.sellerName, listing.itemID, listing.ahStack == 1 ? listing.itemStack : 1);
+                               "({}, '{}', 1, {}, 0, {}, 0, 'AH-Jeuno');",
+                               listing.sellerID, listing.sellerName, listing.itemID, listing.ahStack == 1 ? listing.itemStack : 1);
 
             ret = sql2->Query(qStr.c_str());
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -85,12 +85,12 @@ int32 ah_cleanup(time_point tick, CTaskMgr::CTask* PTask);
 
 void TCPComm(SOCKET socket);
 
-extern void        HandleSearchRequest(CTCPRequestPacket& PTCPRequest);
-extern void        HandleSearchComment(CTCPRequestPacket& PTCPRequest);
-extern void        HandleGroupListRequest(CTCPRequestPacket& PTCPRequest);
-extern void        HandleAuctionHouseHistory(CTCPRequestPacket& PTCPRequest);
-extern void        HandleAuctionHouseRequest(CTCPRequestPacket& PTCPRequest);
-extern search_req  _HandleSearchRequest(CTCPRequestPacket& PTCPRequest);
+extern void       HandleSearchRequest(CTCPRequestPacket& PTCPRequest);
+extern void       HandleSearchComment(CTCPRequestPacket& PTCPRequest);
+extern void       HandleGroupListRequest(CTCPRequestPacket& PTCPRequest);
+extern void       HandleAuctionHouseHistory(CTCPRequestPacket& PTCPRequest);
+extern void       HandleAuctionHouseRequest(CTCPRequestPacket& PTCPRequest);
+extern search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest);
 
 extern std::unique_ptr<ConsoleService> gConsoleService;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

It's been 2 years in the making. At last, I can automatically enforce clang-format on PRs. This should start to alleviate the burden of telling people to format their code: they'll be faced with a big red X if it's wrong.

## Steps to test these changes

Look at CI, it'll tell you off
