### PR TITLE
Fix issue with level capping during merit/limit mode changes

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6783,11 +6783,11 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 blueutils::UnequipAllBlueSpells(PChar);
             }
-            
+
             bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
             if (!canUseMeritMode && PChar->MeritMode == true)
             {
-                if (sql->Query("UPDATE char_exp SET mode = %u WHERE charid = %u", 0, PChar->id) != SQL_ERROR) 
+                if (sql->Query("UPDATE char_exp SET mode = %u WHERE charid = %u", 0, PChar->id) != SQL_ERROR)
                 {
                     PChar->MeritMode = false;
                 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6783,7 +6783,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 blueutils::UnequipAllBlueSpells(PChar);
             }
-			
+            
             bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
             if (!canUseMeritMode && PChar->MeritMode == true)
             {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6783,6 +6783,15 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
             {
                 blueutils::UnequipAllBlueSpells(PChar);
             }
+			
+			bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
+            if (!canUseMeritMode && PChar->MeritMode == true)
+            {
+                if (sql->Query("UPDATE char_exp SET mode = %u WHERE charid = %u", 0, PChar->id) != SQL_ERROR) 
+				{
+					PChar->MeritMode = false;
+				}
+            }
         }
 
         if ((sjob > 0x00) && (sjob < MAX_JOBTYPE) && (PChar->jobs.unlocked & (1 << sjob)))

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6784,13 +6784,13 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
                 blueutils::UnequipAllBlueSpells(PChar);
             }
 			
-			bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
+            bool canUseMeritMode = PChar->jobs.job[PChar->GetMJob()] >= 75 && charutils::hasKeyItem(PChar, 606);
             if (!canUseMeritMode && PChar->MeritMode == true)
             {
                 if (sql->Query("UPDATE char_exp SET mode = %u WHERE charid = %u", 0, PChar->id) != SQL_ERROR) 
-				{
-					PChar->MeritMode = false;
-				}
+                {
+                    PChar->MeritMode = false;
+                }
             }
         }
 


### PR DESCRIPTION
When switching to Merit Mode, then changing jobs, if the new job is not at max
level, the new job will be capped at its current level and not gain EXP nor LP.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes  #2511 

## Steps to test these changes

Have a character that meets Merit Mode requirements (lv 75+ job and key item "Limit Breaker"/606)
Turn on merit mode.
Change jobs to a one that does NOT meet merit mode requirements.

Old behavior: This job will be locked at their current level and not be able to gain EXP or LP. Also, due to not being 75+, the player can't access the Merit menu to toggle back to EXP mode without switching jobs.
New behavior: The DB entry for the character is updated to reflect the Merit Mode change, as well as sending the corrected merit mode status packet.
