### PR TITLE
Add prompt for OS to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,10 @@ assignees:
 - [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated
 - [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
 
+## OS / platform the server is running (if known)
+
+<!-- Windows10 / Unbuntu / Mac / ARM etc -->
+
 ## Branch affected by issue <!-- Change to the branch the issue exists on (if relevant) -->
 
 `base`


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
```
## OS / platform the server is running (if known)

<!-- Windows10 / Unbuntu / Mac / ARM etc -->
```

This one isn't being strictly required but may help us find platform specific problems (or problems relating to non supported platforms), so I thought it was worth at least the PR to add. Close and delete branch if not wanted.

## Steps to test these changes
click button, see text. 
