### PR TITLE
Fix "/heal on" command so that it does not stop healing

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6156,6 +6156,11 @@ void SmallPacket0x0E8(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case ANIMATION_HEALING:
         {
+            if (data.ref<uint8>(0x04) == 0x01)
+            {
+                return;
+            }
+
             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HEALING);
         }
         break;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This fixes an issue with the `/heal` command where the `on` subcommand is ignored, meaning that `/heal on` acts as a toggle for the healing state, rather than ensuring that the PC was healing.

The PR simply adds a guard (similar to that used above in the `ANIMATION_NONE` case for `/heal off`) which checks if `on` was specified and does nothing if the PC is already healing.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1. Have a PC healing (e.g. by using `/heal`)
2. Use `/heal on` 

Expected behaviour: 
 - The PC stays healing 

Current behaviour:
 - The PC stops healing
