### PR TITLE
Add additional Mission RoE Objectives, expand support for Capacity Point bonuses

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -2070,7 +2070,168 @@ function getRoeRecords(triggers)
         -- Tutorial -> Missions (Treasures of Aht Urhgan)
         -----------------------------------
 
-        -- start 1410
+        -- TODO: Needs verification for progressing "Up to" vs requiring mission to be completed.  This appears to
+        -- be the required mission, with the exception of the final in each series which is not officially completed.
+
+        [1410] =
+        { -- Treasures of Aht Urhgan 1
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.A_MERCENARY_LIFE } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1411] =
+        { -- Treasures of Aht Urhgan 2
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.PASSING_GLORY } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1412] =
+        { -- Treasures of Aht Urhgan 3
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.PLAYING_THE_PART } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1413] =
+        { -- Treasures of Aht Urhgan 4
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.SENTINELS_HONOR } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1414] =
+        { -- Treasures of Aht Urhgan 5
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.STIRRINGS_OF_WAR } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1415] =
+        { -- Treasures of Aht Urhgan 6
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.TOAU, xi.mission.id.toau.THE_EMPRESS_CROWNED } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        -----------------------------------
+        -- Tutorial -> Missions (Wings of the Goddess)
+        -----------------------------------
+
+        [1402] =
+        { -- Wings of the Goddess 1
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1403] =
+        { -- Wings of the Goddess 2
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1404] =
+        { -- Wings of the Goddess 3
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.IN_THE_NAME_OF_THE_FATHER } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1405] =
+        { -- Wings of the Goddess 4
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.CROSSROADS_OF_TIME } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1406] =
+        { -- Wings of the Goddess 5
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.FATE_IN_HAZE } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1407] =
+        { -- Wings of the Goddess 6
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.ADIEU_LILISETTE } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1408] =
+        { -- Wings of the Goddess 7
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.GLIMMER_OF_LIFE } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1409] =
+        { -- Wings of the Goddess 8
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.WOTG, xi.mission.id.wotg.A_TOKEN_OF_TROTH } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        -----------------------------------
+        -- Tutorial -> Missions (Adoulin)
+        -----------------------------------
+
+        [1426] =
+        { -- Seekers of Adoulin Chapter 1
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.SOA, xi.mission.id.soa.ARCIELA_APPEARS_AGAIN } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1427] =
+        { -- Seekers of Adoulin Chapter 2
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.SOA, xi.mission.id.soa.YGGDRASIL } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1428] =
+        { -- Seekers of Adoulin Chapter 3
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.SOA, xi.mission.id.soa.GLIMMER_OF_PORTENT } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1429] =
+        { -- Seekers of Adoulin Chapter 4
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.SOA, xi.mission.id.soa.ROYAL_BLESSINGS } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
+
+        [1430] =
+        { -- Seekers of Adoulin Chapter 5
+            trigger = triggers.missionComplete,
+            reqs = { missionComplete = { xi.mission.log_id.SOA, xi.mission.id.soa.UNDYING_LIGHT } },
+            flags = set { "retro" },
+            reward = { sparks = 300, xp = 500 },
+        },
 
         -----------------------------------
         -- Combat (Wide Area) -> Combat (General)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4190,13 +4190,12 @@ namespace charutils
             rawBonus += 2 * (roeutils::RoeSystem.unityLeaderRank[unity - 1] - 1);
         }
 
-        // RoE Objectives (There might be a formulaic way to do some of these)
-        // Nation Mission Completion (10%)
-        for (uint16 nationRecord = 1332; nationRecord <= 1372; nationRecord += 20)
+        // RoE Objectives
+        for (auto const& recordValue : roeCapacityBonusRecords)
         {
-            if (roeutils::GetEminenceRecordCompletion(PChar, nationRecord))
+            if (roeutils::GetEminenceRecordCompletion(PChar, recordValue.first))
             {
-                rawBonus += 10;
+                rawBonus += recordValue.second;
             }
         }
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -50,6 +50,19 @@ enum class EMobDifficulty : uint8
     MAX
 };
 
+// Capacity Bonuses applied based on RoE Completion
+// TODO: Add RoV Completion and Reive bonuses once implemented
+const std::vector<std::pair<uint16, uint8>> roeCapacityBonusRecords = {
+    { 1332, 10 }, // San d'Oria Missions (10%)
+    { 1352, 10 }, // Bastok Missions (10%)
+    { 1372, 10 }, // Windurst Missions (10%)
+    { 1392, 10 }, // Zilart Missions (10%)
+    { 1400, 10 }, // Chains of Promathia Missions (10%)
+    { 1409, 10 }, // Wings of the Goddess Missions (10%)
+    { 1415, 10 }, // Treasures of Aht Urhgan Missions (10%)
+    { 1430, 10 }, // Seekers of Adoulin Missions (10%
+};
+
 namespace charutils
 {
     void LoadExpTable();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Adds ToAU, WotG, and Adoulin RoE Objectives
* Adds additional support for Capacity Point bonuses based on RoE completion
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Complete objectives, kill things with Job Breaker KI
<!-- Clear and detailed steps to test your changes here -->
