### PR TITLE
[lua] Fix "additem" GM command not printing the item name with the full inventory message, add plural message for the same check

### DIFF
--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -47,9 +47,14 @@ function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, a
         return
     end
 
+    -- TODO: check qty and stack size + remaining inventory space instead of hardcoded == 0 check
     -- Ensure the GM has room to obtain the item...
     if player:getFreeSlotsCount() == 0 then
-        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
+        if quantity > 1 then
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED + 1, itemToGet)
+        else
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, itemToGet)
+        end
         return
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Updates !additem GM command to correctly print the item in the message

## Steps to test these changes

use !additem {item} 1 with a full inventory, see "you cannot obtain the {item}"
use !additem {item} 2 with a full inventory, see "you cannot obtain the {item}s"
