### PR TITLE
[core] Merge pet/trust/dynamic entities into 0x700 targid range

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -198,5 +198,5 @@ uint16 CBaseEntity::GetModelId() const
 
 bool CBaseEntity::IsDynamicEntity() const
 {
-    return this->targid >= 0x800;
+    return this->targid >= 0x700;
 }

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -762,6 +762,8 @@ public:
     time_point      LastAttacked;
     battlehistory_t BattleHistory; // Stores info related to most recent combat actions taken towards this entity.
 
+    bool m_bReleaseTargIDOnDeath = false;
+
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer>       PRecastContainer;
     std::unique_ptr<CNotorietyContainer>    PNotorietyContainer;

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -262,8 +262,6 @@ public:
 
     bool m_IsClaimable;
 
-    bool m_bReleaseTargIDOnDeath = false;
-
     static constexpr float sound_range{ 8.f };
     static constexpr float sight_range{ 15.f };
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -44,12 +44,13 @@ CPetEntity::CPetEntity(PET_TYPE petType)
 : CMobEntity()
 , m_PetType(petType)
 {
-    objtype        = TYPE_PET;
-    m_EcoSystem    = ECOSYSTEM::UNCLASSIFIED;
-    allegiance     = ALLEGIANCE_TYPE::PLAYER;
-    m_MobSkillList = 0;
-    m_PetID        = 0;
-    m_IsClaimable  = false;
+    objtype                 = TYPE_PET;
+    m_EcoSystem             = ECOSYSTEM::UNCLASSIFIED;
+    allegiance              = ALLEGIANCE_TYPE::PLAYER;
+    m_MobSkillList          = 0;
+    m_PetID                 = 0;
+    m_IsClaimable           = false;
+    m_bReleaseTargIDOnDeath = true;
 
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CPetController>(this), std::make_unique<CTargetFind>(this));
 }

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -45,13 +45,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 CTrustEntity::CTrustEntity(CCharEntity* PChar)
 : CMobEntity()
 {
-    objtype        = TYPE_TRUST;
-    m_EcoSystem    = ECOSYSTEM::UNCLASSIFIED;
-    allegiance     = ALLEGIANCE_TYPE::PLAYER;
-    m_MobSkillList = 0;
-    PMaster        = PChar;
-    m_MovementType = MELEE_RANGE;
-    m_IsClaimable  = false;
+    objtype                 = TYPE_TRUST;
+    m_EcoSystem             = ECOSYSTEM::UNCLASSIFIED;
+    allegiance              = ALLEGIANCE_TYPE::PLAYER;
+    m_MobSkillList          = 0;
+    PMaster                 = PChar;
+    m_MovementType          = MELEE_RANGE;
+    m_IsClaimable           = false;
+    m_bReleaseTargIDOnDeath = true;
 
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CTrustController>(PChar, this),
                                          std::make_unique<CTargetFind>(this));

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -246,6 +246,11 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     m_pLuaZone->GetZoneEntities()->dynamicTargIds.insert(PEntity->targid);
 
     PEntity->id = 0x1000000 + (ZoneID << 12) + PEntity->targid;
+    // Add 0x100 if targid is >= 0x800 -- observed on retail.
+    if (PEntity->targid >= 0x800)
+    {
+        PEntity->id += 0x100;
+    }
 
     PEntity->loc.zone       = m_pLuaZone;
     PEntity->loc.p.rotation = table.get_or<uint8>("rotation", 0);

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -245,7 +245,7 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
 
     m_pLuaZone->GetZoneEntities()->dynamicTargIds.insert(PEntity->targid);
 
-    PEntity->id = 0x1000100 + (ZoneID << 12) + PEntity->targid;
+    PEntity->id = 0x1000000 + (ZoneID << 12) + PEntity->targid;
 
     PEntity->loc.zone       = m_pLuaZone;
     PEntity->loc.p.rotation = table.get_or<uint8>("rotation", 0);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6616,26 +6616,23 @@ namespace charutils
             return false;
         }
 
