### PR TITLE
[DRAFT] Apply ilvl to Trust

### DIFF
--- a/src/map/entities/trustentity.h
+++ b/src/map/entities/trustentity.h
@@ -61,6 +61,7 @@ public:
     void OnMobSkillFinished(CMobSkillState& state, action_t& action) override;
     void OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action) override;
 
+    uint8               iLvlBonus;
     uint32              m_TrustID{};
     TRUST_MOVEMENT_TYPE m_MovementType;
 };


### PR DESCRIPTION
This builds out the plumbing to apply additional "levels" to the Trust based on the Master's ilvl.
Reference: https://www.bg-wiki.com/ffxi/Category:Trust#Alter_Ego_Statistics_.26_Levels

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

The initial pass at implementing the ilvl bonuses was to just adjust the level of the trust based on the player ilvl, but this created problems with Party EXP. Instead, approached it from the standpoint of faking in levels at the `LoadTrustStatsAndSkills` phase.

Skill values were approximated based on observations from ilvl weapons:

|          |i105|i109|i115|i117|i119|
|---------|---|---|---|---|---|
|Parry     | 54|108|188|215|242|
|Weapon    | 54|108|188|215|242|
|Shield    |   | 48|   |100|112|
|Melee MACC| 42| 85|146|167|188|
|Staff MACC| 51|102|177|203|228|

These have been approximated into tiers in `trustutils`:
100 - 109, 110 - 118, and 119

These boosts apply to the Trust as follows:

STR/DEX/HP/ETC are Modified as Main/Sub Level + iLvl Bonus
EVA/ACC/ATT/RACC/RATT are Modified based on iLvl Parry/Weapon values
MEVA has had a fixed 12.5/ilvl applied since armor varies wildly

I've also added (but commented out) the shield tiering, and also applied the MeleeSkill bonuses to the block where these skills are called out since (currently) trusts don't actually hold weapons (these are applied as ACC/ATT/RACC/RATT instead).

## Steps to test these changes

* Log a test character in
* Add a trust
* Summon the Trust without any ilvl Gear
* Review mod values for STR, INT, HP, MP, ATT, ACC, etc
* Add ilvl gear (e.g. [Outrider Gear](https://www.ffxiah.com/search/item?&name=outrider#adv)
* Equip ilvl gear to get to a target ilvl
* Re-Summon the trust
* Review mod values for STR, INT, HP, MP, ATT, ACC, etc
