### PR TITLE
[cpp][debug] While crashing, don't print things from the std namespace

### DIFF
--- a/src/common/WheatyExceptionReport.cpp
+++ b/src/common/WheatyExceptionReport.cpp
@@ -974,6 +974,17 @@ bool bWriteVariables, HANDLE pThreadHandle)                                     
             &symDisplacement,                               // Address of the variable that will receive the displacement
             &sip.si))                                       // Address of the SYMBOL_INFO structure (inside "sip" object)
         {
+            bool isStdLib = sip.si.NameLen > 3 &&
+                            sip.si.Name[0] == 's' &&
+                            sip.si.Name[1] == 't' &&
+                            sip.si.Name[2] == 'd';
+
+            // Don't print things from the std:: namespace, for clarity
+            if (isStdLib)
+            {
+                continue;
+            }
+
             wsprintf((LPSTR)funcNameBuffer.data(), "%hs+%I64X", sip.si.Name, symDisplacement);
         }
         else                                                // No symbol found.  Print out the logical address instead.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/1979

```
=== Call stack ===
Address           Frame             Function
00007FF6471CDE68  000000C8C91FFCC0  std::_Atomic_storage<bool,1>::store+38 (C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\atomic, line 637)
00007FF6471C5B9D  000000C8C91FFCF0  std::atomic<bool>::operator=+1D (C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include\atomic, line 2199)
00007FF6471C4EDD  000000C8C91FFD20  ConsoleService::stop+1D (C:\ffxi\server\src\common\console_service.cpp, line 142)
00007FF6471D6AB8  000000C8C91FFD60  sig_proc+58 (C:\ffxi\server\src\common\kernel.cpp, line 125)
00007FFA8904B527  000000C8C91FFDB0  _set_error_mode+2D7 ()
00007FFAD6195485  000000C8C91FFEA0  CtrlRoutine+115 ()
00007FFAD7AA54E0  000000C8C91FFED0  BaseThreadInitThunk+10 ()
00007FFAD8B0485B  000000C8C91FFF50  RtlUserThreadStart+2B ()
```

becomes

```
=====================================================
=== Call stack ===
Address           Frame             Function
00007FF646884EDD  00000057E36FFC30  ConsoleService::stop+1D (C:\ffxi\server\src\common\console_service.cpp, line 142)
00007FF646896AB8  00000057E36FFC70  sig_proc+58 (C:\ffxi\server\src\common\kernel.cpp, line 125)
00007FFA8AB7B527  00000057E36FFCC0  _set_error_mode+2D7 ()
00007FFAD6195485  00000057E36FFDB0  CtrlRoutine+115 ()
00007FFAD7AA54E0  00000057E36FFDE0  BaseThreadInitThunk+10 ()
00007FFAD8B0485B  00000057E36FFE60  RtlUserThreadStart+2B ()
```

## Steps to test these changes

CTRL+C during startup, see everything explode
