### PR TITLE
[core] Adjust AoE job ability handling order to match single target, fix COR bust crash in AoE, fix AoE enmity not applying from JA

### DIFF
--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -380,7 +380,9 @@ xi.job_utils.rune_fencer.useVallationValiance = function(player, target, ability
     if player:getID() ~= target:getID() then -- Only the caster can apply effects, including to the party if valiance.
 
         if abilityID == xi.jobAbility.VALIANCE and target:hasStatusEffect(xi.effect.VALLATION) or target:hasStatusEffect(xi.effect.LIEMENT) then -- Valiance is being used on them, and they have Vallation already up or they have liement
-            action:messageID(target:getID(), xi.msg.basic.NO_EFFECT) -- "No effect on <Target>"
+            ability:setMsg(xi.msg.basic.NO_EFFECT) -- "No effect on <Target>"
+        else
+            ability:setMsg(xi.msg.basic.VALIANCE_GAIN_PARTY)
         end
         return
     end
@@ -416,15 +418,15 @@ xi.job_utils.rune_fencer.useVallationValiance = function(player, target, ability
                 if inspirationFCBonus > 0 then -- Inspiration FC is not applied unless Valiance is applied, tested on retail with 2 RUN in a party
                     member:addStatusEffect(xi.effect.FAST_CAST, inspirationFCBonus, 0, duration)
                 end
-            elseif member:getID() == player:getID() then -- caster has Vallation, set no effect message.
-                    action:messageID(player:getID(), xi.msg.basic.JA_NO_EFFECT_2) -- "<Player> uses Valiance.\nNo effect on <Player>."
+            elseif member:getID() == player:getID() then    -- caster has Vallation, set no effect message.
+                ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2) -- "<Player> uses Valiance.\nNo effect on <Player>."
             end
 
         end
     else -- apply effects to target (Vallation)
 
         if target:hasStatusEffect(xi.effect.LIEMENT) then -- no effect if Liement is up
-            action:messageID(player:getID(), xi.msg.basic.JA_NO_EFFECT_2)
+            ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
         else
             local duration = 120 + jobPointBonusDuration
 
@@ -625,7 +627,7 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
     end
 
     if shadowsHit == numHits and cumulativeDamage == 0 then
-        action:messageID(target:getID(), xi.msg.basic.SHADOW_ABSORB) -- set message to blinked hit(s)
+        ability:setMsg(xi.msg.basic.SHADOW_ABSORB) -- set message to blinked hit(s)
         action:reaction(target:getID(), xi.reaction.EVADE + xi.reaction.ABILITY) -- TODO: confirm these bit flags for reaction
 
         return shadowsHit
@@ -636,7 +638,7 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
     action:reaction(target:getID(), xi.reaction.HIT + xi.reaction.ABILITY)
 
     if cumulativeDamage < 0 or (cumulativeDamage == 0 and absorbed) then
-        action:messageID(target:getID(), xi.msg.basic.JA_RECOVERS_HP)
+        ability:setMsg(xi.msg.basic.JA_RECOVERS_HP)
     end
 
     if magicBursted then -- Note: the vanilla client does not report a healed magic burst, but this bit is set.

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1422,7 +1422,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
             PAI->TargetFind->findWithinArea(this, AOE_RADIUS::ATTACKER, distance);
 
-            uint16 msg = 0;
+            uint16 prevMsg = 0;
             for (auto&& PTarget : PAI->TargetFind->m_targets)
             {
                 actionList_t& actionList     = action.getNewActionList();
@@ -1432,24 +1432,28 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                 actionTarget.speceffect      = SPECEFFECT::NONE;
                 actionTarget.animation       = PAbility->getAnimationID();
                 actionTarget.messageID       = PAbility->getMessage();
+                actionTarget.param           = 0;
 
-                if (msg == 0)
-                {
-                    msg = PAbility->getMessage();
-                }
-                else
-                {
-                    msg = PAbility->getAoEMsg();
-                }
+                int32 value = luautils::OnUseAbility(this, PTarget, PAbility, &action);
 
-                if (actionTarget.param < 0)
+                if (prevMsg == 0) // get default message for the first target
                 {
-                    msg                = ability::GetAbsorbMessage(msg);
-                    actionTarget.param = -actionTarget.param;
+                    actionTarget.messageID = PAbility->getMessage();
+                }
+                else // get AoE message for second, if there's a manual override, otherwise return message from PAbility->getMessage().
+                {
+                    actionTarget.messageID = PAbility->getAoEMsg();
                 }
 
-                actionTarget.messageID = msg;
-                actionTarget.param     = luautils::OnUseAbility(this, PTarget, PAbility, &action);
+                actionTarget.param = value;
+
+                if (value < 0)
+                {
+                    actionTarget.messageID = ability::GetAbsorbMessage(prevMsg);
+                    actionTarget.param     = -actionTarget.param;
+                }
+
+                state.ApplyEnmity();
             }
         }
         else
