### PR TITLE
[core] Move entity update in SpawnMob/Trust/Pet back inside if condition

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -530,8 +530,8 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
             if (MOB == PChar->SpawnMOBList.end())
             {
                 PChar->SpawnMOBList.insert(MOB, SpawnIDList_t::value_type(PCurrentMob->id, PCurrentMob));
+                PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
-            PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
 
             // Check to skip aggro routine
             if (PChar->isDead() || PChar->nameflags.flags & FLAG_GM || PCurrentMob->PMaster)
@@ -575,8 +575,8 @@ void CZoneEntities::SpawnPETs(CCharEntity* PChar)
             if (PET == PChar->SpawnPETList.end())
             {
                 PChar->SpawnPETList.insert(PET, SpawnIDList_t::value_type(PCurrentPet->id, PCurrentPet));
+                PChar->updateEntityPacket(PCurrentPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
-            PChar->updateEntityPacket(PCurrentPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
         }
         // Pet not visible, remove it from spawn list if it's in there
         else if (PET != PChar->SpawnPETList.end())
@@ -606,8 +606,8 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
                     if (NPC == PChar->SpawnNPCList.end())
                     {
                         PChar->SpawnNPCList.insert(NPC, SpawnIDList_t::value_type(PCurrentNpc->id, PCurrentNpc));
+                        PChar->updateEntityPacket(PCurrentNpc, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     }
-                    PChar->updateEntityPacket(PCurrentNpc, ENTITY_SPAWN, UPDATE_ALL_MOB);
                 }
                 // npc not visible, remove it from spawn list if it's in there
                 else if (NPC != PChar->SpawnNPCList.end())
@@ -640,9 +640,9 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
                     if (PMaster)
                     {
                         PChar->pushPacket(new CEntitySetNamePacket(PCurrentTrust));
+                        PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
                     }
                 }
-                PChar->updateEntityPacket(PCurrentTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
             // trust not visible, remove it from spawn list if it's in there
             else if (SpawnTrustItr != PChar->SpawnTRUSTList.end())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes 0x00E packet spam, apparently through my ignorance I accidentally made a "spawn/despawn" function into "update everything in range" function

## Steps to test these changes

`!zone monastic cavern`
`!pos 208 3 48`
don't see >1500 R constantly, drop down to 500-700~ and stay there without moving
