### PR TITLE
[Settings] [HNM] Move era functionality to modules

### DIFF
--- a/modules/custom/lua/custom_HNM_system.lua
+++ b/modules/custom/lua/custom_HNM_system.lua
@@ -1,0 +1,161 @@
+-----------------------------------
+-- Common Requires
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/npc_util")
+require("scripts/globals/status")
+require("scripts/globals/zone")
+
+-----------------------------------
+-- ID Requires
+-----------------------------------
+local dragonsAeryID   = require("scripts/zones/Dragons_Aery/IDs")
+local valleySorrowsID = require("scripts/zones/Valley_of_Sorrows/IDs")
+local behemothDomID   = require("scripts/zones/Behemoths_Dominion/IDs")
+
+-----------------------------------
+-- Module definition
+-----------------------------------
+local hnmSystem = Module:new("custom_HNM_System")
+
+-- NOTE: This module attempts to mix both era and retail styles for Land Kings.
+-- It allows NQ Kings to retain their era timed rotation while allowing HQ Kings to be poped from their QMs. For Uncle Teo.
+-- It comes along a ToD perpetuation/retainment system, for server crashes, since this NMs were usually contested by endgame LSs.
+-- Do not use along era_HNM_System module. Choose one or the other.
+
+----------------------------------------------------------------------------------------------------
+-- Dragon's Aery: Fafnir, Nidhogg
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.Zone.onInitialize", function(zone)
+    local hnmPopTime = GetServerVariable("[HNM]Fafnir")   -- Time the NM will spawn at.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Fafnir", hnmPopTime) -- Save pop time.
+    end
+
+    UpdateNMSpawnPoint(dragonsAeryID.mob.FAFNIR)
+
+    -- Spawn mob or set spawn time.
+    if hnmPopTime <= os.time() then
+        SpawnMob(dragonsAeryID.mob.FAFNIR)
+    else
+        GetMobByID(dragonsAeryID.mob.FAFNIR):setRespawnTime(hnmPopTime - os.time())
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.mobs.Fafnir.onMobDespawn", function(mob)
+    super(mob)
+
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Fafnir", os.time() + randomPopTime) -- Save next pop time.
+
+    -- Set spawn time and position.
+    GetMobByID(dragonsAeryID.mob.FAFNIR):setRespawnTime(randomPopTime)
+    UpdateNMSpawnPoint(dragonsAeryID.mob.FAFNIR)
+end)
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.npcs.qm0.onTrade", function(player, npc, trade)
+    if not GetMobByID(dragonsAeryID.mob.FAFNIR):isSpawned() and not GetMobByID(dragonsAeryID.mob.NIDHOGG):isSpawned() then
+        if npcUtil.tradeHasExactly(trade, 3340) and npcUtil.popFromQM(player, npc, dragonsAeryID.mob.NIDHOGG) then
+            player:confirmTrade()
+        end
+    end
+end)
+
+----------------------------------------------------------------------------------------------------
+-- Valley of Sorrows: Adamantoise, Aspidochelone
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.Zone.onInitialize", function(zone)
+    local hnmPopTime = GetServerVariable("[HNM]Adamantoise")   -- Time the NM will spawn at.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Adamantoise", hnmPopTime) -- Save pop time.
+    end
+
+    UpdateNMSpawnPoint(valleySorrowsID.mob.ADAMANTOISE)
+
+    -- Spawn mob or set spawn time.
+    if hnmPopTime <= os.time() then
+        SpawnMob(valleySorrowsID.mob.ADAMANTOISE)
+    else
+        GetMobByID(valleySorrowsID.mob.ADAMANTOISE):setRespawnTime(hnmPopTime - os.time())
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.mobs.Adamantoise.onMobDespawn", function(mob)
+    super(mob)
+
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Adamantoise", os.time() + randomPopTime) -- Save next pop time.
+
+    -- Set spawn time and position.
+    GetMobByID(valleySorrowsID.mob.ADAMANTOISE):setRespawnTime(randomPopTime)
+    UpdateNMSpawnPoint(valleySorrowsID.mob.ADAMANTOISE)
+end)
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.npcs.qm1.onTrade", function(player, npc, trade)
+    if not GetMobByID(valleySorrowsID.mob.ADAMANTOISE):isSpawned() and not GetMobByID(valleySorrowsID.mob.ASPIDOCHELONE):isSpawned() then
+        if npcUtil.tradeHasExactly(trade, 3344) and npcUtil.popFromQM(player, npc, valleySorrowsID.mob.ASPIDOCHELONE) then
+            player:confirmTrade()
+        end
+    end
+end)
+
+----------------------------------------------------------------------------------------------------
+-- Behemoth's Dominion: Behemoth, King Behemoth
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.Zone.onInitialize", function(zone)
+    local hnmPopTime = GetServerVariable("[HNM]Behemoth")   -- Time the NM will spawn at.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Behemoth", hnmPopTime) -- Save pop time.
+    end
+
+    UpdateNMSpawnPoint(behemothDomID.mob.BEHEMOTH)
+
+    -- Spawn mob or set spawn time.
+    if hnmPopTime <= os.time() then
+        SpawnMob(behemothDomID.mob.BEHEMOTH)
+    else
+        GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(hnmPopTime - os.time())
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.mobs.Behemoth.onMobDespawn", function(mob)
+    super(mob)
+
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Behemoth", os.time() + randomPopTime) -- Save next pop time.
+
+    -- Set spawn time and position.
+    GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(randomPopTime)
+    UpdateNMSpawnPoint(behemothDomID.mob.BEHEMOTH)
+end)
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.npcs.qm2.onTrade", function(player, npc, trade)
+    if not GetMobByID(behemothDomID.mob.BEHEMOTH):isSpawned() and not GetMobByID(behemothDomID.mob.KING_BEHEMOTH):isSpawned() then
+        if npcUtil.tradeHasExactly(trade, 3342) and npcUtil.popFromQM(player, npc, behemothDomID.mob.KING_BEHEMOTH) then
+            player:confirmTrade()
+        end
+    end
+end)
+
+return hnmSystem

