### PR TITLE
[Fix] [Interaction] Add missing player argument with npcUtil.giveKeyItem

### DIFF
--- a/scripts/quests/sandoria/RDM_AF1_The_Crimson_Trial.lua
+++ b/scripts/quests/sandoria/RDM_AF1_The_Crimson_Trial.lua
@@ -105,7 +105,7 @@ quest.sections =
                         not player:hasKeyItem(xi.ki.ORCISH_DRIED_FOOD)
                     then
                         player:tradeComplete()
-                        npcUtil.giveKeyItem(xi.ki.ORCISH_DRIED_FOOD)
+                        npcUtil.giveKeyItem(player, xi.ki.ORCISH_DRIED_FOOD)
                     end
                 end,
             },

--- a/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
+++ b/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
@@ -54,7 +54,7 @@ quest.sections =
                 [94] = function(player, csid, option, npc)
                     if option == 1 then -- Accept quest.
                         quest:begin(player)
-                        npcUtil.giveKeyItem(xi.ki.OLD_POCKET_WATCH)
+                        npcUtil.giveKeyItem(player, xi.ki.OLD_POCKET_WATCH)
                     else
                         quest:setVar(player, 'Prog', 1) -- You rejected the quest when first offered.
                     end
@@ -63,7 +63,7 @@ quest.sections =
                 [95] = function(player, csid, option, npc)
                     if option == 1 then -- Accept quest.
                         quest:begin(player)
-                        npcUtil.giveKeyItem(xi.ki.OLD_POCKET_WATCH)
+                        npcUtil.giveKeyItem(player, xi.ki.OLD_POCKET_WATCH)
                     end
                 end,
             },
@@ -171,7 +171,7 @@ quest.sections =
                     quest:setVar(player, 'Prog', 2) -- Saw ghost.
                     player:tradeComplete()
                     player:delKeyItem(xi.ki.OLD_POCKET_WATCH)
-                    npcUtil.giveKeyItem(xi.ki.OLD_BOOTS)
+                    npcUtil.giveKeyItem(player, xi.ki.OLD_BOOTS)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes key items not being given.

## Steps to test these changes

Do the quest
