### PR TITLE
Quest Strinking a balance - add correct interaction binding

### DIFF
--- a/scripts/quests/ahtUrhgan/Striking_a_Balance.lua
+++ b/scripts/quests/ahtUrhgan/Striking_a_Balance.lua
@@ -184,7 +184,7 @@ quest.sections =
                     quest:setVar(player, 'Prog', 4)
                     local newPosition = npcUtil.pickNewPosition(npc:getID(), positionTable)
                     npc:setPos(newPosition.x, newPosition.y, newPosition.z)
-                    return quest:addKeyItem(xi.ki.MUNAHDAS_PACKAGE)
+                    return quest:keyItem(xi.ki.MUNAHDAS_PACKAGE)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

added keyItem binding instead of addKeyItem
