### PR TITLE
Refactor Gear Sets

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2,234 +2,2574 @@
 -- Gear sets
 -- Allows the use of gear sets with modifiers
 -----------------------------------
-require("scripts/globals/status")
+require('scripts/globals/items')
+require('scripts/globals/status')
 -----------------------------------
 
 xi = xi or {}
 xi.gear_sets = xi.gear_sets or {}
 
-local matchtype =
-{
-    any            = 0,
-    earring_weapon = 1,
-    weapon_weapon  = 2,
-    ring_armor     = 3
-}
-
--- placeholder for unknown mod types
--- local modUnknown = 0
-
--- AF3 +2/109/119 set values are based on BGWiki notes.
--- Each set has a 2 piece minimum, with each additional piece adding xxxPieceBonus to the MOD.
-local extraDamageBaseRate = 2
-local extraDamagePieceBonus = 1
-local extraDWAttackBaseRate = 4
-local extraDWAttackPieceBonus = 2
-local extraKickAttackBaseRate = 2
-local extraKickAttackPieceBonus = 1
-local nullDamageBaseRate = 4
-local nullDamagePieceBonus = 2
-local absorbDamageBaseRate = 2
-local absorbDamagePieceBonus = 1
-local instantCastBaseRate = 2
-local instantCastPieceBonus = 1
-local baseRate = 2
-local pieceBonus = 1
---TODO: Migrate remaining AF3 variables to baseRate/pieceBonus and update comment.
-
---              { id, { item, ids, in, no, particular, order }, minimum matches required, match type, mods { id, value, modvalue for each additional match, additional whole set bonus } }
 local gearSets =
 {
-             { id = 1, items = { 16092, 14554, 14969, 15633, 15719 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 500, 0, 0 } } },    --  Usukane's set (5% Haste)
-             { id = 2, items = { 16088, 14550, 14965, 15629, 15715 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.CRITHITRATE, 5, 0, 0 } } },    --  Skadi's set (5% critrate is guess)
-             { id = 3, items = { 16084, 14546, 14961, 15625, 15711 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 5, 0, 0 } } },  --  Ares's set (5% DA)
-             { id = 4, items = { 16107, 14569, 14984, 15648, 15734 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.ACC, 20, 0, 0 } } },           --  Denali Jacket Set (Increases Accuracy +20)
-             { id = 5, items = { 16106, 14568, 14983, 15647, 15733 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.HPP, 10, 0, 0 } } },           --  Askar Korazin Set (Max HP Boost %10)
-             { id = 6, items = { 16069, 14530, 14940, 15609, 15695 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.SUBTLE_BLOW, 8, 0, 0 } } },    --  Pahluwan Khazagand Set (8% is guess)
-             { id = 7, items = { 16100, 14562, 14977, 15641, 15727 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.MATT, 5, 0, 0 } } },           --  Morrigan's Robe Set (+5 Magic. Atk Bonus)
-             { id = 8, items = { 16096, 14558, 14973, 15637, 15723 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.FASTCAST, 5, 0, 0 } } },       --  Marduk's Jubbah Set (5% fastcast)
-             { id = 9, items = { 16108, 14570, 14985, 15649, 15735 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.MDEF, 10, 0, 0 } } },          --  Goliard Saio Set - Total Set Bonus +10% Magic Def. Bonus
+    [1] = -- Usukane's set (5% Haste)
+    {
+        items =
+        {
+            16092,
+            14554,
+            14969,
+            15633,
+            15719,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 500, 0, 0 },
+        },
+    },
 
-             { id = 10, items = { 16064, 14527, 14935, 15606, 15690 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.REFRESH, 1, 0, 0 } } },      --  Yigit Gomlek Set (1mp per tick) Adds "Refresh" effect
-             { id = 11, items = { 11503, 13759, 12745, 14210, 11413 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 500, 0, 0 } } },   --  Perle Hauberk Set 5% haste
-             { id = 12, items = { 11504, 13760, 12746, 14257, 11414 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.STORETP, 8, 0, 0 } } },      --  Aurore Doublet Set  store tp +8
-             { id = 13, items = { 11505, 13778, 12747, 14258, 11415 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.FASTCAST, 4, 2, 0 } } },    -- Teal Set: Fast Cast +4-10%
-             { id = 14, items = { 10890, 10462, 10512, 11980, 10610 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 600, 0, 0 } } },   --  Calma Armor Set haste%6
-             { id = 15, items = { 10892, 10464, 10514, 11982, 10612 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.MACC, 5, 0, 0 } } },        --  Magavan Armor Set  magic accuracy +5
-             { id = 16, items = { 10891, 10463, 10513, 11981, 10611 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.CRITHITRATE, 5, 0, 0 } } },  --  Mustela Harness Set  crit rate 5%
-             { id = 17, items = { 16126, 15744 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.RATT, 15, 0, 0 } } }, -- Bowman's set: Ranged atk +15
-             { id = 18, items = { 16147, 14589, 15010, 16316, 15756 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.ATT, 1, 4.7, 0 } } },        --  Fourth Division Brune Set
-             { id = 19, items = { 16148, 14590, 15011, 16317, 15757 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.COUNTER, 1, 1, 0 } } },      --  Cobra Unit Harness Set
-             { id = 20, items = { 16149, 14591, 15012, 16318, 15758 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.MACC, 1, 1, 0 } } },        --  Cobra Unit Robe Set
-             { id = 21, items = { 6141, 14581, 15005, 16312, 15749 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 1, 1, 0 }, { xi.mod.ATT, 1, 1, 0 } } },       --  Iron Ram Chainmail Set. Double mod here! It is why it has 2 IDs.
-             { id = 23, items = { 16142, 14582, 15006, 16313, 15750 } , matches = 2, matchType = matchtype.any, mods = { { xi.mod.HP, 10, 10, 0 } } },        --  Fourth Division Cuirass Set
-             { id = 24, items = { 16143, 14583, 15007, 16314, 15751 } , matches = 2, matchType = matchtype.any, mods = { { xi.mod.MP, 10, 10, 0 } } },        --  Cobra Unit Coat Set
-             { id = 25, items = { 16062, 14525, 14933, 15604, 15688 } , matches = 5, matchType = matchtype.any, mods = { { xi.mod.UDMGBREATH, -800, 0, 0 }, { xi.mod.UDMGMAGIC, -800, 0, 0 } } },       --  Amir Korazin Set - Double mod here! It is why it has 2 IDs.
+    [2] = -- Skadi's set (5% critrate is guess)
+    {
+        items =
+        {
+            16088,
+            14550,
+            14965,
+            15629,
+            15715,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.CRITHITRATE, 5, 0, 0 },
+        },
+    },
 
-             { id = 27, items = { 11281, 15015, 16337, 11364 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.STORETP, 5, 5, 5 } } },             --  Hachiryu Haramaki Set - Store tp
-             { id = 28, items = { 11064, 11084, 11104, 11124, 11144 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DA_DOUBLE_DMG_RATE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, --  Ravager's Armor +2 Set - Double attack double damage chance
+    [3] = -- Ares's set (5% DA)
+    {
+        items =
+        {
+            16084,
+            14546,
+            14961,
+            15625,
+            15711,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
+        },
+    },
 
-             { id = 29, items = { 11808, 11824, 11850, 11857, 11858 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 5, 0, 0 } } },   --  Fazheluo Mail Set. Set Bonus: "Double Attack"+5%. Active with any 2 pieces.
+    [4] = -- Denali Jacket Set (Increases Accuracy +20)
+    {
+        items =
+        {
+            16107,
+            14569,
+            14984,
+            15648,
+            15734,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC, 20, 0, 0 },
+        },
+    },
 
-             { id = 30, items = { 11809, 11825, 11851, 11855, 11859 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 800, 0, 0 } } }, --  Cuauhtli Harness Set. Set Bonus: Haste+8%. Active with any 2 pieces.
+    [5] = -- Askar Korazin Set (Max HP Boost %10)
+    {
+        items =
+        {
+            16106,
+            14568,
+            14983,
+            15647,
+            15733,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.HPP, 10, 0, 0 },
+        },
+    },
 
-             { id = 31, items = { 11810, 11826, 11852, 11856, 11860 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.MACC, 5, 0, 0 } } },    --  Hyskos Robe Set. Set Bonus: Magic Accuracy+5. Active with any 2 pieces.
-             { id = 32, items = { 10876, 10450, 10500, 11969, 10600 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.REFRESH, 1, 0.4, 0 } } },     --  Ogier's Armor Set. Set Bonus: Adds "Refresh" xi.effect. Provides 1 mp/tick for 2-3 pieces worn, 2 mp/tick for 4-5 pieces worn.
-             { id = 33, items = { 10877, 10451, 10501, 11970, 10601 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.CRITHITRATE, 1, 1, 0 } } },   --  Athos's Armor Set. Set Bonus: Increases rate of critical hits. Gives +3% for the first 2 pieces and +1% for every additional piece.
+    [6] = -- Pahluwan Khazagand Set (Needs Verification)
+    {
+        items =
+        {
+            16069,
+            14530,
+            14940,
+            15609,
+            15695,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.SUBTLE_BLOW, 8, 0, 0 },
+        },
+    },
 
-             -- Capped Tier set, stick it in cappedTierSets below so we can handle it separately (still need to check if it's a set, though)
-             { id = 34, items = { 10878, 10452, 10502, 11971, 10602 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.FASTCAST, 10, 0, 0 } } },        --  Rubeus Armor Set. Set Bonus: Enhances "Fast Cast" effect. 2 or 3 pieces equipped: Fast Cast +4, 4 or 5 pieces equipped: Fast Cast +10
-             { id = 35, items = { 11080, 11100, 11120, 11140, 11160 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } },        --  Navarch's Attire +2 Set. Set Bonus: Augments "Quick Draw". Quick Draw will occasionally deal triple damage.
-             { id = 36, items = { 11082, 11102, 11122, 11142, 11162 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.SAMBA_DOUBLE_DAMAGE, 1, 1.8, 0 } } },                         --  Charis Attire +2 Set. Set Bonus: Augments "Samba". Occasionally doubles damage with Samba up. Adds approximately 1-2% per piece past the first.
-             { id = 37, items = { 11076, 11096, 11116, 11136, 11156 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.EXTRA_DUAL_WIELD_ATTACK, extraDWAttackBaseRate, extraDWAttackPieceBonus, 0 } } },         --  Iga Garb +2 Set. Set Bonus: Augments "Dual Wield". Attacks made while dual wielding occasionally add an extra attack
-             { id = 38, items = { 11074, 11094, 11114, 11134, 11154 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } },        --  Sylvan Attire +2 Set. Set Bonus: Augments "Rapid Shot". Rapid Shots occasionally deal double damage.
-             { id = 39, items = { 11070, 11090, 11110, 11130, 11150 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ABSORB_DMG_CHANCE, absorbDamageBaseRate, absorbDamagePieceBonus, 0 } } },                          --  Creed Armor +2 Set. Set Bonus: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
-             { id = 40, items = { 11075, 11095, 11115, 11135, 11155 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ZANSHIN_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } },          --  Unkai Domaru +2 Set. Set Bonus: Augments "Zanshin". Zanshin attacks will occasionally deal double damage.
-             { id = 41, items = { 11065, 11085, 11105, 11125, 11145 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.EXTRA_KICK_ATTACK, extraKickAttackBaseRate, extraKickAttackPieceBonus, 0 } } },             --  Tantra Attire +2 Set. Set Bonus: Augments "Kick Attacks". Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
-             { id = 42, items = { 11069, 11089, 11109, 11129, 11149 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.TA_TRIPLE_DMG_RATE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } },              --  Raider's Attire +2 Set. Set Bonus: Augments "Triple Attack". Occasionally causes the second and third hits of a Triple Attack to deal triple damage.Verification Needed Requires a minimum of two pieces.
-             { id = 43, items = { 11066, 11086, 11106, 11126, 11146 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.BAR_ELEMENT_NULL_CHANCE, nullDamageBaseRate, nullDamagePieceBonus, 0 } } },        --  Orison Attire +2 Set. Set Bonus: Augments elemental resistance spells. Bar Elemental spells will occasionally nullify damage of the same element.
-             { id = 44, items = { 11083, 11103, 11123, 11143, 11163 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.GRIMOIRE_INSTANT_CAST, instantCastBaseRate, instantCastPieceBonus, 0 } } },          --  Savant's Attire +2 Set. Set Bonus: Augments Grimoire. Spells that match your current Arts will occasionally cast instantly, without recast.
-             { id = 45, items = { 16005, 17756, 17962, 18596, 18760, 19112, 19215, 19271, 19156 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.HP, 30, 0, 0 }, { xi.mod.VIT, 6, 0, 0 }, { xi.mod.ACC, 6, 0, 0 }, { xi.mod.RACC, 6, 0, 0 } } }, --  Paramount Earring Sets. Set Bonus: HP+30, VIT+6, Accuracy+6, Ranged Accuracy+6. Set Bonus is active with any 2 items(Earring+Weapon or Weapon+Weapon)
-             { id = 49, items = { 18761, 18597, 17757, 19218, 18128, 18500, 16004, 18951 }, matches = 2, matchType = matchtype.earring_weapon, mods = { { xi.mod.STR, 6, 0, 0 }, { xi.mod.ATT, 4, 0, 0 }, { xi.mod.RATT, 4, 0, 0 }, { xi.mod.MATT, 2, 0, 0 } } }, --  Supremacy Earring Sets. Set Bonus: STR+6, Attack+4, Ranged Attack+4, "Magic Atk. Bonus"+2. Active with any 2 items(Earring+Weapon)
+    [7] = -- Morrigan's Robe Set (+5 Magic. Atk Bonus)
+    {
+        items =
+        {
+            16100,
+            14562,
+            14977,
+            15641,
+            15727,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.MATT, 5, 0, 0 },
+        },
+    },
 
