### PR TITLE
Add survival guide unlocks to map marker packet

### DIFF
--- a/src/map/packets/map_marker.cpp
+++ b/src/map/packets/map_marker.cpp
@@ -41,5 +41,15 @@ CMapMarkerPacket::CMapMarkerPacket(CCharEntity* PChar)
     ref<uint16>(0x14) = PChar->teleport.homepoint.access[3] & 0xFFFF;
     ref<uint16>(0x16) = (PChar->teleport.homepoint.access[3] & 0xFFFF0000) >> 16;
 
-    // TODO: Cavernous Maws, Abyssea Maws, Survival Guides
+    // Survival guide masks
+    ref<uint16>(0x18) = PChar->teleport.survival.access[0] & 0xFFFF;
+    ref<uint16>(0x1A) = (PChar->teleport.survival.access[0] & 0xFFFF0000) >> 16;
+    ref<uint16>(0x1C) = PChar->teleport.survival.access[1] & 0xFFFF;
+    ref<uint16>(0x1E) = (PChar->teleport.survival.access[1] & 0xFFFF0000) >> 16;
+    ref<uint16>(0x20) = PChar->teleport.survival.access[2] & 0xFFFF;
+    ref<uint16>(0x22) = (PChar->teleport.survival.access[2] & 0xFFFF0000) >> 16;
+    ref<uint16>(0x24) = PChar->teleport.survival.access[3] & 0xFFFF;
+    ref<uint16>(0x26) = (PChar->teleport.survival.access[3] & 0xFFFF0000) >> 16;
+
+    // TODO: Abyssea Maws, Waypoints
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds survival guide unlock data to `CMapMarkerPacket`.  This stops them from flashing on the map when the player has unlocked.

Closes #2798 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Check map with survival guide not unlocked -> See flashing icon
Unlock survival guide -> See non-flashing icon
<!-- Clear and detailed steps to test your changes here -->
