### PR TITLE
Adding support for the vscode extension "Local Lua Debugger"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "koihik.vscode-lua-format",
         "jkiviluoto.tws",
         "sumneko.lua",
-        "wwm.better-align"
+        "wwm.better-align",
+        "tomblind.local-lua-debugger-vscode"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,5 +59,13 @@
                 "exceptions": false,
             },
         },
+        {
+            "name": "(Windows) xi_map Scripts",
+            "type": "lua-local",
+            "request": "launch",
+            "program": {
+                "command": "${workspaceFolder}/xi_map.exe",
+            },
+        },
     ],
 }

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -52,12 +52,7 @@ void lua_init()
     lua.set_function("print", &lua_print);
 
     // Attempt to startup lldebugger
-    std::string packagePath = lua["package"]["path"];
-    lua["package"]["path"]  = "data/scripts/?.lua;data/scripts/?/init.lua;" + packagePath;
-    lua["_require"]         = lua["require"];
-    sol::protected_function protectedRequire = lua["_require"];
-    auto                    result           = protectedRequire("lldebugger");
-
+    auto result = lua["require"]("lldebugger");
     if (result.valid())
     {
         result.get<sol::table>()["start"];

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2022 LandSandBoat Dev Teams
@@ -50,6 +50,23 @@ void lua_init()
 
     // Bind print(...) globally
     lua.set_function("print", &lua_print);
+
+    // Attempt to startup lldebugger
+    std::string packagePath = lua["package"]["path"];
+    lua["package"]["path"]  = "data/scripts/?.lua;data/scripts/?/init.lua;" + packagePath;
+    lua["_require"]         = lua["require"];
+    sol::protected_function protectedRequire = lua["_require"];
+    auto                    result           = protectedRequire("lldebugger");
+
+    if (result.valid())
+    {
+        result.get<sol::table>()["start"];
+        ShowInfo("Started script debugger");
+    }
+    else
+    {
+        ShowInfo("Failed to start script debugger");
+    }
 }
 
 /**


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds support for the vscode extension "Local Lua Debugger" that can be found here.
https://marketplace.visualstudio.com/items?itemName=tomblind.local-lua-debugger-vscode

This code attempts to startup the lldebugger during lua initialization but this only occurs if running xi_map.exe through the vscode debugger. Once it is started you can set breakpoints in vscode using `lldebugger.requestBreak()`. On my own game engine I am able to set breakpoints without the script line but it appears like that line is needed here for now. It must be some environmental issue but I do not know what that is yet.

![image](https://user-images.githubusercontent.com/1189557/191558109-41fa02d6-27a9-44c9-96e2-000317ad2640.png)

## Steps to test these changes

Go into some lua code and add `lldebugger.requestBreak()`. In vscode go to the `Run and Debug (Ctrl+Shft+D)` and change the current configuration to `(Windows) xi_map Scripts` and start the debugger. Now you can watch variables and enjoy a much more pleasant debugging experience!
