### PR TITLE
[lua] Add event update to Beyond Infinity, use zone enums for setPos

### DIFF
--- a/scripts/quests/jeuno/LB10_Beyond_Infinity.lua
+++ b/scripts/quests/jeuno/LB10_Beyond_Infinity.lua
@@ -3,11 +3,13 @@
 -----------------------------------
 -- Log ID: 3, Quest ID: 137
 -- Nomad Moogle : !pos 10.012 1.453 121.883 243
+-----------------------------------
 require('scripts/globals/items')
 require('scripts/globals/keyitems')
 require('scripts/globals/npc_util')
 require('scripts/globals/quests')
 require('scripts/globals/titles')
+require('scripts/globals/zone')
 require('scripts/globals/interaction/quest')
 -----------------------------------
 local ruludeID = require('scripts/zones/RuLude_Gardens/IDs')
@@ -30,7 +32,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
-                player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.PRELUDE_TO_PUISSANCE) == QUEST_COMPLETED
+                player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.PRELUDE_TO_PUISSANCE)
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -52,13 +54,13 @@ quest.sections =
 
                     -- This options also warp you to a BCNM. Note that the quest "Beyond Infinity" is already activated.
                     if option == 14 then
-                        player:setPos(-511.459, 159.004, -210.543, 10, 139) -- Horlais Peek
+                        player:setPos(-511.459, 159.004, -210.543, 10, xi.zone.HORLAIS_PEAK)
                     elseif option == 19 then
-                        player:setPos(-349.899, 104.213, -260.150, 0, 144) -- Waughrum Shrine
+                        player:setPos(-349.899, 104.213, -260.150, 0, xi.zone.WAUGHROON_SHRINE)
                     elseif option == 20 then
-                        player:setPos(299.316, -123.591, 353.760, 66, 146) -- Balga's Dais
+                        player:setPos(299.316, -123.591, 353.760, 66, xi.zone.BALGAS_DAIS)
                     elseif option == 21 then
-                        player:setPos(-225.146, -24.250, 20.057, 255, 206) -- Qu'bia Arena
+                        player:setPos(-225.146, -24.250, 20.057, 255, xi.zone.QUBIA_ARENA)
                     end
                 end,
             },
@@ -91,14 +93,14 @@ quest.sections =
             onEventFinish =
             {
                 [10045] = function(player, csid, option, npc)
-                    if option == 16 then -- Horlais Peek
-                        player:setPos(-511.459, 159.004, -210.543, 10, 139)
-                    elseif option == 22 then -- Waughrum Shrine
-                        player:setPos(-349.899, 104.213, -260.150, 0, 144)
-                    elseif option == 23 then -- Balga's Dais
-                        player:setPos(299.316, -123.591, 353.760, 66, 146)
-                    elseif option == 24 then -- Qu'bia Arena
-                        player:setPos(-225.146, -24.250, 20.057, 255, 206)
+                    if option == 16 then
+                        player:setPos(-511.459, 159.004, -210.543, 10, xi.zone.HORLAIS_PEAK)
+                    elseif option == 22 then
+                        player:setPos(-349.899, 104.213, -260.150, 0, xi.zone.WAUGHROON_SHRINE)
+                    elseif option == 23 then
+                        player:setPos(299.316, -123.591, 353.760, 66, xi.zone.BALGAS_DAIS)
+                    elseif option == 24 then
+                        player:setPos(-225.146, -24.250, 20.057, 255, xi.zone.QUBIA_ARENA)
                     end
                 end,
             },
@@ -108,7 +110,8 @@ quest.sections =
     -- Section: Quest accepted. We failed BCNM.
     {
         check = function(player, status, vars)
-            return status == QUEST_ACCEPTED and vars.Prog == 0 and
+            return status == QUEST_ACCEPTED and
+                vars.Prog == 0 and
                 not player:hasKeyItem(xi.ki.SOUL_GEM_CLASP)
         end,
 
@@ -131,20 +134,34 @@ quest.sections =
                 end,
             },
 
