### PR TITLE
[module] Add custom module to make mazurka generate additional enmity

### DIFF
--- a/modules/custom/lua/mazurka_generates_enmity.lua
+++ b/modules/custom/lua/mazurka_generates_enmity.lua
@@ -1,0 +1,50 @@
+-----------------------------------
+-- Make Mazurka Provoke!
+--
+-- https://www.bg-wiki.com/ffxi/The_History_of_Final_Fantasy_XI/2007
+-- Mar. 8th, 2007: The enmity gained when using Chocobo Mazurka and Raptor Mazurka was reduced.
+-- Just before this patch, BRDs could use Mazurka to generate ridiculous enmity.
+-- The devs did not intend for this to happen and it was quickly patched.
+-- But for a glorious few days, BRDs could tank surprisingly well.
+-----------------------------------
+require("modules/module_utils")
+require("scripts/globals/spell_data")
+-----------------------------------
+local m = Module:new("mazurka_generates_enmity")
+
+local chocoboMazurkaPower = 1.0
+local raptorMazurkaPower = 1.1
+
+local mazurkaProvoke = function(caster, target, spell, power)
+    -- If not Mazurka, bail out
+    if spell:getID() ~= xi.magic.spell.CHOCOBO_MAZURKA and spell:getID() ~= xi.magic.spell.RAPTOR_MAZURKA then
+        return
+    end
+
+    -- Mazurka is a self-targetting spell, so target == caster, so we have to grab the
+    -- entity we've got set as our battle target
+    local battleTarget = caster:getTarget()
+    if battleTarget == nil then
+        return
+    end
+
+    -- TODO: Factor singing and instrument skill into this, etc.
+    local enmity = spell:getTotalTargets() * (100 * power)
+
+    -- Bard Provoke!
+    battleTarget:addEnmity(caster, 0, enmity)
+end
+
+m:addOverride("xi.globals.spells.songs.chocobo_mazurka.onSpellCast", function(caster, target, spell)
+    local songEffect = super(caster, target, spell)
+    mazurkaProvoke(caster, target, spell, chocoboMazurkaPower)
+    return songEffect
+end)
+
+m:addOverride("xi.globals.spells.songs.raptor_mazurka.onSpellCast", function(caster, target, spell)
+    local songEffect = super(caster, target, spell)
+    mazurkaProvoke(caster, target, spell, raptorMazurkaPower)
+    return songEffect
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Makes Mazurka generate additional enmity, depending on how many party members it lands on.

This holds a special place in my heart because when I found out about this in early 2007 I sold a lot of my good gear to buy whatever the Mazurka+ instrument of the day was - at a very heavily inflated price. A few days later this behaviour was patched out.

## Steps to test these changes

Go be a sick BRD/NIN tank.