### PR TITLE
[sql] Commitment Status Effect Flags

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -599,7 +599,7 @@ INSERT INTO `status_effects` VALUES (575,'gestation',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (576,'doubt',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (577,'cait_siths_favor',32,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (578,'fishy_intuition',32,0,0,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (579,'commitment',32,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (579,'commitment',0,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (580,'geo_haste',8388640,0,0,0,0,0,3,0,0);
 INSERT INTO `status_effects` VALUES (581,'flurry_ii',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (583,'apogee',2097185,0,0,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Update Commitment Flags to match Dedication.
Job Change/BCNM/Death/Dispel/etc should not remove effect.

## Steps to test these changes

Gain Commitment Effect
Change Jobs, get Murdered, etc
Observe Effect does not drop
