### PR TITLE
Aptitude Mantle MODs / Cap. Point Augment

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -103,8 +103,8 @@ INSERT INTO `augments` VALUES (70,0,28,33,0,0); -- Cont.
 INSERT INTO `augments` VALUES (71,0,160,-100,0,0); -- Damage Taken -1%
 INSERT INTO `augments` VALUES (72,0,0,0,0,0); -- 72 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (73,0,0,0,0,0); -- 73 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
-INSERT INTO `augments` VALUES (74,0,0,0,0,0); -- Cap. Point +1%
-INSERT INTO `augments` VALUES (75,0,0,0,0,0); -- Cap. Point +33%
+INSERT INTO `augments` VALUES (74,0,915,1,0,0); -- Cap. Point +1%
+INSERT INTO `augments` VALUES (75,0,915,33,0,0); -- Cap. Point +33%
 INSERT INTO `augments` VALUES (76,0,0,0,0,0); -- DMG+33 Unsure if main hand or off hand so leaving values blank for now,goes up in increments of 1 after the initial 33.
 INSERT INTO `augments` VALUES (77,0,0,0,0,0); -- Delay -33% Unsure if main hand or off hand so leaving values blank for now,goes up in increments of 1 after the initial 33.
 INSERT INTO `augments` VALUES (78,0,2,2,0,0); -- HP+2 (count by 2)

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -67241,6 +67241,10 @@ INSERT INTO `item_mods` VALUES (27600,23,20);  -- ATT: 20
 INSERT INTO `item_mods` VALUES (27600,68,-10); -- EVA: -10
 INSERT INTO `item_mods` VALUES (27600,302,2);  -- TRIPLE_ATTACK: 2
 
+-- Aptitude Mantle
+INSERT INTO `item_mods` VALUES (27603,1,13);   -- DEF: 13
+INSERT INTO `item_mods` VALUES (27603,915,25); -- CAPACITY_BONUS: 25
+
 -- Aptitude Mantle +1
 INSERT INTO `item_mods` VALUES (27604,1,14);   -- DEF: 14
 INSERT INTO `item_mods` VALUES (27604,915,30); -- CAPACITY_BONUS: 30


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds Missing MODs for Aptitude Mantle
Populates Augment ID 74/75 with CAPACITY_BONUS

## Steps to test these changes

Log in a fresh GM character and set any job to Level 99
`!additem 27603 1 74 0`
Equip the Aptitude Mantle
`!getmod CAPACITY_BONUS` should return 26 (25 from Item, 1 from augment).
