### PR TITLE
[codeql] Add codeql-config.yml and fix some time syscalls

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "codeql config"
+
+# Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+queries:
+  - uses: security-extended
+  - uses: security-and-quality

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "codeql"
 
 on:
   push:
@@ -45,14 +45,10 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        queries: +security-and-quality
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
+        config-file: ./.github/codeql/codeql-config.yml
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
@@ -65,7 +61,8 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines. 
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - name: Configure and Build
+    - if: matrix.language == 'cpp'
+      name: Configure and Build
       run: |
         mkdir -p build
         CFLAGS=-m64 CXXFLAGS=-m64 LDFLAGS=-m64 cmake -S . -B build
@@ -73,3 +70,21 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        # https://josh-ops.com/posts/github-codeql-ignore-files/
+        upload: false # disable the upload here - we will upload in a different action
+        output: sarif-results
+
+    - name: Filter SARIF
+      uses: zbazztian/filter-sarif@master
+      with:
+        patterns: |
+          -ext/**/*
+          -build/**/*
+        input: sarif-results/${{ matrix.language }}.sarif
+        output: sarif-results/${{ matrix.language }}.sarif
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -85,6 +85,6 @@ jobs:
         output: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -55,6 +55,20 @@ using uint64 = std::uint64_t;
 #if !defined(_MSC_VER)
 #define strcmpi strcasecmp
 #define stricmp strcasecmp
+
+// https://stackoverflow.com/questions/12044519/what-is-the-windows-equivalent-of-the-unix-function-gmtime-r
+// gmtime_r() is the thread-safe version of gmtime(). The MSVC implementation of gmtime() is already thread safe,
+// the returned struct tm* is allocated in thread-local storage.
+// That doesn't make it immune from trouble if the function is called multiple times on the same
+// thread and the returned pointer is stored.
+// You can use gmtime_s() instead. Closest to gmtime_r() but with the arguments reversed
+
+// Provide func_s implementations for Unix
+#define _gmtime_s(a, b)    gmtime_r(b, a)
+#define _localtime_s(a, b) localtime_r(b, a)
+#else // MSVC
+#define _gmtime_s(a, b)    gmtime_s(a, b)
+#define _localtime_s(a, b) localtime_s(a, b)
 #endif
 
 #include <chrono>

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -464,12 +464,12 @@ int32 lobbydata_parse(int32 fd)
                     // Log clients IP info when player spawns into map server
 
                     time_t rawtime;
-                    tm*    convertedTime;
+                    tm     convertedTime;
                     time(&rawtime);
-                    convertedTime = localtime(&rawtime);
+                    _localtime_s(&convertedTime, &rawtime);
 
                     char timeAndDate[128];
-                    strftime(timeAndDate, sizeof(timeAndDate), "%Y:%m:%d %H:%M:%S", convertedTime);
+                    strftime(timeAndDate, sizeof(timeAndDate), "%Y:%m:%d %H:%M:%S", &convertedTime);
 
                     fmtQuery = "INSERT INTO account_ip_record(login_time,accid,charid,client_ip)\
                             VALUES ('%s', %u, %u, '%s');";

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -271,13 +271,13 @@ int32 login_parse(int32 fd)
 
                     // creating new account
                     time_t timecreate;
-                    tm*    timecreateinfo;
+                    tm     timecreateinfo;
 
                     time(&timecreate);
-                    timecreateinfo = localtime(&timecreate);
+                    _localtime_s(&timecreateinfo, &timecreate);
 
                     char strtimecreate[128];
-                    strftime(strtimecreate, sizeof(strtimecreate), "%Y:%m:%d %H:%M:%S", timecreateinfo);
+                    strftime(strtimecreate, sizeof(strtimecreate), "%Y:%m:%d %H:%M:%S", &timecreateinfo);
                     fmtQuery = "INSERT INTO accounts(id,login,password,timecreate,timelastmodify,status,priv)\
                                        VALUES(%d,'%s',PASSWORD('%s'),'%s',NULL,%d,%d);";
 

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -89,99 +89,125 @@ uint32 CVanaTime::getWeekday() const
 uint32 CVanaTime::getSysHour()
 {
     time_t now = time(nullptr);
-    tm*    ltm = localtime(&now);
+    tm     ltm;
 
-    return ltm->tm_hour;
+    _localtime_s(&ltm, &now);
+
+    return ltm.tm_hour;
 }
 
 uint32 CVanaTime::getSysMinute()
 {
     time_t now = time(nullptr);
-    tm*    ltm = localtime(&now);
+    tm     ltm;
 
-    return ltm->tm_min;
+    _localtime_s(&ltm, &now);
+
+    return ltm.tm_min;
 }
 
 uint32 CVanaTime::getSysSecond()
 {
     time_t now = time(nullptr);
-    tm*    ltm = localtime(&now);
+    tm     ltm;
 
-    return ltm->tm_sec;
+    _localtime_s(&ltm, &now);
+
+    return ltm.tm_sec;
 }
 
 uint32 CVanaTime::getSysWeekDay()
 {
     time_t now = time(nullptr);
-    tm*    ltm = localtime(&now);
+    tm     ltm;
 
-    return ltm->tm_wday;
+    _localtime_s(&ltm, &now);
+
+    return ltm.tm_wday;
 }
 
 uint32 CVanaTime::getSysYearDay()
 {
     time_t now = time(nullptr);
-    tm*    ltm = localtime(&now);
+    tm     ltm;
 
-    return ltm->tm_yday;
+    _localtime_s(&ltm, &now);
+
+    return ltm.tm_yday;
 }
 
 uint32 CVanaTime::getJstHour()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_hour;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_hour;
 }
 
 uint32 CVanaTime::getJstMinute()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_min;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_min;
 }
 
 uint32 CVanaTime::getJstSecond()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_sec;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_sec;
 }
 
 uint32 CVanaTime::getJstWeekDay()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_wday;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_wday;
 }
 
 uint32 CVanaTime::getJstDayOfMonth()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_mday;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_mday;
 }
 
 uint32 CVanaTime::getJstYearDay()
 {
     auto now = time(nullptr) + JST_OFFSET;
-    tm*  jtm = gmtime(&now);
+    tm   jtm;
 
-    return jtm->tm_yday;
+    _gmtime_s(&jtm, &now);
+
+    return jtm.tm_yday;
 }
 
 uint32 CVanaTime::getJstMidnight()
 {
-    auto now     = time(nullptr) + JST_OFFSET;
-    tm*  jst     = gmtime(&now);
-    jst->tm_hour = 0;
-    jst->tm_min  = 0;
-    jst->tm_sec  = 0;
-    return static_cast<uint32>(timegm(jst) - JST_OFFSET + (60 * 60 * 24)); // Unix timestamp of the upcoming JST midnight
+    auto now = time(nullptr) + JST_OFFSET;
+    tm   jst;
+
+    _gmtime_s(&jst, &now);
+
+    jst.tm_hour = 0;
+    jst.tm_min  = 0;
+    jst.tm_sec  = 0;
+
+    return static_cast<uint32>(timegm(&jst) - JST_OFFSET + (60 * 60 * 24)); // Unix timestamp of the upcoming JST midnight
 }
 
 uint32 CVanaTime::getVanaTime() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Excludes ext and build folders for codeql scanning

Fixes some warnings about time-related syscalls

```
Use of potentially dangerous function

This rule finds calls to functions that are dangerous to use. Currently, it checks for calls to gmtime, localtime, ctime and asctime.
```

## Steps to test these changes

Everything still works