### PR TITLE
Adjust SMN BP to use current TP when using BPs, initialize uninitialized variable in mob/petskill

### DIFF
--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(45 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(325 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(45 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(325 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -15,7 +15,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(45 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -15,7 +15,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(325 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -13,10 +13,11 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
+
     if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.GEOCRUSH)
     end

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -13,10 +13,11 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
+
     if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.GRANDFALL)
     end

--- a/scripts/globals/abilities/pets/healing_ruby.lua
+++ b/scripts/globals/abilities/pets/healing_ruby.lua
@@ -13,9 +13,9 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local base = 14+target:getMainLvl()+skill:getTP()/12
+    local base = 14+target:getMainLvl()+pet:getTP()/12
     if (pet:getMainLvl()>30) then
-        base = 44 + 3*(pet:getMainLvl()-30) + skill:getTP()/12 * (pet:getMainLvl()*0.075 - 1)
+        base = 44 + 3*(pet:getMainLvl()-30) + pet:getTP()/12 * (pet:getMainLvl()*0.075 - 1)
     end
 
     if (target:getHP()+base > target:getMaxHP()) then

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -13,10 +13,11 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
+
     if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.HEAVENLY_STRIKE)
     end

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -13,10 +13,11 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
+
     if master ~= nil and master:isPC() then
         merits = master:getMerit(xi.merit.METEOR_STRIKE)
     end

--- a/scripts/globals/abilities/pets/meteorite.lua
+++ b/scripts/globals/abilities/pets/meteorite.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dint = pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-    local dmg = 500 + dint*1.5 + skill:getTP()/20
+    local dmg = 500 + dint*1.5 + pet:getTP()/20
     target:updateEnmityFromDamage(pet, dmg)
     target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.LIGHT)
     return dmg

--- a/scripts/globals/abilities/pets/spring_water.lua
+++ b/scripts/globals/abilities/pets/spring_water.lua
@@ -14,7 +14,8 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local base = 47 + pet:getMainLvl()*3
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
+
     if tp < 1000 then
         tp = 1000
     end

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp = pet:getTP()
 
     local damage = math.floor(45 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -13,10 +13,10 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
-
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP()
     local damage = math.floor(325 + 0.025 * tp)
+
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -28,7 +28,7 @@ ability_object.onPetAbility = function(target, pet, skill)
     --add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
     damage.dmg = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, 1)
 
-    local tp = skill:getTP()
+    local tp = pet:getTP()
     if tp < 1000 then
         tp = 1000
     end

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -13,8 +13,8 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
 

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -14,7 +14,7 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
     local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
+    local tp   = pet:getTP()
 
     local damage = math.floor(45 + 0.025*(tp))
     damage = damage + (dINT * 1.5)

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -13,10 +13,10 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onPetAbility = function(target, pet, skill)
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP()
-
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP()
     local damage = math.floor(325 + 0.025*(tp))
+
     damage = damage + (dINT * 1.5)
     damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Geocrush
+-- Wind Blade
 -----------------------------------
 require("scripts/globals/settings")
 require("scripts/globals/status")
@@ -14,8 +14,8 @@ end
 
 ability_object.onPetAbility = function(target, pet, skill)
 
-    local dINT = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
-    local tp = skill:getTP() / 10
+    local dINT   = math.floor(pet:getStat(xi.mod.INT) - target:getStat(xi.mod.INT))
+    local tp     = pet:getTP() / 10
     local master = pet:getMaster()
     local merits = 0
     if master ~= nil and master:isPC() then

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CMobSkillState::CMobSkillState(CMobEntity* PEntity, uint16 targid, uint16 wsid)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
+, m_spentTP(0)
 {
     auto* skill = battleutils::GetMobSkill(wsid);
     if (!skill)

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
+, m_spentTP(0)
 {
     auto* skill = battleutils::GetPetSkill(wsid);
     if (!skill)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

While implementing siren I noticed random/garbage TP values cropping up from this call in lua: `ability:getTP()`, which eventually reads from this variable: `m_spentTP`

That variable is _only_ set here:
```
void CMobSkillState::SpendCost()
{
    if (m_PSkill->isTpSkill())
    {
        m_spentTP  = m_PEntity->health.tp;
        m_PEntity->health.tp = 0;
    }
}
```

And what is `isTpSkill()` you might ask?

```
bool CMobSkill::isTpSkill() const
{
    return !isSpecial() && !isAttackReplacement();
}
```

isSpecial is a flag, 0x04 in `mob_skill_flag` in the db. At a glance it seems that _all_ BPs set the special flag. Therefore, m_spentTP was whatever garbage was in memory when creating MobSkillState/PetSkillState. Aside from that, avatars (and mobs while we're at it) don't use a _stale_ value of when the move was readied for TP, but their current TP value. 

Drafting for comments while I test every BP affected to see if they still work.