### PR TITLE
[core] Fix AoE trust abilities using stale target

### DIFF
--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -156,7 +156,7 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
                 actionTarget.messageID       = PAbility->getMessage();
                 actionTarget.param           = 0;
 
-                int32 value = luautils::OnUseAbility(this, PTarget, PAbility, &action);
+                int32 value = luautils::OnUseAbility(this, PTargetFound, PAbility, &action);
 
                 if (prevMsg == 0) // get default message for the first target
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fix AoE trust abilities using stale target
Fixes  #2897

## Steps to test these changes

Use Qultada, check outgoing action packet using correct target IDs & not having random param per target hit