### PR TITLE
Add setting to disable tells to GMs that are hidden

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -215,6 +215,9 @@ xi.settings.map =
     -- Minimum time between uses of yell command (in seconds).
     YELL_COOLDOWN = 30,
 
+    -- Prevent players from sending tells to hidden GMs. You will still receive them from other GMs.
+    BLOCK_TELL_TO_HIDDEN_GM = false,
+
     -- Command Audit [logging] commands with lower permission than this will not be logged.
     -- Zero for no logging at all. Commands given to non GMs are not logged.
     AUDIT_GM_CMD = false,

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -113,7 +113,11 @@ namespace message
                     std::unique_ptr<CBasicPacket> newPacket = std::make_unique<CBasicPacket>();
                     memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
                     auto gm_sent = newPacket->ref<uint8>(0x05);
-                    if (PChar->nameflags.flags & FLAG_AWAY && !gm_sent)
+                    if (settings::get<bool>("map.BLOCK_TELL_TO_HIDDEN_GM") && PChar->m_isGMHidden && !gm_sent)
+                    {
+                        send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PChar, 0, 0, MsgStd::TellNotReceivedOffline));
+                    }
+                    else if (PChar->nameflags.flags & FLAG_AWAY && !gm_sent)
                     {
                         send(MSG_DIRECT, extra.data(), sizeof(uint32), new CMessageStandardPacket(PChar, 0, 0, MsgStd::TellNotReceivedAway));
                     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

From my own experience in retail, you cannot /tell a GM unless they are actively engaged in an encounter with you.
This will emulate that behavior by allowing GM's to decide whether they want to be contacted by NQ players.

## Steps to test these changes

Log in a normal character and a GM character
1. When GM toggled 'off' or 'on', players can /tell a GM normally
2. Once !hide is activated, players will no longer be able to /tell the GM UNLESS you are another GM.