### PR TITLE
[core] Update ENV VAR handling to be more universal

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -35,16 +35,19 @@ namespace settings
 {
     std::unordered_map<std::string, SettingsVariant_t> settingsMap;
 
-    void network_settings_from_env()
+    // We need this to figure out which environment variables are numbers
+    // so we can pass them to the lua settings properly typed.
+    bool isNumber(const std::string& stringValue)
     {
-        lua["xi"]["settings"]["network"]["SQL_HOST"]     = std::getenv("XI_DB_HOST") ? std::getenv("XI_DB_HOST") : get<std::string>("network.SQL_HOST");
-        lua["xi"]["settings"]["network"]["SQL_PORT"]     = std::getenv("XI_DB_PORT") ? std::stoi(std::getenv("XI_DB_PORT")) : get<uint16>("network.SQL_PORT");
-        lua["xi"]["settings"]["network"]["SQL_LOGIN"]    = std::getenv("XI_DB_USER") ? std::getenv("XI_DB_USER") : get<std::string>("network.SQL_LOGIN");
-        lua["xi"]["settings"]["network"]["SQL_PASSWORD"] = std::getenv("XI_DB_USER_PASSWD") ? std::getenv("XI_DB_USER_PASSWD") : get<std::string>("network.SQL_PASSWORD");
-        lua["xi"]["settings"]["network"]["SQL_DATABASE"] = std::getenv("XI_DB_NAME") ? std::getenv("XI_DB_NAME") : get<std::string>("network.SQL_DATABASE");
+        for (char const c : stringValue)
+        {
+            if (std::isdigit(c) == 0)
+            {
+                return false;
+            }
+        }
 
-        lua["xi"]["settings"]["network"]["ZMQ_IP"]   = std::getenv("XI_MSG_IP") ? std::getenv("XI_MSG_IP") : get<std::string>("network.ZMQ_IP");
-        lua["xi"]["settings"]["network"]["ZMQ_PORT"] = std::getenv("XI_MSG_PORT") ? std::stoi(std::getenv("XI_MSG_PORT")) : get<uint16>("network.ZMQ_PORT");
+        return true;
     }
 
     /**
@@ -181,6 +184,30 @@ namespace settings
                 {
                     settingsMap[key] = innerValObj.as<std::string>();
                 }
+
+                // Apply any environment variables over the default/user settings.
+                auto envKey = fmt::format("XI_{}_{}", to_upper(outerKey), to_upper(innerKey));
+
+                // If we try to assign this value in the if() statement, it will
+                // come back as a bool, so we have to check only then assign in the
+                // block.
+                if (std::getenv(envKey.c_str()))
+                {
+                    auto value = std::string(std::getenv(envKey.c_str()));
+                    ShowInfo(fmt::format("Applying ENV VAR {}: {} -> {}", envKey, key, value));
+
+                    // If we don't convert the PORTS to doubles (or ints), then the LUA
+                    // doesn't interpret them correctly and it breaks everything.
+                    // Therefor we need to check if the value is a number.
+                    if (isNumber(value))
+                    {
+                        settingsMap[key] = std::stod(value);
+                    }
+                    else
+                    {
+                        settingsMap[key] = value;
+                    }
+                }
             }
         }
 
@@ -189,7 +216,7 @@ namespace settings
         {
             auto parts                          = split(key, ".");
             auto outer                          = to_lower(parts[0]);
-            auto inner                          = to_lower(parts[1]);
+            auto inner                          = to_upper(parts[1]);
             lua["xi"]["settings"][outer][inner] = value;
         }
 
@@ -197,7 +224,5 @@ namespace settings
         // to the defaults:
         //
         // lua.safe_script("require('settings/main'); require('settings/default/main'); print(xi.settings)");
-
-        network_settings_from_env();
     }
 } // namespace settings

--- a/tools/wait_for_db_then_launch.sh
+++ b/tools/wait_for_db_then_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while ! mysql --host=$XI_DB_HOST --port=$XI_DB_PORT --user=$XI_DB_USER --password=$XI_DB_USER_PASSWD $XI_DB_NAME -e "SELECT 1 FROM zone_weather LIMIT 1"; do
+while ! mysql --host=$XI_NETWORK_SQL_HOST --port=$XI_NETWORK_SQL_PORT --user=$XI_NETWORK_SQL_LOGIN --password=$XI_NETWORK_SQL_PASSWORD $XI_NETWORK_SQL_DATABASE -e "SELECT 1 FROM zone_weather LIMIT 1"; do
     sleep 5
 done
 sleep 5


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Update settings.cpp to allow for arbitrary configuration of environment variables using the template XI_{outerKey}_{innerKey}.

## Steps to test these changes

Ignoring the Docker stuff, if you set any environment variables before you start like XI_NETWORK_SQL_HOST, or XI_MAIN_SERVER_NAME, it should be automatically reflected in the logs and the runtime behavior when starting up the server.
