### PR TITLE
Fix 'METEORMAULER' (a nil value) error on server startup 

### DIFF
--- a/scripts/zones/Jugner_Forest/mobs/Meteormauler_Zhagtegg.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Meteormauler_Zhagtegg.lua
@@ -10,15 +10,16 @@ local entity = {}
 -- TODO: Implement better pathing systems for guards to follow master
 
 entity.onMobSpawn = function(mob)
+    local meteormauler = mob:getID()
     -- Takes half damage from all attacks
     mob:addMod(xi.mod.DMG,-5000)
 
     -- May spawn in a party with two other Orcs
-    if math.random(1,2) == 1 then
-        GetMobByID(ID.mob.METEORMAULER + 1):setSpawn(mob:getXPos()+2, mob:getYPos(), mob:getZPos())
-        GetMobByID(ID.mob.METEORMAULER + 2):setSpawn(mob:getXPos()+4, mob:getYPos(), mob:getZPos())
-        SpawnMob(ID.mob.METEORMAULER + 1)
-        SpawnMob(ID.mob.METEORMAULER + 2)
+    if math.random(3) == 2 then
+        GetMobByID(meteormauler + 1):setSpawn(mob:getXPos()+2, mob:getYPos(), mob:getZPos())
+        GetMobByID(meteormauler + 2):setSpawn(mob:getXPos()+4, mob:getYPos(), mob:getZPos())
+        SpawnMob(meteormauler + 1)
+        SpawnMob(meteormauler + 2)
     end
 end
 
@@ -46,10 +47,11 @@ entity.onMobDeath = function(mob, player, isKiller)
 end
 
 entity.onMobDespawn = function(mob)
-    UpdateNMSpawnPoint(mob:getID())
+    local meteormauler = mob:getID()
+    UpdateNMSpawnPoint(meteormauler)
     mob:setRespawnTime(75600 + math.random(0, 600)) -- 21 hours, 10 minute window
-    DespawnMob(ID.mob.METEORMAULER + 1)
-    DespawnMob(ID.mob.METEORMAULER + 2)
+    DespawnMob(meteormauler + 1)
+    DespawnMob(meteormauler + 2)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fix 'METEORMAULER' (a nil value) error on server startup by casting mobs ID to a local variable,
adjust helper spawn rate to 1/3 for consistency with the other beastman lair NMs
## Steps to test these changes

Start map server. observe no complaints about METEORMAULER in your startup messages.
