### PR TITLE
[packets] Add setting main.EQUIP_FROM_OTHER_CONTAINERS

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -214,18 +214,19 @@ xi.settings.main =
     GARRISON_RANK                = 2,     -- Set to minumum Nation Rank to start Garrison (default: 2).
 
     -- MISC
-    RIVERNE_PORTERS              = 120,  -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
-    LANTERNS_STAY_LIT            = 1200, -- time in seconds that lanterns in the Den of Rancor stay lit.
-    ENABLE_COP_ZONE_CAP          = 0,    -- Enable or disable lvl cap
-    ALLOW_MULTIPLE_EXP_RINGS     = 0,    -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
-    BYPASS_EXP_RING_ONE_PER_WEEK = 0,    -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
-    NUMBER_OF_DM_EARRINGS        = 1,    -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
-    HOMEPOINT_TELEPORT           = 1,    -- Enables the homepoint teleport system
-    DIG_ABUNDANCE_BONUS          = 0,    -- Increase chance of digging up an item (450  = item digup chance +45)
-    DIG_FATIGUE                  = 1,    -- Set to 0 to disable Dig Fatigue
-    DIG_GRANT_BURROW             = 0,    -- Set to 1 to grant burrow ability
-    DIG_GRANT_BORE               = 0,    -- Set to 1 to grant bore ability
-    ENM_COOLDOWN                 = 120,  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
-    FORCE_SPAWN_QM_RESET_TIME    = 300,  -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
-    GOBBIE_BOX_MIN_AGE           = 45,   -- Minimum character age in days before a character can sign up for Gobbie Mystery Box
+    RIVERNE_PORTERS              = 120,   -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
+    LANTERNS_STAY_LIT            = 1200,  -- time in seconds that lanterns in the Den of Rancor stay lit.
+    ENABLE_COP_ZONE_CAP          = 0,     -- Enable or disable lvl cap
+    ALLOW_MULTIPLE_EXP_RINGS     = 0,     -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
+    BYPASS_EXP_RING_ONE_PER_WEEK = 0,     -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
+    NUMBER_OF_DM_EARRINGS        = 1,     -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
+    HOMEPOINT_TELEPORT           = 1,     -- Enables the homepoint teleport system
+    DIG_ABUNDANCE_BONUS          = 0,     -- Increase chance of digging up an item (450  = item digup chance +45)
+    DIG_FATIGUE                  = 1,     -- Set to 0 to disable Dig Fatigue
+    DIG_GRANT_BURROW             = 0,     -- Set to 1 to grant burrow ability
+    DIG_GRANT_BORE               = 0,     -- Set to 1 to grant bore ability
+    ENM_COOLDOWN                 = 120,   -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
+    FORCE_SPAWN_QM_RESET_TIME    = 300,   -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
+    GOBBIE_BOX_MIN_AGE           = 45,    -- Minimum character age in days before a character can sign up for Gobbie Mystery Box
+    EQUIP_FROM_OTHER_CONTAINERS  = false, -- true/false. Allows equipping items from Mog Satchel, Sack, and Case. Only possible with the use of client addons.
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3257,18 +3257,32 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
     uint8 equipSlotID = data.ref<uint8>(0x05); // charequip slot
     uint8 containerID = data.ref<uint8>(0x06); // container id
 
-    if (containerID != LOC_INVENTORY && containerID != LOC_WARDROBE && containerID != LOC_WARDROBE2 && containerID != LOC_WARDROBE3 &&
-        containerID != LOC_WARDROBE4 && containerID != LOC_WARDROBE5 && containerID != LOC_WARDROBE6 && containerID != LOC_WARDROBE7 &&
-        containerID != LOC_WARDROBE8)
+    bool isAdditionalContainer =
+        settings::get<bool>("main.EQUIP_FROM_OTHER_CONTAINERS") &&
+        (containerID == LOC_MOGSATCHEL ||
+         containerID == LOC_MOGSACK ||
+         containerID == LOC_MOGCASE);
+
+    bool isEquippableInventory =
+        containerID == LOC_INVENTORY ||
+        containerID == LOC_WARDROBE ||
+        containerID == LOC_WARDROBE2 ||
+        containerID == LOC_WARDROBE3 ||
+        containerID == LOC_WARDROBE4 ||
+        containerID == LOC_WARDROBE5 ||
+        containerID == LOC_WARDROBE6 ||
+        containerID == LOC_WARDROBE7 ||
+        containerID == LOC_WARDROBE8 ||
+        isAdditionalContainer;
+
+    bool isLinkshell =
+        equipSlotID == SLOT_LINK1 ||
+        equipSlotID == SLOT_LINK2;
+
+    // Sanity check
+    if (!isEquippableInventory && !isLinkshell)
     {
-        if (equipSlotID != 16 && equipSlotID != 17)
-        {
-            return;
-        }
-        else if (containerID != LOC_MOGSATCHEL && containerID != LOC_MOGSACK && containerID != LOC_MOGCASE)
-        {
-            return;
-        }
+        return;
     }
 
     charutils::EquipItem(PChar, slotID, equipSlotID, containerID); // current


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Flattens the logic inside SmallPacket0x050

Adds a setting to enable/disable to behaviour defined in: https://git.ashitaxi.com/Plugins/AshitaCast/commit/8fcdc3c8aa6ca09eb34b04d7002bb6bae950467f

Only tested the happy path so far, need to use addons to test the bad path

## Steps to test these changes

- Equip items, it still works
- Use addons to force-equip from non-standard places
- Use the new setting to enable/disable this
- Linkshells should still work also
