### PR TITLE
Added Kam'lanaut's Shield into item_equipment.sql and item_mods.sql

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -12226,7 +12226,7 @@ INSERT INTO `item_equipment` VALUES (26403,'srivatsa',99,119,64,658,5,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26406,'kupo_shield',1,0,4194303,56,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26409,'dullahan_shield',1,0,4194303,669,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26410,'diamond_buckler',1,0,4194303,659,1,0,2,0,0);
-INSERT INTO `item_equipment` VALUES (26410,'kamalanauts_shield',1,0,4194303,668,1,0,2,0,0);
+INSERT INTO `item_equipment` VALUES (26412,'kamalanauts_shield',1,0,4194303,668,1,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26413,'voluspa_shield',99,119,193,30,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26414,'twinned_shield',1,0,4194303,672,2,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26419,'ammurapi_shield',99,119,1589788,42,1,0,2,0,0);

--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -12226,6 +12226,7 @@ INSERT INTO `item_equipment` VALUES (26403,'srivatsa',99,119,64,658,5,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26406,'kupo_shield',1,0,4194303,56,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26409,'dullahan_shield',1,0,4194303,669,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26410,'diamond_buckler',1,0,4194303,659,1,0,2,0,0);
+INSERT INTO `item_equipment` VALUES (26410,'kamalanauts_shield',1,0,4194303,668,1,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26413,'voluspa_shield',99,119,193,30,3,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26414,'twinned_shield',1,0,4194303,672,2,0,2,0,0);
 INSERT INTO `item_equipment` VALUES (26419,'ammurapi_shield',99,119,1589788,42,1,0,2,0,0);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -56178,6 +56178,9 @@ INSERT INTO `item_mods` VALUES (26406,135,3); -- COOK: 3
 -- Diamond buckler
 INSERT INTO `item_mods` VALUES (26410,1,1);   -- DEF: 1
 
+-- Kam'lanaut's Shield
+NSERT INTO `item_mods` VALUES (26412,1,1);   -- DEF: 1
+
 -- Ammurapi Shield
 INSERT INTO `item_mods` VALUES (26419,1,47);   -- DEF: 47
 INSERT INTO `item_mods` VALUES (26419,2,22);   -- HP: 22

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -56179,7 +56179,7 @@ INSERT INTO `item_mods` VALUES (26406,135,3); -- COOK: 3
 INSERT INTO `item_mods` VALUES (26410,1,1);   -- DEF: 1
 
 -- Kam'lanaut's Shield
-NSERT INTO `item_mods` VALUES (26412,1,1);   -- DEF: 1
+INSERT INTO `item_mods` VALUES (26412,1,1);   -- DEF: 1
 
 -- Ammurapi Shield
 INSERT INTO `item_mods` VALUES (26419,1,47);   -- DEF: 47


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Makes Kam'lanaut's shield equipable on all jobs with proper defense 1 mod.
Shield size obtained from https://www.bg-wiki.com/ffxi/Kam%27lanaut%27s_Shield 
ModelID obtained using a custom GM command to change model ids in game.

Thanks to Kthulupwns in CatseyeXI for the initial sql which I modified to add the shield into item_equipment.sql

## Steps to test these changes

In current LSB, if you !additem 26412 and try to equip the shield, you can't.
This pr fixes that.