### PR TITLE
Update HXIClient to use version information from settings/default/login.lua

### DIFF
--- a/tools/headlessxi/hxiclient.py
+++ b/tools/headlessxi/hxiclient.py
@@ -17,8 +17,9 @@ class HXIClient:
 
         # Read from version.conf default
         if client_str == '':
-            with open('conf/default/version.conf') as f:
-                client_str = f.readlines()[1].split(":")[1].strip()
+            with open('settings/default/login.lua') as f:
+                settings_file = f.read()
+                client_str = re.search(r'CLIENT_VER = "(.*?)"', settings_file)[1]
 
         print("Client version:", client_str)
         self.client_str = client_str


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Changes parsing and location to pull version info for HXI checks.

Fixes #2164 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Doing that now through CI runs
<!-- Clear and detailed steps to test your changes here -->
