### PR TITLE
Add !skipcs helper

### DIFF
--- a/scripts/commands/skipcs.lua
+++ b/scripts/commands/skipcs.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- func: skipcs
+-- desc: Functions the same as `!release`, but also sends the packet that
+--       triggers the onEventFinish logic for a cutscene.
+--       If no arguments are given, option will default to 0.
+--       You can optionally pass in the option for the cs.
+--   ex: !skipcs 1000
+--     : Calls: onEventFinish(player, csid, option, npc)
+--     : csid: the cs you're in, option: 1000
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "s"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!skipcs (option)")
+end
+
+function onTrigger(player, option)
+    local target = nil
+
+    local cursorTarget = player:getCursorTarget()
+    if cursorTarget then
+        target = cursorTarget
+    else
+        target = player
+    end
+
+    target:skipEvent(option)
+
+    -- NOTE: Since sending a release packet out-of-line can get the client's camera stuck in the middle
+    --     : of the cutscene, we force a zone to the same spot to reset the camera's position.
+    target:setPos(target:getXPos(), target:getYPos(), target:getZPos(), target:getRotPos(), target:getZoneID())
+end

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -93,11 +93,12 @@ public:
     void updateEvent(sol::variadic_args va);       // Updates event
     void updateEventString(sol::variadic_args va); // (string, string, string, string, uint32, ...)
     auto getEventTarget() -> std::optional<CLuaBaseEntity>;
-    bool isInEvent();       // Returns true if the player is in an event
-    void release();         // Stops event
-    bool startSequence();   // Flags the player as being in a sequence
-    bool didGetMessage();   // Used by interaction framework to determine if player triggered something else
-    void resetGotMessage(); // Used by interaction framework to reset if player triggered something else
+    bool isInEvent();                      // Returns true if the player is in an event
+    void release();                        // Stops event
+    void skipEvent(sol::variadic_args va); // Stops event, and triggers the onEventFinished chain of events for that event
+    bool startSequence();                  // Flags the player as being in a sequence
+    bool didGetMessage();                  // Used by interaction framework to determine if player triggered something else
+    void resetGotMessage();                // Used by interaction framework to reset if player triggered something else
 
     void  setFlag(uint32 flags);
     uint8 getMoghouseFlag();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds `!skipcs` and skipEvent() to do as the name implies, there are notes about the limitations in the implementations

## Steps to test these changes

- Make a new character
- Zone into Port Jeuno
- Get the long CS
- !skipcs
- Get zoned, and have the CS marked as finished, won't fire again like if you had used `!release`