-             { id = 53, items = { 16006, 18450, 18499, 18861, 18862, 18952, 19111, 19217, 19272 }, matches = 2, matchType = matchtype.earring_weapon, mods = { { xi.mod.EVA, 10, 0, 0 }, { xi.mod.HPHEAL, 10, 0, 0 }, { xi.mod.ENMITY, -5, 0, 0 } } }, --  Brilliant Earring Set. Set Bonus: Evasion, HP Recovered while healing, Reduces Emnity. Active with any 2 items(Earring+Weapon)
-             { id = 56, items = { 11798, 11362 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.RERAISE_III, 1, 0, 0 } } },        -- Twilight Mail Set. Set Bonus: Auto-Reraise
-             { id = 57, items = { 18244, 17595 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },        -- Begin Jailer weapons: Set is weapon + Virtue stone, bonus 50% extra melee swing.
-             { id = 58, items = { 18244, 17710 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },
-             { id = 59, items = { 18244, 17948 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },
-             { id = 60, items = { 18244, 18100 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },
-             { id = 61, items = { 18244, 18222 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },
-             { id = 62, items = { 18244, 18360 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },
-             { id = 63, items = { 18244, 18397 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AMMO_SWING, 50, 0, 0 } } },        -- End Jailer weapons
-             { id = 71, items = { 28520, 28521 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 7, 0, 0 } } }, -- Bladeborn/Steelflash Earrings
-             { id = 72, items = { 28522, 28523 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DUAL_WIELD, 7, 0, 0 } } }, -- Dudgeon/Heartseeker Earrings
-             { id = 73, items = { 28524, 28525 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.MACC, 12, 0, 0 } } }, -- Psystorm/Lifestorm Earrings
-             { id = 74, items = { 26920, 26921, 27434, 27259, 27260, 26762, 26763, 27074, 27075, 27433 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ZANSHIN_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, -- Samurai 109/119 af3
-             { id = 75, items = { 27414, 27413, 27240, 27239, 27055, 27054, 26901, 26900, 26743, 26742 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.EXTRA_KICK_ATTACK, extraKickAttackBaseRate, extraKickAttackPieceBonus, 0 } } }, -- MNK 109/119 af3
-             { id = 76, items = { 26740, 26741, 27411, 27412, 27238, 27237, 27053, 27054, 26899, 26900 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DA_DOUBLE_DMG_RATE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, -- 109/119 WAR AF3
-             { id = 77, items = { 26750, 26751, 27421, 27422, 27247, 27248, 27063, 27062, 26908, 26909 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.TA_TRIPLE_DMG_RATE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, -- 109/119 THF AF3
-             { id = 78, items = { 26918, 26919, 26761, 26762, 27431, 27432, 27257, 27258, 27072, 27073 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, -- 109/119 RNG AF3
-             { id = 79, items = { 26910, 26911, 26752, 26753, 27424, 27423, 27064, 27065, 27249, 27250 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ABSORB_DMG_CHANCE, absorbDamageBaseRate, absorbDamagePieceBonus, 0 } } }, -- 109/119 PLD AF3
-             { id = 80, items = { 26922, 26923, 26764, 26765, 27076, 27077, 27261, 27262, 27435, 27436 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.EXTRA_DUAL_WIELD_ATTACK, extraDWAttackBaseRate, extraDWAttackPieceBonus, 0 } } }, -- 109/119 NIN AF3
-             { id = 81, items = { 27443, 27444, 26772, 26773, 26930, 26931, 27084, 27085, 27269, 27270 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, extraDamageBaseRate, extraDamagePieceBonus, 0 } } }, -- 109/119 COR AF3
-             { id = 82, items = { 27275, 27276, 27449, 27450, 26778, 26779, 26936, 26937, 27090, 27091 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.GRIMOIRE_INSTANT_CAST, instantCastBaseRate, instantCastPieceBonus, 0 } } }, -- 109/119 SCH AF3
-             { id = 83, items = { 27241, 27242, 27415, 27416, 26744, 26745, 26902, 26903, 27056, 27057 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.BAR_ELEMENT_NULL_CHANCE, nullDamageBaseRate, nullDamagePieceBonus, 0 } } }, -- 109/119 WHM AF3
-             { id = 84, items = { 11867, 10868, 10865 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.REFRESH, 3, 0, 0 } } }, -- Heka's body + NQ or HQ Khat = 3 tick refresh
-             { id = 85, items = { 10868, 11870, 11864, 10865 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.REFRESH, 2, 0, 0 } } }, -- Nefer body/head NQ/HQ combo gives Refresh +2
-             { id = 86, items = { 15852, 15853 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.HP, 50, 0, 0 }, { xi.mod.MP, 50, 0, 0 } } }, -- Dasra's/Nasatya's Ring set gives HP/MP +50
-             { id = 88, items = { 16037, 16038 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.MATT, 5, 0, 0 }, { xi.mod.MACC, 5, 0, 0 } } }, -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
-             { id = 90, items = { 15850, 15851 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ATT, 6, 0, 0 }, { xi.mod.ACC, 12, 0, 0 }, { xi.mod.DEF, 6, 0, 0 } } }, -- Lava's/Kusha's earring set: Atk+6/Acc+12
-             { id = 93, items = { 16146, 14588, 15009, 16315, 15755 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.FIRE_MEVA, 5, 5, 10 }, { xi.mod.ICE_MEVA, 5, 5, 10 }, { xi.mod.WIND_MEVA, 5, 5, 10 }, { xi.mod.EARTH_MEVA, 5, 5, 10 }, { xi.mod.THUNDER_MEVA, 5, 5, 10 }, { xi.mod.WATER_MEVA, 5, 5, 10 }, { xi.mod.LIGHT_MEVA, 5, 5, 10 }, { xi.mod.DARK_MEVA, 5, 5, 10 } } }, --  Iron Ram Haubert Set
-             { id = 101, items = { 16035, 16036 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AGI, 8, 0, 0 } } }, -- Altdorf's/Wilhelm's earring: AGI+8
-             { id = 102, items = { 15042, 11402 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ATT, 5, 0, 0 }, { xi.mod.RATT, 5, 0, 0 } } }, -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
-             { id = 104, items = { 26713, 27853, 27999, 28140, 28279 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.FASTCAST, 4, 2, 0 } } }, -- Teal Set +1: Fast Cast +4-10%
-             { id = 105, items = { 26712, 27852, 27998, 28139, 28278 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.STORETP, 2, 2, 0 } } }, -- Aurore Set +1: Sore TP +2-8%
-             { id = 106, items = { 26711, 27851, 27997, 28138, 28277 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 200, 100, 0 } } }, -- Perle Set +1: Haste +2-5%
-             { id = 107, items = { 27652, 27792, 27932, 28075, 28212 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.MATT, 3, 2, 0 } } }, -- Morrigan's Attire Set +1: Magic Atk. Bonus +3-9%
-             { id = 108, items = { 27651, 27791, 27931, 28074, 28211 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.FASTCAST, 3, 2, 0 } } }, -- Marduk's Attire Set +1: Fast Cast +3-9%
-             { id = 109, items = { 27650, 27790, 27930, 28073, 28210 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.HASTE_GEAR, 300, 200, 0 } } }, -- Usukane Armor Set +1: Haste +3-9%
-             { id = 110, items = { 27649, 27789, 27929, 28072, 28209 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.CRITHITRATE, 3, 2, 0 } } }, -- Skadi's Attire Set +1: Critical hit rate +3-9%
-             { id = 111, items = { 27648, 27788, 27928, 28071, 28208 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 3, 2, 0 } } }, -- Ares' Armor Set +1: Double Attack +3-9%
-             { id = 112, items = { 10315, 10598 },  matches = 2, matchType = matchtype.any, mods = { { xi.mod.DMGMAGIC, -500, 0, 0 } } }, -- Alcedo Cuisses and Gauntlets: Magic damage taken -5%
-             { id = 113, items = { 26204, 25574, 25790, 25828, 25879, 25946 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.SUBTLE_BLOW, 5, 5, 0 } } }, -- Sulevia's Armor Set +2: Subtle Blow +5-20 (Requires Sulevia's Ring to activate set effect)
-             { id = 114, items = { 26206, 25576, 25792, 25830, 25881, 25948 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.COUNTER, 4, 4, 0 } } }, -- Hizamaru Armor Set +2: Counter +4-16% (Requires Hizamaru Ring to activate set effect)
-             { id = 115, items = { 26207, 25577, 25793, 25831, 25882, 25949 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.REFRESH, 1, 1, 0 } } }, -- Inyanga Armor Set +2: Refresh +1-4 (Requires Inyanga Ring to activate set effect)
-             { id = 116, items = { 26205, 25575, 25791, 25829, 25880, 25947 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.REGEN, 3, 3, 0 } } }, -- Meghanada Armor Set +2: Regen +3-12 (Requires Megahanada Ring to activate set effect)
-             { id = 117, items = { 26208, 25578, 25794, 25832, 25883, 25950 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.FAST_CAST, 1, 1, 0 } } }, -- Jhakri Armor Set +2: Fast Cast +1-4% (Requires Jhakri Ring to activate set effect)
-             { id = 118, items = { 26211, 25569, 25797, 25385, 25886, 25953 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.STR, 8, 8, 0 }, { xi.mod.DEX, 8, 8, 0 }, { xi.mod.VIT, 8, 8, 0 } } }, -- Flamma Armor Set +2 STR/DEX/VIT +8-32 (Requires Flamma Ring to activate set effect)
-             { id = 121, items = { 26210, 25573, 25796, 25834, 25885, 25952 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.DEX, 8, 8, 0 }, { xi.mod.VIT, 8, 8, 0 }, { xi.mod.CHR, 8, 8, 0 } } }, -- Tali'ah Armor Set +2 DEX/VIT/CHR +8-32 (Requires Tali'ah Ring to activate set effect)             { id = 124, items = { 26212, 25570, 25798, 25836, 25887, 25954 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.DEX, 8, 8, 0 }, { xi.mod.AGI, 8, 8, 0 }, { xi.mod.CHR, 8, 8, 0 } } }, -- Mummu Armor Set +2 DEX/AGI/CHR +8-32 (Requires Mummu Ring to activate set effect)
-             { id = 127, items = { 26209, 25572, 25795, 25833, 25884, 25951 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.STR, 8, 8, 0 }, { xi.mod.VIT, 8, 8, 0 }, { xi.mod.MND, 8, 8, 0 } } }, -- Ayanmo Armor Set +2 STR/VIT/MND +8-32 (Requires Ayanmo Ring to activate set effect)
-             { id = 130, items = { 26213, 25571, 25799, 25837, 25888, 25955 }, matches = 3, matchType = matchtype.ring_armor, mods = { { xi.mod.VIT, 8, 8, 0 }, { xi.mod.INT, 8, 8, 0 }, { xi.mod.MND, 8, 8, 0 } } }, -- Mallquis Armor Set +2 VIT/INT/MND +8-32 (Requires Mallquis Ring to activate set effect)
-             { id = 133, items = { 26191, 23308, 23643, 23241, 23576, 23174, 23509, 23107, 23442, 23040, 23375 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 WAR
-             { id = 136, items = { 26191, 23309, 23644, 23242, 23577, 23175, 23510, 23108, 23443, 23041, 23376 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 MNK
-             { id = 139, items = { 26085, 23310, 23645, 23243, 23578, 23176, 23511, 23109, 23444, 23042, 23377 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 WHM
-             { id = 142, items = { 26085, 23311, 23646, 23244, 23579, 23177, 23512, 23110, 23445, 23043, 23378 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 BLM
-             { id = 145, items = { 26085, 23312, 23647, 23245, 23580, 23178, 23513, 23111, 23446, 23044, 23379 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 RDM
-             { id = 148, items = { 26191, 23313, 23648, 23246, 23581, 23179, 23514, 23112, 23447, 23045, 23380 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 THF
-             { id = 151, items = { 26191, 23314, 23649, 23247, 23582, 23180, 23515, 23113, 23448, 23046, 23381 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 PLD
-             { id = 154, items = { 26191, 23315, 23650, 23248, 23583, 23181, 23516, 23114, 23449, 23047, 23382 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 DRK
-             { id = 157, items = { 26191, 23316, 23651, 23249, 23584, 23182, 23517, 23115, 23450, 23048, 23383 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 BST
-             { id = 160, items = { 26085, 23317, 23652, 23250, 23585, 23183, 23518, 23116, 23451, 23049, 23384 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 BRD
-             { id = 163, items = { 26191, 23318, 23653, 23251, 23586, 23184, 23519, 23117, 23452, 23050, 23385 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 RNG
-             { id = 166, items = { 26191, 23319, 23654, 23252, 23587, 23185, 23520, 23118, 23453, 23051, 23386 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 SAM
-             { id = 169, items = { 26191, 23320, 23655, 23253, 23588, 23186, 23521, 23119, 23454, 23052, 23387 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 NIN
-             { id = 172, items = { 26191, 23321, 23656, 23254, 23589, 23187, 23522, 23120, 23455, 23053, 23388 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 DRG
-             { id = 175, items = { 26342, 23322, 23657, 23255, 23590, 23188, 23523, 23121, 23456, 23054, 23389 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 SMN
-             { id = 178, items = { 26085, 23323, 23658, 23256, 23591, 23189, 23524, 23122, 23457, 23055, 23390 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 BLU
-             { id = 181, items = { 26191, 23324, 23659, 23257, 23592, 23190, 23525, 23123, 23458, 23056, 23391 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 COR
-             { id = 184, items = { 26191, 23325, 23660, 23258, 23593, 23191, 23526, 23124, 23459, 23057, 23392 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 PUP
-             { id = 187, items = { 26191, 23326, 23661, 23259, 23594, 23192, 23527, 23125, 23460, 23058, 23393 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 DNC (M)
-             { id = 190, items = { 26191, 23327, 23662, 23260, 23595, 23193, 23528, 23126, 23461, 23059, 23394 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 DNC (F)
-             { id = 193, items = { 26085, 23328, 23663, 23261, 23596, 23194, 23529, 23127, 23462, 23060, 23395 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 SCH
-             { id = 196, items = { 26085, 23329, 23664, 23262, 23597, 23195, 23530, 23128, 23463, 23061, 23396 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 GEO
-             { id = 199, items = { 26191, 23330, 23665, 23263, 23598, 23196, 23531, 23129, 23464, 23062, 23397 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 15, 0, 0 }, { xi.mod.RACC, 15, 0, 0 }, { xi.mod.MACC, 15, 0, 0 } } }, -- AF1 119 +2/3 RUN
+    [8] = -- Marduk's Jubbah Set (5% fastcast)
+    {
+        items =
+        {
+            16096,
+            14558,
+            14973,
+            15637,
+            15723,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.FASTCAST, 5, 0, 0 },
+        },
+    },
 
-             { id = 202, items = { 27740, 27881, 28029, 28168, 28306 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.DMGPHYS, -1000, 0, 0 } } },          -- Outrider set (Phys damage taken -10%)
-             { id = 203, items = { 27741, 27882, 28030, 28169, 28307 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.CRIT_DMG_INCREASE, 10, 0, 0 } } }, -- Espial set (Crit damage +10%)
-             { id = 204, items = { 27742, 27883, 28031, 28170, 28308 },  matches = 5, matchType = matchtype.any, mods = { { xi.mod.REFRESH, 3, 0, 0 } } },            -- Wayfarer set (Refresh+3)
-             { id = 205, items = { 26677, 26853, 27029, 27205, 27381 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.BP_DAMAGE, 4, 2, 0 } } }, -- Apogee +1
-             { id = 206, items = { 25612, 25685, 27116, 27301, 27472 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ATT, 20, 10, 0 } } }, -- Ryuo +1
-             { id = 207, items = { 26671, 26847, 27023, 27199, 27375 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DMG, -4, -2, 0 } } }, -- Souveran +1
-             { id = 208, items = { 25610, 25683, 27114, 27299, 27470 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 4, 2, 0 } } }, -- Emicho +1
-             { id = 209, items = { 25618, 25691, 27122, 27307, 27478 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.CURE_POTENCY_II, 4, 2, 0 } } }, -- Kaykaus +1
-             { id = 210, items = { 26675, 26851, 27027, 27203, 27379 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.MARTIAL_ARTS, 8, 4, 0 } } }, -- Rao +1
-             { id = 211, items = { 25614, 25687, 27118, 27303, 27474 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.CRITHITRATE, 4, 2, 0 } } }, -- Adhemar +1
-             { id = 212, items = { 26679, 26855, 27031, 27207, 27383 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 20, 10, 0 } } }, -- Carmine +1
-             { id = 213, items = { 26669, 26845, 27021, 27197, 27373 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0 } } }, -- Lustratio +1
-             { id = 214, items = { 26673, 26849, 27025, 27201, 27377 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.DOUBLE_ATTACK, 4, 2, 0 } } }, -- Argosy +1
-             { id = 215, items = { 25616, 25689, 27120, 27305, 27476 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.MATT, 20, 10, 0 } } }, -- Amalric +1
-             { id = 216, items = { 18947, 15818 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.ACC, 5, 0, 0 }, { xi.mod.SOULEATER_EFFECT, 2, 0, 0 } } }, -- Moliones's Sickle/Ring
-             { id = 218, items = { 11079, 11099, 11119, 11139, 11159 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0 } } }, -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
-             { id = 219, items = { 26770, 26771, 26928, 26929, 27082, 27083, 27267, 27268, 27441, 27442 }, matches = 2, matchType = matchtype.any, mods = { { xi.mod.AUGMENT_BLU_MAGIC, baseRate, pieceBonus, 0 } } },  -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
-             -- next id = 220
+    [9] = -- Goliard Saio Set - Total Set Bonus +10% Magic Def. Bonus
+    {
+        items =
+        {
+            16108,
+            14570,
+            14985,
+            15649,
+            15735,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.MDEF, 10, 0, 0 },
+        },
+    },
+
+    [10] = -- Yigit Gomlek Set (1mp per tick) Adds "Refresh" effect
+    {
+        items =
+        {
+            16064,
+            14527,
+            14935,
+            15606,
+            15690,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.REFRESH, 1, 0, 0 },
+        },
+    },
+
+    [11] = -- Perle Hauberk Set (Haste +5%)
+    {
+        items =
+        {
+            11503,
+            13759,
+            12745,
+            14210,
+            11413,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 500, 0, 0 },
+        },
+    },
+
+    [12] = -- Aurore Doublet Set (Store TP +8)
+    {
+        items =
+        {
+            11504,
+            13760,
+            12746,
+            14257,
+            11414,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.STORETP, 8, 0, 0 }
+        },
+    },
+
+    [13] = -- Teal Set: Fast Cast +4-10%
+    {
+        items =
+        {
+            11505,
+            13778,
+            12747,
+            14258,
+            11415,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.FASTCAST, 4, 2, 0 },
+        },
+    },
+
+    [14] = -- Calma Armor Set haste%6
+    {
+        items =
+        {
+            10890,
+            10462,
+            10512,
+            11980,
+            10610,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 600, 0, 0 },
+        },
+    },
+
+    [15] = -- Magavan Armor Set  magic accuracy +5
+    {
+        items =
+        {
+            10892,
+            10464,
+            10514,
+            11982,
+            10612,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.MACC, 5, 0, 0 },
+        },
+    },
+
+    [16] = -- Mustela Harness Set  crit rate 5%
+    {
+        items =
+        {
+            10891,
+            10463,
+            10513,
+            11981,
+            10611,
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.CRITHITRATE, 5, 0, 0 },
+        },
+    },
+
+    [17] = -- Bowman's set: Ranged atk +15
+    {
+        items =
+        {
+            16126,
+            15744,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.RATT, 15, 0, 0 },
+        },
+    },
+
+    [18] = -- Fourth Division Brune Set
+    {
+        items =
+        {
+            16147,
+            14589,
+            15010,
+            16316,
+            15756,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ATT, 1, 4.7, 0 },
+        },
+    },
+
+    [19] = -- Cobra Unit Harness Set
+    {
+        items =
+        {
+            16148,
+            14590,
+            15011,
+            16317,
+            15757,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.COUNTER, 1, 1, 0 },
+        },
+    },
+
+    [20] = -- Cobra Unit Robe Set
+    {
+        items =
+        {
+            16149,
+            14591,
+            15012,
+            16318,
+            15758,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MACC, 1, 1, 0 },
+        },
+    },
+
+    [21] = -- Iron Ram Chainmail Set.
+    {
+        items =
+        {
+            6141,
+            14581,
+            15005,
+            16312,
+            15749,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ACC, 1, 1, 0 },
+            { xi.mod.ATT, 1, 1, 0 },
+        },
+    },
+
+    [22] = -- Fourth Division Cuirass Set
+    {
+        items =
+        {
+            16142,
+            14582,
+            15006,
+            16313,
+            15750,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HP, 10, 10, 0 },
+        },
+    },
+
+    [23] = -- Cobra Unit Coat Set
+    {
+        items =
+        {
+            16143,
+            14583,
+            15007,
+            16314,
+            15751
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MP, 10, 10, 0 },
+        },
+    },
+
+    [24] = -- Amir Korazin Set - Double mod here! It is why it has 2 IDs.
+    {
+        items =
+        {
+            16062,
+            14525,
+            14933,
+            15604,
+            15688
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.UDMGBREATH, -800, 0, 0 },
+            { xi.mod.UDMGMAGIC,  -800, 0, 0 },
+        },
+    },
+
+    [25] = -- Hachiryu Haramaki Set - Store tp (5, 10, 20)
+    {
+        items =
+        {
+            11281,
+            15015,
+            16337,
+            11364
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.STORETP, 5, 5, 5 },
+        },
+    },
+
+    [26] = -- Ravager's Armor +2 Set - Double attack double damage chance
+    {
+        items =
+        {
+            11064,
+            11084,
+            11104,
+            11124,
+            11144
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
+        },
+    },
+
+    [27] = -- Fazheluo Mail Set. Set Bonus: "Double Attack"+5%. Active with any 2 pieces.
+    {
+        items =
+        {
+            11808,
+            11824,
+            11850,
+            11857,
+            11858
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
+        },
+    },
+
+    [28] = -- Cuauhtli Harness Set. Set Bonus: Haste+8%. Active with any 2 pieces.
+    {
+        items =
+        {
+            11809,
+            11825,
+            11851,
+            11855,
+            11859
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 800, 0, 0 },
+        },
+    },
+
+    [29] = -- Hyskos Robe Set. Set Bonus: Magic Accuracy+5. Active with any 2 pieces.
+    {
+        items =
+        {
+            11810,
+            11826,
+            11852,
+            11856,
+            11860
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MACC, 5, 0, 0 },
+        },
+    },
+
+    [30] = -- Ogier's Armor Set. Set Bonus: Adds "Refresh" xi.effect. Provides 1 mp/tick for 2-3 pieces worn, 2 mp/tick for 4-5 pieces worn.
+    {
+        items =
+        {
+            10876,
+            10450,
+            10500,
+            11969,
+            10600
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.REFRESH, 1, 0.4, 0 },
+        },
+    },
+
+    [31] = -- Athos's Armor Set. Set Bonus: Increases rate of critical hits. Gives +3% for the first 2 pieces and +1% for every additional piece.
+    {
+        items =
+        {
+            10877,
+            10451,
+            10501,
+            11970,
+            10601
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.CRITHITRATE, 1, 1, 0 },
+        },
+    },
+
+    [32] = -- Rubeus Armor Set. Set Bonus: Enhances "Fast Cast" effect. 2 or 3 pieces equipped: Fast Cast +4, 4 or 5 pieces equipped: Fast Cast +10
+    {
+        items =
+        {
+            10878,
+            10452,
+            10502,
+            11971,
+            10602
+        },
+        minMatches = 2,
+        maxMatches = 4, -- Special Case
+        mods =
+        {
+            { xi.mod.FASTCAST, 10, 0, 0 },
+        },
+    },
+
+    [33] = -- Navarch's Attire +2 Set. Set Bonus: Augments "Quick Draw". Quick Draw will occasionally deal triple damage.
+    {
+        items =
+        {
+            11080,
+            11100,
+            11120,
+            11140,
+            11160
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
+        },
+    },
+
+    [34] = -- Charis Attire +2 Set. Set Bonus: Augments "Samba". Occasionally doubles damage with Samba up. Adds approximately 1-2% per piece past the first.
+    {
+        items =
+        {
+            11082,
+            11102,
+            11122,
+            11142,
+            11162
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.SAMBA_DOUBLE_DAMAGE, 1, 1.8, 0 },
+        },
+    },
+
+    [35] = -- Iga Garb +2 Set. Set Bonus: Augments "Dual Wield". Attacks made while dual wielding occasionally add an extra attack
+    {
+        items =
+        {
+            11076,
+            11096,
+            11116,
+            11136,
+            11156
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
         }
+    },
 
-             -- increment id by the number of mods in previous gearset (e.g. id 199 has 3 mods, 199 + 3 = 202)
-             -- so in this example, the next usable id after 199 would be 202.
+    [36] = -- Sylvan Attire +2 Set. Set Bonus: Augments "Rapid Shot". Rapid Shots occasionally deal double damage.
+    {
+        items =
+        {
+            11074,
+            11094,
+            11114,
+            11134,
+            11154
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
+        },
+    },
 
---              { id, { item, ids, in, no, particular, order }, minimum matches required, match type, mods{ id, value, modvalue for each additional match, additional whole set bonus }
+    [37] = -- Creed Armor +2 Set. Set Bonus: Occasionally absorbs damage taken. Set proc believed to be somewhere around 5%, more testing needed. Verification Needed Absorb rate likely varies with # of set pieces.
+    {
+        items =
+        {
+            11070,
+            11090,
+            11110,
+            11130,
+            11150
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
+        },
+    },
 
-local cappedTierSets =
-{
-    -- stick the ids of sets that need their own handling here e.g. Rubeus
-    { id = 34, cappedTier = true },
-    -- AF1 119 +2/+3 sets have 6 possible matching slots, but only 4 tiers. Using cappedTier to enforce a cap on buff level above 5 matches.
-    { id = 133, cappedTier = true },
-    { id = 136, cappedTier = true },
-    { id = 139, cappedTier = true },
-    { id = 142, cappedTier = true },
-    { id = 145, cappedTier = true },
-    { id = 148, cappedTier = true },
-    { id = 151, cappedTier = true },
-    { id = 154, cappedTier = true },
-    { id = 157, cappedTier = true },
-    { id = 160, cappedTier = true },
-    { id = 163, cappedTier = true },
-    { id = 166, cappedTier = true },
-    { id = 169, cappedTier = true },
-    { id = 172, cappedTier = true },
-    { id = 175, cappedTier = true },
-    { id = 178, cappedTier = true },
-    { id = 181, cappedTier = true },
-    { id = 184, cappedTier = true },
-    { id = 187, cappedTier = true },
-    { id = 190, cappedTier = true },
-    { id = 193, cappedTier = true },
-    { id = 196, cappedTier = true },
-    { id = 199, cappedTier = true },
+    [38] = -- Unkai Domaru +2 Set. Set Bonus: Augments "Zanshin". Zanshin attacks will occasionally deal double damage.
+    {
+        items =
+        {
+            11075,
+            11095,
+            11115,
+            11135,
+            11155
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
+        },
+    },
+
+    [39] = -- Tantra Attire +2 Set. Set Bonus: Augments "Kick Attacks". Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
+    {
+        items =
+        {
+            11065,
+            11085,
+            11105,
+            11125,
+            11145
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
+        },
+    },
+
+    [40] = -- Raider's Attire +2 Set. Set Bonus: Augments "Triple Attack". Occasionally causes the second and third hits of a Triple Attack to deal triple damage.Verification Needed Requires a minimum of two pieces.
+    {
+        items =
+        {
+            11069,
+            11089,
+            11109,
+            11129,
+            11149
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
+        },
+    },
+
+    [41] = -- Orison Attire +2 Set. Set Bonus: Augments elemental resistance spells. Bar Elemental spells will occasionally nullify damage of the same element.
+    {
+        items =
+        {
+            11066,
+            11086,
+            11106,
+            11126,
+            11146
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
+        },
+    },
+
+    [42] = -- Savant's Attire +2 Set. Set Bonus: Augments Grimoire. Spells that match your current Arts will occasionally cast instantly, without recast.
+    {
+        items =
+        {
+            11083,
+            11103,
+            11123,
+            11143,
+            11163
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
+        },
+    },
+
+    [43] = -- Paramount Earring Sets. Set Bonus: HP+30, VIT+6, Accuracy+6, Ranged Accuracy+6. Set Bonus is active with any 2 items(Earring+Weapon or Weapon+Weapon)
+    {
+        items =
+        {
+            16005,
+            17756,
+            17962,
+            18596,
+            18760,
+            19112,
+            19215,
+            19271,
+            19156
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HP,  30, 0, 0 },
+            { xi.mod.VIT,  6, 0, 0 },
+            { xi.mod.ACC,  6, 0, 0 },
+            { xi.mod.RACC, 6, 0, 0 },
+        },
+    },
+
+    [44] = -- Supremacy Earring Sets. Set Bonus: STR+6, Attack+4, Ranged Attack+4, "Magic Atk. Bonus"+2. Active with any 2 items(Earring+Weapon)
+    {
+        items =
+        {
+            18761,
+            18597,
+            17757,
+            19218,
+            18128,
+            18500,
+            16004,
+            18951
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.STR,  6, 0, 0 },
+            { xi.mod.ATT,  4, 0, 0 },
+            { xi.mod.RATT, 4, 0, 0 },
+            { xi.mod.MATT, 2, 0, 0 },
+        },
+    },
+
+    [45] = -- Brilliant Earring Set. Set Bonus: Evasion, HP Recovered while healing, Reduces Emnity. Active with any 2 items(Earring+Weapon)
+    {
+        items =
+        {
+            16006,
+            18450,
+            18499,
+            18861,
+            18862,
+            18952,
+            19111,
+            19217,
+            19272
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.EVA,    10, 0, 0 },
+            { xi.mod.HPHEAL, 10, 0, 0 },
+            { xi.mod.ENMITY, -5, 0, 0 },
+        }
+    },
+
+    [46] = -- Twilight Mail Set. Set Bonus: Auto-Reraise
+    {
+        items =
+        {
+            11798,
+            11362
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.RERAISE_III, 1, 0, 0 },
+        },
+    },
+
+    [47] = -- Begin Jailer weapons: Set is weapon + Virtue stone, bonus 50% extra melee swing.
+    {
+        items =
+        {
+            18244,
+            17595
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [48] =
+    {
+        items =
+        {
+            18244,
+            17710
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [49] =
+    {
+        items =
+        {
+            18244,
+            17948
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [50] =
+    {
+        items =
+        {
+            18244,
+            18100
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [51] =
+    {
+        items =
+        {
+            18244,
+            18222
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [52] =
+    {
+        items =
+        {
+            18244,
+            18360
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [53] = -- End Jailer weapons
+    {
+        items =
+        {
+            18244,
+            18397
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AMMO_SWING, 50, 0, 0 },
+        },
+    },
+
+    [54] = -- Bladeborn/Steelflash Earrings
+    {
+        items =
+        {
+            28520,
+            28521
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 7, 0, 0 },
+        },
+    },
+
+    [55] = -- Dudgeon/Heartseeker Earrings
+    {
+        items =
+        {
+            28522,
+            28523
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DUAL_WIELD, 7, 0, 0 },
+        },
+    },
+
+    [56] = -- Psystorm/Lifestorm Earrings
+    {
+        items =
+        {
+            28524,
+            28525
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MACC, 12, 0, 0 },
+        },
+    },
+
+    [57] = -- Samurai 109/119 af3
+    {
+        items =
+        {
+            26920,
+            26921,
+            27434,
+            27259,
+            27260,
+            26762,
+            26763,
+            27074,
+            27075,
+            27433,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
+        },
+    },
+
+    [58] = -- MNK 109/119 af3
+    {
+        items =
+        {
+            27414,
+            27413,
+            27240,
+            27239,
+            27055,
+            27054,
+            26901,
+            26900,
+            26743,
+            26742,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
+        },
+    },
+
+    [59] = -- 109/119 WAR AF3
+    {
+        items =
+        {
+            26740,
+            26741,
+            27411,
+            27412,
+            27238,
+            27237,
+            27053,
+            27054,
+            26899,
+            26900,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
+        },
+    },
+
+    [60] = -- 109/119 THF AF3
+    {
+        items =
+        {
+            26750,
+            26751,
+            27421,
+            27422,
+            27247,
+            27248,
+            27063,
+            27062,
+            26908,
+            26909,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
+        },
+    },
+
+    [61] = -- 109/119 RNG AF3
+    {
+        items =
+        {
+            26918,
+            26919,
+            26761,
+            26762,
+            27431,
+            27432,
+            27257,
+            27258,
+            27072,
+            27073,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
+        },
+    },
+
+    [62] = -- 109/119 PLD AF3
+    {
+        items =
+        {
+            26910,
+            26911,
+            26752,
+            26753,
+            27424,
+            27423,
+            27064,
+            27065,
+            27249,
+            27250,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
+        },
+    },
+
+    [63] = -- 109/119 NIN AF3
+    {
+        items =
+        {
+            26922,
+            26923,
+            26764,
+            26765,
+            27076,
+            27077,
+            27261,
+            27262,
+            27435,
+            27436,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
+        },
+    },
+
+    [64] = -- 109/119 COR AF3
+    {
+        items =
+        {
+            27443,
+            27444,
+            26772,
+            26773,
+            26930,
+            26931,
+            27084,
+            27085,
+            27269,
+            27270,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
+        },
+    },
+
+    [65] = -- 109/119 SCH AF3
+    {
+        items =
+        {
+            27275,
+            27276,
+            27449,
+            27450,
+            26778,
+            26779,
+            26936,
+            26937,
+            27090,
+            27091,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
+        },
+    },
+
+    [66] = -- 109/119 WHM AF3
+    {
+        items =
+        {
+            27241,
+            27242,
+            27415,
+            27416,
+            26744,
+            26745,
+            26902,
+            26903,
+            27056,
+            27057,
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
+        },
+    },
+
+    [67] = -- Heka's body + NQ or HQ Khat = 3 tick refresh
+    {
+        items =
+        {
+            11867,
+            10868,
+            10865
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.REFRESH, 3, 0, 0 },
+        },
+    },
+
+    [68] = -- Nefer body/head NQ/HQ combo gives Refresh +2
+    {
+        items =
+        {
+            10868,
+            11870,
+            11864,
+            10865
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.REFRESH, 2, 0, 0 },
+        },
+    },
+
+    [69] = -- Dasra's/Nasatya's Ring set gives HP/MP +50
+    {
+        items =
+        {
+            15852,
+            15853
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HP, 50, 0, 0 },
+            { xi.mod.MP, 50, 0, 0 },
+        },
+    },
+
+    [70] = -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
+    {
+        items =
+        {
+            16037,
+            16038
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MATT, 5, 0, 0 },
+            { xi.mod.MACC, 5, 0, 0 },
+        },
+    },
+
+    [71] = -- Lava's/Kusha's earring set: Atk+6/Acc+12
+    {
+        items =
+        {
+            15850,
+            15851
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ATT,  6, 0, 0 },
+            { xi.mod.ACC, 12, 0, 0 },
+            { xi.mod.DEF,  6, 0, 0 },
+        },
+    },
+
+    [72] = -- Iron Ram Haubert Set
+    {
+        items =
+        {
+            16146,
+            14588,
+            15009,
+            16315,
+            15755
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.FIRE_MEVA,    5, 5, 10 },
+            { xi.mod.ICE_MEVA,     5, 5, 10 },
+            { xi.mod.WIND_MEVA,    5, 5, 10 },
+            { xi.mod.EARTH_MEVA,   5, 5, 10 },
+            { xi.mod.THUNDER_MEVA, 5, 5, 10 },
+            { xi.mod.WATER_MEVA,   5, 5, 10 },
+            { xi.mod.LIGHT_MEVA,   5, 5, 10 },
+            { xi.mod.DARK_MEVA,    5, 5, 10 },
+        },
+    },
+
+    [73] = -- Altdorf's/Wilhelm's earring: AGI+8
+    {
+        items =
+        {
+            16035,
+            16036
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AGI, 8, 0, 0 },
+        },
+    },
+
+    [74] = -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
+    {
+        items =
+        {
+            15042,
+            11402
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ATT,  5, 0, 0 },
+            { xi.mod.RATT, 5, 0, 0 },
+        },
+    },
+
+    [75] = -- Teal Set +1: Fast Cast +4-10%
+    {
+        items =
+        {
+            26713,
+            27853,
+            27999,
+            28140,
+            28279
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.FASTCAST, 4, 2, 0 },
+        },
+    },
+
+    [76] = -- Aurore Set +1: Sore TP +2-8%
+    {
+        items =
+        {
+            26712,
+            27852,
+            27998,
+            28139,
+            28278
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.STORETP, 2, 2, 0 },
+        },
+    },
+
+    [77] = -- Perle Set +1: Haste +2-5%
+    {
+        items =
+        {
+            26711,
+            27851,
+            27997,
+            28138,
+            28277
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 200, 100, 0 },
+        },
+    },
+
+    [78] = -- Morrigan's Attire Set +1: Magic Atk. Bonus +3-9%
+    {
+        items =
+        {
+            27652,
+            27792,
+            27932,
+            28075,
+            28212
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MATT, 3, 2, 0 },
+        },
+    },
+
+    [79] = -- Marduk's Attire Set +1: Fast Cast +3-9%
+    {
+        items =
+        {
+            27651,
+            27791,
+            27931,
+            28074,
+            28211
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.FASTCAST, 3, 2, 0 },
+        },
+    },
+
+    [80] = -- Usukane Armor Set +1: Haste +3-9%
+    {
+        items =
+        {
+            27650,
+            27790,
+            27930,
+            28073,
+            28210
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.HASTE_GEAR, 300, 200, 0 },
+        },
+    },
+
+    [81] = -- Skadi's Attire Set +1: Critical hit rate +3-9%
+    {
+        items =
+        {
+            27649,
+            27789,
+            27929,
+            28072,
+            28209
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.CRITHITRATE, 3, 2, 0 },
+        },
+    },
+
+    [82] = -- Ares' Armor Set +1: Double Attack +3-9%
+    {
+        items =
+        {
+            27648,
+            27788,
+            27928,
+            28071,
+            28208
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 3, 2, 0 },
+        },
+    },
+
+    [83] = -- Alcedo Cuisses and Gauntlets: Magic damage taken -5%
+    {
+        items =
+        {
+            10315,
+            10598
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DMGMAGIC, -500, 0, 0 },
+        },
+    },
+
+    [84] = -- Sulevia's Armor Set +2: Subtle Blow +5-20
+    {
+        items =
+        {
+            26204,
+            25574,
+            25790,
+            25828,
+            25879,
+            25946
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.SUBTLE_BLOW, 5, 5, 0 },
+        },
+    },
+
+    [85] = -- Hizamaru Armor Set +2: Counter +4-16%
+    {
+        items =
+        {
+            26206,
+            25576,
+            25792,
+            25830,
+            25881,
+            25948
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.COUNTER, 4, 4, 0 },
+        },
+    },
+
+    [86] = -- Inyanga Armor Set +2: Refresh +1-4
+    {
+        items =
+        {
+            26207,
+            25577,
+            25793,
+            25831,
+            25882,
+            25949
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.REFRESH, 1, 1, 0 },
+        },
+    },
+
+    [87] = -- Meghanada Armor Set +2: Regen +3-12
+    {
+        items =
+        {
+            26205,
+            25575,
+            25791,
+            25829,
+            25880,
+            25947
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.REGEN, 3, 3, 0 },
+        },
+    },
+
+    [88] = -- Jhakri Armor Set +2: Fast Cast +1-4%
+    {
+        items =
+        {
+            26208,
+            25578,
+            25794,
+            25832,
+            25883,
+            25950
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.FAST_CAST, 1, 1, 0 },
+        },
+    },
+
+    [89] = -- Flamma Armor Set +2 STR/DEX/VIT +8-32
+    {
+        items =
+        {
+            26211,
+            25569,
+            25797,
+            25385,
+            25886,
+            25953
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.STR, 8, 8, 0 },
+            { xi.mod.DEX, 8, 8, 0 },
+            { xi.mod.VIT, 8, 8, 0 },
+        },
+    },
+
+    [90] = -- Tali'ah Armor Set +2 DEX/VIT/CHR +8-32
+    {
+        items =
+        {
+            26210,
+            25573,
+            25796,
+            25834,
+            25885,
+            25952
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.DEX, 8, 8, 0 },
+            { xi.mod.VIT, 8, 8, 0 },
+            { xi.mod.CHR, 8, 8, 0 },
+        }
+    },
+
+    [91] = -- Mummu Armor Set +2 DEX/AGI/CHR +8-32
+    {
+        items =
+        {
+            26212,
+            25570,
+            25798,
+            25836,
+            25887,
+            25954
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.DEX, 8, 8, 0 },
+            { xi.mod.AGI, 8, 8, 0 },
+            { xi.mod.CHR, 8, 8, 0 },
+        },
+    },
+
+    [92] = -- Ayanmo Armor Set +2 STR/VIT/MND +8-32
+    {
+        items =
+        {
+            26209,
+            25572,
+            25795,
+            25833,
+            25884,
+            25951
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.STR, 8, 8, 0 },
+            { xi.mod.VIT, 8, 8, 0 },
+            { xi.mod.MND, 8, 8, 0 },
+        }
+    },
+
+    [93] = -- Mallquis Armor Set +2 VIT/INT/MND +8-32
+    {
+        items =
+        {
+            26213,
+            25571,
+            25799,
+            25837,
+            25888,
+            25955
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.VIT, 8, 8, 0 },
+            { xi.mod.INT, 8, 8, 0 },
+            { xi.mod.MND, 8, 8, 0 },
+        }
+    },
+
+    [94] = -- AF1 119 +2/3 WAR
+    {
+        items =
+        {
+            26191,
+            23308,
+            23643,
+            23241,
+            23576,
+            23174,
+            23509,
+            23107,
+            23442,
+            23040,
+            23375
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [95] = -- AF1 119 +2/3 MNK
+    {
+        items =
+        {
+            26191,
+            23309,
+            23644,
+            23242,
+            23577,
+            23175,
+            23510,
+            23108,
+            23443,
+            23041,
+            23376
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [96] = -- AF1 119 +2/3 WHM
+    {
+        items =
+        {
+            26085,
+            23310,
+            23645,
+            23243,
+            23578,
+            23176,
+            23511,
+            23109,
+            23444,
+            23042,
+            23377
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [97] = -- AF1 119 +2/3 BLM
+    {
+        items =
+        {
+            26085,
+            23311,
+            23646,
+            23244,
+            23579,
+            23177,
+            23512,
+            23110,
+            23445,
+            23043,
+            23378
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [98] = -- AF1 119 +2/3 RDM
+    {
+        items =
+        {
+            26085,
+            23312,
+            23647,
+            23245,
+            23580,
+            23178,
+            23513,
+            23111,
+            23446,
+            23044,
+            23379
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [99] = -- AF1 119 +2/3 THF
+    {
+        items =
+        {
+            26191,
+            23313,
+            23648,
+            23246,
+            23581,
+            23179,
+            23514,
+            23112,
+            23447,
+            23045,
+            23380
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [100] = -- AF1 119 +2/3 PLD
+    {
+        items =
+        {
+            26191,
+            23314,
+            23649,
+            23247,
+            23582,
+            23180,
+            23515,
+            23113,
+            23448,
+            23046,
+            23381
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [101] = -- AF1 119 +2/3 DRK
+    {
+        items =
+        {
+            26191,
+            23315,
+            23650,
+            23248,
+            23583,
+            23181,
+            23516,
+            23114,
+            23449,
+            23047,
+            23382
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [102] = -- AF1 119 +2/3 BST
+    {
+        items =
+        {
+            26191,
+            23316,
+            23651,
+            23249,
+            23584,
+            23182,
+            23517,
+            23115,
+            23450,
+            23048,
+            23383
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [103] = -- AF1 119 +2/3 BRD
+    {
+        items =
+        {
+            26085,
+            23317,
+            23652,
+            23250,
+            23585,
+            23183,
+            23518,
+            23116,
+            23451,
+            23049,
+            23384
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [104] = -- AF1 119 +2/3 RNG
+    {
+        items =
+        {
+            26191,
+            23318,
+            23653,
+            23251,
+            23586,
+            23184,
+            23519,
+            23117,
+            23452,
+            23050,
+            23385
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [105] = -- AF1 119 +2/3 SAM
+    {
+        items =
+        {
+            26191,
+            23319,
+            23654,
+            23252,
+            23587,
+            23185,
+            23520,
+            23118,
+            23453,
+            23051,
+            23386
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [106] = -- AF1 119 +2/3 NIN
+    {
+        items =
+        {
+            26191,
+            23320,
+            23655,
+            23253,
+            23588,
+            23186,
+            23521,
+            23119,
+            23454,
+            23052,
+            23387
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        }
+    },
+
+    [107] = -- AF1 119 +2/3 DRG
+    {
+        items =
+        {
+            26191,
+            23321,
+            23656,
+            23254,
+            23589,
+            23187,
+            23522,
+            23120,
+            23455,
+            23053,
+            23388
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [108] = -- AF1 119 +2/3 SMN
+    {
+        items =
+        {
+            26342,
+            23322,
+            23657,
+            23255,
+            23590,
+            23188,
+            23523,
+            23121,
+            23456,
+            23054,
+            23389
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        }
+    },
+
+    [109] = -- AF1 119 +2/3 BLU
+    {
+        items =
+        {
+            26085,
+            23323,
+            23658,
+            23256,
+            23591,
+            23189,
+            23524,
+            23122,
+            23457,
+            23055,
+            23390
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [110] = -- AF1 119 +2/3 COR
+    {
+        items =
+        {
+            26191,
+            23324,
+            23659,
+            23257,
+            23592,
+            23190,
+            23525,
+            23123,
+            23458,
+            23056,
+            23391
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [111] = -- AF1 119 +2/3 PUP
+    {
+        items =
+        {
+            26191,
+            23325,
+            23660,
+            23258,
+            23593,
+            23191,
+            23526,
+            23124,
+            23459,
+            23057,
+            23392
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [112] = -- AF1 119 +2/3 DNC (M)
+    {
+        items =
+        {
+            26191,
+            23326,
+            23661,
+            23259,
+            23594,
+            23192,
+            23527,
+            23125,
+            23460,
+            23058,
+            23393
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [113] = -- AF1 119 +2/3 DNC (F)
+    {
+        items =
+        {
+            26191,
+            23327,
+            23662,
+            23260,
+            23595,
+            23193,
+            23528,
+            23126,
+            23461,
+            23059,
+            23394
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [114] = -- AF1 119 +2/3 SCH
+    {
+        items =
+        {
+            26085,
+            23328,
+            23663,
+            23261,
+            23596,
+            23194,
+            23529,
+            23127,
+            23462,
+            23060,
+            23395
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [115] = -- AF1 119 +2/3 GEO
+    {
+        items =
+        {
+            26085,
+            23329,
+            23664,
+            23262,
+            23597,
+            23195,
+            23530,
+            23128,
+            23463,
+            23061,
+            23396
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [116] = -- AF1 119 +2/3 RUN
+    {
+        items =
+        {
+            26191,
+            23330,
+            23665,
+            23263,
+            23598,
+            23196,
+            23531,
+            23129,
+            23464,
+            23062,
+            23397
+        },
+        minMatches = 2,
+        maxMatches = 5,
+        mods =
+        {
+            { xi.mod.ACC,  15, 0, 0 },
+            { xi.mod.RACC, 15, 0, 0 },
+            { xi.mod.MACC, 15, 0, 0 },
+        },
+    },
+
+    [117] = -- Outrider set (Phys damage taken -10%)
+    {
+        items =
+        {
+            27740,
+            27881,
+            28029,
+            28168,
+            28306
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.DMGPHYS, -1000, 0, 0 },
+        },
+    },
+
+    [118] = -- Espial set (Crit damage +10%)
+    {
+        items =
+        {
+            27741,
+            27882,
+            28030,
+            28169,
+            28307
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.CRIT_DMG_INCREASE, 10, 0, 0 },
+        },
+    },
+
+    [119] = -- Wayfarer set (Refresh+3)
+    {
+        items =
+        {
+            27742,
+            27883,
+            28031,
+            28170,
+            28308
+        },
+        minMatches = 5,
+        mods =
+        {
+            { xi.mod.REFRESH, 3, 0, 0 },
+        },
+    },
+
+    [120] = -- Apogee +1
+    {
+        items =
+        {
+            26677,
+            26853,
+            27029,
+            27205,
+            27381
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.BP_DAMAGE, 4, 2, 0 },
+        },
+    },
+
+    [121] = -- Ryuo +1
+    {
+        items =
+        {
+            25612,
+            25685,
+            27116,
+            27301,
+            27472
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ATT, 20, 10, 0 },
+        },
+    },
+
+    [122] = -- Souveran +1
+    {
+        items =
+        {
+            26671,
+            26847,
+            27023,
+            27199,
+            27375
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DMG, -4, -2, 0 },
+        },
+    },
+
+    [123] = -- Emicho +1
+    {
+        items =
+        {
+            25610,
+            25683,
+            27114,
+            27299,
+            27470
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
+        },
+    },
+
+    [124] = -- Kaykaus +1
+    {
+        items =
+        {
+            25618,
+            25691,
+            27122,
+            27307,
+            27478
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.CURE_POTENCY_II, 4, 2, 0 },
+        },
+    },
+
+    [125] = -- Rao +1
+    {
+        items =
+        {
+            26675,
+            26851,
+            27027,
+            27203,
+            27379
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MARTIAL_ARTS, 8, 4, 0 },
+        },
+    },
+
+    [126] = -- Adhemar +1
+    {
+        items =
+        {
+            25614,
+            25687,
+            27118,
+            27303,
+            27474
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.CRITHITRATE, 4, 2, 0 },
+        },
+    },
+
+    [127] = -- Carmine +1
+    {
+        items =
+        {
+            26679,
+            26855,
+            27031,
+            27207,
+            27383
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ACC, 20, 10, 0 },
+        },
+    },
+
+    [128] = -- Lustratio +1
+    {
+        items =
+        {
+            26669,
+            26845,
+            27021,
+            27197,
+            27373
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0 },
+        },
+    },
+
+    [129] = -- Argosy +1
+    {
+        items =
+        {
+            26673,
+            26849,
+            27025,
+            27201,
+            27377
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
+        },
+    },
+
+    [130] = -- Amalric +1
+    {
+        items =
+        {
+            25616,
+            25689,
+            27120,
+            27305,
+            27476
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.MATT, 20, 10, 0 },
+        },
+    },
+
+    [131] = -- Moliones's Sickle/Ring
+    {
+        items =
+        {
+            18947,
+            15818
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.ACC,              5, 0, 0 },
+            { xi.mod.SOULEATER_EFFECT, 2, 0, 0 },
+        },
+    },
+
+    [132] = -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+    {
+        items =
+        {
+            11079,
+            11099,
+            11119,
+            11139,
+            11159
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
+        },
+    },
+
+    [133] = -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+    {
+        items =
+        {
+            26770,
+            26771,
+            26928,
+            26929,
+            27082,
+            27083,
+            27267,
+            27268,
+            27441,
+            27442
+        },
+        minMatches = 2,
+        mods =
+        {
+            { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
+        },
+    }
 }
 
 local function FindMatchByType(gearset, gearMatch)
-    if (gearset.matchType == matchtype.any) then
+    if gearset.matchType == matchtype.any then
         return true
-    elseif (gearset.matchType == matchtype.ring_armor and (gearMatch[xi.slot.HEAD+1] ~= nil or gearMatch[xi.slot.BODY+1] ~= nil or gearMatch[xi.slot.HANDS+1] ~= nil or gearMatch[xi.slot.LEGS+1] ~= nil or gearMatch[xi.slot.FEET+1] ~= nil) and (gearMatch[xi.slot.RING1+1] ~= nil or gearMatch[xi.slot.RING2+1] ~= nil)) then
+    elseif
+        gearset.matchType == matchtype.ring_armor and
+        (
+            gearMatch[xi.slot.HEAD + 1] ~= nil or
+            gearMatch[xi.slot.BODY + 1] ~= nil or
+            gearMatch[xi.slot.HANDS + 1] ~= nil or
+            gearMatch[xi.slot.LEGS + 1] ~= nil or
+            gearMatch[xi.slot.FEET + 1] ~= nil
+        )
+        and
+        (
+            gearMatch[xi.slot.RING1 + 1] ~= nil or
+            gearMatch[xi.slot.RING2 + 1] ~= nil
+        )
+    then
         return true
     end
 
     for _, id in ipairs(gearMatch) do
-        if (gearset.matchType == matchtype.earring_weapon and (gearMatch[xi.slot.MAIN+1] ~= nil or gearMatch[xi.slot.SUB+1] ~= nil) and (gearMatch[xi.slot.EAR1+1] ~= nil or gearMatch[xi.slot.EAR2+1] ~= nil)) then
+        if (gearset.matchType == matchtype.earring_weapon and
+            (gearMatch[xi.slot.MAIN + 1] ~= nil or gearMatch[xi.slot.SUB + 1] ~=
+                nil) and
+            (gearMatch[xi.slot.EAR1 + 1] ~= nil or gearMatch[xi.slot.EAR2 + 1] ~=
+                nil)) then
             return true
-        elseif (gearset.matchType == matchtype.weapon_weapon and (gearMatch[xi.slot.MAIN+1] ~= nil and gearMatch[xi.slot.SUB+1] ~= nil)) then
+        elseif (gearset.matchType == matchtype.weapon_weapon and
+            (gearMatch[xi.slot.MAIN + 1] ~= nil and gearMatch[xi.slot.SUB + 1] ~=
+                nil)) then
             return true
         end
     end
@@ -237,75 +2577,73 @@ local function FindMatchByType(gearset, gearMatch)
     return false
 end
 
-local function handleCappedTierSet(player, gearset, matches)
+local function handleCappedTierSet(player, gearset, minMatches)
     -- Rubeus Armor Set
-    if (gearset.id == 34) then
+    if (gearset.id == 32) then
         local modValue = 0
 
-        if (matches > 1 and matches < 4) then
+        if (minMatches > 1 and minMatches < 4) then
             modValue = 4 -- 2 or 3 pieces
-        elseif (matches > 3) then
+        elseif (minMatches > 3) then
             modValue = 10 -- 4 or 5 pieces
         end
 
         player:addGearSetMod(gearset.id, xi.mod.FASTCAST, modValue)
         return
-    -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
+        -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
     elseif (gearset.id >= 133 and gearset.id <= 199 and gearset.id ~= 175) then
         local modValue = 0
 
-        if (matches == 2) then
-            modValue = 15 -- 2 matches
-        elseif (matches == 3) then
-            modValue = 30 -- 3 matches
-        elseif (matches == 4) then
-            modValue = 45 -- 4 matches
-        elseif (matches >= 5) then
-            modValue = 60 -- 5 or more matches
+        if (minMatches == 2) then
+            modValue = 15 -- 2 minMatches
+        elseif (minMatches == 3) then
+            modValue = 30 -- 3 minMatches
+        elseif (minMatches == 4) then
+            modValue = 45 -- 4 minMatches
+        elseif (minMatches >= 5) then
+            modValue = 60 -- 5 or more minMatches
         end
         player:addGearSetMod(gearset.id, xi.mod.ACC, modValue)
         player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue)
         player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue)
         return
-    -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC (unimplemented)
-    --[[
+        -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC (unimplemented)
+        --[[
     elseif (gearset.id == 175) then
         local modValue = 0
 
-        if (matches == 2) then
-            modValue = 15 -- 2 matches
-        elseif (matches == 3) then
-            modValue = 30 -- 3 matches
-        elseif (matches == 4) then
-            modValue = 45 -- 4 matches
-        elseif (matches >= 5) then
-            modValue = 60 -- 5 or more matches
+        if (minMatches == 2) then
+            modValue = 15 -- 2 minMatches
+        elseif (minMatches == 3) then
+            modValue = 30 -- 3 minMatches
+        elseif (minMatches == 4) then
+            modValue = 45 -- 4 minMatches
+        elseif (minMatches >= 5) then
+            modValue = 60 -- 5 or more minMatches
         end
         --Unimplemented method to add pet mods
         return
-    ]]--
+    ]] --
     end
 end
 
 -----------------------------------
 -- Applys a gear set mod
 -----------------------------------
-local function ApplyMod(player, gearset, matches)
+local function ApplyMod(player, gearset, minMatches)
 
     for _, set in pairs(cappedTierSets) do
         if (set.id == gearset.id) then
-            handleCappedTierSet(player, gearset, matches)
+            handleCappedTierSet(player, gearset, minMatches)
             return
         end
     end
 
-    -- find any additional matches
-    local addMatches = matches - gearset.matches
+    -- find any additional minMatches
+    local addMatches = minMatches - gearset.minMatches
 
-    -- just in case some d00d decides to customize things and complain the script is b0rked
-    if (addMatches < 0) then
-        return
-    end
+    -- just in case someone decides to customize things
+    if (addMatches < 0) then return end
 
     local i = 0
     for _, mod in pairs(gearset.mods) do
@@ -319,7 +2657,7 @@ local function ApplyMod(player, gearset, matches)
         local addSetBonus = 0
 
         -- cause we need all pieces to form a complete set
-        if (matches == #gearset.items) then
+        if (minMatches == #gearset.items) then
             addSetBonus = mod[4]
         end
 
@@ -342,11 +2680,11 @@ xi.gear_sets.checkForGearSet = function(player)
     -- cause we dont want hundreds of function calls
     local equip = {}
     for slot = 0, xi.MAX_SLOTID do
-        equip[slot+1] = player:getEquipID(slot)
+        equip[slot + 1] = player:getEquipID(slot)
     end
 
     for index, gearset in pairs(gearSets) do
-        local matches = 0
+        local minMatches = 0
         if (player:hasGearSetMod(gearset.id) == false) then
             -- local slot = 0
             local gearMatch = {}
@@ -355,9 +2693,9 @@ xi.gear_sets.checkForGearSet = function(player)
                 for slot = 1, xi.MAX_SLOTID do
                     local equipId = equip[slot]
 
-                    -- check the item matches
+                    -- check the item minMatches
                     if (equipId == id) then
-                        matches = matches + 1
+                        minMatches = minMatches + 1
                         gearMatch[slot] = equipId
                         break
                     end
@@ -365,110 +2703,24 @@ xi.gear_sets.checkForGearSet = function(player)
             end
 
             -- doesnt count as a match if the same item is in both slots
-            if (gearMatch[xi.slot.EAR1+1] == gearMatch[xi.slot.EAR2+1] and gearMatch[xi.slot.EAR1+1] ~= nil) then
-                matches = matches - 1
+            if (gearMatch[xi.slot.EAR1 + 1] == gearMatch[xi.slot.EAR2 + 1] and
+                gearMatch[xi.slot.EAR1 + 1] ~= nil) then
+                minMatches = minMatches - 1
             end
-            if (gearMatch[xi.slot.RING1+1] == gearMatch[xi.slot.RING2+1] and gearMatch[xi.slot.RING1+1] ~= nil) then
-                matches = matches - 1
+            if (gearMatch[xi.slot.RING1 + 1] == gearMatch[xi.slot.RING2 + 1] and
+                gearMatch[xi.slot.RING1 + 1] ~= nil) then
+                minMatches = minMatches - 1
             end
-            if (gearMatch[xi.slot.MAIN+1] == gearMatch[xi.slot.SUB+1] and gearMatch[xi.slot.MAIN+1] ~= nil) then
-                matches = matches - 1
+            if (gearMatch[xi.slot.MAIN + 1] == gearMatch[xi.slot.SUB + 1] and
+                gearMatch[xi.slot.MAIN + 1] ~= nil) then
+                minMatches = minMatches - 1
             end
 
-            if (matches >= gearset.matches) then
+            if (minMatches >= gearset.minMatches) then
                 if (FindMatchByType(gearset, gearMatch) == true) then
-                    ApplyMod(player, gearset, matches)
+                    ApplyMod(player, gearset, minMatches)
                 end
             end
         end
     end
 end
-
---[[    Unimplemented sets below
-
-=======
-Empyrean +2
-=======
-
---Aoidos' Attire +2 Set
------------------------------------
-11073 -- Aoidos' Calot+2
-11093 -- Aoidos' Hongreline +2
-11113 -- Aoidos' Manchettes +2
-11133 -- Aoidos' Rhingrave +2
-11153 -- Aoidos' Cothurnes +2
--- Set Bonus: Augments Songs
--- Enhancing songs add an attribute bonus that corresponds to the element of the song (i.e. Thunder-based songs add +DEX). The attribute bonus begins at +1 for 2 pieces, increases by 1 for each additional piece, up to +5 for the whole set. For Dark-based songs, there is a bonus of +10 MP for 2 pieces, and increases by 10 for each additional piece.
-
---Ferine' Attire +2 Set
------------------------------------
-11072 -- Ferine Cabasset+2
-11092 -- Ferine Gausape+2
-11112 -- Ferine Manoplas+2
-11132 -- Ferine Quijotes+2
-11152 -- Ferine Ocreae+2
--- Set Bonus: Attack occ. varies with pet's HP
--- Occasionally increases damage in direct proportion to the percentage of pet's current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
--- 5% Proc Rate
-
---Goetia Attire +2 Set
------------------------------------
-11067 -- Goetia Petasos+2
-11087 -- Goetia Coat+2
-11107 -- Goetia Gloves+2
-11127 -- Goetia Chausses+2
-11147 -- Goetia Sabots+2
--- Set Bonus: Augments "Conserve MP"
--- Occasionally increases damage of elemental spells when Conserve MP is triggered. Increased amount is proportional to twice the ratio of MP conserved.
-
---Bale Armor +2 Set
------------------------------------
-11071 -- Bale Burgeonet+2
-11091 -- Bale Cuirass+2
-11111 -- Bale Gauntlets+2
-11131 -- Bale Flanchard+2
-11151 -- Bale Sollerets+2
--- Set Bonus: Attack occasionally varies with HP
--- Occasionally increases damage in direct proportion to the percentage of current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
-
---Lancer's Armor +2 Set
------------------------------------
-11077 -- Lancer's Mezail+2
-11097 -- Lancer's Plackart+2
-11117 -- Lancer's Vambrace+2
-11137 -- Lancer's Cuissots+2
-11157 -- Lancer's Schynbalds+2
--- Set Bonus: Attack occasionally varies with wyvern's HP.
--- Damage increases proportionate to Wyvern's HP, at 100%, damage is doubled. 2+ pieces required, more pieces increase proc rate. Full +2 set is about a 10% proc rate. (Confirmation needed)
-
---Cirque Attire +2 Set
------------------------------------
-11081 -- Cirque Capello+2
-11101 -- Cirque Farsetto+2
-11121 -- Cirque Gaunti+2
-11141 -- Cirque Pantaloni+2
-11161 -- Cirque Scarpe+2
--- Set Bonus: Attack occasionally varies with automaton's HP.
--- Occasionally increases damage in direct proportion to the percentage of Automaton's current HP. At 100% HP, damage is doubled when triggered, at 50% HP, damage increases by 50%, and so on.
-
---Estoqueur's Attire +2 Set
------------------------------------
-11068 -- Estoqueur's Chappel+2
-11088 -- Estoqueur's Sayon+2
-11108 -- Estoqueur's Gantherots+2
-11128 -- Estoqueur's Fuseau+2
-11148 -- Estoqueur's Houseaux+2
--- Set Bonus: Augments "Composure"
--- Enhances duration of Enhancing Magic cast on OTHERS while under the effect of Composure by 10% for the first 2 pieces, and 15% for any additional pieces thereafter, up to 35% increase for 4 pieces and 50% for all 5 pieces. The "Increases enhancing magic effect duration" of the Estoqueur's Cape, Estoqueur's Houseaux +1 and Estoqueur's Houseaux +2 is multiplicative to this total.
-
---Caller's Attire +2 Set
------------------------------------
-11078 -- Caller's Horn+2
-11098 -- Caller's Doublet+2
-11118 -- Caller's Bracers+2
-11138 -- Caller's Spats+2
-11158 -- Caller's Pigaches+2
--- Set Bonus: Augments "Blood Boon"
--- Occasionally increases damage of Blood Pacts when Blood Boon is triggered. Increased amount is proportional to the ratio of MP conserved.
-
-]]--

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -8,7 +8,12 @@ require('scripts/globals/status')
 
 xi = xi or {}
 xi.gear_sets = xi.gear_sets or {}
-xi.gear_sets.itemToSetId = xi.gear_sets.createItemToSetId()
+
+-- Table Notes:
+-- minEquipped and maxEquipped are optional parameters.  If not set, minEquipped will be set to
+-- a value of 2, and maxEquipped will be set to 0 (not limited).  Mod parameters are the total value
+-- of currently equipped pieces from minEquipped..N (Where N is maxEquipped or the maximum number)
+-- of matches defined within the items table.
 
 local gearSets =
 {
@@ -25,7 +30,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 500, 0, 0 },
+            { xi.mod.HASTE_GEAR, 500 },
         },
     },
 
@@ -42,7 +47,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.CRITHITRATE, 5, 0, 0 },
+            { xi.mod.CRITHITRATE, 5 },
         },
     },
 
@@ -59,7 +64,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
+            { xi.mod.DOUBLE_ATTACK, 5 },
         },
     },
 
@@ -76,7 +81,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.ACC, 20, 0, 0 },
+            { xi.mod.ACC, 20 },
         },
     },
 
@@ -93,7 +98,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.HPP, 10, 0, 0 },
+            { xi.mod.HPP, 10 },
         },
     },
 
@@ -110,7 +115,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.SUBTLE_BLOW, 8, 0, 0 },
+            { xi.mod.SUBTLE_BLOW, 8 },
         },
     },
 
@@ -127,7 +132,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.MATT, 5, 0, 0 },
+            { xi.mod.MATT, 5 },
         },
     },
 
@@ -144,7 +149,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.FASTCAST, 5, 0, 0 },
+            { xi.mod.FASTCAST, 5 },
         },
     },
 
@@ -161,7 +166,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.MDEF, 10, 0, 0 },
+            { xi.mod.MDEF, 10 },
         },
     },
 
@@ -178,7 +183,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.REFRESH, 1, 0, 0 },
+            { xi.mod.REFRESH, 1 },
         },
     },
 
