### PR TITLE
Add mobMod ENCROACH_TARGET for NMs like Claret and Dyinyinga

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2496,6 +2496,7 @@ xi.mobMod =
     NO_LINK             = 69, -- If set, mob cannot link until unset.
     NO_REST             = 70, -- Mob cannot regain hp (e.g. re-burrowing antlions during ENM).
     LEADER              = 71, -- Used for mobs that follow a defined "leader", such as Ul'xzomit mobs.
+    ENCROACH_TARGET     = 72, -- How close a mob will encroach on it's target, attempting to make model to model contact. Encroach distance * 10
 }
 
 -----------------------------------

--- a/scripts/zones/Mount_Zhayolm/mobs/Claret.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Claret.lua
@@ -20,6 +20,7 @@ entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.REGEN, math.floor(mob:getMaxHP()*.004))
     mob:addMod(xi.mod.BINDRES, 40)
     mob:addMod(xi.mod.MOVE, 15)
+    mob:setMobMod(xi.mobMod.ENCROACH_TARGET, 35)
     mob:SetAutoAttackEnabled(false)
 end
 

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Dyinyinga.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Dyinyinga.lua
@@ -6,6 +6,10 @@ require("scripts/globals/hunts")
 -----------------------------------
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.ENCROACH_TARGET, 35)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 511)
 end

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -620,8 +620,9 @@ void CMobController::Move()
         }
     }
 
-    bool  move         = PMob->PAI->PathFind->IsFollowingPath();
-    float attack_range = PMob->GetMeleeRange();
+    bool  move            = PMob->PAI->PathFind->IsFollowingPath();
+    float attack_range    = PMob->GetMeleeRange();
+    float closureDistance = attack_range - 0.2f - (static_cast<float>(PMob->getMobMod(MOBMOD_ENCROACH_TARGET)) / 10.0);
 
     if (PMob->getMobMod(MOBMOD_ATTACK_SKILL_LIST) > 0)
     {
@@ -643,7 +644,7 @@ void CMobController::Move()
         CMobEntity* posShare = (CMobEntity*)PMob->GetEntity(PMob->getMobMod(MOBMOD_SHARE_POS) + PMob->targid, TYPE_MOB);
         PMob->loc            = posShare->loc;
     }
-    else if (((currentDistance > attack_range - 0.2f) || move) && PMob->PAI->CanFollowPath())
+    else if (((currentDistance > closureDistance) || move) && PMob->PAI->CanFollowPath())
     {
         //#TODO: can this be moved to scripts entirely?
         if (PMob->getMobMod(MOBMOD_DRAW_IN) > 0)
@@ -672,7 +673,7 @@ void CMobController::Move()
                 if (!PMob->PAI->PathFind->IsFollowingPath() || distanceSquared(PMob->PAI->PathFind->GetDestination(), PTarget->loc.p) > 10)
                 {
                     // path to the target if we don't have a path already
-                    PMob->PAI->PathFind->PathInRange(PTarget->loc.p, attack_range - 0.2f, PATHFLAG_WALLHACK | PATHFLAG_RUN);
+                    PMob->PAI->PathFind->PathInRange(PTarget->loc.p, closureDistance, PATHFLAG_WALLHACK | PATHFLAG_RUN);
                 }
                 PMob->PAI->PathFind->FollowPath(m_Tick);
                 if (!PMob->PAI->PathFind->IsFollowingPath())

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -100,6 +100,7 @@ enum MOBMODIFIER : int
     MOBMOD_NO_LINK            = 69, // If set, mob cannot link until unset.
     MOBMOD_NO_REST            = 70, // Mob cannot regain hp (e.g. re-burrowing antlions during ENM).
     MOBMOD_LEADER             = 71, // Used for mobs that follow a defined "leader", such as Ul'xzomit mobs.
+    MOBMOD_ENCROACH_TARGET    = 72, // How close a mob will encroach on it's target, attempting to make model to model contact. Encroach distance * 10
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This PR adds a new mob mod, ENCROACH_TARGET, which when enabled on a mob allows the mob to "close in" on its target closer than is normally allowed.  This functionality is used by NMs like Claret and Dyinyinga where they apply a status to the player if they are able to get close enough.  These NMs attempt to make model to model contact with players.

## Steps to test these changes

1. Get to Claret  
> !zone {Mount Zhayolm}   
> !pos 501 -9 53)
2. Turn off GodMode if on.  Enable !Immortal if not on
3. Get a pectin
>!additem 2591 
4. !hp 0 the nearby clot or toggle GM
5. Trade the pectin to the ??? to spawn Claret
6. Note that Claret will get very close to the player, much closer than normal mobs, and a poison is applied.
7. Move away from Claret slowly, note that Claret continues to close in tightly as soon as the player is a little bit away
8. Run from Claret (with speed boost/flee), note that when Claret finally catches up, it encroaches on the player
9. Aggro/pull a clot nearby, note that the clot does not encroach the player even though Claret still does.


Note: This replaces the [closed PR ](https://github.com/LandSandBoat/server/pull/2867)