### PR TITLE
[lua] Add global items require to garrison

### DIFF
--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require('scripts/globals/mobs')
 require('scripts/globals/common')
+require('scripts/globals/items')
 require('scripts/globals/npc_util')
 require('scripts/globals/status')
 require('scripts/globals/utils')


### PR DESCRIPTION
* Fixes a load order/dependency issue with Linux

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes an error where on linux Garrison complains xi.item enum is missing
## Steps to test these changes

run xi_map on linux, don't see error with garrison.lua