### PR TITLE
[Lua] Add ranged attack bonus to 'Warcry'

### DIFF
--- a/scripts/globals/effects/warcry.lua
+++ b/scripts/globals/effects/warcry.lua
@@ -15,6 +15,7 @@ effect_object.onEffectGain = function(target, effect)
     local jpEffect = jpLevel * 3
 
     target:addMod(xi.mod.ATTP, effect:getPower())
+    target:addMod(xi.mod.RATTP, effect:getPower())
     target:addMod(xi.mod.TP_BONUS, effect:getSubPower())
 
     -- Job Point Bonus
@@ -30,6 +31,7 @@ effect_object.onEffectLose = function(target, effect)
     local jpEffect = jpLevel * 3
 
     target:delMod(xi.mod.ATTP, effect:getPower())
+    target:delMod(xi.mod.RATTP, effect:getPower())
     target:delMod(xi.mod.TP_BONUS, effect:getSubPower())
 
     -- Job Point Bonus


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Currently, only berserk is granting ranged attack bonus, Warcry is not.
![image](https://user-images.githubusercontent.com/65316697/178168340-f45ab0eb-3182-4833-8e02-ab557cd358eb.png)

## Steps to test these changes
/checkparam
/ja "Warcry"
/checkparam

check for increased ranged attack.
