### PR TITLE
 Update CParty.cpp to avoid calling class members after deletion, comment cleanup, add initializers

### DIFF
--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -48,7 +48,7 @@ CAlliance::CAlliance(CBattleEntity* PEntity)
 
     // will need to deal with these
     // m_PSyncTarget    = nullptr;
-    //  m_PQuaterMaster = nullptr;
+    //  m_PQuarterMaster = nullptr;
 
     addParty(PEntity->PParty);
     this->aLeader = PEntity->PParty;

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -66,7 +66,7 @@ CParty::CParty(CBattleEntity* PEntity)
     m_PLeader        = nullptr;
     m_PAlliance      = nullptr;
     m_PSyncTarget    = nullptr;
-    m_PQuaterMaster  = nullptr;
+    m_PQuarterMaster = nullptr;
     m_EffectsChanged = false;
     m_PartyID        = 0;
     m_PartyType      = PARTY_MOBS;
@@ -94,18 +94,12 @@ CParty::CParty(uint32 id)
     m_PartyType   = PARTY_PCS;
     m_PartyNumber = 0;
 
-    m_PLeader       = nullptr;
-    m_PSyncTarget   = nullptr;
-    m_PQuaterMaster = nullptr;
+    m_PLeader        = nullptr;
+    m_PSyncTarget    = nullptr;
+    m_PQuarterMaster = nullptr;
 
     m_EffectsChanged = false;
 }
-
-/************************************************************************
- *                                                                      *
- *  Распускаем группу                                                   *
- *                                                                      *
- ************************************************************************/
 
 void CParty::DisbandParty(bool playerInitiated)
 {
@@ -134,7 +128,7 @@ void CParty::DisbandParty(bool playerInitiated)
             PChar->PLatentEffectContainer->CheckLatentsPartyAvatar();
             PChar->pushPacket(new CPartyMemberUpdatePacket(PChar, 0, 0, PChar->getZone()));
 
-            // TODO: TreasurePool должен оставаться у последнего персонажа, но сейчас это не критично
+            // TODO: TreasurePool should stay with the last character, but now it is not critical
 
             if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
             {
@@ -172,12 +166,8 @@ void CParty::DisbandParty(bool playerInitiated)
     delete this;
 }
 
-/************************************************************************
- *                                                                       *
- *  Назначаем роли участникам группы    (только для персонажей)             *
- *                                                                       *
- ************************************************************************/
 
+// Assign roles to group members (players only)
 void CParty::AssignPartyRole(int8* MemberName, uint8 role)
 {
     XI_DEBUG_BREAK_IF(m_PartyType != PARTY_PCS);
@@ -214,12 +204,7 @@ void CParty::AssignPartyRole(int8* MemberName, uint8 role)
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 
-/************************************************************************
- *                                                                      *
- *  Узнаем количество участников группы в указанной зоне                    *
- *                                                                      *
- ************************************************************************/
-
+// get number of members in specified zone
 uint8 CParty::MemberCount(uint16 ZoneID)
 {
     uint8 count = 0;
@@ -240,12 +225,7 @@ uint8 CParty::MemberCount(uint16 ZoneID)
     return count;
 }
 
-/************************************************************************
- *                                                                       *
- *  Returns Entity Pointer to Party Member by Name (used for kick)       *
- *                                                                       *
- ************************************************************************/
-
+// Returns entity pointer to party member by name (used for /pcmd kick or otherwise)
 CBattleEntity* CParty::GetMemberByName(const int8* MemberName)
 {
     XI_DEBUG_BREAK_IF(m_PartyType != PARTY_PCS);
@@ -260,12 +240,6 @@ CBattleEntity* CParty::GetMemberByName(const int8* MemberName)
 
     return nullptr;
 }
-
-/************************************************************************
- *                                                                      *
- *  Удаляем персонажа из группы                                         *
- *                                                                      *
- ************************************************************************/
 
 void CParty::RemoveMember(CBattleEntity* PEntity)
 {
@@ -299,7 +273,7 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                     CCharEntity* PChar = dynamic_cast<CCharEntity*>(PEntity);
                     if (PChar)
                     {
-                        if (m_PQuaterMaster == PChar)
+                        if (m_PQuarterMaster == PChar)
                         {
                             SetQuarterMaster(nullptr);
                         }
@@ -366,7 +340,10 @@ void CParty::DelMember(CBattleEntity* PEntity)
 
     if (m_PLeader == PEntity)
     {
-        RemovePartyLeader(PEntity);
+        if (RemovePartyLeader(PEntity)) // Only reload party if party has not disbanded
+        {
+            this->ReloadParty();
+        }
     }
     else
     {
@@ -380,7 +357,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
                 {
                     CCharEntity* PChar = (CCharEntity*)PEntity;
 
-                    if (m_PQuaterMaster == PChar)
+                    if (m_PQuarterMaster == PChar)
                     {
                         SetQuarterMaster(nullptr);
                     }
@@ -431,8 +408,9 @@ void CParty::DelMember(CBattleEntity* PEntity)
                 break;
             }
         }
+        this->ReloadParty();
     }
-    this->ReloadParty();
+    
 }
 
 void CParty::PopMember(CBattleEntity* PEntity)
@@ -466,18 +444,12 @@ void CParty::PopMember(CBattleEntity* PEntity)
     PEntity->PParty = nullptr;
 }
 
-/************************************************************************
- *                                                                      *
- *  Лидер покидает группу                                               *
- *                                                                      *
- ************************************************************************/
-
-void CParty::RemovePartyLeader(CBattleEntity* PEntity)
+bool CParty::RemovePartyLeader(CBattleEntity* PEntity)
 {
     if (members.empty())
     {
         ShowWarning("CParty::RemovePartyLeader - called when \"member\" list was empty");
-        return;
+        return false;
     }
 
     int ret = sql->Query("SELECT charname FROM accounts_sessions JOIN chars ON accounts_sessions.charid = chars.charid \
@@ -499,7 +471,7 @@ void CParty::RemovePartyLeader(CBattleEntity* PEntity)
                 m_PLeader = member;
                 DelMember(PEntity);
 
-                return;
+                return true;
             }
         }
     }
