### PR TITLE
[LUA] Update Blood Rage & Warcry ability use messages

### DIFF
--- a/scripts/globals/abilities/blood_rage.lua
+++ b/scripts/globals/abilities/blood_rage.lua
@@ -11,7 +11,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useBloodRage(player, target, ability)
+    return xi.job_utils.warrior.useBloodRage(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/abilities/warcry.lua
+++ b/scripts/globals/abilities/warcry.lua
@@ -11,7 +11,7 @@ ability_object.onAbilityCheck = function(player, target, ability)
 end
 
 ability_object.onUseAbility = function(player, target, ability)
-    xi.job_utils.warrior.useWarcry(player, target, ability)
+    return xi.job_utils.warrior.useWarcry(player, target, ability)
 end
 
 return ability_object

--- a/scripts/globals/job_utils/warrior.lua
+++ b/scripts/globals/job_utils/warrior.lua
@@ -37,6 +37,7 @@ end
 -----------------------------------
 xi.job_utils.warrior.useAggressor = function(player, target, ability)
     local merits = player:getMerit(xi.merit.AGGRESSIVE_AIM)
+
     player:addStatusEffect(xi.effect.AGGRESSOR, merits, 0, 180 + player:getMod(xi.mod.AGGRESSOR_DURATION))
 end
 
@@ -45,10 +46,16 @@ xi.job_utils.warrior.useBerserk = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useBloodRage = function(player, target, ability)
-    local power = 20 + player:getJobPointLevel(xi.jp.BLOOD_RAGE_EFFECT)
+    local power    = 20 + player:getJobPointLevel(xi.jp.BLOOD_RAGE_EFFECT)
     local duration = 30 + player:getMod(xi.mod.ENHANCES_BLOOD_RAGE)
 
-    player:addStatusEffect(xi.effect.BLOOD_RAGE, power, 0, duration)
+    target:addStatusEffect(xi.effect.BLOOD_RAGE, power, 0, duration)
+
+    if player:getID() ~= target:getID() then
+        ability:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
+    end
+
+    return xi.effect.BLOOD_RAGE
 end
 
 xi.job_utils.warrior.useBrazenRush = function(player, target, ability)
@@ -72,7 +79,7 @@ xi.job_utils.warrior.useRetaliation = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useTomahawk = function(player, target, ability)
-    local merits = player:getMerit(xi.merit.TOMAHAWK) - 15
+    local merits   = player:getMerit(xi.merit.TOMAHAWK) - 15
     local duration = 30 + merits
 
     target:addStatusEffectEx(xi.effect.TOMAHAWK, 0, 25, 3, duration, 0, 0, 0)
@@ -80,22 +87,30 @@ xi.job_utils.warrior.useTomahawk = function(player, target, ability)
 end
 
 xi.job_utils.warrior.useWarcry = function(player, target, ability)
-    local merit = player:getMerit(xi.merit.SAVAGERY)
-    local power = 0
+    local merit    = player:getMerit(xi.merit.SAVAGERY)
+    local power    = 0
     local duration = 30
 
     if player:getMainJob() == xi.job.WAR then
-        power = math.floor((player:getMainLvl()/4)+4.75)/256
+        power = math.floor((player:getMainLvl() / 4) + 4.75) / 256
     else
-        power = math.floor((player:getSubLvl()/4)+4.75)/256
+        power = math.floor((player:getSubLvl() / 4) + 4.75) / 256
     end
 
-    power = power * 100
+    power    = power * 100
     duration = duration + player:getMod(xi.mod.WARCRY_DURATION)
+
     target:addStatusEffect(xi.effect.WARCRY, power, 0, duration, 0, merit)
+
+    if player:getID() ~= target:getID() then
+        ability:setMsg(xi.msg.basic.JA_ATK_ENHANCED)
+    end
+
+    return xi.effect.WARCRY
 end
 
 xi.job_utils.warrior.useWarriorsCharge = function(player, target, ability)
     local merits = player:getMerit(xi.merit.WARRIORS_CHARGE)
-    player:addStatusEffect(xi.effect.WARRIORS_CHARGE, merits-5, 0, 60)
+
+    player:addStatusEffect(xi.effect.WARRIORS_CHARGE, merits - 5, 0, 60)
 end

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -129,10 +129,12 @@ xi.msg.basic =
     JA_NO_EFFECT           = 156, -- <user> uses <ability>. No effect on <target>. (1 line msg)
     JA_MISS                = 158, -- <user> uses <ability>, but misses. (no name included)
     USES_JA_TAKE_DAMAGE    = 317, -- The <player> uses .. <target> takes .. points of damage.
+    JA_GAIN_EFFECT         = 266, -- <target> gains the effect of <ability>.
     JA_REMOVE_EFFECT_2     = 321, -- <user> uses <ability>. <target>'s <status> wears off.
     JA_NO_EFFECT_2         = 323, -- <user> uses <ability>. No effect on <target>. (2 line msg)
     JA_MISS_2              = 324, -- <user> uses <ability>, but misses <target>. (includes target name)
     JA_RECOVERS_MP         = 451, -- <user> uses <ability>. <target> regains <amount> MP.
+    JA_ATK_ENHANCED        = 285, -- <target>'s attacks are enhanced.
 
     -- Misc Other
     DEFEATS_TARG           = 6,   -- The <player> defeats <target>.

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -48,7 +48,7 @@ INSERT INTO `abilities` VALUES (28,'mijin_gakure',13,0,4,3600,0,110,0,93,2000,0,
 INSERT INTO `abilities` VALUES (29,'spirit_surge',14,0,1,3600,0,0,0,97,2000,0,6,20.0,0,0,0,0,0,'COP');
 INSERT INTO `abilities` VALUES (30,'astral_flow',15,0,1,3600,0,0,0,95,2000,0,6,20.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (31,'berserk',1,15,1,300,1,115,0,0,2000,0,6,20.0,0,1,80,384,0,NULL);
-INSERT INTO `abilities` VALUES (32,'warcry',1,35,1,300,2,0,0,28,2000,0,6,20.0,1,1,300,388,0,NULL);
+INSERT INTO `abilities` VALUES (32,'warcry',1,35,1,300,2,116,0,28,2000,0,6,20.0,1,1,300,388,0,NULL);
 INSERT INTO `abilities` VALUES (33,'defender',1,25,1,180,3,117,0,1,2000,0,6,20.0,0,1,80,386,0,NULL);
 INSERT INTO `abilities` VALUES (34,'aggressor',1,45,1,300,4,118,0,2,2000,0,6,20.0,0,1,80,390,0,NULL);
 INSERT INTO `abilities` VALUES (35,'provoke',1,5,4,30,5,0,0,3,2000,0,6,18.0,0,1,1800,0,0,NULL);
@@ -281,7 +281,7 @@ INSERT INTO `abilities` VALUES (263,'flourishes_iii',19,80,1,0,226,0,0,0,2000,0,
 INSERT INTO `abilities` VALUES (264,'climactic_flourish',19,80,1,90,226,529,0,222,2000,0,6,20.0,0,1,80,0,0,NULL);
 INSERT INTO `abilities` VALUES (265,'libra',20,76,4,60,237,100,0,231,2000,0,6,11.2,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (266,'tactical_switch',18,79,1,180,213,100,0,232,2000,0,6,11.2,0,0,0,0,0,NULL);
-INSERT INTO `abilities` VALUES (267,'blood_rage',1,87,1,300,11,100,0,239,2000,0,6,13.9,1,1,300,0,0,NULL);
+INSERT INTO `abilities` VALUES (267,'blood_rage',1,87,1,300,11,319,0,239,2000,0,6,13.9,1,1,300,0,0,NULL);
 INSERT INTO `abilities` VALUES (269,'impetus',2,88,1,360,31,100,0,240,2000,0,6,20.0,0,1,80,0,0,NULL);
 INSERT INTO `abilities` VALUES (270,'divine_caress',3,83,1,60,32,100,0,254,2000,0,6,20.0,0,0,0,0,0,NULL);
 INSERT INTO `abilities` VALUES (271,'sacrosanctity',3,95,1,600,33,100,0,268,2000,0,6,13.9,1,0,0,0,0,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [X] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes #2786
Updates abilities.sql with the correct base messages for Blood Rage and Warcry.
Updates job_utils/warrior.lua Blood Rage and Warcry with correct message when targeting party members.
Updates abilities/blood_rage.lua and abilities/warcry.lua onUseAbility functions with returns so the message passes through.
Adds two messages (JA_GAIN_EFFECT & JA_ATK_ENHANCED) to globals/msg.lua.
Updates job_utils/warrior.lua formatting.

## Retail Captures

![pol_anxxo9OWSw](https://user-images.githubusercontent.com/16365541/193434209-36ec266c-bb73-48a8-94e3-57e8c45b2582.png)

![pol_g05ksCMTvn](https://user-images.githubusercontent.com/16365541/193434369-1c2e99b4-12ef-434a-b8e6-77b9b9fa4522.png)

![pol_qzcEfIbtGb](https://user-images.githubusercontent.com/16365541/193434212-81757c0f-377e-4b67-8c47-7e0e19ab1813.png)

![pol_xcdS1plvvq](https://user-images.githubusercontent.com/16365541/193434373-fb3b65ea-6c9f-4c91-9806-d96ee4ca3a5a.png)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Upload changes to your server.
2. Load the server.
3. Use the !changejob WAR 99 command.
4. Summon trusts or log in multiple characters.
5. Use Blood Rage and Warcry to confirm their messages match the retail captures.