### PR TITLE
[core] [cmake] [sol] Enable Sol exceptions, remove custom LuaJIT build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set_project_warnings(project_warnings)
 add_definitions(
     -DSOL_ALL_SAFETIES_ON=1
     -DSOL_NO_CHECK_NUMBER_PRECISION=1
+    -DSOL_DEFAULT_PASS_ON_ERROR=1
     -DSOL_PRINT_ERRORS=0
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ set_project_warnings(project_warnings)
 add_definitions(
     -DSOL_ALL_SAFETIES_ON=1
     -DSOL_NO_CHECK_NUMBER_PRECISION=1
-    -DSOL_NO_EXCEPTIONS=1
     -DSOL_PRINT_ERRORS=0
 )
 

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -22,40 +22,41 @@
 #
 # TEST AND MAKE SURE THAT EVERYTHING STILL WORKS!
 
-if (UNIX)
-    message(STATUS "Downloading LuaJIT src")
-    CPMAddPackage(
-        NAME LuaJIT
-        GITHUB_REPOSITORY LuaJIT/LuaJIT
-        GIT_TAG e3bae12fc0461cfa7e4bef3dfed2dad372e5da8d
-        DOWNLOAD_ONLY YES
-    )
-    if (LuaJIT_ADDED)
-
-        # LuaJIT does not run properly on x86_84 systems without -DLUAJIT_NO_UNWIND=1 which disables external unwinding.
-        # Conversely, LuaJIT does not build properly on aarch64 *with* -DLUAJIT_NO_UNWIND=1, so only change the makefile where we know we need it.
-        if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-            message(STATUS "Modifying LuaJIT build flags (adding -DLUAJIT_NO_UNWIND=1)")
-            file(READ "${LuaJIT_SOURCE_DIR}/src/Makefile" FILE_CONTENTS)
-            string(REPLACE "CCOPT= -O2 -fomit-frame-pointer\n" "CCOPT= -O2 -fomit-frame-pointer -fPIC -DLUAJIT_NO_UNWIND=1\n" FILE_CONTENTS "${FILE_CONTENTS}")
-            file(WRITE "${LuaJIT_SOURCE_DIR}/src/Makefile" "${FILE_CONTENTS}")
-        endif()
-
-        # LuaJIT has no CMake support, so we break out to using make on it's own
-        message(STATUS "Building LuaJIT from src")
-
-        if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-            execute_process(COMMAND export MACOSX_DEPLOYMENT_TARGET=11.6 ; make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR}) # TODO don't hardcode MACOSX_DEPLOYMENT_TARGET
-        else()
-            execute_process(COMMAND make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR})
-        endif()
-
-    endif()
-endif()
+########## Removed as we don't need to build LuaJIT with #-DSOL_NO_EXCEPTIONS=1. We may want to build our own LuaJIT in the future, so leaving this commented out.
+#if (UNIX)
+#    message(STATUS "Downloading LuaJIT src")
+#    CPMAddPackage(
+#        NAME LuaJIT
+#        GITHUB_REPOSITORY LuaJIT/LuaJIT
+#        GIT_TAG e3bae12fc0461cfa7e4bef3dfed2dad372e5da8d
+#        DOWNLOAD_ONLY YES
+#    )
+#    if (LuaJIT_ADDED)
+#
+#        # LuaJIT does not run properly on x86_84 systems without -DLUAJIT_NO_UNWIND=1 which disables external unwinding.
+#        # Conversely, LuaJIT does not build properly on aarch64 *with* -DLUAJIT_NO_UNWIND=1, so only change the makefile where we know we need it.
+#        if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
+#            message(STATUS "Modifying LuaJIT build flags (adding -DLUAJIT_NO_UNWIND=1)")
+#            file(READ "${LuaJIT_SOURCE_DIR}/src/Makefile" FILE_CONTENTS)
+#            string(REPLACE "CCOPT= -O2 -fomit-frame-pointer\n" "CCOPT= -O2 -fomit-frame-pointer -fPIC -DLUAJIT_NO_UNWIND=1\n" FILE_CONTENTS "${FILE_CONTENTS}")
+#            file(WRITE "${LuaJIT_SOURCE_DIR}/src/Makefile" "${FILE_CONTENTS}")
+#        endif()
+#
+#        # LuaJIT has no CMake support, so we break out to using make on it's own
+#        message(STATUS "Building LuaJIT from src")
+#
+#        if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+#            execute_process(COMMAND export MACOSX_DEPLOYMENT_TARGET=11.6 ; make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR}) # TODO don't hardcode MACOSX_DEPLOYMENT_TARGET
+#        else()
+#            execute_process(COMMAND make WORKING_DIRECTORY ${LuaJIT_SOURCE_DIR})
+#        endif()
+#
+#    endif()
+#endif()
 
 find_library(LuaJIT_LIBRARY
     NAMES
-        libluajit.a luajit luajit_64 luajit-5.1 libluajit libluajit_64
+        luajit luajit_64 luajit-5.1 libluajit libluajit_64
     PATHS
         ${LuaJIT_SOURCE_DIR}/src/
         ${PROJECT_SOURCE_DIR}/ext/luajit/${libpath}

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -70,7 +70,7 @@ namespace settings
             if (isLua)
             {
                 {
-                    auto res = lua.safe_script_file(filename, &sol::script_pass_on_error);
+                    auto res = lua.safe_script_file(filename);
                     if (!res.valid())
                     {
                         sol::error err = res;
@@ -133,7 +133,7 @@ namespace settings
             if (isLua)
             {
                 {
-                    auto res = lua.safe_script_file(filename, &sol::script_pass_on_error);
+                    auto res = lua.safe_script_file(filename);
                     if (!res.valid())
                     {
                         sol::error err = res;

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -195,7 +195,7 @@ int32 CCommandHandler::call(sol::state& lua, CCharEntity* PChar, const int8* com
         filename = (*maybeRegisteredCommand).second;
     }
 
-    auto loadResult = lua.safe_script_file(filename, &sol::script_pass_on_error);
+    auto loadResult = lua.safe_script_file(filename);
     if (!loadResult.valid())
     {
         sol::error err = loadResult;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -213,7 +213,7 @@ namespace luautils
 
         // Load globals
         // Truly global files first
-        lua.safe_script_file("./scripts/globals/common.lua", &sol::script_pass_on_error);
+        lua.safe_script_file("./scripts/globals/common.lua");
         roeutils::init(); // TODO: Get rid of the need to do this
 
         // Then the rest...
@@ -225,7 +225,7 @@ namespace luautils
                 auto relative_path_string = entry.path().relative_path().generic_string();
                 // auto lua_path = std::filesystem::relative(entry.path(), "./").replace_extension("").generic_string();
                 // ShowInfo("Loading global script %s", lua_path);
-                auto result = lua.safe_script_file(relative_path_string, &sol::script_pass_on_error);
+                auto result = lua.safe_script_file(relative_path_string);
                 if (!result.valid())
                 {
                     sol::error err = result;
@@ -245,7 +245,7 @@ namespace luautils
             {
                 if (entry.path().extension() == ".lua")
                 {
-                    auto result = lua.safe_script_file(entry.path().relative_path().generic_string(), &sol::script_pass_on_error);
+                    auto result = lua.safe_script_file(entry.path().relative_path().generic_string());
                     if (!result.valid())
                     {
                         sol::error err = result;
@@ -505,7 +505,7 @@ namespace luautils
         // Handle Lua module files, then return
         if (!parts.empty() && parts[0] == "modules")
         {
-            auto result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+            auto result = lua.safe_script_file(filename);
             if (!result.valid())
             {
                 sol::error err = result;
@@ -548,7 +548,7 @@ namespace luautils
         // Handle Commands then return
         if (parts.size() == 2 && parts[0] == "commands")
         {
-            auto result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+            auto result = lua.safe_script_file(filename);
             if (!result.valid())
             {
                 sol::error err = result;
@@ -621,7 +621,7 @@ namespace luautils
         }
 
         // Try and load script
-        auto file_result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+        auto file_result = lua.safe_script_file(filename);
         if (!file_result.valid())
         {
             sol::error err = file_result;
@@ -2636,7 +2636,7 @@ namespace luautils
 
         auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", zone_name, name);
 
-        auto script_result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+        auto script_result = lua.safe_script_file(filename);
         if (!script_result.valid())
         {
             return -1;
@@ -2685,7 +2685,7 @@ namespace luautils
 
         auto filename = fmt::format("./scripts/mixins/zones/{}.lua", PMob->loc.zone->GetName());
 
-        auto script_result = lua.safe_script_file(filename, &sol::script_pass_on_error);
+        auto script_result = lua.safe_script_file(filename);
         if (!script_result.valid())
         {
             return -1;

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -124,7 +124,7 @@ namespace moduleutils
     void LoadLuaModules()
     {
         // Load the helper file
-        lua.safe_script_file("./modules/module_utils.lua", &sol::script_pass_on_error);
+        lua.safe_script_file("./modules/module_utils.lua");
 
         // Read lines from init.txt
         std::vector<std::string> list;
@@ -166,7 +166,7 @@ namespace moduleutils
                 std::string filename = path.filename().generic_string();
                 std::string relPath  = path.relative_path().generic_string();
 
-                auto res = lua.safe_script_file(relPath, &sol::script_pass_on_error);
+                auto res = lua.safe_script_file(relPath);
                 if (!res.valid())
                 {
                     sol::error err = res;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Enable Sol exceptions (removal of `-DSOL_NO_EXCEPTIONS=1`)
Remove custom LuaJIT build that needed `-DLUAJIT_NO_UNWIND=1` for x86_64
## Steps to test these changes

setup:
build as normal, run game as normal, login as normal

testing:
Edit an existing lua script by adding whitespace somewhere that won't error, see it reload and no crash.
Edit an existing lua script and force it to error, see it attempt to reload and no crash.
Run "delmodnil" custom command to force an error, see it error in log with no crash.
Edit an existing _global_ lua script such as ChocoboRaising.lua, add whitespate somewhere, see it reload, no crash.
Edit an existing _global_ lua script such as ChocoboRaising.lua, and force it to error see it reload, no crash.

delmodnil.lua as follows:
```
-----------------------------------
-- func: delmodnil
-- desc: Tests passing nil to delMod to see if it crashes linux system
-----------------------------------

require("scripts/globals/status")

cmdprops =
{
    permission = 1,
    parameters = ""
}


function onTrigger(player)
    player:delMod(xi.mod.REGEN, nil)
end
```