### PR TITLE
Better Battlefield Exiting

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -722,6 +722,15 @@ bool CBattlefield::Cleanup(time_point time, bool force)
         if (PChar)
         {
             RemoveEntity(PChar, leavecode);
+        }
+    }
+
+    // Remove all registered players as long as they're in the zone
+    for (auto id : m_RegisteredPlayers)
+    {
+        auto* PChar = GetZone()->GetCharByID(id);
+        if (PChar)
+        {
             PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -724,6 +724,11 @@ bool CBattlefield::Cleanup(time_point time, bool force)
             RemoveEntity(PChar, leavecode);
             PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
+
+            if (PChar->PPet)
+            {
+                PChar->PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+            }
         }
     }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1033,6 +1033,10 @@ void CZone::CharZoneIn(CCharEntity* PChar)
                 // Is not inside of a battlefield arena so remove the battlefield effect
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
                 PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_RESTRICTION);
+                if (PChar->PPet)
+                {
+                    PChar->PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+                }
             }
         }
     }
@@ -1040,6 +1044,10 @@ void CZone::CharZoneIn(CCharEntity* PChar)
     {
         // Player is zoning into a zone that does not have a battlefield but the player has a confrontation effect - remove it
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+        if (PChar->PPet)
+        {
+            PChar->PPet->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+        }
     }
 
     PChar->PLatentEffectContainer->CheckLatentsZone();


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This fixes some issues around exiting battlefields. Such as when a player would "Run Away" from a battlefield they wouldn't be entered anymore and so their battlefield status effect would persist until they zoned.

## Steps to test these changes

Go into any battlefield and run away. Pull out a pet and go into an uncapped zone to see them properly removed when running away.
