### PR TITLE
Fix the MAGIC_TAKE event always triggering twice

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2659,8 +2659,6 @@ namespace luautils
             return -1;
         }
 
-        PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", CLuaBaseEntity(PTarget), CLuaBaseEntity(PCaster), CLuaSpell(PSpell));
-
         sol::function onMagicHit = getEntityCachedFunction(PTarget, "onMagicHit");
         if (!onMagicHit.valid())
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

The `MAGIC_TAKE` event is emitted in `luautils::OnMagicHit()` *only* after `MAGIC_TAKE` is emitted in `CMagicState::Update()`. There's no reason to have the listener trigger in `luautils::OnMagicHit()` since it's always guaranteed to have already just triggered.

This removes the duplicate `MAGIC_TAKE` trigger.

Fixes #2531

## Steps to test these changes

1. In a lua script for a mob, do `mob:addListener("MAGIC_TAKE", "whatever", function(target, caster, spell) print("MAGIC_TAKE") end)`
2. Cast a spell on the mob.
3. Check the console for xi_map.exe
4. Notice only one "MAGIC_TAKE" printed.

Before the fix, there would be two "MAGIC_TAKE" printed.