--- a/modules/era/lua/era_HNM_system.lua
+++ b/modules/era/lua/era_HNM_system.lua
@@ -1,0 +1,264 @@
+-----------------------------------
+-- Common Requires
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/conquest")
+require("scripts/globals/zone")
+
+-----------------------------------
+-- ID Requires
+-----------------------------------
+local dragonsAeryID   = require("scripts/zones/Dragons_Aery/IDs")
+local valleySorrowsID = require("scripts/zones/Valley_of_Sorrows/IDs")
+local behemothDomID   = require("scripts/zones/Behemoths_Dominion/IDs")
+
+-----------------------------------
+-- Module definition
+-----------------------------------
+local hnmSystem = Module:new("era_HNM_System")
+
+-- NOTE: This module attempts to replicate old Land King pop system in an era-accurate way.
+-- It comes along a ToD perpetuation/retainment system, for server crashes, since this NMs were usually contested by endgame LSs.
+-- Do not use along custom_HNM_System module. Choose one or the other.
+
+----------------------------------------------------------------------------------------------------
+-- Dragon's Aery: Fafnir, Nidhogg
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.Zone.onInitialize", function(zone)
+    local hnmPopTime   = GetServerVariable("[HNM]Fafnir")   -- Time the NM will spawn at.
+    local hnmKillCount = GetServerVariable("[HNM]Fafnir_C") -- Number of times NQ King has been slain in a row.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Fafnir", hnmPopTime) -- Save pop time.
+    end
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(dragonsAeryID.mob.NIDHOGG)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(dragonsAeryID.mob.NIDHOGG)
+        else
+            GetMobByID(dragonsAeryID.mob.NIDHOGG):setRespawnTime(hnmPopTime - os.time())
+        end
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(dragonsAeryID.mob.FAFNIR)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(dragonsAeryID.mob.FAFNIR)
+        else
+            GetMobByID(dragonsAeryID.mob.FAFNIR):setRespawnTime(hnmPopTime - os.time())
+        end
+    end
+
+    -- Hide ??? NPC.
+    GetNPCByID(dragonsAeryID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)
+end)
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.mobs.Fafnir.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+    local hnmKillCount  = GetServerVariable("[HNM]Fafnir_C") + 1
+
+    SetServerVariable("[HNM]Fafnir", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Fafnir_C", hnmKillCount)            -- Save kill count.
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(dragonsAeryID.mob.NIDHOGG)
+
+        -- Set spawn time.
+        GetMobByID(dragonsAeryID.mob.NIDHOGG):setRespawnTime(randomPopTime)
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(dragonsAeryID.mob.FAFNIR)
+
+        -- Set spawn time.
+        GetMobByID(dragonsAeryID.mob.FAFNIR):setRespawnTime(randomPopTime)
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Dragons_Aery.mobs.Nidhogg.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Fafnir", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Fafnir_C", 0)                       -- Save kill count.
+
+    -- Setup NQ King.
+    UpdateNMSpawnPoint(dragonsAeryID.mob.FAFNIR)
+
+    -- Set spawn time.
+    GetMobByID(dragonsAeryID.mob.FAFNIR):setRespawnTime(randomPopTime)
+end)
+
+----------------------------------------------------------------------------------------------------
+-- Valley of Sorrows: Adamantoise, Aspidochelone
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.Zone.onInitialize", function(zone)
+    local hnmPopTime   = GetServerVariable("[HNM]Adamantoise")   -- Time the NM will spawn at.
+    local hnmKillCount = GetServerVariable("[HNM]Adamantoise_C") -- Number of times NQ King has been slain in a row.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Adamantoise", hnmPopTime) -- Save pop time.
+    end
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(valleySorrowsID.mob.ASPIDOCHELONE)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(valleySorrowsID.mob.ASPIDOCHELONE)
+        else
+            GetMobByID(valleySorrowsID.mob.ASPIDOCHELONE):setRespawnTime(hnmPopTime - os.time())
+        end
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(valleySorrowsID.mob.ADAMANTOISE)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(valleySorrowsID.mob.ADAMANTOISE)
+        else
+            GetMobByID(valleySorrowsID.mob.ADAMANTOISE):setRespawnTime(hnmPopTime - os.time())
+        end
+    end
+
+    -- Hide ??? NPC.
+    GetNPCByID(valleySorrowsID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
+end)
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.mobs.Adamantoise.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+    local hnmKillCount  = GetServerVariable("[HNM]Adamantoise_C") + 1
+
+    SetServerVariable("[HNM]Adamantoise", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Adamantoise_C", hnmKillCount)            -- Save kill count.
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(valleySorrowsID.mob.ASPIDOCHELONE)
+
+        -- Set spawn time.
+        GetMobByID(valleySorrowsID.mob.ASPIDOCHELONE):setRespawnTime(randomPopTime)
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(valleySorrowsID.mob.ADAMANTOISE)
+
+        -- Set spawn time.
+        GetMobByID(valleySorrowsID.mob.ADAMANTOISE):setRespawnTime(randomPopTime)
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Valley_of_Sorrows.mobs.Aspidochelone.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Adamantoise", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Adamantoise_C", 0)                       -- Save kill count.
+
+    -- Setup NQ King.
+    UpdateNMSpawnPoint(valleySorrowsID.mob.ADAMANTOISE)
+
+    -- Set spawn time.
+    GetMobByID(valleySorrowsID.mob.ADAMANTOISE):setRespawnTime(randomPopTime)
+end)
+
+----------------------------------------------------------------------------------------------------
+-- Behemoth's Dominion: Behemoth, King Behemoth
+----------------------------------------------------------------------------------------------------
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.Zone.onInitialize", function(zone)
+    local hnmPopTime   = GetServerVariable("[HNM]Behemoth")   -- Time the NM will spawn at.
+    local hnmKillCount = GetServerVariable("[HNM]Behemoth_C") -- Number of times NQ King has been slain in a row.
+
+    -- First-time setup.
+    if hnmPopTime == 0 then
+        hnmPopTime = os.time() + math.random(1, 48) * 1800
+
+        SetServerVariable("[HNM]Behemoth", hnmPopTime) -- Save pop time.
+    end
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(behemothDomID.mob.KING_BEHEMOTH)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(behemothDomID.mob.KING_BEHEMOTH)
+        else
+            GetMobByID(behemothDomID.mob.KING_BEHEMOTH):setRespawnTime(hnmPopTime - os.time())
+        end
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(behemothDomID.mob.BEHEMOTH)
+
+        -- Spawn mob or set spawn time.
+        if hnmPopTime <= os.time() then
+            SpawnMob(behemothDomID.mob.BEHEMOTH)
+        else
+            GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(hnmPopTime - os.time())
+        end
+    end
+
+    -- Hide ??? NPC.
+    GetNPCByID(behemothDomID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
+end)
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.mobs.Behemoth.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+    local hnmKillCount  = GetServerVariable("[HNM]Behemoth_C") + 1
+
+    SetServerVariable("[HNM]Behemoth", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Behemoth_C", hnmKillCount)            -- Save kill count.
+
+    -- HQ King.
+    if hnmKillCount > 3 and (math.random(1, 5) == 3 or hnmKillCount > 6) then
+        UpdateNMSpawnPoint(behemothDomID.mob.KING_BEHEMOTH)
+
+        -- Set spawn time.
+        GetMobByID(behemothDomID.mob.KING_BEHEMOTH):setRespawnTime(randomPopTime)
+
+    -- NQ King.
+    else
+        UpdateNMSpawnPoint(behemothDomID.mob.BEHEMOTH)
+
+        -- Set spawn time.
+        GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(randomPopTime)
+    end
+end)
+
+hnmSystem:addOverride("xi.zones.Behemoths_Dominion.mobs.King_Behemoth.onMobDespawn", function(mob)
+    -- Server Variable work.
+    local randomPopTime = 75600 + math.random(0, 6) * 1800
+
+    SetServerVariable("[HNM]Behemoth", os.time() + randomPopTime) -- Save next pop time.
+    SetServerVariable("[HNM]Behemoth_C", 0)                       -- Save kill count.
+
+    -- Setup NQ King.
+    UpdateNMSpawnPoint(behemothDomID.mob.BEHEMOTH)
+
+    -- Set spawn time.
+    GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(randomPopTime)
+end)
+
+return hnmSystem

