### PR TITLE
Allow SUBSTATE_IN_CS for Synthesis Suggestion Packet (0x058)

### DIFF
--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -36,6 +36,7 @@ namespace PacketGuard
         allowList[SUBSTATE_IN_CS][0x01A] = true; // Player Action
         allowList[SUBSTATE_IN_CS][0x03A] = true; // Sort Inventory
         allowList[SUBSTATE_IN_CS][0x053] = true; // LockStyleSet
+        allowList[SUBSTATE_IN_CS][0x058] = true; // Synthesis Suggestion
         allowList[SUBSTATE_IN_CS][0x05A] = true; // Map Update (Conquest, Besieged, Campaign)
         allowList[SUBSTATE_IN_CS][0x05B] = true; // Event Update (Completion or Update)
         allowList[SUBSTATE_IN_CS][0x05C] = true; // Event Update (Update Player Position)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes #2381 

0x058 was being caught by PacketGuard while in CS.  Unable to reproduce Weather NPC after fix; however, there is no legitimate way to request more than one zone's weather while in CS (event ends upon selecting one and receiving status)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Talk to Weather NPC and request weather for a zone
2. Talk to Goldsmithing support NPC, and request Information on Synthesis Materials
<!-- Clear and detailed steps to test your changes here -->
