### PR TITLE
Interaction - Quests: TOAU Olduum fix

### DIFF
--- a/scripts/quests/ahtUrhgan/Olduum.lua
+++ b/scripts/quests/ahtUrhgan/Olduum.lua
@@ -46,7 +46,7 @@ quest.sections =
             ['Dkhaaya'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:checkStartEvent(player, 4)
+                    return quest:progressEvent(4)
                 end
             },
 
@@ -176,7 +176,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, xi.items.LIGHTNING_BAND) then
                         if player:getFreeSlotsCount() == 0 then
-                            return quest:messageSpecial(zones[player:getZoneID()].ITEM_CANNOT_BE_OBTAINED)
+                            return quest:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED)
                         else
                             return quest:progressEvent(2)
                         end


### PR DESCRIPTION
Corrects broken Quest Olduum in TOAU

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. --> This will allow players to start and finish the TOAU Quest Olduum.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here --> I have completed the Quest on my local server to test that this is working as intended.
