### PR TITLE
[sql] Fix grouping in Vuu Puqu The Beguiler droplist

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -21602,7 +21602,7 @@ INSERT INTO `mob_droplist` VALUES (2595,2,0,1000,847,0);    -- Bird Feather (Ste
 -- ZoneID: 145 - Vuu Puqu The Beguiler
 INSERT INTO `mob_droplist` VALUES (2596,1,1,1000,13072,900);        -- Bird Whistle (Group 1 - 90%)
 INSERT INTO `mob_droplist` VALUES (2596,1,1,1000,13837,@UNCOMMON);  -- Bonzes Circlet (Group 1 - Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (2596,1,1,1000,4994,@COMMON);     -- Scroll of Mage's Ballad (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (2596,0,0,1000,4994,@COMMON);     -- Scroll of Mage's Ballad (Common, 15%)
 
 -- ZoneID: 191 - Wadi Crab
 INSERT INTO `mob_droplist` VALUES (2597,0,0,1000,936,200); -- Chunk Of Rock Salt (20.0%)


### PR DESCRIPTION
Kudos to DiscipleOfEris for spotting this!

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Ungroups Scroll of Mage's Ballad from being in the same grouped drop as the other two drops from this mob.
- No drop rates changed for any drops, only drop group assignment of this item.

## Steps to test these changes

Cherry-pick this PR (or wait until it's merged and resync your server with LSB Base branch) and notice that you now correctly have a 15% chance for the Scroll of Mage's Ballad to drop. It previously was coded to be in the same drop group as the other 2 items in the drop pool meaning that it never ever had a chance to ever be obtained.  All the BRDs can now sing ballads to rejoice!!!
