### PR TITLE
[Trust] Extend setTrustTPSkillSettings and add CLOSER_UNTIL_TP Gambit

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -89,8 +89,9 @@ ai.s = ai.select
 -- TP Move Trigger
 ai.tp =
 {
-    ASAP   = 0,
-    RANDOM = 1,
-    OPENER = 2,
-    CLOSER = 3,
+    ASAP            = 0,
+    RANDOM          = 1,
+    OPENER          = 2,
+    CLOSER          = 3,    -- Will Hold TP Indefinitely to close a SC
+    CLOSER_UNTIL_TP = 4,    -- Will Hold TP to close a SC until a certain threshold
 }

--- a/scripts/globals/spells/trust/shantotto_ii.lua
+++ b/scripts/globals/spells/trust/shantotto_ii.lua
@@ -41,7 +41,7 @@ spell_object.onMobSpawn = function(mob)
 
     -- TODO: Her regular attacks have a big range (distance from mob, not AoE)
 
-    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.HIGHEST)
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 2500)
 
     mob:addListener("WEAPONSKILL_USE", "SHANTOTTO_II_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
         if wsid == 3740 then -- Final Exam

--- a/scripts/globals/spells/trust/shikaree_z.lua
+++ b/scripts/globals/spells/trust/shikaree_z.lua
@@ -53,8 +53,7 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.TARGET, ai.c.ALWAYS, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.HIGH_JUMP)
     mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0, ai.r.JA, ai.s.SPECIFIC, xi.ja.SUPER_JUMP)
 
-    -- TODO: Hold TP to 2000 before closing SC
-    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.HIGHEST)
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 2000)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/tenzen.lua
+++ b/scripts/globals/spells/trust/tenzen.lua
@@ -36,7 +36,7 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.SELF, ai.c.HAS_TOP_ENMITY, 0,
         ai.r.JA, ai.s.SPECIFIC, xi.ja.THIRD_EYE)
 
-    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.HIGHEST)
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 1500)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/zeid_ii.lua
+++ b/scripts/globals/spells/trust/zeid_ii.lua
@@ -41,7 +41,7 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.SELF, ai.c.ALWAYS, 0,
                         ai.r.JA, ai.s.SPECIFIC, xi.ja.LAST_RESORT)
 
-    mob:setTrustTPSkillSettings(ai.tp.CLOSER, ai.s.RANDOM)
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.RANDOM, 3000)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -818,8 +818,25 @@ namespace gambits
                     return result;
                     break;
                 }
-                case G_TP_TRIGGER::CLOSER:
+                case G_TP_TRIGGER::CLOSER: // Hold TP indefinitely to close a SC.
                 {
+                    auto* PSCEffect = target->StatusEffectContainer->GetStatusEffect(EFFECT_SKILLCHAIN);
+
+                    // TODO: ...and has a valid WS...
+
+                    return PSCEffect && PSCEffect->GetStartTime() + 3s < server_clock::now() && PSCEffect->GetTier() == 0;
+                    break;
+                }
+                case G_TP_TRIGGER::CLOSER_UNTIL_TP: // Will hold TP to close a SC, but WS immediately once specified value is reached.
+                {
+                    if (tp_value <= 1500) // If the value provided by the script is missing or too low
+                    {
+                        tp_value = 1500; // Apply the minimum TP Hold Threshold
+                    }
+                    if (POwner->health.tp >= tp_value) // tp_value reached
+                    {
+                        return true; // Time to WS!
+                    }
                     auto* PSCEffect = target->StatusEffectContainer->GetStatusEffect(EFFECT_SKILLCHAIN);
 
                     // TODO: ...and has a valid WS...

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -86,10 +86,11 @@ namespace gambits
 
     enum class G_TP_TRIGGER : uint16
     {
-        ASAP   = 0,
-        RANDOM = 1,
-        OPENER = 2,
-        CLOSER = 3,
+        ASAP            = 0,
+        RANDOM          = 1,
+        OPENER          = 2,
+        CLOSER          = 3,    // Will Hold TP Indefinitely to close a SC
+        CLOSER_UNTIL_TP = 4,    // Will Hold TP to close a SC until a certain threshold
     };
 
     struct Predicate_t
@@ -230,6 +231,7 @@ namespace gambits
         std::vector<TrustSkill_t> tp_skills;
         G_TP_TRIGGER              tp_trigger;
         G_SELECT                  tp_select;
+        uint16                    tp_value;
 
     private:
         bool CheckTrigger(CBattleEntity* trigger_target, Predicate_t& predicate);

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -89,8 +89,8 @@ namespace gambits
         ASAP            = 0,
         RANDOM          = 1,
         OPENER          = 2,
-        CLOSER          = 3,    // Will Hold TP Indefinitely to close a SC
-        CLOSER_UNTIL_TP = 4,    // Will Hold TP to close a SC until a certain threshold
+        CLOSER          = 3, // Will Hold TP Indefinitely to close a SC
+        CLOSER_UNTIL_TP = 4, // Will Hold TP to close a SC until a certain threshold
     };
 
     struct Predicate_t

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11883,22 +11883,27 @@ void CLuaBaseEntity::addSimpleGambit(uint16 targ, uint16 cond, uint32 condition_
 }
 
 /************************************************************************
- *  Function: setTrustTPSkillSettings(trigger, select)
+ *  Function: setTrustTPSkillSettings(trigger, select, value)
  *  Purpose :
- *  Example : mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
+ *  Example : mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 1500)
+ *  Notes   : value is optional TP Value
  ************************************************************************/
 
