### PR TITLE
typo fix: AVATAR_S_FAVOR -> AVATARS_FAVOR in fenrir onSpellCast

### DIFF
--- a/scripts/globals/spells/summoning/fenrir.lua
+++ b/scripts/globals/spells/summoning/fenrir.lua
@@ -25,7 +25,7 @@ end
 spell_object.onSpellCast = function(caster, target, spell)
     caster:spawnPet(xi.pet.id.FENRIR)
 
-    if caster:hasStatusEffect(xi.effect.AVATAR_S_FAVOR) then
+    if caster:hasStatusEffect(xi.effect.AVATARS_FAVOR) then
         local effect = caster:getStatusEffect(xi.effect.AVATARS_FAVOR)
         effect:setPower(1) -- resummon resets effect
         xi.avatarsFavor.applyAvatarsFavorAuraToPet(caster, effect)


### PR DESCRIPTION
closes #2357

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
an effect name was typo'd

## Steps to test these changes
summon fenrir before pulling this commit, see log complain about nil effect id

summon after, no more complaint
