### PR TITLE
[lua] Update Reactor Cool Blue Magic to match Retail Behavior

### DIFF
--- a/scripts/globals/spells/blue/reactor_cool.lua
+++ b/scripts/globals/spells/blue/reactor_cool.lua
@@ -25,10 +25,10 @@ spell_object.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spell_object.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.ICE_SPIKES
-    local typeEffectTwo = xi.effect.DEFENSE_BOOST
-    local powerOne = 5
-    local powerTwo = 12
+    local typeEffectOne = xi.effect.DEFENSE_BOOST
+    local typeEffectTwo = xi.effect.ICE_SPIKES
+    local powerOne = 12
+    local powerTwo = 5
     local duration = 120
     local returnEffect = typeEffectOne
 
@@ -42,17 +42,15 @@ spell_object.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if (target:addStatusEffect(typeEffectOne, powerOne, 0, duration) == false and target:addStatusEffect(typeEffectTwo, powerTwo, 0, duration) == false) then -- both statuses fail to apply
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    elseif (target:addStatusEffect(typeEffectOne, powerOne, 0, duration) == false) then -- the first status fails to apply
-        target:addStatusEffect(typeEffectTwo, powerTwo, 0, duration)
-        spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
-        returnEffect = typeEffectTwo
-    else
-        target:addStatusEffect(typeEffectOne, powerOne, 0, duration)
-        target:addStatusEffect(typeEffectTwo, powerTwo, 0, duration)
-        spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
+    -- Reactor Cool Will Overwrite Ice Spikes and Def Boost regardless of Power
+    if target:hasStatusEffect(typeEffectOne) or target:hasStatusEffect(typeEffectTwo) then
+        target:delStatusEffectSilent(typeEffectOne)
+        target:delStatusEffectSilent(typeEffectTwo)
     end
+
+    target:addStatusEffect(typeEffectOne, powerOne, 0, duration)
+    target:addStatusEffect(typeEffectTwo, powerTwo, 0, duration)
+    spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
 
     return returnEffect
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Updates Reactor Cool Script:
Reorder effects to give correct "gains the effect of" message. 
Simplify/Remove conditional effect gain checks as Reactor Cool will explicitly (and silently) overwrite DEF BOOST and ICE SPIKES effects 
Add DEF BOOST and ICE SPIKES

Source: Retail observations as BLU99/BLM49 (steps taken to verify below)

## Steps to test these changes

Cast Ice Spikes
Cast Cocoon
`/checkparam`
Note Increased Defense +50%
Cast Reactor Cool
Note Event Log "... gains effect of Defense Boost" 
Note Event Log no lose effect messages
`/checkparam`
Note Defense now only increased by +12% instead of +50% 
Note that SE Status Timers reset to higher duration