### PR TITLE
Add additional startup logging for MariaDB version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,4 +73,8 @@ add_subdirectory(ext)
 include(ClangTidy)
 include(Fuzzing)
 
+message(STATUS "Configuring src/common/version.cpp")
+configure_file(${CMAKE_SOURCE_DIR}/src/common/version.cpp.in
+               ${CMAKE_SOURCE_DIR}/src/common/version.cpp)
+
 add_subdirectory(src)

--- a/cmake/Git.cmake
+++ b/cmake/Git.cmake
@@ -33,6 +33,3 @@ message(STATUS "GIT_COMMIT_SUBJECT: ${GIT_COMMIT_SUBJECT}")
 if (GIT_COMMIT_SUBJECT)
     string(REGEX REPLACE "\"" "'" GIT_COMMIT_SUBJECT ${GIT_COMMIT_SUBJECT})
 endif()
-
-configure_file(${CMAKE_SOURCE_DIR}/src/common/version.cpp.in
-               ${CMAKE_SOURCE_DIR}/src/common/version.cpp)

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -58,10 +58,6 @@ void lua_init()
         result.get<sol::table>()["start"];
         ShowInfo("Started script debugger");
     }
-    else
-    {
-        ShowInfo("Failed to start script debugger");
-    }
 }
 
 /**

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -158,6 +158,23 @@ SqlConnection::~SqlConnection()
     }
 }
 
+std::string SqlConnection::GetClientVersion()
+{
+    return fmt::format("database client version: {}", MARIADB_PACKAGE_VERSION);
+}
+
+std::string SqlConnection::GetServerVersion()
+{
+    std::string serverVer = "";
+    auto        ret       = Query("SELECT VERSION()");
+    if (ret != SQL_ERROR && NumRows() != 0 && NextRow() == SQL_SUCCESS)
+    {
+        serverVer = GetStringData(0);
+    }
+
+    return fmt::format("database server version: {}", serverVer);
+}
+
 int32 SqlConnection::GetTimeout(uint32* out_timeout)
 {
     TracyZoneScoped;

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -83,6 +83,9 @@ public:
     SqlConnection(const char* user, const char* passwd, const char* host, uint16 port, const char* db);
     ~SqlConnection();
 
+    std::string GetClientVersion();
+    std::string GetServerVersion();
+
     /// Retrieves the timeout of the connection.
     ///
     /// @return SQL_SUCCESS or SQL_ERROR

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -211,6 +211,9 @@ int32 do_init(int32 argc, char** argv)
     ShowInfo("do_init: connecting to database");
     sql = std::make_unique<SqlConnection>();
 
+    ShowInfo(sql->GetClientVersion().c_str());
+    ShowInfo(sql->GetServerVersion().c_str());
+
     sql->Query("DELETE FROM accounts_sessions WHERE IF(%u = 0 AND %u = 0, true, server_addr = %u AND server_port = %u);",
                map_ip.s_addr, map_port, map_ip.s_addr, map_port);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Log MariaDB version on map startup

## Steps to test these changes

See a little more logging when the server starts
