### PR TITLE
Add battlefield option to show the timer UI to the player or not

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -126,6 +126,7 @@ end
 --  - allowSubjob: Determines if character subjobs are enabled or disabled upon entry. Defaults to true. (optional)
 --  - hasWipeGrace: Grants players a 3 minute grace period on a full wipe before ejecting them. Defaults to true. (optional)
 --  - canLoseExp: Determines if a character loses experience points upon death while inside the battlefield. Defaults to true. (optional)
+--  - showTimer: Show the time remaining in the battlefield in the UI for the player. Defaults to true. (optional)
 --  - delayToExit: Amount of time to wait before exiting the battlefield. Defaults to 5 seconds. (optional)
 --  - requiredItems: Items required to be traded to enter the battlefield.
 --                   Needs to be in the format of { itemid, quantity, useMessage = ID.text.*, wearMessage = ID.text.*, wornMessage = ID.text.* }. (optional)
@@ -151,6 +152,7 @@ function Battlefield:new(data)
     obj.allowSubjob = (data.allowSubjob == nil or data.allowSubjob) or false
     obj.hasWipeGrace = (data.hasWipeGrace == nil or data.hasWipeGrace) or false
     obj.canLoseExp = (data.canLoseExp == nil or data.canLoseExp) or false
+    obj.showTimer = (data.showTimer == nil or data.showTimer) or false
     obj.delayToExit = data.delayToExit or 5
     obj.requiredItems = data.requiredItems or {}
     obj.requiredKeyItems = data.requiredKeyItems or {}

--- a/scripts/globals/limbus.lua
+++ b/scripts/globals/limbus.lua
@@ -520,6 +520,7 @@ Limbus.serverVar = ""
 --  - name: The name of the Limbus area
 function Limbus:new(data)
     data.createsWornItem = false
+    data.showTimer = false
     local obj = Battlefield:new(data)
     setmetatable(obj, self)
     obj.name = data.name

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -318,7 +318,11 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
                 m_EnteredPlayers.emplace(PEntity->id);
                 PChar->ClearTrusts();
                 luautils::OnBattlefieldEnter(PChar, this);
-                charutils::SendTimerPacket(PChar, GetRemainingTime());
+
+                if (m_showTimer)
+                {
+                    charutils::SendTimerPacket(PChar, GetRemainingTime());
+                }
 
                 // Try to add the player's pet in case they have one that can
                 if (PChar->PPet != nullptr)

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -202,7 +202,9 @@ public:
     void addGroup(BattlefieldGroup group);
     void handleDeath(CBaseEntity* PEntity);
 
-    uint8                         m_isMission;
+    uint8 m_isMission;
+    bool  m_showTimer = true;
+
     std::set<uint32>              m_RegisteredPlayers;
     std::set<uint32>              m_EnteredPlayers;
     std::vector<CNpcEntity*>      m_NpcList;

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -210,6 +210,8 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
     PBattlefield->SetLevelCap(registration.levelCap);
     PBattlefield->SetMaxParticipants(registration.maxPlayers);
     PBattlefield->SetRuleMask(registration.rules);
+    PBattlefield->m_isMission = registration.isMission;
+    PBattlefield->m_showTimer = registration.showTimer;
 
     m_Battlefields.insert(std::make_pair(PBattlefield->GetArea(), PBattlefield));
 

--- a/src/map/battlefield_handler.h
+++ b/src/map/battlefield_handler.h
@@ -40,6 +40,7 @@ struct BattlefieldRegistration
     uint32               rules      = 0;
     std::chrono::seconds timeLimit  = std::chrono::seconds(0);
     bool                 isMission  = false;
+    bool                 showTimer  = true;
 };
 
 class CBattlefieldHandler

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9258,6 +9258,7 @@ uint8 CLuaBaseEntity::registerBattlefield(sol::object const& arg0, sol::object c
         registration.levelCap   = battlefield["levelCap"];
         registration.timeLimit  = std::chrono::seconds(battlefield.get<int32>("timeLimit"));
         registration.isMission  = battlefield.get_or("isMission", false);
+        registration.showTimer  = battlefield.get_or("showTimer", true);
         registration.rules |= battlefield.get<bool>("allowSubjob") ? RULES_ALLOW_SUBJOBS : 0;
         registration.rules |= battlefield.get<bool>("canLoseExp") ? RULES_LOSE_EXP : 0;
     }


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds battlefield option to show the timer UI to the player or not. It appears that most battlefields do show the timer such as BCNMs and ISNMs but Limbus areas and perhaps some others do not.

## Steps to test these changes

Jump into an area that has a battlefield timer
```
!addkeyitem ZEPHYR_FAN
!pos 121 -171 758 6
```

and one that does not
```
!addkeyitem black_card
!addkeyitem cosmo_cleanse
!pos 600 -0.5 -600 38
```