-void CLuaBaseEntity::setTrustTPSkillSettings(uint16 trigger, uint16 select)
+void CLuaBaseEntity::setTrustTPSkillSettings(uint16 trigger, uint16 select, sol::object const& value)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
 
     using namespace gambits;
+
+    // Optional
+    uint16 tp_value = (value != sol::lua_nil) ? value.as<uint16>() : 0;
 
     auto* trust      = static_cast<CTrustEntity*>(m_PBaseEntity);
     auto* controller = static_cast<CTrustController*>(trust->PAI->GetController());
 
     controller->m_GambitsContainer->tp_trigger = static_cast<G_TP_TRIGGER>(trigger);
     controller->m_GambitsContainer->tp_select  = static_cast<G_SELECT>(select);
+    controller->m_GambitsContainer->tp_value   = tp_value;
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -680,7 +680,7 @@ public:
     void   trustPartyMessage(uint32 message_id);
     void   addSimpleGambit(uint16 targ, uint16 cond, uint32 condition_arg, uint16 react, uint16 select, uint32 selector_arg, sol::object const& retry);
     int32  addFullGambit(lua_State*);
-    void   setTrustTPSkillSettings(uint16 trigger, uint16 select);
+    void   setTrustTPSkillSettings(uint16 trigger, uint16 select, sol::object const& value);
 
     bool isJugPet(); // If the entity has a pet, test if it is a jug pet.
     bool hasValidJugPetItem();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

* Extends setTrustTPSkillSettings to accept optional TP Value, and updates Notes to explain optional usage
* Adds `CLOSER_UNTIL_TP` Gambit which will Hold TP to close a SC until a certain TP Threshold is met/exceeded
* Adds comments to explain Gambit Usage/Behavior
* Updates the 4 Trust scripts that utilized `CLOSER` to use `CLOSER_UNTIL_TP` instead.
* TP thresholds based on BGWiki details: https://www.bg-wiki.com/ffxi/BGWiki:Trusts

## Steps to test these changes

- Add Trusts with CLOSER_UNTIL_TP Gambit:

    `Tenzen (908)` - 1500 TP
    `Shikaree Z (915)` - 2000 TP
    `Zeid II (1010)` - 3000 TP

- Case 1: 

    - Set the trust to just under their Hold Until TP Value (e.g. `!tp 1400` for Tenzen)
    - Engage a mob, observe that the Trust will WS when it hits the defined threshold instead of holding TP

- Case 2:

    - Set the trust to well under their Hold Until TP Value (e.g. `!tp 1000` for Zeid II)
    - Engage a mob, use a WS that will open a skillchain (e.g. Wheeling Thrust)
    - Observe that trust closes SC properly even when they have enough TP, but are under their Hold Until value.