### PR TITLE
[lua] [core] Adjust intimidate/is paralyzed melee/JA messages to match retail, handle untargetable entities + proper super jump implementation

### DIFF
--- a/scripts/globals/abilities/pets/super_climb.lua
+++ b/scripts/globals/abilities/pets/super_climb.lua
@@ -16,7 +16,7 @@ end
 
 abilityObject.onUseAbility = function(pet, target, ability)
     pet:queue(0, function(petArg)
-        petArg:stun(5000)
+        petArg:untargetableAndUnactionable(5000)
     end)
 end
 

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -362,7 +362,7 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
 
     -- Prevent the player from performing actions while in the air
     player:queue(0, function(playerArg)
-        playerArg:stun(5000)
+        playerArg:untargetableAndUnactionable(5000)
     end)
 
     -- If the Dragoon's wyvern is out and alive, tell it to use Super Climb

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -256,6 +256,7 @@ xi.msg.basic =
     RECOVERS_HP             = 24,   -- <target> recovers <number> HP.
     RECOVERS_MP             = 25,   -- <target> recovers <number> MP.
     RECOVERS_HP_AND_MP      = 26,   -- <target> recovers <number> HP and MP.
+    IS_PARALYZED_2          = 84,   -- <target> is paralyzed.
     IS_STATUS               = 203,  -- <target> is <status>.
     IS_NO_LONGER_STATUS     = 204,  -- <target> is no longer <status>.
     GAINS_EFFECT_OF_STATUS  = 205,  -- <target> gains the effect of <status>.

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -174,7 +174,12 @@ bool CAIContainer::UseItem(uint16 targid, uint8 loc, uint8 slotid)
 
 bool CAIContainer::Inactive(duration _duration, bool canChangeState)
 {
-    return ForceChangeState<CInactiveState>(PEntity, _duration, canChangeState);
+    return ForceChangeState<CInactiveState>(PEntity, _duration, canChangeState, false);
+}
+
+bool CAIContainer::Untargetable(duration _duration, bool canChangeState)
+{
+    return ForceChangeState<CInactiveState>(PEntity, _duration, canChangeState, true);
 }
 
 bool CAIContainer::Internal_Engage(uint16 targetid)
