### PR TITLE
Battlefield Required Items 

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -80,6 +80,28 @@ xi.battlefield.id =
     SE_APOLLYON = 1293,
 }
 
+xi.battlefield.itemUses =
+{
+    [xi.items.WARRIORS_TESTIMONY] = 3,
+    [xi.items.MONKS_TESTIMONY] = 3,
+    [xi.items.WHITE_MAGES_TESTIMONY] = 3,
+    [xi.items.BLACK_MAGES_TESTIMONY] = 3,
+    [xi.items.RED_MAGES_TESTIMONY] = 3,
+    [xi.items.THIEFS_TESTIMONY] = 3,
+    [xi.items.PALADINS_TESTIMONY] = 3,
+    [xi.items.DARK_KNIGHTS_TESTIMONY] = 3,
+    [xi.items.BEASTMASTERS_TESTIMONY] = 3,
+    [xi.items.BARDS_TESTIMONY] = 3,
+    [xi.items.RANGERS_TESTIMONY] = 3,
+    [xi.items.SAMURAIS_TESTIMONY] = 3,
+    [xi.items.NINJAS_TESTIMONY] = 3,
+    [xi.items.DRAGOONS_TESTIMONY] = 3,
+    [xi.items.SUMMONERS_TESTIMONY] = 3,
+    [xi.items.BLUE_MAGES_TESTIMONY] = 3,
+    [xi.items.CORSAIRS_TESTIMONY] = 3,
+    [xi.items.PUPPETMASTERS_TESTIMONY] = 3,
+}
+
 Battlefield = setmetatable({}, { __index = Container })
 Battlefield.__index = Battlefield
 Battlefield.__eq = function(m1, m2)
@@ -134,6 +156,12 @@ function Battlefield:new(data)
     obj.groups = {}
     obj.paths = {}
     obj.loot = {}
+
+    -- Determine which items need to be traded as the requiredItems format is incompatable with npcUtil.tradeHasExactly
+    obj.tradeItems = {}
+    for index, value in ipairs(obj.requiredItems) do
+        obj.tradeItems[index] = value
+    end
 
     return obj
 end
@@ -231,8 +259,8 @@ function Battlefield:checkRequirements(player, npc, registrant, trade)
         end
     end
 
-    if trade and #self.requiredItems > 0 then
-        if not npcUtil.tradeHasExactly(trade, self.requiredItems) then
+    if trade and #self.tradeItems > 0 then
+        if not npcUtil.tradeHasExactly(trade, self.tradeItems) then
             return false
         end
     end
@@ -286,13 +314,18 @@ function Battlefield.onEntryTrade(player, npc, trade, onUpdate)
     -- Ensure that the traded item(s) are not worn out
     local contents = xi.battlefield.contentsByZone[zoneId]
     for _, content in ipairs(contents) do
-        if
-            #content.requiredItems > 0 and
-            content.requiredItems[1].wornMessage and
-            player:hasWornItem(content.requiredItems[1])
-        then
-            player:messageBasic(content.requiredItems[1].wornMessage)
-            return false
+        if #content.requiredItems > 0 and content.requiredItems.wornMessage and npcUtil.tradeHas(trade, content.tradeItems) then
+            local itemId = content.requiredItems[1]
+            -- Gets the total number of item uses for the given item. Default to one since that is the majority of them.
+            local totalUses = xi.battlefield.itemUses[itemId] or 1
+            if player:getWornUses(itemId) >= totalUses then
+                if totalUses > 1 then
+                    player:messageSpecial(content.requiredItems.wornMessage, itemId)
+                else
+                    player:messageSpecial(content.requiredItems.wornMessage, 0, 0, 0, itemId)
+                end
+                return false
+            end
         end
     end
 
@@ -425,14 +458,9 @@ function Battlefield:onEntryEventUpdate(player, csid, option, extras)
         local effect = player:getStatusEffect(xi.effect.BATTLEFIELD)
         local zone   = player:getZoneID()
 
