### PR TITLE
[lua] Add Knight's Minne V to shop of Standard Merchant Ferdoulemiont

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
@@ -28,6 +28,7 @@ entity.onTrigger = function(player, npc)
         4997,    16, 3,    -- Scroll of Knight's Minne
         4998,   864, 3,    -- Scroll of Knight's Minne II
         4999,  5148, 3,    -- Scroll of Knight's Minne III
+        5001, 50692, 3,    -- Scroll of Knight's Minne V
         2343,  1984, 3,    -- La Theine Millet
     }
 


### PR DESCRIPTION
* Price set per retail wikis

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Add Knight's Minne V to shop of Standard Merchant Ferdoulemiont in Southern San d'Oria (I-11)

## Steps to test these changes

Examine the NPC's shop prior to this commit, notice that scroll of Knight's Minne V is nowhere to be found.

Examine the NPC's shop after this commit, notice that you can now purchase Knight's Minne V from this NPC.