@@ -212,6 +217,10 @@ bool CAIContainer::Internal_Cast(uint16 targetid, SpellID spellid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
+        if (entity->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CMagicState>(entity, targetid, spellid);
     }
     return false;
@@ -251,6 +260,10 @@ bool CAIContainer::Internal_WeaponSkill(uint16 targid, uint16 wsid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
+        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CWeaponSkillState>(entity, targid, wsid);
     }
     return false;
@@ -261,6 +274,10 @@ bool CAIContainer::Internal_MobSkill(uint16 targid, uint16 wsid)
     auto* entity = dynamic_cast<CMobEntity*>(PEntity);
     if (entity)
     {
+        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CMobSkillState>(entity, targid, wsid);
     }
     return false;
@@ -271,6 +288,10 @@ bool CAIContainer::Internal_PetSkill(uint16 targid, uint16 abilityid)
     auto* entity = dynamic_cast<CPetEntity*>(PEntity);
     if (entity)
     {
+        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CPetSkillState>(entity, targid, abilityid);
     }
     return false;
@@ -281,6 +302,10 @@ bool CAIContainer::Internal_Ability(uint16 targetid, uint16 abilityid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
+        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CAbilityState>(entity, targetid, abilityid);
     }
     return false;
@@ -291,6 +316,10 @@ bool CAIContainer::Internal_RangedAttack(uint16 targetid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
+        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return ChangeState<CRangeState>(entity, targetid);
     }
     return false;
@@ -452,6 +481,11 @@ bool CAIContainer::IsRoaming()
 bool CAIContainer::IsEngaged()
 {
     return PEntity->animation == ANIMATION_ATTACK;
+}
+
+bool CAIContainer::IsUntargetable()
+{
+    return PEntity->PAI->IsCurrentState<CInactiveState>() && static_cast<CInactiveState*>(PEntity->PAI->GetCurrentState())->GetUntargetable();
 }
 
 time_point CAIContainer::getTick()

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -217,7 +217,7 @@ bool CAIContainer::Internal_Cast(uint16 targetid, SpellID spellid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        if (entity->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
         {
             return false;
         }

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -62,6 +62,7 @@ public:
     bool Trigger(CCharEntity* player);
     bool UseItem(uint16 targid, uint8 loc, uint8 slotid);
     bool Inactive(duration _duration, bool canChangeState);
+    bool Untargetable(duration _duration, bool canChangeState); // Used to make owner entity untargetable & inactionable in TargetFind for _duration
 
     /* Internal Controller functions */
     bool Internal_Engage(uint16 targetid);
@@ -106,6 +107,7 @@ public:
     bool IsSpawned();
     bool IsRoaming();
     bool IsEngaged();
+    bool IsUntargetable();
     // whether AI is currently able to change state from external means
     bool CanChangeState();
     bool CanFollowPath();

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../weapon_skill.h"
 #include "../ai_container.h"
 #include "../states/death_state.h"
+#include "../states/inactive_state.h"
 
 CPlayerController::CPlayerController(CCharEntity* _PChar)
 : CController(_PChar)
@@ -50,6 +51,10 @@ bool CPlayerController::Cast(uint16 targid, SpellID spellid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (!PChar->PRecastContainer->HasRecast(RECAST_MAGIC, static_cast<uint16>(spellid), 0))
     {
+        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return CController::Cast(targid, spellid);
     }
     else
@@ -122,6 +127,10 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
             return false;
         }
+        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return PChar->PAI->Internal_Ability(targid, abilityid);
     }
     else
@@ -136,6 +145,10 @@ bool CPlayerController::RangedAttack(uint16 targid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (PChar->PAI->CanChangeState())
     {
+        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return PChar->PAI->Internal_RangedAttack(targid);
     }
     else
@@ -150,6 +163,10 @@ bool CPlayerController::UseItem(uint16 targid, uint8 loc, uint8 slotid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (PChar->PAI->CanChangeState())
     {
+        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        {
+            return false;
+        }
         return PChar->PAI->Internal_UseItem(targid, loc, slotid);
     }
     return false;
@@ -206,6 +223,11 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
         auto* PTarget = PChar->IsValidTarget(targid, battleutils::isValidSelfTargetWeaponskill(wsid) ? TARGET_SELF : TARGET_ENEMY, errMsg);
         if (PTarget)
         {
+            if (PTarget->PAI->IsUntargetable())
+            {
+                return false;
+            }
+
             if (!facing(PChar->loc.p, PTarget->loc.p, 64) && PTarget != PChar)
             {
                 PChar->pushPacket(new CMessageBasicPacket(PChar, PTarget, 0, 0, MSGBASIC_CANNOT_SEE));

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -23,6 +23,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "../../../common/mmo.h"
 #include "../../../common/utils.h"
+#include "../../ai/ai_container.h"
+#include "../../ai/states/inactive_state.h"
 #include "../../alliance.h"
 #include "../../enmity_container.h"
 #include "../../entities/charentity.h"
@@ -414,10 +416,13 @@ validEntity will check if the given entity can be targeted in the AoE.
 */
 bool CTargetFind::validEntity(CBattleEntity* PTarget)
 {
+    // Check if entity is already in list
+    // TODO: Does it make sense to use a hashmap here instead?
     if (std::find(m_targets.begin(), m_targets.end(), PTarget) != m_targets.end())
     {
         return false;
     }
+
     if (!(m_findFlags & FINDFLAGS_DEAD) && PTarget->isDead())
     {
         return false;
@@ -430,6 +435,12 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
     }
 
     if (m_PTarget == PTarget || PTarget->getZone() != m_zone || PTarget->GetUntargetable() || PTarget->status == STATUS_TYPE::INVISIBLE)
+    {
+        return false;
+    }
+
+    // Super Jump or otherwise untargetable
+    if (PTarget->PAI->IsUntargetable())
     {
         return false;
     }

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -65,7 +65,7 @@ bool CAttackState::Update(time_point tick)
             action_t action;
             if (m_PEntity->OnAttack(*this, action))
             {
-                // CMobEntity::OnAttack(...) generates it's own action and sends it there, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
+                // CMobEntity::OnAttack(...) can generate it's own action with a mobmod, and that leaves this action.actionType = 0, which is never valid. Skip sending the packet.
                 if (action.actiontype != ACTION_NONE)
                 {
                     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));

--- a/src/map/ai/states/inactive_state.cpp
+++ b/src/map/ai/states/inactive_state.cpp
@@ -24,10 +24,11 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../status_effect_container.h"
 #include "../ai_container.h"
 
-CInactiveState::CInactiveState(CBaseEntity* PEntity, duration _duration, bool canChangeState)
+CInactiveState::CInactiveState(CBaseEntity* PEntity, duration _duration, bool canChangeState, bool untargetable)
 : CState(PEntity, 0)
 , m_duration(_duration)
 , m_canChangeState(canChangeState)
+, m_untargetable(untargetable)
 {
     if (!canChangeState)
     {

--- a/src/map/ai/states/inactive_state.h
+++ b/src/map/ai/states/inactive_state.h
@@ -27,7 +27,12 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 class CInactiveState : public CState
 {
 public:
-    CInactiveState(CBaseEntity* PEntity, duration _duration, bool canChangeState);
+    CInactiveState(CBaseEntity* PEntity, duration _duration, bool canChangeState, bool untargetable);
+
+    bool GetUntargetable()
+    {
+        return m_untargetable;
+    }
 
 protected:
     virtual bool CanChangeState() override
@@ -42,12 +47,14 @@ protected:
     {
         return false;
     }
+
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override;
 
 private:
     duration m_duration;
     bool     m_canChangeState{ false };
+    bool     m_untargetable{ false };
 };
 
 #endif

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -33,6 +33,7 @@
 #include "../../status_effect_container.h"
 #include "../../utils/battleutils.h"
 #include "../ai_container.h"
+#include "../states/inactive_state.h"
 
 CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid, uint8 flags)
 : CState(PEntity, targid)
@@ -101,22 +102,34 @@ bool CMagicState::Update(time_point tick)
         if (!PTarget || m_errorMsg || !CanCastSpell(PTarget) ||
             (HasMoved() && (m_PEntity->objtype != TYPE_PET || static_cast<CPetEntity*>(m_PEntity)->getPetType() != PET_TYPE::AUTOMATON)))
         {
-            m_interrupted = true;
+            m_PEntity->OnCastInterrupted(*this, action, msg, false);
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+            Complete();
+            return false;
         }
         else if (PTarget->objtype == TYPE_PC)
         {
             CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
             if (PChar->m_Locked)
             {
-                m_interrupted = true;
+                m_PEntity->OnCastInterrupted(*this, action, msg, true);
+                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+                Complete();
+                return false;
             }
 
             if (m_PSpell.get()->getSpellGroup() == SPELLGROUP_TRUST)
             {
                 if (!luautils::OnTrustSpellCastCheckBattlefieldTrusts(PChar))
                 {
-                    msg           = MSGBASIC_TRUST_NO_CAST_TRUST;
-                    m_interrupted = true;
+                    m_PEntity->OnCastInterrupted(*this, action, MSGBASIC_TRUST_NO_CAST_TRUST, true);
+                    action.recast = 2; // seems hardcoded to 2
+                    m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+                    Complete();
+                    return false;
                 }
             }
         }
@@ -132,23 +145,48 @@ bool CMagicState::Update(time_point tick)
 
             if (PChar->m_Locked)
             {
-                m_interrupted = true;
+                m_PEntity->OnCastInterrupted(*this, action, msg, true);
+                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+                Complete();
+                return false;
             }
         }
-        else if (battleutils::IsParalyzed(m_PEntity))
+
+        // Super Jump or otherwise untargetable
+        if (PTarget->PAI->IsUntargetable())
         {
-            msg           = MSGBASIC_IS_PARALYZED;
-            m_interrupted = true;
+            m_PEntity->OnCastInterrupted(*this, action, msg, true);
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+            Complete();
+            return false;
+        }
+
+        if (battleutils::IsParalyzed(m_PEntity))
+        {
+            m_PEntity->setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED_2, static_cast<uint16>(m_PSpell->getID()));
+            action.recast   = 2; // seems hardcoded to 2
+            action.actionid = static_cast<uint16>(m_PSpell->getID());
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+            Complete();
+            return false;
         }
         else if (battleutils::IsIntimidated(m_PEntity, PTarget))
         {
-            msg           = MSGBASIC_IS_INTIMIDATED;
-            m_interrupted = true;
+            m_PEntity->setActionInterrupted(action, PTarget, MSGBASIC_IS_INTIMIDATED, static_cast<uint16>(m_PSpell->getID()));
+            action.recast   = 2; // seems hardcoded to 2
+            action.actionid = static_cast<uint16>(m_PSpell->getID());
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
+
+            Complete();
+            return false;
         }
 
         if (m_interrupted)
         {
-            m_PEntity->OnCastInterrupted(*this, action, msg);
+            m_PEntity->OnCastInterrupted(*this, action, msg, false);
         }
         else
         {
@@ -179,7 +217,7 @@ void CMagicState::Cleanup(time_point tick)
     if (!IsCompleted())
     {
         action_t action;
-        m_PEntity->OnCastInterrupted(*this, action, MSGBASIC_IS_INTERRUPTED);
+        m_PEntity->OnCastInterrupted(*this, action, MSGBASIC_IS_INTERRUPTED, false);
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
     }
 }

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -135,12 +135,14 @@ void CMobSkillState::Cleanup(time_point tick)
         action_t action;
         action.id         = m_PEntity->id;
         action.actiontype = ACTION_MOBABILITY_INTERRUPT;
+        action.actionid   = 28787;
 
         actionList_t& actionList  = action.getNewActionList();
         actionList.ActionTargetID = m_PEntity->id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
-        actionTarget.animation       = m_PSkill->getID();
+        actionTarget.animation       = 0x1FC; // Not perfectly accurate, this animation ID can change from time to time for unknown reasons.
+        actionTarget.reaction        = REACTION::HIT;
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
     }

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -135,12 +135,14 @@ void CPetSkillState::Cleanup(time_point tick)
         action_t action;
         action.id         = m_PEntity->id;
         action.actiontype = ACTION_MOBABILITY_INTERRUPT;
+        action.actionid   = 28787;
 
         actionList_t& actionList  = action.getNewActionList();
         actionList.ActionTargetID = m_PEntity->id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
-        actionTarget.animation       = m_PSkill->getID();
+        actionTarget.animation       = 0x1FC; // Not perfectly accurate, this animation ID can change from time to time for unknown reasons.
+        actionTarget.reaction        = REACTION::HIT;
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
     }

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -710,6 +710,10 @@ public:
     virtual void OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action);
     virtual void OnChangeTarget(CBattleEntity* PTarget);
 
+    // Used to set paralyzed/intimidation action for JA & auto attack
+    void setActionParalyzed(action_t& action, CBattleEntity* PTarget);
+    void setActionIntimidated(action_t& action, CBattleEntity* PTarget);
+
     virtual void OnAbility(CAbilityState&, action_t&)
     {
     }

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -705,14 +705,13 @@ public:
     virtual void           OnDisengage(CAttackState&);
     /* Casting */
     virtual void OnCastFinished(CMagicState&, action_t&);
-    virtual void OnCastInterrupted(CMagicState&, action_t&, MSGBASIC_ID msg);
+    virtual void OnCastInterrupted(CMagicState&, action_t&, MSGBASIC_ID msg, bool blockedCast);
     /* Weaponskill */
     virtual void OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action);
     virtual void OnChangeTarget(CBattleEntity* PTarget);
 
-    // Used to set paralyzed/intimidation action for JA & auto attack
-    void setActionParalyzed(action_t& action, CBattleEntity* PTarget);
-    void setActionIntimidated(action_t& action, CBattleEntity* PTarget);
+    // Used to set an action to an "interrupted" state
+    void setActionInterrupted(action_t& action, CBattleEntity* PTarget, uint16 messageID, uint16 actionID);
 
     virtual void OnAbility(CAbilityState&, action_t&)
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -50,6 +50,7 @@
 #include "../ai/states/ability_state.h"
 #include "../ai/states/attack_state.h"
 #include "../ai/states/death_state.h"
+#include "../ai/states/inactive_state.h"
 #include "../ai/states/item_state.h"
 #include "../ai/states/magic_state.h"
 #include "../ai/states/raise_state.h"
@@ -901,6 +902,12 @@ void CCharEntity::OnDisengage(CAttackState& state)
 bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg)
 {
     TracyZoneScoped;
+
+    if (PTarget->PAI->IsUntargetable())
+    {
+        return false;
+    }
+
     float dist = distance(loc.p, PTarget->loc.p);
 
     if (!IsMobOwner(PTarget))
@@ -1013,14 +1020,14 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
     }
 }
 