@@ -507,11 +479,13 @@ void CParty::RemovePartyLeader(CBattleEntity* PEntity)
     if (m_PLeader == PEntity)
     {
         DisbandParty();
+        return false;
     }
     else
     {
         RemoveMember(PEntity);
     }
+    return true;
 }
 
 std::vector<CParty::partyInfo_t> CParty::GetPartyInfo() const
@@ -533,12 +507,6 @@ std::vector<CParty::partyInfo_t> CParty::GetPartyInfo() const
     }
     return memberinfo;
 }
-
-/************************************************************************
- *                                                                      *
- *  Добавляем персонажа в группу                                            *
- *                                                                      *
- ************************************************************************/
 
 void CParty::AddMember(CBattleEntity* PEntity)
 {
@@ -676,7 +644,7 @@ void CParty::PushMember(CBattleEntity* PEntity)
             }
             if (memberinfo.flags & PARTY_QM)
             {
-                m_PQuaterMaster = PEntity;
+                m_PQuarterMaster = PEntity;
             }
             if (memberinfo.flags & PARTY_SYNC)
             {
@@ -693,55 +661,25 @@ void CParty::SetPartyID(uint32 id)
     m_PartyID = id;
 }
 
-/************************************************************************
- *                                                                      *
- *  Получаем уникальный ID группы                                       *
- *                                                                      *
- ************************************************************************/
-
 uint32 CParty::GetPartyID() const
 {
     return m_PartyID;
 }
-
-/************************************************************************
- *                                                                      *
- *  Получаем указатель на лидера группы                                 *
- *                                                                      *
- ************************************************************************/
 
 CBattleEntity* CParty::GetLeader()
 {
     return m_PLeader;
 }
 
-/************************************************************************
- *                                                                      *
- *  Получаем указатель на цель синхронизации уровней                        *
- *                                                                      *
- ************************************************************************/
-
 CBattleEntity* CParty::GetSyncTarget()
 {
     return m_PSyncTarget;
 }
 
-/************************************************************************
- *                                                                      *
- *  Получаем указатель на владельца сокровищ                                *
- *                                                                      *
- ************************************************************************/
-
 CBattleEntity* CParty::GetQuaterMaster()
 {
-    return m_PQuaterMaster;
+    return m_PQuarterMaster;
 }
