### PR TITLE
Update rocks array to match elements in battleutils.

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -5,12 +5,14 @@
 -- https://ffxiclopedia.wikia.com/wiki/Logging
 -- https://ffxiclopedia.wikia.com/wiki/Mining
 -----------------------------------
+require("scripts/globals/items")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/roe")
 require("scripts/globals/settings")
+require("scripts/globals/spell_data")
 require("scripts/globals/status")
 require("scripts/globals/zone")
 require("scripts/missions/amk/helpers")
@@ -1389,10 +1391,20 @@ local helmInfo =
 }
 
 -----------------------------------
--- colored rocks. do not change this order!
+-- colored rocks array
 -----------------------------------
 
-local rocks = { 769, 771, 770, 772, 773, 774, 776, 775 }
+local rocks =
+{
+    [xi.magic.element.FIRE] = xi.items.RED_ROCK,
+    [xi.magic.element.ICE] = xi.items.TRANSLUCENT_ROCK,
+    [xi.magic.element.WIND] = xi.items.GREEN_ROCK,
+    [xi.magic.element.EARTH] = xi.items.YELLOW_ROCK,
+    [xi.magic.element.THUNDER] = xi.items.PURPLE_ROCK,
+    [xi.magic.element.WATER] = xi.items.BLUE_ROCK,
+    [xi.magic.element.LIGHT] = xi.items.WHITE_ROCK,
+    [xi.magic.element.DARK] = xi.items.BLACK_ROCK,
+}
 
 -----------------------------------
 -- local functions
@@ -1445,7 +1457,7 @@ local function pickItem(player, info)
 
     -- if we picked a colored rock, change it to the day's element
     if item == 769 then
-        item = rocks[VanadielDayElement() + 1]
+        item = rocks[VanadielDayElement()]
     end
 
     return item


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

`HELM.lua` was using the old order of elements in `battleutils.h` to determine what rock to give. This corrects the rocs array to match the new order.

## Steps to test these changes

Compare array to values in battleutils. 
