### PR TITLE
[lua] Add example for paginated menu

### DIFF
--- a/scripts/commands/menu_paginated.lua
+++ b/scripts/commands/menu_paginated.lua
@@ -1,0 +1,77 @@
+-----------------------------------
+-- func: menu_paginated
+-- desc: Shows a paginated test menu with two pages, an option per page.
+-- note: title and options are required.
+--     : onStart, onCancelled, and onEnd are optional.
+--     : You must provide at least one option.
+--     : Incorrectly creating or configuring a menu
+--     : will not result in a crash or broken menus,
+--     : but will produce scary looking warnings in
+--     : the log.
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+-- Forward declarations (required)
+local menu  = {}
+local page1 = {}
+local page2 = {}
+
+-- We need just a tiny delay to let the previous menu context be cleared out
+-- "New pages" are actually just whole new menus!
+local delaySendMenu = function(player)
+    player:timer(50, function(playerArg)
+        playerArg:customMenu(menu)
+    end)
+end
+
+menu =
+{
+    title = "Test Menu (Paginated)",
+    options = {},
+}
+
+page1 =
+{
+    {
+        "Option 1",
+        function(playerArg)
+            playerArg:PrintToPlayer("Option 1 Selected", xi.msg.channel.NS_SAY)
+            playerArg:independentAnimation(playerArg, 251, 4) -- Hearts
+        end,
+    },
+    {
+        "Next Page",
+        function(playerArg)
+            menu.options = page2
+            delaySendMenu(playerArg)
+        end,
+    },
+}
+
+page2 =
+{
+    {
+        "Option 2",
+        function(playerArg)
+            playerArg:PrintToPlayer("Option 2 Selected", xi.msg.channel.NS_SAY)
+            playerArg:independentAnimation(playerArg, 252, 4) -- Music Notes
+        end,
+    },
+    {
+        "Previous Page",
+        function(playerArg)
+            menu.options = page1
+            delaySendMenu(playerArg)
+        end,
+    },
+}
+
+function onTrigger(player)
+    menu.options = page1
+    delaySendMenu(player)
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

![image](https://user-images.githubusercontent.com/1389729/184367156-aa81d34b-4aa0-470e-9abb-deaba95a0e6f.png)

![image](https://user-images.githubusercontent.com/1389729/184367207-3afc5ecf-a0d3-4d69-a757-88df32b18bed.png)


## Steps to test these changes

`!menu_paginated`