### PR TITLE
Fix incorrect Droprates when Group Droprate totals are not 1000

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -957,6 +957,12 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         for (const DropGroup_t& group : DropList.Groups)
         {
+            uint16 total = 0;
+            for (const DropItem_t& item : group.Items)
+            {
+                total += item.DropRate;
+            }
+
             for (int16 roll = 0; roll < maxRolls; ++roll)
             {
                 // Determine if this group should drop an item
@@ -965,7 +971,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                     // Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
                     // Such as 2 items with drop rates of 200 and 800 would be 0-199 and 200-999 respectively
                     uint16 previousRateValue = 0;
-                    uint16 itemRoll          = xirand::GetRandomNumber(1000);
+                    uint16 itemRoll          = xirand::GetRandomNumber(total);
                     for (const DropItem_t& item : group.Items)
                     {
                         if (previousRateValue + item.DropRate > itemRoll)


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

If a mob's droplist includes a group where the group's total drop rates don't add up to 1000, the drop rates will be incorrect. There are two possibilities. The drop rates add up to less than 1000, resulting in a chance for the group to not drop even if the group should have a 100% drop chance. Or the drop rates add up to more than 1000, resulting in the drop rates being out of proportion and even making some items impossible to drop.

This fix rolls the droprate out of the total rate in the group, rather than always 1000. As such, droprates for the items in a group will be proportional to their total, rather than requiring the total come to 1000. So like if you have 5 items with a dropRate of 500, each will have a 20% chance to drop. Similarly, if you have 2 items with a dropRate of 10, each will have a 50% chance to drop.

Fixes #2527

## Steps to test these changes

See #2527
