### PR TITLE
Return out of onTrigger during synthesis 

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1828,6 +1828,12 @@ namespace luautils
     {
         TracyZoneScoped;
 
+        // Clicking objects does nothing if the player is mid synthesis
+        if (PChar->animation == ANIMATION_SYNTH)
+        {
+            return 0;
+        }
+
         auto zone     = (const char*)PChar->loc.zone->GetName();
         auto name     = (const char*)PNpc->GetName();
         auto filename = fmt::format("./scripts/zones/{}/npcs/{}.lua", zone, name);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

tested on retail in multiple places including delivery NPCs, and could not activate any of the NPCs I tried. So I'm preventing those interactions to preempt any potential exploits and this is retail behavior anyway. We already block using the delivery box and send box during synth, and the client side also blocks those in the mog menu as well.

I could have sworn I could open guild shops mid synth and it just makes the synth fail - but when I tried last night the shop didn't react/open
