### PR TITLE
Fix issue with patrol stopping after awhile

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -293,7 +293,7 @@ void CPathFind::FollowPath(time_point tick)
 
     m_onPoint = false;
 
-    pathpoint_t& targetPoint = m_points[m_currentPoint];
+    pathpoint_t targetPoint = m_points[m_currentPoint];
 
     if (isNavMeshEnabled() && m_carefulPathing)
     {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes #2744. Pathing point was being retrieved as a reference and then being set later to look at the next point. This would overtime overwrite all of the path points. This was never noticed before since we didn't reuse the points but now we do.

## Steps to test these changes

Watch an NPC continue to path forever!
