### PR TITLE
[ci] Remove ::set-output usage

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ jobs:
           cat changelog-$(date +'%Y-%m-%d').md
     - name: Capture date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
     - name: Git stash changes
       run: |
           git stash --include-untracked


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [HERE COMES THE CI DANCE WOO] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

GitHub is going to deprecate its usage next year, may as well dump it now

"We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023."

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

## Steps to test these changes

Hope that 🤖 doesn't get mad on the next run in 10 days...
