### PR TITLE
[core] [packets] Add limit of recasts sent to player in CCharRecastPacket to prevent crash

### DIFF
--- a/src/map/packets/char_recast.cpp
+++ b/src/map/packets/char_recast.cpp
@@ -57,5 +57,14 @@ CCharRecastPacket::CCharRecastPacket(CCharEntity* PChar)
         {
             ref<uint32>(0x04) = recasttime; // 2h ability (recast id is 0)
         }
+
+        // Retail currently only allows 31 distinct recasts to be sent in the packet
+        // Reject 32 abilities and higher (zero-indexed)
+        // This may change with Master Levels, as there is some padding that appears to be not used for each recast that could be removed to add more abilities.
+        if (count > 30)
+        {
+            ShowDebug("CCharRecastPacket constructor attempting to send recast packet to player '%s' with > 31 abilities. This is unsupported.", PChar->GetName());
+            break;
+        }
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes 99RUN/99DNC having too many abilities and corrupting the heap by limiting how many recasts are sent to the client.
Fixes #2308

## Steps to test these changes

In config.map, set `SUBJOB_RATIO = 3,` login, !changejob RUN99, !changesjob DNC 99, server doesn't crash
