### PR TITLE
Adding missing use of xi.mod.MAGIC_NULL

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -895,7 +895,8 @@ xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, 
         nukeAbsorbOrNullify = -1
     end
     -- Calculate chance for spell nullification.
-    if math.random(1, 100) < (target:getMod(nullMod[spellElement]) + 1) then
+    local nullifyChance = math.random(1, 100)
+    if nullifyChance < (target:getMod(nullMod[spellElement]) + 1) or nullifyChance < target:getMod(xi.mod.MAGIC_NULL) then
         nukeAbsorbOrNullify = 0
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Handle xi.mod.MAGIC_NULL when calculating magic damage script side. As it stands MAGIC_NULL is not always factored into nullifying magic damage.

## Steps to test these changes

Give a monster `xi.mod.MAGIC_NULL` and see them null magic damage.