+            onEventUpdate =
+            {
+                [10045] = function(player, csid, option, npc)
+                    if option == 9 then
+                        local numMerits = player:getMeritCount()
+
+                        if numMerits >= 1 then
+                            player:setMerits(numMerits - 1)
+                        end
+                    end
+                end,
+            },
+
             onEventFinish =
             {
                 [10045] = function(player, csid, option, npc)
-                    player:setMerits(player:getMeritCount() - 1)
-                    npcUtil.giveKeyItem(player, xi.ki.SOUL_GEM_CLASP)
+                    if option ~= 0 then
+                        npcUtil.giveKeyItem(player, xi.ki.SOUL_GEM_CLASP)
+                    end
 
-                    if option == 17 then -- Horlais Peek
-                        player:setPos(-511.459, 159.004, -210.543, 10, 139)
-                    elseif option == 25 then -- Waughrum Shrine
-                        player:setPos(-349.899, 104.213, -260.150, 0, 144)
-                    elseif option == 26 then -- Balga's Dais
-                        player:setPos(299.316, -123.591, 353.760, 66, 146)
-                    elseif option == 27 then -- Qu'bia Arena
-                        player:setPos(-225.146, -24.250, 20.057, 255, 206)
+                    if option == 17 then
+                        player:setPos(-511.459, 159.004, -210.543, 10, xi.zone.HORLAIS_PEAK)
+                    elseif option == 25 then
+                        player:setPos(-349.899, 104.213, -260.150, 0, xi.zone.WAUGHROON_SHRINE)
+                    elseif option == 26 then
+                        player:setPos(299.316, -123.591, 353.760, 66, xi.zone.BALGAS_DAIS)
+                    elseif option == 27 then
+                        player:setPos(-225.146, -24.250, 20.057, 255, xi.zone.QUBIA_ARENA)
                     end
                 end,
 
@@ -152,14 +169,14 @@ quest.sections =
                     player:confirmTrade()
                     npcUtil.giveKeyItem(player, xi.ki.SOUL_GEM_CLASP)
 
-                    if option == 16 then -- Horlais Peek
-                        player:setPos(-511.459, 159.004, -210.543, 10, 139)
-                    elseif option == 22 then -- Waughrum Shrine
-                        player:setPos(-349.899, 104.213, -260.150, 0, 144)
-                    elseif option == 23 then -- Balga's Dais
-                        player:setPos(299.316, -123.591, 353.760, 66, 146)
-                    elseif option == 24 then -- Qu'bia Arena
-                        player:setPos(-225.146, -24.250, 20.057, 255, 206)
+                    if option == 16 then
+                        player:setPos(-511.459, 159.004, -210.543, 10, xi.zone.HORLAIS_PEAK)
+                    elseif option == 22 then
+                        player:setPos(-349.899, 104.213, -260.150, 0, xi.zone.WAUGHROON_SHRINE)
+                    elseif option == 23 then
+                        player:setPos(299.316, -123.591, 353.760, 66, xi.zone.BALGAS_DAIS)
+                    elseif option == 24 then
+                        player:setPos(-225.146, -24.250, 20.057, 255, xi.zone.QUBIA_ARENA)
                     end
                 end,
             },
@@ -169,7 +186,8 @@ quest.sections =
     -- Section: Quest accepted. We beated the BCNM.
     {
         check = function(player, status, vars)
-            return status == QUEST_ACCEPTED and vars.Prog == 1
+            return status == QUEST_ACCEPTED and
+                vars.Prog == 1
         end,
 
         [xi.zone.RULUDE_GARDENS] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Updates Limit Break quest: Beyond Infinity
* Adds event update for on BCNM failed section for spending 1 merit
* Uses xi.zone enum for setPos zone locations
* Minor formatting/styling

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Follow guide for this quest
<!-- Clear and detailed steps to test your changes here -->
