### PR TITLE
Purakoko Pathing with BONUS!

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/Purakoko.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Purakoko.lua
@@ -5,6 +5,25 @@
 -----------------------------------
 local entity = {}
 
+local paths =
+{
+    { { x = -72.580, y = -10.500, z = 115.877, wait = 2000 } },
+    { { x = -65.567, y = -11.000, z = 120.000, wait = 2000 } },
+    { { x = -59.242, y = -12.500, z = 123.703, wait = 2000 } },
+    { { wait = 2000, rotation = 0 } },
+}
+
+entity.onSpawn = function(npc)
+    npc:initNpcAi()
+    npc:setPos(xi.path.first(paths[1]))
+    npc:pathThrough(paths[1], xi.path.flag.PATROL)
+end
+
+entity.onPathComplete = function(npc)
+    local index = math.random(1, #paths)
+    npc:pathThrough(paths[index], xi.path.flag.PATROL)
+end
+
 entity.onTrade = function(player, npc, trade)
 end
 

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../entities/baseentity.h"
 #include "../../entities/mobentity.h"
 #include "../../zone.h"
+#include "lua/luautils.h"
 
 namespace
 {
@@ -278,8 +279,10 @@ void CPathFind::FollowPath(time_point tick)
         {
             m_timeAtPoint = {};
             ++m_currentPoint;
+            luautils::OnPathPoint(m_POwner);
             if (m_currentPoint >= (int16)m_points.size())
             {
+                luautils::OnPathComplete(m_POwner);
                 FinishedPath();
             }
         }
@@ -322,6 +325,8 @@ void CPathFind::FollowPath(time_point tick)
                 m_timeAtPoint = tick + std::chrono::milliseconds(targetPoint.wait);
                 return;
             }
+
+            luautils::OnPathPoint(m_POwner);
             m_currentPoint++;
         }
         else
@@ -334,6 +339,7 @@ void CPathFind::FollowPath(time_point tick)
 
     if (m_currentPoint >= (int16)m_points.size())
     {
+        luautils::OnPathComplete(m_POwner);
         FinishedPath();
         m_onPoint = true;
     }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1618,7 +1618,9 @@ bool CLuaBaseEntity::pathThrough(sol::table const& pointsTable, sol::object cons
     if (flags & PATHFLAG_PATROL)
     {
         // Grab points from array and store in points array
-        float x, y, z = -1;
+        float x = m_PBaseEntity->loc.p.x;
+        float y = m_PBaseEntity->loc.p.y;
+        float z = m_PBaseEntity->loc.p.z;
         for (std::size_t i = 1; i <= pointsTable.size(); ++i)
         {
             sol::table  pointData = pointsTable[i];

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2908,6 +2908,58 @@ namespace luautils
         {
             sol::error err = result;
             ShowError("luautils::onPath: %s", err.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
+    int32 OnPathPoint(CBaseEntity* PEntity)
+    {
+        TracyZoneScoped;
+
+        if (PEntity == nullptr || PEntity->objtype == TYPE_PC)
+        {
+            return -1;
+        }
+
+        sol::function onPathPoint = getEntityCachedFunction(PEntity, "onPathPoint");
+        if (!onPathPoint.valid())
+        {
+            return -1;
+        }
+
+        auto result = onPathPoint(CLuaBaseEntity(PEntity));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::OnPathPoint: %s", err.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
+    int32 OnPathComplete(CBaseEntity* PEntity)
+    {
+        TracyZoneScoped;
+
+        if (PEntity == nullptr || PEntity->objtype == TYPE_PC)
+        {
+            return -1;
+        }
+
+        sol::function onPathComplete = getEntityCachedFunction(PEntity, "onPathComplete");
+        if (!onPathComplete.valid())
+        {
+            return -1;
+        }
+
+        auto result = onPathComplete(CLuaBaseEntity(PEntity));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::OnPathComplete: %s", err.what());
             return -1;
         }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -260,7 +260,9 @@ namespace luautils
     int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller); // triggers on mob death
     int32 OnMobDespawn(CBaseEntity* PMob);                     // triggers on mob despawn (death not assured)
 
-    int32 OnPath(CBaseEntity* PEntity); // triggers when a patrol npc finishes its pathfind
+    int32 OnPath(CBaseEntity* PEntity);         // triggers when an entity is on a pathfind point
+    int32 OnPathPoint(CBaseEntity* PEntity);    // triggers when an entity stops on a path point and has finished waiting at it
+    int32 OnPathComplete(CBaseEntity* PEntity); // triggers when an entity finishes its pathing
 
     int32 OnBattlefieldHandlerInitialise(CZone* PZone);
     int32 OnBattlefieldInitialise(CBattlefield* PBattlefield); // what to do when initialising battlefield, battlefield:setLocalVar("lootId") here for any which have loot


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Working version of this PR: https://github.com/LandSandBoat/server/pull/1752

- Added Purakoko pathing observed on retail: https://www.youtube.com/watch?v=jsz7TQjPp4Q
- Patrols use previous `x, y, z` but if none had been set before a point such as waiting with a fixed rotation at current position then the NPC would be warped to `-1, -1, -1`. Now these coords are defaulted to the NPCs position.
- Added `onPathPoint` which is very similar to `onPath` but waits until after the specified wait time.
- Added `onPathComplete` which is invoked when the pathing is completed after after the wait time.

## Steps to test these changes

`!pos -72.580 -10.500 115.877`

Watch Purakoko path around~