-void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBASIC_ID msg)
+void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBASIC_ID msg, bool blockedCast)
 {
     TracyZoneScoped;
-    CBattleEntity::OnCastInterrupted(state, action, msg);
+    CBattleEntity::OnCastInterrupted(state, action, msg, blockedCast);
 
     auto* message = state.GetErrorMsg();
 
-    if (message)
+    if (message && action.actiontype != ACTION_MAGIC_INTERRUPT) // Interrupt is handled elsewhere
     {
         pushPacket(message);
     }
@@ -1058,6 +1065,25 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
         else
         {
             PAI->TargetFind->findSingleTarget(PBattleTarget);
+        }
+
+        // Assumed, it's very difficult to produce this due to WS being nearly instant
+        // TODO: attempt to verify.
+        if (PAI->TargetFind->m_targets.size() == 0)
+        {
+            // No targets, perhaps something like Super Jump or otherwise untargetable
+            action.actiontype         = ACTION_MAGIC_FINISH;
+            action.actionid           = 28787; // Some hardcoded magic for interrupts
+            actionList_t& actionList  = action.getNewActionList();
+            actionList.ActionTargetID = id;
+
+            actionTarget_t& actionTarget = actionList.getNewActionTarget();
+
+            actionTarget.animation = 0x1FC; // Assumed, but not verified.
+            actionTarget.messageID = 0;
+            actionTarget.reaction  = REACTION::ABILITY | REACTION::HIT;
+
+            return;
         }
 
         for (auto&& PTarget : PAI->TargetFind->m_targets)
@@ -1204,7 +1230,17 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
         pushPacket(new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
         return;
     }
-    auto*                         PTarget = static_cast<CBattleEntity*>(state.GetTarget());
+
+    auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
+    PAI->TargetFind->reset();
+    PAI->TargetFind->findSingleTarget(PTarget);
+
+    // Check if target is untargetable
+    if (PAI->TargetFind->m_targets.size() == 0)
+    {
+        return;
+    }
+
     std::unique_ptr<CBasicPacket> errMsg;
     if (IsValidTarget(PTarget->targid, PAbility->getValidTarget(), errMsg))
     {
@@ -1231,7 +1267,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (battleutils::IsParalyzed(this))
         {
-            setActionParalyzed(action, PTarget);
+            setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED, 0);
             return;
         }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1231,8 +1231,7 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (battleutils::IsParalyzed(this))
         {
-            // display paralyzed
-            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+            setActionParalyzed(action, PTarget);
             return;
         }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -548,7 +548,7 @@ public:
     virtual void           OnEngage(CAttackState&) override;
     virtual void           OnDisengage(CAttackState&) override;
     virtual void           OnCastFinished(CMagicState&, action_t&) override;
-    virtual void           OnCastInterrupted(CMagicState&, action_t&, MSGBASIC_ID msg) override;
+    virtual void           OnCastInterrupted(CMagicState&, action_t&, MSGBASIC_ID msg, bool blockedCast) override;
     virtual void           OnWeaponSkillFinished(CWeaponSkillState&, action_t&) override;
     virtual void           OnAbility(CAbilityState&, action_t&) override;
     virtual void           OnRangedAttack(CRangeState&, action_t&) override;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -684,17 +684,35 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             PAI->TargetFind->findSingleTarget(PTarget, findFlags);
         }
     }
