### PR TITLE
JP Gift MOD ID Audit - WHM/BLM/RDM

### DIFF
--- a/sql/job_point_gifts.sql
+++ b/sql/job_point_gifts.sql
@@ -331,7 +331,7 @@ INSERT INTO `job_point_gifts` VALUES (5, 1620, 25, 8, 'RDM_Accuracy Bonus');
 INSERT INTO `job_point_gifts` VALUES (5, 1620, 26, 8, 'RDM_Ranged Accuracy Bonus');
 INSERT INTO `job_point_gifts` VALUES (5, 1710, 114, 13, 'RDM_Enfeebling Magic Skill Bonus');
 INSERT INTO `job_point_gifts` VALUES (5, 1805, 113, 13, 'RDM_Enhancing Magic Skill Bonus');
-INSERT INTO `job_point_gifts` VALUES (5, 1900, 432, 8, 'RDM_Enspell Damage');
+INSERT INTO `job_point_gifts` VALUES (5, 1900, 432, 7, 'RDM_Enspell Damage');
 INSERT INTO `job_point_gifts` VALUES (5, 2000, 170, 2, 'RDM_Fast Cast Effect');
 INSERT INTO `job_point_gifts` VALUES (5, 2100, 997, 1, 'RDM_Superior 5');
 INSERT INTO `job_point_gifts` VALUES (5, 2100, 996, 15, 'RDM_1 Hour Delay');


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Audit of MOD IDs/Values for WHM/BLM/RDM in sql/job_point_gifts
Corrects RDM JP1900 Enspell Damage from 8 to 7
Reference: https://www.bg-wiki.com/ffxi/Job%20Points
No adjustments to WHM/BLM

## Steps to test these changes

Add and spend 1900 Job Points on RDM
Confirm correct value for ENSPELL_DMG_BONUS