### PR TITLE
move assault points and zone out logic to rune of releases

### DIFF
--- a/scripts/globals/assault.lua
+++ b/scripts/globals/assault.lua
@@ -140,44 +140,46 @@ xi.assault.instanceOnEventFinish = function(player, csid, zone)
     end
 end
 
-xi.assault.runeReleaseFinish = function(player)
-    local instance = player:getInstance()
-    local chars = instance:getChars()
-    local zone = player:getZoneID()
-    local ID = zones[zone]
-    local playerpoints = math.max((#chars -3)*.1, 0)
-    local points = 0
-    local assaultID = player:getCurrentAssault()
-    local mobs = instance:getMobs()
-    local pointsArea = xi.assault.getAssaultArea(player)
+xi.assault.runeReleaseFinish = function(player, csid, option)
+    if csid == 100 and option == 1 then
+        local instance = player:getInstance()
+        local chars = instance:getChars()
+        local zone = player:getZoneID()
+        local ID = zones[zone]
+        local playerpoints = math.max((#chars -3)*.1, 0)
+        local points = 0
+        local assaultID = player:getCurrentAssault()
+        local mobs = instance:getMobs()
+        local pointsArea = xi.assault.getAssaultArea(player)
 
-    for _, entity in pairs(mobs) do
-        local mobID = entity:getID()
-        DespawnMob(mobID, instance)
-    end
+        for _, entity in pairs(mobs) do
+            local mobID = entity:getID()
+            DespawnMob(mobID, instance)
+        end
 
-    for _, entity in pairs(chars) do
-        if entity:getLocalVar("AssaultPointsAwarded") == 0 then
-            entity:setLocalVar("AssaultPointsAwarded", 1)
+        for _, entity in pairs(chars) do
+            if entity:getLocalVar("AssaultPointsAwarded") == 0 then
+                entity:setLocalVar("AssaultPointsAwarded", 1)
 
-            local pointModifier = xi.assault.missionInfo[assaultID].minimumPoints
-            points = pointModifier - (pointModifier * playerpoints)
-            if entity:getCharVar("Assault_Armband") == 1 then
-                points = points*(1.1)
+                local pointModifier = xi.assault.missionInfo[assaultID].minimumPoints
+                points = pointModifier - (pointModifier * playerpoints)
+                if entity:getCharVar("Assault_Armband") == 1 then
+                    points = points*(1.1)
+                end
+                if entity:hasCompletedAssault(assaultID) then
+                    points = math.floor(points)
+                    entity:setVar("AssaultPromotion", entity:getCharVar("AssaultPromotion") + 1)
+                    entity:addAssaultPoint(pointsArea, points)
+                    entity:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
+                else
+                    points = math.floor(points*(1.5))
+                    entity:setVar("AssaultPromotion", entity:getCharVar("AssaultPromotion") + 5)
+                    entity:addAssaultPoint(pointsArea, points)
+                    entity:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
+                end
+                entity:setVar("AssaultComplete",1)
+                entity:startEvent(102)
             end
-            if entity:hasCompletedAssault(assaultID) then
-                points = math.floor(points)
-                entity:setVar("AssaultPromotion", entity:getCharVar("AssaultPromotion") + 1)
-                entity:addAssaultPoint(pointsArea, points)
-                entity:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
-            else
-                points = math.floor(points*(1.5))
-                entity:setVar("AssaultPromotion", entity:getCharVar("AssaultPromotion") + 5)
-                entity:addAssaultPoint(pointsArea, points)
-                entity:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
-            end
-            entity:setVar("AssaultComplete",1)
-            entity:startEvent(102)
         end
     end
 end

--- a/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
@@ -3,8 +3,8 @@
 --  NPC: Rune of Release
 -- !pos 412 -9 54 55
 -----------------------------------
-local ID = require("scripts/zones/Ilrusi_Atoll/IDs")
-require("scripts/globals/besieged")
+require("scripts/globals/assault")
+require("scripts/globals/zone")
 -----------------------------------
 local entity = {}
 
@@ -14,7 +14,7 @@ end
 entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
-    if (instance:completed()) then
+    if instance:completed() then
         player:startEvent(100, 4)
     end
 
@@ -25,33 +25,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local instance = player:getInstance()
-    local chars = instance:getChars()
-    local id = instance:getID()
-    local points = 0
-    local playerpoints = ((#chars -3)*100)
-
-    if (csid == 100 and option == 1) then
-        if id == 41 or id == 43 then
-            points = 1100 - math.max(playerpoints, 0)
-        end
-        for i, v in pairs(chars) do
-            v:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
-            v:addAssaultPoint(ILRUSI_ASSAULT_POINT, points)
-            v:setCharVar("AssaultComplete", 1)
-            if (v:hasCompletedAssault(v:getCurrentAssault())) then
-                v:incrementCharVar("AssaultPromotion", 1)
-            else
-                v:incrementCharVar("AssaultPromotion", 5)
-            end
-            v:startEvent(102)
-        end
-    end
-    if csid == 102 then
-        for i, v in pairs(chars) do
-            v:setPos(0, 0, 0, 0, 54)
-        end
-    end
+    xi.assault.instanceOnEventFinish(player, csid, xi.zone.ARRAPAGO_REEF)
+    xi.assault.runeReleaseFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Lebros_Cavern/instances/excavation_duty.lua
+++ b/scripts/zones/Lebros_Cavern/instances/excavation_duty.lua
@@ -5,7 +5,6 @@ local ID = require("scripts/zones/Lebros_Cavern/IDs")
 require("scripts/globals/assault")
 require("scripts/globals/instance")
 require("scripts/globals/items")
-require("scripts/globals/zone")
 -----------------------------------
 local instance_object = {}
 
@@ -59,7 +58,6 @@ instance_object.onInstanceComplete = function(instance)
 end
 
 instance_object.onEventFinish = function(player, csid, option)
-    xi.assault.instanceOnEventFinish(player, csid, xi.zone.MOUNT_ZHAYOLM)
 end
 
 return instance_object

--- a/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
@@ -1,7 +1,8 @@
 -----------------------------------
 -- Area: Lebros Cavern
 -----------------------------------
-local ID = require("scripts/zones/Lebros_Cavern/IDs")
+require("scripts/globals/assault")
+require("scripts/globals/zone")
 -----------------------------------
 local entity = {}
 
@@ -9,49 +10,21 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local instance = npc:getInstance()
 
-    if (instance:completed()) then
+    if instance:completed() then
         player:startEvent(100, 2)
     end
 
     return 1
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    local instance = player:getInstance()
-    local chars = instance:getChars()
-    local id = instance:getID()
-    local points = 0
-    local playerpoints = ((#chars -3)*100)
-
-        if (csid == 100 and option == 1) then
-        if id == 21 or id == 23 then
-            points = 1000 - math.max(playerpoints, 0)
-        end
-        for i, v in pairs(chars) do
-            v:messageSpecial(ID.text.ASSAULT_POINTS_OBTAINED, points)
-            v:addAssaultPoint(LEBROS_ASSAULT_POINT, points)
-            v:setCharVar("AssaultComplete", 1)
-            if (v:hasCompletedAssault(v:getCurrentAssault())) then
-                v:incrementCharVar("AssaultPromotion", 1)
-            else
-                v:incrementCharVar("AssaultPromotion", 5)
-            end
-            v:startEvent(102)
-        end
-    end
-    if (csid == 102) then
-        for i, v in pairs(chars) do
-            v:setPos(0, 0, 0, 0, 61)
-        end
-    end
+    xi.assault.instanceOnEventFinish(player, csid, xi.zone.MOUNT_ZHAYOLM)
+    xi.assault.runeReleaseFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Leujaoam_Sanctum/instances/leujaoam_cleansing.lua
+++ b/scripts/zones/Leujaoam_Sanctum/instances/leujaoam_cleansing.lua
@@ -6,7 +6,6 @@ local ID = require("scripts/zones/Leujaoam_Sanctum/IDs")
 require("scripts/globals/assault")
 require("scripts/globals/instance")
 require("scripts/globals/items")
-require("scripts/globals/zone")
 -----------------------------------
 local instance_object = {}
 
@@ -60,7 +59,6 @@ instance_object.onInstanceComplete = function(instance)
 end
 
 instance_object.onEventFinish = function(player, csid, option)
-    xi.assault.instanceOnEventFinish(player, csid, xi.zone.CAEDARVA_MIRE)
 end
 
 return instance_object

--- a/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
@@ -3,6 +3,7 @@
 -- Rune of Release
 -----------------------------------
 require("scripts/globals/assault")
+require("scripts/globals/zone")
 -----------------------------------
 local entity = {}
 
@@ -23,9 +24,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 100 and option == 1 then
-        xi.assault.runeReleaseFinish(player)
-    end
+    xi.assault.instanceOnEventFinish(player, csid, xi.zone.CAEDARVA_MIRE)
+    xi.assault.runeReleaseFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Mamool_Ja_Training_Grounds/instances/imperial_agent_rescue.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/instances/imperial_agent_rescue.lua
@@ -6,7 +6,6 @@ local ID = require("scripts/zones/Mamool_Ja_Training_Grounds/IDs")
 require("scripts/globals/assault")
 require("scripts/globals/instance")
 require("scripts/globals/items")
-require("scripts/globals/zone")
 -----------------------------------
 local instance_object = {}
 
@@ -58,7 +57,6 @@ instance_object.onInstanceComplete = function(instance)
 end
 
 instance_object.onEventFinish = function(player, csid, option)
-    xi.assault.instanceOnEventFinish(player, csid, xi.zone.BHAFLAU_THICKETS)
 end
 
 return instance_object

--- a/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Mamool Ja Training Grounds
 -----------------------------------
-local ID = require("scripts/zones/Mamool_Ja_Training_Grounds/IDs")
 require("scripts/globals/assault")
+require("scripts/globals/zone")
 -----------------------------------
 local entity = {}
 
@@ -10,7 +10,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local instance = npc:getInstance()
 
     if instance:completed() then
@@ -18,16 +17,14 @@ entity.onTrigger = function(player, npc)
     end
 
     return 1
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 100 and option == 1 then
-        xi.assault.runeReleaseFinish(player)
-    end
+    xi.assault.instanceOnEventFinish(player, csid, xi.zone.BHAFLAU_THICKETS)
+    xi.assault.runeReleaseFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Periqia/instances/seagull_grounded.lua
+++ b/scripts/zones/Periqia/instances/seagull_grounded.lua
@@ -7,7 +7,6 @@ require("scripts/globals/instance")
 require("scripts/globals/items")
 require("scripts/globals/pathfind")
 require("scripts/globals/utils")
-require("scripts/globals/zone")
 -----------------------------------
 local instance_object = {}
 
@@ -62,7 +61,6 @@ instance_object.onInstanceComplete = function(instance)
 end
 
 instance_object.onEventFinish = function(player, csid, option)
-    xi.assault.instanceOnEventFinish(player, csid, xi.zone.CAEDARVA_MIRE)
 end
 
 instance_object.onTrack = function(instance)

--- a/scripts/zones/Periqia/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Periqia/npcs/Rune_of_Release.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Periqia/IDs")
 require("scripts/globals/assault")
+require("scripts/globals/zone")
 -----------------------------------
 local entity = {}
 
@@ -24,9 +25,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 100 and option == 1 then
-        xi.assault.runeReleaseFinish(player)
-    end
+    xi.assault.instanceOnEventFinish(player, csid, xi.zone.CAEDARVA_MIRE)
+    xi.assault.runeReleaseFinish(player, csid, option)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

since the cs for leaving an assault is from the rune of release it doesnt go through the instance lua, which is better anyway and reduces duplicated code in 50 assault when it can all be handled in 5 rune luas.


