### PR TITLE
Confirm trade of mannequin parts in It's Raining Mannequins

### DIFF
--- a/scripts/quests/otherAreas/Its_Raining_Mannequins.lua
+++ b/scripts/quests/otherAreas/Its_Raining_Mannequins.lua
@@ -128,6 +128,8 @@ quest.sections =
             onEventFinish =
             {
                 [309] = function(player, csid, option, npc)
+                    player:confirmTrade()
+
                     quest:setVar(player, 'Prog', 3)
                     quest:setVar(player, 'Wait', os.time())
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds player:confirmTrade() on event finish after trading parts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Trade items, and they should be removed from the player.
<!-- Clear and detailed steps to test your changes here -->
