### PR TITLE
[TRUST] Ferreous Coffin

### DIFF
--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -21,6 +21,7 @@ ai.target =
     CASTER     = 7,
     TOP_ENMITY = 8,
     CURILLA    = 9, -- Special case for Rainemard
+    PARTY_DEAD = 10,
 }
 ai.t = ai.target
 
@@ -51,7 +52,6 @@ ai.condition =
     PT_HAS_TANK        = 21,
     NOT_PT_HAS_TANK    = 22,
     IS_ECOSYSTEM       = 23,
-    IS_DEAD            = 24,
 }
 ai.c = ai.condition
 

--- a/scripts/globals/gambits.lua
+++ b/scripts/globals/gambits.lua
@@ -51,6 +51,7 @@ ai.condition =
     PT_HAS_TANK        = 21,
     NOT_PT_HAS_TANK    = 22,
     IS_ECOSYSTEM       = 23,
+    IS_DEAD            = 24,
 }
 ai.c = ai.condition
 

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -25,7 +25,6 @@ spell_object.onMobSpawn = function(mob)
 
     mob:addMod(xi.mod.HPP, -10)
     mob:addMod(xi.mod.MPP, 35)
-    mob:addMod(xi.mod.HPP, -10)
     mob:addMod(xi.mod.REFRESH, 2)
     mob:addMod(xi.mod.ENHANCES_CURSNA, 20)
 

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -1,5 +1,12 @@
 -----------------------------------
 -- Trust: Ferreous Coffin
+-- Auto Refresh II (Cleric's Bliaut +2). HP-10%, MP+35%
+-- Will only cast Raise III on KO party members in casting range.
+-- Will only cast status ailment removal spells on the player with the highest enmity.
+-- Has a high Cursna success rate (only casts on the highest threat player) Official note
+-- Ferreous Coffin only uses Randgrith and benefits from relic aftermath (acc +20).
+-- Will use TP as soon as he gets it, so he is good at maintaining enemy Evasion Down and initiating Light skillchains.
+-- Casts Haste on party members regardless of job.
 -----------------------------------
 require("scripts/globals/trust")
 -----------------------------------
@@ -15,6 +22,46 @@ end
 
 spell_object.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.message_offset.SPAWN)