@@ -195,7 +200,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 500, 0, 0 },
+            { xi.mod.HASTE_GEAR, 500 },
         },
     },
 
@@ -212,7 +217,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.STORETP, 8, 0, 0 }
+            { xi.mod.STORETP, 8 }
         },
     },
 
@@ -229,7 +234,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.FASTCAST, 4, 2, 0 },
+            { xi.mod.FASTCAST, 4, 6, 8, 10 },
         },
     },
 
@@ -246,7 +251,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 600, 0, 0 },
+            { xi.mod.HASTE_GEAR, 600 },
         },
     },
 
@@ -263,7 +268,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.MACC, 5, 0, 0 },
+            { xi.mod.MACC, 5 },
         },
     },
 
@@ -280,7 +285,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.CRITHITRATE, 5, 0, 0 },
+            { xi.mod.CRITHITRATE, 5 },
         },
     },
 
@@ -294,7 +299,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.RATT, 15, 0, 0 },
+            { xi.mod.RATT, 15 },
         },
     },
 
@@ -311,11 +316,11 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ATT, 1, 4.7, 0 },
+            { xi.mod.ATT, 1, 5, 10, 15 },
         },
     },
 
-    [19] = -- Cobra Unit Harness Set
+    [19] = -- Cobra Unit Harness Set (Needs Verification)
     {
         items =
         {
@@ -328,11 +333,11 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.COUNTER, 1, 1, 0 },
+            { xi.mod.COUNTER, 1, 2, 3, 4 },
         },
     },
 
-    [20] = -- Cobra Unit Robe Set
+    [20] = -- Cobra Unit Robe Set (Needs Verification)
     {
         items =
         {
@@ -345,7 +350,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MACC, 1, 1, 0 },
+            { xi.mod.MACC, 1, 2, 3, 4 },
         },
     },
 
@@ -362,8 +367,8 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ACC, 1, 1, 0 },
-            { xi.mod.ATT, 1, 1, 0 },
+            { xi.mod.ACC, 1, 2, 3, 4 },
+            { xi.mod.ATT, 1, 2, 3, 4 },
         },
     },
 
@@ -380,7 +385,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.HP, 10, 10, 0 },
+            { xi.mod.HP, 10, 20, 30, 40 },
         },
     },
 
@@ -397,11 +402,11 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MP, 10, 10, 0 },
+            { xi.mod.MP, 10, 20, 30, 40 },
         },
     },
 
-    [24] = -- Amir Korazin Set - Double mod here! It is why it has 2 IDs.
+    [24] = -- Amir Korazin Set
     {
         items =
         {
@@ -414,12 +419,12 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.UDMGBREATH, -800, 0, 0 },
-            { xi.mod.UDMGMAGIC,  -800, 0, 0 },
+            { xi.mod.UDMGBREATH, -800 },
+            { xi.mod.UDMGMAGIC,  -800 },
         },
     },
 
-    [25] = -- Hachiryu Haramaki Set - Store tp (5, 10, 20)
+    [25] = -- Hachiryu Haramaki Set - Store TP
     {
         items =
         {
@@ -431,7 +436,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.STORETP, 5, 5, 5 },
+            { xi.mod.STORETP, 5, 10, 20 },
         },
     },
 
@@ -448,7 +453,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
+            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 3, 4, 5 },
         },
     },
 
@@ -465,7 +470,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
+            { xi.mod.DOUBLE_ATTACK, 5 },
         },
     },
 
@@ -482,7 +487,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 800, 0, 0 },
+            { xi.mod.HASTE_GEAR, 800 },
         },
     },
 
@@ -499,7 +504,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MACC, 5, 0, 0 },
+            { xi.mod.MACC, 5 },
         },
     },
 
@@ -516,7 +521,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.REFRESH, 1, 0.4, 0 },
+            { xi.mod.REFRESH, 1, 1, 2, 2 },
         },
     },
 
@@ -533,7 +538,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.CRITHITRATE, 1, 1, 0 },
+            { xi.mod.CRITHITRATE, 3, 4, 5, 6 },
         },
     },
 
