### PR TITLE
[LUA] Add missing returns to Chakra and Chi Blast

### DIFF
--- a/scripts/globals/abilities/chakra.lua
+++ b/scripts/globals/abilities/chakra.lua
@@ -14,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useChakra(player, target, ability)
+    return xi.job_utils.monk.useChakra(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/chi_blast.lua
+++ b/scripts/globals/abilities/chi_blast.lua
@@ -14,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.monk.useChiBlast(player, target, ability)
+    return xi.job_utils.monk.useChiBlast(player, target, ability)
 end
 
 return ability_object


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adds missing `return` to Chakra and Chi Blast files.
Bug presents itself as abilities returning 0 HP restored or 0 damage inflicted.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Upload changes to your server.
2. Use the `!changejob mnk 99` command.
3. Target yourself and use the `!hp 1` command.
4. Use Chakra and confirm HP restored is not registering as 0.
5. Target a mob, use Chi Blast, and confirm damage is not registering as 0.