### PR TITLE
[core] Fix block rate wrapping with Ochain + Reprisal, fix reprisal spikes not appearing

### DIFF
--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -267,7 +267,7 @@ namespace attackutils
     {
         if (facing(PDefender->loc.p, PAttacker->loc.p, 64) && !PDefender->StatusEffectContainer->HasPreventActionEffect())
         {
-            return (xirand::GetRandomNumber(100) < battleutils::GetBlockRate(PAttacker, PDefender));
+            return (xirand::GetRandomNumber<float>(100) < battleutils::GetBlockRate(PAttacker, PDefender));
         }
         return false;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -894,7 +894,7 @@ namespace battleutils
                     break;
 
                 case SPIKE_REPRISAL:
-                    if (Action->reaction == REACTION::BLOCK)
+                    if ((Action->reaction & REACTION::BLOCK) == REACTION::BLOCK)
                     {
                         PAttacker->takeDamage(spikesDamage, PDefender, ATTACK_TYPE::MAGICAL, DAMAGE_TYPE::LIGHT);
                     }
@@ -1769,24 +1769,24 @@ namespace battleutils
     http://www.ffxiah.com/forum/topic/21671/paladin-faq-info-and-trade-studies/34/#2581818
     https://docs.google.com/spreadsheet/ccc?key=0AkX3maplDraRdFdCZHI2OU93aVgtWlZhN3ozZEtnakE#gid=0
     http://www.ffxionline.com/forums/paladin/55139-shield-data-size-2-vs-size-3-a.html
-    https://www.bg-wiki.com/ffxi/Shield_Skill - Base calculations
+    https://www.bg-wiki.com/ffxi/Shield_Skill - Base calculations - does not floor
     https://www.ffxiah.com/forum/topic/53625/make-paladin-great-again/6/#3434884 - Palisade +base block rate
 
     Base block rates are (small to large shield type) 55% -> 50% -> 45% -> 30%
     Aegis is a special case, having the base block rate of a size 2 type.
     ************************************************************************/
-    uint8 GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
+    float GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender)
     {
-        int8   base          = 0;
+        float  base          = 0;
         int8   shieldSize    = 3;
-        int8   blockRate     = 0;
-        int8   skillModifier = 0;
+        float  blockRate     = 0;
+        float  skillModifier = 0;
         int16  blockRateMod  = PDefender->getMod(Mod::SHIELDBLOCKRATE);
         int16  palisadeMod   = PDefender->getMod(Mod::PALISADE_BLOCK_BONUS);
         float  reprisalMult  = 1.0f;
         auto*  weapon        = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]);
         uint16 attackSkill   = PAttacker->GetSkill((SKILLTYPE)(weapon ? weapon->getSkillType() : 0));
-        uint16 blockSkill    = PDefender->GetSkill(SKILL_SHIELD);
+        float  blockSkill    = PDefender->GetSkill(SKILL_SHIELD);
 
         if (PDefender->objtype == TYPE_PC)
         {
@@ -1847,8 +1847,8 @@ namespace battleutils
             case 5: // Aegis and Srivatsa
                 base = 50;
                 break;
-            case 6: // Ochain
-                base = 110;
+            case 6: // Ochain -- https://www.bg-wiki.com/ffxi/Category:Shields
+                base = 108;
                 break;
             default:
                 return 0;
@@ -1857,7 +1857,7 @@ namespace battleutils
         // Check for Reprisal and adjust skill and block rate bonus multiplier
         if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_REPRISAL))
         {
-            blockSkill   = (uint16)(blockSkill * 1.15f);
+            blockSkill   = blockSkill * 1.15f;
             reprisalMult = 1.5f; // Default is 1.5x
 
             // Adamas and Priwen set the multiplier to 3.0x while equipped
@@ -1867,12 +1867,12 @@ namespace battleutils
             }
         }
 
-        skillModifier = (int16)((blockSkill - attackSkill) * 0.2325f);
+        skillModifier = (blockSkill - attackSkill) * 0.2325f;
 
         // Add skill and Palisade bonuses
         base += skillModifier + palisadeMod;
         // Multiply by Reprisal's bonus
-        base = (int8)(base * reprisalMult);
+        base = base * reprisalMult;
         // Add Chance of Successful Block
         base += blockRateMod;
 
@@ -2111,10 +2111,10 @@ namespace battleutils
 
                             if (PDefender->StatusEffectContainer->HasStatusEffect({ EFFECT_INVINCIBLE, EFFECT_SENTINEL }))
                             {
-                                blockedDamage = (baseDamage * (100 - absorb)) / 100;
+                                blockedDamage = (baseDamage * (100.f - absorb)) / 100.f;
                             }
 
-                            spikesDamage = blockedDamage * (effectPower / 100);
+                            spikesDamage = blockedDamage * (effectPower / 100.f);
 
                             // Set Reprisal spike damage
                             PDefender->setModifier(Mod::SPIKES_DMG, spikesDamage);

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -148,7 +148,7 @@ namespace battleutils
     uint8 GetRangedCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     int8  GetDexCritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     int8  GetAGICritBonus(CBattleEntity* PAttacker, CBattleEntity* PDefender);
-    uint8 GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
+    float GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8 GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, float bonusAttPercent);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Removed all flooring for block rate, as [block rate does no have any flooring](https://www.bg-wiki.com/ffxi/Shield_Skill)
Fixes block rate wrapping with Ochain, block rate "base" was int8, and Ochain's base block rate of 108~ was dangerously close to wrapping as is. 
Fixes reprisal spikes not showing
Fix reprisal spikes dmg multiplier being floored unintentionally which set dmg to 0
## Steps to test these changes

Equip ochain, block lower level stuff with reprisal, see capped block rate & spikes + dmg