### PR TITLE
Unify status type between cpp and lua to have MOB rather than UPDATE

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -84,7 +84,7 @@ xi.race =
 xi.status =
 {
     NORMAL          =  0,
-    UPDATE          =  1,
+    MOB             =  1,
     DISAPPEAR       =  2,
     INVISIBLE       =  3,
     STATUS_4        =  4,

--- a/scripts/globals/voidwalker.lua
+++ b/scripts/globals/voidwalker.lua
@@ -470,7 +470,7 @@ xi.voidwalker.onHealing = function(player)
         end
         mob:hideName(false)
         mob:setUntargetable(false)
-        mob:setStatus(xi.status.UPDATE)
+        mob:setStatus(xi.status.MOB)
         mob:updateClaim(player)
     elseif mobNearest.distance >= 300 then
         player:messageSpecial(zoneTextTable.VOIDWALKER_MOB_TOO_FAR, mobNearest.keyItem)

--- a/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
@@ -52,7 +52,7 @@ entity.onMobFight = function(mob, target)
             mobPet:updateEnmity(target)
             mobPet:setPos(mobPos.x, mobPos.y, mobPos.z, mobPos.rot)
             mob:setLocalVar("popTime", os.time())
-            mobPet:setStatus(xi.status.UPDATE)
+            mobPet:setStatus(xi.status.MOB)
             mobPet:timer(1000, function(mobArg) mobArg:useMobAbility(1838) end)
             mobPet:timer(4000, function(mobArg) mobArg:setStatus(xi.status.DISAPPEAR) end)
         end

--- a/scripts/zones/Nyzul_Isle/mobs/Gem_Heister_Roorooroon.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Gem_Heister_Roorooroon.lua
@@ -54,7 +54,7 @@ local function dropBomb(mob)
     local pos      = mob:getPos()
 
     bombMob:setPos(pos.x, pos.y, pos.z, pos.rot)
-    bombMob:setStatus(xi.status.UPDATE)
+    bombMob:setStatus(xi.status.MOB)
 
     if target ~= nil then
         bombMob:updateEnmity(target)

--- a/scripts/zones/Nyzul_Isle/mobs/Stealth_Bomber_Gagaroon.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Stealth_Bomber_Gagaroon.lua
@@ -54,7 +54,7 @@ local function dropBomb(mob)
     local pos      = mob:getPos()
 
     bombMob:setPos(pos.x, pos.y, pos.z, pos.rot)
-    bombMob:setStatus(xi.status.UPDATE)
+    bombMob:setStatus(xi.status.MOB)
 
     if target ~= nil then
         bombMob:updateEnmity(target)

--- a/scripts/zones/RoMaeve/mobs/Shikigami_Weapon.lua
+++ b/scripts/zones/RoMaeve/mobs/Shikigami_Weapon.lua
@@ -53,7 +53,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobEngaged = function(mob, target)
-    mob:setStatus(xi.status.UPDATE)
+    mob:setStatus(xi.status.MOB)
 end
 
 entity.onMobDisengage = function(mob)

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -44,7 +44,7 @@ enum ENTITYTYPE : uint8
 enum class STATUS_TYPE : uint8
 {
     NORMAL        = 0,
-    MOB           = 1, // STATUS_UPDATE = 1,
+    MOB           = 1,
     DISAPPEAR     = 2,
     INVISIBLE     = 3,
     STATUS_4      = 4,


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

A little bit of code cleanup to unify the status type names between c++ and lua

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
