### PR TITLE
Update roe_records.lua

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -4971,7 +4971,7 @@ function getRoeRecords(triggers)
         -- Combat (Region) - Escha 1
         -----------------------------------
 
-        [750] =
+        [885] =
         { -- Conflict: Escha - Zi'Tah I
             trigger = triggers.mobKill,
             goal = 10,
@@ -4980,7 +4980,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [751] =
+        [886] =
         { -- Conflict: Escha - Zi'Tah II
             trigger = triggers.mobKill,
             goal = 10,
@@ -4989,7 +4989,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [752] =
+        [887] =
         { -- Conflict: Escha - Zi'Tah III
             trigger = triggers.mobKill,
             goal = 10,
@@ -4998,7 +4998,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [753] =
+        [888] =
         { -- Conflict: Escha - Zi'Tah IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5007,7 +5007,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [754] =
+        [889] =
         { -- Conflict: Escha - Zi'Tah V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5016,7 +5016,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [755] =
+        [901] =
         { -- Conflict: Escha - Zi'Tah VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5025,7 +5025,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [756] =
+        [902] =
         { -- Conflict: Escha - Zi'Tah VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5034,7 +5034,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [757] =
+        [903] =
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
@@ -5043,7 +5043,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [758] =
+        [904] =
         { -- Conflict: Escha - Ru'Aun II
             trigger = triggers.mobKill,
             goal = 10,
@@ -5052,7 +5052,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [759] =
+        [905] =
         { -- Conflict: Escha - Ru'Aun III
             trigger = triggers.mobKill,
             goal = 10,
@@ -5061,7 +5061,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [760] =
+        [906] =
         { -- Conflict: Escha - Ru'Aun IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5070,7 +5070,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [761] =
+        [907] =
         { -- Conflict: Escha - Ru'Aun V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5079,7 +5079,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [762] =
+        [908] =
         { -- Conflict: Escha - Ru'Aun VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5088,7 +5088,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [763] =
+        [909] =
         { -- Conflict: Escha - Ru'Aun VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5097,7 +5097,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [764] =
+        [910] =
         { -- Conflict: Escha - Ru'Aun VIII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5106,7 +5106,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [765] =
+        [911] =
         { -- Conflict: Escha - Ru'Aun IX
             trigger = triggers.mobKill,
             goal = 10,
@@ -5115,7 +5115,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [766] =
+        [912] =
         { -- Conflict: Escha - Ru'Aun X
             trigger = triggers.mobKill,
             goal = 10,
@@ -5128,7 +5128,7 @@ function getRoeRecords(triggers)
         -- Combat (Region) - Escha 2
         -----------------------------------
 
-        [767] =
+        [943] =
         { -- Conflict: Reisenjima I
             trigger = triggers.mobKill,
             goal = 10,
@@ -5137,7 +5137,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [768] =
+        [944] =
         { -- Conflict: Reisenjima II
             trigger = triggers.mobKill,
             goal = 10,
@@ -5146,7 +5146,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [769] =
+        [945] =
         { -- Conflict: Reisenjima III
             trigger = triggers.mobKill,
             goal = 10,
@@ -5155,7 +5155,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [770] =
+        [946] =
         { -- Conflict: Reisenjima IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5164,7 +5164,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [771] =
+        [947] =
         { -- Conflict: Reisenjima V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5173,7 +5173,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [772] =
+        [948] =
         { -- Conflict: Reisenjima VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5182,7 +5182,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [773] =
+        [949] =
         { -- Conflict: Reisenjima VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5191,7 +5191,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [774] =
+        [950] =
         { -- Conflict: Reisenjima XIII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5200,7 +5200,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [775] =
+        [951] =
         { -- Conflict: Reisenjima IX
             trigger = triggers.mobKill,
             goal = 10,
@@ -5209,7 +5209,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [776] =
+        [952] =
         { -- Conflict: Reisenjima X
             trigger = triggers.mobKill,
             goal = 10,
@@ -5218,7 +5218,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [777] =
+        [953] =
         { -- Conflict: Reisenjima XI
             trigger = triggers.mobKill,
             goal = 10,

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5036,7 +5036,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Il'Aern" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Ilaern" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5017,6 +5017,7 @@ function getRoeRecords(triggers)
 
         [901] =
         { -- Conflict: Escha - Zi'Tah VI
+            trigger = triggers.mobKill,
             goal = 10,
             reqs = { mobName = set { "Eschan_Puk" }, zone = set { 288 } },
             flags = set { "repeat" },

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5105,7 +5105,7 @@ function getRoeRecords(triggers)
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
-
+        
         [911] =
         { -- Conflict: Escha - Ru'Aun IX
             trigger = triggers.mobKill,

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -4970,7 +4970,6 @@ function getRoeRecords(triggers)
         -----------------------------------
         -- Combat (Region) - Escha 1
         -----------------------------------
-
         [885] =
         { -- Conflict: Escha - Zi'Tah I
             trigger = triggers.mobKill,
@@ -4981,19 +4980,19 @@ function getRoeRecords(triggers)
         },
 
         [886] =
-        { -- Conflict: Escha - Zi'Tah II
-            trigger = triggers.mobKill,
-            goal = 10,
-            reqs = { mobName = set { "Eschan_Bugard" }, zone = set { 288 } },
-            flags = set { "repeat" },
-            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
-        },
+       { -- Conflict: Escha - Zi'Tah II
+           trigger = triggers.mobKill,
+           goal = 10,
+           reqs = { mobName = set { "Eschan_Bugard" }, zone = set { 288 } },
+           flags = set { "repeat" },
+           reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+       },
 
         [887] =
         { -- Conflict: Escha - Zi'Tah III
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Tarichuck" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Tarichuk" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5002,7 +5001,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Dragon" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Shadow_Dragon" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5018,7 +5017,6 @@ function getRoeRecords(triggers)
 
         [901] =
         { -- Conflict: Escha - Zi'Tah VI
-            trigger = triggers.mobKill,
             goal = 10,
             reqs = { mobName = set { "Eschan_Puk" }, zone = set { 288 } },
             flags = set { "repeat" },
@@ -5038,7 +5036,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Il'aern" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Il'Aern" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5056,7 +5054,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun III
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Euhvi" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Euvhi" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5065,7 +5063,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Clionidae" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Clionid" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5083,7 +5081,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun VI
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Amobean" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Amoeban" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5127,7 +5125,6 @@ function getRoeRecords(triggers)
         -----------------------------------
         -- Combat (Region) - Escha 2
         -----------------------------------
-
         [943] =
         { -- Conflict: Reisenjima I
             trigger = triggers.mobKill,
@@ -5159,7 +5156,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Idomitable_Faaz" }, zone = set { 291 } },
+            reqs = { mobName = set { "Indomitable_Faaz" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5168,13 +5165,13 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima V
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Territorial_Mantise" }, zone = set { 291 } },
+            reqs = { mobName = set { "Territorial_Mantis" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
         [948] =
-        { -- Conflict: Reisenjima VI
+       { -- Conflict: Reisenjima VI
             trigger = triggers.mobKill,
             goal = 10,
             reqs = { mobName = set { "Devouring_Mosquito" }, zone = set { 291 } },
@@ -5192,12 +5189,12 @@ function getRoeRecords(triggers)
         },
 
         [950] =
-        { -- Conflict: Reisenjima XIII
+        { -- Conflict: Reisenjima VIII
             trigger = triggers.mobKill,
             goal = 10,
             reqs = { mobName = set { "Quarrelsome_Hippogryph" }, zone = set { 291 } },
             flags = set { "repeat" },
-            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+           reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
         [951] =
@@ -5212,7 +5209,7 @@ function getRoeRecords(triggers)
         [952] =
         { -- Conflict: Reisenjima X
             trigger = triggers.mobKill,
-            goal = 10,
+           goal = 10,
             reqs = { mobName = set { "Glowering_Ladybug" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5038,7 +5038,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan_Li'aern" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Il'aern" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5105,7 +5105,7 @@ function getRoeRecords(triggers)
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
-        
+
         [911] =
         { -- Conflict: Escha - Ru'Aun IX
             trigger = triggers.mobKill,

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -4975,7 +4975,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Yztarg" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Yztarg" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -4984,7 +4984,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah II
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Bugard" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Bugard" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -4993,7 +4993,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah III
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Tarichuck" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Tarichuck" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5002,7 +5002,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Dragon" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Dragon" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5011,7 +5011,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah V
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Mosquito" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Mosquito" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5020,7 +5020,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah VI
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Puk" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Puk" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5029,7 +5029,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Zi'Tah VII
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Opo-opo" }, zone = set { 288 } },
+            reqs = { mobName = set { "Eschan_Opo-opo" }, zone = set { 288 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5038,7 +5038,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Li'aern" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Li'aern" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5047,7 +5047,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun II
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Phuabo" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Phuabo" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5056,7 +5056,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun III
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Euhvi" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Euhvi" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5065,7 +5065,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Clionidae" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Clionidae" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5074,7 +5074,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun V
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Hpemde" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Hpemde" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5083,7 +5083,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun VI
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Amobean" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Amobean" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5092,7 +5092,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun VII
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Xzomit" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Xzomit" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5101,7 +5101,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun VIII
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Murex" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Murex" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5110,7 +5110,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun IX
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Ghrah" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Ghrah" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5119,7 +5119,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Escha - Ru'Aun X
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Eschan Limule" }, zone = set { 289 } },
+            reqs = { mobName = set { "Eschan_Limule" }, zone = set { 289 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5132,7 +5132,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima I
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Obstreperous Panopt" }, zone = set { 291 } },
+            reqs = { mobName = set { "Obstreperous_Panopt" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5141,7 +5141,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima II
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Snaggletoothed Tiger" }, zone = set { 291 } },
+            reqs = { mobName = set { "Snaggletoothed_Tiger" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5150,7 +5150,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima III
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Agitated Chapuli" }, zone = set { 291 } },
+            reqs = { mobName = set { "Agitated_Chapuli" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5159,7 +5159,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima IV
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Idomitable Faaz" }, zone = set { 291 } },
+            reqs = { mobName = set { "Idomitable_Faaz" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5168,7 +5168,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima V
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Territorial Mantise" }, zone = set { 291 } },
+            reqs = { mobName = set { "Territorial_Mantise" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5177,7 +5177,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima VI
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Devouring Mosquito" }, zone = set { 291 } },
+            reqs = { mobName = set { "Devouring_Mosquito" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5186,7 +5186,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima VII
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Lentic Toad" }, zone = set { 291 } },
+            reqs = { mobName = set { "Lentic_Toad" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5195,7 +5195,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima XIII
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Quarrelsome Hippogryph" }, zone = set { 291 } },
+            reqs = { mobName = set { "Quarrelsome_Hippogryph" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
@@ -5204,7 +5204,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima IX
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Rampaging Beetle" }, zone = set { 291 } },
+            reqs = { mobName = set { "Rampaging_Beetle" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
@@ -5213,7 +5213,7 @@ function getRoeRecords(triggers)
         { -- Conflict: Reisenjima X
             trigger = triggers.mobKill,
             goal = 10,
-            reqs = { mobName = set { "Glowering Ladybug" }, zone = set { 291 } },
+            reqs = { mobName = set { "Glowering_Ladybug" }, zone = set { 291 } },
             flags = set { "repeat" },
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -4971,9 +4971,261 @@ function getRoeRecords(triggers)
         -- Combat (Region) - Escha 1
         -----------------------------------
 
+        [622] =
+        { -- Conflict: Escha - Zi'Tah I
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Yztarg" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [623] =
+        { -- Conflict: Escha - Zi'Tah II
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Bugard" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [624] =
+        { -- Conflict: Escha - Zi'Tah III
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Tarichuck" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [625] =
+        { -- Conflict: Escha - Zi'Tah IV
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Dragon" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [626] =
+        { -- Conflict: Escha - Zi'Tah V
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Mosquito" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [627] =
+        { -- Conflict: Escha - Zi'Tah VI
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Puk" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [628] =
+        { -- Conflict: Escha - Zi'Tah VII
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Opo-opo" }, zone = set { 288 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [629] =
+        { -- Conflict: Escha - Ru'Aun I
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Li'aern" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [630] =
+        { -- Conflict: Escha - Ru'Aun II
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Phuabo" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [631] =
+        { -- Conflict: Escha - Ru'Aun III
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Euhvi" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [632] =
+        { -- Conflict: Escha - Ru'Aun IV
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Clionidae" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [633] =
+        { -- Conflict: Escha - Ru'Aun V
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Hpemde" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [634] =
+        { -- Conflict: Escha - Ru'Aun VI
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Amobean" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [635] =
+        { -- Conflict: Escha - Ru'Aun VII
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Xzomit" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [636] =
+        { -- Conflict: Escha - Ru'Aun VIII
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Murex" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [637] =
+        { -- Conflict: Escha - Ru'Aun IX
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Ghrah" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [638] =
+        { -- Conflict: Escha - Ru'Aun X
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Eschan Limule" }, zone = set { 289 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
         -----------------------------------
         -- Combat (Region) - Escha 2
         -----------------------------------
+
+        [639] =
+        { -- Conflict: Reisenjima I
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Obstreperous Panopt" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [640] =
+        { -- Conflict: Reisenjima II
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Snaggletoothed Tiger" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [641] =
+        { -- Conflict: Reisenjima III
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Agitated Chapuli" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [642] =
+        { -- Conflict: Reisenjima IV
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Idomitable Faaz" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [643] =
+        { -- Conflict: Reisenjima V
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Territorial Mantise" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [644] =
+        { -- Conflict: Reisenjima VI
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Devouring Mosquito" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [645] =
+        { -- Conflict: Reisenjima VII
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Lentic Toad" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [646] =
+        { -- Conflict: Reisenjima XIII
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Quarrelsome Hippogryph" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [647] =
+        { -- Conflict: Reisenjima IX
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Rampaging Beetle" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
+        },
+
+        [648] =
+        { -- Conflict: Reisenjima X
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Glowering Ladybug" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
+
+        [649] =
+        { -- Conflict: Reisenjima XI
+            trigger = triggers.mobKill,
+            goal = 10,
+            reqs = { mobName = set { "Lucani" }, zone = set { 291 } },
+            flags = set { "repeat" },
+            reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
+        },
 
         -----------------------------------
         -- Harvesting - Original Areas

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -4971,7 +4971,7 @@ function getRoeRecords(triggers)
         -- Combat (Region) - Escha 1
         -----------------------------------
 
-        [622] =
+        [750] =
         { -- Conflict: Escha - Zi'Tah I
             trigger = triggers.mobKill,
             goal = 10,
@@ -4980,7 +4980,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [623] =
+        [751] =
         { -- Conflict: Escha - Zi'Tah II
             trigger = triggers.mobKill,
             goal = 10,
@@ -4989,7 +4989,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [624] =
+        [752] =
         { -- Conflict: Escha - Zi'Tah III
             trigger = triggers.mobKill,
             goal = 10,
@@ -4998,7 +4998,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [625] =
+        [753] =
         { -- Conflict: Escha - Zi'Tah IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5007,7 +5007,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [626] =
+        [754] =
         { -- Conflict: Escha - Zi'Tah V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5016,7 +5016,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [627] =
+        [755] =
         { -- Conflict: Escha - Zi'Tah VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5025,7 +5025,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [628] =
+        [756] =
         { -- Conflict: Escha - Zi'Tah VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5034,7 +5034,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [629] =
+        [757] =
         { -- Conflict: Escha - Ru'Aun I
             trigger = triggers.mobKill,
             goal = 10,
@@ -5043,7 +5043,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [630] =
+        [758] =
         { -- Conflict: Escha - Ru'Aun II
             trigger = triggers.mobKill,
             goal = 10,
@@ -5052,7 +5052,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [631] =
+        [759] =
         { -- Conflict: Escha - Ru'Aun III
             trigger = triggers.mobKill,
             goal = 10,
@@ -5061,7 +5061,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [632] =
+        [760] =
         { -- Conflict: Escha - Ru'Aun IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5070,7 +5070,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [633] =
+        [761] =
         { -- Conflict: Escha - Ru'Aun V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5079,7 +5079,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [634] =
+        [762] =
         { -- Conflict: Escha - Ru'Aun VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5088,7 +5088,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [635] =
+        [763] =
         { -- Conflict: Escha - Ru'Aun VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5097,7 +5097,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [636] =
+        [764] =
         { -- Conflict: Escha - Ru'Aun VIII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5106,7 +5106,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [637] =
+        [765] =
         { -- Conflict: Escha - Ru'Aun IX
             trigger = triggers.mobKill,
             goal = 10,
@@ -5115,7 +5115,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [638] =
+        [766] =
         { -- Conflict: Escha - Ru'Aun X
             trigger = triggers.mobKill,
             goal = 10,
@@ -5128,7 +5128,7 @@ function getRoeRecords(triggers)
         -- Combat (Region) - Escha 2
         -----------------------------------
 
-        [639] =
+        [767] =
         { -- Conflict: Reisenjima I
             trigger = triggers.mobKill,
             goal = 10,
@@ -5137,7 +5137,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [640] =
+        [768] =
         { -- Conflict: Reisenjima II
             trigger = triggers.mobKill,
             goal = 10,
@@ -5146,7 +5146,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [641] =
+        [769] =
         { -- Conflict: Reisenjima III
             trigger = triggers.mobKill,
             goal = 10,
@@ -5155,7 +5155,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [642] =
+        [770] =
         { -- Conflict: Reisenjima IV
             trigger = triggers.mobKill,
             goal = 10,
@@ -5164,7 +5164,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [643] =
+        [771] =
         { -- Conflict: Reisenjima V
             trigger = triggers.mobKill,
             goal = 10,
@@ -5173,7 +5173,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [644] =
+        [772] =
         { -- Conflict: Reisenjima VI
             trigger = triggers.mobKill,
             goal = 10,
@@ -5182,7 +5182,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [645] =
+        [773] =
         { -- Conflict: Reisenjima VII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5191,7 +5191,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [646] =
+        [774] =
         { -- Conflict: Reisenjima XIII
             trigger = triggers.mobKill,
             goal = 10,
@@ -5200,7 +5200,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [647] =
+        [775] =
         { -- Conflict: Reisenjima IX
             trigger = triggers.mobKill,
             goal = 10,
@@ -5209,7 +5209,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6392 } },
         },
 
-        [648] =
+        [776] =
         { -- Conflict: Reisenjima X
             trigger = triggers.mobKill,
             goal = 10,
@@ -5218,7 +5218,7 @@ function getRoeRecords(triggers)
             reward = { sparks = 300, xp = 900, capacity = 150, accolades = 30, item = { 6391 } },
         },
 
-        [649] =
+        [777] =
         { -- Conflict: Reisenjima XI
             trigger = triggers.mobKill,
             goal = 10,


### PR DESCRIPTION
added roe quests for escha areas

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds in the RoE's for Regions Escha - Zi'Tah, Escha - Ru'Aun, and Reisenjima
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
All records are working except for Conflict: Escha - Zi'Tah VI, for some reason it does not want to work.

## Steps to test these changes

Step1: zone into escha - zi'tah / ru'aun / resisenjima
Step2: activate the RoE Quests (menu, menu, quests, objective list, Combat (Region), Escha 1 or Escha 2, Activate desired record.
Step3: kill objective mob 10x
Step4: Get reward (exp, sparks, accolades, and either a bead pouch or silt pouch), neither silt or eschan beads are implemented at this time but you can mass store the pouches.
<!-- Clear and detailed steps to test your changes here -->
