### PR TITLE
[core] Dump logging backtrace on crash, remove assert/__debugbreak from XI_DEBUG_BREAK_IF

### DIFF
--- a/src/common/WheatyExceptionReport.cpp
+++ b/src/common/WheatyExceptionReport.cpp
@@ -311,8 +311,21 @@ LONG WINAPI WheatyExceptionReport::WheatyUnhandledExceptionFilter(
         Log(_T("Memory dump: %s"), m_szDumpFileName);
         std::time_t t = std::time(nullptr);
         Log(_T(fmt::format("Time of crash: {:%Y/%m/%d %H:%M:%S}", fmt::localtime(t)).c_str()));
+        Log(_T("Process Uptime: %s"), GetUptimeString());
+        PrintSystemInfo();
+        Log(_T("Process Memory Usage: %s"), GetMemoryUsageString());
+        Log(_T("Git Branch: %s"), version::GetGitBranch());
+        Log(_T("Git Commit Subject: %s"), version::GetGitCommitSubject());
+        Log(_T("Git SHA: %s"), version::GetGitSha());
+        Log(_T("Git Date: %s"), version::GetGitDate());
+        Log(_T("====================================================="));
+
+        DumpBacktrace();
+
+        Log(_T("====================================================="));
 
         GenerateExceptionReport(pExceptionInfo);
+
     }
 
     Log(_T(fmt::format("WheatyUnhandledExceptionFilter Exit").c_str()));
