### PR TITLE
Ensure migrations are always run in order

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -46,7 +46,7 @@ except Exception as e:
 
 def populate_migrations():
     migration_list = []
-    for file in os.scandir("migrations"):
+    for file in sorted(os.scandir("migrations"), key=lambda e: e.name):
         if file.name.endswith(".py") and file.name != "utils.py":
             name = file.name.replace(".py", "")
             module = importlib.import_module("migrations." + name)


### PR DESCRIPTION
Co-authored-by: Corey <cocosolos@pm.me>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Ensure migrations are always run in order

## Steps to test these changes

Run migrations, see them in the correct order (they were before, but it wasn't guaranteed, maybe by platform?)
