### PR TITLE
[core] Implement CSynthSuggestionListPacket

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -204,6 +204,10 @@ xi.crafting.getCraftSkillCap = function(player, craftID)
     return (rank + 1) * 10
 end
 
+xi.crafting.getRealSkill = function(player, craftID)
+    return math.floor(player:getCharSkillLevel(craftID) / 10)
+end
+
 -----------------------------------
 -- getAdvImageSupportCost
 -----------------------------------

--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
 
     if guildMember == 1 then
         if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
-            player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0) -- Event doesn't work
+            player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0)
         else
             player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 28674, 0, 0)
         end

--- a/scripts/zones/Windurst_Woods/npcs/Anillah.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Anillah.lua
@@ -15,12 +15,12 @@ end
 
 entity.onTrigger = function(player, npc)
     local guildMember = xi.crafting.isGuildMember(player, 3)
-    local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
-    local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
+    local skillCap    = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
+    local skillLevel  = xi.crafting.getRealSkill(player, xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
-            player:startEvent(10015, skillCap, skillLevel, 2, 511, player:getGil(), 0, 0, 0) -- p1 = skill level
+            player:startEvent(10015, skillCap, skillLevel, 2, 511, player:getGil(), 0, 0, 0)
         else
             player:startEvent(10015, skillCap, skillLevel, 2, 511, player:getGil(), 7108, 0, 0)
         end

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3414,19 +3414,33 @@ void SmallPacket0x053(map_session_data_t* const PSession, CCharEntity* const PCh
     }
 }
 
