### PR TITLE
Require weapons unequipped for second Token of Troth Event

### DIFF
--- a/scripts/missions/wotg/53_Token_of_Troth.lua
+++ b/scripts/missions/wotg/53_Token_of_Troth.lua
@@ -30,15 +30,13 @@ mission.sections =
             ['Bulwark_Gate'] =
             {
                 onTrigger = function(player, npc)
-                    if mission:getVar(player, 'Status') == 0 then
-                        if
-                            player:getEquipID(xi.slot.MAIN) ~= 0 or
-                            player:getEquipID(xi.slot.SUB) ~= 0
-                        then
-                            return mission:event(117, 0, 23, 1756, 0, 0, 0, 1, 1)
-                        else
-                            return mission:progressEvent(115, 98, 5, 1756, 0, 0, 1, 0)
-                        end
+                    if
+                        player:getEquipID(xi.slot.MAIN) ~= 0 or
+                        player:getEquipID(xi.slot.SUB) ~= 0
+                    then
+                        return mission:event(117, 0, 23, 1756, 0, 0, 0, 1, 1)
+                    elseif mission:getVar(player, 'Status') == 0 then
+                        return mission:progressEvent(115, 98, 5, 1756, 0, 0, 1, 0)
                     else
                         return mission:progressEvent(116, 98, 5, 1756, 0, 0, 0, 1, 0)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Requires weapons to be unequipped for second event in Token of Troth to match retail
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Equip weapons prior to Event 116, then unequip.
<!-- Clear and detailed steps to test your changes here -->
