### PR TITLE
Battlefield Interactions: Reconnect, kick, and reentry

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -325,7 +325,8 @@ function Battlefield.onEntryTrigger(player, npc)
             return false
         end
 
-        player:startEvent(32000, 0, 0, 0, content.index, 0, 0, 0, 0)
+        local options = utils.mask.setBit(0, content.index, true)
+        player:startEvent(32000, 0, 0, 0, options, 0, 0, 0, 0)
         return true
     end
 
@@ -602,6 +603,11 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
     end
 
     player:messageSpecial(ID.text.TIME_LIMIT_FOR_THIS_BATTLE_IS, 0, 0, 0, math.floor(self.timeLimit / 60))
+
+    if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
+        local status = player:getStatusEffect(xi.effect.BATTLEFIELD)
+        status:setSubPower(1)
+    end
 end
 
 function Battlefield:onBattlefieldDestroy(battlefield)
@@ -612,6 +618,9 @@ function Battlefield:onBattlefieldLeave(player, battlefield, leavecode)
         self:onBattlefieldWin(player, battlefield)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         self:onBattlefieldLoss(player, battlefield)
+    elseif player:hasStatusEffect(xi.effect.BATTLEFIELD) then
+        local status = player:getStatusEffect(xi.effect.BATTLEFIELD)
+        status:setSubPower(0)
     end
 end
 
@@ -621,6 +630,10 @@ function Battlefield:onBattlefieldWin(player, battlefield)
 end
 
 function Battlefield:onBattlefieldLoss(player, battlefield)
+    player:startEvent(32002, self.lossEventParams)
+end
+
+function Battlefield:onBattlefieldKick(player)
     player:startEvent(32002, self.lossEventParams)
 end
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -521,11 +521,6 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
 
         m_EnteredPlayers.erase(m_EnteredPlayers.find(PEntity->id));
 
-        if (leavecode != BATTLEFIELD_LEAVE_CODE_WARPDC)
-        {
-            m_RegisteredPlayers.erase(m_RegisteredPlayers.find(PEntity->id));
-        }
-
         if (leavecode != 255)
         {
             // todo: probably shouldnt hardcode this
@@ -607,10 +602,9 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
     }
 
     // Remove enmity from valid battle entities
-    if (auto* PBattleEntity = dynamic_cast<CBattleEntity*>(PEntity))
+    auto* PBattleEntity = dynamic_cast<CBattleEntity*>(PEntity);
+    if (PBattleEntity)
     {
-        PBattleEntity->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
-        PBattleEntity->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
         ClearEnmityForEntity(PBattleEntity);
     }
 
@@ -725,6 +719,8 @@ bool CBattlefield::Cleanup(time_point time, bool force)
         if (PChar)
         {
             RemoveEntity(PChar, leavecode);
+            PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
         }
     }
 

--- a/src/map/battlefield_handler.h
+++ b/src/map/battlefield_handler.h
@@ -57,12 +57,16 @@ public:
     bool          IsEntered(CCharEntity* PChar);
     bool          ReachedMaxCapacity(int battlefieldId = -1) const;
     uint8         MaxBattlefieldAreas() const;
+    void          addOrphanedPlayer(CCharEntity* PChar);
 
 private:
     CZone*                       m_PZone;
     uint8                        m_MaxBattlefields; // usually 3 except dynamis, einherjar, besieged, ...
     std::map<int, CBattlefield*> m_Battlefields;    // area
     std::map<uint32, uint8>      m_ReservedAreas;   // <charid, area>
+
+    // Players that need to be kicked from whatever battlefield they were in
+    std::vector<std::pair<uint32, time_point>> m_orphanedPlayers;
 };
 
 #endif

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4474,6 +4474,16 @@ namespace luautils
         }
     }
 
+    void OnBattlefieldKick(CCharEntity* PChar)
+    {
+        TracyZoneScoped;
+
+        CStatusEffect* status = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD);
+        uint16         power  = status->GetPower();
+
+        invokeBattlefieldEvent(power, "onBattlefieldKick", CLuaBaseEntity(PChar));
+    }
+
     /********************************************************************
         onBattlefieldRegister - callback when you successfully register a BCNM.
         For example, trading an orb, selecting the battle.

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -269,6 +269,7 @@ namespace luautils
 
     void OnBattlefieldEnter(CCharEntity* PChar, CBattlefield* PBattlefield);                  // triggers when enter a bcnm
     void OnBattlefieldLeave(CCharEntity* PChar, CBattlefield* PBattlefield, uint8 LeaveCode); // see battlefield.h BATTLEFIELD_LEAVE_CODE
+    void OnBattlefieldKick(CCharEntity* PChar);
 
     void OnBattlefieldRegister(CCharEntity* PChar, CBattlefield* PBattlefield); // triggers when successfully registered a bcnm
     void OnBattlefieldDestroy(CBattlefield* PBattlefield);                      // triggers when BCNM is destroyed

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1022,6 +1022,26 @@ void CZone::CharZoneIn(CCharEntity* PChar)
         {
             PBattlefield->InsertEntity(PChar, true);
         }
+        else if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
+        {
+            // Player is in a zone with a battlefield but they are not part of one.
+            if (PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetSubPower() == 1)
+            {
+                // If inside of the battlefield arena then kick them out
+                m_BattlefieldHandler->addOrphanedPlayer(PChar);
+            }
+            else
+            {
+                // Is not inside of a battlefield arena so remove the battlefield effect
+                PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+                PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
+            }
+        }
+    }
+    else if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
+    {
+        // Player is zoning into a zone that does not have a battlefield but the player has a confrontation effect - remove it
+        PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
     }
 
     PChar->PLatentEffectContainer->CheckLatentsZone();


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds proper handling with battlefield interactions

1. When a player disconnects inside a battlefield and logs with the battlefield having been destroyed then they should be kicked from the battlefield.
2. When a player disconnects inside a battlefield but other party members are in the battlefield then they should rejoin the battlefield.
3. A player should be able to leave a battlefield and reenter for some battlefield fights (those that don't require a KI from all players to enter)

The way I went about solving this is to set the battlefield effect subpower to 1 when the player enters the battlefield and to 0 when exiting the battlefield. When reconnecting we check if the subpower is 1 (inside battlefield) and eject if they cant rejoin the battlefield.

These changes are based off of the following captures:
https://www.youtube.com/watch?v=V0Qp99O1AkA
https://www.youtube.com/watch?v=SeKiF3qFiAQ

## Steps to test these changes

Attempt the aforementioned interactions and observe they are correct.

Useful commands for testing with Brothers fight.
```
!addkeyitem ZEPHYR_FAN
!pos 121 -171 758 6
```