### PR TITLE
Autoskip battlefield cutscenes when reentering without zoning

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -477,7 +477,8 @@ function Battlefield:onEntryEventUpdate(player, csid, option, extras)
         end
     end
 
-    player:updateEvent(result, self.index, 0, clearTime, partySize, self:checkSkipCutscene(player))
+    local autoSkipCS = self:getLocalVar(player, "CS") == 1 and 100 or 0
+    player:updateEvent(result, self.index, autoSkipCS, clearTime, partySize, self:checkSkipCutscene(player))
     player:updateEventString(name)
     return status < xi.battlefield.status.LOCKED and result < xi.battlefield.returnCode.LOCKED
 end
@@ -494,6 +495,7 @@ end
 
 function Battlefield:onEventFinishEnter(player, csid, option)
     player:setLocalVar("[battlefield]area", 0)
+    self:setLocalVar(player, "CS", 1)
 end
 
 function Battlefield:onEventFinishWin(player, csid, option)


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Battlefield cutscenes are automatically skipped if the player has already viewed it without zoning.

## Steps to test these changes

Add the following code to flames_for_the_dead.lua or setup mission status appropriately.
```lua
function content:checkRequirements(player, npc, registrant, trade)
    return true
end
```

`!pos -720 9 -441 6`

Enter Flames for the Dead fight and watch the (somewhat lengthy) cutscene. Turn around and "Run away" from the fight. Reenter the fight and it should skip the cutscene.