### PR TITLE
[sql] Quick Drop Groups Audit

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -18940,8 +18940,8 @@ INSERT INTO `mob_droplist` VALUES (2374,0,0,1000,939,170); -- Hecteyes Eye (17.0
 INSERT INTO `mob_droplist` VALUES (2375,0,0,1000,914,480);     -- Vial Of Mercury (48.0%)
 INSERT INTO `mob_droplist` VALUES (2375,0,0,1000,939,250);     -- Hecteyes Eye (25.0%)
 INSERT INTO `mob_droplist` VALUES (2375,0,0,1000,15222,@RARE); -- Spelunkers Hat (Rare, 5%)
-INSERT INTO `mob_droplist` VALUES (2375,0,1,1000,4717,950);    -- Scroll Of Refresh (Group 1 - 95.0%)
-INSERT INTO `mob_droplist` VALUES (2375,0,1,1000,4850,@RARE);  -- Scroll Of Refresh Ii (Group 1 - Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2375,1,1,1000,4717,950);    -- Scroll Of Refresh (Group 1 - 95.0%)
+INSERT INTO `mob_droplist` VALUES (2375,1,1,1000,4850,@RARE);  -- Scroll Of Refresh Ii (Group 1 - Rare, 5%)
 
 -- ZoneID: 204 - Talos
 INSERT INTO `mob_droplist` VALUES (2376,0,0,1000,914,110); -- Vial Of Mercury (11.0%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Audits `mob_droplist.sql`, looking for the following:
* Rows that had a `dropType` set to `1`, a `groupId` higher than `0`, and that had values for `itemRate` not totaling up to 1000 (100%) for the set group(s).
  * HURRAY! None found!!!
* Rows that had a `dropType` set to 0 and a `groupId` higher than `0`
  * HURRAY! None found!!!
* Rows that had a `groupId` higher than `0` and **didn't also** have a `dropType` set to `1`
  * One instance found, resolved by changing the `dropType` from `0` to `1`

## Steps to test these changes

Cherry-pick this PR (or wait until it's merged and resync your server with LSB Base branch) and notice that you now correctly have a rejoicefully high 95% chance for the Scroll Refresh to drop **OR** a super sads low 5% chance for the Scroll of Refresh II to drop off Taisaijin. It previously was coded for neither to be in the same drop group and instead be affected by Treasure Hunter along with all the other items this mob drops.

It is *tai*me to *sai* and *refresh* yourself with some *jin* while farming this NM!

I'll see myself out now.