### PR TITLE
Interaction: FIX ZM13 - The Gate of the Gods missing event

### DIFF
--- a/scripts/missions/rotz/13_The_Gate_of_the_Gods.lua
+++ b/scripts/missions/rotz/13_The_Gate_of_the_Gods.lua
@@ -22,6 +22,17 @@ mission.reward =
 
 mission.sections =
 {
+   {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == mission.missionId and missionStatus == 0
+        end,
+
+        [xi.zone.HALL_OF_THE_GODS] =
+        {
+            ['Shimmering_Circle'] = mission:progressEvent(3),
+        },
+    },
+
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId


### PR DESCRIPTION
Fix

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. --> Fixes a current bug within ZM13 not allowing players to progress in the RoZ Mission 13 (ZM13)
Currently players who interact with the "Shimmering circle" do not receive a CS (Event) to progress them into the Ru'Aun gardens portion of the mission. This correction allows the CS to progress the player to the entrance of Ru'Aun allowing them to continue on with the mission.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here --> Added in CS trigger for Shimmering circle, Added the mission using !addmission 3 24, tested the CS and was moved to the correct location to continue the mission.
