### PR TITLE
Resolve issue with Jeuno guards not selling CP items

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1108,10 +1108,13 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
 end
 
 xi.conquest.overseerOnEventUpdate = function(player, csid, option, guardNation)
+    local pNation = player:getNation()
+    if guardNation == xi.nation.OTHER then
+        guardNation = pNation
+    end
     local stock = getStock(player, guardNation, option)
 
     if stock ~= nil then
-        local pNation = player:getNation()
         local pRank   = GetNationRank(pNation)
         local u1 = 2 -- default: player is correct job and level to equip item
         local u2 = 0 -- default: player has enough CP for item


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Pulling over from Eden source, this makes it possible to buy CP items from the Jeuno guards

## Steps to test these changes

Talk to any of the Jeuno guards to buy CP items belonging to whatever nation your character belongs to
