### PR TITLE
[LUA] Create job_utils/red_mage and migrate JA functionality

### DIFF
--- a/scripts/globals/abilities/chainspell.lua
+++ b/scripts/globals/abilities/chainspell.lua
@@ -5,18 +5,16 @@
 -- Recast Time: 1:00:00
 -- Duration: 0:01:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
-    return 0, 0
+    return xi.job_utils.red_mage.checkChainspell(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.CHAINSPELL, 1, 0, 60)
+    xi.job_utils.red_mage.useChainspell(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/composure.lua
+++ b/scripts/globals/abilities/composure.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 5:00
 -- Duration: 120 minutes
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,8 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:delStatusEffect(xi.effect.COMPOSURE)
-    player:addStatusEffect(xi.effect.COMPOSURE, 1, 0, 7200)
+    xi.job_utils.red_mage.useComposure(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/convert.lua
+++ b/scripts/globals/abilities/convert.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 10:00
 -- Duration: Instant
 -----------------------------------
-require("scripts/globals/jobpoints")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,19 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    local playerMP = player:getMP()
-    local playerHP = player:getHP()
-    local jpValue = player:getJobPointLevel(xi.jp.CONVERT_EFFECT)
-
-    if playerMP > 0 then
-        -- Murgleis sword augments Convert.
-        if player:getMod(xi.mod.AUGMENTS_CONVERT) > 0 and playerHP > player:getMaxHP()/2 then
-            playerHP = playerHP * player:getMod(xi.mod.AUGMENTS_CONVERT)
-        end
-
-        player:setHP(playerMP + (playerHP * (jpValue * 0.01)))
-        player:setMP(playerHP)
-    end
+    xi.job_utils.red_mage.useConvert(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/saboteur.lua
+++ b/scripts/globals/abilities/saboteur.lua
@@ -5,8 +5,7 @@
 -- Recast Time: 5:00
 -- Duration: 1:00
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -15,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    player:addStatusEffect(xi.effect.SABOTEUR, 0, 0, 60)
+    xi.job_utils.red_mage.useSaboteur(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/spontaneity.lua
+++ b/scripts/globals/abilities/spontaneity.lua
@@ -5,7 +5,7 @@
 -- Recast Time: 10:00
 -- Duration: 1:00
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
@@ -14,7 +14,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    target:addStatusEffect(xi.effect.SPONTANEITY, 1, 0, 60)
+    xi.job_utils.red_mage.useSpontaneity(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/stymie.lua
+++ b/scripts/globals/abilities/stymie.lua
@@ -5,17 +5,16 @@
 -- Recast Time: 1:00:00
 -- Duration: Stymie fades after either sixty seconds passes or a spell lands, but it does not fade if the spell is resisted.
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/job_utils/red_mage")
 -----------------------------------
 local ability_object = {}
 
 ability_object.onAbilityCheck = function(player, target, ability)
-    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
-    return 0, 0
+    return xi.job_utils.red_mage.checkStymie(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    target:addStatusEffect(xi.effect.STYMIE, 0, 0, 60)
+    xi.job_utils.red_mage.useStymie(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/job_utils/red_mage.lua
+++ b/scripts/globals/job_utils/red_mage.lua
@@ -1,0 +1,65 @@
+-----------------------------------
+-- Red Mage Job Utilities
+-----------------------------------
+require('scripts/globals/items')
+require("scripts/globals/msg")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+-----------------------------------
+xi = xi or {}
+xi.job_utils = xi.job_utils or {}
+xi.job_utils.red_mage = xi.job_utils.red_mage or {}
+
+-----------------------------------
+-- Ability Check Functions
+-----------------------------------
+xi.job_utils.red_mage.checkChainspell = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    return 0, 0
+end
+
+xi.job_utils.red_mage.checkStymie = function(player, target, ability)
+    ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))
+    return 0, 0
+end
+
+-----------------------------------
+-- Ability Use Functions
+-----------------------------------
+xi.job_utils.red_mage.useChainspell = function(player, target, ability)
+    player:addStatusEffect(xi.effect.CHAINSPELL, 1, 0, 60)
+end
+
+xi.job_utils.red_mage.useComposure = function(player, target, ability)
+    player:delStatusEffect(xi.effect.COMPOSURE)
+    player:addStatusEffect(xi.effect.COMPOSURE, 1, 0, 7200)
+end
+
+xi.job_utils.red_mage.useConvert = function(player, target, ability)
+    local playerMP = player:getMP()
+    local playerHP = player:getHP()
+    local jpValue  = player:getJobPointLevel(xi.jp.CONVERT_EFFECT)
+
+    if playerMP > 0 then
+        -- Murgleis sword augments Convert
+        if player:getMod(xi.mod.AUGMENTS_CONVERT) > 0 and playerHP > player:getMaxHP() / 2 then
+            playerHP = playerHP * player:getMod(xi.mod.AUGMENTS_CONVERT)
+        end
+
+        player:setHP(playerMP + (playerHP * (jpValue * 0.01)))
+        player:setMP(playerHP)
+    end
+end
+
+xi.job_utils.red_mage.useSaboteur = function(player, target, ability)
+    player:addStatusEffect(xi.effect.SABOTEUR, 1, 0, 60)
+end
+
+xi.job_utils.red_mage.useSpontaneity = function(player, target, ability)
+    target:addStatusEffect(xi.effect.SPONTANEITY, 1, 0, 60)
+end
+
+xi.job_utils.red_mage.useStymie = function(player, target, ability)
+    target:addStatusEffect(xi.effect.STYMIE, 1, 0, 60)
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Create job_utils/red_mage.lua and populates necessary ability check and ability use functions.
- Moves functionality from all Red Mage globals/abilities files to globals/job_utils/red_mage.lua.
- Adjusts minor formatting.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Upload changes to your server.
2. Load the server.
3. Use the !changejob RDM 99 command.
4. Use all JA's to confirm they do not throw errors.
