### PR TITLE
[core] Add check to recv_parse in map.cpp to ignore packets that are too small

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -594,6 +594,10 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
 
     try
     {
+        if (size <= (FFXI_HEADER_SIZE + 16)) // check for underflow or no-data packet
+        {
+            return -1;
+        }
         checksumResult = checksum((uint8*)(buff + FFXI_HEADER_SIZE), (uint32)(size - (FFXI_HEADER_SIZE + 16)), (char*)(buff + size - 16));
     }
     catch (...)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes #2956 

## Steps to test these changes

Login as normal, play the game, etc.
