### PR TITLE
Fix wyverns disappearing on certain types of zoning

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -416,7 +416,7 @@ void CCharEntity::setPetZoningInfo()
     {
         switch (((CPetEntity*)PPet)->getPetType())
         {
-            case PET_TYPE::JUG_PET:
+            case PET_TYPE::AVATAR:
             case PET_TYPE::AUTOMATON:
             case PET_TYPE::WYVERN:
                 petZoningInfo.petHP   = PPet->health.hp;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2660,6 +2660,8 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
+        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
         if (va[4].is<double>())
         {
             auto zoneid = va[4].as<uint16>();
@@ -2668,22 +2670,22 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
-            if (static_cast<CCharEntity*>(m_PBaseEntity)->PPet != nullptr)
+            if (PChar->PPet != nullptr)
             {
-                static_cast<CCharEntity*>(m_PBaseEntity)->setPetZoningInfo();
+                PChar->setPetZoningInfo();
             }
 
-            static_cast<CCharEntity*>(m_PBaseEntity)->loc.destination = zoneid;
-            static_cast<CCharEntity*>(m_PBaseEntity)->status          = STATUS_TYPE::DISAPPEAR;
-            static_cast<CCharEntity*>(m_PBaseEntity)->loc.boundary    = 0;
-            static_cast<CCharEntity*>(m_PBaseEntity)->m_moghouseID    = 0;
-            static_cast<CCharEntity*>(m_PBaseEntity)->clearPacketList();
-            charutils::SendToZone(static_cast<CCharEntity*>(m_PBaseEntity), 2, zoneutils::GetZoneIPP(m_PBaseEntity->loc.destination));
-            //static_cast<CCharEntity*>(m_PBaseEntity)->loc.zone->DecreaseZoneCounter(static_cast<CCharEntity*>(m_PBaseEntity));
+            PChar->loc.destination = zoneid;
+            PChar->status          = STATUS_TYPE::DISAPPEAR;
+            PChar->loc.boundary    = 0;
+            PChar->m_moghouseID    = 0;
+            PChar->clearPacketList();
+            charutils::SendToZone(PChar, 2, zoneutils::GetZoneIPP(PChar->loc.destination));
+            //PChar->loc.zone->DecreaseZoneCounter(PChar);
         }
-        else if (static_cast<CCharEntity*>(m_PBaseEntity)->status != STATUS_TYPE::DISAPPEAR)
+        else if (PChar->status != STATUS_TYPE::DISAPPEAR)
         {
-            static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CPositionPacket(static_cast<CCharEntity*>(m_PBaseEntity)));
+            PChar->pushPacket(new CPositionPacket(PChar));
         }
     }
     m_PBaseEntity->updatemask |= UPDATE_POS;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2681,7 +2681,7 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
             PChar->m_moghouseID    = 0;
             PChar->clearPacketList();
             charutils::SendToZone(PChar, 2, zoneutils::GetZoneIPP(PChar->loc.destination));
