### PR TITLE
[core] [packets] Add nullptr check for player's zone when checking packet backlog

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -901,6 +901,12 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     TracyZoneString(fmt::format("{} packets remaining", remainingPackets));
     if (remainingPackets > MAX_PACKET_BACKLOG_SIZE)
     {
+        if (PChar->loc.zone == nullptr)
+        {
+            ShowWarning(fmt::format("Packet backlog exists for char {} with a nullptr zone. Clearing packet list.", PChar->name));
+            PChar->clearPacketList();
+            return 0;
+        }
         ShowWarning(fmt::format("Packet backlog for char {} in {} is {}! Limit is: {}",
                                 PChar->name, PChar->loc.zone->GetName(), remainingPackets, MAX_PACKET_BACKLOG_SIZE));
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Does what it says on the tin, add nullptr check for player's zone when sending outgoing packets. I tested this as so much it builds, but producing the exact condition where this would trigger doesn't seem reasonable upon testing.

Fixes #2718

## Steps to test these changes

Somehow get a nullptr zone and also have a packet backlog, don't crash.