### PR TITLE
Add Settings option to keep jug pets through zoning

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -239,4 +239,7 @@ xi.settings.map =
     --  Gobbie Mystery Box settings
     DAILY_TALLY_AMOUNT = 10,
     DAILY_TALLY_LIMIT  = 50000,
+    
+    -- Enable/disable keeping jug pets through zoning
+    KEEP_JUGPET_THROUGH_ZONING = false,
 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -416,6 +416,12 @@ void CCharEntity::setPetZoningInfo()
     {
         switch (((CPetEntity*)PPet)->getPetType())
         {
+            case PET_TYPE::JUG_PET:
+                if (!settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"))
+                {
+                    break;
+                }
+                [[fallthrough]];
             case PET_TYPE::AVATAR:
             case PET_TYPE::AUTOMATON:
             case PET_TYPE::WYVERN:

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -431,6 +431,12 @@ void SmallPacket0x00C(map_session_data_t* const PSession, CCharEntity* const PCh
         {
             switch (PChar->petZoningInfo.petType)
             {
+                case PET_TYPE::JUG_PET:
+                    if (!settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"))
+                    {
+                        break;
+                    }
+                    [[fallthrough]];
                 case PET_TYPE::AVATAR:
                 case PET_TYPE::AUTOMATON:
                 case PET_TYPE::WYVERN:


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Server admins can use this by changing the `KEEP_JUGPET_THROUGH_ZONING` option in their `settings/map.lua`. Setting to false follows retail behavior. Setting to true will keep jug pets through zoning just like wyverns.

Closes #2544 

## Steps to test these changes

1. Go to `settings/map.lua`.
2. Change the `KEEP_JUGPET_THROUGH_ZONING` to true or false. Your choice.
3. Restart your server.
4. Enter game. Switch to beastmaster and equip a jug.
5. Summon your jug pet with Call Beast.
6. Move to another zone (or into town and then back out of town).
7. Observe that whether your jug pet returns to your or not is based on the `KEEP_JUGPET_THROUGH_ZONING` option.
