### PR TITLE
change load order setting gets checked in

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3258,10 +3258,9 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
     uint8 containerID = data.ref<uint8>(0x06); // container id
 
     bool isAdditionalContainer =
-        settings::get<bool>("main.EQUIP_FROM_OTHER_CONTAINERS") &&
-        (containerID == LOC_MOGSATCHEL ||
-         containerID == LOC_MOGSACK ||
-         containerID == LOC_MOGCASE);
+        containerID == LOC_MOGSATCHEL ||
+        containerID == LOC_MOGSACK ||
+        containerID == LOC_MOGCASE;
 
     bool isEquippableInventory =
         containerID == LOC_INVENTORY ||
@@ -3273,7 +3272,8 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
         containerID == LOC_WARDROBE6 ||
         containerID == LOC_WARDROBE7 ||
         containerID == LOC_WARDROBE8 ||
-        isAdditionalContainer;
+        (settings::get<bool>("main.EQUIP_FROM_OTHER_CONTAINERS") &&
+        isAdditionalContainer);
 
     bool isLinkshell =
         equipSlotID == SLOT_LINK1 ||


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
I know its not being -used- her at the moment, but the additional containers still -are- additional containers, regardless of the settings state. So this just re-orders things to reflect that. Otherwise, when the setting is false, the entire bool there was also false. This didn't impact ability to equip. Nitpicky of me maybe.

## Steps to test these changes
print true/false status of each bool before and after.
