### PR TITLE
CoP 8-2: Fix typo in mission log enum

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ixghrah.lua
@@ -131,7 +131,7 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDeath  = function(mob, player, isKiller)
-    if (player:getCurrentMission(xi.mission.log_id.cop) == xi.mission.id.cop.A_FATE_DECIDED  and player:getCharVar("PromathiaStatus")==1) then
+    if player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.A_FATE_DECIDED and player:getCharVar("PromathiaStatus") == 1 then
         player:setCharVar("PromathiaStatus", 2)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
This PR addresses an issue where Ix'grah will repeatedly spawn when clicking cermet gate in Grand Palace because the charVar does not update correctly.

I realize this chapter of CoP is yet to be converted, so I'll leave it up to you guys if you want to accept this or not.

## Steps to test these changes

1. !zone Grand Palace
2. !pos to Ix'grah
3. touch cermet portal
4. kill NM
5. make sure charvar incremented to 5.
