### PR TITLE
Rename Yngvi Earring to Ygnvi Choker, remove from AH listing

### DIFF
--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -19705,7 +19705,7 @@ INSERT INTO `item_basic` VALUES (26035,0,'moonlight_nodowa','moonlight_nodowa',1
 INSERT INTO `item_basic` VALUES (26036,0,'moonbeam_necklace','moonbeam_necklace',1,2084,22,0,0);
 INSERT INTO `item_basic` VALUES (26037,0,'moonlight_necklace','moonlight_necklace',1,2080,22,0,0);
 INSERT INTO `item_basic` VALUES (26038,0,'regal_necklace','regal_necklace',1,63568,0,0,0);
-INSERT INTO `item_basic` VALUES (26040,0,'yngvi_earring','yngvi_earring',1,34820,22,0,3225);
+INSERT INTO `item_basic` VALUES (26040,0,'yngvi_choker','yngvi_choker',1,34820,0,0,3225);
 INSERT INTO `item_basic` VALUES (26078,0,'kyrenes_earring','kyrenes_earring',1,34820,0,0,0);
 INSERT INTO `item_basic` VALUES (26079,0,'hypaspist_earring','hypaspist_earring',1,34820,0,0,0);
 INSERT INTO `item_basic` VALUES (26080,0,'mache_earring','mache_earring',1,2084,24,0,0);


### PR DESCRIPTION
This was renamed and as it is RA/EX it should not be on the AH.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Yngvi Choker has been renamed from Yngvi Earring. It was also RA/EX but on the AH.

## Steps to test these changes