-        if (entity->targid < 0x400 || entity->targid >= 0x800)
+        if (entity->objtype == TYPE_MOB)
         {
-            if (entity->objtype == TYPE_MOB)
-            {
-                spawnlist = &PChar->SpawnMOBList;
-            }
-            else if (entity->objtype == TYPE_NPC)
-            {
-                spawnlist = &PChar->SpawnNPCList;
-            }
+            spawnlist = &PChar->SpawnMOBList;
         }
-        else if (entity->targid < 0x700)
+        else if (entity->objtype == TYPE_NPC)
+        {
+            spawnlist = &PChar->SpawnNPCList;
+        }
+        else if (entity->objtype == TYPE_PC)
         {
             spawnlist = &PChar->SpawnPCList;
         }
-        else if (entity->targid < 0x780)
+        else if (entity->objtype == TYPE_PET)
         {
             spawnlist = &PChar->SpawnPETList;
         }
-        else if (entity->targid < 0x800)
+        else if (entity->objtype == TYPE_TRUST)
         {
             spawnlist = &PChar->SpawnTRUSTList;
         }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -162,7 +162,13 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
         }
         m_zone->GetZoneEntities()->dynamicTargIds.insert(PPet->targid);
 
-        PPet->id                = 0x1000000 + (m_zone->GetID() << 12) + PPet->targid;
+        PPet->id = 0x1000000 + (m_zone->GetID() << 12) + PPet->targid;
+        // Add 0x100 if targid is >= 0x800 -- observed on retail.
+        if (PPet->targid >= 0x800)
+        {
+            PPet->id += 0x100;
+        }
+
         PPet->loc.zone          = m_zone;
         m_petList[PPet->targid] = PPet;
 
@@ -193,7 +199,14 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
         }
         m_zone->GetZoneEntities()->dynamicTargIds.insert(targid);
 
-        PTrust->id                  = 0x1000000 + (m_zone->GetID() << 12) + targid;
+        PTrust->id = 0x1000000 + (m_zone->GetID() << 12) + targid;
+
+        // Add 0x100 if targid is >= 0x800 -- observed on retail.
+        if (targid >= 0x800)
+        {
+            PTrust->id += 0x100;
+        }
+
         PTrust->targid              = targid;
         PTrust->loc.zone            = m_zone;
         m_trustList[PTrust->targid] = PTrust;

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -76,6 +76,7 @@ typedef std::pair<float, CCharEntity*> CharScorePair;
 CZoneEntities::CZoneEntities(CZone* zone)
 : m_zone(zone)
 , m_Transport(nullptr)
+, lastCharPersistTargId(0)
 {
     lastCharComputeTargId = 0;
 }
