### PR TITLE
Fixing Throne Room Battlefields

### DIFF
--- a/scripts/battlefields/Throne_Room/shadow_lord_battle.lua
+++ b/scripts/battlefields/Throne_Room/shadow_lord_battle.lua
@@ -17,8 +17,8 @@ local content = BattlefieldMission:new({
     levelCap      = 75,
     timeLimit     = utils.minutes(30),
     index         = 0,
-    entryNpc      = "Throne_Room",
-    exitNpc       = "Throne_Room_Exit",
+    entryNpc      = "_4l1",
+    exitNpcs      = { "_4l2", "_4l3", "_4l4" },
 
     mission               = xi.mission.id.nation.SHADOW_LORD,
     requiredMissionStatus = 3,

--- a/scripts/battlefields/Throne_Room/where_two_paths_converge.lua
+++ b/scripts/battlefields/Throne_Room/where_two_paths_converge.lua
@@ -9,14 +9,14 @@ require("scripts/globals/missions")
 -----------------------------------
 
 local content = BattlefieldMission:new({
-    zoneId                = xi.zone.THRONE_ROOM,
-    battlefieldId         = xi.battlefield.id.WHERE_TWO_PATHS_CONVERGE,
-    maxPlayers            = 6,
-    levelCap              = 75,
-    timeLimit             = utils.minutes(30),
-    index                 = 1,
-    entryNpc              = "Throne_Room",
-    exitNpc               = "Throne_Room_Exit",
+    zoneId        = xi.zone.THRONE_ROOM,
+    battlefieldId = xi.battlefield.id.WHERE_TWO_PATHS_CONVERGE,
+    maxPlayers    = 6,
+    levelCap      = 75,
+    timeLimit     = utils.minutes(30),
+    index         = 1,
+    entryNpc      = "_4l1",
+    exitNpcs      = { "_4l2", "_4l3", "_4l4" },
 
     missionArea           = xi.mission.log_id.BASTOK,
     mission               = xi.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE,

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1177,7 +1177,8 @@ function BattlefieldMission:checkSkipCutscene(player)
 end
 
 function BattlefieldMission:onBattlefieldWin(player, battlefield)
-    local current = player:getCurrentMission(self.missionArea)
+    local missionArea = self.missionArea or player:getNation()
+    local current = player:getCurrentMission(missionArea)
     if current == self.mission then
         player:setLocalVar("battlefieldWin", battlefield:getID())
     end

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -359,7 +359,8 @@ end
 --  - levelCap: Level cap imposed upon the battlefield. Defaults to 0 - no level cap. (optional)
 --  - area: Some battlefields has multiple areas (Burning Circles) while others have fixed areas (Apollyon). Set to have a fixed area. (optional)
 --  - entryNpc: The name of the NPC used for entering (required)
---  - exitNpc: The name of the NPC used for exiting
+--  - exitNpc: The name of the NPC used for exiting (optional)
+--  - exitNpcs: The names of the NPC used for exiting (optional)
 --  - allowSubjob: Determines if character subjobs are enabled or disabled upon entry. Defaults to true. (optional)
 --  - hasWipeGrace: Grants players a 3 minute grace period on a full wipe before ejecting them. Defaults to true. (optional)
 --  - canLoseExp: Determines if a character loses experience points upon death while inside the battlefield. Defaults to true. (optional)
@@ -382,7 +383,13 @@ function Battlefield:new(data)
     obj.entryNpc = data.entryNpc
 
     obj.area = data.area
-    obj.exitNpc = data.exitNpc
+
+    if data.exitNpcs then
+        obj.exitNpcs = data.exitNpcs
+    elseif data.exitNpc then
+        obj.exitNpcs = { data.exitNpc }
+    end
+
     obj.title = data.title
     obj.grantXP = data.grantXP
     obj.levelCap = data.levelCap or 0
@@ -417,7 +424,7 @@ function Battlefield:register()
     -- Only hookup the entry and exit listeners if there aren't any other battlefields already registered for that entrance
     local setupEvents = true
     local setupEntryNpc = true
-    local setupExitNpc = true
+    local setupExitNpcs = true
     if utils.hasKey(self.zoneId, xi.battlefield.contentsByZone) then
         local contents = xi.battlefield.contentsByZone[self.zoneId]
         for _, content in ipairs(contents) do
@@ -425,7 +432,7 @@ function Battlefield:register()
             if self.battlefieldId == content.battlefieldId and content.hasListeners then
                 setupEvents = true
                 setupEntryNpc = true
-                setupExitNpc = true
+                setupExitNpcs = true
                 break
             end
 
@@ -436,9 +443,17 @@ function Battlefield:register()
             if self.entryNpc == content.entryNpc then
                 setupEntryNpc = false
             end
-            if self.exitNpc == content.exitNpc then
-                setupExitNpc = false
+
+            -- If there is any overlap between the exit NPCs then we do not setup the exit NPCs
+            if self.exitNpcs then
+                for _, exitNpc in ipairs(self.exitNpcs) do
+                    if utils.contains(exitNpc, content.exitNpcs) then
+                        setupExitNpcs = false
+                        break
+                    end
+                end
             end
+
         end
     end
 
@@ -473,13 +488,15 @@ function Battlefield:register()
         })
     end
 
-    if setupExitNpc and self.exitNpc then
-        utils.append(zoneSection, {
-            [self.exitNpc] =
-            {
-                onTrigger = Battlefield.onExitTrigger,
-            }
-        })
+    if setupExitNpcs and self.exitNpcs then
+        for _, exitNpc in ipairs(self.exitNpcs) do
+            utils.append(zoneSection, {
+                [exitNpc] =
+                {
+                    onTrigger = Battlefield.onExitTrigger,
+                }
+            })
+        end
     end
 
     xi.battlefield.contents[self.battlefieldId] = self

--- a/scripts/missions/bastok/5_2_Xarcabard_Land_of_Truths.lua
+++ b/scripts/missions/bastok/5_2_Xarcabard_Land_of_Truths.lua
@@ -137,7 +137,7 @@ mission.sections =
 
         [xi.zone.THRONE_ROOM] =
         {
-            ['Throne_Room'] =
+            ['_4l1'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then

--- a/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
+++ b/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
@@ -120,7 +120,7 @@ mission.sections =
 
         [xi.zone.THRONE_ROOM] =
         {
-            ['Throne_Room'] =
+            ['_4l1'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then

--- a/scripts/missions/windurst/5_2_The_Shadow_Awaits.lua
+++ b/scripts/missions/windurst/5_2_The_Shadow_Awaits.lua
@@ -124,7 +124,7 @@ mission.sections =
 
         [xi.zone.THRONE_ROOM] =
         {
-            ['Throne_Room'] =
+            ['_4l1'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then

--- a/scripts/zones/Throne_Room/npcs/_4l1.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l1.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Throne Room
+--  NPC: Throne Room
+-- Type: Door
+-- !pos -111 -6 0 165
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, extras)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Throne_Room/npcs/_4l2.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l2.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Throne Room
+--  NPC: Ore Door
+-- Type: Door
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, extras)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Throne_Room/npcs/_4l3.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l3.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Throne Room
+--  NPC: Ore Door
+-- Type: Door
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, extras)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Throne_Room/npcs/_4l4.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l4.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Throne Room
+--  NPC: Ore Door
+-- Type: Door
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, extras)
+end
+
+entity.onEventFinish = function(player, csid, option)
+end
+
+return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Apparently the client uses the entity names for some cutscenes such as opening doors in the Throne Room. I changed this awhile back and it broke things and now I'm reverting that. In order to keep the name we needed to support multiple exits in the battlefield setup.

An additional change is to fix an issue where winning some mission battlefields would not advance the mission status properly.

Thanks to @N3ckB3ard to bringing this to my attention.

## Steps to test these changes

```
!addmission 1 15
!setmissionstatus <t> 2 1
!pos -111 -6 0.1 165
```

Go through the cutscenes, go into the battlefield, Run away from the battlefield, go back and defeat the Shadow Lord and everything should progress nicely.