### PR TITLE
Hook up level restriction and targeting for Garrison (part 3)

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1,7 +1,5 @@
 -----------------------------------
---
---     Functions for Conquest system
---
+-- Functions for Conquest system
 -----------------------------------
 require("scripts/globals/teleports")
 require("scripts/globals/keyitems")
@@ -14,7 +12,6 @@ require("scripts/globals/items")
 require("scripts/globals/extravaganza")
 require("scripts/globals/garrison")
 -----------------------------------
-
 xi = xi or {}
 xi.conquest = xi.conquest or {}
 
@@ -995,7 +992,6 @@ end
 -----------------------------------
 
 xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardType)
-
     if xi.garrison.onTrade(player, npc, trade, guardNation) then
         return
     end
@@ -1196,6 +1192,10 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
     local sRegion  = player:getCharVar("supplyQuest_region")
     local sOutpost = outposts[sRegion]
     local mOffset  = zones[player:getZoneID()].text.CONQUEST
+
+    if xi.garrison.onEventFinish(player, csid, option, guardNation, guardType, guardRegion) then
+        return
+    end
 
     -- SIGNET
     if option == 1 then

--- a/scripts/globals/effects/level_restriction.lua
+++ b/scripts/globals/effects/level_restriction.lua
@@ -7,10 +7,9 @@ require("scripts/globals/msg")
 local effect_object = {}
 
 effect_object.onEffectGain = function(target, effect)
-    target:levelRestriction(effect:getPower())
-    target:messageBasic(xi.msg.basic.LEVEL_IS_RESTRICTED, effect:getPower()) -- <target>'s level is restricted to <param>
-
     if target:getObjType() == xi.objType.PC then
+        target:levelRestriction(effect:getPower())
+        target:messageBasic(xi.msg.basic.LEVEL_IS_RESTRICTED, effect:getPower()) -- <target>'s level is restricted to <param>
         target:clearTrusts()
     end
 end
@@ -19,7 +18,9 @@ effect_object.onEffectTick = function(target, effect)
 end
 
 effect_object.onEffectLose = function(target, effect)
-    target:levelRestriction(0)
+    if target:getObjType() == xi.objType.PC then
+        target:levelRestriction(0)
+    end
 end
 
 return effect_object

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -203,12 +203,12 @@ xi.settings.main =
     ENABLE_LOGIN_CAMPAIGN = 0,
 
     -- GARRISON
-    GARRISON_LOCKOUT             = 1800, -- Time in seconds before a new garrison can be started (default: 1800)
-    GARRISON_TIME_LIMIT          = 1800, -- Time in seconds before lose ongoing garrison (default: 1800)
-    GARRISON_ONCE_PER_WEEK       = 0,    -- Set to 1 to bypass the limit of one garrison per Conquest Tally Week.
-    GARRISON_PARTY_LIMIT         = 18,   -- Set to max party members you want to do garrison (default: 18).
-    GARRISON_NATION_BYPASS       = 0,    -- Set to 1 to bypass the nation requirement.
-    GARRISON_RANK                = 2,    -- Set to minumum Nation Rank to start Garrison (default: 2).
+    GARRISON_LOCKOUT             = 1800,  -- Time in seconds before a new garrison can be started (default: 1800)
+    GARRISON_TIME_LIMIT          = 1800,  -- Time in seconds before lose ongoing garrison (default: 1800)
+    GARRISON_ONCE_PER_WEEK       = 0,     -- Set to 1 to bypass the limit of one garrison per Conquest Tally Week.
+    GARRISON_PARTY_LIMIT         = 18,    -- Set to max party members you want to do garrison (default: 18).
+    GARRISON_NATION_BYPASS       = 0,     -- Set to 1 to bypass the nation requirement.
+    GARRISON_RANK                = 2,     -- Set to minumum Nation Rank to start Garrison (default: 2).
 
     -- MISC
     RIVERNE_PORTERS              = 120,  -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -330,7 +330,7 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         PMob->spawnAnimation = static_cast<SPAWN_ANIMATION>(table["specialSpawnAnimation"].get_or(false) ? 1 : 0);
 
         // Ensure mobs get a function for onMobDeath
-        auto onMobDeath = table["onMobDeath"].get_or<sol::function>(sol::lua_nil);
+        auto onMobDeath = table["onMobDeath"].get<sol::function>();
         if (!onMobDeath.valid())
         {
             cacheEntry["onMobDeath"] = []() {}; // Empty func

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1371,8 +1371,6 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
     {
         auto* PMob = m_mobList[targid];
 
-        ShowInfo(fmt::format("Releasing {} ({})", PMob->name, PMob->targid).c_str());
-
         for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
         {
             CCharEntity* PChar = (CCharEntity*)it->second;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds some basic stuff for Garrison, hidden behind a setting that doesn't exist, so you have to jump through not-so-obvious hoops to enable it.

## Steps to test these changes

Go to dunes when your nation is in charge, `!additem 1531`, trade it to the dude.
See:
- Helpful trader NPCs spawn
- Enemy mobs spawn
- They start fighting
- You can't fight other mobs
- Garrison is over when the NPCs, Mobs, or Players are all dead
- No loot
- (You can get mannequin bits dropping though!)
