### PR TITLE
Add onEquip, onUnequip item bindings and `DEFEATED_MOB` listener

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -21,7 +21,7 @@ ATTACKED - Defender, attacker, action
 DISENGAGE - Entity
 DEATH - Entity, optionalKiller
 DESPAWN - Entity
-
+DEFEATED_MOB - Mob, Attacker, optParams (Note: optParams is the same table in onMobDeath)
 EXPERIENCE_POINTS - Entity, exp
 
 TAKE_DAMAGE - Entity, amount, optionalAttacker, attackType, damageType

--- a/scripts/globals/items/chaosbringer.lua
+++ b/scripts/globals/items/chaosbringer.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- ID: 16607
+-- Chaosbringer
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemDrop = function(target, item)
+   target:setCharVar('ChaosbringerKills', 0)
+end
+
+itemObject.onItemEquip = function(target, item)
+    target:addListener('DEFEATED_MOB', 'CHAOSBRINGER_KILLS', function(mob, player, optParams)
+        if
+            (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == QUEST_ACCEPTED or
+            player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == QUEST_ACCEPTED) and
+            target:getCharVar('ChaosbringerKills') < 200 and
+            optParams.isKiller and
+            not optParams.isWeaponSkillKill
+        then
+            player:incrementCharVar("ChaosbringerKills", 1)
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(target, item)
+    target:removeListener('CHAOSBRINGER_KILLS')
+end
+
+return itemObject

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -16,20 +16,6 @@ xi.mob = xi.mob or {}
 
 -- onMobDeathEx is called from the core
 xi.mob.onMobDeathEx = function(mob, player, isKiller, isWeaponSkillKill)
-    -- Things that happen only to the person who landed killing blow
-    if isKiller then
-        -- DRK quest - Blade Of Darkness
-        if
-            (player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == QUEST_ACCEPTED or
-            player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == QUEST_ACCEPTED) and
-            player:getEquipID(xi.slot.MAIN) == 16607 and
-            player:getCharVar("ChaosbringerKills") < 200 and
-            not isWeaponSkillKill
-        then
-            player:incrementCharVar("ChaosbringerKills", 1)
-        end
-    end
-
     xi.magian.checkMagianTrial(player, { ['mob'] = mob, ['triggerWs'] = false })
 end
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2580,6 +2580,52 @@ namespace luautils
         return 0;
     }
 
+    int32 OnItemEquip(CBaseEntity* PUser, CItem* PItem)
+    {
+        TracyZoneScoped;
+
+        auto filename = fmt::format("./scripts/globals/items/{}.lua", PItem->getName());
+
+        sol::function onItemEquip = GetCacheEntryFromFilename(filename)["onItemEquip"].get<sol::function>();
+        if (!onItemEquip.valid())
+        {
+            return -1;
+        }
+
+        auto result = onItemEquip(CLuaBaseEntity(PUser), CLuaItem(PItem));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onItemEquip: %s", err.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
+    int32 OnItemUnequip(CBaseEntity* PUser, CItem* PItem)
+    {
+        TracyZoneScoped;
+
+        auto filename = fmt::format("./scripts/globals/items/{}.lua", PItem->getName());
+
+        sol::function onItemUnequip = GetCacheEntryFromFilename(filename)["onItemUnequip"].get<sol::function>();
+        if (!onItemUnequip.valid())
+        {
+            return -1;
+        }
+
+        auto result = onItemUnequip(CLuaBaseEntity(PUser), CLuaItem(PItem));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onItemUnequip: %s", err.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
     // Check for gear sets  (e.g Set: enhances haste effect)
     int32 CheckForGearSet(CBaseEntity* PTarget)
     {
@@ -3363,6 +3409,8 @@ namespace luautils
                         sol::error err = result;
                         ShowError("luautils::onMobDeath: %s", err.what());
                     }
+
+                    PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", LuaMobEntity, optLuaAllyEntity, optParams);
                 }
             });
             // clang-format on

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -236,7 +236,9 @@ namespace luautils
     int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem);                                                                                     // triggers when item is used
     auto  OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr) -> std::tuple<int32, int32, int32>; // check to see if item can be used
     int32 OnItemDrop(CBaseEntity* PUser, CItem* PItem);                                                                                                          // trigger when an item is dropped
-    int32 CheckForGearSet(CBaseEntity* PTarget);                                                                                                                 // check for gear sets
+    int32 OnItemEquip(CBaseEntity* PUser, CItem* PItem);
+    int32 OnItemUnequip(CBaseEntity* PUser, CItem* PItem);
+    int32 CheckForGearSet(CBaseEntity* PTarget); // check for gear sets
 
     int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);                                                       // triggers when a player attempts to cast a spell
     int32 OnSpellCast(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PSpell);                                                         // triggered when casting a spell

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1788,6 +1788,8 @@ namespace charutils
                 break;
             }
 
+            luautils::OnItemUnequip(PChar, PItem);
+
             if (update)
             {
                 charutils::BuildingCharSkillsTable(PChar);
@@ -2513,6 +2515,11 @@ namespace charutils
             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_AFTERMATH);
             BuildingCharWeaponSkills(PChar);
             PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+        }
+
+        if (PItem != nullptr)
+        {
+            luautils::OnItemEquip(PChar, PItem);
         }
 
         charutils::BuildingCharSkillsTable(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Adds the following item bindings:
`onItemEquip(player, item)`
`onItemUnequip(player, item)`

Adds Trigger logic to the noKiller == false block of onMobDeath with the listener `DEFEATED_MOB` calling out with the same function parameters `(mob, player, optParams)`.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Add quest Blade of Darkness or Blade of Death
2. !additem 16607 (Chaosbringer)
3. Kill things without using weaponskill
4. Verify charvar `ChaosbringerKills` increments

<!-- Clear and detailed steps to test your changes here -->
