### PR TITLE
Add Throwing Tomahawk to items.lua, update lua references

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -3109,6 +3109,7 @@ xi.items =
     FORTITUDE_AXE                   = 18222,
     ORPHIC_EGG                      = 18256,
     BIBIKI_SEASHELL                 = 18257,
+    THROWING_TOMAHAWK               = 18258,
     CAESTUS                         = 18263,
     SPHARAI                         = 18264,
     BATARDEAU                       = 18269,

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Warrior Job Utilities
 -----------------------------------
+require('scripts/globals/items')
 require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
@@ -24,7 +25,7 @@ end
 xi.job_utils.warrior.checkTomahawk = function(player, target, ability)
     local ammoID = player:getEquipID(xi.slot.AMMO)
 
-    if ammoID == 18258 then
+    if ammoID == xi.items.THROWING_TOMAHAWK then
         return 0, 0
     else
         return xi.msg.basic.CANNOT_PERFORM, 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Missed this in code review, adds Throwing Tomahawk to enum, and updates ref in warrior job_utils global.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
