### PR TITLE
changed where env variables are loaded

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -157,6 +157,8 @@ namespace settings
             }
         }
 
+        network_settings_from_env();
+
         // Scrape user settings into cpp's settingsMap
         // This will overwrite the defaults, if user settings exist. Otherwise the
         // defaults will be left intact.
@@ -197,7 +199,5 @@ namespace settings
         // to the defaults:
         //
         // lua.safe_script("require('settings/main'); require('settings/default/main'); print(xi.settings)");
-
-        network_settings_from_env();
     }
 } // namespace settings


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Load important environment variables again in a way that matters.

## Steps to test these changes

Use environment variables for you sensitive data instead of silly-ole -settings scripts.
