### PR TITLE
[lua] [abyssea] Fix blue pyxis in Abyssea giving too much time

### DIFF
--- a/scripts/globals/abyssea/sturdypyxis/time.lua
+++ b/scripts/globals/abyssea/sturdypyxis/time.lua
@@ -17,8 +17,8 @@ xi.pyxis.time.giveTime = function(npc, player)
             member:isPC()
         then
             local effect = member:getStatusEffect(xi.effect.VISITANT)
-            local oldDuration = tonumber(effect:getTimeRemaining())
-            local newDuration = (oldDuration + tonumber(10 * 60)) * 1000
+            local oldDuration = effect:getTimeRemaining()
+            local newDuration = oldDuration + 10 * 60 * 1000
 
             member:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 3, 10, 1)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes #2855

## Steps to test these changes

Get Azure light in abyssea, get time chest, get +10 minutes to your stay instead of +... a lot
