### PR TITLE
Mobs should only regain TP inside combat

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1951,7 +1951,10 @@ void CStatusEffectContainer::TickRegen(time_point tick)
             m_POwner->addMP(refresh);
         }
 
-        m_POwner->addTP(regain);
+        if (m_POwner->objtype != TYPE_MOB || m_POwner->PAI->IsEngaged())
+        {
+            m_POwner->addTP(regain);
+        }
 
         if (m_POwner->PPet && ((CPetEntity*)(m_POwner->PPet))->getPetType() == PET_TYPE::AUTOMATON)
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Small but impactful change I made for Eden a few years back.

This prevents mobs from regaining TP while outside of combat. What currently happens is that mobs that do have regain will end up with max TP when you first engage them so they always start with some huge mobskill. This is especially noticed in battlefields.

## Steps to test these changes

Find a mob with regain and it will no longer have 3000 TP when you first engage it.
