### PR TITLE
[core] [packets] fixup CEventPacket and CEventStringPacket to match retail behavior

### DIFF
--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -31,19 +31,24 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
     this->setType(0x32);
     this->setSize(0x14);
 
-    uint32 npcID = 0;
-    auto*  PNpc  = eventInfo->targetEntity;
+    uint32       npcServerID = 0;
+    uint32       npcLocalID  = 0;
+    CBaseEntity* PNpc        = eventInfo->targetEntity;
+
     if (PNpc)
     {
-        npcID = PNpc->id;
+        npcServerID = PNpc->id;
+        npcLocalID  = PNpc->targid;
     }
     else
     {
         // Fallback to our own CharID because giving a value
         // of zero makes the game hang.
-        npcID = PChar->id;
+        npcServerID = PChar->id;
+        npcLocalID  = PChar->targid;
     }
-    ref<uint32>(0x04) = npcID;
+
+    ref<uint32>(0x04) = npcServerID;
 
     if (eventInfo->params.size() > 0 || eventInfo->textTable != -1)
     {
@@ -59,7 +64,7 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
             }
         }
 
-        ref<uint16>(0x28) = PChar->m_TargID;
+        ref<uint16>(0x28) = npcLocalID;
 
         ref<uint16>(0x2A) = PChar->getZone();
         if (eventInfo->textTable != -1)
@@ -72,11 +77,11 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
         }
 
         ref<uint16>(0x2C) = eventInfo->eventId;
-        ref<uint8>(0x2E)  = 8; // если патаметров меньше, чем 8, то после завершения события камера "прыгнет" за спину персонажу
+        ref<uint8>(0x2E)  = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
     }
     else
     {
-        ref<uint16>(0x08) = PChar->targid;
+        ref<uint16>(0x08) = npcLocalID;
         ref<uint16>(0x0C) = eventInfo->eventId;
 
         ref<uint16>(0x0A) = PChar->getZone();

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -31,8 +31,25 @@ CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
     this->setType(0x33);
     this->setSize(0x70);
 
-    ref<uint32>(0x04) = PChar->id;
-    ref<uint16>(0x08) = PChar->m_TargID;
+    uint32       npcServerID = 0;
+    uint32       npcLocalID  = 0;
+    CBaseEntity* PNpc        = eventInfo->targetEntity;
+
+    if (PNpc)
+    {
+        npcServerID = PNpc->id;
+        npcLocalID  = PNpc->targid;
+    }
+    else
+    {
+        // Fallback to our own CharID because giving a value
+        // of zero makes the game hang.
+        npcServerID = PChar->id;
+        npcLocalID  = PChar->targid;
+    }
+
+    ref<uint32>(0x04) = npcServerID;
+    ref<uint16>(0x08) = npcLocalID;
     ref<uint16>(0x0A) = PChar->getZone();
     ref<uint16>(0x0C) = eventInfo->eventId;
     ref<uint8>(0x0E)  = 8; // camera "jumps" behind the character if < 8 params


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjust IDs used in CEventPacket and CEventString packet to match retail behavior. When available, they should be set to the NPC that initiated the event. If a region is walked into, it assigns the character's IDs likely because an NPC interaction didn't start the event.
Fixes #1886

## Steps to test these changes

Use any event such as HP warping, have it still work. (Currently, CEventStringPacket is not used in `base`)
