### PR TITLE
Battlefield Member Entry

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -512,14 +512,14 @@ function Battlefield:isValidEntry(player, npc)
     return self.entryNpc == npc:getName()
 end
 
-function Battlefield:checkRequirements(player, npc, registrant, trade)
+function Battlefield:checkRequirements(player, npc, isRegistrant, trade)
     if not self:isValidEntry(player, npc) then
         return false
     end
 
-    -- Do not show battlefields when either they don't require items and player is trading or
+    -- Do not show battlefields to registrant when either they don't require items and player is trading or
     -- that do require items and but player is not trading
-    if (trade == nil) ~= (#self.tradeItems == 0) then
+    if isRegistrant and (trade == nil) ~= (#self.tradeItems == 0) then
         return false
     end
 
@@ -639,7 +639,7 @@ function Battlefield.onEntryTrigger(player, npc)
             return
         end
 
-        if not content:checkRequirements(player, npc, content.id) then
+        if not content:checkRequirements(player, npc, false) then
             return
         end
 
@@ -1158,8 +1158,11 @@ function BattlefieldMission:new(data)
     return obj
 end
 
-function BattlefieldMission:checkRequirements(player, npc, registrant, trade)
-    Battlefield.checkRequirements(self, player, npc, registrant, trade)
+function BattlefieldMission:checkRequirements(player, npc, isRegistrant, trade)
+    if not Battlefield.checkRequirements(self, player, npc, isRegistrant, trade) then
+        return false
+    end
+
     local missionArea = self.missionArea or player:getNation()
     local current = player:getCurrentMission(missionArea)
     local missionStatusArea = self.missionStatusArea or player:getNation()

--- a/scripts/zones/Apollyon/IDs.lua
+++ b/scripts/zones/Apollyon/IDs.lua
@@ -423,6 +423,7 @@ zones[xi.zone.APOLLYON] =
     {
         npc =
         {
+            PORTAL = {},
             ITEM_CRATES = {},
             TIME_CRATES = {},
             RECOVER_CRATES = {},
@@ -441,6 +442,7 @@ zones[xi.zone.APOLLYON] =
 
         npc =
         {
+            PORTAL = {},
             ITEM_CRATES = {},
             TIME_CRATES =
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes #2989
Resolves issue with party members entering a new battlefield when that battlefield requires traded items.
Resolves issue with player not meeting all requirements to enter mission battlefield but still presented option to enter
Resolves log warning about some limbus areas not having portals

## Steps to test these changes

```
!addkeyitem black_card
!addkeyitem cosmo_cleanse
!additem 1909
!additem 1910
!additem 1987
!additem 1988
!pos 600 -0.5 -600 38
```
Create a party and have one player trade chips to enter Central Apollyon and then try to get a party member to enter and they should be able to.