### PR TITLE
Kaiser Behemoth cast Meteor in Apollyon NW

### DIFF
--- a/scripts/battlefields/Apollyon/nw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/nw_apollyon.lua
@@ -370,6 +370,7 @@ content.groups =
         {
             [xi.mobMod.ALLI_HATE] = 50,
             [xi.mobMod.MAGIC_COOL] = 30,
+            [xi.mobMod.SEVERE_SPELL_CHANCE] = 100,
         },
 
         setup = enpowerBoss,

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -1525,7 +1525,7 @@ INSERT INTO `mob_groups` VALUES (23,2661,38,'Millenary_Mossback',0,128,2858,1900
 INSERT INTO `mob_groups` VALUES (24,202,38,'Apollyon_Scavenger',0,128,2858,4750,0,75,77,0);
 INSERT INTO `mob_groups` VALUES (25,883,38,'Cynoprosopi',0,128,2858,15000,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (26,1771,38,'Gorynich',0,128,2862,5000,0,79,79,0);
-INSERT INTO `mob_groups` VALUES (27,6732,38,'Kaiser_Behemoth',0,128,2860,15000,0,85,85,0);
+INSERT INTO `mob_groups` VALUES (27,6732,38,'Kaiser_Behemoth',0,128,2860,15000,1000,85,85,0);
 INSERT INTO `mob_groups` VALUES (28,2289,38,'Kronprinz_Behemoth',0,128,2863,7000,1000,78,78,0);
 INSERT INTO `mob_groups` VALUES (29,1515,38,'Ghost_Clot',0,128,2856,10000,0,82,83,0);
 INSERT INTO `mob_groups` VALUES (30,2634,38,'Metalloid_Amoeba',0,128,2856,7500,0,80,80,0);

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -540,6 +540,9 @@ INSERT INTO `mob_pool_mods` VALUES (7039,4,15,1);  -- SIGHT_RANGE: 15
 INSERT INTO `mob_pool_mods` VALUES (7039,5,15,1);  -- SOUND_RANGE: 15
 INSERT INTO `mob_pool_mods` VALUES (7039,11,30,1); -- LINK_RADIUS: 30
 
+-- Kaiser Behemoth (Apollyon NW)
+INSERT INTO `mob_pool_mods` VALUES (6732,3,100,1); -- MP_BASE: 100
+
 /*!40000 ALTER TABLE `mob_pool_mods` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes issues with Kaiser Behemoth in Apollyon NW not casting Meteor correctly

## Steps to test these changes

```
!addkeyitem red_card
!addkeyitem cosmo_cleanse
!pos -600 -0.5 -600 38
```

Once inside Apollyon NW use `gotoid 16932985` and engage the Kaiser Behemoth and it'll cast Meteor now.