### PR TITLE
[core] Add nullptr checks around target->PAI->IsUntargetable() calls

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -217,7 +217,7 @@ bool CAIContainer::Internal_Cast(uint16 targetid, SpellID spellid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targetid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -260,7 +260,7 @@ bool CAIContainer::Internal_WeaponSkill(uint16 targid, uint16 wsid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -274,7 +274,7 @@ bool CAIContainer::Internal_MobSkill(uint16 targid, uint16 wsid)
     auto* entity = dynamic_cast<CMobEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -288,7 +288,7 @@ bool CAIContainer::Internal_PetSkill(uint16 targid, uint16 abilityid)
     auto* entity = dynamic_cast<CPetEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -302,7 +302,7 @@ bool CAIContainer::Internal_Ability(uint16 targetid, uint16 abilityid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targetid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -316,7 +316,7 @@ bool CAIContainer::Internal_RangedAttack(uint16 targetid)
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        if (auto target = entity->GetEntity(targetid); target->PAI->IsUntargetable())
+        if (auto target = entity->GetEntity(targetid); target && target->PAI->IsUntargetable())
         {
             return false;
         }

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -51,7 +51,7 @@ bool CPlayerController::Cast(uint16 targid, SpellID spellid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (!PChar->PRecastContainer->HasRecast(RECAST_MAGIC, static_cast<uint16>(spellid), 0))
     {
-        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -127,7 +127,7 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
             return false;
         }
-        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -145,7 +145,7 @@ bool CPlayerController::RangedAttack(uint16 targid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (PChar->PAI->CanChangeState())
     {
-        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }
@@ -163,7 +163,7 @@ bool CPlayerController::UseItem(uint16 targid, uint8 loc, uint8 slotid)
     auto* PChar = static_cast<CCharEntity*>(POwner);
     if (PChar->PAI->CanChangeState())
     {
-        if (auto target = PChar->GetEntity(targid); target->PAI->IsUntargetable())
+        if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())
         {
             return false;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [🤞] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Apparently what I thought checked null didn't. This adds some nullptr checks near target->PAI->IsUntargetable()

## Steps to test these changes

Despawn a target during a mob's ready animation and not crash
