### PR TITLE
[JAs] Add functionality to WAR JA Tomahawk

### DIFF
--- a/scripts/globals/effects/tomahawk.lua
+++ b/scripts/globals/effects/tomahawk.lua
@@ -1,0 +1,51 @@
+-----------------------------------
+-- xi.effect.TOMAHAWK
+-----------------------------------
+require("scripts/globals/status")
+require("scripts/globals/magic")
+-----------------------------------
+local effect_object = {}
+local physSDT = {xi.mod.SLASH_SDT, xi.mod.PIERCE_SDT, xi.mod.IMPACT_SDT, xi.mod.HTH_SDT}
+
+effect_object.onEffectGain = function(target, effect)
+    for i = 1, #physSDT do
+        local sdtModPhys = target:getMod(physSDT[i])
+        local reductionPhys = (1000 - sdtModPhys) * 0.25
+
+        target:addMod(physSDT[i], reductionPhys)
+    end
+
+    for i = 1, #xi.magic.specificDmgTakenMod do
+        local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
+        local reductionMagic = sdtModMagic * 0.25
+    
+        target:addMod(xi.magic.specificDmgTakenMod[i], -reductionMagic)
+    end
+end
+
+effect_object.onEffectTick = function(target, effect)
+end
+
+effect_object.onEffectLose = function(target, effect)
+    for i = 1, #physSDT do
+        local sdtModPhys = target:getMod(physSDT[i])
+        local restorePhys = (1000 - sdtModPhys) / 0.75
+
+        if sdtModPhys <= 250 then
+            restorePhys = sdtModPhys
+        elseif sdtModPhys >= 1000 then
+            restorePhys = 0
+        end
+
+        target:delMod(physSDT[i], restorePhys)
+    end
+
+    for i = 1, #xi.magic.specificDmgTakenMod do
+        local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
+        local restoreMagic = (sdtModMagic / 0.75) - sdtModMagic
+
+        target:delMod(xi.magic.specificDmgTakenMod[i], -restoreMagic)
+    end
+end
+
+return effect_object

--- a/scripts/globals/effects/tomahawk.lua
+++ b/scripts/globals/effects/tomahawk.lua
@@ -18,7 +18,7 @@ effect_object.onEffectGain = function(target, effect)
     for i = 1, #xi.magic.specificDmgTakenMod do
         local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
         local reductionMagic = sdtModMagic * 0.25
-    
+
         target:addMod(xi.magic.specificDmgTakenMod[i], -reductionMagic)
     end
 end

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -22,8 +22,13 @@ xi.job_utils.warrior.checkMightyStrikes = function(player, target, ability)
 end
 
 xi.job_utils.warrior.checkTomahawk = function(player, target, ability)
-    --Placeholder code. Needs to check for direction and equiped ammo.
-    return 0, 0
+    local ammoID = player:getEquipID(xi.slot.AMMO)
+
+    if ammoID == 18258 then
+        return 0, 0
+    else
+        return xi.msg.basic.CANNOT_PERFORM, 0
+    end
 end
 
 -----------------------------------
@@ -63,7 +68,10 @@ xi.job_utils.warrior.useRetaliation = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useTomahawk = function(player, target, ability)
-    --placeholder
+    local merits = player:getMerit(xi.merit.TOMAHAWK) - 15
+    local duration = 30 + merits
+
+    target:addStatusEffectEx(xi.effect.TOMAHAWK, 0, 25, 3, duration, 0, 0, 0)
 end
 
 xi.job_utils.warrior.useWarcry = function(player, target, ability)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -838,9 +838,10 @@ xi.effect =
     ELEMENTALRES_DOWN        = 802, -- Elemental resistance down
     FULL_SPEED_AHEAD         = 803, -- Helper for quest: Full Speed Ahead!
     HYSTERIA                 = 804, -- Used for Hysteroanima to stop after readying a weaponskill with no msg.
