### PR TITLE
Implement Quest: A Beaked Blusterer

### DIFF
--- a/scripts/quests/abyssea/A_Beaked_Blusterer.lua
+++ b/scripts/quests/abyssea/A_Beaked_Blusterer.lua
@@ -1,0 +1,81 @@
+-----------------------------------
+-- A_Beaked_Blusterer
+-----------------------------------
+-- !addquest 8 176
+-----------------------------------
+require('scripts/globals/interaction/quest')
+require('scripts/globals/abyssea')
+require('scripts/globals/keyitems')
+require('scripts/globals/npc_util')
+require('scripts/globals/quests')
+require('scripts/globals/titles')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_BEAKED_BLUSTERER)
+
+quest.reward = {}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE and
+                xi.abyssea.getHeldTraverserStones(player) >= 1 and
+                player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) >= QUEST_ACCEPTED
+        end,
+
+        [xi.zone.SOUTH_GUSTABERG] =
+        {
+            ['Cavernous_Maw'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(0)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [0] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED and player:hasTitle(xi.title.BENNU_DEPLUMER)
+        end,
+
+        [xi.zone.SOUTH_GUSTABERG] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    return 1
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [1] = function(player, csid, option)
+                    if option == 1 then
+                        player:updateEvent(xi.abyssea.getZoneKIReward(player))
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [1] = function(player, csid, option, npc)
+                    -- NOTE: Give the key item prior to completing the quest so that we reward the correct
+                    -- KI!  If we complete first, it'll adjust the total completed count, and be off by one!
+                    npcUtil.giveKeyItem(player, xi.abyssea.getZoneKIReward(player))
+                    quest:complete(player)
+                end,
+            },
+        },
+    },
+}
+
+return quest


### PR DESCRIPTION
Fixed abyssea entrance quest not being obtained correctly

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixed abyssea entrance quest not being obtained correctly
Cavernous_Maw 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
