### PR TITLE
[core] Add routine for dynamic mob/npc ID lookups on startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -445,6 +445,7 @@
         "ForceCrash",
         "BuildString",
         "SendLuaFuncStringToZone",
+        "DYNAMIC_LOOKUP",
     ],
     "Lua.diagnostics.disable": [
         "lowercase-global"

--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -7,6 +7,8 @@
 
 xi = xi or {}
 
+DYNAMIC_LOOKUP = -1
+
 xi.zoneType =
 {
     NONE           = 0,

--- a/scripts/zones/Arrapago_Reef/IDs.lua
+++ b/scripts/zones/Arrapago_Reef/IDs.lua
@@ -51,15 +51,15 @@ zones[xi.zone.ARRAPAGO_REEF] =
     },
     mob =
     {
-        BLOODY_BONES_PH       =
+        BLOODY_BONES_PH =
         {
             [16998653] = 16998655, -- 136.234 -6.831 468.779
         },
-        MEDUSA                = 16998862,
-        LIL_APKALLU           = 16998871,
-        VELIONIS              = 16998872,
-        ZAREEHKL_THE_JUBILANT = 16998873,
-        NUHN                  = 16998874,
+        MEDUSA                = DYNAMIC_LOOKUP,
+        LIL_APKALLU           = DYNAMIC_LOOKUP,
+        VELIONIS              = DYNAMIC_LOOKUP,
+        ZAREEHKL_THE_JUBILANT = DYNAMIC_LOOKUP,
+        NUHN                  = DYNAMIC_LOOKUP,
     },
     npc =
     {

--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -11,8 +11,9 @@ xi.settings = xi.settings or {}
 
 xi.settings.logging =
 {
-    DEBUG_NAVMESH = false,
-    DEBUG_PACKETS = false,
-    DEBUG_ACTIONS = false,
-    DEBUG_SQL     = false,
+    DEBUG_NAVMESH   = false,
+    DEBUG_PACKETS   = false,
+    DEBUG_ACTIONS   = false,
+    DEBUG_SQL       = false,
+    DEBUG_ID_LOOKUP = false,
 }

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -61,10 +61,11 @@ namespace logging
 #define ShowCritical(...) { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_CRITICAL(spdlog::get("critical"), _msgStr); }
 
 // Debug Loggers
-#define DebugNavmesh(...) { if (settings::get<bool>("logging.DEBUG_NAVMESH")) { ShowDebug(__VA_ARGS__); } }
-#define DebugPackets(...) { if (settings::get<bool>("logging.DEBUG_PACKETS")) { ShowDebug(__VA_ARGS__); } }
-#define DebugActions(...) { if (settings::get<bool>("logging.DEBUG_ACTIONS")) { ShowDebug(__VA_ARGS__); } }
-#define DebugSQL(...)     { if (settings::get<bool>("logging.DEBUG_SQL")) { ShowDebug(__VA_ARGS__); } }
+#define DebugNavmesh(...)  { if (settings::get<bool>("logging.DEBUG_NAVMESH")) { ShowDebug(__VA_ARGS__); } }
+#define DebugPackets(...)  { if (settings::get<bool>("logging.DEBUG_PACKETS")) { ShowDebug(__VA_ARGS__); } }
+#define DebugActions(...)  { if (settings::get<bool>("logging.DEBUG_ACTIONS")) { ShowDebug(__VA_ARGS__); } }
+#define DebugSQL(...)      { if (settings::get<bool>("logging.DEBUG_SQL")) { ShowDebug(__VA_ARGS__); } }
+#define DebugIDLookup(...) { if (settings::get<bool>("logging.DEBUG_ID_LOOKUP")) { ShowDebug(__VA_ARGS__); } }
 
 // Special Loggers (different patterns)
 #define ShowLua(...) { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_INFO(spdlog::get("lua"), _msgStr); }

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -129,6 +129,8 @@ namespace luautils
     auto GetCacheEntryFromFilename(std::string filename) -> sol::table;
     void OnEntityLoad(CBaseEntity* PEntity);
 
+    void PopulateIDLookups(std::optional<uint16> maybeZoneId = std::nullopt);
+
     void  SendEntityVisualPacket(uint32 npcid, const char* command);
     void  InitInteractionGlobal();
     auto  GetZone(uint16 zoneId) -> std::optional<CLuaZone>;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -259,6 +259,8 @@ int32 do_init(int32 argc, char** argv)
     fishingutils::InitializeFishingSystem();
     instanceutils::LoadInstanceList();
 
+    luautils::PopulateIDLookups();
+
     ShowInfo("do_init: server is binding with port %u", map_port == 0 ? settings::get<uint16>("network.MAP_PORT") : map_port);
     map_fd = makeBind_udp(INADDR_ANY, map_port == 0 ? settings::get<uint16>("network.MAP_PORT") : map_port);
 

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -212,6 +212,8 @@ global_objects=(
 
     ForceCrash
     BuildString
+
+    DYNAMIC_LOOKUP
 )
 
 ignores=(


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Behold! Black magic!

This is a step towards not having to keep mob and npc IDs in the Lua scripts, where they rot and get left behind after version updates - breaking things.

This will take any simple entry in ID.mob or ID.npc that has it's value set to DYNAMIC_LOOKUP (-1) and go through the mobs/npcs for that zone and match on the first entry with the same name (forced to upper case).

## Steps to test these changes

Go to a zone where I've enabled the dynamic lookup, and make sure the mobs still work.

You could also print out the ID values and make sure they're not -1.