### PR TITLE
Fixed Haste Augments to work correctly 

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -75,8 +75,8 @@ INSERT INTO `augments` VALUES (45,0,366,1,0,0); -- DMG:+1 (melee,not ranged...Ma
 INSERT INTO `augments` VALUES (46,0,366,-1,0,0); -- DMG:-1 (melee,not ranged...Mainhand only?)
 INSERT INTO `augments` VALUES (47,0,380,1,0,0); -- Delay:+1% (melee,not ranged)
 INSERT INTO `augments` VALUES (48,0,380,-1,0,0); -- Delay:-1% (melee,not ranged)
-INSERT INTO `augments` VALUES (49,0,384,100,0,0); -- Haste+1
-INSERT INTO `augments` VALUES (50,0,384,-100,0,0); -- Slow+1
+INSERT INTO `augments` VALUES (49,100,384,1,0,0); -- Haste+1
+INSERT INTO `augments` VALUES (50,100,384,-1,0,0); -- Slow+1
 INSERT INTO `augments` VALUES (51,0,72,1,0,0); -- HP recovered while healing+1
 INSERT INTO `augments` VALUES (52,0,71,1,0,0); -- MP recovered while healing+1
 INSERT INTO `augments` VALUES (53,0,168,-1,0,0); -- Spell interruption rate down 1%


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](ht ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

was having issue where haste augment wasn't reading like it should it was returning a value of 105 on augmented gear made changes 

i equipped a piece of augmented gear did !getmod 384 it returned 105 value then i changed the value to 1 and the multiplier to 100 and did !getmod 384 again and got the 600 value it should be 

i did the same steps for slow as well with the same results changing the value to -1 and the multiplier to 100 fixed the issue for slow 

## Steps to test these changes



<!-- Clear and detailed steps to test your changes here -->

<img width="409" alt="Screenshot 2022-09-22 012358" src="https://user-images.githubusercontent.com/1095718/191670195-c9caa6c2-5c9a-4bfc-a1d0-2bf173a69f60.png">

<img width="426" alt="Screenshot 2022-09-22 012407" src="https://user-images.githubusercontent.com/1095718/191670218-0bac7c8a-fbbe-40fa-a70d-8a575fc730e7.png">

<img width="376" alt="Screenshot 2022-09-22 014102" src="https://user-images.githubusercontent.com/1095718/191670252-48b346cf-9a5c-4b36-aba4-2ddf3f43fcb8.png">

<img width="393" alt="Screenshot 2022-09-22 014354" src="https://user-images.githubusercontent.com/1095718/191670423-c57195ca-c08c-4bb0-b634-816c661235d5.png">

<img width="377" alt="Screenshot 2022-09-22 014411" src="https://user-images.githubusercontent.com/1095718/191670452-dfa623db-a4f3-480d-a1cc-aab2c1e4527a.png">

<img width="380" alt="Screenshot 2022-09-22 014907" src="https://user-images.githubusercontent.com/1095718/191670466-9a54fa7a-9ff5-4322-98b0-32179de0f691.png">
