### PR TITLE
[sql] Correct pet Siren mob pool

### DIFF
--- a/sql/pet_list.sql
+++ b/sql/pet_list.sql
@@ -101,4 +101,4 @@ INSERT INTO `pet_list` VALUES (72, 'StormwakerFrame', 5127, 1, 99, 0, 0);
 -- INSERT INTO `pet_list` VALUES (73, 'AdventuringFellow', 0, 1, 99, 0, 0);
 -- 74 is Chocobo in the enum..
 INSERT INTO `pet_list` VALUES (75, 'Luopan', 6040, 1, 99, 0, 0);
-INSERT INTO `pet_list` VALUES (76, 'Siren', 7041, 1, 99, 0, 0);
+INSERT INTO `pet_list` VALUES (76, 'Siren', 7047, 1, 99, 0, 0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Siren's mob pool was changed to 7047 at some point, so this adjusts Siren to use that mob pool.

## Steps to test these changes

Summon Siren and see Siren, not Ramuh.
