### PR TITLE
[lua] [core] [trusts] Enforce battlefield max player count for trusts

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -110,6 +110,15 @@ bool CMagicState::Update(time_point tick)
             {
                 m_interrupted = true;
             }
+
+            if (m_PSpell.get()->getSpellGroup() == SPELLGROUP_TRUST)
+            {
+                if (!luautils::OnTrustSpellCastCheckBattlefieldTrusts(PChar))
+                {
+                    msg           = MSGBASIC_TRUST_NO_CAST_TRUST;
+                    m_interrupted = true;
+                }
+            }
         }
         else if (PTarget->objtype == TYPE_PET)
         {

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../entities/charentity.h"
 #include "../entities/mobentity.h"
 #include "../entities/npcentity.h"
+#include "../entities/trustentity.h"
 #include "../status_effect_container.h"
 #include "../utils/mobutils.h"
 #include "../utils/zoneutils.h"
@@ -81,6 +82,16 @@ uint32 CLuaBattlefield::getFightTime()
     return std::chrono::duration_cast<std::chrono::seconds>(get_server_start_time() - m_PLuaBattlefield->GetFightTime()).count();
 }
 
+uint32 CLuaBattlefield::getMaxParticipants()
+{
+    return static_cast<uint32>(m_PLuaBattlefield->GetMaxParticipants());
+}
+
+uint32 CLuaBattlefield::getPlayerCount()
+{
+    return static_cast<uint32>(m_PLuaBattlefield->GetPlayerCount());
+}
+
 sol::table CLuaBattlefield::getPlayers()
 {
     auto table = lua.create_table();
@@ -90,6 +101,25 @@ sol::table CLuaBattlefield::getPlayers()
         if (PChar)
         {
             table.add(CLuaBaseEntity(PChar));
+        }
+    });
+    // clang-format on
+    return table;
+}
+
+sol::table CLuaBattlefield::getPlayersAndTrusts()
+{
+    auto table = lua.create_table();
+    // clang-format off
+    m_PLuaBattlefield->ForEachPlayer([&](CCharEntity* PChar)
+    {
+        if (PChar)
+        {
+            table.add(CLuaBaseEntity(PChar));
+            for (auto PTrust : PChar->PTrusts)
+            {
+                table.add(CLuaBaseEntity(PTrust));
+            }
         }
     });
     // clang-format on
@@ -274,7 +304,10 @@ void CLuaBattlefield::Register()
     SOL_REGISTER("getFightTick", CLuaBattlefield::getFightTick);
     SOL_REGISTER("getWipeTime", CLuaBattlefield::getWipeTime);
     SOL_REGISTER("getFightTime", CLuaBattlefield::getFightTime);
+    SOL_REGISTER("getMaxParticipants", CLuaBattlefield::getMaxParticipants);
+    SOL_REGISTER("getPlayerCount", CLuaBattlefield::getPlayerCount);
     SOL_REGISTER("getPlayers", CLuaBattlefield::getPlayers);
+    SOL_REGISTER("getPlayersAndTrusts", CLuaBattlefield::getPlayersAndTrusts);
     SOL_REGISTER("getMobs", CLuaBattlefield::getMobs);
     SOL_REGISTER("getNPCs", CLuaBattlefield::getNPCs);
     SOL_REGISTER("getAllies", CLuaBattlefield::getAllies);

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -50,7 +50,10 @@ public:
     uint32   getFightTick();
     uint32   getWipeTime();
     uint32   getFightTime();
+    uint32   getMaxParticipants();
+    uint32   getPlayerCount();
     auto     getPlayers() -> sol::table;
+    auto     getPlayersAndTrusts() -> sol::table;
     auto     getMobs(bool required, bool adds) -> sol::table;
     auto     getNPCs() -> sol::table;
     auto     getAllies() -> sol::table;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2698,6 +2698,28 @@ namespace luautils
         return result.get_type(0) == sol::type::number ? result.get<int32>(0) : 0;
     }
 
+    bool OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster) // Check if trust count would go over the limit when cast finishes (for simultaneous multi-party casts
+    {
+        TracyZoneScoped;
+
+        sol::function checkBattlefieldTrustCount = lua["xi"]["trust"]["checkBattlefieldTrustCount"];
+
+        if (!checkBattlefieldTrustCount.valid())
+        {
+            return false;
+        }
+
+        auto result = checkBattlefieldTrustCount(CLuaBaseEntity(PCaster));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::OnTrustSpellCastCheckBattlefieldTrusts: %s", err.what());
+            return 0;
+        }
+
+        return result.get_type(0) == sol::type::boolean ? result.get<bool>(0) : true;
+    }
+
     int32 OnMobInitialize(CBaseEntity* PMob)
     {
         TracyZoneScoped;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -242,6 +242,7 @@ namespace luautils
     auto  OnMobMagicPrepare(CBattleEntity* PCaster, CBattleEntity* PTarget, std::optional<SpellID> startingSpellId) -> std::optional<SpellID>; // triggered when monster wants to use a spell on target
     int32 OnMagicHit(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                                                          // triggered when spell cast on monster
     int32 OnWeaponskillHit(CBattleEntity* PMob, CBaseEntity* PAttacker, uint16 PWeaponskill);                                                  // Triggered when Weaponskill strikes monster
+    bool  OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster);                                                                      // Triggered if spell is a trust spell during onCast to determine to interrupt spell or not
 
     int32 OnMobInitialize(CBaseEntity* PMob); // Used for passive trait
     int32 ApplyMixins(CBaseEntity* PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Enforces trust count to match BCNM upper limit of battlefields.

## Steps to test these changes

!additem sky_orb
!zone balga's dais
enter Creeping Doom, which has a 3 player limit

attempt to summon 3 trusts, you should be stopped at 2.

Exit, give yourself another sky orb, enter Harem Scarem
You will now be able to summon 5 trusts.

Players reduce max trust count too -- Creeping Doom only allows you to summon one trust total with one other player, and Harem Scarem will only allow you to summon 4 total in the entire battlefield. You can verify this by dropping party and each player can summon their own trusts.