### PR TITLE
Fix issue with called Wyvern pets not being added to battlefields

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -302,6 +302,12 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
                 PChar->ClearTrusts();
                 luautils::OnBattlefieldEnter(PChar, this);
                 charutils::SendTimerPacket(PChar, GetRemainingTime());
+
+                // Try to add the player's pet in case they have one that can
+                if (PChar->PPet != nullptr)
+                {
+                    InsertEntity(PChar->PPet, true);
+                }
             }
             else if (!IsRegistered(PChar))
             {
@@ -330,7 +336,12 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
 
             if (pet && pet->PMaster && pet->PMaster->objtype == TYPE_PC)
             {
-                // dont enter player pet
+                // Only allow Wyvern pets to enter
+                if (pet->getPetType() == PET_TYPE::WYVERN)
+                {
+                    pet->m_bcnmID        = GetID();
+                    pet->m_battlefieldID = GetArea();
+                }
             }
             else
             {

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -336,12 +336,9 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
 
             if (pet && pet->PMaster && pet->PMaster->objtype == TYPE_PC)
             {
-                // Only allow Wyvern pets to enter
-                if (pet->getPetType() == PET_TYPE::WYVERN)
-                {
-                    pet->m_bcnmID        = GetID();
-                    pet->m_battlefieldID = GetArea();
-                }
+                // Properly set the existing pet to exist within this battlefield
+                pet->m_bcnmID        = GetID();
+                pet->m_battlefieldID = GetArea();
             }
             else
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes an issue with Wyvern pets not being added to a battlefield when its master is. This causes mobs to behavior incorrectly with the Wyvern.

## Steps to test these changes

```
!zone 139
!additem 1177
!changejob drg 75
```
Call your Wyvern and trade the Comet Orb to initiate Eye of the Tiger. Engage with Gerjis and allow your Wyvern to take hate. Once Gerjis is targeting your Wyvern then use `!tp 3000` while targeting Gerjis to see Gerjis correctly perform a TP attack on your Wyvern. Without this fix it would fail.