### PR TITLE
[lua] Update !additem command to intitalize quantity to 1 if nil, check retval of player:addItem

### DIFF
--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -41,6 +41,9 @@ function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, a
         itemToGet = tonumber(item)
     end
 
+    -- if quantity is nil, assume 1 qty
+    quantity = quantity or 1
+
     -- At this point, if there's no item found, exit out of the function
     if itemToGet == 0 then
         error(player, "Item not found.")
@@ -60,7 +63,7 @@ function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, a
 
     -- Give the GM the item...
     player:addItem(itemToGet, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
-    if quantity and quantity > 1 then
+    if quantity > 1 then
         player:messageSpecial(ID.text.ITEM_OBTAINED + 9, itemToGet, quantity)
     else
         player:messageSpecial(ID.text.ITEM_OBTAINED, itemToGet)

--- a/scripts/commands/additem.lua
+++ b/scripts/commands/additem.lua
@@ -62,10 +62,12 @@ function onTrigger(player, item, quantity, aug0, aug0val, aug1, aug1val, aug2, a
     end
 
     -- Give the GM the item...
-    player:addItem(itemToGet, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
-    if quantity > 1 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED + 9, itemToGet, quantity)
-    else
-        player:messageSpecial(ID.text.ITEM_OBTAINED, itemToGet)
+    local obtained = player:addItem(itemToGet, quantity, aug0, aug0val, aug1, aug1val, aug2, aug2val, aug3, aug3val, trialId)
+    if obtained then
+        if quantity and quantity > 1 then
+            player:messageSpecial(ID.text.ITEM_OBTAINED + 9, itemToGet, quantity)
+        else
+            player:messageSpecial(ID.text.ITEM_OBTAINED, itemToGet)
+        end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

The !additem command was not initializing quantity, so if you had a full inventory and did not specify quantity the script would error.
The additem command was also incorrectly informing you both got and didn't get rare items if you had that item already (revtal of addItem was not being checked)

## Steps to test these changes

Get a full inventory
`!additem onion_sword` and receive a full inventory message
`!additem onion_sword 1` and receive a full inventory message
![image](https://user-images.githubusercontent.com/60417494/196099510-e4a67a24-bbd4-47fd-937f-4a55ac80222d.png)

`!additem sky_orb` x2
The first time you should get sky orb, second time it should only tell you that you can't get the item
