### PR TITLE
[SQL] JP Gift MOD ID Audit - WAR

### DIFF
--- a/sql/job_point_gifts.sql
+++ b/sql/job_point_gifts.sql
@@ -25,7 +25,7 @@ INSERT INTO `job_point_gifts` VALUES (1, 30, 26, 5, 'WAR_Ranged Accuracy Bonus')
 INSERT INTO `job_point_gifts` VALUES (1, 45, 31, 5, 'WAR_Magic Evasion Bonus');
 INSERT INTO `job_point_gifts` VALUES (1, 50, 997, 1, 'WAR_Superior 1');
 INSERT INTO `job_point_gifts` VALUES (1, 55, 915, 9, 'WAR_Capacity Point Bonus');
-INSERT INTO `job_point_gifts` VALUES (1, 60, 31, 5, 'WAR_Magic Accuracy Bonus');
+INSERT INTO `job_point_gifts` VALUES (1, 60, 30, 5, 'WAR_Magic Accuracy Bonus');
 INSERT INTO `job_point_gifts` VALUES (1, 80, 903, 50, 'WAR_Enhances "Fencer" effect.');
 INSERT INTO `job_point_gifts` VALUES (1, 95, 915, 11, 'WAR_Capacity Point Bonus');
 INSERT INTO `job_point_gifts` VALUES (1, 100, 165, 5, 'WAR_Critical Hit Bonus');


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Audit of MOD IDs for WAR in sql/job_point_gifts
Corrects JP60 MOD ID from MEVA to MACC

## Steps to test these changes

Add and spend 60 Job Points on WAR, confirm appropriate MACC value.
