### PR TITLE
[lgtm] Fix Wider type comparison and always-true conditions reported in LGTM

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -18,6 +18,14 @@ xi.settings.map =
     MAX_TIME_LASTUPDATE = 60,
 
     -- --------------------------------
+    -- SQL settings
+    -- --------------------------------
+
+    -- Used by serverutils::PersistServerVar() for the maximum attempts to retry verification
+    -- of a written Server Variable.
+    SETVAR_RETRY_MAX = 3,
+
+    -- --------------------------------
     -- Game settings
     -- --------------------------------
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -814,7 +814,7 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
             PacketList_t packetList = PChar->getPacketList();
             packets                 = 0;
 
-            while (!packetList.empty() && *buffsize + packetList.front()->getSize() < MAX_BUFFER_SIZE && packets < PacketCount)
+            while (!packetList.empty() && *buffsize + packetList.front()->getSize() < MAX_BUFFER_SIZE && static_cast<size_t>(packets) < PacketCount)
             {
                 PSmallPacket = packetList.front();
                 packetList.pop_front();

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1272,7 +1272,8 @@ namespace petutils
                 cost = 13;
             }
         }
-        else if ((id >= PETID_IFRIT && id <= PETID_DIABOLOS) || id == PETID_SIREN)
+        // NOTE: This condition covers PETID_IFRIT through the below conditions
+        else if (id <= PETID_DIABOLOS || id == PETID_SIREN)
         {
             if (level < 10)
             {

--- a/src/map/utils/serverutils.cpp
+++ b/src/map/utils/serverutils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -106,8 +106,7 @@ namespace serverutils
         int32 tries  = 0;
         int32 verify = INT_MIN;
 
-        // TODO: Move into new-style settings
-        auto SETVAR_RETRY_MAX = 3;
+        auto setVarMaxRetry = settings::get<uint8>("map.SETVAR_RETRY_MAX");
 
         do
         {
@@ -123,7 +122,7 @@ namespace serverutils
                 sql->Query("INSERT INTO server_variables VALUES ('%s', %i) ON DUPLICATE KEY UPDATE value = %i;", name, value, value);
             }
 
-            if (SETVAR_RETRY_MAX > 0)
+            if (setVarMaxRetry > 0)
             {
                 // Cannot usleep(microseconds) or use std::this_thread::sleep_for(std::chrono::microseconds(usec))
                 // because, you guessed it, DSP design.  Close inspection of other DSP code shows sleeping is not
@@ -155,6 +154,6 @@ namespace serverutils
             {
                 break;
             }
-        } while (verify != value && tries < SETVAR_RETRY_MAX);
+        } while (verify != value && tries < setVarMaxRetry);
     }
 } // namespace serverutils

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -550,10 +550,11 @@ void HandleAuctionHouseRequest(CTCPRequestPacket& PTCPRequest)
     for (uint8 i = 0; i < PacketsCount; ++i)
     {
         CAHItemsListPacket PAHPacket(20 * i);
+        uint16             itemListSize = static_cast<uint16>(ItemList.size());
 
-        PAHPacket.SetItemCount((uint16)ItemList.size());
+        PAHPacket.SetItemCount(itemListSize);
 
-        for (uint16 y = 20 * i; (y != 20 * (i + 1)) && (y < ItemList.size()); ++y)
+        for (uint16 y = 20 * i; (y != 20 * (i + 1)) && (y < itemListSize); ++y)
         {
             PAHPacket.AddItem(ItemList.at(y));
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
* Adds SETVAR_RETRY_MAX to new settings format
* Fixes comparison of wider type in send_parse
* Removes always-true condition in petutils
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
