### PR TITLE
Alter Ego Extravaganza - Hide [S] Trust Vendors when campaign inactive

### DIFF
--- a/scripts/globals/extravaganza.lua
+++ b/scripts/globals/extravaganza.lua
@@ -35,6 +35,18 @@ xi.extravaganza.getShadowEraCiphers = function(npc)
     return cipherNpcs[npc:getName()]
 end
 
+----------------------------------------------------------------
+-- Check if Extravaganza is active, hide [S] vendors if inactive
+----------------------------------------------------------------
+
+xi.extravaganza.shadowEraHide = function(npc)
+    local active = xi.extravaganza.campaignActive()
+
+    if active == xi.extravaganza.campaign.NONE or active == xi.extravaganza.campaign.SPRING_FALL then
+        GetNPCByID(npc):setStatus(xi.status.DISAPPEAR)
+    end
+end
+
 ----------------------------------------------------------
 -- Check if Extravaganza is Active, set Ciphers, Launch CS
 ----------------------------------------------------------
@@ -46,9 +58,6 @@ xi.extravaganza.shadowEraTrigger = function(player, npc, notes)
         player:setLocalVar("ShadowCipher1", cipherids[1])
         player:setLocalVar("ShadowCipher2", cipherids[2])
         player:startEvent(7300, 0, notes, 6)
-    else
-        -- TODO: Need Cap of CS with params when event not active
-        -- for now have NPC stare blankly
     end
 end
 

--- a/scripts/zones/Bastok_Markets_[S]/IDs.lua
+++ b/scripts/zones/Bastok_Markets_[S]/IDs.lua
@@ -41,6 +41,7 @@ zones[xi.zone.BASTOK_MARKETS_S] =
     },
     npc =
     {
+        SHENNI = 17134281,
     },
 }
 

--- a/scripts/zones/Bastok_Markets_[S]/Zone.lua
+++ b/scripts/zones/Bastok_Markets_[S]/Zone.lua
@@ -3,11 +3,13 @@
 -----------------------------------
 local ID = require('scripts/zones/Bastok_Markets_[S]/IDs')
 require('scripts/globals/chocobo')
+require('scripts/globals/extravaganza')
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
+    xi.extravaganza.shadowEraHide(ID.npc.SHENNI)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Southern_San_dOria_[S]/IDs.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/IDs.lua
@@ -63,6 +63,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA_S] =
     },
     npc =
     {
+        SHIXO = 17105699,
     },
 }
 

--- a/scripts/zones/Southern_San_dOria_[S]/Zone.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/Zone.lua
@@ -5,11 +5,13 @@ local ID = require('scripts/zones/Southern_San_dOria_[S]/IDs')
 require('scripts/globals/chocobo')
 require('scripts/globals/quests')
 require('scripts/globals/zone')
+require('scripts/globals/extravaganza')
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
+    xi.extravaganza.shadowEraHide(ID.npc.SHIXO)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Windurst_Waters_[S]/IDs.lua
+++ b/scripts/zones/Windurst_Waters_[S]/IDs.lua
@@ -47,6 +47,7 @@ zones[xi.zone.WINDURST_WATERS_S] =
     },
     npc =
     {
+        SHUVO = 17163023,
     },
 }
 

--- a/scripts/zones/Windurst_Waters_[S]/Zone.lua
+++ b/scripts/zones/Windurst_Waters_[S]/Zone.lua
@@ -3,11 +3,13 @@
 -----------------------------------
 local ID = require('scripts/zones/Windurst_Waters_[S]/IDs')
 require('scripts/globals/chocobo')
+require('scripts/globals/extravaganza')
 -----------------------------------
 local zone_object = {}
 
 zone_object.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
+    xi.extravaganza.shadowEraHide(ID.npc.SHUVO)
 end
 
 zone_object.onZoneIn = function(player, prevZone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Shadowreign Trust Vendors (Shenni, Shuvo, Shixo) do not spawn when the Summer/NY campaign is inactive. 
Adds logic to hide NPCs when Summer/NY campaign is inactive.

Source: Retail observations

## Steps to test these changes

Enable or Disable Summer/NY Campaign (settings/main > `ENABLE_TRUST_ALTER_EGO_EXTRAVAGANZA`)
Visit NPC locations (e.g. `!gotoid 17134281`)
NPC will be visible during Summer/NY Campaign, hidden if not.