### PR TITLE
[sql] Use CHAR instead of VARCHAR in PopulateIDLookups conversion

### DIFF
--- a/sql/pet_list.sql
+++ b/sql/pet_list.sql
@@ -11,7 +11,7 @@ SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 
 DROP TABLE IF EXISTS `pet_list`;
 CREATE TABLE IF NOT EXISTS `pet_list` (
-  `petid` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `petid` int(10) unsigned NOT NULL,
   `name` char(15) NOT NULL,
   `poolid` int(10) unsigned NOT NULL DEFAULT '0',
   `minLevel` tinyint(2) unsigned NOT NULL DEFAULT '0',
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `pet_list` (
   `time` int(10) unsigned NOT NULL DEFAULT '0',
   `element` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`petid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=17 ;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Contenu de la table `pet_list`

--- a/sql/water_points.sql
+++ b/sql/water_points.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `water_points` (
   `pos_y` float(7,2) NOT NULL DEFAULT '0.00',
   `pos_z` float(7,2) NOT NULL DEFAULT '0.00',
   PRIMARY KEY (`waterid`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=17 ;
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 
 --
 -- Contenu de la table `water_points`

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -814,7 +814,7 @@ namespace luautils
                                         // TODO: Execute this as a single query per-zone and pull out the desired results.
                                         auto query = fmt::sprintf("SELECT npcid FROM npc_list "
                                                             "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
-                                                            "UPPER(REPLACE(CAST(`name` as VARCHAR(64)), '-', '_')) = '%s' "
+                                                            "UPPER(REPLACE(CAST(`name` as CHAR(64)), '-', '_')) = '%s' "
                                                             "LIMIT 1;", PZone->GetID(), name.c_str());
                                         DebugIDLookup(query.c_str());
                                         auto ret = sql->Query(query.c_str());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

I wasn't able to repro locally, but this query still works while using CHAR, so it's worth a go to try and fix the issue.

Might fix: https://github.com/LandSandBoat/server/issues/2939

https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_convert

CAST might not accept VARCHAR

## Steps to test these changes

See no MySQL errors on startup