### PR TITLE
Add ON_TRIGGER Event

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -149,6 +149,7 @@ bool CAIContainer::Trigger(CCharEntity* player)
 {
     // TODO: ensure idempotency of all onTrigger lua calls (i.e. chests can only be opened once)
     bool isDoor = luautils::OnTrigger(player, PEntity) == -1;
+    PEntity->PAI->EventHandler.triggerListener("ON_TRIGGER", CLuaBaseEntity(player), CLuaBaseEntity(PEntity));
     if (CanChangeState())
     {
         auto ret = ChangeState<CTriggerState>(PEntity, player->targid, isDoor);


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds an `ON_TRIGGER` event so that scripts can add listeners to when an entity is triggered. This is useful as it makes it possible to handle a trigger for multiple entities with the same code without having to setup an script file for it.

I imagine this could be used in many places but the specific use case I have in mind is once again for Limbus (seeing a pattern here?) and looks like the example below. Currently the solution is to have all of the loot for the entire limbus zone be in a single script resulting in a massive script. With this solution we'll be able to have all of the loot defined in each individual battlefield and then retrieved with the provided `getTreasure`.

```lua
function xi.limbus.setupItemCrates(crates, getTreasure)
    for i, crate in ipairs(crates) do
        crate:removeListener("TRIGGER_ITEM_CRATE")
        crate:addListener("ON_TRIGGER", "TRIGGER_ITEM_CRATE", function(player, npc)
            npcUtil.openCrate(npc, function()
                player:getBattlefield():setChestID(npc:getID(), npc:getLocalVar("win") == 1)
                xi.limbus.handleLootRolls(battlefield, getTreasure(crate:getID()), nil, npc)
            end)
        end)
    end
end
```

## Steps to test these changes

Pretty straight forward
