### PR TITLE
[LUA] Correct Flee movement speed increase

### DIFF
--- a/scripts/globals/abilities/flee.lua
+++ b/scripts/globals/abilities/flee.lua
@@ -15,7 +15,7 @@ end
 
 ability_object.onUseAbility = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.FLEE_DURATION)
-    player:addStatusEffect(xi.effect.FLEE, 100, 0, duration)
+    player:addStatusEffect(xi.effect.FLEE, 60, 0, duration)
 end
 
 return ability_object

--- a/scripts/globals/abilities/flee.lua
+++ b/scripts/globals/abilities/flee.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Ability: Flee
--- Increases movement speed.
+-- Increases movement speed by +60%
 -- Obtained: Thief Level 25
 -- Recast Time: 5:00
 -- Duration: 0:30
@@ -15,7 +15,7 @@ end
 
 ability_object.onUseAbility = function(player, target, ability)
     local duration = 30 + player:getMod(xi.mod.FLEE_DURATION)
-    player:addStatusEffect(xi.effect.FLEE, 60, 0, duration)
+    player:addStatusEffect(xi.effect.FLEE, 61, 0, duration)
 end
 
 return ability_object


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Updates Flee to reflect retail movement speed increase to +60% rather than the +100% it is set to currently

Setting the modifier FLEE value to 61 within Flee.lua reflects +60% movement increase from 0%

Good Info:
Retail capture with addon to check movement speed
https://www.bg-wiki.com/ffxi/Flee
http://wiki.ffo.jp/html/1682.html

Bad Info:
https://ffxiclopedia.fandom.com/wiki/Flee_(Status_Effect)

## Steps to test these changes
Use Flee. Player should reflect a +60% movement speed increase 

<!-- Clear and detailed steps to test your changes here -->
