### PR TITLE
[LUA] Create job_utils/black_mage, migrate and update JA functionality

### DIFF
--- a/scripts/globals/abilities/cascade.lua
+++ b/scripts/globals/abilities/cascade.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 00:01:00
 -- Duration: 0:01:00 or the next spell cast
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.CASCADE, 4, 0, 60)
+    xi.job_utils.black_mage.useCascade(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/elemental_seal.lua
+++ b/scripts/globals/abilities/elemental_seal.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 10:00
 -- Duration: 1 Spell or 60 seconds, whichever occurs first.
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.ELEMENTAL_SEAL, 1, 0, 60)
+    xi.job_utils.black_mage.useElementalSeal(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/enmity_douse.lua
+++ b/scripts/globals/abilities/enmity_douse.lua
@@ -4,8 +4,7 @@
 -- Obtained: BLM Level 87
 -- Recast Time: 0:10:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -14,12 +13,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
---[[    if target:isMob() then
-        local enmityShed = 100
-        if player:getMainJob() ~= xi.job.BLM then
-            enmityShed = 1000
-        end
-    end ]]--
+    xi.job_utils.black_mage.useEnmityDouse(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/mana_wall.lua
+++ b/scripts/globals/abilities/mana_wall.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 00:10:00
 -- Duration: 00:05:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.MANA_WALL, 4, 0, 300)
+    xi.job_utils.black_mage.useManaWall(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/manafont.lua
+++ b/scripts/globals/abilities/manafont.lua
@@ -5,18 +5,16 @@
 -- Recast Time: 1:00:00
 -- Duration: 0:01:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
-    return 0, 0
+    return xi.job_utils.black_mage.checkManafont(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.MANAFONT, 1, 0, 60)
+    xi.job_utils.black_mage.useManafont(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/manawell.lua
+++ b/scripts/globals/abilities/manawell.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 00:10:00 or the next spell cast
 -- Duration: 0:01:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    target:addStatusEffect(xi.effect.MANAWELL, 4, 0, 60)
+    xi.job_utils.black_mage.useManawell(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/subtle_sorcery.lua
+++ b/scripts/globals/abilities/subtle_sorcery.lua
@@ -5,18 +5,16 @@
 -- Recast Time: 01:00:00
 -- Duration: 00:01:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/black_mage")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
-    return 0, 0
+    return xi.job_utils.black_mage.checkSubtleSorcery(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.SUBTLE_SORCERY, 4, 0, 60)
+    xi.job_utils.black_mage.useSubtleSorcery(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/effects/subtle_sorcery.lua
+++ b/scripts/globals/effects/subtle_sorcery.lua
@@ -6,6 +6,7 @@ require("scripts/globals/status")
 -----------------------------------
 local effect_object = {}
 
+-- Spell Cumulative Enmity reduction handled in magic_state.cpp
 effect_object.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.SUBTLE_SORCERY_EFFECT)
 

--- a/scripts/globals/effects/subtle_sorcery.lua
+++ b/scripts/globals/effects/subtle_sorcery.lua
@@ -14,14 +14,12 @@ effect_object.onEffectGain = function(target, effect)
 end
 
 effect_object.onEffectTick = function(target, effect)
-    target:addMod(xi.mod.ENMITY, -20)
 end
 
 effect_object.onEffectLose = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.SUBTLE_SORCERY_EFFECT)
 
     target:delMod(xi.mod.MACC, 100)
-    target:delMod(xi.mod.ENMITY)
     target:delMod(xi.mod.UFASTCAST, jpValue)
 end
 

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -1,0 +1,59 @@
+-----------------------------------
+-- Black Mage Job Utilities
+-----------------------------------
+require('scripts/globals/items')
+require("scripts/globals/msg")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+-----------------------------------
+xi = xi or {}
+xi.job_utils = xi.job_utils or {}
+xi.job_utils.black_mage = xi.job_utils.black_mage or {}
+
+-----------------------------------
+-- Ability Check Functions
+-----------------------------------
+xi.job_utils.black_mage.checkManafont = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    return 0, 0
+end
+
+xi.job_utils.black_mage.checkSubtleSorcery = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    return 0, 0
+end
+
+-----------------------------------
+-- Ability Use Functions
+-----------------------------------
+xi.job_utils.black_mage.useCascade = function(player, target, ability)
+    player:addStatusEffect(xi.effect.CASCADE, 4, 0, 60)
+end
+
+xi.job_utils.black_mage.useElementalSeal = function(player, target, ability)
+    player:addStatusEffect(xi.effect.ELEMENTAL_SEAL, 1, 0, 60)
+end
+
+xi.job_utils.black_mage.useEnmityDouse = function(player, target, ability)
+    if target:isMob() then
+        target:setCE(player, 1)
+        target:setVE(player, 0)
+    end
+end
+
+xi.job_utils.black_mage.useManafont = function(player, target, ability)
+    player:addStatusEffect(xi.effect.MANAFONT, 1, 0, 60)
+end
+
+xi.job_utils.black_mage.useManaWall = function(player, target, ability)
+    player:addStatusEffect(xi.effect.MANA_WALL, 4, 0, 300)
+end
+
+xi.job_utils.black_mage.useManawell = function(player, target, ability)
+    target:addStatusEffect(xi.effect.MANAWELL, 4, 0, 60)
+end
+
+xi.job_utils.black_mage.useSubtleSorcery = function(player, target, ability)
+    player:addStatusEffect(xi.effect.SUBTLE_SORCERY, 4, 0, 60)
+end

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -28,7 +28,7 @@ end
 -- Ability Use Functions
 -----------------------------------
 xi.job_utils.black_mage.useCascade = function(player, target, ability)
-    player:addStatusEffect(xi.effect.CASCADE, 4, 0, 60)
+    player:addStatusEffect(xi.effect.CASCADE, 1, 0, 60)
 end
 
 xi.job_utils.black_mage.useElementalSeal = function(player, target, ability)
@@ -47,13 +47,13 @@ xi.job_utils.black_mage.useManafont = function(player, target, ability)
 end
 
 xi.job_utils.black_mage.useManaWall = function(player, target, ability)
-    player:addStatusEffect(xi.effect.MANA_WALL, 4, 0, 300)
+    player:addStatusEffect(xi.effect.MANA_WALL, 1, 0, 300)
 end
 
 xi.job_utils.black_mage.useManawell = function(player, target, ability)
-    target:addStatusEffect(xi.effect.MANAWELL, 4, 0, 60)
+    target:addStatusEffect(xi.effect.MANAWELL, 1, 0, 60)
 end
 
 xi.job_utils.black_mage.useSubtleSorcery = function(player, target, ability)
-    player:addStatusEffect(xi.effect.SUBTLE_SORCERY, 4, 0, 60)
+    player:addStatusEffect(xi.effect.SUBTLE_SORCERY, 1, 0, 60)
 end

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -286,7 +286,7 @@ INSERT INTO `abilities` VALUES (269,'impetus',2,88,1,360,31,100,0,240,2000,0,6,2
 INSERT INTO `abilities` VALUES (270,'divine_caress',3,83,1,60,32,100,0,254,2000,0,6,20.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (271,'sacrosanctity',3,95,1,600,33,100,0,268,2000,0,6,13.9,1,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (272,'enmity_douse',4,87,4,600,34,100,0,257,2000,0,6,18.0,0,1,0,0,0,NULL); -- check animation
-INSERT INTO `abilities` VALUES (273,'manawell',4,95,1,600,35,100,0,252,2000,0,6,20.0,0,1,80,0,0,NULL);
+INSERT INTO `abilities` VALUES (273,'manawell',4,95,3,600,35,100,0,252,2000,0,6,20.0,0,1,80,0,0,NULL);
 INSERT INTO `abilities` VALUES (274,'saboteur',5,83,1,300,36,0,0,258,2000,0,6,20.0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (275,'spontaneity',5,95,3,600,37,0,0,259,2000,0,6,20.0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (276,'conspirator',6,87,1,300,40,0,0,237,2000,0,6,14.0,1,1,80,0,4,'ABYSSEA');

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -328,6 +328,11 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
     {
         m_PEntity->addModifier(Mod::ENMITY, -(m_PEntity->getMod(Mod::DIVINE_BENISON) >> 1)); // Half of divine benison mod amount = -enmity
     }
+    // Subtle Sorcery sets Cumulative Enmity of spells to 0
+    if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SUBTLE_SORCERY))
+    {
+        ce = 0;
+    }
 
     if (PTarget != nullptr)
     {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9922,8 +9922,8 @@ int32 CLuaBaseEntity::getVE(CLuaBaseEntity const* target)
 /************************************************************************
  *  Function: setCE()
  *  Purpose : Sets a specified amount of Cumulative Enmity against an Entity
- *  Example : target:setCE(player, petCE * petEnmityBonus)
- *  Notes   : Currently only used in scripts/globals/abilities/ventriloquy.lua
+ *  Example : target:setCE(player, newEnmity)
+ *  Notes   : See Enmity Douse and Ventriloquy
  ************************************************************************/
 
 void CLuaBaseEntity::setCE(CLuaBaseEntity* target, uint16 amount)
@@ -9936,8 +9936,8 @@ void CLuaBaseEntity::setCE(CLuaBaseEntity* target, uint16 amount)
 /************************************************************************
  *  Function: setVE()
  *  Purpose : Sets a specified amount of Volatile Enmity against an Entity
- *  Example : target:setVE(player, petVE * petEnmityBonus)
- *  Notes   : Currently only used in scripts/globals/abilities/ventriloquy.lua
+ *  Example : target:setVE(player, newEnmity)
+ *  Notes   : See Enmity Douse and Ventriloquy
  ************************************************************************/
 
 void CLuaBaseEntity::setVE(CLuaBaseEntity* target, uint16 amount)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Create job_utils/black_mage.lua and populates necessary ability check and ability use functions.
- Moves functionality from all Black Mage globals/abilities files to globals/job_utils/black_mage.lua.
- Adds functionality to Enmity Douse.
- Updates Manawell to target self and party members.
- Removes -ENMITY mod from Subtle Sorcery effect onEffectTick (Ability's enmity effect will need further supporting work).
- Removes erroring delMod ENMITY from Subtle Sorcery effect onEffectLose (Ability's enmity effect will need further supporting work).
- Updates notes for lua_baseentity.cpp setCE and setVE functions no longer used exclusively by Ventriloquy.

**References**
https://www.bg-wiki.com/ffxi/Enmity_Douse
https://www.bg-wiki.com/ffxi/Manawell
https://www.bg-wiki.com/ffxi/Subtle_Sorcery

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Upload changes to your server.
2. Load the server.
3. Use the !changejob BLM 99 command.
4. Use all JA's to confirm they do not throw errors.