+
+    mob:addMod(xi.mod.HPP, -10)
+    mob:addMod(xi.mod.MPP, 35)
+    mob:addMod(xi.mod.HPP, -10)
+    mob:addMod(xi.mod.REFRESH, 2)
+    mob:addMod(xi.mod.ENHANCES_CURSNA, 20)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLOW, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.ERASE)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.NOT_STATUS, xi.effect.HASTE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.HASTE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE)
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.STATUS, xi.effect.SLEEP_II, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.HPP_LT, 75, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE)
+
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PARALYSIS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.PARALYNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.BLINDNESS, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.BLINDNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.SILENCE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.SILENA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.PETRIFICATION, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STONA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.DISEASE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.VIRUNA)
+
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.CURSE_I, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.CURSE_II, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.BANE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+    mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.DOOM, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
+
+    mob:addSimpleGambit(ai.t.PARTY, ai.c.IS_DEAD, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
+
+    mob:addListener("WEAPONSKILL_USE", "FERREOUS_COFFIN_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
+        if wsid == 170 then -- Randgrith
+        -- Return to the dust whence you came! Randgrith!!!
+            if math.random(100) <= 66 then
+                xi.trust.message(mobArg, xi.trust.message_offset.SPECIAL_MOVE_1)
+            end
+            mob:addStatusEffect(xi.effect.ACCURACY_BOOST, 20, 0, 20) -- Cheat in Relic AM ACC
+            -- TODO: Expand Relic (Mjollnir) Handling (Occ. Double Damage, etc)
+        end
+    end)
+
+    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 end
 
 spell_object.onMobDespawn = function(mob)

--- a/scripts/globals/spells/trust/ferreous_coffin.lua
+++ b/scripts/globals/spells/trust/ferreous_coffin.lua
@@ -48,7 +48,7 @@ spell_object.onMobSpawn = function(mob)
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.BANE, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
     mob:addSimpleGambit(ai.t.TOP_ENMITY, ai.c.STATUS, xi.effect.DOOM, ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURSNA)
 
-    mob:addSimpleGambit(ai.t.PARTY, ai.c.IS_DEAD, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
+    mob:addSimpleGambit(ai.t.PARTY_DEAD, ai.c.ALWAYS, 0, ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.RAISE)
 
     mob:addListener("WEAPONSKILL_USE", "FERREOUS_COFFIN_WEAPONSKILL_USE", function(mobArg, target, wsid, tp, action)
         if wsid == 170 then -- Randgrith

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3559,7 +3559,7 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Semih_Lafihna',1055,3490); -- Stell
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Elivira',1056,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Noillurie',1057,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lhu_Mhakaracca',1058,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ferreous_Coffin',1059,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ferreous_Coffin',1059,170); -- Randgrith
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lilisette',1060,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Mumor',1061,0);
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Uka_Totlihn',1062,167); -- Judgement

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -73,6 +73,7 @@ INSERT INTO `mob_skills` VALUES (166,82,'true_strike',0,7.0,2000,0,4,0,0,0,6,8,0
 INSERT INTO `mob_skills` VALUES (167,83,'judgment',0,7.0,2000,0,4,0,0,0,6,8,0);
 INSERT INTO `mob_skills` VALUES (168,84,'hexa_strike',0,7.0,2000,0,4,0,0,0,11,0,0);
 INSERT INTO `mob_skills` VALUES (169,85,'black_halo',0,7.0,2000,0,4,0,0,0,12,2,0);
+INSERT INTO `mob_skills` VALUES (170,86,'randgrith',0,7.0,2000,0,4,0,0,0,13,12,0);
 INSERT INTO `mob_skills` VALUES (241,241,'netherspikes',4,10.0,2000,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (242,242,'carnal_nightmare',1,10.0,2000,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (243,243,'aegis_schism',0,7.0,2000,0,4,0,0,0,0,0,0);

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -108,6 +108,20 @@ namespace gambits
             {
                 return CheckTrigger(POwner->PMaster, predicate);
             }
+            else if (predicate.target == G_TARGET::PARTY_DEAD)
+            {
+                auto result = false;
+                // clang-format off
+                static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                {
+                    if (PMember->isDead())
+                    {
+                        result = true;
+                    }
+                });
+                // clang-format on
+                return result;
+            }
             else if (predicate.target == G_TARGET::TANK)
             {
                 auto result = false;
@@ -260,6 +274,21 @@ namespace gambits
                 else if (gambit.predicates[0].target == G_TARGET::MASTER)
                 {
                     target = POwner->PMaster;
+                }
+                else if (gambit.predicates[0].target == G_TARGET::PARTY_DEAD)
+                {
+                    auto* mob = POwner->GetBattleTarget();
+                    if (mob != nullptr)
+                    {
+                        //clang-format off
+                        static_cast<CCharEntity*>(POwner->PMaster)->ForParty([&](CBattleEntity* PMember) {
+                            if (PMember->isDead())
+                            {
+                                target = PMember;
+                            }
+                        });
+                        //clang-format on
+                    }
                 }
                 else if (gambit.predicates[0].target == G_TARGET::TANK)
                 {
@@ -773,11 +802,6 @@ namespace gambits
             case G_CONDITION::RANDOM:
             {
                 return xirand::GetRandomNumber<uint16>(100) < (int16)predicate.condition_arg;
-                break;
-            }
-            case G_CONDITION::IS_DEAD:
-            {
-                return trigger_target->isDead();
                 break;
             }
             default:

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -280,14 +280,14 @@ namespace gambits
                     auto* mob = POwner->GetBattleTarget();
                     if (mob != nullptr)
                     {
-                        //clang-format off
+                        // clang-format off
                         static_cast<CCharEntity*>(POwner->PMaster)->ForParty([&](CBattleEntity* PMember) {
                             if (PMember->isDead())
                             {
                                 target = PMember;
                             }
                         });
-                        //clang-format on
+                        // clang-format on
                     }
                 }
                 else if (gambit.predicates[0].target == G_TARGET::TANK)

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -775,6 +775,11 @@ namespace gambits
                 return xirand::GetRandomNumber<uint16>(100) < (int16)predicate.condition_arg;
                 break;
             }
+            case G_CONDITION::IS_DEAD:
+            {
+                return trigger_target->isDead();
+                break;
+            }
             default:
             {
                 return false;

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -54,6 +54,7 @@ namespace gambits
         PT_HAS_TANK        = 21,
         NOT_PT_HAS_TANK    = 22,
         IS_ECOSYSTEM       = 23,
+        IS_DEAD            = 24,
     };
 
     enum class G_REACTION : uint16

--- a/src/map/ai/helpers/gambits_container.h
+++ b/src/map/ai/helpers/gambits_container.h
@@ -26,6 +26,7 @@ namespace gambits
         CASTER     = 7,
         TOP_ENMITY = 8,
         CURILLA    = 9, // Special case for Rainemard
+        PARTY_DEAD = 10,
     };
 
     enum class G_CONDITION : uint16
@@ -54,7 +55,6 @@ namespace gambits
         PT_HAS_TANK        = 21,
         NOT_PT_HAS_TANK    = 22,
         IS_ECOSYSTEM       = 23,
-        IS_DEAD            = 24,
     };
 
     enum class G_REACTION : uint16

--- a/src/map/mob_spell_container.cpp
+++ b/src/map/mob_spell_container.cpp
@@ -39,6 +39,7 @@ void CMobSpellContainer::ClearSpells()
     m_debuffList.clear();
     m_healList.clear();
     m_naList.clear();
+    m_raiseList.clear();
     m_hasSpells = false;
 }
 
@@ -81,6 +82,11 @@ void CMobSpellContainer::AddSpell(SpellID spellId)
         // na spell and erase
         m_naList.push_back(spellId);
     }