@@ -548,10 +553,9 @@ local gearSets =
             xi.items.RUBEUS_BOOTS,
         },
         minEquipped = 2,
-        maxEquipped = 4, -- Special Case
         mods =
         {
-            { xi.mod.FASTCAST, 10, 0, 0 },
+            { xi.mod.FASTCAST, 4, 4, 10, 10 },
         },
     },
 
@@ -568,7 +572,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -585,7 +589,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.SAMBA_DOUBLE_DAMAGE, 1, 1.8, 0 },
+            { xi.mod.SAMBA_DOUBLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -602,7 +606,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
+            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 2, 3, 4, 5 },
         }
     },
 
@@ -619,7 +623,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -636,7 +640,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
+            { xi.mod.ABSORB_DMG_CHANCE, 2, 3, 4, 5 },
         },
     },
 
@@ -653,7 +657,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -670,7 +674,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
+            { xi.mod.EXTRA_KICK_ATTACK, 2, 3, 4, 5 },
         },
     },
 
@@ -687,7 +691,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
+            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 3, 4, 5 },
         },
     },
 
@@ -704,7 +708,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
+            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 2, 3, 4, 5 },
         },
     },
 
@@ -721,7 +725,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
+            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 3, 4, 5 },
         },
     },
 
@@ -740,12 +744,13 @@ local gearSets =
             xi.items.BALISARDE,
         },
         minEquipped = 2,
+        maxEquipped = 2,
         mods =
         {
-            { xi.mod.HP,  30, 0, 0 },
-            { xi.mod.VIT,  6, 0, 0 },
-            { xi.mod.ACC,  6, 0, 0 },
-            { xi.mod.RACC, 6, 0, 0 },
+            { xi.mod.HP,  30 },
+            { xi.mod.VIT,  6 },
+            { xi.mod.ACC,  6 },
+            { xi.mod.RACC, 6 },
         },
     },
 
@@ -763,12 +768,13 @@ local gearSets =
             xi.items.VENDETTA,
         },
         minEquipped = 2,
+        maxEquipped = 2,
         mods =
         {
-            { xi.mod.STR,  6, 0, 0 },
-            { xi.mod.ATT,  4, 0, 0 },
-            { xi.mod.RATT, 4, 0, 0 },
-            { xi.mod.MATT, 2, 0, 0 },
+            { xi.mod.STR,  6 },
+            { xi.mod.ATT,  4 },
+            { xi.mod.RATT, 4 },
+            { xi.mod.MATT, 2 },
         },
     },
 
@@ -787,11 +793,12 @@ local gearSets =
             xi.items.YAGENTOSHIRO,
         },
         minEquipped = 2,
+        maxEquipped = 2,
         mods =
         {
-            { xi.mod.EVA,    10, 0, 0 },
-            { xi.mod.HPHEAL, 10, 0, 0 },
-            { xi.mod.ENMITY, -5, 0, 0 },
+            { xi.mod.EVA,    10 },
+            { xi.mod.HPHEAL, 10 },
+            { xi.mod.ENMITY, -5 },
         }
     },
 
@@ -805,7 +812,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.RERAISE_III, 1, 0, 0 },
+            { xi.mod.RERAISE_III, 1 },
         },
     },
 
@@ -819,7 +826,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -833,7 +840,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -847,7 +854,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -861,7 +868,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -875,7 +882,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -889,7 +896,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -903,7 +910,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AMMO_SWING, 50, 0, 0 },
+            { xi.mod.AMMO_SWING, 50 },
         },
     },
 
@@ -917,7 +924,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 7, 0, 0 },
+            { xi.mod.DOUBLE_ATTACK, 7 },
         },
     },
 
@@ -931,7 +938,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DUAL_WIELD, 7, 0, 0 },
+            { xi.mod.DUAL_WIELD, 7 },
         },
     },
 
@@ -945,7 +952,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MACC, 12, 0, 0 },
+            { xi.mod.MACC, 12 },
         },
     },
 
@@ -967,7 +974,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -989,7 +996,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
+            { xi.mod.EXTRA_KICK_ATTACK, 2, 3, 4, 5 },
         },
     },
 
@@ -1011,7 +1018,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
+            { xi.mod.DA_DOUBLE_DMG_RATE, 2, 3, 4, 5 },
         },
     },
 
@@ -1033,7 +1040,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
+            { xi.mod.TA_TRIPLE_DMG_RATE, 2, 3, 4, 5 },
         },
     },
 
@@ -1055,7 +1062,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -1077,7 +1084,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
+            { xi.mod.ABSORB_DMG_CHANCE, 2, 3, 4, 5 },
         },
     },
 
@@ -1099,7 +1106,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
+            { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 2, 3, 4, 5 },
         },
     },
 
@@ -1121,7 +1128,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
+            { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 3, 4, 5 },
         },
     },
 
@@ -1143,7 +1150,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
+            { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 3, 4, 5 },
         },
     },
 
@@ -1165,7 +1172,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
+            { xi.mod.BAR_ELEMENT_NULL_CHANCE, 2, 3, 4, 5 },
         },
     },
 
@@ -1180,9 +1187,10 @@ local gearSets =
             xi.items.NEFER_KALASIRIS_P1,
         },
         minEquipped = 2,
+        maxEquipped = 2,
         mods =
         {
-            { xi.mod.REFRESH, 3, 0, 0 },
+            { xi.mod.REFRESH, 3 },
         },
     },
 
@@ -1196,8 +1204,8 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.HP, 50, 0, 0 },
-            { xi.mod.MP, 50, 0, 0 },
+            { xi.mod.HP, 50 },
+            { xi.mod.MP, 50 },
         },
     },
 
@@ -1211,8 +1219,8 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MATT, 5, 0, 0 },
-            { xi.mod.MACC, 5, 0, 0 },
+            { xi.mod.MATT, 5 },
+            { xi.mod.MACC, 5 },
         },
     },
 
@@ -1226,9 +1234,9 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ATT,  6, 0, 0 },
-            { xi.mod.ACC, 12, 0, 0 },
-            { xi.mod.DEF,  6, 0, 0 },
+            { xi.mod.ATT,  6 },
+            { xi.mod.ACC, 12 },
+            { xi.mod.DEF,  6 },
         },
     },
 
@@ -1245,14 +1253,14 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.FIRE_MEVA,    5, 5, 10 },
-            { xi.mod.ICE_MEVA,     5, 5, 10 },
-            { xi.mod.WIND_MEVA,    5, 5, 10 },
-            { xi.mod.EARTH_MEVA,   5, 5, 10 },
-            { xi.mod.THUNDER_MEVA, 5, 5, 10 },
-            { xi.mod.WATER_MEVA,   5, 5, 10 },
-            { xi.mod.LIGHT_MEVA,   5, 5, 10 },
-            { xi.mod.DARK_MEVA,    5, 5, 10 },
+            { xi.mod.FIRE_MEVA,    5, 10, 15, 30 },
+            { xi.mod.ICE_MEVA,     5, 10, 15, 30 },
+            { xi.mod.WIND_MEVA,    5, 10, 15, 30 },
+            { xi.mod.EARTH_MEVA,   5, 10, 15, 30 },
+            { xi.mod.THUNDER_MEVA, 5, 10, 15, 30 },
+            { xi.mod.WATER_MEVA,   5, 10, 15, 30 },
+            { xi.mod.LIGHT_MEVA,   5, 10, 15, 30 },
+            { xi.mod.DARK_MEVA,    5, 10, 15, 30 },
         },
     },
 
@@ -1266,7 +1274,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AGI, 8, 0, 0 },
+            { xi.mod.AGI, 8 },
         },
     },
 
@@ -1280,8 +1288,8 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ATT,  5, 0, 0 },
-            { xi.mod.RATT, 5, 0, 0 },
+            { xi.mod.ATT,  5 },
+            { xi.mod.RATT, 5 },
         },
     },
 
@@ -1298,7 +1306,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.FASTCAST, 4, 2, 0 },
+            { xi.mod.FASTCAST, 4, 6, 8, 10 },
         },
     },
 
@@ -1315,7 +1323,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.STORETP, 2, 2, 0 },
+            { xi.mod.STORETP, 2, 4, 6, 8 },
         },
     },
 
@@ -1332,7 +1340,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 200, 100, 0 },
+            { xi.mod.HASTE_GEAR, 2, 3, 4, 5 },
         },
     },
 
@@ -1349,7 +1357,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MATT, 3, 2, 0 },
+            { xi.mod.MATT, 3, 5, 7, 9 },
         },
     },
 
@@ -1366,7 +1374,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.FASTCAST, 3, 2, 0 },
+            { xi.mod.FASTCAST, 3, 5, 7, 9 },
         },
     },
 
@@ -1383,7 +1391,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.HASTE_GEAR, 300, 200, 0 },
+            { xi.mod.HASTE_GEAR, 300, 500, 700, 900 },
         },
     },
 
@@ -1400,7 +1408,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.CRITHITRATE, 3, 2, 0 },
+            { xi.mod.CRITHITRATE, 3, 5, 7, 9 },
         },
     },
 
@@ -1417,7 +1425,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 3, 2, 0 },
+            { xi.mod.DOUBLE_ATTACK, 3, 5, 7, 9 },
         },
     },
 
@@ -1431,7 +1439,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DMGMAGIC, -500, 0, 0 },
+            { xi.mod.DMGMAGIC, -500 },
         },
     },
 
@@ -1450,7 +1458,7 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.SUBTLE_BLOW, 5, 5, 0 },
+            { xi.mod.SUBTLE_BLOW, 5, 10, 15, 20 },
         },
     },
 
@@ -1469,7 +1477,7 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.COUNTER, 4, 4, 0 },
+            { xi.mod.COUNTER, 4, 8, 12, 16 },
         },
     },
 
@@ -1488,7 +1496,7 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.REFRESH, 1, 1, 0 },
+            { xi.mod.REFRESH, 1, 2, 3, 4 },
         },
     },
 
@@ -1507,7 +1515,7 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.REGEN, 3, 3, 0 },
+            { xi.mod.REGEN, 3, 6, 9, 12 },
         },
     },
 
@@ -1526,7 +1534,7 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.FAST_CAST, 1, 1, 0 },
+            { xi.mod.FAST_CAST, 1, 2, 3, 4 },
         },
     },
 
@@ -1545,9 +1553,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.STR, 8, 8, 0 },
-            { xi.mod.DEX, 8, 8, 0 },
-            { xi.mod.VIT, 8, 8, 0 },
+            { xi.mod.STR, 8, 16, 24, 32 },
+            { xi.mod.DEX, 8, 16, 24, 32 },
+            { xi.mod.VIT, 8, 16, 24, 32 },
         },
     },
 
@@ -1566,9 +1574,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.DEX, 8, 8, 0 },
-            { xi.mod.VIT, 8, 8, 0 },
-            { xi.mod.CHR, 8, 8, 0 },
+            { xi.mod.DEX, 8, 16, 24, 32 },
+            { xi.mod.VIT, 8, 16, 24, 32 },
+            { xi.mod.CHR, 8, 16, 24, 32 },
         }
     },
 
@@ -1587,9 +1595,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.DEX, 8, 8, 0 },
-            { xi.mod.AGI, 8, 8, 0 },
-            { xi.mod.CHR, 8, 8, 0 },
+            { xi.mod.DEX, 8, 16, 24, 32 },
+            { xi.mod.AGI, 8, 16, 24, 32 },
+            { xi.mod.CHR, 8, 16, 24, 32 },
         },
     },
 
@@ -1608,9 +1616,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.STR, 8, 8, 0 },
-            { xi.mod.VIT, 8, 8, 0 },
-            { xi.mod.MND, 8, 8, 0 },
+            { xi.mod.STR, 8, 16, 24, 32 },
+            { xi.mod.VIT, 8, 16, 24, 32 },
+            { xi.mod.MND, 8, 16, 24, 32 },
         }
     },
 
@@ -1629,9 +1637,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.VIT, 8, 8, 0 },
-            { xi.mod.INT, 8, 8, 0 },
-            { xi.mod.MND, 8, 8, 0 },
+            { xi.mod.VIT, 8, 16, 24, 32 },
+            { xi.mod.INT, 8, 16, 24, 32 },
+            { xi.mod.MND, 8, 16, 24, 32 },
         }
     },
 
@@ -1655,9 +1663,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1681,9 +1689,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1707,9 +1715,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1733,9 +1741,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1759,9 +1767,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1785,9 +1793,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1811,9 +1819,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1837,9 +1845,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1863,9 +1871,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1889,9 +1897,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1915,9 +1923,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1941,9 +1949,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -1967,9 +1975,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         }
     },
 
@@ -1993,9 +2001,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2019,9 +2027,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         }
     },
 
@@ -2045,9 +2053,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2071,9 +2079,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2097,9 +2105,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2123,9 +2131,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2149,9 +2157,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2175,9 +2183,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2201,9 +2209,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2227,9 +2235,9 @@ local gearSets =
         maxEquipped = 5,
         mods =
         {
-            { xi.mod.ACC,  15, 0, 0 },
-            { xi.mod.RACC, 15, 0, 0 },
-            { xi.mod.MACC, 15, 0, 0 },
+            { xi.mod.ACC,  15, 30, 45, 60 },
+            { xi.mod.RACC, 15, 30, 45, 60 },
+            { xi.mod.MACC, 15, 30, 45, 60 },
         },
     },
 
@@ -2246,7 +2254,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.DMGPHYS, -1000, 0, 0 },
+            { xi.mod.DMGPHYS, -1000 },
         },
     },
 
@@ -2263,7 +2271,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.CRIT_DMG_INCREASE, 10, 0, 0 },
+            { xi.mod.CRIT_DMG_INCREASE, 10 },
         },
     },
 
@@ -2280,7 +2288,7 @@ local gearSets =
         minEquipped = 5,
         mods =
         {
-            { xi.mod.REFRESH, 3, 0, 0 },
+            { xi.mod.REFRESH, 3 },
         },
     },
 
@@ -2297,7 +2305,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.BP_DAMAGE, 4, 2, 0 },
+            { xi.mod.BP_DAMAGE, 4, 6, 8, 10 },
         },
     },
 
@@ -2314,7 +2322,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ATT, 20, 10, 0 },
+            { xi.mod.ATT, 20, 30, 40, 50 },
         },
     },
 
@@ -2331,7 +2339,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DMG, -4, -2, 0 },
+            { xi.mod.DMG, -4, -6, -8, -10 },
         },
     },
 
@@ -2348,7 +2356,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
+            { xi.mod.DOUBLE_ATTACK, 4, 6, 8, 10 },
         },
     },
 
@@ -2365,7 +2373,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.CURE_POTENCY_II, 4, 2, 0 },
+            { xi.mod.CURE_POTENCY_II, 4, 6, 8, 10 },
         },
     },
 
@@ -2382,7 +2390,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MARTIAL_ARTS, 8, 4, 0 },
+            { xi.mod.MARTIAL_ARTS, 8, 12, 16, 20 },
         },
     },
 
@@ -2399,7 +2407,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.CRITHITRATE, 4, 2, 0 },
+            { xi.mod.CRITHITRATE, 4, 6, 8, 10 },
         },
     },
 
@@ -2416,7 +2424,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ACC, 20, 10, 0 },
+            { xi.mod.ACC, 20, 30, 40, 50 },
         },
     },
 
@@ -2433,7 +2441,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0 },
+            { xi.mod.ALL_WSDMG_FIRST_HIT, 4, 6, 8, 10 },
         },
     },
 
@@ -2450,7 +2458,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
+            { xi.mod.DOUBLE_ATTACK, 4, 6, 8, 10 },
         },
     },
 
@@ -2467,7 +2475,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.MATT, 20, 10, 0 },
+            { xi.mod.MATT, 20, 30, 40, 50 },
         },
     },
 
@@ -2481,8 +2489,8 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.ACC,              5, 0, 0 },
-            { xi.mod.SOULEATER_EFFECT, 2, 0, 0 },
+            { xi.mod.ACC,              5 },
+            { xi.mod.SOULEATER_EFFECT, 2 },
         },
     },
 
@@ -2499,7 +2507,7 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
+            { xi.mod.AUGMENT_BLU_MAGIC, 2, 3, 4, 5 },
         },
     },
 
@@ -2521,14 +2529,13 @@ local gearSets =
         minEquipped = 2,
         mods =
         {
-            { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
+            { xi.mod.AUGMENT_BLU_MAGIC, 2, 3, 4, 5 },
         },
     }
 }
 
 -- Build Table to lookup Set ID based on Item ID.  This is cached in xi.gear_sets.itemToSetId table,
 -- and only rebuilt on loading the gear_sets global into cache.
-
 xi.gear_sets.createItemToSetId = function()
     local itemTable = {}
 
@@ -2540,6 +2547,8 @@ xi.gear_sets.createItemToSetId = function()
 
     return itemTable
 end
+
+xi.gear_sets.itemToSetId = xi.gear_sets.createItemToSetId()
 
 -- Global function to check for equipped sets and apply mods.  This is called by
 -- core on equip and unequip of an item.
@@ -2562,10 +2571,10 @@ xi.gear_sets.checkForGearSet = function(player)
         local minEquippedReq = gearSets[setId].minEquipped and gearSets[setId].minEquipped or 2
         local maxEquippedReq = gearSets[setId].maxEquipped and gearSets[setId].maxEquipped or 0
 
-        if setCount >= minEquipped then
+        if setCount >= minEquippedReq then
             local modTierIndex = math.min(setCount, maxEquippedReq) - minEquippedReq
 