-        -- Handle traded items
-        for _, item in ipairs(self.requiredItems) do
-            if item.wearMessage and player:hasItem(item[1]) then
-                player:createWornItem(item[1])
-                player:messageSpecial(item.wearMessage, item[1])
-            else
-                player:tradeComplete()
-            end
+        -- Handle traded items if not wearing them
+        if self.requiredItems.wearMessage == nil and #self.tradeItems > 0 then
+            player:tradeComplete()
         end
 
         -- Handle party/alliance members
@@ -586,9 +614,16 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
             end
         end
 
-        for _, item in ipairs(self.requiredItems) do
-            if item.message ~= 0 then
-                player:messageSpecial(item.message, 0, 0, 0, item[0])
+        if self.requiredItems.wearMessage and player:hasItem(self.requiredItems[1]) then
+            local itemId = self.requiredItems[1]
+            local uses = player:incrementItemWear(itemId)
+            -- Gets the total number of item uses for the given item. Default to one since that is the majority of them.
+            local totalUses = xi.battlefield.itemUses[itemId] or 1
+            if totalUses > 1 then
+                local remaining = totalUses - uses
+                player:messageSpecial(self.requiredItems.wearMessage, itemId, remaining + 1, remaining)
+            else
+                player:messageSpecial(self.requiredItems.wearMessage, 0, 0, 0, itemId)
             end
         end
     end

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -604,27 +604,25 @@ end
 
 function Battlefield:onBattlefieldEnter(player, battlefield)
     local initiatorId, _ = battlefield:getInitiator()
-    if player:getID() == initiatorId then
-        if #self.requiredKeyItems > 0 then
-            for _, item in ipairs(self.requiredKeyItems) do
-                player:delKeyItem(item)
-            end
-            if self.requiredKeyItems.message ~= 0 then
-                player:messageSpecial(self.requiredKeyItems.message, unpack(self.requiredKeyItems))
-            end
+    if #self.requiredKeyItems > 0 and ((not self.requiredKeyItems.onlyInitiator) or player:getID() == initiatorId) then
+        for _, item in ipairs(self.requiredKeyItems) do
+            player:delKeyItem(item)
         end
+        if self.requiredKeyItems.message ~= 0 then
+            player:messageSpecial(self.requiredKeyItems.message, unpack(self.requiredKeyItems))
+        end
+    end
 
-        if self.requiredItems.wearMessage and player:hasItem(self.requiredItems[1]) then
-            local itemId = self.requiredItems[1]
-            local uses = player:incrementItemWear(itemId)
-            -- Gets the total number of item uses for the given item. Default to one since that is the majority of them.
-            local totalUses = xi.battlefield.itemUses[itemId] or 1
-            if totalUses > 1 then
-                local remaining = totalUses - uses
-                player:messageSpecial(self.requiredItems.wearMessage, itemId, remaining + 1, remaining)
-            else
-                player:messageSpecial(self.requiredItems.wearMessage, 0, 0, 0, itemId)
-            end
+    if player:getID() == initiatorId and self.requiredItems.wearMessage and player:hasItem(self.requiredItems[1]) then
+        local itemId = self.requiredItems[1]
+        local uses = player:incrementItemWear(itemId)
+        -- Gets the total number of item uses for the given item. Default to one since that is the majority of them.
+        local totalUses = xi.battlefield.itemUses[itemId] or 1
+        if totalUses > 1 then
+            local remaining = totalUses - uses
+            player:messageSpecial(self.requiredItems.wearMessage, itemId, remaining + 1, remaining)
+        else
+            player:messageSpecial(self.requiredItems.wearMessage, 0, 0, 0, itemId)
         end
     end
 

--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -987,7 +987,7 @@ xi.bcnm.onTrade = function(player, npc, trade, onUpdate)
             return false
 
         -- Check for already used Orb or testimony.
-        elseif player:hasWornItem(itemId) then
+        elseif player:getWornUses(itemId) > 0 then
             player:messageBasic(xi.msg.basic.ITEM_UNABLE_TO_USE_2, 0, 0) -- Unable to use item.
             return false
         end
@@ -1180,7 +1180,7 @@ xi.bcnm.onEventUpdate = function(player, csid, option, extras)
 
                     -- Set other traded item to worn
                     elseif player:hasItem(item) and player:getName() == initiatorName then
-                        player:createWornItem(item)
+                        player:incrementItemWear(item)
                     end
                 end
 

