### PR TITLE
[core] Segfault fixes

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -270,6 +270,11 @@ namespace luautils
         return 0;
     }
 
+    void cleanup()
+    {
+        moduleutils::CleanupLuaModules();
+    }
+
     /************************************************************************
      *                                                                       *
      *  Освобождение lua                                                     *

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -122,6 +122,7 @@ namespace luautils
     int32 init();
     int32 garbageCollectStep();
     int32 garbageCollectFull();
+    void  cleanup();
 
     void ReloadFilewatchList();
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -366,7 +366,7 @@ void do_final(int code)
 
     timer_final();
     socket_final();
-
+    luautils::cleanup();
     logging::ShutDown();
 
     if (code != EXIT_SUCCESS)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -341,10 +341,11 @@ namespace battleutils
      ************************************************************************/
     void FreePetSkillList()
     {
-        for (auto iter = g_PPetSkillList.begin(); iter != g_PPetSkillList.end();)
+        for (auto& petskill : g_PPetSkillList)
         {
-            g_PPetSkillList.erase(iter);
+            delete petskill.second;
         }
+        g_PPetSkillList.clear();
     }
 
     /************************************************************************

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -205,6 +205,11 @@ namespace moduleutils
         }
     }
 
+    void CleanupLuaModules()
+    {
+        overrides.clear();
+    }
+
     void TryApplyLuaModules()
     {
         for (auto& override : overrides)

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -103,6 +103,7 @@ namespace moduleutils
     // problems.
 
     void LoadLuaModules();
+    void CleanupLuaModules();
     void TryApplyLuaModules();
     void ReportLuaModuleUsage();
 }; // namespace moduleutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjusts petskill cleanup to not segfault (apparently, the delete call was deleting the iterator)
Add lua module cleanup. It seems that modules were being cleaned up as one of the last exit steps automatically as things were going out of scope, and lua modules were trying to cleanup after the Lua state disappeared, so I gathered.

## Steps to test these changes

Build on linux, start xi_map, type "exit", receive no segfault.
