### PR TITLE
Imps regain horns after some time

### DIFF
--- a/scripts/mixins/families/imp.lua
+++ b/scripts/mixins/families/imp.lua
@@ -6,9 +6,24 @@ g_mixins.families = g_mixins.families or {}
 g_mixins.families.imp = function(impMob)
 
     -- 20% chance to break horn on critical hit
+    -- Reacquires horn in stages of 30, 35, 40, 45, and a very rare 60 seconds
     impMob:addListener("CRITICAL_TAKE", "IMP_CRITICAL_TAKE", function(mob)
-        if math.random(100) < 20 and mob:getAnimationSub() == 0 then
+        local random = math.random(100)
+        if random < 20 and mob:getAnimationSub() == 0 then
             mob:setAnimationSub(1)
+            if mob:getLocalVar("hornDisabled") ~= 1 then
+                local time = 0
+                if random <= 2 then
+                    time = 60
+                else
+                    time = 25 + (math.ceil(random / 5) * 5)
+                end
+                mob:timer(time * 1000, function(mobArg)
+                    if mob:isAlive() then
+                        mob:setAnimationSub(0)
+                    end
+                end)
+            end
         end
     end)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

retail testing shows that Imps regain their horns at varying times of 30, 35, 40, 45, and 60 seconds which is very rare to see
uses the same random that causes the horn to break to apply the time that it will reapply it  (1,19)

## Steps to test these changes

fight an imp, with godmode to hit the crits
once horn breaks turn back to it and withon 60s it will get a new one
