### PR TITLE
[sql] Drop Group 834 Audit

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -7007,8 +7007,8 @@ INSERT INTO `mob_droplist` VALUES (833,0,0,1000,2375,@UNCOMMON); -- Zhayolm Card
 
 -- ZoneID:   1 - Fishtrap
 -- ZoneID:   2 - Fishtrap
-INSERT INTO `mob_droplist` VALUES (834,0,0,1000,1727,80); -- Piece Of Garhada Teak Lumber (8.0%)
-INSERT INTO `mob_droplist` VALUES (834,0,0,1000,1617,60); -- Flytrap Leaf (6.0%)
+INSERT INTO `mob_droplist` VALUES (834,0,0,1000,1727,@UNCOMMON); -- Piece Of Garhada Teak Lumber (Uncommon, 10%)
+INSERT INTO `mob_droplist` VALUES (834,0,0,1000,1617,@VRARE);    -- Flytrap Leaf (Very Rare, 1%)
 
 -- ZoneID:  15 - Fistule
 INSERT INTO `mob_droplist` VALUES (835,0,0,1000,11518,@ALWAYS);   -- Rokugo Hachimaki (Always, 100%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Audits Drop Group 834 (fishtraps fished up)
* Audit entails analyzing the drops listed for this group in mob_droplist.sql and verifying the drop rates of all drops listed for this group.
  * Drops were checked primarily against the TH0 column for an item on FFXIDB.  If an item wasn't found for a particular mob in a particular zone on FFXIDB then FFXIclopedia was checked (which was a drop rate of 0.00% in all instances). Sample sizes/confidence ratings were taken into account for both sites.
    * Drop rates for both sites were then converted to usage of the ``@variables``.
    * Drop rates of all mobs listed included in this Drop Group were then averaged (2 mobs total).  This average value was then converted to usage of the ``@variables``.

## Steps to test these changes
Due to this audit, overall drop rates did change.  This will be moreso noticed if there isn't a character applying Treasure Hunter to modify the drop chances.

The 1% rate for item Flytrap Leaf was used due to a count of 29 kills done (across both sites) and only the TH3+ rate was the one that recorded a 20% rate for 5 kills and a confidence rating of around 40%.  Because of this and the unknown amount of TH actually used for this, the very rare drop rate (1%) was used.  Please let me know if this drop rate needs to be adjusted.