+    else // Out of range
+    {
+        action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
+        action.actionid           = 0;
+        actionList_t& actionList  = action.getNewActionList();
+        actionList.ActionTargetID = PTarget->id;
 
-    uint16 targets = (uint16)PAI->TargetFind->m_targets.size();
+        actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.animation       = 0x1FC; // Hardcoded magic sent from the server
+        actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY;
+        actionTarget.speceffect      = SPECEFFECT::BLOOD;
+        return;
+    }
 
+    uint16 targets = static_cast<uint16>(PAI->TargetFind->m_targets.size());
+
+    // No targets, perhaps something like Super Jump or otherwise untargetable
     if (targets == 0)
     {
         action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
+        action.actionid           = 28787; // Some hardcoded magic for interrupts
         actionList_t& actionList  = action.getNewActionList();
         actionList.ActionTargetID = id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
-        actionTarget.animation       = PSkill->getID();
+        actionTarget.animation       = 0x1FC; // Hardcoded magic sent from the server
+        actionTarget.messageID       = 0;
+        actionTarget.reaction        = REACTION::ABILITY | REACTION::HIT;
+
         return;
     }
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -201,10 +201,10 @@ void CPetEntity::OnAbility(CAbilityState& state, action_t& action)
         {
             return;
         }
+
         if (battleutils::IsParalyzed(this))
         {
-            // display paralyzed
-            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+            setActionParalyzed(action, PTarget);
             return;
         }
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -184,7 +184,7 @@ void CPetEntity::Spawn()
     }
 
     // NOTE: This is purposefully calling CBattleEntity's impl.