-/************************************************************************
- *                                                                        *
- *  Request synthesis suggestion                                            *
- *                                                                        *
+/*************************************************************************
+ *                                                                       *
+ *  Request synthesis suggestion                                         *
+ *                                                                       *
  ************************************************************************/
 
 void SmallPacket0x058(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    uint16 skillID    = data.ref<uint16>(0x04);
-    uint16 skillLevel = data.ref<uint16>(0x06);
+    uint16 skillID     = data.ref<uint16>(0x04);
+    uint16 skillLevel  = data.ref<uint16>(0x06); // Player's current skill level (whole number only)
+    uint8  requestType = data.ref<uint8>(0x0A);  // 02 is list view, 03 is recipe
+    uint8  skillRank   = data.ref<uint8>(0x12);  // Requested Rank for item suggestions
 
-    PChar->pushPacket(new CSynthSuggestionPacket(skillID, skillLevel));
+    if (requestType == 2)
+    {
+        // For pagination, the client sends the range in increments of 16. (0..0x10, 0x10..0x20, etc)
+        // uint16 resultMax  = data.ref<uint16>(0x0E); // Unused, maximum in range is always 16 greater
+        uint16 resultMin = data.ref<uint16>(0x0C);
+
+        PChar->pushPacket(new CSynthSuggestionListPacket(skillID, skillLevel, skillRank, resultMin));
+    }
+    else
+    {
+        uint16 selectedRecipeOffset = data.ref<uint16>(0x10);
+        PChar->pushPacket(new CSynthSuggestionRecipePacket(skillID, skillLevel, skillRank, selectedRecipeOffset));
+    }
 }
 
 /************************************************************************

--- a/src/map/packets/synth_suggestion.cpp
+++ b/src/map/packets/synth_suggestion.cpp
@@ -25,62 +25,71 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "synth_suggestion.h"
 #include <map>
 
-CSynthSuggestionPacket::CSynthSuggestionPacket(uint16 skillID, uint16 skillLevel)
+CSynthSuggestionListPacket::CSynthSuggestionListPacket(uint16 skillID, uint16 skillLevel, uint8 skillRank, uint16 resultOffset)
 {
     this->setType(0x31);
     this->setSize(0x34);
 
-    char craftname[8];
-    memset(craftname, 0, 8);
+    ref<uint8>(0x0A) = skillLevel;
 
-    switch (skillID)
+    const char* craftName = craftSkillDbNames[skillID - 1].c_str();
+    uint8       minSkill  = skillRank * 10;
+    uint8       maxSkill  = (skillRank + 1) * 10;
+
+    if (skillLevel < maxSkill)
     {
-        // TODO: There might be a better way than this
-        // TODO: Also confirm that this order is consistent, else
-        //      we might get recipes for the wrong guild
-        case (1):
-            strncpy(craftname, "Wood", 8);
-            break;
-        case (2):
-            strncpy(craftname, "Smith", 8);
-            break;
-        case (3):
-            strncpy(craftname, "Gold", 8);
-            break;
-        case (4):
-            strncpy(craftname, "Cloth", 8);
-            break;
-        case (5):
-            strncpy(craftname, "Leather", 8);
-            break;
-        case (6):
-            strncpy(craftname, "Bone", 8);
-            break;
-        case (7):
-            strncpy(craftname, "Alchemy", 8);
-            break;
-        case (8):
-            strncpy(craftname, "Cook", 8);
-            break;
+        maxSkill = skillLevel;
     }
 
-    const char* fmtQuery = "SELECT KeyItem, Wood, Smith, Gold, Cloth, Leather, Bone, \
-          Alchemy, Cook, Crystal, Result, Ingredient1, Ingredient2, \
-          Ingredient3, Ingredient4, Ingredient5, Ingredient6, \
-          Ingredient7, Ingredient8 \
-        FROM synth_recipes \
-        WHERE `%s` >= GREATEST(`Wood`,`Smith`,`Gold`,`Cloth`, \
-              `Bone`,`Alchemy`,`Cook`) AND \
-          %s BETWEEN %u AND %u \
-        ORDER BY RAND ( ) \
-        LIMIT 1;";
+    const char* fmtQuery = "SELECT Result FROM synth_recipes INNER JOIN item_basic ON Result = item_basic.itemid \
+        WHERE `%s` >= GREATEST(`Wood`, `Smith`, `Gold`, `Cloth`, `Leather`, `Bone`, `Alchemy`, `Cook`) AND \
+        `%s` BETWEEN %u AND %u AND Desynth = 0 ORDER BY `%s`, item_basic.name LIMIT %d, 17;";
 
-    // TODO: Confirm the conditions under which a recipe can be selected
-    // TODO: Is there a better way to run this query than comparing the
-    //      craft level of the "main" craft against the craft level of
-    //      each craft one at a time to ensure we are only getting
-    //      recipes intended for the craft we are seeking to improve?
-    int32 ret = sql->Query(fmtQuery, craftname, craftname, skillLevel + 5, skillLevel + 10);
+    int32 ret = sql->Query(fmtQuery, craftName, craftName, minSkill, maxSkill, craftName, resultOffset);
+
+    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    {
+        uint8 itemIdOffset = 0x10;
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            ref<uint16>(itemIdOffset) = sql->GetUIntData(0);
+
+            itemIdOffset += 2;
+            if (itemIdOffset == 0x30)
+            {
+                // The 17th result of a query is not displayed in the menu, but instead is used to signal
+                // to the client that another page is available.  This item ID is stored at 0x32.
+                itemIdOffset += 2;
+            }
+        }
+    }
+
+    ref<uint16>(0x30) = 0x02;
+}
+
+CSynthSuggestionRecipePacket::CSynthSuggestionRecipePacket(uint16 skillID, uint16 skillLevel, uint8 skillRank, uint16 selectedRecipeOffset)
+{
+    this->setType(0x31);
+    this->setSize(0x34);
+
+    const char* craftName = craftSkillDbNames[skillID - 1].c_str();
+    uint8       minSkill  = skillRank * 10;
+    uint8       maxSkill  = (skillRank + 1) * 10;
+
+    if (skillLevel < maxSkill)
+    {
+        maxSkill = skillLevel;
+    }
+
+    ShowDebug("%d", selectedRecipeOffset);
+
+    const char* fmtQuery = "SELECT KeyItem, Wood, Smith, Gold, Cloth, Leather, Bone, Alchemy, Cook, Crystal, Result, \
+        Ingredient1, Ingredient2, Ingredient3, Ingredient4, Ingredient5, Ingredient6, Ingredient7, Ingredient8 \
+        FROM synth_recipes INNER JOIN item_basic ON Result = item_basic.itemid \
+        WHERE `%s` >= GREATEST(`Wood`, `Smith`, `Gold`, `Cloth`, `Leather`, `Bone`, `Alchemy`, `Cook`) AND \
+        `%s` BETWEEN %u AND %u AND Desynth = 0 ORDER BY `%s`, item_basic.name LIMIT %d, 1;";
+
+    int32 ret = sql->Query(fmtQuery, craftName, craftName, minSkill, maxSkill, craftName, selectedRecipeOffset);
 
     if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
     {

--- a/src/map/packets/synth_suggestion.h
+++ b/src/map/packets/synth_suggestion.h
@@ -26,10 +26,27 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "basic.h"
 
-class CSynthSuggestionPacket : public CBasicPacket
+const std::vector<std::string> craftSkillDbNames = {
+    "Wood",
+    "Smith",
+    "Gold",
+    "Cloth",
+    "Leather",
+    "Bone",
+    "Alchemy",
+    "Cook",
+};
+
+class CSynthSuggestionListPacket : public CBasicPacket
 {
 public:
-    CSynthSuggestionPacket(uint16 skillID, uint16 skillLevel);
+    CSynthSuggestionListPacket(uint16 skillID, uint16 skillLevel, uint8 skillRank, uint16 resultOffset);
+};
+
+class CSynthSuggestionRecipePacket : public CBasicPacket
+{
+public:
+    CSynthSuggestionRecipePacket(uint16 skillID, uint16 skillLevel, uint8 skillRank, uint16 selectedRecipeOffset);
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Closes #2639 

* Implements `CSynthSuggestionListPacket` as one of the possible formats for 0x31 packet which provides an potential list of items to populate menu.
* Adds additional logic to 0x058 SmallPacket handling to determine which Synth Suggestion to send (List, Recipe)


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Talk to Crafting Support NPC and see possible crafts.
<!-- Clear and detailed steps to test your changes here -->

NOTE: The data displayed may need to be refined further, as it does not take into account subcrafts (if they are required to be at cap to display in the menu-based lists).