### PR TITLE
[cpp] Add workaround to render names and looks of equipped dynamic entities

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -239,25 +239,6 @@ struct look_t
         sub     = look[8];
         ranged  = look[9];
     }
-
-    look_t(std::vector<uint16>& look)
-    {
-        if (look.size() != 10)
-        {
-            throw std::runtime_error(fmt::format("Bad look size passed to look_t constructor (expected 10, got: {})", look.size()));
-        }
-
-        size    = look[0];
-        modelid = look[1];
-        head    = look[2];
-        body    = look[3];
-        hands   = look[4];
-        legs    = look[5];
-        feet    = look[6];
-        main    = look[7];
-        sub     = look[8];
-        ranged  = look[9];
-    }
 };
 
 struct skills_t

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -826,10 +826,19 @@ std::string trim(std::string const& str, std::string const& whitespace)
 
 look_t stringToLook(std::string str)
 {
+    look_t out{};
+
+    // Sanity checks
     // Remove "0x" if found
-    if (str[0] == '0' && str[1] == 'x')
+    if (str.size() == 42 && str[0] == '0' && str[1] == 'x')
     {
         str = str.substr(2);
+    }
+
+    // Only support full-string looks
+    if (str.size() != 40)
+    {
+        return out;
     }
 
     // A 16-bit number is represented by *4* string characters
@@ -848,10 +857,24 @@ look_t stringToLook(std::string str)
     for (auto& entry : hex)
     {
         // Swap endian-ness
-        entry = (entry >> 8) | (entry << 8);
+        auto top    = entry << 8;
+        auto bottom = entry >> 8;
+        entry       = top | bottom;
     }
 
-    look_t out(hex);
+    out.size = hex[0];
+
+    out.face = hex[1] & 0x00FF;
+    out.race = hex[1] >> 8;
+
+    out.head   = hex[2] &= ~0x1000;
+    out.body   = hex[3] &= ~0x2000;
+    out.hands  = hex[4] &= ~0x3000;
+    out.legs   = hex[5] &= ~0x4000;
+    out.feet   = hex[6] &= ~0x5000;
+    out.main   = hex[7] &= ~0x6000;
+    out.sub    = hex[8] &= ~0x7000;
+    out.ranged = hex[9] &= ~0x8000;
 
     return out;
 }

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -163,8 +163,8 @@ enum UPDATETYPE : uint8
     UPDATE_HP       = 0x04,
     UPDATE_COMBAT   = 0x07,
     UPDATE_NAME     = 0x08,
-    UPDATE_LOOK     = 0x10,
     UPDATE_ALL_MOB  = 0x0F,
+    UPDATE_LOOK     = 0x10,
     UPDATE_ALL_CHAR = 0x1F,
     UPDATE_DESPAWN  = 0x20,
 };

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -345,16 +345,11 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     }
     else if (table["look"].get_type() == sol::type::string)
     {
-        auto lookStr = table.get<std::string>("look");
-        if (lookStr.size() >= 4 && ((lookStr[1] == 'x' && lookStr[3] == '1') || lookStr[1] == '1'))
-        {
-            PEntity->look.size = MODEL_EQUIPPED;
-        }
-        auto look = stringToLook(lookStr);
-        std::memcpy(&PEntity->look, &look, sizeof(PEntity->look));
+        auto lookStr  = table.get<std::string>("look");
+        PEntity->look = stringToLook(lookStr);
     }
 
-    PEntity->updatemask |= UPDATE_ALL_MOB;
+    PEntity->updatemask |= UPDATE_ALL_CHAR;
 
     return CLuaBaseEntity(PEntity);
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add workaround to render names and looks of equipped dynamic entities

- Fix stringToLook
- Add flip-flopping logic to entity_update for equipped dynamic entities
- Misc cleanup

**NOTE**

Since for this case we're flip-flopping between different packet update types, the client will sometimes forget what information came before it. This can lead to periodic flashes of the equipped entities losing their clothes, or their name disappearing. This isn't very frequent, and it fixes itself a second or so later.

Best I could figure out without modifying the client 🤷 

Tested with modified `!fafnir`:
```lua
    local entry = utils.randomEntry({
        { "Noillurie", "0x01000A0457105720573057405750546100700080" },
        { "Iron Ram Knight", "0x0100000338100D200D300D400D50C1601B700000" },
        { "Python Merc.", "0x01000E0772100F2072300F400F5064602E703280" },
    })

    local name = entry[1]
    local look = entry[2]

    local zone = player:getZone()
    local mob = zone:insertDynamicEntity({
        -- NPC or MOB
        objtype = xi.objType.MOB,

        -- The name visible to players
        -- NOTE: Even if you plan on making the name invisible, we're using it internally for lookups
        --     : So populate it with something unique-ish even if you aren't going to use it.
        --     : You can then hide the name with entity:hideName(true)
        -- NOTE: This name CAN include spaces and underscores.
        name = name,
        look = look,
```

![image](https://user-images.githubusercontent.com/1389729/196168162-19d7ee98-da6e-4217-a597-b0ad575acacd.png)


## Steps to test these changes

Modify !fafnir to use look strings, spawn some stuff and mess around with it

