### PR TITLE
Fix ToAU: 'The Wayward Automaton' char vars

### DIFF
--- a/scripts/zones/Caedarva_Mire/mobs/Caedarva_Toad.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Caedarva_Toad.lua
@@ -8,11 +8,11 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onMobDeath = function(mob, player, isKiller)
-    local theWaywardAutomation = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
-    local theWaywardAutomationProgress = player:getCharVar("TheWaywardAutomationProgress")
+    local theWaywardAutomaton = player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_WAYWARD_AUTOMATON)
+    local theWaywardAutomatonProgress = player:getCharVar("TheWaywardAutomatonProgress")
 
-    if (theWaywardAutomation == QUEST_ACCEPTED and theWaywardAutomationProgress == 2 and player:getCharVar("TheWaywardAutomationNM") == 0) then
-        player:setCharVar("TheWaywardAutomationNM", 1)
+    if theWaywardAutomaton == QUEST_ACCEPTED and theWaywardAutomatonProgress == 2 and player:getCharVar("TheWaywardAutomatonNM") == 0 then
+        player:setCharVar("TheWaywardAutomatonNM", 1)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Allows the completion of PUP AF1 The Wayward Automaton.
Currently the Caedarva Toad NM does not set the correct charvars that would allow the player to complete the quest.

## Steps to test these changes

Accept the quest,
Kill NM,
Complete quest.
