### PR TITLE
[core] fix "/sea region" crash in dynamis

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -695,7 +695,7 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
     uint8 minRank = 0;
     uint8 maxRank = 0;
 
-    uint16 areas[10] = {};
+    uint16 areas[15] = {};
 
     uint32 flags = 0;
 
@@ -706,7 +706,6 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
 
     uint8 commentType = 0;
 
-    memset(areas, 0, sizeof(areas));
     // ShowInfo("Received a search packet with size %u byte", size);
 
     while (bitOffset < workloadBits)
@@ -927,7 +926,7 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
     sr.commentType = commentType;
 
     sr.nameLen = nameLen;
-    memcpy(sr.zoneid, areas, sizeof(sr.zoneid));
+    memcpy(&sr.zoneid, areas, sizeof(sr.zoneid));
     if (nameLen > 0)
     {
         sr.name.insert(0, name);

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -23,7 +23,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 struct search_req
 {
-    uint16      zoneid[10];
+    uint16      zoneid[15];
     uint8       jobid;
     uint8       minlvl;
     uint8       maxlvl;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes `/sea region` crash in dynamis
Removes a needless memset due to the initialize already being used
Adjusts existing memset to use & as per standard convention

Apparently the client is now requesting >10 zones on /sea region in dynamis, and search's stack got corrupted trying to insert more than 10.


## Steps to test these changes

!zone dynamis - beaucedine
/sea region
get search results