### PR TITLE
Fix default maximum value for equipped gearset pieces

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2569,7 +2569,7 @@ xi.gear_sets.checkForGearSet = function(player)
     -- Apply Mods for each set after boundary checking the counts.
     for setId, setCount in pairs(equippedSets) do
         local minEquippedReq = gearSets[setId].minEquipped and gearSets[setId].minEquipped or 2
-        local maxEquippedReq = gearSets[setId].maxEquipped and gearSets[setId].maxEquipped or 0
+        local maxEquippedReq = gearSets[setId].maxEquipped and gearSets[setId].maxEquipped or (xi.MAX_SLOTID + 1)
 
         if setCount >= minEquippedReq then
             local modTierIndex = math.min(setCount, maxEquippedReq) - minEquippedReq


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Sets the default maximum value for gear sets to 16 from 0, which caused error on sets without a value explicitly defined
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Equip Adhemar or War AF3 sets, see no error
<!-- Clear and detailed steps to test your changes here -->
