### PR TITLE
Implement Save and Load of Equipment on Job Change

### DIFF
--- a/sql/char_equip_saved.sql
+++ b/sql/char_equip_saved.sql
@@ -1,0 +1,26 @@
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+-- ----------------------------
+-- Table structure for char_equip_saved
+-- ----------------------------
+DROP TABLE IF EXISTS `char_equip_saved`;
+CREATE TABLE IF NOT EXISTS `char_equip_saved` (
+    `charid` int(10) unsigned NOT NULL,
+    `jobid` tinyint(2) unsigned NOT NULL,
+    `main` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `sub` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ranged` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ammo` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `head` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `body` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `hands` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `legs` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `feet` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `neck` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `waist` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ear1` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ear2` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ring1` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `ring2` smallint(5) unsigned NOT NULL DEFAULT '0',
+    `back` smallint(5) unsigned NOT NULL DEFAULT '0',
+    PRIMARY KEY (`charid`, `jobid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 AVG_ROW_LENGTH=20;

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -47,6 +47,7 @@ BEGIN
     DELETE FROM `char_blacklist`  WHERE `charid_owner` = OLD.charid;
     DELETE FROM `char_effects`    WHERE `charid` = OLD.charid;
     DELETE FROM `char_equip`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_equip_saved` WHERE `charid` = OLD.charid;
     DELETE FROM `char_exp`        WHERE `charid` = OLD.charid;
     DELETE FROM `char_history`    WHERE `charid` = OLD.charid;
     DELETE FROM `char_inventory`  WHERE `charid` = OLD.charid;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6798,6 +6798,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
             JOBTYPE prevjob = PChar->GetMJob();
             PChar->resetPetZoningInfo();
 
+            charutils::SaveJobChangeGear(PChar);
             charutils::RemoveAllEquipment(PChar);
             PChar->SetMJob(mjob);
             PChar->SetMLevel(PChar->jobs.job[PChar->GetMJob()]);
@@ -6865,6 +6866,7 @@ void SmallPacket0x100(map_session_data_t* const PSession, CCharEntity* const PCh
         PChar->PRecastContainer->ChangeJob();
         charutils::BuildingCharAbilityTable(PChar);
         charutils::BuildingCharWeaponSkills(PChar);
+        charutils::LoadJobChangeGear(PChar);
 
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DISPELABLE | EFFECTFLAG_ROLL | EFFECTFLAG_ON_JOBCHANGE);
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -115,6 +115,8 @@ namespace charutils
     void   DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity, uint16 ItemID);
     void   CheckValidEquipment(CCharEntity* PChar);
     void   CheckEquipLogic(CCharEntity* PChar, SCRIPTTYPE ScriptType, uint32 param);
+    void   SaveJobChangeGear(CCharEntity* PChar);
+    void   LoadJobChangeGear(CCharEntity* PChar);
     void   EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
     void   UnequipItem(CCharEntity* PChar, uint8 equipSlotID,
                        bool update = true); // call with update == false to prevent calls to UpdateHealth() - used for correct handling of stats on armor swaps

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -64,6 +64,7 @@ player_data = [
     'char_blacklist.sql',
     'char_effects.sql',
     'char_equip.sql',
+    'char_equip_saved.sql',
     'char_exp.sql',
     'char_history.sql',
     'char_inventory.sql',


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
+ Implements the saving of the last equipped gear on a job prior to a job change.
+ Implements the loading of the last equipped gear when changing to a different job.

Notes:
+ This will equip items of the same itemID in different slots by looking for unique pointers.
+ The load function is further down in the call stack as to allow for the propagation of the dual wield trait.
+ The system does allow for the moving of items between containers then re-equipping of them.
+ The system only allows for re-equipping of gear that is field accessible.

## Steps to test these changes
+ Tested by swapping between jobs in a Moghouse with varying levels of equipment (sometimes blank slots, sometimes a full equipment screen).
+ Tested by equipping items from other inventories besides the inventory itself.
+ Tested by moving an item from one inventory to another and changing jobs.
+ Tested equipping gear from Mog Safe which failed as intended.
+ Tested equipping a deleted item which did not equip anything as intended.
+ Tested equipping items with the same itemID in both the same container and in separate containers, which resulted in both items being equipped.
+ Tested with 2 Kunai on a NIN was reequipped when changing from NIN -> another job -> NIN.
