### PR TITLE
[core] Remove Mobspell list ID limit

### DIFF
--- a/src/map/mob_spell_list.h
+++ b/src/map/mob_spell_list.h
@@ -29,8 +29,6 @@
 
 #include "spell.h"
 
-#define MAX_MOBSPELLLIST_ID 500
-
 typedef struct
 {
     SpellID spellId;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removes the requirement of a spell list limit on loading.

Tested by running around and poking mobs and ensuring they still use their proper spells

## Steps to test these changes

make new spell lists over id 500 and have fun.
