### PR TITLE
[Interaction] San d'oria 8-2 Add missionstatus checks to prevent skipping steps

### DIFF
--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -227,7 +227,8 @@ mission.sections =
             ['qm11'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1) then
+                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1) and
+                        player:getMissionStatus(mission.areaId) > 1 then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1)
                     end
@@ -237,7 +238,8 @@ mission.sections =
             ['qm12'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2) then
+                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2) and
+                        player:getMissionStatus(mission.areaId) > 1 then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2)
                     end
@@ -247,7 +249,8 @@ mission.sections =
             ['qm13'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3) then
+                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3) and
+                        player:getMissionStatus(mission.areaId) > 1 then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3)
                     end

--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -227,8 +227,10 @@ mission.sections =
             ['qm11'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1) and
-                        player:getMissionStatus(mission.areaId) > 1 then
+                    if 
+                        not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1) and
+                        player:getMissionStatus(mission.areaId) >= 2 
+                    then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1)
                     end
@@ -238,8 +240,10 @@ mission.sections =
             ['qm12'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2) and
-                        player:getMissionStatus(mission.areaId) > 1 then
+                    if 
+                        not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2) and
+                        player:getMissionStatus(mission.areaId) >= 2 
+                    then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2)
                     end
@@ -249,8 +253,10 @@ mission.sections =
             ['qm13'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3) and
-                        player:getMissionStatus(mission.areaId) > 1 then
+                    if 
+                        not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3) and
+                        player:getMissionStatus(mission.areaId) >= 2 
+                    then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3)
                     end

--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -227,9 +227,9 @@ mission.sections =
             ['qm11'] =
             {
                 onTrigger = function(player, npc)
-                    if 
+                    if
                         not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1) and
-                        player:getMissionStatus(mission.areaId) >= 2 
+                        player:getMissionStatus(mission.areaId) >= 2
                     then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1)
@@ -240,9 +240,9 @@ mission.sections =
             ['qm12'] =
             {
                 onTrigger = function(player, npc)
-                    if 
+                    if
                         not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2) and
-                        player:getMissionStatus(mission.areaId) >= 2 
+                        player:getMissionStatus(mission.areaId) >= 2
                     then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2)
@@ -253,9 +253,9 @@ mission.sections =
             ['qm13'] =
             {
                 onTrigger = function(player, npc)
-                    if 
+                    if
                         not player:hasKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3) and
-                        player:getMissionStatus(mission.areaId) >= 2 
+                        player:getMissionStatus(mission.areaId) >= 2
                     then
                         player:setMissionStatus(mission.areaId, player:getMissionStatus(mission.areaId) + 1)
                         return mission:keyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3)


### PR DESCRIPTION
I affirm_
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've tested my code and the things my code has changed since the last commit in the PR and will test after any later commits

## What does this pull request do?
Fixes an error where a player can proceed through a mission without following the correct steps.

Describe what your PR does here. If it closes an existing issue, you can mention: 
It creates a check to stop the player from progressing past the point they shouldn't.

## Steps to test these changes
Below

<!-- Clear and detailed steps to test your changes here -->
In this mission, the player gets the mission from the gate guard and then is supposed to go for two cutscenes: The king, and Rahal, and thus updates their mission status to 2 (One each respectively). Players who pick up the quest are currently able to go directly to the KI portion of this mission and obtain the three KI which adjusts their mission status to 3 which then locks them permanently in that mission status unable to go back or forward. They should not be able to obtain this KI without talking to the king and Rahal first, therefore a mission status check of greater than 1 is required (utilized the greater than symbol due to the fact it is a +1 variable on each of the key item collections. so a flat number would not be appropriate.). 

The reproducibility of this error was tested on a base LSB server, and the correction was tested and fully functional on the base LSB server. Attempted the steps of the bug which was not present on a fix, repeated the correct steps and was able to finish the mission. 

