### PR TITLE
Battlefield Groups

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -851,3 +851,61 @@ void CBattlefield::ForEachAlly(const std::function<void(CMobEntity*)>& func)
         func(ally);
     }
 }
+
+void CBattlefield::addGroup(BattlefieldGroup group)
+{
+    if (group.randomDeathCallback.valid())
+    {
+        group.randomMobId = xirand::GetRandomElement(group.mobIds);
+    }
+    m_groups.push_back(group);
+}
+
+void CBattlefield::handleDeath(CBaseEntity* PEntity)
+{
+    if (PEntity->objtype != TYPE_MOB || m_groups.empty())
+    {
+        return;
+    }
+
+    for (auto& group : m_groups)
+    {
+        for (uint32 mobId : group.mobIds)
+        {
+            if (mobId == PEntity->id)
+            {
+                ++group.deathCount;
+
+                if (group.deathCallback.valid())
+                {
+                    group.deathCallback(CLuaBaseEntity(PEntity), group.deathCount);
+                }
+
+                if (group.allDeathCallback.valid() && group.deathCount >= group.mobIds.size())
+                {
+                    // Validate all mobs in the group are dead since they may have been revived
+                    uint16 deathCount = 0;
+                    for (auto& deathMobId : group.mobIds)
+                    {
+                        CMobEntity* PMob = (CMobEntity*)zoneutils::GetEntity(deathMobId, TYPE_MOB | TYPE_PET);
+                        if (PMob->isDead())
+                        {
+                            ++deathCount;
+                        }
+                    }
+
+                    if (deathCount == group.mobIds.size())
+                    {
+                        group.allDeathCallback(CLuaBaseEntity(PEntity));
+                    }
+                }
+
+                if (group.randomDeathCallback.valid() && mobId == group.randomMobId)
+                {
+                    group.randomDeathCallback(CLuaBaseEntity(PEntity));
+                }
+                break;
+            }
+        }
+    }
+}

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -30,6 +30,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../common/cbasetypes.h"
 #include "../common/mmo.h"
 #include <unordered_map>
+#include "sol/sol.hpp"
 
 enum BCRULES : uint8
 {
@@ -117,6 +118,16 @@ struct BattlefieldInitiator_t
     }
 };
 
+struct BattlefieldGroup
+{
+    std::vector<uint32> mobIds;
+    sol::function       deathCallback;
+    sol::function       randomDeathCallback;
+    sol::function       allDeathCallback;
+    uint8               deathCount  = 0;
+    uint32              randomMobId = 0;
+};
+
 class CBattlefield : public std::enable_shared_from_this<CBattlefield>
 {
 public:
@@ -182,8 +193,12 @@ public:
     void         Cleanup();
     bool         LoadMobs();
     bool         SpawnLoot(CBaseEntity* PEntity = nullptr);
-    uint8        m_isMission;
 
+    // Groups
+    void addGroup(BattlefieldGroup group);
+    void handleDeath(CBaseEntity* PEntity);
+
+    uint8                         m_isMission;
     std::set<uint32>              m_RegisteredPlayers;
     std::set<uint32>              m_EnteredPlayers;
     std::vector<CNpcEntity*>      m_NpcList;
@@ -214,6 +229,7 @@ private:
     bool m_Attacked{ false };
 
     std::unordered_map<std::string, uint64_t> m_LocalVars;
+    std::vector<BattlefieldGroup>             m_groups;
 };
 
 #endif

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -29,8 +29,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "../common/cbasetypes.h"
 #include "../common/mmo.h"
-#include <unordered_map>
 #include "sol/sol.hpp"