-            for _, modData in gearSets[setId].mods do
+            for _, modData in ipairs(gearSets[setId].mods) do
                 player:addGearSetMod(setId, modData[1], modData[modTierIndex + 2])
             end
         end

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -15,11 +15,11 @@ local gearSets =
     {
         items =
         {
-            16092,
-            14554,
-            14969,
-            15633,
-            15719,
+            xi.items.USUKANE_SOMEN,
+            xi.items.USUKANE_HARAMAKI,
+            xi.items.USUKANE_GOTE,
+            xi.items.USUKANE_HIZAYOROI,
+            xi.items.USUKANE_SUNE_ATE,
         },
         minMatches = 5,
         mods =
@@ -32,11 +32,11 @@ local gearSets =
     {
         items =
         {
-            16088,
-            14550,
-            14965,
-            15629,
-            15715,
+            xi.items.SKADIS_VISOR,
+            xi.items.SKADIS_CUIRIE,
+            xi.items.SKADIS_BAZUBANDS,
+            xi.items.SKADIS_CHAUSSES,
+            xi.items.SKADIS_JAMBEAUX,
         },
         minMatches = 5,
         mods =
@@ -49,11 +49,11 @@ local gearSets =
     {
         items =
         {
-            16084,
-            14546,
-            14961,
-            15625,
-            15711,
+            xi.items.ARES_MASK,
+            xi.items.ARES_CUIRASS,
+            xi.items.ARES_GAUNTLETS,
+            xi.items.ARES_FLANCHARD,
+            xi.items.ARES_SOLLERETS,
         },
         minMatches = 5,
         mods =
@@ -66,11 +66,11 @@ local gearSets =
     {
         items =
         {
-            16107,
-            14569,
-            14984,
-            15648,
-            15734,
+            xi.items.DENALI_BONNET,
+            xi.items.DENALI_JACKET,
+            xi.items.DENALI_WRISTBANDS,
+            xi.items.DENALI_KECKS,
+            xi.items.DENALI_GAMASHES,
         },
         minMatches = 5,
         mods =
@@ -83,11 +83,11 @@ local gearSets =
     {
         items =
         {
-            16106,
-            14568,
-            14983,
-            15647,
-            15733,
+            xi.items.ASKAR_ZUCCHETTO,
+            xi.items.ASKAR_KORAZIN,
+            xi.items.ASKAR_MANOPOLAS,
+            xi.items.ASKAR_DIRS,
+            xi.items.ASKAR_GAMBIERAS,
         },
         minMatches = 5,
         mods =
@@ -100,11 +100,11 @@ local gearSets =
     {
         items =
         {
-            16069,
-            14530,
-            14940,
-            15609,
-            15695,
+            xi.items.PAHLUWAN_QALANSUWA,
+            xi.items.PAHLUWAN_KHAZAGAND,
+            xi.items.PAHLUWAN_DASTANAS,
+            xi.items.PAHLUWAN_SERAWEELS,
+            xi.items.PAHLUWAN_CRACKOWS,
         },
         minMatches = 5,
         mods =
@@ -117,11 +117,11 @@ local gearSets =
     {
         items =
         {
-            16100,
-            14562,
-            14977,
-            15641,
-            15727,
+            xi.items.MORRIGANS_CORONAL,
+            xi.items.MORRIGANS_ROBE,
+            xi.items.MORRIGANS_CUFFS,
+            xi.items.MORRIGANS_SLOPS,
+            xi.items.MORRIGANS_PIGACHES,
         },
         minMatches = 5,
         mods =
@@ -134,11 +134,11 @@ local gearSets =
     {
         items =
         {
-            16096,
-            14558,
-            14973,
-            15637,
-            15723,
+            xi.items.MARDUKS_TIARA,
+            xi.items.MARDUKS_JUBBAH,
+            xi.items.MARDUKS_DASTANAS,
+            xi.items.MARDUKS_SHALWAR,
+            xi.items.MARDUKS_CRACKOWS,
         },
         minMatches = 5,
         mods =
@@ -151,11 +151,11 @@ local gearSets =
     {
         items =
         {
-            16108,
-            14570,
-            14985,
-            15649,
-            15735,
+            xi.items.GOLIARD_CHAPEAU,
+            xi.items.GOLIARD_SAIO,
+            xi.items.GOLIARD_CUFFS,
+            xi.items.GOLIARD_TREWS,
+            xi.items.GOLIARD_CLOGS,
         },
         minMatches = 5,
         mods =
@@ -168,11 +168,11 @@ local gearSets =
     {
         items =
         {
-            16064,
-            14527,
-            14935,
-            15606,
-            15690,
+            xi.items.YIGIT_TURBAN,
+            xi.items.YIGIT_GOMLEK,
+            xi.items.YIGIT_GAGES,
+            xi.items.YIGIT_SERAWEELS,
+            xi.items.YIGIT_CRACKOWS,
         },
         minMatches = 5,
         mods =
@@ -185,11 +185,11 @@ local gearSets =
     {
         items =
         {
-            11503,
-            13759,
-            12745,
-            14210,
-            11413,
+            xi.items.PERLE_SALADE,
+            xi.items.PERLE_HAUBERK,
+            xi.items.PERLE_MOUFLES,
+            xi.items.PERLE_BRAYETTES,
+            xi.items.PERLE_SOLLERETS,
         },
         minMatches = 5,
         mods =
@@ -202,11 +202,11 @@ local gearSets =
     {
         items =
         {
-            11504,
-            13760,
-            12746,
-            14257,
-            11414,
+            xi.items.AURORE_BERET,
+            xi.items.AURORE_DOUBLET,
+            xi.items.AURORE_GLOVES,
+            xi.items.AURORE_BRAIS,
+            xi.items.AURORE_GAITERS,
         },
         minMatches = 5,
         mods =
@@ -219,11 +219,11 @@ local gearSets =
     {
         items =
         {
-            11505,
-            13778,
-            12747,
-            14258,
-            11415,
+            xi.items.TEAL_CHAPEAU,
+            xi.items.TEAL_SAIO,
+            xi.items.TEAL_CUFFS,
+            xi.items.TEAL_SLOPS,
+            xi.items.TEAL_PIGACHES,
         },
         minMatches = 2,
         mods =
@@ -236,11 +236,11 @@ local gearSets =
     {
         items =
         {
-            10890,
-            10462,
-            10512,
-            11980,
-            10610,
+            xi.items.CALMA_ARMET,
+            xi.items.CALMA_BREASTPLATE,
+            xi.items.CALMA_GAUNTLETS,
+            xi.items.CALMA_HOSE,
+            xi.items.CALMA_LEGGINGS,
         },
         minMatches = 5,
         mods =
@@ -253,11 +253,11 @@ local gearSets =
     {
         items =
         {
-            10892,
-            10464,
-            10514,
-            11982,
-            10612,
+            xi.items.MAGAVAN_BERET,
+            xi.items.MAGAVAN_FROCK,
+            xi.items.MAGAVAN_MITTS,
+            xi.items.MAGAVAN_SLOPS,
+            xi.items.MAGAVAN_CLOGS,
         },
         minMatches = 5,
         mods =
@@ -270,11 +270,11 @@ local gearSets =
     {
         items =
         {
-            10891,
-            10463,
-            10513,
-            11981,
-            10611,
+            xi.items.MUSTELA_MASK,
+            xi.items.MUSTELA_HARNESS,
+            xi.items.MUSTELA_GLOVES,
+            xi.items.MUSTELA_BRAIS,
+            xi.items.MUSTELA_BOOTS,
         },
         minMatches = 5,
         mods =
@@ -287,8 +287,8 @@ local gearSets =
     {
         items =
         {
-            16126,
-            15744,
+            xi.items.BOWMANS_MASK,
+            xi.items.BOWMANS_LEDELSENS,
         },
         minMatches = 2,
         mods =
@@ -301,11 +301,11 @@ local gearSets =
     {
         items =
         {
-            16147,
-            14589,
-            15010,
-            16316,
-            15756,
+            xi.items.FOURTH_DIVISION_HAUBE,
+            xi.items.FOURTH_DIVISION_BRUNNE,
+            xi.items.FOURTH_DIVISION_HENTZES,
+            xi.items.FOURTH_DIVISION_SCHOSS,
+            xi.items.FOURTH_DIVISION_SCHUHS,
         },
         minMatches = 2,
         mods =
@@ -318,11 +318,11 @@ local gearSets =
     {
         items =
         {
-            16148,
-            14590,
-            15011,
-            16317,
-            15757,
+            xi.items.COBRA_UNIT_CAP,
+            xi.items.COBRA_UNIT_HARNESS,
+            xi.items.COBRA_UNIT_MITTENS,
+            xi.items.COBRA_UNIT_SUBLIGAR,
+            xi.items.COBRA_UNIT_LEGGINGS,
         },
         minMatches = 2,
         mods =
@@ -335,11 +335,11 @@ local gearSets =
     {
         items =
         {
-            16149,
-            14591,
-            15012,
-            16318,
-            15758,
+            xi.items.COBRA_UNIT_CLOCHE,
+            xi.items.COBRA_UNIT_ROBE,
+            xi.items.COBRA_UNIT_GLOVES,
+            xi.items.COBRA_UNIT_TREWS,
+            xi.items.COBRA_UNIT_CRACKOWS,
         },
         minMatches = 2,
         mods =
@@ -352,11 +352,11 @@ local gearSets =
     {
         items =
         {
-            6141,
-            14581,
-            15005,
-            16312,
-            15749,
+            xi.items.IRON_RAM_HELM,
+            xi.items.IRON_RAM_CHAINMAIL,
+            xi.items.IRON_RAM_MUFFLERS,
+            xi.items.IRON_RAM_BREECHES,
+            xi.items.IRON_RAM_SOLLERETS,
         },
         minMatches = 2,
         mods =
@@ -370,11 +370,11 @@ local gearSets =
     {
         items =
         {
-            16142,
-            14582,
-            15006,
-            16313,
-            15750,
+            xi.items.FOURTH_DIVISION_ARMET,
+            xi.items.FOURTH_DIVISION_CUIRASS,
+            xi.items.FOURTH_DIVISION_GAUNTLETS,
+            xi.items.FOURTH_DIVISION_CUISSES,
+            xi.items.FOURTH_DIVISION_SABATONS,
         },
         minMatches = 2,
         mods =
@@ -387,11 +387,11 @@ local gearSets =
     {
         items =
         {
-            16143,
-            14583,
-            15007,
-            16314,
-            15751
+            xi.items.COBRA_UNIT_HAT,
+            xi.items.COBRA_UNIT_COAT,
+            xi.items.COBRA_UNIT_CUFFS,
+            xi.items.COBRA_UNIT_SLOPS,
+            xi.items.COBRA_UNIT_PIGACHES,
         },
         minMatches = 2,
         mods =
@@ -404,11 +404,11 @@ local gearSets =
     {
         items =
         {
-            16062,
-            14525,
-            14933,
-            15604,
-            15688
+            xi.items.AMIR_PUGGAREE,
+            xi.items.AMIR_KORAZIN,
+            xi.items.AMIR_KOLLUKS,
+            xi.items.AMIR_DIRS,
+            xi.items.AMIR_BOOTS,
         },
         minMatches = 5,
         mods =
@@ -422,10 +422,10 @@ local gearSets =
     {
         items =
         {
-            11281,
-            15015,
-            16337,
-            11364
+            xi.items.HACHIRYU_HARAMAKI,
+            xi.items.HACHIRYU_KOTE,
+            xi.items.HACHIRYU_HAIDATE,
+            xi.items.HACHIRYU_SUNE_ATE,
         },
         minMatches = 2,
         mods =
@@ -438,11 +438,11 @@ local gearSets =
     {
         items =
         {
-            11064,
-            11084,
-            11104,
-            11124,
-            11144
+            xi.items.RAVAGERS_MASK_P2,
+            xi.items.RAVAGERS_LORICA_P2,
+            xi.items.RAVAGERS_MUFFLERS_P2,
+            xi.items.RAVAGERS_CUISSES_P2,
+            xi.items.RAVAGERS_CALLIGAE_P2,
         },
         minMatches = 2,
         mods =
@@ -455,11 +455,11 @@ local gearSets =
     {
         items =
         {
-            11808,
-            11824,
-            11850,
-            11857,
-            11858
+            xi.items.FAZHELUO_HELM,
+            xi.items.FAZHELUO_HELM_P1,
+            xi.items.FAZHELUO_MAIL,
+            xi.items.FAZHELUO_RADIANT_MAIL,
+            xi.items.FAZHELUO_MAIL_P1,
         },
         minMatches = 2,
         mods =
@@ -472,11 +472,11 @@ local gearSets =
     {
         items =
         {
-            11809,
-            11825,
-            11851,
-            11855,
-            11859
+            xi.items.CUAUHTLI_HEADPIECE,
+            xi.items.CUAUHTLI_HEADPIECE_P1,
+            xi.items.CUAUHTLI_HARNESS,
+            xi.items.MEXTLI_HARNESS,
+            xi.items.CUAUHTLI_HARNESS_P1,
         },
         minMatches = 2,
         mods =
@@ -489,11 +489,11 @@ local gearSets =
     {
         items =
         {
-            11810,
-            11826,
-            11852,
-            11856,
-            11860
+            xi.items.HYKSOS_KHAT,
+            xi.items.HYKSOS_KHAT_P1,
+            xi.items.HYKSOS_ROBE,
+            xi.items.ANHUR_ROBE,
+            xi.items.HYKSOS_ROBE_P1,
         },
         minMatches = 2,
         mods =
@@ -506,11 +506,11 @@ local gearSets =
     {
         items =
         {
-            10876,
-            10450,
-            10500,
-            11969,
-            10600
+            xi.items.OGIERS_HELM,
+            xi.items.OGIERS_SURCOAT,
+            xi.items.OGIERS_GAUNTLETS,
+            xi.items.OGIERS_BREECHES,
+            xi.items.OGIERS_LEGGINGS,
         },
         minMatches = 2,
         mods =
@@ -523,11 +523,11 @@ local gearSets =
     {
         items =
         {
-            10877,
-            10451,
-            10501,
-            11970,
-            10601
+            xi.items.ATHOSS_CHAPEAU,
+            xi.items.ATHOSS_TABARD,
+            xi.items.ATHOSS_GLOVES,
+            xi.items.ATHOSS_TIGHTS,
+            xi.items.ATHOSS_BOOTS,
         },
         minMatches = 2,
         mods =
@@ -540,11 +540,11 @@ local gearSets =
     {
         items =
         {
-            10878,
-            10452,
-            10502,
-            11971,
-            10602
+            xi.items.RUBEUS_BANDEAU,
+            xi.items.RUBEUS_JACKET,
+            xi.items.RUBEUS_GLOVES,
+            xi.items.RUBEUS_SPATS,
+            xi.items.RUBEUS_BOOTS,
         },
         minMatches = 2,
         maxMatches = 4, -- Special Case
@@ -558,11 +558,11 @@ local gearSets =
     {
         items =
         {
-            11080,
-            11100,
-            11120,
-            11140,
-            11160
+            xi.items.NAVARCHS_TRICORNE_P2,
+            xi.items.NAVARCHS_FRAC_P2,
+            xi.items.NAVARCHS_GANTS_P2,
+            xi.items.NAVARCHS_CULOTTES_P2,
+            xi.items.NAVARCHS_BOTTES_P2,
         },
         minMatches = 2,
         mods =
@@ -575,11 +575,11 @@ local gearSets =
     {
         items =
         {
-            11082,
-            11102,
-            11122,
-            11142,
-            11162
+            xi.items.CHARIS_TIARA_P2,
+            xi.items.CHARIS_CASAQUE_P2,
+            xi.items.CHARIS_BANGLES_P2,
+            xi.items.CHARIS_TIGHTS_P2,
+            xi.items.CHARIS_TOE_SHOES_P2,
         },
         minMatches = 2,
         mods =
@@ -592,11 +592,11 @@ local gearSets =
     {
         items =
         {
-            11076,
-            11096,
-            11116,
-            11136,
-            11156
+            xi.items.IGA_ZUKIN_P2,
+            xi.items.IGA_NINGI_P2,
+            xi.items.IGA_TEKKO_P2,
+            xi.items.IGA_HAKAMA_P2,
+            xi.items.IGA_KYAHAN_P2,
         },
         minMatches = 2,
         mods =
@@ -609,11 +609,11 @@ local gearSets =
     {
         items =
         {
-            11074,
-            11094,
-            11114,
-            11134,
-            11154
+            xi.items.SYLVAN_GAPETTE_P2,
+            xi.items.SYLVAN_CABAN_P2,
+            xi.items.SYLVAN_GLOVELETTES_P2,
+            xi.items.SYLVAN_BRAGUES_P2,
+            xi.items.SYLVAN_BOTTILLONS_P2,
         },
         minMatches = 2,
         mods =
@@ -626,11 +626,11 @@ local gearSets =
     {
         items =
         {
-            11070,
-            11090,
-            11110,
-            11130,
-            11150
+            xi.items.CREED_ARMET_P2,
+            xi.items.CREED_CUIRASS_P2,
+            xi.items.CREED_GAUNTLETS_P2,
+            xi.items.CREED_CUISSES_P2,
+            xi.items.CREED_SABATONS_P2,
         },
         minMatches = 2,
         mods =
@@ -643,11 +643,11 @@ local gearSets =
     {
         items =
         {
-            11075,
-            11095,
-            11115,
-            11135,
-            11155
+            xi.items.UNKAI_KABUTO_P2,
+            xi.items.UNKAI_DOMARU_P2,
+            xi.items.UNKAI_KOTE_P2,
+            xi.items.UNKAI_HAIDATE_P2,
+            xi.items.UNKAI_SUNE_ATE_P2,
         },
         minMatches = 2,
         mods =
@@ -660,11 +660,11 @@ local gearSets =
     {
         items =
         {
-            11065,
-            11085,
-            11105,
-            11125,
-            11145
+            xi.items.TANTRA_CROWN_P2,
+            xi.items.TANTRA_CYCLAS_P2,
+            xi.items.TANTRA_GLOVES_P2,
+            xi.items.TANTRA_HOSE_P2,
+            xi.items.TANTRA_GAITERS_P2,
         },
         minMatches = 2,
         mods =
@@ -677,11 +677,11 @@ local gearSets =
     {
         items =
         {
-            11069,
-            11089,
-            11109,
-            11129,
-            11149
+            xi.items.RAIDERS_BONNET_P2,
+            xi.items.RAIDERS_VEST_P2,
+            xi.items.RAIDERS_ARMLETS_P2,
+            xi.items.RAIDERS_CULOTTES_P2,
+            xi.items.RAIDERS_POULAINES_P2,
         },
         minMatches = 2,
         mods =
@@ -694,11 +694,11 @@ local gearSets =
     {
         items =
         {
-            11066,
-            11086,
-            11106,
-            11126,
-            11146
+            xi.items.ORISON_CAP_P2,
+            xi.items.ORISON_BLIAUD_P2,
+            xi.items.ORISON_MITTS_P2,
+            xi.items.ORISON_PANTALOONS_P2,
+            xi.items.ORISON_DUCKBILLS_P2,
         },
         minMatches = 2,
         mods =
@@ -711,11 +711,11 @@ local gearSets =
     {
         items =
         {
-            11083,
-            11103,
-            11123,
-            11143,
-            11163
+            xi.items.SAVANTS_BONNET_P2,
+            xi.items.SAVANTS_GOWN_P2,
+            xi.items.SAVANTS_BRACERS_P2,
+            xi.items.SAVANTS_PANTS_P2,
+            xi.items.SAVANTS_LOAFERS_P2,
         },
         minMatches = 2,
         mods =
@@ -728,15 +728,15 @@ local gearSets =
     {
         items =
         {
-            16005,
-            17756,
-            17962,
-            18596,
-            18760,
-            19112,
-            19215,
-            19271,
-            19156
+            xi.items.PARAMOUNT_EARRING,
+            xi.items.SINFENDER,
+            xi.items.FLEETWING,
+            xi.items.KEBBIE,
+            xi.items.USESHI,
+            xi.items.FARSEER,
+            xi.items.AMANOKAKOYUMI,
+            xi.items.OSORAKU,
+            xi.items.BALISARDE,
         },
         minMatches = 2,
         mods =
@@ -752,14 +752,14 @@ local gearSets =
     {
         items =
         {
-            18761,
-            18597,
-            17757,
-            19218,
-            18128,
-            18500,
-            16004,
-            18951
+            xi.items.SUPREMACY_EARRING,
+            xi.items.ACANTHA_SHAVERS,
+            xi.items.CATALYST,
+            xi.items.MERVEILLEUSE,
+            xi.items.MURDERER,
+            xi.items.SKYSTRIDER,
+            xi.items.SPARTH,
+            xi.items.VENDETTA,
         },
         minMatches = 2,
         mods =
@@ -775,15 +775,15 @@ local gearSets =
     {
         items =
         {
-            16006,
-            18450,
-            18499,
-            18861,
-            18862,
-            18952,
-            19111,
-            19217,
-            19272
+            xi.items.BRILLIANT_EARRING,
+            xi.items.MUKADEMARU,
+            xi.items.ALASTOR,
+            xi.items.GRANDEUR,
+            xi.items.CLEARPATH,
+            xi.items.FAUCHEUSE,
+            xi.items.SILKTONE,
+            xi.items.BASILISK,
+            xi.items.YAGENTOSHIRO,
         },
         minMatches = 2,
         mods =
@@ -798,8 +798,8 @@ local gearSets =
     {
         items =
         {
-            11798,
-            11362
+            xi.items.TWILIGHT_HELM,
+            xi.items.TWILIGHT_MAIL,
         },
         minMatches = 2,
         mods =
@@ -812,8 +812,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            17595
+            xi.items.VIRTUE_STONE,
+            xi.items.HOPE_STAFF,
         },
         minMatches = 2,
         mods =
@@ -826,8 +826,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            17710
+            xi.items.VIRTUE_STONE,
+            xi.items.JUSTICE_SWORD,
         },
         minMatches = 2,
         mods =
@@ -840,8 +840,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            17948
+            xi.items.VIRTUE_STONE,
+            xi.items.TEMPERANCE_AXE,
         },
         minMatches = 2,
         mods =
@@ -854,8 +854,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            18100
+            xi.items.VIRTUE_STONE,
+            xi.items.LOVE_HALBERD,
         },
         minMatches = 2,
         mods =
@@ -868,8 +868,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            18222
+            xi.items.VIRTUE_STONE,
+            xi.items.FORTITUDE_AXE,
         },
         minMatches = 2,
         mods =
@@ -882,8 +882,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            18360
+            xi.items.VIRTUE_STONE,
+            xi.items.FAITH_BAGHNAKHS,
         },
         minMatches = 2,
         mods =
@@ -896,8 +896,8 @@ local gearSets =
     {
         items =
         {
-            18244,
-            18397
+            xi.items.VIRTUE_STONE,
+            xi.items.PRUDENCE_ROD,
         },
         minMatches = 2,
         mods =
@@ -910,8 +910,8 @@ local gearSets =
     {
         items =
         {
-            28520,
-            28521
+            xi.items.STEELFLASH_EARRING,
+            xi.items.BLADEBORN_EARRING,
         },
         minMatches = 2,
         mods =
@@ -924,8 +924,8 @@ local gearSets =
     {
         items =
         {
-            28522,
-            28523
+            xi.items.DUDGEON_EARRING,
+            xi.items.HEARTSEEKER_EARRING,
         },
         minMatches = 2,
         mods =
@@ -938,8 +938,8 @@ local gearSets =
     {
         items =
         {
-            28524,
-            28525
+            xi.items.LIFESTORM_EARRING,
+            xi.items.PSYSTORM_EARRING,
         },
         minMatches = 2,
         mods =
@@ -952,16 +952,16 @@ local gearSets =
     {
         items =
         {
-            26920,
-            26921,
-            27434,
-            27259,
-            27260,
-            26762,
-            26763,
-            27074,
-            27075,
-            27433,
+            xi.items.KASUGA_DOMARU,
+            xi.items.KASUGA_DOMARU_P1,
+            xi.items.KASUGA_SUNE_ATE_P1,
+            xi.items.KASUGA_HAIDATE,
+            xi.items.KASUGA_HAIDATE_P1,
+            xi.items.KASUGA_KABUTO,
+            xi.items.KASUGA_KABUTO_P1,
+            xi.items.KASUGA_KOTE,
+            xi.items.KASUGA_KOTE_P1,
+            xi.items.KASUGA_SUNE_ATE,
         },
         minMatches = 2,
         mods =
@@ -974,16 +974,16 @@ local gearSets =
     {
         items =
         {
-            27414,
-            27413,
-            27240,
-            27239,
-            27055,
-            27054,
-            26901,
-            26900,
-            26743,
-            26742,
+            xi.items.BHIKKU_GAITERS_P1,
+            xi.items.BHIKKU_GAITERS,
+            xi.items.BHIKKU_HOSE_P1,
+            xi.items.BHIKKU_HOSE,
+            xi.items.BHIKKU_GLOVES_P1,
+            xi.items.BHIKKU_GLOVES,
+            xi.items.BHIKKU_CYCLAS_P1,
+            xi.items.BHIKKU_CYCLAS,
+            xi.items.BHIKKU_CROWN_P1,
+            xi.items.BHIKKU_CROWN,
         },
         minMatches = 2,
         mods =
@@ -996,16 +996,16 @@ local gearSets =
     {
         items =
         {
-            26740,
-            26741,
-            27411,
-            27412,
-            27238,
-            27237,
-            27053,
-            27054,
-            26899,
-            26900,
+            xi.items.BOII_MASK,
+            xi.items.BOII_MASK_P1,
+            xi.items.BOII_CALLIGAE,
+            xi.items.BOII_CALLIGAE_P1,
+            xi.items.BOII_CUISSES_P1,
+            xi.items.BOII_CUISSES,
+            xi.items.BOII_MUFFLERS_P1,
+            xi.items.BOII_MUFFLERS,
+            xi.items.BOII_LORICA_P1,
+            xi.items.BOII_LORICA,
         },
         minMatches = 2,
         mods =
@@ -1018,16 +1018,16 @@ local gearSets =
     {
         items =
         {
-            26750,
-            26751,
-            27421,
-            27422,
-            27247,
-            27248,
-            27063,
-            27062,
-            26908,
-            26909,
+            xi.items.SKULKERS_BONNET,
+            xi.items.SKULKERS_BONNET_P1,
+            xi.items.SKULKERS_POULAINES,
+            xi.items.SKULKERS_POULAINES_P1,
+            xi.items.SKULKERS_CULOTTES,
+            xi.items.SKULKERS_CULOTTES_P1,
+            xi.items.SKULKERS_ARMLETS_P1,
+            xi.items.SKULKERS_ARMLETS,
+            xi.items.SKULKERS_VEST,
+            xi.items.SKULKERS_VEST_P1,
         },
         minMatches = 2,
         mods =
@@ -1040,16 +1040,16 @@ local gearSets =
     {
         items =
         {
-            26918,
-            26919,
-            26761,
-            26762,
-            27431,
-            27432,
-            27257,
-            27258,
-            27072,
-            27073,
+            xi.items.AMINI_CABAN,
+            xi.items.AMINI_CABAN_P1,
+            xi.items.AMINI_GAPETTE_P1,
+            xi.items.AMINI_GAPETTE,
+            xi.items.AMINI_BOTTILLONS,
+            xi.items.AMINI_BOTTILLONS_P1,
+            xi.items.AMINI_BRAGUE,
+            xi.items.AMINI_BRAGUE_P1,
+            xi.items.AMINI_GLOVELETTES,
+            xi.items.AMINI_GLOVELETTES_P1,
         },
         minMatches = 2,
         mods =
@@ -1062,16 +1062,16 @@ local gearSets =
     {
         items =
         {
-            26910,
-            26911,
-            26752,
-            26753,
-            27424,
-            27423,
-            27064,
-            27065,
-            27249,
-            27250,
+            xi.items.CHEVALIERS_CUIRASS,
+            xi.items.CHEVALIERS_CUIRASS_P1,
+            xi.items.CHEVALIERS_ARMET,
+            xi.items.CHEVALIERS_ARMET_P1,
+            xi.items.CHEVALIERS_SABATONS_P1,
+            xi.items.CHEVALIERS_SABATONS,
+            xi.items.CHEVALIERS_GAUNTLETS,
+            xi.items.CHEVALIERS_GAUNTLETS_P1,
+            xi.items.CHEVALIERS_CUISSES,
+            xi.items.CHEVALIERS_CUISSES_P1,
         },
         minMatches = 2,
         mods =
@@ -1084,16 +1084,16 @@ local gearSets =
     {
         items =
         {
-            26922,
-            26923,
-            26764,
-            26765,
-            27076,
-            27077,
-            27261,
-            27262,
-            27435,
-            27436,
+            xi.items.HATTORI_NINGI,
+            xi.items.HATTORI_NINGI_P1,
+            xi.items.HATTORI_ZUKIN,
+            xi.items.HATTORI_ZUKIN_P1,
+            xi.items.HATTORI_TEKKO,
+            xi.items.HATTORI_TEKKO_P1,
+            xi.items.HATTORI_HAKAMA,
+            xi.items.HATTORI_HAKAMA_P1,
+            xi.items.HATTORI_KYAHAN,
+            xi.items.HATTORI_KYAHAN_P1,
         },
         minMatches = 2,
         mods =
@@ -1106,16 +1106,16 @@ local gearSets =
     {
         items =
         {
-            27443,
-            27444,
-            26772,
-            26773,
-            26930,
-            26931,
-            27084,
-            27085,
-            27269,
-            27270,
+            xi.items.CHASSEURS_BOTTES,
+            xi.items.CHASSEURS_BOTTES_P1,
+            xi.items.CHASSEURS_TRICORNE,
+            xi.items.CHASSEURS_TRICORNE_P1,
+            xi.items.CHASSEURS_FRAC,
+            xi.items.CHASSEURS_FRAC_P1,
+            xi.items.CHASSEURS_GANTS,
+            xi.items.CHASSEURS_GANTS_P1,
+            xi.items.CHASSEURS_CULOTTES,
+            xi.items.CHASSEURS_CULOTTES_P1,
         },
         minMatches = 2,
         mods =
@@ -1128,16 +1128,16 @@ local gearSets =
     {
         items =
         {
-            27275,
-            27276,
-            27449,
-            27450,
-            26778,
-            26779,
-            26936,
-            26937,
-            27090,
-            27091,
+            xi.items.ARBATEL_PANTS,
+            xi.items.ARBATEL_PANTS_P1,
+            xi.items.ARBATEL_LOAFERS,
+            xi.items.ARBATEL_LOAFERS_P1,
+            xi.items.ARBATEL_BONNET,
+            xi.items.ARBATEL_BONNET_P1,
+            xi.items.ARBATEL_GOWN,
+            xi.items.ARBATEL_GOWN_P1,
+            xi.items.ARBATEL_BRACERS,
+            xi.items.ARBATEL_BRACERS_P1,
         },
         minMatches = 2,
         mods =
@@ -1150,16 +1150,16 @@ local gearSets =
     {
         items =
         {
-            27241,
-            27242,
-            27415,
-            27416,
-            26744,
-            26745,
-            26902,
-            26903,
-            27056,
-            27057,
+            xi.items.EBERS_PANTALOONS,
+            xi.items.EBERS_PANTALOONS_P1,
+            xi.items.EBERS_DUCKBILLS,
+            xi.items.EBERS_DUCKBILLS_P1,
+            xi.items.EBERS_CAP,
+            xi.items.EBERS_CAP_P1,
+            xi.items.EBERS_BLIAUD,
+            xi.items.EBERS_BLIAUD_P1,
+            xi.items.EBERS_MITTS,
+            xi.items.EBERS_MITTS_P1,
         },
         minMatches = 2,
         mods =
@@ -1172,9 +1172,9 @@ local gearSets =
     {
         items =
         {
-            11867,
-            10868,
-            10865
+            xi.items.HEKAS_KALASIRIS,
+            xi.items.NEFER_KHAT_P1,
+            xi.items.NEFER_KHAT,
         },
         minMatches = 2,
         mods =
@@ -1187,10 +1187,10 @@ local gearSets =
     {
         items =
         {
-            10868,
-            11870,
-            11864,
-            10865
+            xi.items.NEFER_KHAT_P1,
+            xi.items.NEFER_KALASIRIS_P1,
+            xi.items.NEFER_KALASIRIS,
+            xi.items.NEFER_KHAT,
         },
         minMatches = 2,
         mods =
@@ -1203,8 +1203,8 @@ local gearSets =
     {
         items =
         {
-            15852,
-            15853
+            xi.items.NASATYAS_RING,
+            xi.items.DASRAS_RING,
         },
         minMatches = 2,
         mods =
@@ -1218,8 +1218,8 @@ local gearSets =
     {
         items =
         {
-            16037,
-            16038
+            xi.items.HELENUSS_EARRING,
+            xi.items.CASSANDRAS_EARRING,
         },
         minMatches = 2,
         mods =
@@ -1233,8 +1233,8 @@ local gearSets =
     {
         items =
         {
-            15850,
-            15851
+            xi.items.LAVAS_RING,
+            xi.items.KUSHAS_RING,
         },
         minMatches = 2,
         mods =
@@ -1249,11 +1249,11 @@ local gearSets =
     {
         items =
         {
-            16146,
-            14588,
-            15009,
-            16315,
-            15755
+            xi.items.IRON_RAM_SALLET,
+            xi.items.IRON_RAM_HAUBERK,
+            xi.items.IRON_RAM_DASTANAS,
+            xi.items.IRON_RAM_HOSE,
+            xi.items.IRON_RAM_GREAVES,
         },
         minMatches = 2,
         mods =
@@ -1273,8 +1273,8 @@ local gearSets =
     {
         items =
         {
-            16035,
-            16036
+            xi.items.ALTDORFS_EARRING,
+            xi.items.WILHELMS_EARRING,
         },
         minMatches = 2,
         mods =
@@ -1287,8 +1287,8 @@ local gearSets =
     {
         items =
         {
-            15042,
-            11402
+            xi.items.GOTHIC_GAUNTLETS,
+            xi.items.GOTHIC_SABATONS,
         },
         minMatches = 2,
         mods =
@@ -1302,11 +1302,11 @@ local gearSets =
     {
         items =
         {
-            26713,
-            27853,
-            27999,
-            28140,
-            28279
+            xi.items.TEAL_CHAPEAU_P1,
+            xi.items.TEAL_SAIO_P1,
+            xi.items.TEAL_CUFFS_P1,
+            xi.items.TEAL_SLOPS_P1,
+            xi.items.TEAL_PIGACHES_P1,
         },
         minMatches = 2,
         mods =
@@ -1315,15 +1315,15 @@ local gearSets =
         },
     },
 
-    [76] = -- Aurore Set +1: Sore TP +2-8%
+    [76] = -- Aurore Set +1: Store TP +2-8
     {
         items =
         {
-            26712,
-            27852,
-            27998,
-            28139,
-            28278
+            xi.items.AURORE_BERET_P1,
+            xi.items.AURORE_DOUBLET_P1,
+            xi.items.AURORE_GLOVES_P1,
+            xi.items.AURORE_BRAIS_P1,
+            xi.items.AURORE_GAITERS_P1,
         },
         minMatches = 2,
         mods =
@@ -1336,11 +1336,11 @@ local gearSets =
     {
         items =
         {
-            26711,
-            27851,
-            27997,
-            28138,
-            28277
+            xi.items.PERLE_SALADE_P1,
+            xi.items.PERLE_HAUBERK_P1,
+            xi.items.PERLE_MOUFLES_P1,
+            xi.items.PERLE_BRAYETTES_P1,
+            xi.items.PERLE_SOLLERETS_P1,
         },
         minMatches = 2,
         mods =
@@ -1353,11 +1353,11 @@ local gearSets =
     {
         items =
         {
-            27652,
-            27792,
-            27932,
-            28075,
-            28212
+            xi.items.MORRIGANS_CORONAL_P1,
+            xi.items.MORRIGANS_ROBE_P1,
+            xi.items.MORRIGANS_CUFFS_P1,
+            xi.items.MORRIGANS_SLOPS_P1,
+            xi.items.MORRIGANS_PIGACHES_P1,
         },
         minMatches = 2,
         mods =
@@ -1370,11 +1370,11 @@ local gearSets =
     {
         items =
         {
-            27651,
-            27791,
-            27931,
-            28074,
-            28211
+            xi.items.MARDUKS_TIARA_P1,
+            xi.items.MARDUKS_JUBBAH_P1,
+            xi.items.MARDUKS_DASTANAS_P1,
+            xi.items.MARDUKS_SHALWAR_P1,
+            xi.items.MARDUKS_CRACKOWS_P1,
         },
         minMatches = 2,
         mods =
@@ -1387,11 +1387,11 @@ local gearSets =
     {
         items =
         {
-            27650,
-            27790,
-            27930,
-            28073,
-            28210
+            xi.items.USUKANE_SOMEN_P1,
+            xi.items.USUKANE_HARAMAKI_P1,
+            xi.items.USUKANE_GOTE_P1,
+            xi.items.USUKANE_HIZAYOROI_P1,
+            xi.items.USUKANE_SUNE_ATE_P1,
         },
         minMatches = 2,
         mods =
@@ -1404,11 +1404,11 @@ local gearSets =
     {
         items =
         {
-            27649,
-            27789,
-            27929,
-            28072,
-            28209
+            xi.items.SKADIS_VISOR_P1,
+            xi.items.SKADIS_CUIRIE_P1,
+            xi.items.SKADIS_BAZUBANDS_P1,
+            xi.items.SKADIS_CHAUSSES_P1,
+            xi.items.SKADIS_JAMBEAUX_P1,
         },
         minMatches = 2,
         mods =
@@ -1421,11 +1421,11 @@ local gearSets =
     {
         items =
         {
-            27648,
-            27788,
-            27928,
-            28071,
-            28208
+            xi.items.ARES_MASK_P1,
+            xi.items.ARES_CUIRASS_P1,
+            xi.items.ARES_GAUNTLETS_P1,
+            xi.items.ARES_FLANCHARD_P1,
+            xi.items.ARES_SOLLERETS_P1,
         },
         minMatches = 2,
         mods =
@@ -1438,8 +1438,8 @@ local gearSets =
     {
         items =
         {
-            10315,
-            10598
+            xi.items.ALCEDO_GAUNTLETS,
+            xi.items.ALCEDO_CUISSES,
         },
         minMatches = 2,
         mods =
@@ -1452,12 +1452,12 @@ local gearSets =
     {
         items =
         {
-            26204,
-            25574,
-            25790,
-            25828,
-            25879,
-            25946
+            xi.items.SULEVIAS_RING,
+            xi.items.SULEVIAS_MASK_P2,
+            xi.items.SULEVIAS_PLATEMAIL_P2,
+            xi.items.SULEVIAS_GAUNTLETS_P2,
+            xi.items.SULEVIAS_CUISSES_P2,
+            xi.items.SULEVIAS_LEGGINGS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1471,12 +1471,12 @@ local gearSets =
     {
         items =
         {
-            26206,
-            25576,
-            25792,
-            25830,
-            25881,
-            25948
+            xi.items.HIZAMARU_RING,
+            xi.items.HIZAMARU_SOMEN_P2,
+            xi.items.HIZAMARU_HARAMAKI_P2,
+            xi.items.HIZAMARU_KOTE_P2,
+            xi.items.HIZAMARU_HIZAYOROI_P2,
+            xi.items.HIZAMARU_SUNE_ATE_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1490,12 +1490,12 @@ local gearSets =
     {
         items =
         {
-            26207,
-            25577,
-            25793,
-            25831,
-            25882,
-            25949
+            xi.items.INYANGA_RING,
+            xi.items.INYANGA_TIARA_P2,
+            xi.items.INYANGA_JUBBAH_P2,
+            xi.items.INYANGA_DASTANAS_P2,
+            xi.items.INYANGA_SHALWAR_P2,
+            xi.items.INYANGA_CRACKOWS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1509,12 +1509,12 @@ local gearSets =
     {
         items =
         {
-            26205,
-            25575,
-            25791,
-            25829,
-            25880,
-            25947
+            xi.items.MEGHANADA_RING,
+            xi.items.MEGHANADA_VISOR_P2,
+            xi.items.MEGHANADA_CUIRIE_P2,
+            xi.items.MEGHANADA_GLOVES_P2,
+            xi.items.MEGHANADA_CHAUSSES_P2,
+            xi.items.MEGHANADA_JAMBEAUX_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1528,12 +1528,12 @@ local gearSets =
     {
         items =
         {
-            26208,
-            25578,
-            25794,
-            25832,
-            25883,
-            25950
+            xi.items.JHAKRI_RING,
+            xi.items.JHAKRI_CORONAL_P2,
+            xi.items.JHAKRI_ROBE_P2,
+            xi.items.JHAKRI_CUFFS_P2,
+            xi.items.JHAKRI_SLOPS_P2,
+            xi.items.JHAKRI_PIGACHES_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1547,12 +1547,12 @@ local gearSets =
     {
         items =
         {
-            26211,
-            25569,
-            25797,
-            25385,
-            25886,
-            25953
+            xi.items.FLAMMA_RING,
+            xi.items.FLAMMA_ZUCCHETTO_P2,
+            xi.items.FLAMMA_KORAZIN_P2,
+            xi.items.FLAMMA_MANOPOLAS_P2,
+            xi.items.FLAMMA_DIRS_P2,
+            xi.items.FLAMMA_GAMBIERAS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1568,12 +1568,12 @@ local gearSets =
     {
         items =
         {
-            26210,
-            25573,
-            25796,
-            25834,
-            25885,
-            25952
+            xi.items.TALIAH_RING,
+            xi.items.TALIAH_TURBAN_P2,
+            xi.items.TALIAH_MANTEEL_P2,
+            xi.items.TALIAH_GAGES_P2,
+            xi.items.TALIAH_SERAWEELS_P2,
+            xi.items.TALIAH_CRACKOWS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1589,12 +1589,12 @@ local gearSets =
     {
         items =
         {
-            26212,
-            25570,
-            25798,
-            25836,
-            25887,
-            25954
+            xi.items.MUMMU_RING,
+            xi.items.MUMMU_BONNET_P2,
+            xi.items.MUMMU_JACKET_P2,
+            xi.items.MUMMU_WRISTS_P2,
+            xi.items.MUMMU_KECKS_P2,
+            xi.items.MUMMU_GAMASHES_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1610,12 +1610,12 @@ local gearSets =
     {
         items =
         {
-            26209,
-            25572,
-            25795,
-            25833,
-            25884,
-            25951
+            xi.items.AYANMO_RING,
+            xi.items.AYANMO_ZUCCHETTO_P2,
+            xi.items.AYANMO_CORAZZA_P2,
+            xi.items.AYANMO_MANOPOLAS_P2,
+            xi.items.AYANMO_COSCIALES_P2,
+            xi.items.AYANMO_GAMBIERAS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1631,12 +1631,12 @@ local gearSets =
     {
         items =
         {
-            26213,
-            25571,
-            25799,
-            25837,
-            25888,
-            25955
+            xi.items.MALLQUIS_RING,
+            xi.items.MALLQUIS_CHAPEAU_P2,
+            xi.items.MALLQUIS_SAIO_P2,
+            xi.items.MALLQUIS_CUFFS_P2,
+            xi.items.MALLQUIS_TREWS_P2,
+            xi.items.MALLQUIS_CLOGS_P2,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1652,17 +1652,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23308,
-            23643,
-            23241,
-            23576,
-            23174,
-            23509,
-            23107,
-            23442,
-            23040,
-            23375
+            xi.items.REGAL_RING,
+            xi.items.PUMMELERS_CALLIGAE_P2,
+            xi.items.PUMMELERS_CALLIGAE_P3,
+            xi.items.PUMMELERS_CUISSES_P2,
+            xi.items.PUMMELERS_CUISSES_P3,
+            xi.items.PUMMELERS_MUFFLERS_P2,
+            xi.items.PUMMELERS_MUFFLERS_P3,
+            xi.items.PUMMELERS_LORICA_P2,
+            xi.items.PUMMELERS_LORICA_P3,
+            xi.items.PUMMELERS_MASK_P2,
+            xi.items.PUMMELERS_MASK_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1678,17 +1678,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23309,
-            23644,
-            23242,
-            23577,
-            23175,
-            23510,
-            23108,
-            23443,
-            23041,
-            23376
+            xi.items.REGAL_RING,
+            xi.items.ANCHORITES_GAITERS_P2,
+            xi.items.ANCHORITES_GAITERS_P3,
+            xi.items.ANCHORITES_HOSE_P2,
+            xi.items.ANCHORITES_HOSE_P3,
+            xi.items.ANCHORITES_GLOVES_P2,
+            xi.items.ANCHORITES_GLOVES_P3,
+            xi.items.ANCHORITES_CYCLAS_P2,
+            xi.items.ANCHORITES_CYCLAS_P3,
+            xi.items.ANCHORITES_CROWN_P2,
+            xi.items.ANCHORITES_CROWN_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1704,17 +1704,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23310,
-            23645,
-            23243,
-            23578,
-            23176,
-            23511,
-            23109,
-            23444,
-            23042,
-            23377
+            xi.items.REGAL_EARRING,
+            xi.items.THEOPHANY_DUCKBILLS_P2,
+            xi.items.THEOPHANY_DUCKBILLS_P3,
+            xi.items.THEOPHANY_PANTALOONS_P2,
+            xi.items.THEOPHANY_PANTALOONS_P3,
+            xi.items.THEOPHANY_MITTS_P2,
+            xi.items.THEOPHANY_MITTS_P3,
+            xi.items.THEOPHANY_BRIAULT_P2,
+            xi.items.THEOPHANY_BRIAULT_P3,
+            xi.items.THEOPHANY_CAP_P2,
+            xi.items.THEOPHANY_CAP_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1730,17 +1730,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23311,
-            23646,
-            23244,
-            23579,
-            23177,
-            23512,
-            23110,
-            23445,
-            23043,
-            23378
+            xi.items.REGAL_EARRING,
+            xi.items.SPAEKONAS_SABOTS_P2,
+            xi.items.SPAEKONAS_SABOTS_P3,
+            xi.items.SPAEKONAS_TONBAN_P2,
+            xi.items.SPAEKONAS_TONBAN_P3,
+            xi.items.SPAEKONAS_GLOVES_P2,
+            xi.items.SPAEKONAS_GLOVES_P3,
+            xi.items.SPAEKONAS_COAT_P2,
+            xi.items.SPAEKONAS_COAT_P3,
+            xi.items.SPAEKONAS_PETASOS_P2,
+            xi.items.SPAEKONAS_PETASOS_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1756,17 +1756,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23312,
-            23647,
-            23245,
-            23580,
-            23178,
-            23513,
-            23111,
-            23446,
-            23044,
-            23379
+            xi.items.REGAL_EARRING,
+            xi.items.ATROPHY_BOOTS_P2,
+            xi.items.ATROPHY_BOOTS_P3,
+            xi.items.ATROPHY_TIGHTS_P2,
+            xi.items.ATROPHY_TIGHTS_P3,
+            xi.items.ATROPHY_GLOVES_P2,
+            xi.items.ATROPHY_GLOVES_P3,
+            xi.items.ATROPHY_TABARD_P2,
+            xi.items.ATROPHY_TABARD_P3,
+            xi.items.ATROPHY_CHAPEAU_P2,
+            xi.items.ATROPHY_CHAPEAU_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1782,17 +1782,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23313,
-            23648,
-            23246,
-            23581,
-            23179,
-            23514,
-            23112,
-            23447,
-            23045,
-            23380
+            xi.items.REGAL_RING,
+            xi.items.PILLAGERS_POULAINES_P2,
+            xi.items.PILLAGERS_POULAINES_P3,
+            xi.items.PILLAGERS_CULOTTES_P2,
+            xi.items.PILLAGERS_CULOTTES_P3,
+            xi.items.PILLAGERS_ARMLETS_P2,
+            xi.items.PILLAGERS_ARMLETS_P3,
+            xi.items.PILLAGERS_VEST_P2,
+            xi.items.PILLAGERS_VEST_P3,
+            xi.items.PILLAGERS_BONNET_P2,
+            xi.items.PILLAGERS_BONNET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1808,17 +1808,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23314,
-            23649,
-            23247,
-            23582,
-            23180,
-            23515,
-            23113,
-            23448,
-            23046,
-            23381
+            xi.items.REGAL_RING,
+            xi.items.REVERENCE_LEGGINGS_P2,
+            xi.items.REVERENCE_LEGGINGS_P3,
+            xi.items.REVERENCE_BREECHES_P2,
+            xi.items.REVERENCE_BREECHES_P3,
+            xi.items.REVERENCE_GAUNTLETS_P2,
+            xi.items.REVERENCE_GAUNTLETS_P3,
+            xi.items.REVERENCE_SURCOAT_P2,
+            xi.items.REVERENCE_SURCOAT_P3,
+            xi.items.REVERENCE_CORONET_P2,
+            xi.items.REVERENCE_CORONET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1834,17 +1834,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23315,
-            23650,
-            23248,
-            23583,
-            23181,
-            23516,
-            23114,
-            23449,
-            23047,
-            23382
+            xi.items.REGAL_RING,
+            xi.items.IGNOMINY_SOLLERETS_P2,
+            xi.items.IGNOMINY_SOLLERETS_P3,
+            xi.items.IGNOMINY_FLANCHARD_P2,
+            xi.items.IGNOMINY_FLANCHARD_P3,
+            xi.items.IGNOMINY_GAUNTLETS_P2,
+            xi.items.IGNOMINY_GAUNTLETS_P3,
+            xi.items.IGNOMINY_CUIRASS_P2,
+            xi.items.IGNOMINY_CUIRASS_P3,
+            xi.items.IGNOMINY_BURGONET_P2,
+            xi.items.IGNOMINY_BURGONET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1860,17 +1860,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23316,
-            23651,
-            23249,
-            23584,
-            23182,
-            23517,
-            23115,
-            23450,
-            23048,
-            23383
+            xi.items.REGAL_RING,
+            xi.items.TOTEMIC_GAITERS_P2,
+            xi.items.TOTEMIC_GAITERS_P3,
+            xi.items.TOTEMIC_TROUSERS_P2,
+            xi.items.TOTEMIC_TROUSERS_P3,
+            xi.items.TOTEMIC_GLOVES_P2,
+            xi.items.TOTEMIC_GLOVES_P3,
+            xi.items.TOTEMIC_JACKCOAT_P2,
+            xi.items.TOTEMIC_JACKCOAT_P3,
+            xi.items.TOTEMIC_HELM_P2,
+            xi.items.TOTEMIC_HELM_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1886,17 +1886,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23317,
-            23652,
-            23250,
-            23585,
-            23183,
-            23518,
-            23116,
-            23451,
-            23049,
-            23384
+            xi.items.REGAL_EARRING,
+            xi.items.BRIOSO_SLIPPERS_P2,
+            xi.items.BRIOSO_SLIPPERS_P3,
+            xi.items.BRIOSO_CANNIONS_P2,
+            xi.items.BRIOSO_CANNIONS_P3,
+            xi.items.BRIOSO_CUFFS_P2,
+            xi.items.BRIOSO_CUFFS_P3,
+            xi.items.BRIOSO_JUSTAUCORPS_P2,
+            xi.items.BRIOSO_JUSTAUCORPS_P3,
+            xi.items.BRIOSO_ROUNDLET_P2,
+            xi.items.BRIOSO_ROUNDLET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1912,17 +1912,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23318,
-            23653,
-            23251,
-            23586,
-            23184,
-            23519,
-            23117,
-            23452,
-            23050,
-            23385
+            xi.items.REGAL_RING,
+            xi.items.ORION_SOCKS_P2,
+            xi.items.ORION_SOCKS_P3,
+            xi.items.ORION_BRACCAE_P2,
+            xi.items.ORION_BRACCAE_P3,
+            xi.items.ORION_BRACERS_P2,
+            xi.items.ORION_BRACERS_P3,
+            xi.items.ORION_JERKIN_P2,
+            xi.items.ORION_JERKIN_P3,
+            xi.items.ORION_BERET_P2,
+            xi.items.ORION_BERET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1938,17 +1938,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23319,
-            23654,
-            23252,
-            23587,
-            23185,
-            23520,
-            23118,
-            23453,
-            23051,
-            23386
+            xi.items.REGAL_RING,
+            xi.items.WAKIDO_SUNE_ATE_P2,
+            xi.items.WAKIDO_SUNE_ATE_P3,
+            xi.items.WAKIDO_HAIDATE_P2,
+            xi.items.WAKIDO_HAIDATE_P3,
+            xi.items.WAKIDO_KOTE_P2,
+            xi.items.WAKIDO_KOTE_P3,
+            xi.items.WAKIDO_DOMARU_P2,
+            xi.items.WAKIDO_DOMARU_P3,
+            xi.items.WAKIDO_KABUTO_P2,
+            xi.items.WAKIDO_KABUTO_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1964,17 +1964,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23320,
-            23655,
-            23253,
-            23588,
-            23186,
-            23521,
-            23119,
-            23454,
-            23052,
-            23387
+            xi.items.REGAL_RING,
+            xi.items.HACHIYA_KYAHAN_P2,
+            xi.items.HACHIYA_KYAHAN_P3,
+            xi.items.HACHIYA_HAKAMA_P2,
+            xi.items.HACHIYA_HAKAMA_P3,
+            xi.items.HACHIYA_TEKKO_P2,
+            xi.items.HACHIYA_TEKKO_P3,
+            xi.items.HACHIYA_CHAINMAIL_P2,
+            xi.items.HACHIYA_CHAINMAIL_P3,
+            xi.items.HACHIYA_HATSUBURI_P2,
+            xi.items.HACHIYA_HATSUBURI_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -1990,17 +1990,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23321,
-            23656,
-            23254,
-            23589,
-            23187,
-            23522,
-            23120,
-            23455,
-            23053,
-            23388
+            xi.items.REGAL_RING,
+            xi.items.VISHAP_GREAVES_P2,
+            xi.items.VISHAP_GREAVES_P3,
+            xi.items.VISHAP_BRAIS_P2,
+            xi.items.VISHAP_BRAIS_P3,
+            xi.items.VISHAP_FINGER_GAUNTLETS_P2,
+            xi.items.VISHAP_FINGER_GAUNTLETS_P3,
+            xi.items.VISHAP_MAIL_P2,
+            xi.items.VISHAP_MAIL_P3,
+            xi.items.VISHAP_ARMET_P2,
+            xi.items.VISHAP_ARMET_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2016,17 +2016,17 @@ local gearSets =
     {
         items =
         {
-            26342,
-            23322,
-            23657,
-            23255,
-            23590,
-            23188,
-            23523,
-            23121,
-            23456,
-            23054,
-            23389
+            xi.items.REGAL_BELT,
+            xi.items.CONVOKERS_PIGACHES_P2,
+            xi.items.CONVOKERS_PIGACHES_P3,
+            xi.items.CONVOKERS_SPATS_P2,
+            xi.items.CONVOKERS_SPATS_P3,
+            xi.items.CONVOKERS_BRACERS_P2,
+            xi.items.CONVOKERS_BRACERS_P3,
+            xi.items.CONVOKERS_DOUBLET_P2,
+            xi.items.CONVOKERS_DOUBLET_P3,
+            xi.items.CONVOKERS_HORN_P2,
+            xi.items.CONVOKERS_HORN_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2042,17 +2042,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23323,
-            23658,
-            23256,
-            23591,
-            23189,
-            23524,
-            23122,
-            23457,
-            23055,
-            23390
+            xi.items.REGAL_EARRING,
+            xi.items.ASSIMILATORS_CHARUQS_P2,
+            xi.items.ASSIMILATORS_CHARUQS_P3,
+            xi.items.ASSIMILATORS_SHALWAR_P2,
+            xi.items.ASSIMILATORS_SHALWAR_P3,
+            xi.items.ASSIMILATORS_BAZUBANDS_P2,
+            xi.items.ASSIMILATORS_BAZUBANDS_P3,
+            xi.items.ASSIMILATORS_JUBBAH_P2,
+            xi.items.ASSIMILATORS_JUBBAH_P3,
+            xi.items.ASSIMILATORS_KEFFIYEH_P2,
+            xi.items.ASSIMILATORS_KEFFIYEH_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2068,17 +2068,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23324,
-            23659,
-            23257,
-            23592,
-            23190,
-            23525,
-            23123,
-            23458,
-            23056,
-            23391
+            xi.items.REGAL_RING,
+            xi.items.LAKSAMANAS_BOTTES_P2,
+            xi.items.LAKSAMANAS_BOTTES_P3,
+            xi.items.LAKSAMANAS_TREWS_P2,
+            xi.items.LAKSAMANAS_TREWS_P3,
+            xi.items.LASKAMANAS_GANTS_P2,
+            xi.items.LASKAMANAS_GANTS_P3,
+            xi.items.LAKSAMANAS_FRAC_P2,
+            xi.items.LAKSAMANAS_FRAC_P3,
+            xi.items.LAKSAMANAS_TRICORNE_P2,
+            xi.items.LAKSAMANAS_TRICORNE_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2094,17 +2094,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23325,
-            23660,
-            23258,
-            23593,
-            23191,
-            23526,
-            23124,
-            23459,
-            23057,
-            23392
+            xi.items.REGAL_RING,
+            xi.items.FOIRE_BABOUCHES_P2,
+            xi.items.FOIRE_BABOUCHES_P3,
+            xi.items.FOIRE_CHURIDARS_P2,
+            xi.items.FOIRE_CHURIDARS_P3,
+            xi.items.FOIRE_DASTANAS_P2,
+            xi.items.FOIRE_DASTANAS_P3,
+            xi.items.FOIRE_TOBE_P2,
+            xi.items.FOIRE_TOBE_P3,
+            xi.items.FOIRE_TAJ_P2,
+            xi.items.FOIRE_TAJ_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2120,17 +2120,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23326,
-            23661,
-            23259,
-            23594,
-            23192,
-            23527,
-            23125,
-            23460,
-            23058,
-            23393
+            xi.items.REGAL_RING,
+            xi.items.MAXIXI_TIARA_M_P2,
+            xi.items.MAXIXI_CASAQUE_M_P2,
+            xi.items.MAXIXI_BANGLES_M_P2,
+            xi.items.MAXIXI_TIGHTS_M_P2,
+            xi.items.MAXIXI_TOE_SHOES_M_P2,
+            xi.items.MAXIXI_TIARA_M_P3,
+            xi.items.MAXIXI_CASAQUE_M_P3,
+            xi.items.MAXIXI_BANGLES_M_P3,
+            xi.items.MAXIXI_TIGHTS_M_P3,
+            xi.items.MAXIXI_TOE_SHOES_M_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2146,17 +2146,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23327,
-            23662,
-            23260,
-            23595,
-            23193,
-            23528,
-            23126,
-            23461,
-            23059,
-            23394
+            xi.items.REGAL_RING,
+            xi.items.MAXIXI_TIARA_F_P2,
+            xi.items.MAXIXI_CASAQUE_F_P2,
+            xi.items.MAXIXI_BANGLES_F_P2,
+            xi.items.MAXIXI_TIGHTS_F_P2,
+            xi.items.MAXIXI_TOE_SHOES_F_P2,
+            xi.items.MAXIXI_TIARA_F_P3,
+            xi.items.MAXIXI_CASAQUE_F_P3,
+            xi.items.MAXIXI_BANGLES_F_P3,
+            xi.items.MAXIXI_TIGHTS_F_P3,
+            xi.items.MAXIXI_TOE_SHOES_F_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2172,17 +2172,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23328,
-            23663,
-            23261,
-            23596,
-            23194,
-            23529,
-            23127,
-            23462,
-            23060,
-            23395
+            xi.items.REGAL_EARRING,
+            xi.items.ACADEMICS_LOAFERS_P2,
+            xi.items.ACADEMICS_LOAFERS_P3,
+            xi.items.ACADEMICS_PANTS_P2,
+            xi.items.ACADEMICS_PANTS_P3,
+            xi.items.ACADEMICS_BRACERS_P2,
+            xi.items.ACADEMICS_BRACERS_P3,
+            xi.items.ACADEMICS_GOWN_P2,
+            xi.items.ACADEMICS_GOWN_P3,
+            xi.items.ACADEMICS_MORTARBOARD_P2,
+            xi.items.ACADEMICS_MORTARBOARD_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2198,17 +2198,17 @@ local gearSets =
     {
         items =
         {
-            26085,
-            23329,
-            23664,
-            23262,
-            23597,
-            23195,
-            23530,
-            23128,
-            23463,
-            23061,
-            23396
+            xi.items.REGAL_EARRING,
+            xi.items.GEOMANCY_SANDALS_P2,
+            xi.items.GEOMANCY_SANDALS_P3,
+            xi.items.GEOMANCY_PANTS_P2,
+            xi.items.GEOMANCY_PANTS_P3,
+            xi.items.GEOMANCY_MITAINES_P2,
+            xi.items.GEOMANCY_MITAINES_P3,
+            xi.items.GEOMANCY_TUNIC_P2,
+            xi.items.GEOMANCY_TUNIC_P3,
+            xi.items.GEOMANCY_GALERO_P2,
+            xi.items.GEOMANCY_GALERO_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2224,17 +2224,17 @@ local gearSets =
     {
         items =
         {
-            26191,
-            23330,
-            23665,
-            23263,
-            23598,
-            23196,
-            23531,
-            23129,
-            23464,
-            23062,
-            23397
+            xi.items.REGAL_RING,
+            xi.items.RUNEISTS_BOOTS_P2,
+            xi.items.RUNEISTS_BOOTS_P3,
+            xi.items.RUNIESTS_TROUSERS_P2,
+            xi.items.RUNEISTS_TROUSERS_P3,
+            xi.items.RUNEISTS_MITONS_P2,
+            xi.items.RUNEISTS_MITONS_P3,
+            xi.items.RUNEISTS_COAT_P2,
+            xi.items.RUNEISTS_COAT_P3,
+            xi.items.RUNEISTS_BANDEAU_P2,
+            xi.items.RUNEISTS_BANDEAU_P3,
         },
         minMatches = 2,
         maxMatches = 5,
@@ -2250,11 +2250,11 @@ local gearSets =
     {
         items =
         {
-            27740,
-            27881,
-            28029,
-            28168,
-            28306
+            xi.items.OUTRIDER_MASK,
+            xi.items.OUTRIDER_MAIL,
+            xi.items.OUTRIDER_MITTENS,
+            xi.items.OUTRIDER_HOSE,
+            xi.items.OUTRIDER_GREAVES,
         },
         minMatches = 5,
         mods =
@@ -2267,11 +2267,11 @@ local gearSets =
     {
         items =
         {
-            27741,
-            27882,
-            28030,
-            28169,
-            28307
+            xi.items.ESPIAL_CAP,
+            xi.items.ESPIAL_GAMBISON,
+            xi.items.ESPIAL_BRACERS,
+            xi.items.ESPIAL_HOSE,
+            xi.items.ESPIAL_SOCKS,
         },
         minMatches = 5,
         mods =
@@ -2284,11 +2284,11 @@ local gearSets =
     {
         items =
         {
-            27742,
-            27883,
-            28031,
-            28170,
-            28308
+            xi.items.WAYFARER_CIRCLET,
+            xi.items.WAYFARER_ROBE,
+            xi.items.WAYFARER_CUFFS,
+            xi.items.WAYFARER_SLOPS,
+            xi.items.WAYFARER_CLOGS,
         },
         minMatches = 5,
         mods =
@@ -2301,11 +2301,11 @@ local gearSets =
     {
         items =
         {
-            26677,
-            26853,
-            27029,
-            27205,
-            27381
+            xi.items.APOGEE_CROWN_P1,
+            xi.items.APOGEE_DALMATICA_P1,
+            xi.items.APOGEE_MITTS_P1,
+            xi.items.APOGEE_SLACKS_P1,
+            xi.items.APOGEE_PUMPS_P1,
         },
         minMatches = 2,
         mods =
@@ -2318,11 +2318,11 @@ local gearSets =
     {
         items =
         {
-            25612,
-            25685,
-            27116,
-            27301,
-            27472
+            xi.items.RYUO_SOMEN_P1,
+            xi.items.RYUO_DOMARU_P1,
+            xi.items.RYUO_TEKKO_P1,
+            xi.items.RYUO_HAKAMA_P1,
+            xi.items.RYUO_SUNE_ATE_P1,
         },
         minMatches = 2,
         mods =
@@ -2335,11 +2335,11 @@ local gearSets =
     {
         items =
         {
-            26671,
-            26847,
-            27023,
-            27199,
-            27375
+            xi.items.SOUVERAN_SCHALLER_P1,
+            xi.items.SOUVERAN_CUIRASS_P1,
+            xi.items.SOUVERAN_HANDSCHUHS_P1,
+            xi.items.SOUVERAN_DIECHLINGS_P1,
+            xi.items.SOUVERAN_SCHUHS_P1,
         },
         minMatches = 2,
         mods =
@@ -2352,11 +2352,11 @@ local gearSets =
     {
         items =
         {
-            25610,
-            25683,
-            27114,
-            27299,
-            27470
+            xi.items.EMICHO_CORONET_P1,
+            xi.items.EMICHO_HAUBERT_P1,
+            xi.items.EMICHO_GAUNTLETS_P1,
+            xi.items.EMICHO_HOSE_P1,
+            xi.items.EMICHO_GAMBIERAS_P1,
         },
         minMatches = 2,
         mods =
@@ -2369,11 +2369,11 @@ local gearSets =
     {
         items =
         {
-            25618,
-            25691,
-            27122,
-            27307,
-            27478
+            xi.items.KAYKAUS_MITRA_P1,
+            xi.items.KAYKAUS_BLIAUT_P1,
+            xi.items.KAYKAUS_CUFFS_P1,
+            xi.items.KAYKAUS_TIGHTS_P1,
+            xi.items.KAYKAUS_BOOTS_P1,
         },
         minMatches = 2,
         mods =
@@ -2386,11 +2386,11 @@ local gearSets =
     {
         items =
         {
-            26675,
-            26851,
-            27027,
-            27203,
-            27379
+            xi.items.RAO_KABUTO_P1,
+            xi.items.RAO_TOGI_P1,
+            xi.items.RAO_KOTE_P1,
+            xi.items.RAO_HAIDATE_P1,
+            xi.items.RAO_SUNE_ATE_P1,
         },
         minMatches = 2,
         mods =
@@ -2403,11 +2403,11 @@ local gearSets =
     {
         items =
         {
-            25614,
-            25687,
-            27118,
-            27303,
-            27474
+            xi.items.ADHEMAR_BONNET_P1,
+            xi.items.ADHEMAR_JACKET_P1,
+            xi.items.ADHEMAR_WRISTBANDS_P1,
+            xi.items.ADHEMAR_KECKS_P1,
+            xi.items.ADHEMAR_GAMASHES_P1,
         },
         minMatches = 2,
         mods =
@@ -2420,11 +2420,11 @@ local gearSets =
     {
         items =
         {
-            26679,
-            26855,
-            27031,
-            27207,
-            27383
+            xi.items.CARMINE_MASK_P1,
+            xi.items.CARMINE_SCALE_MAIL_P1,
+            xi.items.CARMINE_FINGER_GAUNTLETS_P1,
+            xi.items.CARMINE_CUISSES_P1,
+            xi.items.CARMINE_GREAVES_P1,
         },
         minMatches = 2,
         mods =
@@ -2437,11 +2437,11 @@ local gearSets =
     {
         items =
         {
-            26669,
-            26845,
-            27021,
-            27197,
-            27373
+            xi.items.LUSTRATIO_CAP_P1,
+            xi.items.LUSTRATIO_HARNESS_P1,
+            xi.items.LUSTRATIO_MITTENS_P1,
+            xi.items.LUSTRATIO_SUBLIGAR_P1,
+            xi.items.LUSTRATIO_LEGGINGS_P1,
         },
         minMatches = 2,
         mods =
@@ -2454,11 +2454,11 @@ local gearSets =
     {
         items =
         {
-            26673,
-            26849,
-            27025,
-            27201,
-            27377
+            xi.items.ARGOSY_CELATA_P1,
+            xi.items.ARGOSY_HAUBERK_P1,
+            xi.items.ARGOSY_MUFFLERS_P1,
+            xi.items.ARGOSY_BREECHES_P1,
+            xi.items.ARGOSY_SOLLERETS_P1,
         },
         minMatches = 2,
         mods =
@@ -2471,11 +2471,11 @@ local gearSets =
     {
         items =
         {
-            25616,
-            25689,
-            27120,
-            27305,
-            27476
+            xi.items.AMALRIC_COIF_P1,
+            xi.items.AMALRIC_DOUBLET_P1,
+            xi.items.AMALRIC_GAGES_P1,
+            xi.items.AMALRIC_SLOPS_P1,
+            xi.items.AMALRIC_NAILS_P1,
         },
         minMatches = 2,
         mods =
@@ -2488,8 +2488,8 @@ local gearSets =
     {
         items =
         {
-            18947,
-            15818
+            xi.items.MOLIONESS_SICKLE,
+            xi.items.MOLIONESS_RING,
         },
         minMatches = 2,
         mods =
@@ -2503,11 +2503,11 @@ local gearSets =
     {
         items =
         {
-            11079,
-            11099,
-            11119,
-            11139,
-            11159
+            xi.items.MAVI_KAVUK_P2,
+            xi.items.MAVI_MINTAN_P2,
+            xi.items.MAVI_BAZUBANDS_P2,
+            xi.items.MAVI_TAYT_P2,
+            xi.items.MAVI_BASMAK_P2,
         },
         minMatches = 2,
         mods =
@@ -2520,16 +2520,16 @@ local gearSets =
     {
         items =
         {
-            26770,
-            26771,
-            26928,
-            26929,
-            27082,
-            27083,
-            27267,
-            27268,
-            27441,
-            27442
+            xi.items.HASHISHIN_KAVUK,
+            xi.items.HASHISHIN_KAVUK_P1,
+            xi.items.HASHISHIN_MINTAN,
+            xi.items.HASHISHIN_MINTAN_P1,
+            xi.items.HASHISHIN_BAZUBANDS,
+            xi.items.HASHISHIN_BAZUBANDS_P1,
+            xi.items.HASHISHIN_TAYT,
+            xi.items.HASHISHIN_TAYT_P1,
+            xi.items.HASHISHIN_BASMAK,
+            xi.items.HASHISHIN_BASMAK_P1,
         },
         minMatches = 2,
         mods =
@@ -2538,44 +2538,6 @@ local gearSets =
         },
     }
 }
-
-local function FindMatchByType(gearset, gearMatch)
-    if gearset.matchType == matchtype.any then
-        return true
-    elseif
-        gearset.matchType == matchtype.ring_armor and
-        (
-            gearMatch[xi.slot.HEAD + 1] ~= nil or
-            gearMatch[xi.slot.BODY + 1] ~= nil or
-            gearMatch[xi.slot.HANDS + 1] ~= nil or
-            gearMatch[xi.slot.LEGS + 1] ~= nil or
-            gearMatch[xi.slot.FEET + 1] ~= nil
-        )
-        and
-        (
-            gearMatch[xi.slot.RING1 + 1] ~= nil or
-            gearMatch[xi.slot.RING2 + 1] ~= nil
-        )
-    then
-        return true
-    end
-
-    for _, id in ipairs(gearMatch) do
-        if (gearset.matchType == matchtype.earring_weapon and
-            (gearMatch[xi.slot.MAIN + 1] ~= nil or gearMatch[xi.slot.SUB + 1] ~=
-                nil) and
-            (gearMatch[xi.slot.EAR1 + 1] ~= nil or gearMatch[xi.slot.EAR2 + 1] ~=
-                nil)) then
-            return true
-        elseif (gearset.matchType == matchtype.weapon_weapon and
-            (gearMatch[xi.slot.MAIN + 1] ~= nil and gearMatch[xi.slot.SUB + 1] ~=
-                nil)) then
-            return true
-        end
-    end
-
-    return false
-end
 
 local function handleCappedTierSet(player, gearset, minMatches)
     -- Rubeus Armor Set
@@ -2589,7 +2551,6 @@ local function handleCappedTierSet(player, gearset, minMatches)
         end
 
         player:addGearSetMod(gearset.id, xi.mod.FASTCAST, modValue)
-        return
         -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
     elseif (gearset.id >= 133 and gearset.id <= 199 and gearset.id ~= 175) then
         local modValue = 0
@@ -2606,24 +2567,6 @@ local function handleCappedTierSet(player, gearset, minMatches)
         player:addGearSetMod(gearset.id, xi.mod.ACC, modValue)
         player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue)
         player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue)
-        return
-        -- AF1 119 +2/+3 SMN Avatar:ACC/RACC/MACC (unimplemented)
-        --[[
-    elseif (gearset.id == 175) then
-        local modValue = 0
-
-        if (minMatches == 2) then
-            modValue = 15 -- 2 minMatches
-        elseif (minMatches == 3) then
-            modValue = 30 -- 3 minMatches
-        elseif (minMatches == 4) then
-            modValue = 45 -- 4 minMatches
-        elseif (minMatches >= 5) then
-            modValue = 60 -- 5 or more minMatches
-        end
-        --Unimplemented method to add pet mods
-        return
-    ]] --
     end
 end
 
@@ -2677,49 +2620,29 @@ end
 xi.gear_sets.checkForGearSet = function(player)
     player:clearGearSetMods()
 
-    -- cause we dont want hundreds of function calls
-    local equip = {}
-    for slot = 0, xi.MAX_SLOTID do
-        equip[slot + 1] = player:getEquipID(slot)
+    -- Cache current equipped items
+    local equippedItems = {}
+    for equipmentSlot = 0, xi.MAX_SLOTID do
+        equippedItems[equipmentSlot + 1] = player:getEquipID(equipmentSlot)
     end
 
-    for index, gearset in pairs(gearSets) do
-        local minMatches = 0
-        if (player:hasGearSetMod(gearset.id) == false) then
-            -- local slot = 0
-            local gearMatch = {}
+    for setId, setData in pairs(gearSets) do
+        local numMatches = 0
 
-            for _, id in pairs(gearset.items) do
+        if not player:hasGearSetMod(setId) then
+            for _, itemId in ipairs(setData.items) do
                 for slot = 1, xi.MAX_SLOTID do
-                    local equipId = equip[slot]
+                    local equipId = equippedItems[slot]
 
-                    -- check the item minMatches
-                    if (equipId == id) then
-                        minMatches = minMatches + 1
-                        gearMatch[slot] = equipId
+                    if equipId == itemId then
+                        numMatches = numMatches + 1
                         break
                     end
                 end
             end
 
-            -- doesnt count as a match if the same item is in both slots
-            if (gearMatch[xi.slot.EAR1 + 1] == gearMatch[xi.slot.EAR2 + 1] and
-                gearMatch[xi.slot.EAR1 + 1] ~= nil) then
-                minMatches = minMatches - 1
-            end
-            if (gearMatch[xi.slot.RING1 + 1] == gearMatch[xi.slot.RING2 + 1] and
-                gearMatch[xi.slot.RING1 + 1] ~= nil) then
-                minMatches = minMatches - 1
-            end
-            if (gearMatch[xi.slot.MAIN + 1] == gearMatch[xi.slot.SUB + 1] and
-                gearMatch[xi.slot.MAIN + 1] ~= nil) then
-                minMatches = minMatches - 1
-            end
-
-            if (minMatches >= gearset.minMatches) then
-                if (FindMatchByType(gearset, gearMatch) == true) then
-                    ApplyMod(player, gearset, minMatches)
-                end
+            if numMatches >= setData.minMatches then
+                ApplyMod(player, setData, numMatches)
             end
         end
     end

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -8,6 +8,7 @@ require('scripts/globals/status')
 
 xi = xi or {}
 xi.gear_sets = xi.gear_sets or {}
+xi.gear_sets.itemToSetId = xi.gear_sets.createItemToSetId()
 
 local gearSets =
 {
@@ -21,7 +22,7 @@ local gearSets =
             xi.items.USUKANE_HIZAYOROI,
             xi.items.USUKANE_SUNE_ATE,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.HASTE_GEAR, 500, 0, 0 },
@@ -38,7 +39,7 @@ local gearSets =
             xi.items.SKADIS_CHAUSSES,
             xi.items.SKADIS_JAMBEAUX,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.CRITHITRATE, 5, 0, 0 },
@@ -55,7 +56,7 @@ local gearSets =
             xi.items.ARES_FLANCHARD,
             xi.items.ARES_SOLLERETS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
@@ -72,7 +73,7 @@ local gearSets =
             xi.items.DENALI_KECKS,
             xi.items.DENALI_GAMASHES,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.ACC, 20, 0, 0 },
@@ -89,7 +90,7 @@ local gearSets =
             xi.items.ASKAR_DIRS,
             xi.items.ASKAR_GAMBIERAS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.HPP, 10, 0, 0 },
@@ -106,7 +107,7 @@ local gearSets =
             xi.items.PAHLUWAN_SERAWEELS,
             xi.items.PAHLUWAN_CRACKOWS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.SUBTLE_BLOW, 8, 0, 0 },
@@ -123,7 +124,7 @@ local gearSets =
             xi.items.MORRIGANS_SLOPS,
             xi.items.MORRIGANS_PIGACHES,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.MATT, 5, 0, 0 },
@@ -140,7 +141,7 @@ local gearSets =
             xi.items.MARDUKS_SHALWAR,
             xi.items.MARDUKS_CRACKOWS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.FASTCAST, 5, 0, 0 },
@@ -157,7 +158,7 @@ local gearSets =
             xi.items.GOLIARD_TREWS,
             xi.items.GOLIARD_CLOGS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.MDEF, 10, 0, 0 },
@@ -174,7 +175,7 @@ local gearSets =
             xi.items.YIGIT_SERAWEELS,
             xi.items.YIGIT_CRACKOWS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.REFRESH, 1, 0, 0 },
@@ -191,7 +192,7 @@ local gearSets =
             xi.items.PERLE_BRAYETTES,
             xi.items.PERLE_SOLLERETS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.HASTE_GEAR, 500, 0, 0 },
@@ -208,7 +209,7 @@ local gearSets =
             xi.items.AURORE_BRAIS,
             xi.items.AURORE_GAITERS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.STORETP, 8, 0, 0 }
@@ -225,7 +226,7 @@ local gearSets =
             xi.items.TEAL_SLOPS,
             xi.items.TEAL_PIGACHES,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.FASTCAST, 4, 2, 0 },
@@ -242,7 +243,7 @@ local gearSets =
             xi.items.CALMA_HOSE,
             xi.items.CALMA_LEGGINGS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.HASTE_GEAR, 600, 0, 0 },
@@ -259,7 +260,7 @@ local gearSets =
             xi.items.MAGAVAN_SLOPS,
             xi.items.MAGAVAN_CLOGS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.MACC, 5, 0, 0 },
@@ -276,7 +277,7 @@ local gearSets =
             xi.items.MUSTELA_BRAIS,
             xi.items.MUSTELA_BOOTS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.CRITHITRATE, 5, 0, 0 },
@@ -290,7 +291,7 @@ local gearSets =
             xi.items.BOWMANS_MASK,
             xi.items.BOWMANS_LEDELSENS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.RATT, 15, 0, 0 },
@@ -307,7 +308,7 @@ local gearSets =
             xi.items.FOURTH_DIVISION_SCHOSS,
             xi.items.FOURTH_DIVISION_SCHUHS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ATT, 1, 4.7, 0 },
@@ -324,7 +325,7 @@ local gearSets =
             xi.items.COBRA_UNIT_SUBLIGAR,
             xi.items.COBRA_UNIT_LEGGINGS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.COUNTER, 1, 1, 0 },
@@ -341,7 +342,7 @@ local gearSets =
             xi.items.COBRA_UNIT_TREWS,
             xi.items.COBRA_UNIT_CRACKOWS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MACC, 1, 1, 0 },
@@ -358,7 +359,7 @@ local gearSets =
             xi.items.IRON_RAM_BREECHES,
             xi.items.IRON_RAM_SOLLERETS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ACC, 1, 1, 0 },
@@ -376,7 +377,7 @@ local gearSets =
             xi.items.FOURTH_DIVISION_CUISSES,
             xi.items.FOURTH_DIVISION_SABATONS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HP, 10, 10, 0 },
@@ -393,7 +394,7 @@ local gearSets =
             xi.items.COBRA_UNIT_SLOPS,
             xi.items.COBRA_UNIT_PIGACHES,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MP, 10, 10, 0 },
@@ -410,7 +411,7 @@ local gearSets =
             xi.items.AMIR_DIRS,
             xi.items.AMIR_BOOTS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.UDMGBREATH, -800, 0, 0 },
@@ -427,7 +428,7 @@ local gearSets =
             xi.items.HACHIRYU_HAIDATE,
             xi.items.HACHIRYU_SUNE_ATE,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.STORETP, 5, 5, 5 },
@@ -444,7 +445,7 @@ local gearSets =
             xi.items.RAVAGERS_CUISSES_P2,
             xi.items.RAVAGERS_CALLIGAE_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
@@ -461,7 +462,7 @@ local gearSets =
             xi.items.FAZHELUO_RADIANT_MAIL,
             xi.items.FAZHELUO_MAIL_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 5, 0, 0 },
@@ -478,7 +479,7 @@ local gearSets =
             xi.items.MEXTLI_HARNESS,
             xi.items.CUAUHTLI_HARNESS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HASTE_GEAR, 800, 0, 0 },
@@ -495,7 +496,7 @@ local gearSets =
             xi.items.ANHUR_ROBE,
             xi.items.HYKSOS_ROBE_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MACC, 5, 0, 0 },
@@ -512,7 +513,7 @@ local gearSets =
             xi.items.OGIERS_BREECHES,
             xi.items.OGIERS_LEGGINGS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.REFRESH, 1, 0.4, 0 },
@@ -529,7 +530,7 @@ local gearSets =
             xi.items.ATHOSS_TIGHTS,
             xi.items.ATHOSS_BOOTS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.CRITHITRATE, 1, 1, 0 },
@@ -546,8 +547,8 @@ local gearSets =
             xi.items.RUBEUS_SPATS,
             xi.items.RUBEUS_BOOTS,
         },
-        minMatches = 2,
-        maxMatches = 4, -- Special Case
+        minEquipped = 2,
+        maxEquipped = 4, -- Special Case
         mods =
         {
             { xi.mod.FASTCAST, 10, 0, 0 },
@@ -564,7 +565,7 @@ local gearSets =
             xi.items.NAVARCHS_CULOTTES_P2,
             xi.items.NAVARCHS_BOTTES_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
@@ -581,7 +582,7 @@ local gearSets =
             xi.items.CHARIS_TIGHTS_P2,
             xi.items.CHARIS_TOE_SHOES_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.SAMBA_DOUBLE_DAMAGE, 1, 1.8, 0 },
@@ -598,7 +599,7 @@ local gearSets =
             xi.items.IGA_HAKAMA_P2,
             xi.items.IGA_KYAHAN_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
@@ -615,7 +616,7 @@ local gearSets =
             xi.items.SYLVAN_BRAGUES_P2,
             xi.items.SYLVAN_BOTTILLONS_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
@@ -632,7 +633,7 @@ local gearSets =
             xi.items.CREED_CUISSES_P2,
             xi.items.CREED_SABATONS_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
@@ -649,7 +650,7 @@ local gearSets =
             xi.items.UNKAI_HAIDATE_P2,
             xi.items.UNKAI_SUNE_ATE_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
@@ -666,7 +667,7 @@ local gearSets =
             xi.items.TANTRA_HOSE_P2,
             xi.items.TANTRA_GAITERS_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
@@ -683,7 +684,7 @@ local gearSets =
             xi.items.RAIDERS_CULOTTES_P2,
             xi.items.RAIDERS_POULAINES_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
@@ -700,7 +701,7 @@ local gearSets =
             xi.items.ORISON_PANTALOONS_P2,
             xi.items.ORISON_DUCKBILLS_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
@@ -717,7 +718,7 @@ local gearSets =
             xi.items.SAVANTS_PANTS_P2,
             xi.items.SAVANTS_LOAFERS_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
@@ -738,7 +739,7 @@ local gearSets =
             xi.items.OSORAKU,
             xi.items.BALISARDE,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HP,  30, 0, 0 },
@@ -761,7 +762,7 @@ local gearSets =
             xi.items.SPARTH,
             xi.items.VENDETTA,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.STR,  6, 0, 0 },
@@ -785,7 +786,7 @@ local gearSets =
             xi.items.BASILISK,
             xi.items.YAGENTOSHIRO,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.EVA,    10, 0, 0 },
@@ -801,7 +802,7 @@ local gearSets =
             xi.items.TWILIGHT_HELM,
             xi.items.TWILIGHT_MAIL,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.RERAISE_III, 1, 0, 0 },
@@ -815,7 +816,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.HOPE_STAFF,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -829,7 +830,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.JUSTICE_SWORD,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -843,7 +844,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.TEMPERANCE_AXE,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -857,7 +858,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.LOVE_HALBERD,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -871,7 +872,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.FORTITUDE_AXE,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -885,7 +886,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.FAITH_BAGHNAKHS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -899,7 +900,7 @@ local gearSets =
             xi.items.VIRTUE_STONE,
             xi.items.PRUDENCE_ROD,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AMMO_SWING, 50, 0, 0 },
@@ -913,7 +914,7 @@ local gearSets =
             xi.items.STEELFLASH_EARRING,
             xi.items.BLADEBORN_EARRING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 7, 0, 0 },
@@ -927,7 +928,7 @@ local gearSets =
             xi.items.DUDGEON_EARRING,
             xi.items.HEARTSEEKER_EARRING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DUAL_WIELD, 7, 0, 0 },
@@ -941,7 +942,7 @@ local gearSets =
             xi.items.LIFESTORM_EARRING,
             xi.items.PSYSTORM_EARRING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MACC, 12, 0, 0 },
@@ -963,7 +964,7 @@ local gearSets =
             xi.items.KASUGA_KOTE_P1,
             xi.items.KASUGA_SUNE_ATE,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ZANSHIN_DOUBLE_DAMAGE, 2, 1, 0 },
@@ -985,7 +986,7 @@ local gearSets =
             xi.items.BHIKKU_CROWN_P1,
             xi.items.BHIKKU_CROWN,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.EXTRA_KICK_ATTACK, 2, 1, 0 },
@@ -1007,7 +1008,7 @@ local gearSets =
             xi.items.BOII_LORICA_P1,
             xi.items.BOII_LORICA,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DA_DOUBLE_DMG_RATE, 2, 1, 0 },
@@ -1029,7 +1030,7 @@ local gearSets =
             xi.items.SKULKERS_VEST,
             xi.items.SKULKERS_VEST_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.TA_TRIPLE_DMG_RATE, 2, 1, 0 },
@@ -1051,7 +1052,7 @@ local gearSets =
             xi.items.AMINI_GLOVELETTES,
             xi.items.AMINI_GLOVELETTES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.RAPID_SHOT_DOUBLE_DAMAGE, 2, 1, 0 },
@@ -1073,7 +1074,7 @@ local gearSets =
             xi.items.CHEVALIERS_CUISSES,
             xi.items.CHEVALIERS_CUISSES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ABSORB_DMG_CHANCE, 2, 1, 0 },
@@ -1095,7 +1096,7 @@ local gearSets =
             xi.items.HATTORI_KYAHAN,
             xi.items.HATTORI_KYAHAN_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.EXTRA_DUAL_WIELD_ATTACK, 4, 2, 0 },
@@ -1117,7 +1118,7 @@ local gearSets =
             xi.items.CHASSEURS_CULOTTES,
             xi.items.CHASSEURS_CULOTTES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.QUICK_DRAW_TRIPLE_DAMAGE, 2, 1, 0 },
@@ -1139,7 +1140,7 @@ local gearSets =
             xi.items.ARBATEL_BRACERS,
             xi.items.ARBATEL_BRACERS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.GRIMOIRE_INSTANT_CAST, 2, 1, 0 },
@@ -1161,52 +1162,38 @@ local gearSets =
             xi.items.EBERS_MITTS,
             xi.items.EBERS_MITTS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.BAR_ELEMENT_NULL_CHANCE, 4, 2, 0 },
         },
     },
 
-    [67] = -- Heka's body + NQ or HQ Khat = 3 tick refresh
+    [67] = -- Heka/Nefer body + NQ or HQ Khat = 2 tick refresh
     {
         items =
         {
             xi.items.HEKAS_KALASIRIS,
-            xi.items.NEFER_KHAT_P1,
             xi.items.NEFER_KHAT,
+            xi.items.NEFER_KHAT_P1,
+            xi.items.NEFER_KALASIRIS,
+            xi.items.NEFER_KALASIRIS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.REFRESH, 3, 0, 0 },
         },
     },
 
-    [68] = -- Nefer body/head NQ/HQ combo gives Refresh +2
-    {
-        items =
-        {
-            xi.items.NEFER_KHAT_P1,
-            xi.items.NEFER_KALASIRIS_P1,
-            xi.items.NEFER_KALASIRIS,
-            xi.items.NEFER_KHAT,
-        },
-        minMatches = 2,
-        mods =
-        {
-            { xi.mod.REFRESH, 2, 0, 0 },
-        },
-    },
-
-    [69] = -- Dasra's/Nasatya's Ring set gives HP/MP +50
+    [68] = -- Dasra's/Nasatya's Ring set gives HP/MP +50
     {
         items =
         {
             xi.items.NASATYAS_RING,
             xi.items.DASRAS_RING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HP, 50, 0, 0 },
@@ -1214,14 +1201,14 @@ local gearSets =
         },
     },
 
-    [70] = -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
+    [69] = -- Helenus's/Cassandra's earring set: Mag atk bonus+5 and Mag acc +5
     {
         items =
         {
             xi.items.HELENUSS_EARRING,
             xi.items.CASSANDRAS_EARRING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MATT, 5, 0, 0 },
@@ -1229,14 +1216,14 @@ local gearSets =
         },
     },
 
-    [71] = -- Lava's/Kusha's earring set: Atk+6/Acc+12
+    [70] = -- Lava's/Kusha's earring set: Atk+6/Acc+12
     {
         items =
         {
             xi.items.LAVAS_RING,
             xi.items.KUSHAS_RING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ATT,  6, 0, 0 },
@@ -1245,7 +1232,7 @@ local gearSets =
         },
     },
 
-    [72] = -- Iron Ram Haubert Set
+    [71] = -- Iron Ram Haubert Set
     {
         items =
         {
@@ -1255,7 +1242,7 @@ local gearSets =
             xi.items.IRON_RAM_HOSE,
             xi.items.IRON_RAM_GREAVES,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.FIRE_MEVA,    5, 5, 10 },
@@ -1269,28 +1256,28 @@ local gearSets =
         },
     },
 
-    [73] = -- Altdorf's/Wilhelm's earring: AGI+8
+    [72] = -- Altdorf's/Wilhelm's earring: AGI+8
     {
         items =
         {
             xi.items.ALTDORFS_EARRING,
             xi.items.WILHELMS_EARRING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AGI, 8, 0, 0 },
         },
     },
 
-    [74] = -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
+    [73] = -- Gothic Gauntlets/Sabatons: Atk/RAtk +5
     {
         items =
         {
             xi.items.GOTHIC_GAUNTLETS,
             xi.items.GOTHIC_SABATONS,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ATT,  5, 0, 0 },
@@ -1298,7 +1285,7 @@ local gearSets =
         },
     },
 
-    [75] = -- Teal Set +1: Fast Cast +4-10%
+    [74] = -- Teal Set +1: Fast Cast +4-10%
     {
         items =
         {
@@ -1308,14 +1295,14 @@ local gearSets =
             xi.items.TEAL_SLOPS_P1,
             xi.items.TEAL_PIGACHES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.FASTCAST, 4, 2, 0 },
         },
     },
 
-    [76] = -- Aurore Set +1: Store TP +2-8
+    [75] = -- Aurore Set +1: Store TP +2-8
     {
         items =
         {
@@ -1325,14 +1312,14 @@ local gearSets =
             xi.items.AURORE_BRAIS_P1,
             xi.items.AURORE_GAITERS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.STORETP, 2, 2, 0 },
         },
     },
 
-    [77] = -- Perle Set +1: Haste +2-5%
+    [76] = -- Perle Set +1: Haste +2-5%
     {
         items =
         {
@@ -1342,14 +1329,14 @@ local gearSets =
             xi.items.PERLE_BRAYETTES_P1,
             xi.items.PERLE_SOLLERETS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HASTE_GEAR, 200, 100, 0 },
         },
     },
 
-    [78] = -- Morrigan's Attire Set +1: Magic Atk. Bonus +3-9%
+    [77] = -- Morrigan's Attire Set +1: Magic Atk. Bonus +3-9%
     {
         items =
         {
@@ -1359,14 +1346,14 @@ local gearSets =
             xi.items.MORRIGANS_SLOPS_P1,
             xi.items.MORRIGANS_PIGACHES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MATT, 3, 2, 0 },
         },
     },
 
-    [79] = -- Marduk's Attire Set +1: Fast Cast +3-9%
+    [78] = -- Marduk's Attire Set +1: Fast Cast +3-9%
     {
         items =
         {
@@ -1376,14 +1363,14 @@ local gearSets =
             xi.items.MARDUKS_SHALWAR_P1,
             xi.items.MARDUKS_CRACKOWS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.FASTCAST, 3, 2, 0 },
         },
     },
 
-    [80] = -- Usukane Armor Set +1: Haste +3-9%
+    [79] = -- Usukane Armor Set +1: Haste +3-9%
     {
         items =
         {
@@ -1393,14 +1380,14 @@ local gearSets =
             xi.items.USUKANE_HIZAYOROI_P1,
             xi.items.USUKANE_SUNE_ATE_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.HASTE_GEAR, 300, 200, 0 },
         },
     },
 
-    [81] = -- Skadi's Attire Set +1: Critical hit rate +3-9%
+    [80] = -- Skadi's Attire Set +1: Critical hit rate +3-9%
     {
         items =
         {
@@ -1410,14 +1397,14 @@ local gearSets =
             xi.items.SKADIS_CHAUSSES_P1,
             xi.items.SKADIS_JAMBEAUX_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.CRITHITRATE, 3, 2, 0 },
         },
     },
 
-    [82] = -- Ares' Armor Set +1: Double Attack +3-9%
+    [81] = -- Ares' Armor Set +1: Double Attack +3-9%
     {
         items =
         {
@@ -1427,28 +1414,28 @@ local gearSets =
             xi.items.ARES_FLANCHARD_P1,
             xi.items.ARES_SOLLERETS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 3, 2, 0 },
         },
     },
 
-    [83] = -- Alcedo Cuisses and Gauntlets: Magic damage taken -5%
+    [82] = -- Alcedo Cuisses and Gauntlets: Magic damage taken -5%
     {
         items =
         {
             xi.items.ALCEDO_GAUNTLETS,
             xi.items.ALCEDO_CUISSES,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DMGMAGIC, -500, 0, 0 },
         },
     },
 
-    [84] = -- Sulevia's Armor Set +2: Subtle Blow +5-20
+    [83] = -- Sulevia's Armor Set +2: Subtle Blow +5-20
     {
         items =
         {
@@ -1459,15 +1446,15 @@ local gearSets =
             xi.items.SULEVIAS_CUISSES_P2,
             xi.items.SULEVIAS_LEGGINGS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.SUBTLE_BLOW, 5, 5, 0 },
         },
     },
 
-    [85] = -- Hizamaru Armor Set +2: Counter +4-16%
+    [84] = -- Hizamaru Armor Set +2: Counter +4-16%
     {
         items =
         {
@@ -1478,15 +1465,15 @@ local gearSets =
             xi.items.HIZAMARU_HIZAYOROI_P2,
             xi.items.HIZAMARU_SUNE_ATE_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.COUNTER, 4, 4, 0 },
         },
     },
 
-    [86] = -- Inyanga Armor Set +2: Refresh +1-4
+    [85] = -- Inyanga Armor Set +2: Refresh +1-4
     {
         items =
         {
@@ -1497,15 +1484,15 @@ local gearSets =
             xi.items.INYANGA_SHALWAR_P2,
             xi.items.INYANGA_CRACKOWS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.REFRESH, 1, 1, 0 },
         },
     },
 
-    [87] = -- Meghanada Armor Set +2: Regen +3-12
+    [86] = -- Meghanada Armor Set +2: Regen +3-12
     {
         items =
         {
@@ -1516,15 +1503,15 @@ local gearSets =
             xi.items.MEGHANADA_CHAUSSES_P2,
             xi.items.MEGHANADA_JAMBEAUX_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.REGEN, 3, 3, 0 },
         },
     },
 
-    [88] = -- Jhakri Armor Set +2: Fast Cast +1-4%
+    [87] = -- Jhakri Armor Set +2: Fast Cast +1-4%
     {
         items =
         {
@@ -1535,15 +1522,15 @@ local gearSets =
             xi.items.JHAKRI_SLOPS_P2,
             xi.items.JHAKRI_PIGACHES_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.FAST_CAST, 1, 1, 0 },
         },
     },
 
-    [89] = -- Flamma Armor Set +2 STR/DEX/VIT +8-32
+    [88] = -- Flamma Armor Set +2 STR/DEX/VIT +8-32
     {
         items =
         {
@@ -1554,8 +1541,8 @@ local gearSets =
             xi.items.FLAMMA_DIRS_P2,
             xi.items.FLAMMA_GAMBIERAS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.STR, 8, 8, 0 },
@@ -1564,7 +1551,7 @@ local gearSets =
         },
     },
 
-    [90] = -- Tali'ah Armor Set +2 DEX/VIT/CHR +8-32
+    [89] = -- Tali'ah Armor Set +2 DEX/VIT/CHR +8-32
     {
         items =
         {
@@ -1575,8 +1562,8 @@ local gearSets =
             xi.items.TALIAH_SERAWEELS_P2,
             xi.items.TALIAH_CRACKOWS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.DEX, 8, 8, 0 },
@@ -1585,7 +1572,7 @@ local gearSets =
         }
     },
 
-    [91] = -- Mummu Armor Set +2 DEX/AGI/CHR +8-32
+    [90] = -- Mummu Armor Set +2 DEX/AGI/CHR +8-32
     {
         items =
         {
@@ -1596,8 +1583,8 @@ local gearSets =
             xi.items.MUMMU_KECKS_P2,
             xi.items.MUMMU_GAMASHES_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.DEX, 8, 8, 0 },
@@ -1606,7 +1593,7 @@ local gearSets =
         },
     },
 
-    [92] = -- Ayanmo Armor Set +2 STR/VIT/MND +8-32
+    [91] = -- Ayanmo Armor Set +2 STR/VIT/MND +8-32
     {
         items =
         {
@@ -1617,8 +1604,8 @@ local gearSets =
             xi.items.AYANMO_COSCIALES_P2,
             xi.items.AYANMO_GAMBIERAS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.STR, 8, 8, 0 },
@@ -1627,7 +1614,7 @@ local gearSets =
         }
     },
 
-    [93] = -- Mallquis Armor Set +2 VIT/INT/MND +8-32
+    [92] = -- Mallquis Armor Set +2 VIT/INT/MND +8-32
     {
         items =
         {
@@ -1638,8 +1625,8 @@ local gearSets =
             xi.items.MALLQUIS_TREWS_P2,
             xi.items.MALLQUIS_CLOGS_P2,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.VIT, 8, 8, 0 },
@@ -1648,7 +1635,7 @@ local gearSets =
         }
     },
 
-    [94] = -- AF1 119 +2/3 WAR
+    [93] = -- AF1 119 +2/3 WAR
     {
         items =
         {
@@ -1664,8 +1651,8 @@ local gearSets =
             xi.items.PUMMELERS_MASK_P2,
             xi.items.PUMMELERS_MASK_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1674,7 +1661,7 @@ local gearSets =
         },
     },
 
-    [95] = -- AF1 119 +2/3 MNK
+    [94] = -- AF1 119 +2/3 MNK
     {
         items =
         {
@@ -1690,8 +1677,8 @@ local gearSets =
             xi.items.ANCHORITES_CROWN_P2,
             xi.items.ANCHORITES_CROWN_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1700,7 +1687,7 @@ local gearSets =
         },
     },
 
-    [96] = -- AF1 119 +2/3 WHM
+    [95] = -- AF1 119 +2/3 WHM
     {
         items =
         {
@@ -1716,8 +1703,8 @@ local gearSets =
             xi.items.THEOPHANY_CAP_P2,
             xi.items.THEOPHANY_CAP_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1726,7 +1713,7 @@ local gearSets =
         },
     },
 
-    [97] = -- AF1 119 +2/3 BLM
+    [96] = -- AF1 119 +2/3 BLM
     {
         items =
         {
@@ -1742,8 +1729,8 @@ local gearSets =
             xi.items.SPAEKONAS_PETASOS_P2,
             xi.items.SPAEKONAS_PETASOS_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1752,7 +1739,7 @@ local gearSets =
         },
     },
 
-    [98] = -- AF1 119 +2/3 RDM
+    [97] = -- AF1 119 +2/3 RDM
     {
         items =
         {
@@ -1768,8 +1755,8 @@ local gearSets =
             xi.items.ATROPHY_CHAPEAU_P2,
             xi.items.ATROPHY_CHAPEAU_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1778,7 +1765,7 @@ local gearSets =
         },
     },
 
-    [99] = -- AF1 119 +2/3 THF
+    [98] = -- AF1 119 +2/3 THF
     {
         items =
         {
@@ -1794,8 +1781,8 @@ local gearSets =
             xi.items.PILLAGERS_BONNET_P2,
             xi.items.PILLAGERS_BONNET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1804,7 +1791,7 @@ local gearSets =
         },
     },
 
-    [100] = -- AF1 119 +2/3 PLD
+    [99] = -- AF1 119 +2/3 PLD
     {
         items =
         {
@@ -1820,8 +1807,8 @@ local gearSets =
             xi.items.REVERENCE_CORONET_P2,
             xi.items.REVERENCE_CORONET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1830,7 +1817,7 @@ local gearSets =
         },
     },
 
-    [101] = -- AF1 119 +2/3 DRK
+    [100] = -- AF1 119 +2/3 DRK
     {
         items =
         {
@@ -1846,8 +1833,8 @@ local gearSets =
             xi.items.IGNOMINY_BURGONET_P2,
             xi.items.IGNOMINY_BURGONET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1856,7 +1843,7 @@ local gearSets =
         },
     },
 
-    [102] = -- AF1 119 +2/3 BST
+    [101] = -- AF1 119 +2/3 BST
     {
         items =
         {
@@ -1872,8 +1859,8 @@ local gearSets =
             xi.items.TOTEMIC_HELM_P2,
             xi.items.TOTEMIC_HELM_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1882,7 +1869,7 @@ local gearSets =
         },
     },
 
-    [103] = -- AF1 119 +2/3 BRD
+    [102] = -- AF1 119 +2/3 BRD
     {
         items =
         {
@@ -1898,8 +1885,8 @@ local gearSets =
             xi.items.BRIOSO_ROUNDLET_P2,
             xi.items.BRIOSO_ROUNDLET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1908,7 +1895,7 @@ local gearSets =
         },
     },
 
-    [104] = -- AF1 119 +2/3 RNG
+    [103] = -- AF1 119 +2/3 RNG
     {
         items =
         {
@@ -1924,8 +1911,8 @@ local gearSets =
             xi.items.ORION_BERET_P2,
             xi.items.ORION_BERET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1934,7 +1921,7 @@ local gearSets =
         },
     },
 
-    [105] = -- AF1 119 +2/3 SAM
+    [104] = -- AF1 119 +2/3 SAM
     {
         items =
         {
@@ -1950,8 +1937,8 @@ local gearSets =
             xi.items.WAKIDO_KABUTO_P2,
             xi.items.WAKIDO_KABUTO_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1960,7 +1947,7 @@ local gearSets =
         },
     },
 
-    [106] = -- AF1 119 +2/3 NIN
+    [105] = -- AF1 119 +2/3 NIN
     {
         items =
         {
@@ -1976,8 +1963,8 @@ local gearSets =
             xi.items.HACHIYA_HATSUBURI_P2,
             xi.items.HACHIYA_HATSUBURI_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -1986,7 +1973,7 @@ local gearSets =
         }
     },
 
-    [107] = -- AF1 119 +2/3 DRG
+    [106] = -- AF1 119 +2/3 DRG
     {
         items =
         {
@@ -2002,8 +1989,8 @@ local gearSets =
             xi.items.VISHAP_ARMET_P2,
             xi.items.VISHAP_ARMET_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2012,7 +1999,7 @@ local gearSets =
         },
     },
 
-    [108] = -- AF1 119 +2/3 SMN
+    [107] = -- AF1 119 +2/3 SMN
     {
         items =
         {
@@ -2028,8 +2015,8 @@ local gearSets =
             xi.items.CONVOKERS_HORN_P2,
             xi.items.CONVOKERS_HORN_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2038,7 +2025,7 @@ local gearSets =
         }
     },
 
-    [109] = -- AF1 119 +2/3 BLU
+    [108] = -- AF1 119 +2/3 BLU
     {
         items =
         {
@@ -2054,8 +2041,8 @@ local gearSets =
             xi.items.ASSIMILATORS_KEFFIYEH_P2,
             xi.items.ASSIMILATORS_KEFFIYEH_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2064,7 +2051,7 @@ local gearSets =
         },
     },
 
-    [110] = -- AF1 119 +2/3 COR
+    [109] = -- AF1 119 +2/3 COR
     {
         items =
         {
@@ -2080,8 +2067,8 @@ local gearSets =
             xi.items.LAKSAMANAS_TRICORNE_P2,
             xi.items.LAKSAMANAS_TRICORNE_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2090,7 +2077,7 @@ local gearSets =
         },
     },
 
-    [111] = -- AF1 119 +2/3 PUP
+    [110] = -- AF1 119 +2/3 PUP
     {
         items =
         {
@@ -2106,8 +2093,8 @@ local gearSets =
             xi.items.FOIRE_TAJ_P2,
             xi.items.FOIRE_TAJ_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2116,7 +2103,7 @@ local gearSets =
         },
     },
 
-    [112] = -- AF1 119 +2/3 DNC (M)
+    [111] = -- AF1 119 +2/3 DNC (M)
     {
         items =
         {
@@ -2132,8 +2119,8 @@ local gearSets =
             xi.items.MAXIXI_TIGHTS_M_P3,
             xi.items.MAXIXI_TOE_SHOES_M_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2142,7 +2129,7 @@ local gearSets =
         },
     },
 
-    [113] = -- AF1 119 +2/3 DNC (F)
+    [112] = -- AF1 119 +2/3 DNC (F)
     {
         items =
         {
@@ -2158,8 +2145,8 @@ local gearSets =
             xi.items.MAXIXI_TIGHTS_F_P3,
             xi.items.MAXIXI_TOE_SHOES_F_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2168,7 +2155,7 @@ local gearSets =
         },
     },
 
-    [114] = -- AF1 119 +2/3 SCH
+    [113] = -- AF1 119 +2/3 SCH
     {
         items =
         {
@@ -2184,8 +2171,8 @@ local gearSets =
             xi.items.ACADEMICS_MORTARBOARD_P2,
             xi.items.ACADEMICS_MORTARBOARD_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2194,7 +2181,7 @@ local gearSets =
         },
     },
 
-    [115] = -- AF1 119 +2/3 GEO
+    [114] = -- AF1 119 +2/3 GEO
     {
         items =
         {
@@ -2210,8 +2197,8 @@ local gearSets =
             xi.items.GEOMANCY_GALERO_P2,
             xi.items.GEOMANCY_GALERO_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2220,7 +2207,7 @@ local gearSets =
         },
     },
 
-    [116] = -- AF1 119 +2/3 RUN
+    [115] = -- AF1 119 +2/3 RUN
     {
         items =
         {
@@ -2236,8 +2223,8 @@ local gearSets =
             xi.items.RUNEISTS_BANDEAU_P2,
             xi.items.RUNEISTS_BANDEAU_P3,
         },
-        minMatches = 2,
-        maxMatches = 5,
+        minEquipped = 2,
+        maxEquipped = 5,
         mods =
         {
             { xi.mod.ACC,  15, 0, 0 },
@@ -2246,7 +2233,7 @@ local gearSets =
         },
     },
 
-    [117] = -- Outrider set (Phys damage taken -10%)
+    [116] = -- Outrider set (Phys damage taken -10%)
     {
         items =
         {
@@ -2256,14 +2243,14 @@ local gearSets =
             xi.items.OUTRIDER_HOSE,
             xi.items.OUTRIDER_GREAVES,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.DMGPHYS, -1000, 0, 0 },
         },
     },
 
-    [118] = -- Espial set (Crit damage +10%)
+    [117] = -- Espial set (Crit damage +10%)
     {
         items =
         {
@@ -2273,14 +2260,14 @@ local gearSets =
             xi.items.ESPIAL_HOSE,
             xi.items.ESPIAL_SOCKS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.CRIT_DMG_INCREASE, 10, 0, 0 },
         },
     },
 
-    [119] = -- Wayfarer set (Refresh+3)
+    [118] = -- Wayfarer set (Refresh+3)
     {
         items =
         {
@@ -2290,14 +2277,14 @@ local gearSets =
             xi.items.WAYFARER_SLOPS,
             xi.items.WAYFARER_CLOGS,
         },
-        minMatches = 5,
+        minEquipped = 5,
         mods =
         {
             { xi.mod.REFRESH, 3, 0, 0 },
         },
     },
 
-    [120] = -- Apogee +1
+    [119] = -- Apogee +1
     {
         items =
         {
@@ -2307,14 +2294,14 @@ local gearSets =
             xi.items.APOGEE_SLACKS_P1,
             xi.items.APOGEE_PUMPS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.BP_DAMAGE, 4, 2, 0 },
         },
     },
 
-    [121] = -- Ryuo +1
+    [120] = -- Ryuo +1
     {
         items =
         {
@@ -2324,14 +2311,14 @@ local gearSets =
             xi.items.RYUO_HAKAMA_P1,
             xi.items.RYUO_SUNE_ATE_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ATT, 20, 10, 0 },
         },
     },
 
-    [122] = -- Souveran +1
+    [121] = -- Souveran +1
     {
         items =
         {
@@ -2341,14 +2328,14 @@ local gearSets =
             xi.items.SOUVERAN_DIECHLINGS_P1,
             xi.items.SOUVERAN_SCHUHS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DMG, -4, -2, 0 },
         },
     },
 
-    [123] = -- Emicho +1
+    [122] = -- Emicho +1
     {
         items =
         {
@@ -2358,14 +2345,14 @@ local gearSets =
             xi.items.EMICHO_HOSE_P1,
             xi.items.EMICHO_GAMBIERAS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
         },
     },
 
-    [124] = -- Kaykaus +1
+    [123] = -- Kaykaus +1
     {
         items =
         {
@@ -2375,14 +2362,14 @@ local gearSets =
             xi.items.KAYKAUS_TIGHTS_P1,
             xi.items.KAYKAUS_BOOTS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.CURE_POTENCY_II, 4, 2, 0 },
         },
     },
 
-    [125] = -- Rao +1
+    [124] = -- Rao +1
     {
         items =
         {
@@ -2392,14 +2379,14 @@ local gearSets =
             xi.items.RAO_HAIDATE_P1,
             xi.items.RAO_SUNE_ATE_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MARTIAL_ARTS, 8, 4, 0 },
         },
     },
 
-    [126] = -- Adhemar +1
+    [125] = -- Adhemar +1
     {
         items =
         {
@@ -2409,14 +2396,14 @@ local gearSets =
             xi.items.ADHEMAR_KECKS_P1,
             xi.items.ADHEMAR_GAMASHES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.CRITHITRATE, 4, 2, 0 },
         },
     },
 
-    [127] = -- Carmine +1
+    [126] = -- Carmine +1
     {
         items =
         {
@@ -2426,14 +2413,14 @@ local gearSets =
             xi.items.CARMINE_CUISSES_P1,
             xi.items.CARMINE_GREAVES_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ACC, 20, 10, 0 },
         },
     },
 
-    [128] = -- Lustratio +1
+    [127] = -- Lustratio +1
     {
         items =
         {
@@ -2443,14 +2430,14 @@ local gearSets =
             xi.items.LUSTRATIO_SUBLIGAR_P1,
             xi.items.LUSTRATIO_LEGGINGS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ALL_WSDMG_FIRST_HIT, 4, 2, 0 },
         },
     },
 
-    [129] = -- Argosy +1
+    [128] = -- Argosy +1
     {
         items =
         {
@@ -2460,14 +2447,14 @@ local gearSets =
             xi.items.ARGOSY_BREECHES_P1,
             xi.items.ARGOSY_SOLLERETS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.DOUBLE_ATTACK, 4, 2, 0 },
         },
     },
 
-    [130] = -- Amalric +1
+    [129] = -- Amalric +1
     {
         items =
         {
@@ -2477,21 +2464,21 @@ local gearSets =
             xi.items.AMALRIC_SLOPS_P1,
             xi.items.AMALRIC_NAILS_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.MATT, 20, 10, 0 },
         },
     },
 
-    [131] = -- Moliones's Sickle/Ring
+    [130] = -- Moliones's Sickle/Ring
     {
         items =
         {
             xi.items.MOLIONESS_SICKLE,
             xi.items.MOLIONESS_RING,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.ACC,              5, 0, 0 },
@@ -2499,7 +2486,7 @@ local gearSets =
         },
     },
 
-    [132] = -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+    [131] = -- Mavi +2 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
     {
         items =
         {
@@ -2509,14 +2496,14 @@ local gearSets =
             xi.items.MAVI_TAYT_P2,
             xi.items.MAVI_BASMAK_P2,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
         },
     },
 
-    [133] = -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
+    [132] = -- AF3 BLU 109/119 Set: Occasionally triples the WSC of Blue Magic Spells. Will stack with Chain Affinity.
     {
         items =
         {
@@ -2531,7 +2518,7 @@ local gearSets =
             xi.items.HASHISHIN_BASMAK,
             xi.items.HASHISHIN_BASMAK_P1,
         },
-        minMatches = 2,
+        minEquipped = 2,
         mods =
         {
             { xi.mod.AUGMENT_BLU_MAGIC, 2, 1, 0 },
@@ -2539,110 +2526,47 @@ local gearSets =
     }
 }
 
-local function handleCappedTierSet(player, gearset, minMatches)
-    -- Rubeus Armor Set
-    if (gearset.id == 32) then
-        local modValue = 0
+-- Build Table to lookup Set ID based on Item ID.  This is cached in xi.gear_sets.itemToSetId table,
+-- and only rebuilt on loading the gear_sets global into cache.
 
-        if (minMatches > 1 and minMatches < 4) then
-            modValue = 4 -- 2 or 3 pieces
-        elseif (minMatches > 3) then
-            modValue = 10 -- 4 or 5 pieces
+xi.gear_sets.createItemToSetId = function()
+    local itemTable = {}
+
+    for setId, setData in pairs(gearSets) do
+        for _, itemId in ipairs(setData.items) do
+            itemTable[itemId] = setId
         end
-
-        player:addGearSetMod(gearset.id, xi.mod.FASTCAST, modValue)
-        -- AF1 119+2/+3 ACC/RACC/MACC Sets EXCEPT SMN
-    elseif (gearset.id >= 133 and gearset.id <= 199 and gearset.id ~= 175) then
-        local modValue = 0
-
-        if (minMatches == 2) then
-            modValue = 15 -- 2 minMatches
-        elseif (minMatches == 3) then
-            modValue = 30 -- 3 minMatches
-        elseif (minMatches == 4) then
-            modValue = 45 -- 4 minMatches
-        elseif (minMatches >= 5) then
-            modValue = 60 -- 5 or more minMatches
-        end
-        player:addGearSetMod(gearset.id, xi.mod.ACC, modValue)
-        player:addGearSetMod(gearset.id + 1, xi.mod.RACC, modValue)
-        player:addGearSetMod(gearset.id + 2, xi.mod.MACC, modValue)
     end
+
+    return itemTable
 end
 
------------------------------------
--- Applys a gear set mod
------------------------------------
-local function ApplyMod(player, gearset, minMatches)
-
-    for _, set in pairs(cappedTierSets) do
-        if (set.id == gearset.id) then
-            handleCappedTierSet(player, gearset, minMatches)
-            return
-        end
-    end
-
-    -- find any additional minMatches
-    local addMatches = minMatches - gearset.minMatches
-
-    -- just in case someone decides to customize things
-    if (addMatches < 0) then return end
-
-    local i = 0
-    for _, mod in pairs(gearset.mods) do
-        local modId = mod[1]
-        local modValue = mod[2]
-
-        -- value/multiplier for additional pieces
-        local addMatchValue = mod[3]
-
-        -- additional bonus for complete set
-        local addSetBonus = 0
-
-        -- cause we need all pieces to form a complete set
-        if (minMatches == #gearset.items) then
-            addSetBonus = mod[4]
-        end
-
-        -- add bonus mods per piece
-        if (addMatches ~= 0 and addMatchValue ~= 0) then
-            modValue = modValue + (addMatchValue * addMatches)
-        end
-
-        player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus)
-        i = i + 1
-    end
-end
-
------------------------------------
--- Checks for gear sets present on a player
------------------------------------
+-- Global function to check for equipped sets and apply mods.  This is called by
+-- core on equip and unequip of an item.
 xi.gear_sets.checkForGearSet = function(player)
     player:clearGearSetMods()
 
-    -- Cache current equipped items
-    local equippedItems = {}
+    -- Build a table containing equipped Set IDs, and the count for each one.
+    local equippedSets = {}
     for equipmentSlot = 0, xi.MAX_SLOTID do
-        equippedItems[equipmentSlot + 1] = player:getEquipID(equipmentSlot)
+        local equipId = player:getEquipID(equipmentSlot)
+        local setId   = xi.gear_sets.itemToSetId[equipId]
+
+        if setId then
+            equippedSets[setId] = equippedSets[setId] and (equippedSets[setId] + 1) or 1
+        end
     end
 
-    for setId, setData in pairs(gearSets) do
-        local numMatches = 0
+    -- Apply Mods for each set after boundary checking the counts.
+    for setId, setCount in pairs(equippedSets) do
+        local minEquippedReq = gearSets[setId].minEquipped and gearSets[setId].minEquipped or 2
+        local maxEquippedReq = gearSets[setId].maxEquipped and gearSets[setId].maxEquipped or 0
 
-        if not player:hasGearSetMod(setId) then
-            for _, itemId in ipairs(setData.items) do
-                for slot = 1, xi.MAX_SLOTID do
-                    local equipId = equippedItems[slot]
+        if setCount >= minEquipped then
+            local modTierIndex = math.min(setCount, maxEquippedReq) - minEquippedReq
 
-                    if equipId == itemId then
-                        numMatches = numMatches + 1
-                        break
-                    end
-                end
-            end
-
-            if numMatches >= setData.minMatches then
-                ApplyMod(player, setData, numMatches)
+            for _, modData in gearSets[setId].mods do
+                player:addGearSetMod(setId, modData[1], modData[modTierIndex + 2])
             end
         end
     end

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -195,7 +195,7 @@ struct UnlockedAttachments_t
 
 struct GearSetMod_t
 {
-    uint8  modNameId;
+    uint8  setId;
     Mod    modId;
     uint16 modValue;
 };

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4214,46 +4214,14 @@ int8 CLuaBaseEntity::getShieldSize()
 }
 
 /************************************************************************
- *  Function: hasGearSetMod()
- *  Purpose : Need to research functionality more to provide description
- *  Example :  if not player:hasGearSetMod(gearset.id) then
- *  Notes   : Used exclusively in scripts/globals/gear_sets.lua
- ************************************************************************/
-
-bool CLuaBaseEntity::hasGearSetMod(uint8 modNameId)
-{
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
-    {
-        for (auto exsistingMod : PChar->m_GearSetMods)
-        {
-            if (modNameId == exsistingMod.modNameId)
-            {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-/************************************************************************
  *  Function: addGearSetMod()
  *  Purpose : Need to research functionality more to provide description
- *  Example : player:addGearSetMod(gearset.id + i, modId, modValue + addSetBonus)
+ *  Example : player:addGearSetMod(setId, modId, modValue)
  *  Notes   : Used exclusively in scripts/globals/gear_sets.lua
  ************************************************************************/
 
-void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
+void CLuaBaseEntity::addGearSetMod(uint8 setId, Mod modId, uint16 modValue)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    GearSetMod_t gearSetMod = {};
-    gearSetMod.modNameId    = modNameId;
-    gearSetMod.modId        = modId;
-    gearSetMod.modValue     = modValue;
-
     CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
     if (!PChar)
@@ -4262,13 +4230,10 @@ void CLuaBaseEntity::addGearSetMod(uint8 modNameId, Mod modId, uint16 modValue)
         return;
     }
 
-    for (auto& exsistingMod : PChar->m_GearSetMods)
-    {
-        if (gearSetMod.modNameId == exsistingMod.modNameId)
-        {
-            return;
-        }
-    }
+    GearSetMod_t gearSetMod = {};
+    gearSetMod.setId        = setId;
+    gearSetMod.modId        = modId;
+    gearSetMod.modValue     = modValue;
 
     PChar->m_GearSetMods.push_back(gearSetMod);
     PChar->addModifier(gearSetMod.modId, gearSetMod.modValue);
@@ -14614,7 +14579,6 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getShieldSize", CLuaBaseEntity::getShieldSize);
 
-    SOL_REGISTER("hasGearSetMod", CLuaBaseEntity::hasGearSetMod);
     SOL_REGISTER("addGearSetMod", CLuaBaseEntity::addGearSetMod);
     SOL_REGISTER("clearGearSetMods", CLuaBaseEntity::clearGearSetMods);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Refactors Gear Sets for the following items:
* Reformats and Expands gearSets table
* All Item IDs are now using items.lua enum
* Mod Values are based on number of set pieces equipped for a set (no math, just N set pieces starting at minEquipped)
* Dynamically creates Item ID lookup to set ID table on cache to prevent potentially iterating over all sets/items
* Updates logic for Lua bindings, removes unused hasGearSetMod binding
* Sets maximum limit for equipped items in set (optional)
* Audits and updates previously defined set definitions

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Equip set and non-set items, see mods applied and removed as expected.

![image](https://user-images.githubusercontent.com/81713309/191310206-c55fd333-9f2b-4a9b-ac77-1dd0fa35f264.png)

<!-- Clear and detailed steps to test your changes here -->
