### PR TITLE
Adjustments to provide persistence to Hydra time-of-death

### DIFF
--- a/modules/custom/lua/persist_nm_time_of_deaths.lua
+++ b/modules/custom/lua/persist_nm_time_of_deaths.lua
@@ -16,6 +16,7 @@ local m = Module:new("persist_nm_time_of_deaths")
 local nms_to_persist =
 {
     { "Behemoths_Dominion", "Behemoth", function() return 75600 + math.random(0, 6) * 1800 end }, -- 21 - 24 hours with half hour windows
+    { "Wajaom_Woodlands", "Hydra", function() return 172800 + math.random(0, 24) * 3600 end }, -- 2 - 3 days with 1-hour windows
 }
 
 -- NOTE: At the time we iterate over these entries, the Lua zone and mob objects won't be ready,

--- a/scripts/zones/Wajaom_Woodlands/IDs.lua
+++ b/scripts/zones/Wajaom_Woodlands/IDs.lua
@@ -52,6 +52,7 @@ zones[xi.zone.WAJAOM_WOODLANDS] =
         },
         ZORAAL_JA_S_PKUUCHA    = 16986197,
         PERCIPIENT_ZORAAL_JA   = 16986198,
+        HYDRA                  = 16986355,
         VULPANGUE              = 16986428,
         IRIZ_IMA               = 16986429,
         GOTOH_ZHA_THE_REDOLENT = 16986430,

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -16,8 +16,6 @@ end
 zone_object.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helm.type.HARVESTING)
     xi.chocobo.initZone(zone)
-    UpdateNMSpawnPoint(ID.mob.HYDRA)
-    GetMobByID(ID.mob.HYDRA):setRespawnTime(math.random(48, 72) * 3600)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -16,6 +16,8 @@ end
 zone_object.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helm.type.HARVESTING)
     xi.chocobo.initZone(zone)
+    UpdateNMSpawnPoint(ID.mob.HYDRA)
+    GetMobByID(ID.mob.HYDRA):setRespawnTime(math.random(48, 72) * 3600)
 end
 
 zone_object.onZoneIn = function(player, prevZone)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -2496,7 +2496,7 @@ INSERT INTO `mob_groups` VALUES (34,4364,51,'Woodtroll_Dark_Knight',300,0,2480,0
 INSERT INTO `mob_groups` VALUES (35,4368,51,'Woodtroll_Ranger',330,0,2485,0,0,72,73,0);
 INSERT INTO `mob_groups` VALUES (36,5863,51,'Gharial',7200,0,3075,16000,0,82,83,0);
 INSERT INTO `mob_groups` VALUES (37,71,51,'Air_Elemental',330,4,38,0,0,75,75,0);
-INSERT INTO `mob_groups` VALUES (38,2018,51,'Hydra',172800,0,3147,73000,0,80,80,0);
+INSERT INTO `mob_groups` VALUES (38,2018,51,'Hydra',0,0,3147,73000,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (39,2534,51,'Mamool_Ja_Sophist',300,0,1602,0,0,72,73,0);
 INSERT INTO `mob_groups` VALUES (40,2508,51,'Mamool_Ja_Bounder',300,0,1588,0,0,72,73,0);
 INSERT INTO `mob_groups` VALUES (41,2533,51,'Mamool_Ja_Savant',300,0,1602,0,0,72,73,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Currently, Hydra will not persist even if added to the `persist_nm_time_of_deaths` module. This is because mobs get initialized and spawned before zones' onInitialize gets called, so the module isn't having the intended effect (in this case) because the mob is already spawned. 

By setting the respawntime to 0 in the database, and handing this process off to Lua, we are preventing the mob from automatically spawning and allowing the module to do the work.

## Steps to test these changes

1. kill mob, wait for despawn, watch log for 'writing server variable'.
2. check '[Respawn]Hydra', confirm it has incremented. convert it to earth time
3. restart the map server, notice the mob is not automatically spawned
4. wait for [Respawn]Hydra to == earth time and mob should spawn.

For testing, i decreased the spawn times to 1 - 3 minutes in the Hydra.lua