-    // TODO: Calling a grand-parent's impl. of an overrideden function is bad
+    // TODO: Calling a grand-parent's impl. of an overridden function is bad
     CBattleEntity::Spawn();
     luautils::OnMobSpawn(this);
 }
@@ -204,7 +204,7 @@ void CPetEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (battleutils::IsParalyzed(this))
         {
-            setActionParalyzed(action, PTarget);
+            setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED_2, 0);
             return;
         }
 
@@ -307,17 +307,34 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
             PAI->TargetFind->findSingleTarget(PTarget, findFlags);
         }
     }
+    else // Out of range
+    {
+        action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
+        actionList_t& actionList  = action.getNewActionList();
+        actionList.ActionTargetID = PTarget->id;
+
+        actionTarget_t& actionTarget = actionList.getNewActionTarget();
+        actionTarget.animation       = 0x1FC; // Hardcoded magic sent from the server
+        actionTarget.messageID       = MSGBASIC_TOO_FAR_AWAY;
+        actionTarget.speceffect      = SPECEFFECT::BLOOD;
+        return;
+    }
 
     uint16 targets = (uint16)PAI->TargetFind->m_targets.size();
 
-    if (targets == 0) // TODO: Is this "too far away?"
+    // No targets, perhaps something like Super Jump or otherwise untargetable
+    if (targets == 0)
     {
         action.actiontype         = ACTION_MOBABILITY_INTERRUPT;
+        action.actionid           = 28787; // Some hardcoded magic for interrupts
         actionList_t& actionList  = action.getNewActionList();
         actionList.ActionTargetID = id;
 
         actionTarget_t& actionTarget = actionList.getNewActionTarget();
-        actionTarget.animation       = PSkill->getID();
+        actionTarget.animation       = 0x1FC;
+        actionTarget.messageID       = 0;
+        actionTarget.reaction        = REACTION::ABILITY | REACTION::HIT;
+
         return;
     }
 

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -127,7 +127,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (battleutils::IsParalyzed(this))
         {
-            setActionParalyzed(action, PTarget);
+            setActionInterrupted(action, PTarget, MSGBASIC_IS_PARALYZED, 0);
             return;
         }
 