@@ -638,15 +651,6 @@ PEXCEPTION_POINTERS pExceptionInfo)
     __try
     {
         PEXCEPTION_RECORD pExceptionRecord = pExceptionInfo->ExceptionRecord;
-
-        Log(_T("Process Uptime: %s"), GetUptimeString());
-        PrintSystemInfo();
-        Log(_T("Process Memory Usage: %s"), GetMemoryUsageString());
-        Log(_T("Git Branch: %s"), version::GetGitBranch());
-        Log(_T("Git Commit Subject: %s"), version::GetGitCommitSubject());
-        Log(_T("Git SHA: %s"), version::GetGitSha());
-        Log(_T("Git Date: %s"), version::GetGitDate());
-        Log(_T("====================================================="));
 
         PCONTEXT pCtx = pExceptionInfo->ContextRecord;
 

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -14,31 +14,12 @@
 #define DEBUG
 #endif
 
-// define a break macro for debugging.
-#if defined(DEBUG)
-#if defined(_MSC_VER)
-#define XI_DEBUG_BREAK_IF(_CONDITION_)                      \
-    if (_CONDITION_)                                        \
-    {                                                       \
-        ShowError("HIT DEBUG CONDITION: %s", #_CONDITION_); \
-        __debugbreak();                                     \
+// define a break macro for debugging
+#define XI_DEBUG_BREAK_IF(_CONDITION_)                               \
+    if (_CONDITION_)                                                 \
+    {                                                                \
+        ShowCritical("HIT DEBUG BREAK CONDITION: %s", #_CONDITION_); \
     }
-#else
-#include "assert.h"
-#define XI_DEBUG_BREAK_IF(_CONDITION_)                      \
-    if (_CONDITION_)                                        \
-    {                                                       \
-        ShowError("HIT DEBUG CONDITION: %s", #_CONDITION_); \
-        assert(!(_CONDITION_));                             \
-    }
-#endif
-#else
-#define XI_DEBUG_BREAK_IF(_CONDITION_)                      \
-    if (_CONDITION_)                                        \
-    {                                                       \
-        ShowError("HIT DEBUG CONDITION: %s", #_CONDITION_); \
-    }
-#endif
 
 // typedef/using
 using int8  = std::int8_t;

--- a/src/common/debug_linux.cpp
+++ b/src/common/debug_linux.cpp
@@ -19,6 +19,8 @@ void dumpBacktrace(int signal)
     printer.color_mode = backward::ColorMode::always;
     printer.address    = true;
 
+    DumpBacktrace();
+
     std::ostringstream traceStream;
     printer.print(trace, traceStream);
     spdlog::get("critical")->critical(traceStream.str());

--- a/src/common/debug_osx.cpp
+++ b/src/common/debug_osx.cpp
@@ -19,6 +19,8 @@ void dumpBacktrace(int signal)
     printer.color_mode = backward::ColorMode::always;
     printer.address    = true;
 
+    DumpBacktrace();
+
     std::ostringstream traceStream;
     printer.print(trace, traceStream);
     spdlog::get("critical")->critical(traceStream.str());

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -84,7 +84,7 @@ namespace logging
 
         spdlog::set_level(spdlog::level::debug);
 
-        spdlog::enable_backtrace(10);
+        spdlog::enable_backtrace(16);
     }
 
     void ShutDown()

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -61,15 +61,17 @@ namespace logging
 #define ShowCritical(...) { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_CRITICAL(spdlog::get("critical"), _msgStr); }
 
 // Debug Loggers
-#define DebugNavmesh(...)  { if (settings::get<bool>("logging.DEBUG_NAVMESH")) { ShowDebug(__VA_ARGS__); } }
-#define DebugPackets(...)  { if (settings::get<bool>("logging.DEBUG_PACKETS")) { ShowDebug(__VA_ARGS__); } }
-#define DebugActions(...)  { if (settings::get<bool>("logging.DEBUG_ACTIONS")) { ShowDebug(__VA_ARGS__); } }
-#define DebugSQL(...)      { if (settings::get<bool>("logging.DEBUG_SQL")) { ShowDebug(__VA_ARGS__); } }
+#define DebugNavmesh(...)  { if (settings::get<bool>("logging.DEBUG_NAVMESH"))   { ShowDebug(__VA_ARGS__); } }
+#define DebugPackets(...)  { if (settings::get<bool>("logging.DEBUG_PACKETS"))   { ShowDebug(__VA_ARGS__); } }
+#define DebugActions(...)  { if (settings::get<bool>("logging.DEBUG_ACTIONS"))   { ShowDebug(__VA_ARGS__); } }
+#define DebugSQL(...)      { if (settings::get<bool>("logging.DEBUG_SQL"))       { ShowDebug(__VA_ARGS__); } }
 #define DebugIDLookup(...) { if (settings::get<bool>("logging.DEBUG_ID_LOOKUP")) { ShowDebug(__VA_ARGS__); } }
-#define DebugModules(...)  { if (settings::get<bool>("logging.DEBUG_MODULES")) { ShowDebug(__VA_ARGS__); } }
+#define DebugModules(...)  { if (settings::get<bool>("logging.DEBUG_MODULES"))   { ShowDebug(__VA_ARGS__); } }
 
 // Special Loggers (different patterns)
 #define ShowLua(...) { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_INFO(spdlog::get("lua"), _msgStr); }
+
+#define DumpBacktrace() spdlog::get("trace")->dump_backtrace()
 
 // clang-format on
 

--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -141,7 +141,6 @@ bool CLatentEffect::Activate()
         else
         {
             m_POwner->addModifier(m_ModValue, m_ModPower);
-            // ShowTrace("LATENT ACTIVATED: %d, Current value: %d", m_ModValue, m_POwner->getMod(m_ModValue));
         }
 
         m_Activated = true;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -226,8 +226,9 @@ namespace luautils
             if (entry.path().extension() == ".lua")
             {
                 auto relative_path_string = entry.path().relative_path().generic_string();
-                auto lua_path             = std::filesystem::relative(entry.path(), "./").replace_extension("").generic_string();
-                ShowTrace("Loading global script %s", lua_path);
+
+                ShowTrace("Loading global script %s", relative_path_string);
+
                 auto result = lua.safe_script_file(relative_path_string);
                 if (!result.valid())
                 {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -824,10 +824,11 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                 return "Unknown";
         }
     };
-    auto actionStr = actionToStr(action);
-    TracyZoneString(fmt::format("Player Action: {}: {} -> targid: {}", PChar->GetName(), actionStr, TargID));
 
-    DebugActions(fmt::format("CLIENT {} PERFORMING ACTION {} (0x{:02X})", PChar->GetName(), actionStr, action));
+    auto actionStr = fmt::format("Player Action: {}: {} (0x{:02X}) -> targid: {}", PChar->GetName(), actionToStr(action), action, TargID);
+    TracyZoneString(actionStr);
+    ShowTrace(actionStr);
+    DebugActions(actionStr);
 
     switch (action)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Gives a little more utility to `ShowTrace`. On crash, it'll poop out the last 16 messages that were sent to Trace.

```txt
=====================================================
!!! CRASH !!!
Exception code: C0000005 (ACCESS_VIOLATION)
Fault address: 00007FF7ABBEEFC2 01:000000000009DFC2
Process Name: C:\ffxi\server\xi_map.exe
Full crash report: C:\ffxi\server\dmp\xi_map.exe_21-10_12-6-13.log
Memory dump: C:\ffxi\server\dmp\xi_map.exe_21-10_12-6-13.dmp
Time of crash: 2022/10/21 12:06:13
Process Uptime: 90 seconds
Processor: AMD Ryzen 9 5900HS with Radeon Graphics
Number Of Threads: 16
OS: Windows 10 Home Edition (Version 10.0, Build 22621)
Process Memory Usage: 2277MiB / 32768MiB
Git Branch: base
Git Commit Subject: Merge pull request #2988 from jmcmorris/purakoko_pathing
Git SHA: 42459d6ae1-dirty
Git Date: Thu Oct 20 23:56:38 2022
=====================================================
****************** Backtrace Start ******************
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/278/Zone.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Walk_of_Echoes_[P2]/Zone.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/286/Zone.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Walk_of_Echoes_[P1]/Zone.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/unknown/instances/TEST.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Ilrusi_Atoll/instances/lamia_no_13.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Lebros_Cavern/instances/lebros_supplies.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Leujaoam_Sanctum/instances/orichalcum_survey.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Bhaflau_Remnants/instances/bhaflau_remnants.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Silver_Sea_Remnants/instances/silver_sea_remnants.lua
luautils::CacheLuaObjectFromFile: File does not exist: ./scripts/zones/Ruhotz_Silvermines/instances/fire_in_the_hole.lua
Player Action: Testo: Complete Character Update (0x14) -> targid: 1024
Player Action: Testo: Spellcast (0x03) -> targid: 431
Player Action: Testo: Attack (0x02) -> targid: 441
Player Action: Testo: Spellcast (0x03) -> targid: 441
Player Action: Testo: Spellcast (0x03) -> targid: 441
****************** Backtrace End ********************
=====================================================
=== Call stack ===
Address           Frame             Function
00007FF7ABBEEFC2  0000009C225F9780  crash+12 (C:\ffxi\server\src\common\utils.cpp, line 904)
00007FF7ABFAA0EF  0000009C225F97B0  <lambda_076974e227e09c50d47056ebc6a55e62>::operator()+F (C:\ffxi\server\src\map\lua\luautils.cpp, line 189)
00007FF7ABFAA10D  0000009C225F97E0  <lambda_076974e227e09c50d47056ebc6a55e62>::<lambda_invoker_cdecl>+D (C:\ffxi\server\src\map\lua\luautils.cpp, line 189)
```

Good for tracking down who was the last person to do something during a crash.

Also removes the "kill server" condition from XI_DEBUG_BREAK_IF, which does more harm than good these days. (It'll still log the condition)

## Steps to test these changes

- Do some stuff
- Gm command: `!crash`