### PR TITLE
[core] [Linux] Add crash detect message to warn user of long error generation time

### DIFF
--- a/src/common/debug_linux.cpp
+++ b/src/common/debug_linux.cpp
@@ -8,6 +8,8 @@
 
 void dumpBacktrace(int signal)
 {
+    ShowCritical("Crash detected, generating traceback (this may take a while)");
+
     backward::StackTrace trace;
     backward::Printer    printer;
 

--- a/src/common/debug_osx.cpp
+++ b/src/common/debug_osx.cpp
@@ -8,6 +8,8 @@
 
 void dumpBacktrace(int signal)
 {
+    ShowCritical("Crash detected, generating traceback (this may take a while)");
+
     backward::StackTrace trace;
     backward::Printer    printer;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Does what it says on the tin,

Adds a log message to warn the user when a crash is detected that it may take a while to generate the traceback.
## Steps to test these changes

use `crash` command on xi_map and see the message.