--- a/scripts/zones/Behemoths_Dominion/Zone.lua
+++ b/scripts/zones/Behemoths_Dominion/Zone.lua
@@ -2,16 +2,12 @@
 -- Zone: Behemoths_Dominion (127)
 -----------------------------------
 local ID = require("scripts/zones/Behemoths_Dominion/IDs")
-require("scripts/globals/settings")
+require("scripts/globals/conquest")
 require("scripts/globals/zone")
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
-    if xi.settings.main.LandKingSystem_NQ ~= 1 then
-        UpdateNMSpawnPoint(ID.mob.BEHEMOTH)
-        GetMobByID(ID.mob.BEHEMOTH):setRespawnTime(900 + math.random(0, 6) * 1800)
-    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)

--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -4,21 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Behemoths_Dominion/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
-    end
-    if xi.settings.main.LandKingSystem_HQ == 0 then
-        SetDropRate(270, 3342, 0) -- do not drop savory_shank
-    end
-
     mob:setLocalVar("[rage]timer", 1800) -- 30 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
@@ -26,30 +21,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    local timeOfDeath = GetServerVariable("[POP]King_Behemoth")
-    local kills       = GetServerVariable("[PH]King_Behemoth")
-    local popNow      = (math.random(1, 5) == 3 or kills > 6)
-
-    if xi.settings.main.LandKingSystem_HQ ~= 1 and timeOfDeath <= os.time() and popNow then
-        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
-        if xi.settings.main.LandKingSystem_NQ == 0 then
-            DisallowRespawn(ID.mob.BEHEMOTH, true)
-        end
-
-        DisallowRespawn(ID.mob.KING_BEHEMOTH, false)
-        UpdateNMSpawnPoint(ID.mob.KING_BEHEMOTH)
-        GetMobByID(ID.mob.KING_BEHEMOTH):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    else
-        if xi.settings.main.LandKingSystem_NQ ~= 1 then
-            UpdateNMSpawnPoint(ID.mob.BEHEMOTH)
-            GetMobByID(ID.mob.BEHEMOTH):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-            SetServerVariable("[PH]King_Behemoth", kills + 1)
-        end
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -4,7 +4,6 @@
 -----------------------------------
 local ID = require("scripts/zones/Behemoths_Dominion/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 require("scripts/globals/magic")
@@ -18,11 +17,10 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
-    end
-
     mob:setLocalVar("[rage]timer", 3600) -- 60 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.BEHEMOTH_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
@@ -44,26 +42,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Set King_Behemoth's Window Open Time
-    if xi.settings.main.LandKingSystem_HQ ~= 1 then
-        local wait = 72 * 3600
-        SetServerVariable("[POP]King_Behemoth", os.time() + wait) -- 3 days
-        if xi.settings.main.LandKingSystem_HQ == 0 then -- Is time spawn only
-            DisallowRespawn(mob:getID(), true)
-        end
-    end
-
-    -- Set Behemoth's spawnpoint and respawn time (21-24 hours)
-    if xi.settings.main.LandKingSystem_NQ ~= 1 then
-        SetServerVariable("[PH]King_Behemoth", 0)
-        DisallowRespawn(ID.mob.BEHEMOTH, false)
-        UpdateNMSpawnPoint(ID.mob.BEHEMOTH)
-        GetMobByID(ID.mob.BEHEMOTH):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.BEHEMOTH_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
+++ b/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
@@ -6,22 +6,18 @@
 -----------------------------------
 local ID = require("scripts/zones/Behemoths_Dominion/IDs")
 require("scripts/globals/npc_util")
-require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onSpawn = function(npc)
-    if xi.settings.main.LandKingSystem_NQ < 1 and xi.settings.main.LandKingSystem_HQ < 1 then
-        npc:setStatus(xi.status.DISAPPEAR)
-    end
 end
 
 entity.onTrade = function(player, npc, trade)
     if not GetMobByID(ID.mob.BEHEMOTH):isSpawned() and not GetMobByID(ID.mob.KING_BEHEMOTH):isSpawned() then
-        if xi.settings.main.LandKingSystem_NQ ~= 0 and npcUtil.tradeHas(trade, 3341) and npcUtil.popFromQM(player, npc, ID.mob.BEHEMOTH) then
+        if npcUtil.tradeHasExactly(trade, 3341) and npcUtil.popFromQM(player, npc, ID.mob.BEHEMOTH) then
             player:confirmTrade()
-        elseif xi.settings.main.LandKingSystem_HQ ~= 0 and npcUtil.tradeHas(trade, 3342) and npcUtil.popFromQM(player, npc, ID.mob.KING_BEHEMOTH) then
+        elseif npcUtil.tradeHasExactly(trade, 3342) and npcUtil.popFromQM(player, npc, ID.mob.KING_BEHEMOTH) then
             player:confirmTrade()
         end
     end

--- a/scripts/zones/Dragons_Aery/Zone.lua
+++ b/scripts/zones/Dragons_Aery/Zone.lua
@@ -1,34 +1,27 @@
 -----------------------------------
---
 -- Zone: Dragons_Aery (154)
---
 -----------------------------------
 local ID = require("scripts/zones/Dragons_Aery/IDs")
 require("scripts/globals/conquest")
-require("scripts/globals/settings")
 require("scripts/globals/zone")
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
-    if (xi.settings.main.LandKingSystem_NQ ~= 1) then
-        UpdateNMSpawnPoint(ID.mob.FAFNIR)
-        GetMobByID(ID.mob.FAFNIR):setRespawnTime(900 + math.random(0, 6) * 1800)
-    end
+end
+
+zone_object.onConquestUpdate = function(zone, updatetype)
+    xi.conq.onConquestUpdate(zone, updatetype)
 end
 
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(-60.006, -2.915, -39.501, 202)
     end
 
     return cs
-end
-
-zone_object.onConquestUpdate = function(zone, updatetype)
-    xi.conq.onConquestUpdate(zone, updatetype)
 end
 
 zone_object.onRegionEnter = function(player, region)

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -4,21 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Dragons_Aery/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)
-    end
-    if xi.settings.main.LandKingSystem_HQ == 0 then
-        SetDropRate(918, 3340, 0) -- do not drop cup_of_sweet_tea
-    end
-
     mob:setLocalVar("[rage]timer", 3600) -- 60 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
