### PR TITLE
[core] Add inactivity watchdog to kernel

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -36,6 +36,8 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/version.cpp # auto-generated
     ${CMAKE_CURRENT_SOURCE_DIR}/version.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/watchdog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/watchdog.h
     ${CMAKE_CURRENT_SOURCE_DIR}/zlib.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h
     $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/debug_windows.cpp>

--- a/src/common/watchdog.cpp
+++ b/src/common/watchdog.cpp
@@ -1,0 +1,66 @@
+/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "watchdog.h"
+
+Watchdog::Watchdog(duration timeout, std::function<void()> callback)
+: m_timeout(timeout)
+, m_callback(callback)
+, m_lastUpdate(server_clock::now())
+, m_running(true)
+{
+    m_watchdog = std::thread(&Watchdog::_innerFunc, this);
+}
+
+Watchdog::~Watchdog()
+{
+    if (m_running)
+    {
+        std::unique_lock<std::mutex> lock(m_bottlneck);
+
+        m_running = false;
+        m_stopCondition.notify_all();
+
+        m_watchdog.join();
+    }
+}
+
+void Watchdog::update()
+{
+    std::unique_lock<std::mutex> lock(m_bottlneck);
+    m_lastUpdate = server_clock::now();
+}
+
+void Watchdog::_innerFunc()
+{
+    std::unique_lock<std::mutex> lock(m_bottlneck);
+
+    while ((server_clock::now() - m_lastUpdate) < m_timeout)
+    {
+        m_stopCondition.wait_for(lock, m_timeout);
+    }
+
+    if (m_running)
+    {
+        m_running = false;
+        m_callback();
+    }
+}

--- a/src/common/watchdog.h
+++ b/src/common/watchdog.h
@@ -1,0 +1,52 @@
+/*
+===========================================================================
+
+  Copyright (c) 2022 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+#pragma once
+
+#include "cbasetypes.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+class Watchdog
+{
+public:
+    Watchdog(duration timeout, std::function<void()> callback);
+    ~Watchdog();
+
+    void update();
+
+private:
+    void _innerFunc();
+
+    using voidFunc_t = std::function<void()>;
+
+    duration   m_timeout;
+    voidFunc_t m_callback;
+    time_point m_lastUpdate;
+
+    std::thread             m_watchdog;
+    std::atomic_bool        m_running;
+    std::mutex              m_bottlneck;
+    std::condition_variable m_stopCondition;
+};


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

If for some reason the main tick of the kernel (currently used in all processes) takes longer than 2000ms, something is very very wrong. You're either debugging something, or you've manufactured an infinite loop and are starving the process of the opportunity to do logic, service sockets, accept connections and keep client connections alive.

I was originally going to have this kill the process so that operators could have their stuff auto-restart, but that was clashing with attached debuggers etc.

So I've opted to just fire a one-off critical message. It'll fire when debugging, but that's not a big deal right?

## Steps to test these changes

Insert a `std::this_thread::sleep(n)` somewhere in native code, or attach a debugger, or make a fat loop somewhere in Lua and see the message get printed.
