### PR TITLE
Implement Hundredfaced Hapool Ja (Mamook)

### DIFF
--- a/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Mamook
+--  Mob: Hundredfaced Hapool Ja
+-----------------------------------
+require("scripts/globals/spell_data")
+require("scripts/globals/titles")
+require("scripts/globals/status")
+mixins = { require("scripts/mixins/job_special") }
+-----------------------------------
+local ID = require("scripts/zones/Mamook/IDs")
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    local hundredfacedHapoolJa = mob:getID()
+    mob:addListener("MAGIC_USE", "SPAWN_CLONES", function(mobArg, target, spell, action)
+        local spellId = spell:getID()
+        local hateTarget = GetMobByID(hundredfacedHapoolJa):getTarget()
+
+        -- Utsusemi: Ichi (3 clones)
+        if spellId == xi.magic.spell.UTSUSEMI_ICHI then
+            for clone = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 3 do
+                if not GetMobByID(clone):isSpawned() then
+                    GetMobByID(clone):setSpawn(mob:getXPos()+math.random(1, 5), mob:getYPos(), mob:getZPos()+math.random(1, 5))
+                    SpawnMob(clone):updateEnmity(hateTarget)
+                end
+            end
+
+        -- Utsusemi: Ni/San (4 clones)
+        elseif spellId == xi.magic.spell.UTSUSEMI_NI or spellId == xi.magic.spell.UTSUSEMI_SAN then
+            for clone = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 4 do
+                if not GetMobByID(clone):isSpawned() then
+                    GetMobByID(clone):setSpawn(mob:getXPos()+math.random(1, 5), mob:getYPos(), mob:getZPos()+math.random(1, 5))
+                    SpawnMob(clone):updateEnmity(hateTarget)
+                end
+            end
+        end
+
+        for i = hundredfacedHapoolJa + 1, hundredfacedHapoolJa + 4 do
+            local pet = GetMobByID(i)
+            if pet:getCurrentAction() == xi.act.ROAMING then
+                pet:updateEnmity(target)
+            end
+        end
+    end)
+end
+
+entity.onMobEngaged = function(mob, target)
+    mob:castSpell(xi.magic.spell.UTSUSEMI_SAN, mob)
+end
+
+entity.onMobDeath = function(mob, player, isKiller)
+    local hundredfacedHapoolJa = mob:getID()
+    for i = 1, 4 do DespawnMob(hundredfacedHapoolJa + i) end
+end
+
+entity.onMobDespawn = function(mob)
+    local hundredfacedHapoolJa = mob:getID()
+    for i = 1, 4 do DespawnMob(hundredfacedHapoolJa + i) end
+end
+
+return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -3185,6 +3185,7 @@ INSERT INTO `mob_groups` VALUES (68,6754,65,'Venomfang',0,128,0,0,0,78,78,0);
 INSERT INTO `mob_groups` VALUES (69,6755,65,'Yalungur',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (70,6756,65,'Predatory_Colibri',0,128,0,0,0,99,99,0);
 INSERT INTO `mob_groups` VALUES (71,3807,65,'Suhur_Mas',960,0,2359,0,0,68,71,0);
+INSERT INTO `mob_groups` VALUES (72,7056,65,'Hundredfaced_clone',0,128,0,0,0,75,90,0);
 
 -- ------------------------------------------------------------
 -- Mamool_Ja_Training_Grounds (Zone 66)

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7114,6 +7114,10 @@ INSERT INTO `mob_pools` VALUES (7053,'Titan_Prime_TSTBE','Titan_Prime',45,0x0000
 INSERT INTO `mob_pools` VALUES (7054,'Leviathan_Prime_TSTBW','Leviathan_Prime',40,0x00001B0300000000000000000000000000000000,4,4,8,240,100,0,1,1,1,18,0,0,0,3,0,0,0,0,0,1182,40);
 
 INSERT INTO `mob_pools` VALUES (7055,'Armoury_Crate','Armoury_Crate',183,0x0000C00300000000000000000000000000000000,1,0,0,240,100,1024,0,0,0,64,0,0,0,131,8,0,0,0,0,0,183);
+
+-- Mamook (cont.) - Utsusemi clones of Hundredfaced_Hapool_Ja 
+INSERT INTO `mob_pools` VALUES (7056,'Hundredfaced_clone','Hundredfaced_Hapool_Ja',176,0x0600530600000000000000000000000000000000,13,13,10,280,100,0,1,1,1,2,0,32,0,159,4,0,7,0,0,176,176);
+
 -- ------------------------------------------------------------
 -- Start of Ambuscade section
 -- NOTE: The mobs are changed every update in the DATs, so using out-of-date


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

As it stands, on server init, the NM will be up along with his 4 'clones' by default. However
according to FFXIClopedia, and confirmed by me research in retail, the clones spawn only when NM uses Utsusemi.

## Steps to test these changes

engage mob, wait until it uses utsusemi, and clones should spawn around him, rather than being pre-spawned