@@ -26,30 +21,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    local timeOfDeath = GetServerVariable("[POP]Nidhogg")
-    local kills       = GetServerVariable("[PH]Nidhogg")
-    local popNow      = math.random(1, 5) == 3 or kills > 6
-
-    if xi.settings.main.LandKingSystem_HQ ~= 1 and timeOfDeath <= os.time() and popNow then
-        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
-        if xi.settings.main.LandKingSystem_NQ == 0 then
-            DisallowRespawn(ID.mob.FAFNIR, true)
-        end
-
-        DisallowRespawn(ID.mob.NIDHOGG, false)
-        UpdateNMSpawnPoint(ID.mob.NIDHOGG)
-        GetMobByID(ID.mob.NIDHOGG):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    else
-        if xi.settings.main.LandKingSystem_NQ ~= 1 then
-            UpdateNMSpawnPoint(ID.mob.FAFNIR)
-            GetMobByID(ID.mob.FAFNIR):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-            SetServerVariable("[PH]Nidhogg", kills + 1)
-        end
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -4,18 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Dragons_Aery/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)
-    end
-
     mob:setLocalVar("[rage]timer", 3600) -- 60 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.FAFNIR_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onMobFight = function(mob, target)
@@ -37,26 +35,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Set Nidhogg's Window Open Time
-    if xi.settings.main.LandKingSystem_HQ ~= 1 then
-        local wait = 72 * 3600
-        SetServerVariable("[POP]Nidhogg", os.time() + wait) -- 3 days
-        if xi.settings.main.LandKingSystem_HQ == 0 then -- Is time spawn only
-            DisallowRespawn(mob:getID(), true)
-        end
-    end
-
-    -- Set Fafnir's spawnpoint and respawn time (21-24 hours)
-    if xi.settings.main.LandKingSystem_NQ ~= 1 then
-        SetServerVariable("[PH]Nidhogg", 0)
-        DisallowRespawn(ID.mob.FAFNIR, false)
-        UpdateNMSpawnPoint(ID.mob.FAFNIR)
-        GetMobByID(ID.mob.FAFNIR):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.FAFNIR_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Dragons_Aery/npcs/qm0.lua
+++ b/scripts/zones/Dragons_Aery/npcs/qm0.lua
@@ -6,22 +6,18 @@
 -----------------------------------
 local ID = require("scripts/zones/Dragons_Aery/IDs")
 require("scripts/globals/npc_util")
