### PR TITLE
[lua] Adjust sparksshop.lua to only allow qty > 1 on select categories

### DIFF
--- a/scripts/globals/sparkshop.lua
+++ b/scripts/globals/sparkshop.lua
@@ -626,8 +626,13 @@ function xi.sparkshop.onEventUpdate(player,csid,option)
     local category = bit.band(option, 0xFF)
     local selection = bit.rshift(option, 16)
 
-    local qty = bit.band(bit.rshift(option, 10), 0x3F)
-    qty = qty > 0 and qty or 1
+    local qty = 1
+    local requested_qty = bit.band(bit.rshift(option, 10), 0x3F)
+
+    -- only skillup books and currencies can have qty > 1 aside from special cases such as ammo or shurikens
+    if category == 2 or category == 20 or category == 30 then
+        qty = requested_qty
+    end
 
     -- There are three specific cases for Sparks rewards currently implemented:
     -- 1. Grant an Item based on Sparks cost (Category <= 10 or 12)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjusts some logic to prevent bad quantities for items you can only purchase in single quantities
Fixes #2397

## Steps to test these changes
Follow bug report steps in #2397 where you select an option that lets you change quantity and go back to a weapon/armor that normally has 1 qty and get only 1 qty