@@ -1461,7 +1465,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             actionTarget.speceffect      = SPECEFFECT::RECOIL;
             actionTarget.animation       = PAbility->getAnimationID();
             actionTarget.param           = 0;
-            auto prevMsg                 = actionTarget.messageID;
+            uint16 prevMsg               = actionTarget.messageID;
 
             // Check for special situations from Steal (The Tenshodo Showdown quest)
             if (PAbility->getID() == ABILITY_STEAL)

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -144,7 +144,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
             PAI->TargetFind->findWithinArea(this, AOE_RADIUS::ATTACKER, distance);
 
-            uint16 msg = 0;
+            uint16 prevMsg = 0;
             for (auto&& PTarget : PAI->TargetFind->m_targets)
             {
                 actionList_t& actionList     = action.getNewActionList();
@@ -154,24 +154,28 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
                 actionTarget.speceffect      = SPECEFFECT::NONE;
                 actionTarget.animation       = PAbility->getAnimationID();
                 actionTarget.messageID       = PAbility->getMessage();
+                actionTarget.param           = 0;
 
-                if (msg == 0)
-                {
-                    msg = PAbility->getMessage();
-                }
-                else
-                {
-                    msg = PAbility->getAoEMsg();
-                }
+                int32 value = luautils::OnUseAbility(this, PTarget, PAbility, &action);
 
-                if (actionTarget.param < 0)
+                if (prevMsg == 0) // get default message for the first target
                 {
-                    msg                = ability::GetAbsorbMessage(msg);
-                    actionTarget.param = -actionTarget.param;
+                    actionTarget.messageID = PAbility->getMessage();
+                }
+                else // get AoE message for second, if there's a manual override, otherwise return message from PAbility->getMessage().
+                {
+                    actionTarget.messageID = PAbility->getAoEMsg();
                 }
 
-                actionTarget.messageID = msg;
-                actionTarget.param     = luautils::OnUseAbility(this, PTarget, PAbility, &action);
+                actionTarget.param = value;
+
+                if (value < 0)
+                {
+                    actionTarget.messageID = ability::GetAbsorbMessage(prevMsg);
+                    actionTarget.param     = -actionTarget.param;
+                }
+
+                state.ApplyEnmity();
             }
         }
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adjusts AoE JA handling to match single target, lua hooks into onUseAbility could not properly use action:setMsg. This caused a crash with code that was valid for single target, but invalid for AoE during busts for COR.

Adds enmity calculation back in for AoE JA usage, helps with #2400

Adjusts RUN messages to account for aforementioned action:setMsg issues, adds in a few explicit messages that were missing but working unintentionally previously due to stale message usage.

## Steps to test these changes

Go in a party, use phantom rolls on windower with timers on, doubleup until bust, don't crash
Use Vallation and then Valiance when in a party, see proper messages.
claim a mob, use !getenmity on a mob, wait for VE to hit 0, use an AoE ability like One For All, check !getenmity, note CE/VE has risen