### PR TITLE
Add Inundation and relevant scroll

### DIFF
--- a/scripts/globals/items/scroll_of_inundation.lua
+++ b/scripts/globals/items/scroll_of_inundation.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- ID: 5106
+-- Scroll of Inundation
+-- Teaches the white Inundation
+-----------------------------------
+local item_object = {}
+
+item_object.onItemCheck = function(target)
+    return target:canLearnSpell(xi.magic.spell.INUNDATION)
+end
+
+item_object.onItemUse = function(target)
+    target:addSpell(xi.magic.spell.INUNDATION)
+end
+
+return item_object

--- a/scripts/globals/spells/white/inundation.lua
+++ b/scripts/globals/spells/white/inundation.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Spell: Inundation
+-- Spell accuracy is most highly affected by Enfeebling Magic Skill, Magic Accuracy, and MND.
+-----------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+require("scripts/globals/utils")
+-----------------------------------
+local spell_object = {}
+
+spell_object.onMagicCastingCheck = function(caster, target, spell)
+    return 0
+end
+
+spell_object.onSpellCast = function(caster, target, spell)
+    target:addStatusEffect(xi.effect.INUNDATION, 1, 0, 300) --Inundated, 5min duration
+    spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
+    return xi.effect.INUNDATION
+end
+
+return spell_object


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [?] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Splits the inundation changes from the unrelated changes in PR: https://github.com/LandSandBoat/server/pull/2677

## Steps to test these changes

Untested
