### PR TITLE
[LUA] Update ID Shift to DYNAMIC_LOOKUP in Bhaflau Thickets

### DIFF
--- a/scripts/zones/Bhaflau_Thickets/IDs.lua
+++ b/scripts/zones/Bhaflau_Thickets/IDs.lua
@@ -61,8 +61,8 @@ zones[xi.zone.BHAFLAU_THICKETS] =
             [16990398] = 16990403, -- -119 -15 -651
         },
         HARVESTMAN         = 16990252,
-        LIVIDROOT_AMOOSHAH = 16990473,
-        DEA                = 16990474,
+        LIVIDROOT_AMOOSHAH = DYNAMIC_LOOKUP,
+        DEA                = DYNAMIC_LOOKUP,
     },
     npc =
     {

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
@@ -3,9 +3,10 @@
 --  NPC: ??? (Spawn Lividroot Amooshah(ZNM T2))
 -- !pos 334 -10 184 52
 -----------------------------------
-local ID = require("scripts/zones/Bhaflau_Thickets/IDs")
+require("scripts/zones/Bhaflau_Thickets/IDs")
 require("scripts/globals/npc_util")
 -----------------------------------
+local ID = zones[xi.zone.BHAFLAU_THICKETS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
@@ -1,12 +1,10 @@
------------------------------------
 -- Area: Bhaflau Thickets
 --  NPC: ??? (Spawn Lividroot Amooshah(ZNM T2))
 -- !pos 334 -10 184 52
 -----------------------------------
-require("scripts/zones/Bhaflau_Thickets/IDs")
+local ID = zones[xi.zone.BHAFLAU_THICKETS]
 require("scripts/globals/npc_util")
 -----------------------------------
-local ID = zones[xi.zone.BHAFLAU_THICKETS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
@@ -3,9 +3,10 @@
 --  NPC: ??? (Spawn Dea(ZNM T3))
 -- !pos -34 -32 481 52
 -----------------------------------
-local ID = require("scripts/zones/Bhaflau_Thickets/IDs")
+require("scripts/zones/Bhaflau_Thickets/IDs")
 require("scripts/globals/npc_util")
 -----------------------------------
+local ID = zones[xi.zone.BHAFLAU_THICKETS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
@@ -3,10 +3,9 @@
 --  NPC: ??? (Spawn Dea(ZNM T3))
 -- !pos -34 -32 481 52
 -----------------------------------
-require("scripts/zones/Bhaflau_Thickets/IDs")
+local ID = zones[xi.zone.BHAFLAU_THICKETS]
 require("scripts/globals/npc_util")
 -----------------------------------
-local ID = zones[xi.zone.BHAFLAU_THICKETS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

A recent retail update in Bhaflau Thickets shifted the ID's of two ZNM ID's. Setting these ID's to DYNAMIC_LOOKUP will help correct this shift. I used #2351 as a reference for my update.

## Steps to test these changes

Using `!spawnmob 16990473` to spawn Lividroot Amooshah returns an error for invalid mobid. Updating to dynamic lookup to bypass invalid mobid.

Using `!spawnmob 16990474` to spawn Dea returns an error for invalid mobid. Updating to dynamic lookup to bypass invalid mobid.