--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -68,7 +68,7 @@ end
 local function getOrbEvent(player, trade)
     for itemID, orbData in pairs(shamiOrbItems) do
         if npcUtil.tradeHasExactly(trade, itemID) then
-            if player:hasWornItem(itemID) then
+            if player:getWornUses(itemID) > 0 then
                 return 22
             else
                 return orbData[1]

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -214,8 +214,8 @@ public:
     bool   delItem(uint16 itemID, int32 quantity, sol::object const& containerID);
     bool   addUsedItem(uint16 itemID);                                                      // Add charged item with timer already on full cooldown
     bool   addTempItem(uint16 itemID, sol::object const& arg1);                             // Add temp item to Entity Temp inventory
-    bool   hasWornItem(uint16 itemID);                                                      // Check if the item is already worn (player:hasWornItem(itemid))
-    void   createWornItem(uint16 itemID);                                                   // Update this item in worn item (player:createWornItem(itemid))
+    uint8  getWornUses(uint16 itemID);                                                      // Check if the item is already worn
+    uint8  incrementItemWear(uint16 itemID);                                                // Increment the item's worn value and returns it
     auto   findItem(uint16 itemID, sol::object const& location) -> std::optional<CLuaItem>; // Like hasItem, but returns the item object (nil if not found)
 
     void createShop(uint8 size, sol::object const& arg1);                                               // Prepare the container for work of shop ??

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -134,7 +134,7 @@ auto CLuaItem::getMatchingTrials() -> sol::table
     return table;
 }
 
-uint8 CLuaItem::getWornItem()
+uint8 CLuaItem::getWornUses()
 {
     return m_PLuaItem->m_extra[0];
 }
@@ -340,7 +340,7 @@ void CLuaItem::Register()
     SOL_REGISTER("getSlotID", CLuaItem::getSlotID);
     SOL_REGISTER("getTrialNumber", CLuaItem::getTrialNumber);
     SOL_REGISTER("getMatchingTrials", CLuaItem::getMatchingTrials);
-    SOL_REGISTER("getWornItem", CLuaItem::getWornItem);
+    SOL_REGISTER("getWornUses", CLuaItem::getWornUses);
     SOL_REGISTER("isType", CLuaItem::isType);
     SOL_REGISTER("isSubType", CLuaItem::isSubType);
     SOL_REGISTER("getName", CLuaItem::getName);

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -52,7 +52,7 @@ public:
     uint8  getSlotID();     // get the slot id
     uint16 getTrialNumber();
     auto   getMatchingTrials() -> sol::table; // returns a table of trial #'s which match this item precisely
-    uint8  getWornItem();                     // check if the item has been used
+    uint8  getWornUses();                     // check if the item has been used
     uint32 getBasePrice();                    // get the base sell price
 
     bool isType(uint8 type);       // check the item type


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

1. Adds support for "worn" items being used more than once. I believe this is used solely for testimonies.
2. Fixes several issues and messaging around trading items to enter a battlefield.

Initially this was suppose to only fix the first item; however, while testing it I came to realize I never tested required items in the new battlefield system since none of the converted example battlefields used required items.

## Steps to test these changes

For testing I made the following changes.

```lua
-- brothers.lua
requiredItems = { xi.items.BLACK_MAGES_TESTIMONY, wearMessage = ID.text.TESTIMONY_USED, wornMessage = ID.text.TESTIMONY_IS_TORN },
-- requiredKeyItems = { xi.ki.ZEPHYR_FAN, message = ID.text.ZEPHYR_RIPS },

-- holy_cow.lua
requiredItems = { xi.items.STAR_ORB, wearMessage = ID.text.A_CRACK_HAS_FORMED, wornMessage = ID.text.THERE_IS_A_CRACK },
-- requiredKeyItems = { xi.ki.ZEPHYR_FAN, message = ID.text.ZEPHYR_RIPS },

-- zones/Bearclaw_Pinnacle/IDs.lua (add to text)
TESTIMONY_IS_TORN = 7123,
TESTIMONY_USED = 7124,
```

For Brothers (Testimony test)
```
!pos 121 -171 758 6
!additem 1429
```

For Holy Cow (Orb test)
```
!pos -520 25 -801 6
!additem 1131
```