-
-/************************************************************************
- *                                                                       *
- *  Получаем список флагов персонажа                                     *
- *                                                                       *
- ************************************************************************/
 
 uint16 CParty::GetMemberFlags(CBattleEntity* PEntity)
 {
@@ -774,7 +712,7 @@ uint16 CParty::GetMemberFlags(CBattleEntity* PEntity)
     {
         Flags |= PARTY_LEADER;
     }
-    if (PEntity == m_PQuaterMaster)
+    if (PEntity == m_PQuarterMaster)
     {
         Flags |= PARTY_QM;
     }
@@ -883,13 +821,7 @@ void CParty::ReloadParty()
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Обновляем статусы членов группы для выбранного персонажа                *
- *  Возвращаем номер персонажа в группе                                 *
- *                                                                      *
- ************************************************************************/
-
+// update party info for PChar
 void CParty::ReloadPartyMembers(CCharEntity* PChar)
 {
     PChar->ReloadPartyDec();
@@ -921,12 +853,7 @@ void CParty::ReloadPartyMembers(CCharEntity* PChar)
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Обновляем TreasurePool для указанного персонажа                     *
- *                                                                      *
- ************************************************************************/
-
+// update treasure pool for specified character
 void CParty::ReloadTreasurePool(CCharEntity* PChar)
 {
     if (PChar == nullptr)
@@ -992,12 +919,6 @@ void CParty::ReloadTreasurePool(CCharEntity* PChar)
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Устанавливаем лидера группы                                         *
- *                                                                      *
- ************************************************************************/
-
 void CParty::SetLeader(const char* MemberName)
 {
     if (m_PartyType == PARTY_PCS)
@@ -1045,12 +966,6 @@ void CParty::SetLeader(const char* MemberName)
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Устанавливаем цель синхронизации уровней                                *
- *                                                                      *
- ************************************************************************/
-
 void CParty::SetSyncTarget(int8* MemberName, uint16 message)
 {
     CBattleEntity* PEntity = nullptr;
@@ -1079,7 +994,7 @@ void CParty::SetSyncTarget(int8* MemberName, uint16 message)
             {
                 for (auto& member : members)
                 {
-                    if (member->StatusEffectContainer->HasStatusEffect({ EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_SYNC }))
+                    if (member->StatusEffectContainer->HasStatusEffect({ EFFECT_LEVEL_RESTRICTION, EFFECT_LEVEL_SYNC, EFFECT_SJ_RESTRICTION, EFFECT_CONFRONTATION, EFFECT_BATTLEFIELD }))
                     {
                         ((CCharEntity*)GetLeader())->pushPacket(new CMessageBasicPacket((CCharEntity*)GetLeader(), (CCharEntity*)GetLeader(), 0, 0, 543));
                         return;
@@ -1142,16 +1057,10 @@ void CParty::SetSyncTarget(int8* MemberName, uint16 message)
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Усранавливаем владельца сокровищ                                        *
- *                                                                      *
- ************************************************************************/
-
 void CParty::SetQuarterMaster(const char* MemberName)
 {
     CBattleEntity* PEntity = MemberName ? GetMemberByName((const int8*)MemberName) : nullptr;
-    m_PQuaterMaster        = PEntity;
+    m_PQuarterMaster        = PEntity;
     sql->Query("UPDATE accounts_parties SET partyflag = partyflag & ~%d WHERE partyid = %u AND partyflag & %d", PARTY_QM, m_PartyID, PARTY_QM);
     if (MemberName != nullptr)
     {
@@ -1161,14 +1070,9 @@ void CParty::SetQuarterMaster(const char* MemberName)
     }
 }
 
-/************************************************************************
- *                                                                      *
- *  Отправляем пакет всем членам группы, если зона указана как 0 или        *
- *  членам группы в указанной зоне.                                     *
- *  Пакет для PPartyMember не отправляется в обоих случаях.             *
- *                                                                      *
- ************************************************************************/
-
+// Send a packet to all members of the group if the zone is specified as 0
+// or to the party members in the specified zone.
+// Packet for PPartyMember is not sent in both cases
 void CParty::PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet)
 {
     for (auto& i : members)
@@ -1372,13 +1276,13 @@ void CParty::RefreshFlags(std::vector<partyInfo_t>& info)
                 {
                     if (member->id == memberinfo.id)
                     {
-                        m_PQuaterMaster = member;
+                        m_PQuarterMaster = member;
                         found           = true;
                     }
                 }
                 if (!found)
                 {
-                    m_PQuaterMaster = nullptr;
+                    m_PQuarterMaster = nullptr;
                 }
             }
             if (memberinfo.flags & PARTY_SYNC)

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -51,13 +51,13 @@
 // should have brace-or-equal initializers when MSVC supports it
 struct CParty::partyInfo_t
 {
-    uint32      id;
-    uint32      partyid;
-    uint32      allianceid;
-    std::string name;
-    uint16      flags;
-    uint16      zone;
-    uint16      prev_zone;
+    uint32      id         = {};
+    uint32      partyid    = {};
+    uint32      allianceid = {};
+    std::string name       = {};
+    uint16      flags      = {};
+    uint16      zone       = {};
+    uint16      prev_zone  = {};
 };
 
 // Constructor
@@ -165,7 +165,6 @@ void CParty::DisbandParty(bool playerInitiated)
     }
     delete this;
 }
-
 
 // Assign roles to group members (players only)
 void CParty::AssignPartyRole(int8* MemberName, uint8 role)
@@ -410,7 +409,6 @@ void CParty::DelMember(CBattleEntity* PEntity)
         }
         this->ReloadParty();
     }
-    
 }
 
 void CParty::PopMember(CBattleEntity* PEntity)
@@ -1060,7 +1058,7 @@ void CParty::SetSyncTarget(int8* MemberName, uint16 message)
 void CParty::SetQuarterMaster(const char* MemberName)
 {
     CBattleEntity* PEntity = MemberName ? GetMemberByName((const int8*)MemberName) : nullptr;
-    m_PQuarterMaster        = PEntity;
+    m_PQuarterMaster       = PEntity;
     sql->Query("UPDATE accounts_parties SET partyflag = partyflag & ~%d WHERE partyid = %u AND partyflag & %d", PARTY_QM, m_PartyID, PARTY_QM);
     if (MemberName != nullptr)
     {
@@ -1277,7 +1275,7 @@ void CParty::RefreshFlags(std::vector<partyInfo_t>& info)
                     if (member->id == memberinfo.id)
                     {
                         m_PQuarterMaster = member;
-                        found           = true;
+                        found            = true;
                     }
                 }
                 if (!found)

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -107,19 +107,19 @@ public:
 
 private:
     struct partyInfo_t;
-    uint32    m_PartyID;     // уникальный ID группы
-    PARTYTYPE m_PartyType;   // тип существ, составляющих группу
+    uint32    m_PartyID;     // unique party ID
+    PARTYTYPE m_PartyType;   // the type of party (players or mobs)
     uint8     m_PartyNumber; // party number in alliance
 
-    CBattleEntity* m_PLeader;       // лидер группы
-    CBattleEntity* m_PSyncTarget;   // цель синхронизации уровней
-    CBattleEntity* m_PQuaterMaster; // владелец сокровищ
+    CBattleEntity* m_PLeader;        // party leader
+    CBattleEntity* m_PSyncTarget;    // the CBattleEntity the party is being synced to
+    CBattleEntity* m_PQuarterMaster; // the assigned Quartermaster
 
     bool m_EffectsChanged;
 
-    void                     SetLeader(const char* MemberName);         // устанавливаем лидера группы
-    void                     SetQuarterMaster(const char* MemberName);  // устанавливаем владельца сокровищ
-    void                     RemovePartyLeader(CBattleEntity* PEntity); // лидер покидает группу
+    void                     SetLeader(const char* MemberName);         // set party leader
+    void                     SetQuarterMaster(const char* MemberName);  // set Quartermaster
+    bool                     RemovePartyLeader(CBattleEntity* PEntity); // attempt to remove the leader of the party. Returns false if party is disbanded or otherwise invalid.
     std::vector<partyInfo_t> GetPartyInfo() const;
     void                     RefreshFlags(std::vector<partyInfo_t>&);
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Update CParty.cpp to avoid calling class members after deletion
* Add more statuses to prevent Level Sync activation in CParty.cpp
* Fix spelling of "Quartermaster" in CParty.cpp
* Update comments in CParty.cpp, prune comments that only indicate the name of the function


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Make a party with _3_ members, have the party leader leave the party, the party should reload correctly. Then have the new leader leave the party and the party should disband*
Other general party/alliance disband/create.
*Note: This is not current retail behavior but it's what LSB currently does as of writing.