### PR TITLE
Update Crafting Expert quests to leverage CSynthSuggestionListPacket

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -60,19 +60,7 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if expertQuestStatus == 600 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7188)
-        player:showText(npc, 7190)
-        player:startEvent(300, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(300, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(300, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -57,7 +57,7 @@ entity.onTrigger = function(player, npc)
 
     if player:getCharVar("AlchemyExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_ALCHEMIST) then
-            expertQuestStatus = 550
+            expertQuestStatus = 640
         else
             expertQuestStatus = 600
         end
@@ -80,17 +80,6 @@ entity.onTrigger = function(player, npc)
 
         -- The Parameters are Item IDs for the Recipe
         player:startEvent(590, item, 2774, 929, 4103, 2777, 4103)
-
-    elseif expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7237)
-        player:showText(npc, 7239)
-        player:startEvent(120, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
 
     else
         player:startEvent(120, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -60,19 +60,7 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 6838)
-        player:showText(npc, 6840)
-        player:startEvent(101, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(101, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(101, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 -- 908  909  910  920  927  101  102

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -61,19 +61,7 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7062)
-        player:showText(npc, 7064)
-        player:startEvent(621, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(621, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(621, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 -- 621  622  759  16  0

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -60,19 +60,7 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7138)
-        player:showText(npc, 7140)
-        player:startEvent(626, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(626, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(626, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 -- 626  627  16  0  73  74

--- a/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
@@ -79,16 +79,6 @@ entity.onTrigger = function(player, npc)
 
         -- The Parameters are Item IDs for the Recipe
         player:startEvent(944, item, 2773, 917, 917, 2776, 4103)
-    elseif expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7014)
-        player:showText(npc, 7016)
-        player:startEvent(648, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
     else
         player:startEvent(648, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -54,25 +54,13 @@ entity.onTrigger = function(player, npc)
 
     if player:getCharVar("CookingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.WAY_OF_THE_CULINARIAN) then
-            expertQuestStatus = 550
+            expertQuestStatus = 768
         else
-            expertQuestStatus = 600
+            expertQuestStatus = 512
         end
     end
 
-    if expertQuestStatus == 550 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7260)
-        player:showText(npc, 7262)
-        player:startEvent(10013, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(10013, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(10013, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 -- 978  983  980  981  10013  10014

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -60,19 +60,7 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if expertQuestStatus == 600 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7450)
-        player:showText(npc, 7452)
-        player:startEvent(10016, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
-    else
-        player:startEvent(10016, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
-    end
+    player:startEvent(10016, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
 end
 
 -- 10016  10017  710  711  712  713  714  715  764

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -80,17 +80,6 @@ entity.onTrigger = function(player, npc)
         player:startEvent(704)
     elseif player:getCharVar("moral") == 3 and player:getLocalVar("moralZone") == 0 and player:getCharVar("moralWait") <= os.time() then
         player:startEvent(705)
-
-    elseif expertQuestStatus == 600 then
-        --[[
-        Feeding the proper parameter currently hangs the client in cutscene. This may
-        possibly be due to an unimplemented packet or function (display recipe?) Work
-        around to present dialog to player to let them know the trade is ready to be
-        received by triggering with lower rank up parameters.
-        --]]
-        player:showText(npc, 7339)
-        player:showText(npc, 7341)
-        player:startEvent(10011, testItem, realSkill, 44, guildMember, 0, 0, 0, 0)
     else
         player:startEvent(10011, testItem, realSkill, rankCap, guildMember, expertQuestStatus, 0, 0, 0)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

With the merge of #2649, Synthesis Suggestions are working.
Updates Guild Leader scripts to provide proper Expert Quest dialog and removes previous workarounds.
Updates `expertQuestStatus` values in two Guild Leader scripts.

## Steps to test these changes

Create a fresh GM Character

**Goldsmithing**
`!gotoid 17739790`
`!setskill goldsmithing 98`
`!setcraftrank goldsmithing 8`

Talk to Reinberta
Sign up for guild
Talk to Reinberta, get standard craft rank up dialog for Veteran
`!setcraftrank goldsmithing 9`
Talk to Reinberta
Accept Expert Quest
`!addkeyitem way_of_the_goldsmith`
Talk to Reinberta
Observe proper dialog including recipe:

![image](https://user-images.githubusercontent.com/3996176/188511063-3d5f1bd4-5205-46c8-ae1d-54db751ce4f4.png)
