### PR TITLE
[core] Remove explicit db name from dynamic queries, replace `-` with `_` in name lookups

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -791,7 +791,7 @@ namespace luautils
                                     if (outerName == "mob")
                                     {
                                         // TODO: Execute this as a single query per-zone and pull out the desired results.
-                                        auto query = fmt::sprintf("SELECT mobid FROM xidb.mob_spawn_points "
+                                        auto query = fmt::sprintf("SELECT mobid FROM mob_spawn_points "
                                                             "WHERE ((mobid >> 12) & 0xFFF) = %i AND "
                                                             "UPPER(REPLACE(mobname, '-', '_')) = '%s' "
                                                             "LIMIT 1;", PZone->GetID(), name.c_str());
@@ -808,7 +808,7 @@ namespace luautils
                                     else if (outerName == "npc")
                                     {
                                         // TODO: Execute this as a single query per-zone and pull out the desired results.
-                                        auto query = fmt::sprintf("SELECT npcid FROM xidb.npc_list "
+                                        auto query = fmt::sprintf("SELECT npcid FROM npc_list "
                                                             "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
                                                             "UPPER(REPLACE(CAST(`name` as VARCHAR(64)), '-', '_')) = '%s' "
                                                             "LIMIT 1;", PZone->GetID(), name.c_str());

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -793,7 +793,7 @@ namespace luautils
                                         // TODO: Execute this as a single query per-zone and pull out the desired results.
                                         auto query = fmt::sprintf("SELECT mobid FROM xidb.mob_spawn_points "
                                                             "WHERE ((mobid >> 12) & 0xFFF) = %i AND "
-                                                            "UPPER(mobname) = '%s' "
+                                                            "UPPER(REPLACE(mobname, '-', '_')) = '%s' "
                                                             "LIMIT 1;", PZone->GetID(), name.c_str());
                                         DebugIDLookup(query.c_str());
                                         auto ret = sql->Query(query.c_str());
@@ -810,7 +810,7 @@ namespace luautils
                                         // TODO: Execute this as a single query per-zone and pull out the desired results.
                                         auto query = fmt::sprintf("SELECT npcid FROM xidb.npc_list "
                                                             "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
-                                                            "UPPER(CAST(`name` as VARCHAR(64))) = '%s' "
+                                                            "UPPER(REPLACE(CAST(`name` as VARCHAR(64)), '-', '_')) = '%s' "
                                                             "LIMIT 1;", PZone->GetID(), name.c_str());
                                         DebugIDLookup(query.c_str());
                                         auto ret = sql->Query(query.c_str());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
* Removes xidb from queries
* Adds string replacement for `-` with `_` in mob and npc name lookup results

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Dynamic lookups with names with `-` in them should be successful, database queries without main db named xidb should be successful
<!-- Clear and detailed steps to test your changes here -->
