### PR TITLE
[npc] Add Western Adoulin Auction Counter script

### DIFF
--- a/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Area: Western Adoulin
+--  NPC: Auction Counter
+-----------------------------------
+require("scripts/quests/tutorial")
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.tutorial.onAuctionTrigger(player)
+    player:sendMenu(3)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
@@ -2,8 +2,6 @@
 -- Area: Western Adoulin
 --  NPC: Auction Counter
 -----------------------------------
-require("scripts/quests/tutorial")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)

--- a/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Auction_Counter.lua
@@ -8,7 +8,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.tutorial.onAuctionTrigger(player)
     player:sendMenu(3)
 end
 


### PR DESCRIPTION
Adds auction house to western adoulin

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds the auction house to western adoulin. I cant take credit for this as i just copied the code from the auction counter file in southern sandoria
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Visit the auction house and buy/sell things
<!-- Clear and detailed steps to test your changes here -->
