### PR TITLE
[lua] Add '!trustengage' custom helper

### DIFF
--- a/scripts/commands/trustengage.lua
+++ b/scripts/commands/trustengage.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- func: trustengage
+-- desc: Sets the engagement type of a players trusts
+-----------------------------------
+require("scripts/globals/settings")
+
+cmdprops =
+{
+    permission = 0,
+    parameters = "i"
+}
+
+local types =
+{
+    [0] = { 0, "Retail: Master engage and melee swing" },
+    [1] = { 1, "Attack: Master engage" },
+}
+
+function error(player)
+    player:PrintToPlayer(string.format("!trustengage <type number>\n" ..
+    "0: %s\n" ..
+    "1: %s", types[0][2], types[1][2]))
+    local type = player:getCharVar("TrustEngageType")
+    player:PrintToPlayer(string.format("Currently set to:\n %i: %s", type, types[type][2]))
+end
+
+function onTrigger(player, type)
+    if xi.settings.main.ENABLE_TRUST_CUSTOM_ENGAGEMENT ~= 1 then
+        player:PrintToPlayer("Trust custom engage conditions are disabled.")
+        return
+    end
+
+    if type == nil or type < 0 or type > 1 then
+        error(player)
+    end
+
+    player:setCharVar("TrustEngageType", type);
+    player:PrintToPlayer(string.format("Set Trust engage type to: %i: %s", type, types[type][2]))
+end

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -114,8 +114,9 @@ xi.settings.main =
     USE_ADOULIN_WEAPON_SKILL_CHANGES = true, -- true/false. Change to toggle new Adoulin weapon skill damage calculations
 
     -- TRUSTS
-    ENABLE_TRUST_CASTING = 1,
-    ENABLE_TRUST_QUESTS  = 1,
+    ENABLE_TRUST_CASTING           = 1,
+    ENABLE_TRUST_QUESTS            = 1,
+    ENABLE_TRUST_CUSTOM_ENGAGEMENT = 0,
 
     HARVESTING_BREAK_CHANCE = 33, -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
     EXCAVATION_BREAK_CHANCE = 33, -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

As always, I had assumed that someone else would step in and provide this. I laid it out to be very easy to add. But here we are.

Depends on https://github.com/LandSandBoat/server/pull/2067 to be performant, and not need a strange caching solution.

Allows you to set the engagement type of your trusts

## Steps to test these changes

- `!trustengage` to see help menu
- Summon a trust
- Engage as normal, but stay out of melee range
- `!trustengage 1`
- See the trust run in
- Further engagements will act this way
- Will survive zoning and logging in/out
- `!trustengage 0` to go back to normal/retail