+#include <unordered_map>
 
 enum BCRULES : uint8
 {

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -28,6 +28,7 @@
 #include "../ai/states/attack_state.h"
 #include "../ai/states/mobskill_state.h"
 #include "../ai/states/weaponskill_state.h"
+#include "../battlefield.h"
 #include "../conquest_system.h"
 #include "../enmity_container.h"
 #include "../entities/charentity.h"
@@ -1394,6 +1395,12 @@ void CMobEntity::OnDespawn(CDespawnState& /*unused*/)
 void CMobEntity::Die()
 {
     TracyZoneScoped;
+
+    if (PBattlefield != nullptr)
+    {
+        PBattlefield->handleDeath(this);
+    }
+
     m_THLvl = PEnmityContainer->GetHighestTH();
     PEnmityContainer->Clear();
     PAI->ClearStateStack();

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -303,7 +303,7 @@ void CLuaBattlefield::addGroups(sol::table groups)
         QueryByNameResult_t entities;
         for (const std::string& name : mobNames)
         {
-            const QueryByNameResult_t result = m_PLuaBattlefield->GetZone()->queryEntitiesByName(name);
+            const QueryByNameResult_t& result = m_PLuaBattlefield->GetZone()->queryEntitiesByName(name);
             entities.insert(entities.end(), result.begin(), result.end());
         }
 

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -75,6 +75,7 @@ public:
     bool cleanup(bool cleanup);
     void win();
     void lose();
+    void addGroups(sol::table groups);
 
     static void Register();
 };

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -421,29 +421,13 @@ auto CLuaZone::getBackgroundMusicNight()
 
 sol::table CLuaZone::queryEntitiesByName(std::string const& name)
 {
-    TracyZoneScoped;
+    const QueryByNameResult_t& entities = m_pLuaZone->queryEntitiesByName(name);
 
     auto table = lua.create_table();
-
-    // TODO: Make work for instances
-    // TODO: Replace with a constant-time lookup
-    // clang-format off
-    m_pLuaZone->ForEachNpc([&](CNpcEntity* PNpc)
+    for (CBaseEntity* entity : entities)
     {
-        if (std::string((const char*)PNpc->GetName()) == name)
-        {
-            table.add(CLuaBaseEntity(PNpc));
-        }
-    });
-
-    m_pLuaZone->ForEachMob([&](CMobEntity* PMob)
-    {
-        if (std::string((const char*)PMob->GetName()) == name)
-        {
-            table.add(CLuaBaseEntity(PMob));
-        }
-    });
-    // clang-format on
+        table.add(CLuaBaseEntity(entity));
+    }
 
     if (table.empty())
     {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -244,6 +244,40 @@ void CZone::SetBackgroundMusicNight(uint8 music)
     m_zoneMusic.m_songNight = music;
 }
 
+const QueryByNameResult_t& CZone::queryEntitiesByName(std::string const& name)
+{
+    TracyZoneScoped;
+
+    // Use memoization since lookups are typically for the same mob names
+    auto result = m_queryByNameResults.find(name);
+    if (result != m_queryByNameResults.end())
+    {
+        return result->second;
+    }
+
+    std::vector<CBaseEntity*> entities;
+
+    // TODO: Make work for instances
+    ForEachNpc([&](CNpcEntity* PNpc)
+               {
+                   if (std::string((const char*)PNpc->GetName()) == name)
+                   {
+                       entities.push_back(PNpc);
+                   }
+               });
+
+    ForEachMob([&](CMobEntity* PMob)
+               {
+                   if (std::string((const char*)PMob->GetName()) == name)
+                   {
+                       entities.push_back(PMob);
+                   }
+               });
+
+    m_queryByNameResults[name] = std::move(entities);
+    return m_queryByNameResults[name];
+}
+
 uint32 CZone::GetLocalVar(const char* var)
 {
     return m_LocalVars[var];

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -258,6 +258,7 @@ const QueryByNameResult_t& CZone::queryEntitiesByName(std::string const& name)
     std::vector<CBaseEntity*> entities;
 
     // TODO: Make work for instances
+    // clang-format off
     ForEachNpc([&](CNpcEntity* PNpc)
     {
         if (std::string((const char*)PNpc->GetName()) == name)
@@ -273,6 +274,7 @@ const QueryByNameResult_t& CZone::queryEntitiesByName(std::string const& name)
             entities.push_back(PMob);
         }
      });
+    // clang-format on
 
     m_queryByNameResults[name] = std::move(entities);
     return m_queryByNameResults[name];

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -259,18 +259,20 @@ const QueryByNameResult_t& CZone::queryEntitiesByName(std::string const& name)
 
     // TODO: Make work for instances
     ForEachNpc([&](CNpcEntity* PNpc)
-               {
-                   if (std::string((const char*)PNpc->GetName()) == name)
-                   {
-                       entities.push_back(PNpc);
-                   } });
+    {
+        if (std::string((const char*)PNpc->GetName()) == name)
+        {
+            entities.push_back(PNpc);
+        }
+    });
 
     ForEachMob([&](CMobEntity* PMob)
-               {
-                   if (std::string((const char*)PMob->GetName()) == name)
-                   {
-                       entities.push_back(PMob);
-                   } });
+    {
+        if (std::string((const char*)PMob->GetName()) == name)
+        {
+            entities.push_back(PMob);
+        }
+     });
 
     m_queryByNameResults[name] = std::move(entities);
     return m_queryByNameResults[name];

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -263,16 +263,14 @@ const QueryByNameResult_t& CZone::queryEntitiesByName(std::string const& name)
                    if (std::string((const char*)PNpc->GetName()) == name)
                    {
                        entities.push_back(PNpc);
-                   }
-               });
+                   } });
 
     ForEachMob([&](CMobEntity* PMob)
                {
                    if (std::string((const char*)PMob->GetName()) == name)
                    {
                        entities.push_back(PMob);
-                   }
-               });
+                   } });
 
     m_queryByNameResults[name] = std::move(entities);
     return m_queryByNameResults[name];

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -511,6 +511,8 @@ typedef std::map<uint16, zoneWeather_t> weatherVector_t;
 
 typedef std::map<uint16, CBaseEntity*> EntityList_t;
 
