### PR TITLE
[core] Remove floor of 1% on restraint

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -596,9 +596,7 @@ void CAttack::ProcessDamage()
             float boostPerRound = ((m_attacker->GetWeaponDelay(false) / 1000.0f) * 60.0f) / 385.0f;
             float remainder     = effect->GetSubPower() / 100.0f;
 
-            // Cap floor at 1 WSD per hit
             // Calculate bonuses from Enhances Restraint, Job Point upgrades, and remainder from previous hit
-            boostPerRound = std::clamp<float>(boostPerRound, 1, boostPerRound);
             boostPerRound = (boostPerRound * (1 + m_attacker->getMod(Mod::ENHANCES_RESTRAINT) / 100.0f) * (1 + jpBonus / 100.0f)) + remainder;
 
             // Calculate new remainder and multiply by 100 so significant digits aren't lost


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removes floor of 1% on restraint.
Fixes #2542
Probably fixes #2484

The issue that was causing the crash was std::clamp being called with a max smaller than the min, and the stl appears to have not taken kindly to that. It exposed the fact that there appears to be no actual minimum on restraint gain according to testing at https://web.archive.org/web/20220818040052/http://robonosto.blogspot.com/2012/09/restraint-revisited.html, so removing the line solved 2 problems.

## Steps to test these changes

Forcefully use restraint on Abquhbah, IronEater, IShieldUC trusts with `!exec target:useJobAbility(252,target)`, attack a mob and don't crash.
