### PR TITLE
add mog house check to initial RoV cut scene event

### DIFF
--- a/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
+++ b/scripts/missions/rov/1_01_Rhapsodies_of_Vanadiel.lua
@@ -38,7 +38,8 @@ mission.sections[1] = {}
 mission.sections[1].check = function(player, currentMission, missionStatus, vars)
     return currentMission == mission.missionId and
         xi.settings.main.ENABLE_ROV == 1 and
-        player:getMainLvl() >= 3
+        player:getMainLvl() >= 3 and
+        not player:isInMogHouse()
 end
 
 local rovZoneInEvent =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Checks if player is in a mog house before triggering zone in CS for RoV mission 1
Closes #2546

## Steps to test these changes
<!-- Clear and detailed steps to test your changes here -->
Make a new character
Make it a GM
use !changejob JOB 75 (where JOB is any valid Job shorthand, such as RDM)
enter moghouse, see that no RoV CS triggers