+using QueryByNameResult_t = std::vector<CBaseEntity*>;
+
 int32 zone_update_weather(uint32 tick, CTaskMgr::CTask* PTask);
 
 class CZone
@@ -537,6 +539,8 @@ public:
     void SetPartyBattleMusic(uint8 music);
     void SetBackgroundMusicDay(uint8 music);
     void SetBackgroundMusicNight(uint8 music);
+
+    const QueryByNameResult_t& queryEntitiesByName(std::string const& name);
 
     uint32 GetLocalVar(const char* var);
     void   SetLocalVar(const char* var, uint32 val);
@@ -646,6 +650,8 @@ private:
     CTreasurePool* m_TreasurePool; // глобальный TreasuerPool
 
     time_point m_timeZoneEmpty; // The time_point when the last player left the zone
+
+    std::unordered_map<std::string, QueryByNameResult_t> m_queryByNameResults;
 
 protected:
     CTaskMgr::CTask* ZoneTimer; // указатель на созданный таймер - ZoneServer. необходим для возможности его остановки


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adding Battlefield groups to support logic associated with a group of mobs. The initial goal for this was to make Limbus mob groups easier to implement but this can easily be used to implement other battlefields. One of the main advantages of this is that it reduces a great deal of repeated logic spread through mob files and localizes it in a single script.

Below is an example of how this groups will look in script. @zach2good suggested I get the mob ids through another means which I'm going to look into doing for the real thing.

```lua
local groups =
{
    -- Floor 1
    {
        -- Boss
        mobs = { "Ghost_Clot" },
        stationary = true,
        mods =
        {
            [xi.mod.IMPACT_SDT] = 0,
            [xi.mod.HTH_SDT] = 0,
            [xi.mod.SLASH_SDT] = 1250,
        },
        death = function(mob, count)
            xi.limbus.openDoor(mob:getBattlefield(), ID.npc.APOLLYON_SE_PORTAL[1])
        end,
    },
    {
        mobs = { "Metalloid_Amoeba" },
        stationary = true,
        mods =
        {
            [xi.mod.IMPACT_SDT] = 0,
            [xi.mod.HTH_SDT] = 0,
            [xi.mod.SLASH_SDT] = 1250,
        },
        setup = function(mobs)
            print("Setup Limbus")
            print(mobs)
            for _, mob in pairs(mobs) do
                print("setup mob"..mob:getID())
            end
        end,
        death = function(mob, count)
            print("Metalloid Amoeba "..mob:getID().." : Death Count: "..count);
            if count == 2 then
                -- xi.limbus.spawnFrom(mob, ID.npc.APOLLYON_SE_TIME_CRATES[1])
            elseif count == 4 then
                -- xi.limbus.spawnRecoverFrom(mob, ID.npc.APOLLYON_SE_RECOVER_CRATES[1])
            elseif count == 8 then
                -- xi.limbus.spawnFrom(mob, ID.npc.APOLLYON_SE_ITEM_CRATES[1])
            end
        end,
        allDeath = function(mob)
            print("all dead")
        end,
        randomDeath = function(mob)
            print("random dead"..mob:getID())
        end,
    },
    {
        mobs = { "Metalloid_Amoeba", "Ghost_Clot" },
        allDeath = function(mob)
            print("all dead including boss")
        end,
    }
}

battlefield:addGroups(groups)
```

## Steps to test these changes

Take the above example and place it into `se_apollyon.lua` and place the addGroups function into `onBattlefieldInitialise`.
```
!zone Apollyon
!addkeyitem cosmo_cleanse
!addkeyitem black_card
```
Enter into SE Apollyon and kill some mobs to see print statements pop up in xi_map console.