@@ -529,6 +529,24 @@ void CTrustEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& act
         else
         {
             PAI->TargetFind->findSingleTarget(PBattleTarget);
+        }
+
+        // Assumed, it's very difficult to produce this due to WS being nearly instant
+        // TODO: attempt to verify.
+        if (PAI->TargetFind->m_targets.size() == 0)
+        {
+            // No targets, perhaps something like Super Jump or otherwise untargetable
+            action.actiontype         = ACTION_MAGIC_FINISH;
+            action.actionid           = 28787; // Some hardcoded magic for interrupts
+            actionList_t& actionList  = action.getNewActionList();
+            actionList.ActionTargetID = id;
+
+            actionTarget_t& actionTarget = actionList.getNewActionTarget();
+            actionTarget.animation       = 0x1FC; // assumed
+            actionTarget.messageID       = 0;
+            actionTarget.reaction        = REACTION::ABILITY | REACTION::HIT;
+
+            return;
         }
 
         for (auto&& PTarget : PAI->TargetFind->m_targets)

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -127,7 +127,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
         if (battleutils::IsParalyzed(this))
         {
-            loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, PTarget, 0, 0, MSGBASIC_IS_PARALYZED));
+            setActionParalyzed(action, PTarget);
             return;
         }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13840,7 +13840,7 @@ bool CLuaBaseEntity::hasPreventActionEffect()
 
 /************************************************************************
  *  Function: stun()
- *  Purpose : Stuns a mob for a specified amount of time (in ms)
+ *  Purpose : Stuns an entity for a specified amount of time (in ms)
  *  Example : mob:stun(5000) -- Stun for 5 seconds
  *  Notes   : To Do: Change to seconds for standardization?
  ************************************************************************/
