### PR TITLE
Replace messageSpecial with messageName for multiline text in Prelude to a Storm

### DIFF
--- a/scripts/missions/wotg/31_Prelude_to_a_Storm.lua
+++ b/scripts/missions/wotg/31_Prelude_to_a_Storm.lua
@@ -39,8 +39,14 @@ mission.sections =
 
         [xi.zone.XARCABARD_S] =
         {
-            -- TODO: This might need to be messageName to correct formatting.
-            ['Rally_Point_Red'] = mission:messageSpecial(pastXarcabardID.text.REQUIRED_TO_DELIVER),
+            ['Rally_Point_Red'] =
+            {
+                onTrigger = function(player, npc)
+                    player:messageName(pastXarcabardID.text.REQUIRED_TO_DELIVER, nil)
+
+                    return mission:noAction()
+                end,
+            },
 
             ['Rally_Point_Green'] =
             {
@@ -51,7 +57,9 @@ mission.sections =
                         return mission:progressEvent(21, 137, 300, 200, 100, 0, 6553620, 0, 0)
                     elseif missionStatus == 1 then
                         if player:hasKeyItem(xi.ki.MAGELIGHT_SIGNAL_FLARE) then
-                            return mission:messageSpecial(pastXarcabardID.text.HELP_FEDERATION_PREPARE)
+                            player:messageName(pastXarcabardID.text.HELP_FEDERATION_PREPARE, nil)
+
+                            return mission:noAction()
                         else
                             return mission:progressEvent(25, 137, 23, 2963)
                         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Corrects formatting for multiline messages:

messageSpecial (incorrect):
![image](https://user-images.githubusercontent.com/81713309/180741662-b20a9c08-ee45-46fd-9890-beccca142e01.png)

messageName (correct):
![image](https://user-images.githubusercontent.com/81713309/180741726-83c68ea8-b35c-440f-bc11-fcde214cbc6a.png)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
See above, the same line in image 2 is used in the adjustment.
<!-- Clear and detailed steps to test your changes here -->