+    else if (spell->isRaise())
+    {
+        // raise family
+        m_raiseList.push_back(spellId);
+    }
     else if (spell->isHeal())
     { // includes blue mage healing spells, wild carrot etc
         // add to healing
@@ -108,8 +114,9 @@ void CMobSpellContainer::RemoveSpell(SpellID spellId)
     findAndRemove(m_debuffList, spellId);
     findAndRemove(m_healList, spellId);
     findAndRemove(m_naList, spellId);
+    findAndRemove(m_raiseList, spellId);
 
-    m_hasSpells = !(m_gaList.empty() && m_damageList.empty() && m_buffList.empty() && m_debuffList.empty() && m_healList.empty() && m_naList.empty());
+    m_hasSpells = !(m_gaList.empty() && m_damageList.empty() && m_buffList.empty() && m_debuffList.empty() && m_healList.empty() && m_naList.empty() && m_raiseList.empty());
 }
 
 // Used in Gambits to see if the Trust can cast the spell
@@ -164,6 +171,7 @@ std::optional<SpellID> CMobSpellContainer::GetBestAvailable(SPELLFAMILY family)
         searchInList(m_debuffList);
         searchInList(m_healList);
         searchInList(m_naList);
+        searchInList(m_raiseList);
     }
 
     // Assume the highest ID is the best (back of the vector)
@@ -723,6 +731,11 @@ bool CMobSpellContainer::HasHealSpells() const
 bool CMobSpellContainer::HasNaSpells() const
 {
     return !m_naList.empty();
+}
+
+bool CMobSpellContainer::HasRaiseSpells() const
+{
+    return !m_raiseList.empty();
 }
 
 bool CMobSpellContainer::HasDebuffSpells() const

--- a/src/map/mob_spell_container.h
+++ b/src/map/mob_spell_container.h
@@ -55,6 +55,7 @@ public:
     bool HasBuffSpells() const;
     bool HasHealSpells() const;
     bool HasNaSpells() const;
+    bool HasRaiseSpells() const;
     bool HasDebuffSpells() const;
     bool HasSevereSpells() const;
 
@@ -76,6 +77,7 @@ public:
     std::vector<SpellID> m_debuffList;
     std::vector<SpellID> m_healList;
     std::vector<SpellID> m_naList;
+    std::vector<SpellID> m_raiseList;
     std::vector<SpellID> m_severeList;
 
 private:

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -171,6 +171,11 @@ bool CSpell::isNa()
     return (static_cast<uint16>(m_ID) >= 14 && static_cast<uint16>(m_ID) <= 20) || m_ID == SpellID::Erase;
 }
 
+bool CSpell::isRaise()
+{
+    return (static_cast<uint16>(m_ID) >= 12 && static_cast<uint16>(m_ID) <= 13) || m_ID == SpellID::Raise_III || m_ID == SpellID::Arise;
+}
+
 bool CSpell::isSevere()
 {
     return m_ID == SpellID::Death || m_ID == SpellID::Impact || m_ID == SpellID::Meteor || m_ID == SpellID::Meteor_II || m_ID == SpellID::Comet;

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -726,6 +726,7 @@ enum class SpellID : uint16
     Gain_MND             = 491,
     Gain_CHR             = 492,
     Temper               = 493,
+    Arise                = 494,
     Adloquium            = 495,
     Firaja               = 496,
     Blizzaja             = 497,
@@ -1086,6 +1087,7 @@ public:
     bool        isCure();           // is a Cure spell
     bool        isDebuff();         // is a debuff spell
     bool        isNa();             // is a -na spell
+    bool        isRaise();          // is a raise spell (e.g. Trust: Ferreous Coffin)
     bool        canHitShadow();     // check if spell ignores shadows
 
     void setRadius(float radius);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Updates Trust Script for Ferreous Coffin
Updates Gambits, Mob Spell Container, and Spell CPP.
Updates mob skills, spells SQL.

Closes #431

## Steps to test these changes

Build a Party of at least two
Cast Ferreous Coffin
Engage a mob
Watch standard WHM behavior
`!hp 0` your 2nd party member
Observe Ferreous Coffin cast the highest available Raise on your fallen party member.

