### PR TITLE
[dbtool] Change order of functions on load

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -600,11 +600,11 @@ def main():
     if fetch_credentials() == False:
         return
     fetch_configs()
-    fetch_versions()
     #Check MySQL path/availability
     if not os.path.exists(mysql_bin + 'mysql' + exe):
         adjust_mysql_bin()
         write_configs()
+    fetch_versions()
     #CLI args
     if len(sys.argv) > 1:
         arg1 = str(sys.argv[1])


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Verify mysql path before calling check_versions. Fixes an issue when
mysql isn't in PATH and DB doesn't exist where mysqladmin.exe is not
recognized.

See: #2468

## Steps to test these changes

1. Change `SQL_DATABASE` in settings/network.lua to a nonexistent DB 
2. Remove mysql from PATH environment variable
3. Delete `mysql_bin` from tools/config.yaml
4. Open dbtool and verify you're prompted for mysql path before being asked if you want to create the new DB.