### PR TITLE
Add proper Bomb Queen pet spawning mechanics

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -27,7 +27,7 @@ entity.onMobFight = function(mob, target)
         local mobId = mob:getID()
         local canSpawnPet = false
         for id = mobId + 1, mobId + 5 do
-            if GetMobByID(id):getCurrentAction() == 0 then
+            if GetMobByID(id):getCurrentAction() == xi.action.NONE then
                 canSpawnPet = true
                 break
             end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -16,23 +16,57 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar("petCooldown", os.time() + 5) -- five seconds for first pet
+    mob:setLocalVar("spawn_time", os.time() + 5) -- five seconds for first pet
 end
 
 entity.onMobFight = function(mob, target)
-    -- every ~20 seconds after first pet, a new pet will spawn around queen's position.
-    -- 49.5% (198/400) chance for Prince/Princess. 1% (4/400) chance for Bomb Bastard.
-    if os.time() > mob:getLocalVar("petCooldown") then
-        local petId = mob:getID() + 1 + math.floor(math.random(0, 399) / 99)
-        local pet = GetMobByID(petId)
+    if os.time() >= mob:getLocalVar("spawn_time") then
+        mob:setLocalVar("spawn_time", os.time() + 30)
+        local mobId = mob:getID()
+        local canSpawnPet = false
+        for id = mobId + 1, mobId + 5 do
+            if GetMobByID(id):getCurrentAction() == 0 then
+                canSpawnPet = true
+                break
+            end
+        end
+        if canSpawnPet then
+            mob:entityAnimationPacket("casm")
+            mob:timer(5000, function(mob)
+                if mob:isDead() then
+                    return
+                end
+                mob:entityAnimationPacket("shsm")
+                local mobId = mob:getID()
 
-        if pet and not pet:isSpawned() then
-            local pos = mob:getPos()
-            pet:setSpawn(pos.x + math.random(-2, 2), pos.y, pos.z + math.random(-2, 2), pos.rot)
-            pet:spawn()
-            pet:updateEnmity(target)
+                -- Pick a random Prince or Princess
+                petId = 0
+                offset = math.random(4)
+                for i = 0, 3 do
+                    id = mobId + 1 + (offset + i) % 4
+                    if GetMobByID(id):getCurrentAction() == 0 then
+                        petId = id
+                        break
+                    end
+                end
 
-            mob:setLocalVar("petCooldown", os.time() + 20)
+                -- If no Princes or Princesses remain then try the Bastard
+                if petId == 0 then
+                    petId = mobId + 5
+                    if GetMobByID(petId):getCurrentAction() ~= 0 then
+                        return
+                    end
+                end
+
+                local pet = GetMobByID(petId)
+                local pos = mob:getPos()
+                pet:setSpawn(pos.x + math.random(-2, 2), pos.y, pos.z + math.random(-2, 2), pos.rot)
+                pet:spawn()
+                local newtarget = mob:getTarget()
+                if newtarget then
+                    pet:updateEnmity(newtarget)
+                end
+            end)
         end
     end
 end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -20,6 +20,8 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
+    -- Every 30 seconds spawn a random Prince or Princess. If none remain then summon the Bastard.
+    -- Retail confirmed
     if os.time() >= mob:getLocalVar("spawn_time") then
         mob:setLocalVar("spawn_time", os.time() + 30)
         local mobId = mob:getID()
@@ -32,19 +34,19 @@ entity.onMobFight = function(mob, target)
         end
         if canSpawnPet then
             mob:entityAnimationPacket("casm")
-            mob:timer(5000, function(mob)
-                if mob:isDead() then
+            mob:timer(5000, function(bombQueen)
+                if bombQueen:isDead() then
                     return
                 end
-                mob:entityAnimationPacket("shsm")
-                local mobId = mob:getID()
+                bombQueen:entityAnimationPacket("shsm")
+                local bombQueenId = mob:getID()
 
                 -- Pick a random Prince or Princess
-                petId = 0
-                offset = math.random(4)
+                local petId = 0
+                local offset = math.random(4)
                 for i = 0, 3 do
-                    id = mobId + 1 + (offset + i) % 4
-                    if GetMobByID(id):getCurrentAction() == 0 then
+                    local id = bombQueenId + 1 + (offset + i) % 4
+                    if GetMobByID(id):getCurrentAction() == xi.action.NONE then
                         petId = id
                         break
                     end
@@ -52,8 +54,8 @@ entity.onMobFight = function(mob, target)
 
                 -- If no Princes or Princesses remain then try the Bastard
                 if petId == 0 then
-                    petId = mobId + 5
-                    if GetMobByID(petId):getCurrentAction() ~= 0 then
+                    petId = bombQueenId + 5
+                    if GetMobByID(petId):getCurrentAction() ~= xi.action.NONE then
                         return
                     end
                 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Another Eden patch - Add animation to Bomb Queen pet spawning and spawn only princes or princesses at random. Only spawn the bastard as a last resort (such good flavor).
Either Wiggo or I tested this on retail (cant find the capture) but Bastard is so rare because the pets always self-destruct after 10 seconds so you really only see the Bastard if you sleep the pets.

## Steps to test these changes

Spawn Bomb Queen and let her spawn her pets
