### PR TITLE
reset mobs ability list on a full roam heal

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -825,6 +825,7 @@ void CMobController::DoRoamTick(time_point tick)
                     PMob->m_HiPCLvl     = 0;
                     PMob->m_HiPartySize = 0;
                     PMob->m_giveExp     = true;
+                    PMob->m_UsedSkillIds.clear();
                 }
             }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

resets the ability list a mob generates while fighting on a full heal roam cycle.

fixes scenario:
player A fights mob and either dies or runs away after it did the TP move a bluemage could learn
later down the line player B (a bluemage) comes and kills the same mob and it never did the TP move that they wanted to learn yet they still learned it because it was retained in memory

## Steps to test these changes

detailed in above