-require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onSpawn = function(npc)
-    if xi.settings.main.LandKingSystem_NQ < 1 and xi.settings.main.LandKingSystem_HQ < 1 then
-        npc:setStatus(xi.status.DISAPPEAR)
-    end
 end
 
 entity.onTrade = function(player, npc, trade)
     if not GetMobByID(ID.mob.FAFNIR):isSpawned() and not GetMobByID(ID.mob.NIDHOGG):isSpawned() then
-        if xi.settings.main.LandKingSystem_NQ ~= 0 and npcUtil.tradeHas(trade, 3339) and npcUtil.popFromQM(player, npc, ID.mob.FAFNIR) then
+        if npcUtil.tradeHasExactly(trade, 3339) and npcUtil.popFromQM(player, npc, ID.mob.FAFNIR) then
             player:confirmTrade()
-        elseif xi.settings.main.LandKingSystem_HQ ~= 0 and npcUtil.tradeHas(trade, 3340) and npcUtil.popFromQM(player, npc, ID.mob.NIDHOGG) then
+        elseif npcUtil.tradeHasExactly(trade, 3340) and npcUtil.popFromQM(player, npc, ID.mob.NIDHOGG) then
             player:confirmTrade()
         end
     end

--- a/scripts/zones/Valley_of_Sorrows/Zone.lua
+++ b/scripts/zones/Valley_of_Sorrows/Zone.lua
@@ -1,20 +1,13 @@
 -----------------------------------
