### PR TITLE
Add mod NULL_BREATH_DAMAGE

### DIFF
--- a/documentation/mods_by_id.txt
+++ b/documentation/mods_by_id.txt
@@ -249,8 +249,9 @@
     DUAL_WIELD                   = 259, // Percent reduction in dual wield delay.
     CURE_POTENCY_II              = 260, // % cure potency II | bonus from gear is capped at 30
 
-    // SPARE IDs 261 to 287
+    // SPARE IDs 261 to 286
 
+    NULL_BREATH_DAMAGE           = 287, // Occasionally annuls damage from breath attacks, in percents
     DOUBLE_ATTACK                = 288, // Percent chance to proc
     SUBTLE_BLOW                  = 289, // How much TP to reduce.
     ENF_MAG_POTENCY              = 290, // Increases Enfeebling magic potency %

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1364,6 +1364,7 @@ xi.mod =
     MAGIC_DAMAGE                    = 311, --  Magic damage added directly to the spell's base damage
 
     -- Gear set modifiers
+    NULL_BREATH_DAMAGE              = 287,  -- Occasionally annuls damage from breath attacks, in percents
     DA_DOUBLE_DMG_RATE              = 408,  -- Double attack's double damage chance %.
     TA_TRIPLE_DMG_RATE              = 409,  -- Triple attack's triple damage chance %.
     ZANSHIN_DOUBLE_DAMAGE           = 410,  -- Zanshin's double damage chance %.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -686,6 +686,7 @@ enum class Mod
     WYVERN_BREATH = 402, //
 
     // Gear set modifiers
+    NULL_BREATH_DAMAGE       = 287, // Occasionally annuls damage from breath attacks, in percents
     DA_DOUBLE_DMG_RATE       = 408, // Double attack's double damage chance %.
     TA_TRIPLE_DMG_RATE       = 409, // Triple attack's triple damage chance %.
     ZANSHIN_DOUBLE_DAMAGE    = 410, // Zanshin's double damage chance %.
@@ -899,7 +900,7 @@ enum class Mod
     // 156 to 159
     // 192 to 223
     // 239
-    // 261 to 287
+    // 261 to 286
     // 888
     // 936
     //

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5187,7 +5187,7 @@ namespace battleutils
         }
         else if (xirand::GetRandomNumber(100) < PDefender->getMod(Mod::NULL_BREATH_DAMAGE))
         {
-        damage = 0;
+            damage = 0;
         }
         else
         {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5185,6 +5185,10 @@ namespace battleutils
         {
             damage = -damage;
         }
+        else if (xirand::GetRandomNumber(100) < PDefender->getMod(Mod::NULL_BREATH_DAMAGE))
+        {
+        damage = 0;
+        }
         else
         {
             damage           = HandleSevereDamage(PDefender, damage, false);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds mod NULL_BREATH_DAMAGE to occasionally nullify breath damage

## Steps to test these changes

Take breath damage with porog cask+1 mods equiped

