### PR TITLE
Latent effects: Set/check all the modifiers related to additional effect modifier application, not just the addType.

### DIFF
--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -104,25 +104,47 @@ void CLatentEffect::SetModPower(int16 power)
     m_ModPower = power;
 }
 
+bool CLatentEffect::ModOnItemOnly(Mod modID)
+{
+    if (modID == Mod::DMG ||
+        modID == Mod::ITEM_ADDEFFECT_TYPE ||
+        modID == Mod::ITEM_SUBEFFECT ||
+        modID == Mod::ITEM_ADDEFFECT_DMG ||
+        modID == Mod::ITEM_ADDEFFECT_CHANCE ||
+        modID == Mod::ITEM_ADDEFFECT_ELEMENT ||
+        modID == Mod::ITEM_ADDEFFECT_STATUS ||
+        modID == Mod::ITEM_ADDEFFECT_POWER ||
+        modID == Mod::ITEM_ADDEFFECT_DURATION)
+    {
+        return true;
+    }
+    return false;
+}
+
 bool CLatentEffect::Activate()
 {
     if (!IsActivated())
     {
-        // additional effect/dmg latents add mod to weapon, not player
-        if (GetModValue() == Mod::ITEM_ADDEFFECT_TYPE || GetModValue() == Mod::DMG)
+        // Additional effect/dmg latents add mod to item, not player
+        if (ModOnItemOnly(GetModValue()))
         {
-            CCharEntity* PChar  = (CCharEntity*)m_POwner;
-            CItemWeapon* weapon = (CItemWeapon*)PChar->getEquip((SLOTTYPE)GetSlot());
+            CCharEntity*    PChar = static_cast<CCharEntity*>(m_POwner);
+            CItemEquipment* item  = PChar->getEquip((SLOTTYPE)GetSlot());
 
-            weapon->addModifier(CModifier(GetModValue(), GetModPower()));
+            if (item)
+            {
+                item->addModifier(CModifier(GetModValue(), GetModPower()));
+                // ShowTrace("LATENT ACTIVATED: %d, Current item modifier value: %d", m_ModValue, item->getModifier(m_ModValue));
+            }
         }
+        // Other modifiers go on the player
         else
         {
             m_POwner->addModifier(m_ModValue, m_ModPower);
+            // ShowTrace("LATENT ACTIVATED: %d, Current value: %d", m_ModValue, m_POwner->getMod(m_ModValue));
         }
 
         m_Activated = true;
-        // printf("LATENT ACTIVATED: %d, Current value: %d\n", m_ModValue, m_POwner->getMod(m_ModValue));
         return true;
     }
     return false;
@@ -132,21 +154,20 @@ bool CLatentEffect::Deactivate()
 {
     if (IsActivated())
     {
-        // remove the modifier from weapon, not player
-        if (GetModValue() == Mod::ITEM_ADDEFFECT_TYPE || GetModValue() == Mod::DMG)
+        // Remove the modifier from item, not player
+        if (ModOnItemOnly(GetModValue()))
         {
-            CCharEntity* PChar  = (CCharEntity*)m_POwner;
-            CItemWeapon* weapon = (CItemWeapon*)PChar->getEquip((SLOTTYPE)GetSlot());
+            CCharEntity*    PChar = static_cast<CCharEntity*>(m_POwner);
+            CItemEquipment* item  = PChar->getEquip((SLOTTYPE)GetSlot());
 
-            int16 modPower = GetModPower();
-
-            if (weapon != nullptr && (weapon->isType(ITEM_EQUIPMENT) || weapon->isType(ITEM_WEAPON)))
+            if (item != nullptr && (item->isType(ITEM_EQUIPMENT) || item->isType(ITEM_WEAPON)))
             {
                 if (GetModValue() == Mod::ITEM_ADDEFFECT_TYPE)
                 {
-                    for (auto& i : weapon->modList)
+                    for (auto& i : item->modList)
                     {
-                        // ensure the additional effect is fully removed from the weapon
+                        // Ensure the additional effect is fully removed from the item,
+                        // because the code handling mods on items needs a rewrite.
                         if (i.getModID() == Mod::ITEM_ADDEFFECT_TYPE)
                         {
                             i.setModAmount(0);
@@ -155,10 +176,12 @@ bool CLatentEffect::Deactivate()
                 }
                 else
                 {
-                    weapon->addModifier(CModifier(GetModValue(), -modPower));
+                    // Todo: item modifier functions need rewrite (there is no delMod, and the input to addMod is different)
+                    item->addModifier(CModifier(GetModValue(), -GetModPower()));
                 }
             }
         }
+        // Remove other modifiers from player
         else
         {
             m_POwner->delModifier(m_ModValue, m_ModPower);

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -121,6 +121,7 @@ public:
     void SetSlot(uint8 slot);
     void SetModValue(Mod value);
     void SetModPower(int16 power);
+    bool ModOnItemOnly(Mod modID);
     bool Activate();
     bool Deactivate();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
So I have been trying to add some additional effects that need to be latent triggered, and was scratching my head at how not all the sql rows seemed to be working. Changing equipment I started getting unexpected values for proc chance and such.

Turned out only the addEffect Type modifier was being correctly set the items - they go on the item, not the player. 

This is important because we do not want the proc rates and such to stack up when multiple items get equipped.

~~Additionally attempt to cleanup old legacy code from back when addEffects were hard coded in battleutils many years ago.~~

~~Some weird loops and such were used back then and oddities like "Adding" a negative mod or zero'ing it out rather than just delMod to reverse it.~~

Lessons Learned: that loop and setting 0 as well as "adding" negative mod amounts are all because normal functionality for mod handling on item objects is largely crap where it isn't outright nonexistent. I can't fully fix this without rewriting parts of item_equipment.cpp either.

## Steps to test these changes
1. rebuild
2. make latent add effects in the latents table
3. gm yourself the item and go pick on some mobs
4. do the same with some existing latent items unrelated to additional effect, just to be sure I didn't break them!