---
 -- Zone: Valley_of_Sorrows (128)
---
 -----------------------------------
 local ID = require("scripts/zones/Valley_of_Sorrows/IDs")
 require("scripts/globals/conquest")
-require("scripts/globals/settings")
 require("scripts/globals/zone")
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
-    if (xi.settings.main.LandKingSystem_NQ ~= 1) then
-        UpdateNMSpawnPoint(ID.mob.ADAMANTOISE)
-        GetMobByID(ID.mob.ADAMANTOISE):setRespawnTime(900 + math.random(0, 6) * 1800)
-    end
 end
 
 zone_object.onConquestUpdate = function(zone, updatetype)
@@ -24,7 +17,7 @@ end
 zone_object.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
         player:setPos(45.25, -2.115, -140.562, 0)
     end
 

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -4,21 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Valley_of_Sorrows/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
-    end
-    if xi.settings.main.LandKingSystem_HQ == 0 then
-        SetDropRate(24, 3344, 0) -- do not drop clump_of_red_pondweed
-    end
-
     mob:setLocalVar("[rage]timer", 1800) -- 30 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
@@ -26,30 +21,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    local timeOfDeath = GetServerVariable("[POP]Aspidochelone")
-    local kills       = GetServerVariable("[PH]Aspidochelone")
-    local popNow      = math.random(1, 5) == 3 or kills > 6
-
-    if xi.settings.main.LandKingSystem_HQ ~= 1 and timeOfDeath <= os.time() and popNow then
-        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
-        if xi.settings.main.LandKingSystem_NQ == 0 then
-            DisallowRespawn(ID.mob.ADAMANTOISE, true)
-        end
-
-        DisallowRespawn(ID.mob.ASPIDOCHELONE, false)
-        UpdateNMSpawnPoint(ID.mob.ASPIDOCHELONE)
-        GetMobByID(ID.mob.ASPIDOCHELONE):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    else
-        if xi.settings.main.LandKingSystem_NQ ~= 1 then
-            UpdateNMSpawnPoint(ID.mob.ADAMANTOISE)
-            GetMobByID(ID.mob.ADAMANTOISE):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-            SetServerVariable("[PH]Aspidochelone", kills + 1)
-        end
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -4,18 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Valley_of_Sorrows/IDs")
 mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    if xi.settings.main.LandKingSystem_NQ > 0 or xi.settings.main.LandKingSystem_HQ > 0 then