-    -- PLACEHOLDER           = 805, -- Description
-    -- 805-1022
-    -- PLACEHOLDER             = 1023 -- The client dat file seems to have only this many "slots", results of exceeding that are untested.
+    TOMAHAWK                 = 805, -- Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    -- PLACEHOLDER           = 806, -- Description
+    -- 806-1022
+    -- PLACEHOLDER           = 1023 -- The client dat file seems to have only this many "slots", results of exceeding that are untested.
 }
 
 -----------------------------------

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -669,6 +669,7 @@ INSERT INTO `status_effects` VALUES (800,'dynamis',33554432,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (801,'meditate',32,0,0,0,0,0,7,0,0);
 INSERT INTO `status_effects` VALUES (802,'elemental_resistance_down',8389408,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (803,'full_speed_ahead',768,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (805,'tomahawk',544,0,0,0,0,0,0,0,0);
 
 /*!40000 ALTER TABLE `status_effects` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -699,51 +699,51 @@ enum EFFECT
     // Effect icons in packet can go from 0-767, so no custom effects should go in that range.
 
     // Purchased from Cruor Prospector
-    EFFECT_ABYSSEA_STR             = 768,
-    EFFECT_ABYSSEA_DEX             = 769,
-    EFFECT_ABYSSEA_VIT             = 770,
-    EFFECT_ABYSSEA_AGI             = 771,
-    EFFECT_ABYSSEA_INT             = 772,
-    EFFECT_ABYSSEA_MND             = 773,
-    EFFECT_ABYSSEA_CHR             = 774,
-    EFFECT_ABYSSEA_HP              = 775,
-    EFFECT_ABYSSEA_MP              = 776,
+    EFFECT_ABYSSEA_STR = 768,
+    EFFECT_ABYSSEA_DEX = 769,
+    EFFECT_ABYSSEA_VIT = 770,
+    EFFECT_ABYSSEA_AGI = 771,
+    EFFECT_ABYSSEA_INT = 772,
+    EFFECT_ABYSSEA_MND = 773,
+    EFFECT_ABYSSEA_CHR = 774,
+    EFFECT_ABYSSEA_HP  = 775,
+    EFFECT_ABYSSEA_MP  = 776,
 
     // *Prowess increases not currently retail accurate.
     // GoV Prowess bonus effects, real effect at ID 474
-    EFFECT_PROWESS_CASKET_RATE     = 777, // (Unimplemented)
-    EFFECT_PROWESS_SKILL_RATE      = 778, // (Unimplemented)
-    EFFECT_PROWESS_CRYSTAL_YIELD   = 779, // (Unimplemented)
-    EFFECT_PROWESS_TH              = 780, // +1 per tier
-    EFFECT_PROWESS_ATTACK_SPEED    = 781, // *flat 4% for now
-    EFFECT_PROWESS_HP_MP           = 782, // Base 3% and another 1% per tier.
-    EFFECT_PROWESS_ACC_RACC        = 783, // *flat 4% for now
-    EFFECT_PROWESS_ATT_RATT        = 784, // *flat 4% for now
-    EFFECT_PROWESS_MACC_MATK       = 785, // *flat 4% for now
-    EFFECT_PROWESS_CURE_POTENCY    = 786, // *flat 4% for now
-    EFFECT_PROWESS_WS_DMG          = 787, // (Unimplemented) 2% per tier.
-    EFFECT_PROWESS_KILLER          = 788, // *flat +4 for now
+    EFFECT_PROWESS_CASKET_RATE   = 777, // (Unimplemented)
+    EFFECT_PROWESS_SKILL_RATE    = 778, // (Unimplemented)
+    EFFECT_PROWESS_CRYSTAL_YIELD = 779, // (Unimplemented)
+    EFFECT_PROWESS_TH            = 780, // +1 per tier
+    EFFECT_PROWESS_ATTACK_SPEED  = 781, // *flat 4% for now
+    EFFECT_PROWESS_HP_MP         = 782, // Base 3% and another 1% per tier.
+    EFFECT_PROWESS_ACC_RACC      = 783, // *flat 4% for now
+    EFFECT_PROWESS_ATT_RATT      = 784, // *flat 4% for now
+    EFFECT_PROWESS_MACC_MATK     = 785, // *flat 4% for now
+    EFFECT_PROWESS_CURE_POTENCY  = 786, // *flat 4% for now
+    EFFECT_PROWESS_WS_DMG        = 787, // (Unimplemented) 2% per tier.
+    EFFECT_PROWESS_KILLER        = 788, // *flat +4 for now
     // End GoV Prowess fakery
-    EFFECT_FIELD_SUPPORT_FOOD      = 789, // Used by Fov/GoV food buff.
-    EFFECT_MARK_OF_SEED            = 790, // Tracks 30 min timer in ACP mission "Those Who Lurk in Shadows (II)"
-    EFFECT_ALL_MISS                = 791, // All attacks miss (ie - Tiamat while flying)
-    EFFECT_SUPER_BUFF              = 792, // Boss buff (ie - Nidhogg "2hour")
-    EFFECT_NINJUTSU_ELE_DEBUFF     = 793,
-    EFFECT_HEALING                 = 794,
-    EFFECT_LEAVEGAME               = 795,
-    EFFECT_HASTE_SAMBA_HASTE       = 796, // Small JA Haste given by Haste Samba on hit
-    EFFECT_TELEPORT                = 797,
-    EFFECT_CHAINBOUND              = 798,
-    EFFECT_SKILLCHAIN              = 799,
-    EFFECT_DYNAMIS                 = 800,
-    EFFECT_MEDITATE                = 801, // Dummy effect for SAM Meditate JA
-    EFFECT_ELEMENTALRES_DOWN       = 802, // Elemental resistance down
-    EFFECT_FULL_SPEED_AHEAD        = 803, // Used to track Full Speed Ahead quest minigame
-    EFFECT_HYSTERIA                = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
-    EFFECT_TOMAHAWK                = 805, // Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
-    // EFFECT_PLACEHOLDER             = 806  // Description
+    EFFECT_FIELD_SUPPORT_FOOD  = 789, // Used by Fov/GoV food buff.
+    EFFECT_MARK_OF_SEED        = 790, // Tracks 30 min timer in ACP mission "Those Who Lurk in Shadows (II)"
+    EFFECT_ALL_MISS            = 791, // All attacks miss (ie - Tiamat while flying)
+    EFFECT_SUPER_BUFF          = 792, // Boss buff (ie - Nidhogg "2hour")
+    EFFECT_NINJUTSU_ELE_DEBUFF = 793,
+    EFFECT_HEALING             = 794,
+    EFFECT_LEAVEGAME           = 795,
+    EFFECT_HASTE_SAMBA_HASTE   = 796, // Small JA Haste given by Haste Samba on hit
+    EFFECT_TELEPORT            = 797,
+    EFFECT_CHAINBOUND          = 798,
+    EFFECT_SKILLCHAIN          = 799,
+    EFFECT_DYNAMIS             = 800,
+    EFFECT_MEDITATE            = 801, // Dummy effect for SAM Meditate JA
+    EFFECT_ELEMENTALRES_DOWN   = 802, // Elemental resistance down
+    EFFECT_FULL_SPEED_AHEAD    = 803, // Used to track Full Speed Ahead quest minigame
+    EFFECT_HYSTERIA            = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
+    EFFECT_TOMAHAWK            = 805, // Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    // EFFECT_PLACEHOLDER           = 806  // Description
     // 806-1022
-    // EFFECT_PLACEHOLDER             = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
+    // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
 };
 
 #define MAX_EFFECTID 806 // 768 real + 38 custom

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -699,53 +699,54 @@ enum EFFECT
     // Effect icons in packet can go from 0-767, so no custom effects should go in that range.
 
     // Purchased from Cruor Prospector
-    EFFECT_ABYSSEA_STR = 768,
-    EFFECT_ABYSSEA_DEX = 769,
-    EFFECT_ABYSSEA_VIT = 770,
-    EFFECT_ABYSSEA_AGI = 771,
-    EFFECT_ABYSSEA_INT = 772,
-    EFFECT_ABYSSEA_MND = 773,
-    EFFECT_ABYSSEA_CHR = 774,
-    EFFECT_ABYSSEA_HP  = 775,
-    EFFECT_ABYSSEA_MP  = 776,
+    EFFECT_ABYSSEA_STR             = 768,
+    EFFECT_ABYSSEA_DEX             = 769,
+    EFFECT_ABYSSEA_VIT             = 770,
+    EFFECT_ABYSSEA_AGI             = 771,
+    EFFECT_ABYSSEA_INT             = 772,
+    EFFECT_ABYSSEA_MND             = 773,
+    EFFECT_ABYSSEA_CHR             = 774,
+    EFFECT_ABYSSEA_HP              = 775,
+    EFFECT_ABYSSEA_MP              = 776,
 
     // *Prowess increases not currently retail accurate.
     // GoV Prowess bonus effects, real effect at ID 474
-    EFFECT_PROWESS_CASKET_RATE   = 777, // (Unimplemented)
-    EFFECT_PROWESS_SKILL_RATE    = 778, // (Unimplemented)
-    EFFECT_PROWESS_CRYSTAL_YIELD = 779, // (Unimplemented)
-    EFFECT_PROWESS_TH            = 780, // +1 per tier
-    EFFECT_PROWESS_ATTACK_SPEED  = 781, // *flat 4% for now
-    EFFECT_PROWESS_HP_MP         = 782, // Base 3% and another 1% per tier.
-    EFFECT_PROWESS_ACC_RACC      = 783, // *flat 4% for now
-    EFFECT_PROWESS_ATT_RATT      = 784, // *flat 4% for now
-    EFFECT_PROWESS_MACC_MATK     = 785, // *flat 4% for now
-    EFFECT_PROWESS_CURE_POTENCY  = 786, // *flat 4% for now
-    EFFECT_PROWESS_WS_DMG        = 787, // (Unimplemented) 2% per tier.
-    EFFECT_PROWESS_KILLER        = 788, // *flat +4 for now
+    EFFECT_PROWESS_CASKET_RATE     = 777, // (Unimplemented)
+    EFFECT_PROWESS_SKILL_RATE      = 778, // (Unimplemented)
+    EFFECT_PROWESS_CRYSTAL_YIELD   = 779, // (Unimplemented)
+    EFFECT_PROWESS_TH              = 780, // +1 per tier
+    EFFECT_PROWESS_ATTACK_SPEED    = 781, // *flat 4% for now
+    EFFECT_PROWESS_HP_MP           = 782, // Base 3% and another 1% per tier.
+    EFFECT_PROWESS_ACC_RACC        = 783, // *flat 4% for now
+    EFFECT_PROWESS_ATT_RATT        = 784, // *flat 4% for now
+    EFFECT_PROWESS_MACC_MATK       = 785, // *flat 4% for now
+    EFFECT_PROWESS_CURE_POTENCY    = 786, // *flat 4% for now
+    EFFECT_PROWESS_WS_DMG          = 787, // (Unimplemented) 2% per tier.
+    EFFECT_PROWESS_KILLER          = 788, // *flat +4 for now
     // End GoV Prowess fakery
-    EFFECT_FIELD_SUPPORT_FOOD  = 789, // Used by Fov/GoV food buff.
-    EFFECT_MARK_OF_SEED        = 790, // Tracks 30 min timer in ACP mission "Those Who Lurk in Shadows (II)"
-    EFFECT_ALL_MISS            = 791, // All attacks miss (ie - Tiamat while flying)
-    EFFECT_SUPER_BUFF          = 792, // Boss buff (ie - Nidhogg "2hour")
-    EFFECT_NINJUTSU_ELE_DEBUFF = 793,
-    EFFECT_HEALING             = 794,
-    EFFECT_LEAVEGAME           = 795,
-    EFFECT_HASTE_SAMBA_HASTE   = 796, // Small JA Haste given by Haste Samba on hit
-    EFFECT_TELEPORT            = 797,
-    EFFECT_CHAINBOUND          = 798,
-    EFFECT_SKILLCHAIN          = 799,
-    EFFECT_DYNAMIS             = 800,
-    EFFECT_MEDITATE            = 801, // Dummy effect for SAM Meditate JA
-    EFFECT_ELEMENTALRES_DOWN   = 802, // Elemental resistance down
-    EFFECT_FULL_SPEED_AHEAD    = 803, // Used to track Full Speed Ahead quest minigame
-    EFFECT_HYSTERIA            = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
-    // EFFECT_PLACEHOLDER           = 805  // Description
-    // 805-1022
-    // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
+    EFFECT_FIELD_SUPPORT_FOOD      = 789, // Used by Fov/GoV food buff.
+    EFFECT_MARK_OF_SEED            = 790, // Tracks 30 min timer in ACP mission "Those Who Lurk in Shadows (II)"
+    EFFECT_ALL_MISS                = 791, // All attacks miss (ie - Tiamat while flying)
+    EFFECT_SUPER_BUFF              = 792, // Boss buff (ie - Nidhogg "2hour")
+    EFFECT_NINJUTSU_ELE_DEBUFF     = 793,
+    EFFECT_HEALING                 = 794,
+    EFFECT_LEAVEGAME               = 795,
+    EFFECT_HASTE_SAMBA_HASTE       = 796, // Small JA Haste given by Haste Samba on hit
+    EFFECT_TELEPORT                = 797,
+    EFFECT_CHAINBOUND              = 798,
+    EFFECT_SKILLCHAIN              = 799,
+    EFFECT_DYNAMIS                 = 800,
+    EFFECT_MEDITATE                = 801, // Dummy effect for SAM Meditate JA
+    EFFECT_ELEMENTALRES_DOWN       = 802, // Elemental resistance down
+    EFFECT_FULL_SPEED_AHEAD        = 803, // Used to track Full Speed Ahead quest minigame
+    EFFECT_HYSTERIA                = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
+    EFFECT_TOMAHAWK                = 805, // Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    // EFFECT_PLACEHOLDER             = 806  // Description
+    // 806-1022
+    // EFFECT_PLACEHOLDER             = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
 };
 
-#define MAX_EFFECTID 805 // 768 real + 32 custom
+#define MAX_EFFECTID 806 // 768 real + 38 custom
 
 /************************************************************************
  *                                                                       *


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds retail functionality to Warrior Job Ability "Tomahawk".

Physical Damage Type SDT (Slashing/Piercing/Impact/H2H) will be reduced by 25% when using Tomahawk.

- 1000 SLASH_SDT = Take 100% damage from the damage type
    - Tomahawk provides no bonus vulnerability at 1000 base Physical SDT
- 0 SLASH_SDT = Take 0% damage from the damage type
    - Tomahawk provides a maximum 250/25% bonus vulnerability at 0 base Physical SDT

Magic Damage Type SDT (Fire/Ice/Wind/Earth/Thunder/Water/Light/Dark) will be reduced by 25% when using Tomahawk.

- 10000 FIRE_SDT = Take 0% damage from the damage type
    - Tomahawk provides a maximum of 2500/25% bonus vulnerability at 10000 base Magic SDT
- 0 FIRE_SDT = Take 100% damage from the damage type
    - Tomahawk provides no bonus vulnerability at 0 base Magic SDT

**References**

https://www.bg-wiki.com/ffxi/Tomahawk_(Ability)
https://ffxiclopedia.fandom.com/wiki/Tomahawk_(Ability)
https://www.bg-wiki.com/ffxi/Jailer_of_Temperance
https://ffxiclopedia.fandom.com/wiki/Jailer_of_Temperance

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Load the changes onto your server.
Select a mob and !gotoid mobID.
Target the mob.
Use the "!setmod 49-61 value" command to set the physical and magic SDT mod values.
0 Physical and 10000 Magic SDT should block all damage from those damage types.
Use Tomahawk and SDT stat should be reduced by 25%, allowing damage through to the mob.