@@ -154,23 +155,14 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
     TracyZoneScoped;
     if (PPet != nullptr)
     {
-        uint16 targid = 0x700;
+        PPet->targid = m_zone->GetZoneEntities()->GetNewDynamicTargID();
+        if (PPet->targid >= 0x900)
+        {
+            ShowError("CZoneEntities::InsertPET : targid is high (03hX), update packets will be ignored", PPet->targid);
+        }
+        m_zone->GetZoneEntities()->dynamicTargIds.insert(PPet->targid);
 
-        for (EntityList_t::const_iterator it = m_petList.begin(); it != m_petList.end(); ++it)
-        {
-            if (targid != it->first)
-            {
-                break;
-            }
-            targid++;
-        }
-        if (targid >= 0x780)
-        {
-            ShowError("CZone::InsertPET : targid is high (03hX)", targid);
-            return;
-        }
-        PPet->id                = 0x1000000 + (m_zone->GetID() << 12) + targid;
-        PPet->targid            = targid;
+        PPet->id                = 0x1000000 + (m_zone->GetID() << 12) + PPet->targid;
         PPet->loc.zone          = m_zone;
         m_petList[PPet->targid] = PPet;
 
@@ -178,7 +170,7 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
         {
             CCharEntity* PCurrentChar = (CCharEntity*)it->second;
 
-            if (distance(PPet->loc.p, PCurrentChar->loc.p) < 50)
+            if (distance(PPet->loc.p, PCurrentChar->loc.p) <= 50)
             {
                 PCurrentChar->SpawnPETList[PPet->id] = PPet;
                 PCurrentChar->updateEntityPacket(PPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
@@ -194,21 +186,13 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
     TracyZoneScoped;
     if (PTrust != nullptr)
     {
-        uint16 targid = 0x780;
+        uint16 targid = m_zone->GetZoneEntities()->GetNewDynamicTargID();
+        if (targid >= 0x900)
+        {
+            ShowError("CZoneEntities::InsertTRUST : targid is high (03hX), update packets will be ignored", targid);
+        }
+        m_zone->GetZoneEntities()->dynamicTargIds.insert(targid);
 
-        for (EntityList_t::const_iterator it = m_trustList.begin(); it != m_trustList.end(); ++it)
-        {
-            if (targid != it->first)
-            {
-                break;
-            }
-            targid++;
-        }
-        if (targid >= 0x800)
-        {
-            ShowError("CZone::InsertTRUST : targid is high (03hX)", targid);
-            return;
-        }
         PTrust->id                  = 0x1000000 + (m_zone->GetID() << 12) + targid;
         PTrust->targid              = targid;
         PTrust->loc.zone            = m_zone;
@@ -218,7 +202,7 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
         {
             CCharEntity* PCurrentChar = (CCharEntity*)it->second;
 
-            if (distance(PTrust->loc.p, PCurrentChar->loc.p) < 50)
+            if (distance(PTrust->loc.p, PCurrentChar->loc.p) <= 50)
             {
                 if (PCurrentChar->targid == ((CBattleEntity*)PTrust)->PMaster->targid)
                 {
@@ -485,7 +469,7 @@ uint16 CZoneEntities::GetNewCharTargID()
 uint16 CZoneEntities::GetNewDynamicTargID()
 {
     // NOTE: 0x0E (entity_update) entity updates are valid for 0 to 1023 and 1792 to 2303
-    uint16 targid = 0x800;
+    uint16 targid = 0x700;
     for (auto it : dynamicTargIds)
     {
         if (targid != it)
@@ -523,25 +507,27 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
     for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
     {
         CMobEntity*             PCurrentMob = (CMobEntity*)it->second;
-        SpawnIDList_t::iterator MOB         = PChar->SpawnMOBList.lower_bound(PCurrentMob->id);
+        SpawnIDList_t::iterator MOB         = PChar->SpawnMOBList.find(PCurrentMob->id);
 
         float CurrentDistance = distance(PChar->loc.p, PCurrentMob->loc.p);
 
-        if (PCurrentMob->status != STATUS_TYPE::DISAPPEAR && CurrentDistance < 50)
+        // Is this mob "visible" to the player?
+        if (PCurrentMob->status != STATUS_TYPE::DISAPPEAR && CurrentDistance <= 50)
         {
-            if (MOB == PChar->SpawnMOBList.end() || PChar->SpawnMOBList.key_comp()(PCurrentMob->id, MOB->first))
+            // mob not in update list for player, add it in
+            if (MOB == PChar->SpawnMOBList.end())
             {
                 PChar->SpawnMOBList.insert(MOB, SpawnIDList_t::value_type(PCurrentMob->id, PCurrentMob));
-                PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
+            PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
 
+            // Check to skip aggro routine
             if (PChar->isDead() || PChar->nameflags.flags & FLAG_GM || PCurrentMob->PMaster)
             {
                 continue;
             }
 
-            // проверка ночного/дневного сна монстров уже учтена в проверке CurrentAction, т.к. во сне монстры не ходят ^^
-
+            // checking monsters night/daytime sleep is already taken into account in the CurrentAction check, because monsters don't move in their sleep
             const EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PCurrentMob->GetMLevel());
 
             CMobController* PController = static_cast<CMobController*>(PCurrentMob->PAI->GetController());
@@ -553,13 +539,10 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
                 PCurrentMob->PEnmityContainer->AddBaseEnmity(PChar);
             }
         }
-        else
+        else if (MOB != PChar->SpawnMOBList.end())
         {
-            if (MOB != PChar->SpawnMOBList.end() && !(PChar->SpawnMOBList.key_comp()(PCurrentMob->id, MOB->first)))
-            {
-                PChar->SpawnMOBList.erase(MOB);
-                PChar->updateEntityPacket(PCurrentMob, ENTITY_DESPAWN, UPDATE_NONE);
-            }
+            PChar->SpawnMOBList.erase(MOB);
+            PChar->updateEntityPacket(PCurrentMob, ENTITY_DESPAWN, UPDATE_NONE);
         }
     }
 }
@@ -567,26 +550,27 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
 void CZoneEntities::SpawnPETs(CCharEntity* PChar)
 {
     TracyZoneScoped;
+
     for (EntityList_t::const_iterator it = m_petList.begin(); it != m_petList.end(); ++it)
     {
         CPetEntity*             PCurrentPet = (CPetEntity*)it->second;
-        SpawnIDList_t::iterator PET         = PChar->SpawnPETList.lower_bound(PCurrentPet->id);
+        SpawnIDList_t::iterator PET         = PChar->SpawnPETList.find(PCurrentPet->id);
 
-        if ((PCurrentPet->status == STATUS_TYPE::NORMAL || PCurrentPet->status == STATUS_TYPE::MOB) && distance(PChar->loc.p, PCurrentPet->loc.p) < 50)
+        // Is this pet "visible" to the player?
+        if ((PCurrentPet->status == STATUS_TYPE::NORMAL || PCurrentPet->status == STATUS_TYPE::MOB) && distance(PChar->loc.p, PCurrentPet->loc.p) <= 50)
         {
-            if (PET == PChar->SpawnPETList.end() || PChar->SpawnPETList.key_comp()(PCurrentPet->id, PET->first))
+            // pet not in update list for player, add it in
+            if (PET == PChar->SpawnPETList.end())
             {
                 PChar->SpawnPETList.insert(PET, SpawnIDList_t::value_type(PCurrentPet->id, PCurrentPet));
-                PChar->updateEntityPacket(PCurrentPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
+            PChar->updateEntityPacket(PCurrentPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
         }
-        else
+        // Pet not visible, remove it from spawn list if it's in there
+        else if (PET != PChar->SpawnPETList.end())
         {
-            if (PET != PChar->SpawnPETList.end() && !(PChar->SpawnPETList.key_comp()(PCurrentPet->id, PET->first)))
-            {
-                PChar->SpawnPETList.erase(PET);
-                PChar->updateEntityPacket(PCurrentPet, ENTITY_DESPAWN, UPDATE_NONE);
-            }
+            PChar->SpawnPETList.erase(PET);
+            PChar->updateEntityPacket(PCurrentPet, ENTITY_DESPAWN, UPDATE_NONE);
         }
     }
 }
@@ -599,25 +583,25 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
         for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
         {
             CNpcEntity*             PCurrentNpc = (CNpcEntity*)it->second;
-            SpawnIDList_t::iterator NPC         = PChar->SpawnNPCList.lower_bound(PCurrentNpc->id);
+            SpawnIDList_t::iterator NPC         = PChar->SpawnNPCList.find(PCurrentNpc->id);
 
             if (PCurrentNpc->status == STATUS_TYPE::NORMAL || PCurrentNpc->status == STATUS_TYPE::MOB)
             {
-                if (distance(PChar->loc.p, PCurrentNpc->loc.p) < 50)
+                // Is this npc "visible" to the player?
+                if (distance(PChar->loc.p, PCurrentNpc->loc.p) <= 50)
                 {
-                    if (NPC == PChar->SpawnNPCList.end() || PChar->SpawnNPCList.key_comp()(PCurrentNpc->id, NPC->first))
+                    // npc not in update list for player, add it in
+                    if (NPC == PChar->SpawnNPCList.end())
                     {
                         PChar->SpawnNPCList.insert(NPC, SpawnIDList_t::value_type(PCurrentNpc->id, PCurrentNpc));
-                        PChar->updateEntityPacket(PCurrentNpc, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     }
+                    PChar->updateEntityPacket(PCurrentNpc, ENTITY_SPAWN, UPDATE_ALL_MOB);
                 }
-                else
+                // npc not visible, remove it from spawn list if it's in there
+                else if (NPC != PChar->SpawnNPCList.end())
                 {
-                    if (NPC != PChar->SpawnNPCList.end() && !(PChar->SpawnNPCList.key_comp()(PCurrentNpc->id, NPC->first)))
-                    {
-                        PChar->SpawnNPCList.erase(NPC);
-                        PChar->updateEntityPacket(PCurrentNpc, ENTITY_DESPAWN, UPDATE_NONE);
-                    }
+                    PChar->SpawnNPCList.erase(NPC);
+                    PChar->updateEntityPacket(PCurrentNpc, ENTITY_DESPAWN, UPDATE_NONE);
                 }
             }
         }
@@ -631,28 +615,27 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
     {
         if (CTrustEntity* PCurrentTrust = dynamic_cast<CTrustEntity*>(TrustItr->second))
         {
-            SpawnIDList_t::iterator SpawnTrustItr = PChar->SpawnTRUSTList.lower_bound(PCurrentTrust->id);
+            SpawnIDList_t::iterator SpawnTrustItr = PChar->SpawnTRUSTList.find(PCurrentTrust->id);
             CCharEntity*            PMaster       = dynamic_cast<CCharEntity*>(PCurrentTrust->PMaster);
 
-            if (PCurrentTrust->status == STATUS_TYPE::NORMAL && distance(PChar->loc.p, PCurrentTrust->loc.p) < 50)
+            // Is this trust "visible" to the player?
+            if (PCurrentTrust->status == STATUS_TYPE::NORMAL && distance(PChar->loc.p, PCurrentTrust->loc.p) <= 50)
             {
-                if (SpawnTrustItr == PChar->SpawnTRUSTList.end() || PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, SpawnTrustItr->first))
+                // trust not in update list for player, add it in
+                if (SpawnTrustItr == PChar->SpawnTRUSTList.end())
                 {
                     PChar->SpawnTRUSTList.insert(SpawnTrustItr, SpawnIDList_t::value_type(PCurrentTrust->id, PCurrentTrust));
-                    PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     if (PMaster)
                     {
                         PChar->pushPacket(new CEntitySetNamePacket(PCurrentTrust));
                     }
                 }
+                PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
-            else
+            // trust not visible, remove it from spawn list if it's in there
+            else if (SpawnTrustItr != PChar->SpawnTRUSTList.end())
             {
-                if (SpawnTrustItr != PChar->SpawnTRUSTList.end() && !(PChar->SpawnTRUSTList.key_comp()(PCurrentTrust->id, SpawnTrustItr->first)))
-                {
-                    PChar->SpawnTRUSTList.erase(SpawnTrustItr);
-                    PChar->updateEntityPacket(PCurrentTrust, ENTITY_DESPAWN, UPDATE_NONE);
-                }
+                PChar->SpawnTRUSTList.erase(SpawnTrustItr);
             }
         }
     }
@@ -921,8 +904,7 @@ CBaseEntity* CZoneEntities::GetEntity(uint16 targid, uint8 filter)
             }
         }
     }
-    // TODO: Combine Trusts and Pets into the same id space
-    else if (targid < 0x780) // 1920
+    else if (targid < 0x1000) // 1792 - 4096 are dynamic entities
     {
         if (filter & TYPE_PET)
         {
@@ -932,9 +914,6 @@ CBaseEntity* CZoneEntities::GetEntity(uint16 targid, uint8 filter)
                 return it->second;
             }
         }
-    }
-    else if (targid < 0x800) // 2048
-    {
         if (filter & TYPE_TRUST)
         {
             EntityList_t::const_iterator it = m_trustList.find(targid);
@@ -943,9 +922,6 @@ CBaseEntity* CZoneEntities::GetEntity(uint16 targid, uint8 filter)
                 return it->second;
             }
         }
-    }
-    else if (targid < 0x1000) // 2048 - 4096 are dynamic entities
-    {
         if (filter & TYPE_NPC)
         {
             EntityList_t::const_iterator it = m_npcList.find(targid);
@@ -1209,22 +1185,19 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 
                                 if (entity)
                                 {
-                                    if (entity->targid < 0x400 || entity->targid >= 0x800) // TODO: Don't hard code me!
+                                    if (entity->objtype == TYPE_MOB)
                                     {
-                                        if (entity->objtype == TYPE_MOB)
-                                        {
-                                            spawnlist = PCurrentChar->SpawnMOBList;
-                                        }
-                                        else if (entity->objtype == TYPE_NPC)
-                                        {
-                                            spawnlist = PCurrentChar->SpawnNPCList;
-                                        }
+                                        spawnlist = PCurrentChar->SpawnMOBList;
                                     }
-                                    else if (entity->targid < 0x780)
+                                    else if (entity->objtype == TYPE_NPC)
+                                    {
+                                        spawnlist = PCurrentChar->SpawnNPCList;
+                                    }
+                                    else if (entity->objtype == TYPE_PET)
                                     {
                                         spawnlist = PCurrentChar->SpawnPETList;
                                     }
-                                    else if (entity->targid < 0x800)
+                                    else if (entity->objtype == TYPE_TRUST)
                                     {
                                         spawnlist = PCurrentChar->SpawnTRUSTList;
                                     }
@@ -1325,17 +1298,19 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
 
     luautils::OnZoneTick(this->m_zone);
 
-    std::unordered_set<uint16> entitiesToRelease;
-    for (EntityList_t::const_iterator it = m_mobList.begin(); it != m_mobList.end(); ++it)
+    EntityList_t::iterator it = m_mobList.begin();
+    while (it != m_mobList.end())
     {
         CMobEntity* PMob = dynamic_cast<CMobEntity*>(it->second);
         if (!PMob)
         {
+            it++;
             continue;
         }
 
         if (PMob->PBattlefield && PMob->PBattlefield->CanCleanup())
         {
+            it++;
             continue;
         }
 
@@ -1362,28 +1337,22 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                 PMob->PParty->RemoveMember(PMob);
             }
 
-            entitiesToRelease.insert(PMob->targid);
-        }
-    }
-
-    // TODO: Handle NPCs
-    for (auto targid : entitiesToRelease)
-    {
-        auto* PMob = m_mobList[targid];
-
-        for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
-        {
-            CCharEntity* PChar = (CCharEntity*)it->second;
-            if (distance(PChar->loc.p, PMob->loc.p) < 50)
+            for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
             {
-                PChar->SpawnMOBList.erase(PMob->id);
+                CCharEntity* PChar = (CCharEntity*)it->second;
+                if (distance(PChar->loc.p, PMob->loc.p) < 50)
+                {
+                    PChar->SpawnMOBList.erase(PMob->id);
+                }
             }
-        }
 
-        delete PMob;
-        m_mobList[targid] = nullptr;
-        m_mobList.erase(targid);
-        dynamicTargIds.erase(targid);
+            it->second = nullptr;
+            m_mobList.erase(it++);
+            dynamicTargIds.erase(PMob->targid);
+            delete PMob;
+            continue;
+        }
+        it++;
     }
 
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
@@ -1392,7 +1361,8 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
         PNpc->PAI->Tick(tick);
     }
 
-    for (EntityList_t::const_iterator it = m_petList.begin(); it != m_petList.end(); ++it)
+    it = m_petList.begin();
+    while (it != m_petList.end())
     {
         // TODO: This static cast includes Battlefield Allies. Allies shouldn't be handled here in
         //     : this way, but we need to do this to keep allies working (for now).
@@ -1406,18 +1376,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                 PPet->StatusEffectContainer->TickEffects(tick);
             }
             PPet->PAI->Tick(tick);
-        }
-    }
 
-    // TODO: It is cheap to iterate the pets list again, we're only acting on disappearing pets,
-    //       but it's wasteful. Fix me!
-    EntityList_t::iterator pit = m_petList.begin();
-    while (pit != m_petList.end())
-    {
-        // TODO: This static cast includes Battlefield Allies. Allies shouldn't be handled here in
-        //     : this way, but we need to do this to keep allies working (for now).
-        if (auto* PPet = static_cast<CPetEntity*>(pit->second))
-        {
             if (PPet->status == STATUS_TYPE::DISAPPEAR)
             {
                 for (auto PMobIt : m_mobList)
@@ -1427,23 +1386,18 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                 }
                 if (PPet->getPetType() != PET_TYPE::AUTOMATON || !PPet->PMaster)
                 {
-                    delete pit->second;
-                    pit->second = nullptr;
+                    delete it->second;
+                    it->second = nullptr;
                 }
-                m_petList.erase(pit++);
-            }
-            else
-            {
-                ++pit;
+                dynamicTargIds.erase(it->first);
+                m_petList.erase(it++);
+                continue;
             }
         }
-        else
-        {
-            ++pit;
-        }
+        it++;
     }
-
-    for (EntityList_t::const_iterator it = m_trustList.begin(); it != m_trustList.end(); ++it)
+    it = m_trustList.begin();
+    while (it != m_trustList.end())
     {
         if (CTrustEntity* PTrust = dynamic_cast<CTrustEntity*>(it->second))
         {
@@ -1455,16 +1409,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                 PTrust->StatusEffectContainer->TickEffects(tick);
             }
             PTrust->PAI->Tick(tick);
-        }
-    }
 
-    // TODO: It is cheap to iterate the trust list again, we're only acting on disappearing trusts,
-    //       but it's wasteful. Fix me!
-    EntityList_t::iterator trustit = m_trustList.begin();
-    while (trustit != m_trustList.end())
-    {
-        if (auto* PTrust = dynamic_cast<CTrustEntity*>(trustit->second))
-        {
             if (PTrust->status == STATUS_TYPE::DISAPPEAR)
             {
                 for (auto& list : { m_mobList, m_trustList }) // Remove from Mobs and Trusts
@@ -1486,15 +1431,14 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_regions)
                     }
                 }
 
-                delete trustit->second;
-                trustit->second = nullptr;
-                m_trustList.erase(trustit++);
-            }
-            else
-            {
-                ++trustit;
+                delete it->second;
+                it->second = nullptr;
+                dynamicTargIds.erase(it->first);
+                m_trustList.erase(it++);
+                continue;
             }
         }