-        GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
-    end
-
     mob:setLocalVar("[rage]timer", 3600) -- 60 minutes
+
+    -- Despawn the ???
+    GetNPCByID(ID.npc.ADAMANTOISE_QM):setStatus(xi.status.DISAPPEAR)
 end
 
 entity.onMobDeath = function(mob, player, isKiller)
@@ -23,26 +21,8 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Set Aspidochelone's Window Open Time
-    if xi.settings.main.LandKingSystem_HQ ~= 1 then
-        local wait = 72 * 3600
-        SetServerVariable("[POP]Aspidochelone", os.time() + wait) -- 3 days
-        if xi.settings.main.LandKingSystem_HQ == 0 then -- Is time spawn only
-            DisallowRespawn(mob:getID(), true)
-        end
-    end
-
-    -- Set Adamantoise's spawnpoint and respawn time (21-24 hours)
-    if xi.settings.main.LandKingSystem_NQ ~= 1 then
-        SetServerVariable("[PH]Aspidochelone", 0)
-        DisallowRespawn(ID.mob.ADAMANTOISE, false)
-        UpdateNMSpawnPoint(ID.mob.ADAMANTOISE)
-        GetMobByID(ID.mob.ADAMANTOISE):setRespawnTime(75600 + math.random(0, 6) * 1800) -- 21 - 24 hours with half hour windows
-    end
     -- Respawn the ???
