### PR TITLE
[core] Improve CLuaBaseEntity::injectActionPacket()

### DIFF
--- a/scripts/commands/injectaction.lua
+++ b/scripts/commands/injectaction.lua
@@ -21,6 +21,18 @@ function onTrigger(player, actionId, animationId, speceffect, reaction, message)
         return
     end
 
+    if actionId == 0 or actionId > 15 then
+        error(player, "<action ID> is out of range. Current valid and tested action IDs are 1-15.")
+        return
+    end
+
+    local target = player:getCursorTarget()
+
+    if not target then
+        error(player, "No valid target found")
+        return
+    end
+
     -- validate animationId
     if animationId == nil then
         error(player, "You must provide an animation ID.")
@@ -41,5 +53,5 @@ function onTrigger(player, actionId, animationId, speceffect, reaction, message)
     end
 
     -- inject action packet
-    player:injectActionPacket(actionId, animationId, speceffect, reaction, message)
+    player:injectActionPacket(target:getID(), actionId, animationId, speceffect, reaction, message, 10, 1)
 end

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -78,7 +78,7 @@ public:
 
     // Packets, Events, and Flags
     void injectPacket(std::string const& filename); // Send the character a packet kept in a file
-    void injectActionPacket(uint16 action, uint16 anim, uint16 spec, uint16 react, uint16 message);
+    void injectActionPacket(uint32 inTargetID, uint16 inCategory, uint16 inAnimationID, uint16 inSpecEffect, uint16 inReaction, uint16 inMessage, uint16 inActionParam, uint16 inParam);
     void entityVisualPacket(std::string const& command, sol::object const& entity);
     void entityAnimationPacket(const char* command, sol::object const& target);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Improves functionality of CLuaBaseEntity::injectActionPacket to be "limitless" in what you can do on a single target.

Needed for #2044  and possibly other future NMs like Plouton who use actions to update the client's model or simply play an animation via action packet with no side effects.

## Steps to test these changes

see attached lua command, [yoinkitem.zip](https://github.com/LandSandBoat/server/files/9437305/yoinkitem.zip)

use !yoinkitem on a target to "steal" a cool item, either a nice ring or a player's main weapon, which they then unequip and it looks like it worked.

![image](https://user-images.githubusercontent.com/60417494/185830854-c59537ee-226e-47a1-9438-e1edecfcf783.png)
Yoink!