+        it++;
     }
 
     for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)


### PR DESCRIPTION
* Various cleanup along the way, such as removing several unnecessary re-iteratons of std::maps

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Merges pet/trust/dynamic entity into 0x700+ range
Cleanups along the way, notably removal of several needless re-searches of lists or redundant looping of the same list

## Steps to test these changes

targid sharing:
Summon trust, note targid 0x700
Summon a pet, note targid 0x701
`!fafnir`, note targid 0x702

desummon pet and trust, wait for nameplates to disappear
`!fafnir` x2
note new targids of 0x700 and 0x701
`!hp 0` on the fafnir targid 0x702, wait for nameplate to disappear
summon pet or trust
note targid of 0x702 on trust or pet

basic entity checks:
run in/out of range of pets and mobs and see them appear/disappear
you can use `!setmod move -100` to "bind" your pet in place to do this. Doesn't work on trusts because they teleport.

Extra credit:
breakpoint in `CZoneEntities::ZoneServer` and verify that `m_petList` and `m_trustList` are set back to size 0 after trusts and pets are despawned from the zone

Old checklist for dynamic entities:
- [x]     spawn fafnir
- [x]     still be able to target and punch him in the face
- [x]     cast spells on him
- [x]     Same with other regular mobs
- [x]     make sure instances still work
- [x]     make sure bcnms still work
- [x]     make sure !gotoid works on a dynamic entities ID
- [x]     make sure !gotoid works on a dynamic entities ID when the entities targid is above 0x800