### PR TITLE
[dbtool] Fix errorcodes for MariaDB

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -36,6 +36,7 @@ if not subprocess.call(['git', '-C', "../", 'status'], stderr=subprocess.STDOUT,
 # External Deps (requirements.txt)
 try:
     import mariadb
+    from mariadb.constants import *
     from git import Repo
     import yaml
     import colorama
@@ -348,11 +349,11 @@ def connect():
                 port=port)
         cur = db.cursor()
     except mariadb.Error as err:
-        if err.errno == mariadb.errorcode.ER_ACCESS_DENIED_ERROR:
+        if err.errno == mariadb.constants.ERR.ER_ACCESS_DENIED_ERROR:
             print(colorama.Fore.RED + 'Incorrect mysql_login or mysql_password, update ../settings/network.lua.')
             close()
             return False
-        elif err.errno == mariadb.errorcode.ER_BAD_DB_ERROR:
+        elif err.errno == mariadb.constants.ERR.ER_BAD_DB_ERROR:
             print(colorama.Fore.RED + 'Database ' + database + ' does not exist.')
             if input('Would you like to create new database: ' + database + '? [y/N] ').lower() == 'y':
                 create_command = '"' + mysql_bin + 'mysqladmin' + exe + '" -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' CREATE ' + database

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -352,7 +352,6 @@ def connect():
         if err.errno == mariadb.constants.ERR.ER_ACCESS_DENIED_ERROR:
             print(colorama.Fore.RED + 'Incorrect mysql_login or mysql_password, update ../settings/network.lua.')
             close()
-            return False
         elif err.errno == mariadb.constants.ERR.ER_BAD_DB_ERROR:
             print(colorama.Fore.RED + 'Database ' + database + ' does not exist.')
             if input('Would you like to create new database: ' + database + '? [y/N] ').lower() == 'y':
@@ -373,6 +372,7 @@ def close():
         cur.close()
         db.close()
     time.sleep(0.5)
+    quit()
 
 def setup_db():
     fetch_files()
@@ -660,7 +660,6 @@ def main():
         print(colorama.ansi.clear_screen())
         if 'q' == selection:
             close()
-            return
         if 'e' == selection and express_enabled:
             express_update()
             continue


### PR DESCRIPTION
MySQL -> MariaDB

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- MariaDB connector uses a different module for error code constants. Swap out the MySQL ones.
- Exit the program when `close` is called, fixing a crash when login/password is wrong. There's other ways to fix this but I think exiting is expected when closing anyway.

## Steps to test these changes

Rename `SQL_DATABASE` in the settings/network.lua file to a nonexistent database and be prompted to create it when running dbtool instead of crashing.
Change `SQL_PASSWORD` and/or `SQL_LOGIN` to something incorrect and exit gracefully.
