### PR TITLE
Fix Battlefield Party Member Entry

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -639,7 +639,7 @@ function Battlefield.onEntryTrigger(player, npc)
             return
         end
 
-        if not content:checkRequirements(player, npc, content.id, false) then
+        if not content:checkRequirements(player, npc, content.id) then
             return
         end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Resolved issue with party members not being able to enter new battlefields. This was caused by a bad variable being passed to `checkRequirements`. This is specifically `trade` which should be nil when not trading instead of false.

## Steps to test these changes

Attempt to enter any battlefield implemented with the new framework with two characters in a party.

```
-- Name: NW Apollyon
!addkeyitem red_card
!addkeyitem cosmo_cleanse
!pos -600 -0.5 -600 38
```