### PR TITLE
[sql] update char_effects.sql "subid" field to int(10) to match CStatusEffectContainer

### DIFF
--- a/sql/char_effects.sql
+++ b/sql/char_effects.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `char_effects` (
   `power` smallint(5) unsigned NOT NULL DEFAULT '0',
   `tick` int(10) unsigned NOT NULL DEFAULT '0',
   `duration` int(10) unsigned NOT NULL DEFAULT '0',
-  `subid` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `subid` int(10) unsigned NOT NULL DEFAULT '0',
   `subpower` smallint(5) NOT NULL DEFAULT '0',
   `tier` smallint(5) unsigned NOT NULL DEFAULT '0',
   `flags` int(8) unsigned NOT NULL DEFAULT '0',

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1584,7 +1584,7 @@ void CStatusEffectContainer::LoadStatusEffects()
             }
             CStatusEffect* PStatusEffect =
                 new CStatusEffect(effectID, (uint16)sql->GetUIntData(1), (uint16)sql->GetUIntData(2),
-                                  sql->GetUIntData(3), duration, (uint16)sql->GetUIntData(5), (uint16)sql->GetUIntData(6),
+                                  sql->GetUIntData(3), duration, sql->GetUIntData(5), (uint16)sql->GetUIntData(6),
                                   (uint16)sql->GetUIntData(7), flags);
 
             PEffectList.push_back(PStatusEffect);

--- a/tools/migrations/char_effects_subid_size.py
+++ b/tools/migrations/char_effects_subid_size.py
@@ -1,0 +1,21 @@
+import mysql.connector
+
+def migration_name():
+    return "Adjusting char_effects table column subid size to int."
+
+def check_preconditions(cur):
+    return
+
+def needs_to_run(cur):
+    # Ensure subid is currently smallint
+    cur.execute("SHOW COLUMNS FROM char_effects WHERE FIELD = 'subid' AND TYPE = 'smallint(5) unsigned';")
+    if cur.fetchone():
+        return True
+    return False
+
+def migrate(cur, db):
+    try:
+        cur.execute("ALTER TABLE char_effects MODIFY subid int(10) unsigned NOT NULL DEFAULT '0';")
+        db.commit()
+    except mysql.connector.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Updates char_effects.sql "subid" field to int(10) to match CStatusEffectContainer's uint32 getter/setter
Fixes #2265

## Steps to test these changes

Use any phantom roll
logout
do not see DB errors