### PR TITLE
[lobby] add listen_fd print to connect_client sAccept failure debug message

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -748,7 +748,7 @@ int connect_client(int listen_fd, sockaddr_in& client_address)
     fd = sAccept(listen_fd, (struct sockaddr*)&client_address, &len);
     if (fd == -1)
     {
-        ShowError("connect_client: accept failed (code %d)!", sErrno);
+        ShowError("connect_client: accept failed (code %d, listen_fd %d)!", sErrno, listen_fd);
         return -1;
     }
     if (fd == 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Prints extra debug info when sAccept fails in lobby during connect_client

## Steps to test these changes

Theoretically, trip the sAccept to fail which will print the message on connect.
