### PR TITLE
[chore] Simplify logic in SqlConnection()

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -105,17 +105,13 @@ SqlConnection::SqlConnection(const char* user, const char* passwd, const char* h
 {
     TracyZoneScoped;
 
-    try
-    {
-        self = new Sql_t();
-    }
-    catch (const std::exception& e)
-    {
-        ShowCritical("Sql_t allocation failed!: %s", e.what());
-    }
+    self = new Sql_t();
 
-    mysql_init(&self->handle);
-    if (self == nullptr)
+    // Allocates or initializes a MYSQL object suitable for mysql_real_connect().
+    // If mysql is a NULL pointer, the function allocates, initializes, and returns a new object.
+    // Otherwise, the object is initialized and the address of the object is returned.
+    // If mysql_init() allocates a new object, it is freed when mysql_close() is called to close the connection.
+    if (mysql_init(&self->handle) == nullptr)
     {
         ShowCritical("mysql_init failed!");
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

I misunderstood what the codeql warning was complaining about.

`operator new` doesn't need to be null-checked, because if it fails it'll throw, rather than provide a nullptr.

This PR simplifies that section and comments it

## Steps to test these changes

Everything still works
