### PR TITLE
[lua] Fix Shady Business quest

### DIFF
--- a/scripts/quests/bastok/Shady_Business.lua
+++ b/scripts/quests/bastok/Shady_Business.lua
@@ -51,7 +51,7 @@ quest.sections =
             ['Talib'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.items.ZINC_ORE, 4 } }) then
+                    if npcUtil.tradeHasExactly(trade, { { xi.items.CHUNK_OF_ZINC_ORE, 4 } }) then
                         return quest:progressEvent(91)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

* Corrected name of item in Shady_Business.lua from **ZINC_ORE** to **CHUNK_OF_ZINC_ORE** (to match item name in items.lua global).

## Steps to test these changes

* Attempt to complete the above quest by trading 4 zinc ore to NPC Talib in Port Bastok.
* Be confused at how shady the NPC is being when nothing happens.
* Cherry-pick this PR (or wait for it to be merged with the Base branch and sync with Base branch).
* Trade 4 zinc ore to NPC Talib again.
* Rejoice in the NPC now accepting the trade and giving you gil and Tenshodo (Norg) fame in return! 