### PR TITLE
Fix formatting in packet_system conditional

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3273,7 +3273,7 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
         containerID == LOC_WARDROBE7 ||
         containerID == LOC_WARDROBE8 ||
         (settings::get<bool>("main.EQUIP_FROM_OTHER_CONTAINERS") &&
-        isAdditionalContainer);
+         isAdditionalContainer);
 
     bool isLinkshell =
         equipSlotID == SLOT_LINK1 ||


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fi es sanity fail
## Steps to test these changes
CI should not fail
<!-- Clear and detailed steps to test your changes here -->
