### PR TITLE
Add navmesh safety checks to findClosestValidPoint and findFurthestValidPoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -434,6 +434,7 @@
         "UpdateNMSpawnPoint",
         "SetDropRate",
         "NearLocation",
+        "GetFurthestValidPosition",
         "Terminate",
         "GetHealingTickDelay",
         "GetReadOnlyItem",

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -432,6 +432,13 @@ bool CNavMesh::validPosition(const position_t& position)
 
 bool CNavMesh::findClosestValidPoint(const position_t& position, float* validPoint)
 {
+    TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return true;
+    }
+
     float spos[3];
     CNavMesh::ToDetourPos(&position, spos);
 
@@ -459,6 +466,13 @@ bool CNavMesh::findClosestValidPoint(const position_t& position, float* validPoi
 
 bool CNavMesh::findFurthestValidPoint(const position_t& startPosition, const position_t& endPosition, float* validEndPoint)
 {
+    TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return true;
+    }
+
     float spos[3];
     CNavMesh::ToDetourPos(&startPosition, spos);
 
@@ -538,6 +552,11 @@ void CNavMesh::snapToValidPosition(position_t& position)
 bool CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter)
 {
     TracyZoneScoped;
+
+    if (!m_navMesh)
+    {
+        return true;
+    }
 
     float verticalDistance = abs(start.y - end.y);
     if (verticalDistance > 2 * verticalLimit)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [nope] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds checks for navmesh in these functions. If you don't have a navmesh loaded when you call these, you could crash. This is the same approach as all the other navmesh functions.

## Steps to test these changes

Call these functions without a navmesh loaded, don't crash?