### PR TITLE
[core] Fix order of dynamic id lookup

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -759,6 +759,11 @@ namespace luautils
 
     void PopulateIDLookups(std::optional<uint16> maybeZoneId)
     {
+        TracyZoneScoped;
+
+        // Make sure this has been run at least once!
+        auto result = lua.safe_script_file("scripts/globals/zone.lua");
+
         // clang-format off
         auto handleZone = [&](CZone* PZone)
         {
@@ -776,45 +781,46 @@ namespace luautils
                         {
                             if (innerKey.get_type() == sol::type::string && innerValue.get_type() == sol::type::number)
                             {
-                                auto name = innerKey.as<std::string>();
+                                auto name = to_upper(innerKey.as<std::string>());
                                 auto num  = innerValue.as<int32>();
 
+                                // -1 == DYNAMIC_LOOKUP
                                 if (num == -1)
                                 {
                                     bool found = false;
                                     if (outerName == "mob")
                                     {
-                                        PZone->ForEachMob([&](CMobEntity* PMob)
+                                        // TODO: Execute this as a single query per-zone and pull out the desired results.
+                                        auto query = fmt::sprintf("SELECT mobid FROM xidb.mob_spawn_points "
+                                                            "WHERE ((mobid >> 12) & 0xFFF) = %i AND "
+                                                            "UPPER(mobname) = '%s' "
+                                                            "LIMIT 1;", PZone->GetID(), name.c_str());
+                                        DebugIDLookup(query.c_str());
+                                        auto ret = sql->Query(query.c_str());
+                                        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
                                         {
-                                            if (!found)
-                                            {
-                                                auto keyName = to_upper(std::string((const char*)PMob->GetName()));
-                                                if (keyName == name)
-                                                {
-                                                    lua["zones"][PZone->GetID()][outerName][keyName] = PMob->id;
-                                                    found = true;
-                                                    DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
-                                                        zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][keyName].get<uint32>()));
-                                                }
-                                            }
-                                        });
+                                            lua["zones"][PZone->GetID()][outerName][name] = sql->GetUIntData(0);
+                                            found = true;
+                                            DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
+                                                zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][name].get<uint32>()));
+                                        }
                                     }
                                     else if (outerName == "npc")
                                     {
-                                        PZone->ForEachNpc([&](CNpcEntity* PNpc)
+                                        // TODO: Execute this as a single query per-zone and pull out the desired results.
+                                        auto query = fmt::sprintf("SELECT npcid FROM xidb.npc_list "
+                                                            "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
+                                                            "UPPER(CAST(`name` as VARCHAR(64))) = '%s' "
+                                                            "LIMIT 1;", PZone->GetID(), name.c_str());
+                                        DebugIDLookup(query.c_str());
+                                        auto ret = sql->Query(query.c_str());
+                                        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
                                         {
-                                            if (!found)
-                                            {
-                                                auto keyName = to_upper(std::string((const char*)PNpc->GetName()));
-                                                if (keyName == name)
-                                                {
-                                                    lua["zones"][PZone->GetID()][outerName][keyName] = PNpc->id;
-                                                    found = true;
-                                                    DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
-                                                        zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][keyName].get<uint32>()));
-                                                }
-                                            }
-                                        });
+                                            lua["zones"][PZone->GetID()][outerName][name] = sql->GetUIntData(0);
+                                            found = true;
+                                            DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
+                                                zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][name].get<uint32>()));
+                                        }
                                     }
 
                                     if (!found)
@@ -826,6 +832,8 @@ namespace luautils
                         }
                     }
                 }
+                // Re-publish to package.loaded. This is the same as loading the contents of a script with require("name").
+                lua["package"]["loaded"][fmt::format("scripts/zones/{}/IDs", zoneName)] = lua["zones"][PZone->GetID()];
             }
         };
 
@@ -833,7 +841,10 @@ namespace luautils
         {
             zoneutils::ForEachZone([&](CZone* PZone)
             {
-                handleZone(PZone);
+                if (PZone->GetIP() != 0)
+                {
+                    handleZone(PZone);
+                }
             });
         }
         else
@@ -3226,6 +3237,7 @@ namespace luautils
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(PKiller);
 
         auto optParams = lua.create_table();
+
         optParams["isKiller"]          = false;
         optParams["noKiller"]          = true;
         optParams["isWeaponSkillKill"] = false;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -260,8 +260,6 @@ int32 do_init(int32 argc, char** argv)
     fishingutils::InitializeFishingSystem();
     instanceutils::LoadInstanceList();
 
-    luautils::PopulateIDLookups();
-
     ShowInfo("do_init: server is binding with port %u", map_port == 0 ? settings::get<uint16>("network.MAP_PORT") : map_port);
     map_fd = makeBind_udp(INADDR_ANY, map_port == 0 ? settings::get<uint16>("network.MAP_PORT") : map_port);
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -680,6 +680,9 @@ namespace zoneutils
             g_PZoneList[0] = CreateZone(0);
         }
 
+        // IDs attached to xi.zone[name] need to be populated before NPCs and Mobs are loaded
+        luautils::PopulateIDLookups();
+
         LoadNPCList();
         LoadMOBList();
         campaign::LoadState();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Jiggles the load order of DYNAMIC_LOOKUP a bit to ensure the IDs are populated and published to `package.loaded`/`require` before any zone or mob or npc scripts sees them - stopping any bad lookups.

Fixes https://github.com/LandSandBoat/server/issues/2841

## Steps to test these changes

The steps in https://github.com/LandSandBoat/server/issues/2841
