### PR TITLE
Move missing navmesh error to its own existing message type

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -427,7 +427,7 @@ void CZone::LoadNavMesh()
 
     if (!m_navMesh->load(file))
     {
-        ShowCritical("CZone::LoadNavMesh: Cannot load navemesh file (%s)", file);
+        DebugNavmesh("CZone::LoadNavMesh: Cannot load navmesh file (%s)", file);
         delete m_navMesh;
         m_navMesh = nullptr;
     }


### PR DESCRIPTION
…ssible to intentionally run with no navmeshes, so this isn't a critical error (just a minor one).

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Changes the message type of a recently added navmesh error to be the navmesh specific messaging

## Steps to test these changes
delete a navmesh, restart and observe message