-            //PChar->loc.zone->DecreaseZoneCounter(PChar);
+            // PChar->loc.zone->DecreaseZoneCounter(PChar);
         }
         else if (PChar->status != STATUS_TYPE::DISAPPEAR)
         {

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2668,6 +2668,11 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
+            if (((CCharEntity*)m_PBaseEntity)->PPet != nullptr)
+            {
+                ((CCharEntity*)m_PBaseEntity)->setPetZoningInfo();
+            }
+
             ((CCharEntity*)m_PBaseEntity)->loc.destination = zoneid;
             ((CCharEntity*)m_PBaseEntity)->status          = STATUS_TYPE::DISAPPEAR;
             ((CCharEntity*)m_PBaseEntity)->loc.boundary    = 0;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2668,22 +2668,22 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
-            if (((CCharEntity*)m_PBaseEntity)->PPet != nullptr)
+            if (static_cast<CCharEntity*>(m_PBaseEntity)->PPet != nullptr)
             {
-                ((CCharEntity*)m_PBaseEntity)->setPetZoningInfo();
+                static_cast<CCharEntity*>(m_PBaseEntity)->setPetZoningInfo();
             }
 
-            ((CCharEntity*)m_PBaseEntity)->loc.destination = zoneid;
-            ((CCharEntity*)m_PBaseEntity)->status          = STATUS_TYPE::DISAPPEAR;
-            ((CCharEntity*)m_PBaseEntity)->loc.boundary    = 0;
-            ((CCharEntity*)m_PBaseEntity)->m_moghouseID    = 0;
-            ((CCharEntity*)m_PBaseEntity)->clearPacketList();
-            charutils::SendToZone((CCharEntity*)m_PBaseEntity, 2, zoneutils::GetZoneIPP(m_PBaseEntity->loc.destination));
-            //((CCharEntity*)m_PBaseEntity)->loc.zone->DecreaseZoneCounter(((CCharEntity*)m_PBaseEntity));
+            static_cast<CCharEntity*>(m_PBaseEntity)->loc.destination = zoneid;
+            static_cast<CCharEntity*>(m_PBaseEntity)->status          = STATUS_TYPE::DISAPPEAR;
+            static_cast<CCharEntity*>(m_PBaseEntity)->loc.boundary    = 0;
+            static_cast<CCharEntity*>(m_PBaseEntity)->m_moghouseID    = 0;
+            static_cast<CCharEntity*>(m_PBaseEntity)->clearPacketList();
+            charutils::SendToZone(static_cast<CCharEntity*>(m_PBaseEntity), 2, zoneutils::GetZoneIPP(m_PBaseEntity->loc.destination));
+            //static_cast<CCharEntity*>(m_PBaseEntity)->loc.zone->DecreaseZoneCounter(static_cast<CCharEntity*>(m_PBaseEntity));
         }
-        else if (((CCharEntity*)m_PBaseEntity)->status != STATUS_TYPE::DISAPPEAR)
+        else if (static_cast<CCharEntity*>(m_PBaseEntity)->status != STATUS_TYPE::DISAPPEAR)
         {
-            ((CCharEntity*)m_PBaseEntity)->pushPacket(new CPositionPacket((CCharEntity*)m_PBaseEntity));
+            static_cast<CCharEntity*>(m_PBaseEntity)->pushPacket(new CPositionPacket(static_cast<CCharEntity*>(m_PBaseEntity)));
         }
     }
     m_PBaseEntity->updatemask |= UPDATE_POS;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -441,10 +441,10 @@ void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PCh
                 default:
                     break;
             }
+            // Reset the petZoning info
+            PChar->resetPetZoningInfo();
         }
     }
-    // Reset the petZoning info
-    PChar->resetPetZoningInfo();
 }
 
 /************************************************************************

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -432,7 +432,6 @@ void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PCh
             switch (PChar->petZoningInfo.petType)
             {
                 case PET_TYPE::AUTOMATON:
-                case PET_TYPE::JUG_PET:
                 case PET_TYPE::WYVERN:
                 case PET_TYPE::LUOPAN:
                     petutils::SpawnPet(PChar, PChar->petZoningInfo.petID, true);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -431,6 +431,7 @@ void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             switch (PChar->petZoningInfo.petType)
             {
+                case PET_TYPE::AVATAR:
                 case PET_TYPE::AUTOMATON:
                 case PET_TYPE::WYVERN:
                 case PET_TYPE::LUOPAN:


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Wyverns, Automatons, and Avatars weren't being respawned when leaving town (if you entered with it) or when zoning via the `luautils::setPos()` function, which includes NPC interactions and the `!zone` command. They should now be retained in those instances.

Also, Jug Pets were being kept through normal zoning, but I've been informed that is not retail behavior so it will be removed by this PR as well.

Fixes #2536 
Fixes #2535 

## Steps to test these changes

See #2536 

More information on how this is handled by retail for different types of pets and different types of zoning would be valuable.