-    if xi.settings.main.LandKingSystem_HQ == 2 or xi.settings.main.LandKingSystem_NQ == 2 then
-        GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
-    end
+    GetNPCByID(ID.npc.ADAMANTOISE_QM):updateNPCHideTime(xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
+++ b/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
@@ -6,22 +6,18 @@
 -----------------------------------
 local ID = require("scripts/zones/Valley_of_Sorrows/IDs")
 require("scripts/globals/npc_util")
-require("scripts/globals/settings")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}
 
 entity.onSpawn = function(npc)
-    if xi.settings.main.LandKingSystem_NQ < 1 and xi.settings.main.LandKingSystem_HQ < 1 then
-        npc:setStatus(xi.status.DISAPPEAR)
-    end
 end
 
 entity.onTrade = function(player, npc, trade)
     if not GetMobByID(ID.mob.ADAMANTOISE):isSpawned() and not GetMobByID(ID.mob.ASPIDOCHELONE):isSpawned() then
-        if xi.settings.main.LandKingSystem_NQ ~= 0 and npcUtil.tradeHas(trade, 3343) and npcUtil.popFromQM(player, npc, ID.mob.ADAMANTOISE) then
+        if npcUtil.tradeHasExactly(trade, 3343) and npcUtil.popFromQM(player, npc, ID.mob.ADAMANTOISE) then
             player:confirmTrade()
-        elseif xi.settings.main.LandKingSystem_HQ ~= 0 and npcUtil.tradeHas(trade, 3344) and npcUtil.popFromQM(player, npc, ID.mob.ASPIDOCHELONE) then
+        elseif npcUtil.tradeHasExactly(trade, 3344) and npcUtil.popFromQM(player, npc, ID.mob.ASPIDOCHELONE) then
             player:confirmTrade()
         end
     end

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -154,11 +154,6 @@ xi.settings.main =
     CHEST_MAX_ILLUSION_TIME  = 3600,  -- 1 hour
     CHEST_MIN_ILLUSION_TIME  = 1800,  -- 30 minutes
 
-    -- Sets spawn type for: Behemoth, Fafnir, Adamantoise, King Behemoth, Nidhog, Aspidochelone.
-    -- Use 0 for timed spawns, 1 for force pop only, 2 for both
-    LandKingSystem_NQ = 1,
-    LandKingSystem_HQ = 1,
-
     -- Multiplier to NM lottery spawn chance. (Default 1.0) eg. 0 = disable lottery spawns. -1 for always 100% chance.
     NM_LOTTERY_CHANCE = 1.0,
     -- Multiplier to NM lottery cooldown time (Default 1.0) eg. 2.0 = twice as long. 0 = no cooldowns.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

It removes era (and custom) settings for Kand Kings pop mechanics and moves their logic to modules, in order to preserve functionality and keep the code clean.

## Steps to test these changes

Set up a server and launch it. If using any of the 2 modules, Their Pop Times will be saved to server variables. From that point on, just a matter of waiting.
