### PR TITLE
Battlefield Ejection For Registrant

### DIFF
--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -178,6 +178,12 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
             PBattlefield->SetLocalVar("loot", lootid);
         }
 
+        if (!PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD))
+        {
+            PChar->StatusEffectContainer->AddStatusEffect(
+                new CStatusEffect(EFFECT_BATTLEFIELD, EFFECT_BATTLEFIELD, PBattlefield->GetID(), 0, 0, PChar->id, PBattlefield->GetArea()), true);
+        }
+
         luautils::OnBattlefieldRegister(PChar, PBattlefield);
         luautils::OnBattlefieldInitialise(PBattlefield);
         PBattlefield->InsertEntity(PChar, true);
@@ -214,6 +220,12 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
     PBattlefield->m_showTimer = registration.showTimer;
 
     m_Battlefields.insert(std::make_pair(PBattlefield->GetArea(), PBattlefield));
+
+    if (!PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD))
+    {
+        PChar->StatusEffectContainer->AddStatusEffect(
+            new CStatusEffect(EFFECT_BATTLEFIELD, EFFECT_BATTLEFIELD, PBattlefield->GetID(), 0, 0, PChar->id, PBattlefield->GetArea()), true);
+    }
 
     luautils::OnBattlefieldRegister(PChar, PBattlefield);
     luautils::OnBattlefieldInitialise(PBattlefield);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add battlefield effect for registrant earlier so that way the effect's subpower in `onBattlefieldEnter` is set to indicate that the registrant is inside the battlefield so they'll be properly ejected if they log back in after the battlefield has been cleaned up.

This is done in two places because one is for the old battlefield system and the other is for the new one.

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/292

## Steps to test these changes

Go into a limbus area and logout and then log back in and it should eject you from the battlefield.
```
!addkeyitem red_card
!addkeyitem cosmo_cleanse
!pos -600 -0.5 -600 38
```