@@ -13848,6 +13848,19 @@ bool CLuaBaseEntity::hasPreventActionEffect()
 void CLuaBaseEntity::stun(uint32 milliseconds)
 {
     m_PBaseEntity->PAI->Inactive(std::chrono::milliseconds(milliseconds), false);
+}
+
+/************************************************************************
+ *  Function: untargetableAndUnactionable()
+ *  Purpose : Puts an entity into a stun state
+ *            Also disallows them from being targed as part of a check in PAI->TargetFind
+ *  Example : mob:stun(5000) -- Stun for 5 seconds
+ *  Notes   : To Do: Change to seconds for standardization?
+ ************************************************************************/
+
+void CLuaBaseEntity::untargetableAndUnactionable(uint32 milliseconds)
+{
+    m_PBaseEntity->PAI->Untargetable(std::chrono::milliseconds(milliseconds), false);
 }
 
 /************************************************************************
@@ -15224,6 +15237,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("restoreFromChest", CLuaBaseEntity::restoreFromChest);
     SOL_REGISTER("hasPreventActionEffect", CLuaBaseEntity::hasPreventActionEffect);
     SOL_REGISTER("stun", CLuaBaseEntity::stun);
+    SOL_REGISTER("untargetableAndUnactionable", CLuaBaseEntity::untargetableAndUnactionable);
 
     SOL_REGISTER("getPool", CLuaBaseEntity::getPool);
     SOL_REGISTER("getDropID", CLuaBaseEntity::getDropID);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -804,6 +804,7 @@ public:
     void restoreFromChest(CLuaBaseEntity* PLuaBaseEntity, uint32 restoreType);
     bool hasPreventActionEffect();
     void stun(uint32 milliseconds);
+    void untargetableAndUnactionable(uint32 milliseconds);
 
     uint32 getPool(); // Returns a mobs pool ID. If entity is not a mob, returns nil.
     uint32 getDropID();

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -50,6 +50,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_CANNOT_USE_IN_AREA    = 40,  /* cannot use in this area */
     MSGBASIC_UNABLE_TO_CAST_SPELLS = 49,  /* The <player> is unable to cast spells. */
     MSGBASIC_MAGIC_NO_EFFECT       = 75,  /* <caster>'s <spell> has no effect on <target>. */
+    MSGBASIC_IS_PARALYZED_2        = 84,  /* <target> is paralyzed. */
     MSGBASIC_MAGIC_TELEPORT        = 93,  /* <caster> casts <spell>. <target> vanishes. */
     MSGBASIC_WAIT_LONGER           = 94,  /* You must wait longer to perform that action. */
     MSGBASIC_PLAYER_DEFEATED_BY    = 97,  /* <player> was defeated by the <target>. */
@@ -57,6 +58,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_USES_JA2              = 101, /* The <player> uses .. */
     MSGBASIC_USES_RECOVERS_HP      = 102, /* The <player> uses .. <target> recovers .. HP. */
     MSGBASIC_SKILL_RECOVERS_HP     = 103, /* The <player> uses .. <target> recovers .. HP. */
+    MSGBASIC_IS_STATUS             = 203, /* <target> is <status>. */
 
     MSGBASIC_USES_JA_TAKE_DAMAGE      = 317, /* The <player> uses .. <target> takes .. points of damage. */
     MSGBASIC_IS_INTIMIDATED           = 106, /* The <player> is intimidated by <target>'s presence. */

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3415,7 +3415,7 @@ namespace battleutils
 
     bool IsParalyzed(CBattleEntity* PAttacker)
     {
-        return (xirand::GetRandomNumber(100) < std::clamp(PAttacker->getMod(Mod::PARALYZE) - PAttacker->getMod(Mod::PARALYZERES), 0, 100));
+        return (xirand::GetRandomNumber(100) < PAttacker->getMod(Mod::PARALYZE));
     }
 
     /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adjust intimidate/is paralyzed melee/JA messages to match retail

* Fixed duplicate "is paralyzed" messages by sending it properly as an action with the right param/animation
* Move claim on auto attack to match retail jank where you can still claim a monster with an auto attack that is paralyzed
* Move auto attack timer to above para/intimidate checks for trust timer
* Add intimidation check to abilities
* Add super jump untargetable implementation
* Add various untargetable checks to states

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!setmod paralyze 100` on a target and additionally a player, see it emit one "Is Paralyzed" message per action
`!changejob BST 99`, have a non-beastmen mob attack you, see a single "x intimidated by" message
`!setmod humanoid_killer 100` on a mob, attack it and see constant intimidates on spells/melee attacks
Use super jump and see the mob lose target on you during a spell cast or post TP move ready
Super jump "untargetable" state is testable with `!exec target:untargetableAndUnactionable(5000)` for 5 seconds of being untargetable