### PR TITLE
[ci] Require multiline conditionals to not have data on start or end of blocks

### DIFF
--- a/scripts/commands/getskill.lua
+++ b/scripts/commands/getskill.lua
@@ -24,8 +24,14 @@ function onTrigger(player, skillName, target)
     local skillID = tonumber(skillName) or xi.skill[string.upper(skillName)]
     local targ = nil
 
-    if skillID == nil or skillID == 0 or (skillID > 12 and skillID < 25)
-    or skillID == 46 or skillID == 47 or skillID > 57 then
+    if
+        skillID == nil or
+        skillID == 0 or
+        (skillID > 12 and skillID < 25) or
+        skillID == 46 or
+        skillID == 47 or
+        skillID > 57
+    then
         error(player, "You must specify a valid skill.")
         return
     end

--- a/scripts/commands/setskill.lua
+++ b/scripts/commands/setskill.lua
@@ -31,8 +31,14 @@ function onTrigger(player, skillName, skillLV, target)
     local skillID = tonumber(skillName) or xi.skill[string.upper(skillName)]
     local targ
 
-    if skillID == nil or skillID == 0 or (skillID > 12 and skillID < 25)
-    or skillID == 46 or skillID == 47 or skillID > 57 then
+    if
+        skillID == nil or
+        skillID == 0 or
+        (skillID > 12 and skillID < 25) or
+        skillID == 46 or
+        skillID == 47 or
+        skillID > 57
+    then
         error(player, "You must specify a valid skill.")
         return
     end

--- a/scripts/globals/abilities/pets/tail_whip.lua
+++ b/scripts/globals/abilities/pets/tail_whip.lua
@@ -28,7 +28,8 @@ abilityObject.onPetAbility = function(target, pet, skill)
     end
     duration = duration * resm
 
-    if duration > 0 and
+    if
+        duration > 0 and
         xi.summon.avatarPhysicalHit(skill, totaldamage) and
         not target:hasStatusEffect(xi.effect.WEIGHT)
     then

--- a/scripts/globals/abilities/shadowbind.lua
+++ b/scripts/globals/abilities/shadowbind.lua
@@ -13,8 +13,12 @@ require("scripts/globals/msg")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if ((player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.MARKSMANSHIP and player:getWeaponSkillType(xi.slot.AMMO) == xi.skill.MARKSMANSHIP) or
-    (player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.ARCHERY and player:getWeaponSkillType(xi.slot.AMMO) == xi.skill.ARCHERY)) then
+    if
+        (player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.MARKSMANSHIP and
+        player:getWeaponSkillType(xi.slot.AMMO) == xi.skill.MARKSMANSHIP) or
+        (player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.ARCHERY and
+        player:getWeaponSkillType(xi.slot.AMMO) == xi.skill.ARCHERY)
+    then
         return 0, 0
     end
     return 216, 0 -- You do not have an appropriate ranged weapon equipped.

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -728,8 +728,11 @@ function AbilityFinalAdjustments(dmg, mob, skill, target, skilltype, skillparam,
     end
 
     --handle pd
-    if ((target:hasStatusEffect(xi.effect.PERFECT_DODGE) or target:hasStatusEffect(xi.effect.ALL_MISS) )
-            and skilltype == xi.attackType.PHYSICAL) then
+    if
+        (target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        target:hasStatusEffect(xi.effect.ALL_MISS)) and
+        skilltype == xi.attackType.PHYSICAL
+    then
         skill:setMsg(xi.msg.basic.JA_MISS_2)
         return 0
     end

--- a/scripts/globals/beastmentreasure.lua
+++ b/scripts/globals/beastmentreasure.lua
@@ -276,18 +276,20 @@ xi.beastmentreasure.handleQmOnTrade = function(player, npc, trade, digsiteids)
     local zoneid = player:getZoneID()
     local digsite = getAssignedDigSite(player)
 
-    if npcUtil.tradeHasExactly(trade, 605)
-        and player:getCharVar(zoneData[zoneid].statusvar) == QUEST_COMPLETED
-        and npc:getID() == digsiteids[digsite] then
-            --[[ Event 105 needs args to spawn and animate a treasure chest
-                 Example args from retail capture: 105 123 450762 1745 201805 7 723 490292 4095
-                 An arg in the 5th parameter will spawn and animate a chest somewhere in the zone
-                    based on some internal list in the game files. For example, an arg of 7, as
-                    in the retail capture above, will spawn and animate a chest at Yuhtunga Jungle
-                    qm10. Chests will spawn at a static location regardless of whether or not
-                    coordinates are passed in, and will always be rotated to face the player.
-            ]]--
-            player:startEvent(105, zoneid, 0, 0, 0, digsite - 1)
+    if
+        npcUtil.tradeHasExactly(trade, 605) and
+        player:getCharVar(zoneData[zoneid].statusvar) == QUEST_COMPLETED and
+        npc:getID() == digsiteids[digsite]
+    then
+        --[[ Event 105 needs args to spawn and animate a treasure chest
+             Example args from retail capture: 105 123 450762 1745 201805 7 723 490292 4095
+             An arg in the 5th parameter will spawn and animate a chest somewhere in the zone
+             based on some internal list in the game files. For example, an arg of 7, as
+             in the retail capture above, will spawn and animate a chest at Yuhtunga Jungle
+             qm10. Chests will spawn at a static location regardless of whether or not
+             coordinates are passed in, and will always be rotated to face the player.
+        ]]--
+        player:startEvent(105, zoneid, 0, 0, 0, digsite - 1)
     end
 end
 

--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -146,8 +146,10 @@ local function getCasketID(mob)
 
     for i = baseChestId, baseChestId + 15 do
         if timeElapsedCheck(GetNPCByID(i)) then
-            if GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.DESPAWNED or
-                GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == 0 then
+            if
+                GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == casketInfo.spawnStatus.DESPAWNED or
+                GetNPCByID(i):getLocalVar("[caskets]SPAWNSTATUS") == 0
+            then
                 chestId = i
                 break
             end

--- a/scripts/globals/damage/tp.lua
+++ b/scripts/globals/damage/tp.lua
@@ -31,9 +31,10 @@ function xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
         modifiedDelay = (delay * (100 - attacker:getMod(xi.mod.DUAL_WIELD)) / 100) / 2
     elseif attacker:isUsingH2H() then
 
-        if attacker:getObjType() == xi.objType.PC then             -- handle h2h with > 1 swing only on PC
-            if (attacker:getEquippedItem(xi.slot.SUB) ~= nil or    -- equipped shield = one swing
-                attacker:getSkillRank(xi.skill.HAND_TO_HAND) == 0) -- zero h2h rank skill = one swing
+        if attacker:getObjType() == xi.objType.PC then            -- handle h2h with > 1 swing only on PC
+            if
+                attacker:getEquippedItem(xi.slot.SUB) ~= nil or   -- equipped shield = one swing
+                attacker:getSkillRank(xi.skill.HAND_TO_HAND) == 0 -- zero h2h rank skill = one swing
             then
                 modifiedDelay = math.max((delay - attacker:getMod(xi.mod.MARTIAL_ARTS)), 96) -- min delay of 96 total, -- https://www.bg-wiki.com/ffxi/Attack_Speed
                 canZanshin = true -- Zanshin can proc on an "unarmed" swing                  -- https://www.bg-wiki.com/ffxi/Zanshin

--- a/scripts/globals/items/olde_rarab_tail.lua
+++ b/scripts/globals/items/olde_rarab_tail.lua
@@ -16,8 +16,12 @@ itemObject.onItemUse = function(target)
     local duration = 90
     local ID = zones[target:getZoneID()]
 
-    if not target:hasStatusEffect(typeEffect) and (target:getID() == ID.mob.ATORI_TUTORI_QM[1] or
-    target:getID() == ID.mob.ATORI_TUTORI_QM[2] or target:getID() == ID.mob.ATORI_TUTORI_QM[3]) then
+    if
+        not target:hasStatusEffect(typeEffect) and
+        (target:getID() == ID.mob.ATORI_TUTORI_QM[1] or
+        target:getID() == ID.mob.ATORI_TUTORI_QM[2] or
+        target:getID() == ID.mob.ATORI_TUTORI_QM[3])
+    then
         target:addStatusEffect(typeEffect, 1, 3, duration)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)

--- a/scripts/globals/items/tidal_talisman.lua
+++ b/scripts/globals/items/tidal_talisman.lua
@@ -8,7 +8,8 @@ local itemObject = {}
 itemObject.onItemCheck = function(target)
     local result = 56
     local zone = target:getZoneID()
-    if (zone == 238 or zone == 239 or zone == 240 or zone == 241 or zone == 242 or -- Windurst
+    if
+        zone == 238 or zone == 239 or zone == 240 or zone == 241 or zone == 242 or -- Windurst
         zone == 234 or zone == 235 or zone == 236 or zone == 237 or -- Bastok
         zone == 230 or zone == 231 or zone == 232 or zone == 233 or -- San d'Oria
         ((zone == 243 or zone == 244 or zone == 245 or zone == 246) and target:hasKeyItem(xi.ki.AIRSHIP_PASS_FOR_KAZHAM)) or -- Jeuno
@@ -16,8 +17,9 @@ itemObject.onItemCheck = function(target)
         zone == 249 or -- Mhaura
         zone == 250 or -- Kazham
         zone == 50 or -- Aht Urhgan Whitegate
-        zone == 53) -- Nashmau
-        then result = 0
+        zone == 53 -- Nashmau
+    then
+        result = 0
     end
     return result
 end

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -58,11 +58,13 @@ local function getPlayerTrialByItemId(player, itemId)
 
     for index, obj in pairs(trialsPlayer) do
         local trialId = obj.trial
-        if trials[trialId] and
-           trials[trialId].reqs and
-           trials[trialId].reqs.itemId and
-           trials[trialId].reqs.itemId[itemId] and
-           trialsPlayer[index].progress < trialsPlayer[index].objectiveTotal then
+        if
+            trials[trialId] and
+            trials[trialId].reqs and
+            trials[trialId].reqs.itemId and
+            trials[trialId].reqs.itemId[itemId] and
+            trialsPlayer[index].progress < trialsPlayer[index].objectiveTotal
+        then
             table.insert(resultTrials, { trial = trialId, progress = trialsPlayer[index].progress, objectiveTotal = trialsPlayer[index].objectiveTotal })
         end
     end

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -157,7 +157,8 @@ local function getSpellBonusAcc(caster, target, spell, params)
         end,
 
         [xi.job.SCH] = function()
-            if (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
+            if
+                (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
                 (spellGroup == xi.magic.spellGroup.BLACK and caster:hasStatusEffect(xi.effect.PENURY))
             then
                 local jpValue = caster:getJobPointLevel(xi.jp.STRATEGEM_EFFECT_I)

--- a/scripts/globals/mobskills/ix_aern_mnk.lua
+++ b/scripts/globals/mobskills/ix_aern_mnk.lua
@@ -10,8 +10,11 @@ require("scripts/globals/msg")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if (mob:getPool() == 4661 and mob:getHPP() <= 50
-    and mob:getLocalVar("BracerMode") == 1) then
+    if
+        mob:getPool() == 4661 and
+        mob:getHPP() <= 50 and
+        mob:getLocalVar("BracerMode") == 1
+    then
         return 0
     else
         return 1

--- a/scripts/globals/mobskills/luminous_lance.lua
+++ b/scripts/globals/mobskills/luminous_lance.lua
@@ -11,17 +11,20 @@ local mobskillObject = {}
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     local lanceTime = mob:getLocalVar("lanceTime")
     local lanceOut = mob:getLocalVar("lanceOut")
-    if (not (target:hasStatusEffect(xi.effect.PHYSICAL_SHIELD) and target:hasStatusEffect(xi.effect.MAGIC_SHIELD)))
-        and (lanceTime + 60 < mob:getBattleTime()) and target:getCurrentAction() ~= xi.act.MOBABILITY_USING
-        and lanceOut == 1 then
 
+    if
+        not (target:hasStatusEffect(xi.effect.PHYSICAL_SHIELD) and target:hasStatusEffect(xi.effect.MAGIC_SHIELD)) and
+        lanceTime + 60 < mob:getBattleTime() and
+        target:getCurrentAction() ~= xi.act.MOBABILITY_USING and
+        lanceOut == 1
+    then
         return 0
     end
+
     return 1
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-
     mob:showText(mob, ID.text.SELHTEUS_TEXT + 1)
 
     local numhits = 1

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -252,7 +252,8 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
         end
 
     -- Divine magic and Non-Player Elemental magic. TODO: Investigate "inflection point" (I) and its relation with the terms "soft cap" and "hard cap"
-    elseif skillType == xi.skill.DIVINE_MAGIC or
+    elseif
+        skillType == xi.skill.DIVINE_MAGIC or
         (skillType == xi.skill.ELEMENTAL_MAGIC and not caster:isPC())
     then
         local spellMultiplier = pTable[spellId][mNPC] -- M

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -332,9 +332,11 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
 
     local missChance = math.random()
 
-    if (missChance <= calcParams.hitRate or-- See if we hit the target
+    if
+        (missChance <= calcParams.hitRate or -- See if we hit the target
         calcParams.guaranteedHit or
-        calcParams.melee and math.random() < attacker:getMod(xi.mod.ZANSHIN) / 100) and
+        calcParams.melee and
+        math.random() < attacker:getMod(xi.mod.ZANSHIN) / 100) and
         not calcParams.mustMiss
     then
         if not shadowAbsorb(target) then

--- a/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
+++ b/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
@@ -36,11 +36,8 @@ local moogleTriggerEvent =
     ['Moogle'] =
     {
         onTrade = function(player, npc, trade)
-            if npcUtil.tradeHasExactly(trade, {
-                    xi.items.ORCISH_PLATE_ARMOR,
-                    xi.items.QUADAV_BACKSCALE,
-                    xi.items.YAGUDO_CAULK
-                })
+            if
+                npcUtil.tradeHasExactly(trade, { xi.items.ORCISH_PLATE_ARMOR, xi.items.QUADAV_BACKSCALE, xi.items.YAGUDO_CAULK })
             then
                 return mission:progressEvent(30024)
             end

--- a/scripts/mixins/families/puk.lua
+++ b/scripts/mixins/families/puk.lua
@@ -34,21 +34,37 @@ g_mixins.families.puk = function(mob)
     end)
 
     mob:addListener("ROAM_TICK", "PUK_ROAM_TICK", function(puk)
-        if (VanadielDayOfTheWeek() == xi.day.WINDSDAY or puk:getWeather() == xi.weather.WIND or
-        puk:getWeather() == xi.weather.GALES) and puk:getMod(xi.mod.REGAIN) == 0 then
+        if
+            (VanadielDayOfTheWeek() == xi.day.WINDSDAY or
+            puk:getWeather() == xi.weather.WIND or
+            puk:getWeather() == xi.weather.GALES) and
+            puk:getMod(xi.mod.REGAIN) == 0
+        then
             puk:setMod(xi.mod.REGAIN, 30)
-        elseif VanadielDayOfTheWeek() ~= xi.day.WINDSDAY and puk:getWeather() == xi.weather.WIND and
-        puk:getWeather() == xi.weather.GALES and puk:getMod(xi.mod.REGAIN) ~= 0 then
+        elseif
+            VanadielDayOfTheWeek() ~= xi.day.WINDSDAY and
+            puk:getWeather() == xi.weather.WIND and
+            puk:getWeather() == xi.weather.GALES and
+            puk:getMod(xi.mod.REGAIN) ~= 0
+        then
             puk:setMod(xi.mod.REGAIN, 0)
         end
     end)
 
     mob:addListener("COMBAT_TICK", "PUK_COMBAT_TICK", function(puk)
-        if (VanadielDayOfTheWeek() == xi.day.WINDSDAY or puk:getWeather() == xi.weather.WIND or
-        puk:getWeather() == xi.weather.GALES) and puk:getMod(xi.mod.REGAIN) == 0 then
+        if
+            (VanadielDayOfTheWeek() == xi.day.WINDSDAY or
+            puk:getWeather() == xi.weather.WIND or
+            puk:getWeather() == xi.weather.GALES) and
+            puk:getMod(xi.mod.REGAIN) == 0
+        then
             puk:setMod(xi.mod.REGAIN, 30)
-        elseif VanadielDayOfTheWeek() ~= xi.day.WINDSDAY and puk:getWeather() == xi.weather.WIND and
-        puk:getWeather() == xi.weather.GALES and puk:getMod(xi.mod.REGAIN) ~= 0 then
+        elseif
+            VanadielDayOfTheWeek() ~= xi.day.WINDSDAY and
+            puk:getWeather() == xi.weather.WIND and
+            puk:getWeather() == xi.weather.GALES and
+            puk:getMod(xi.mod.REGAIN) ~= 0
+        then
             puk:setMod(xi.mod.REGAIN, 0)
         end
     end)

--- a/scripts/quests/jeuno/helpers.lua
+++ b/scripts/quests/jeuno/helpers.lua
@@ -80,7 +80,8 @@ function xi.jeuno.helpers.GobbiebagQuest:new(params)
                 ['Bluffnix'] =
                 {
                     onTrade = function(player, npc, trade)
-                        if  npcUtil.tradeHasExactly(trade, params.tradeItems) or
+                        if
+                            npcUtil.tradeHasExactly(trade, params.tradeItems) or
                             npcUtil.tradeHasExactly(trade, params.tradeStew)
                         then
                             return quest:progressEvent(73, getCompleteDiaglogueId(player))

--- a/scripts/quests/otherAreas/Its_Raining_Mannequins.lua
+++ b/scripts/quests/otherAreas/Its_Raining_Mannequins.lua
@@ -113,12 +113,14 @@ quest.sections =
                 end,
 
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, {
-                        xi.items.MANNEQUIN_HEAD,
-                        xi.items.MANNEQUIN_BODY,
-                        xi.items.MANNEQUIN_HANDS,
-                        xi.items.MANNEQUIN_LEGS,
-                        xi.items.MANNEQUIN_FEET })
+                    if
+                        npcUtil.tradeHasExactly(trade, {
+                            xi.items.MANNEQUIN_HEAD,
+                            xi.items.MANNEQUIN_BODY,
+                            xi.items.MANNEQUIN_HANDS,
+                            xi.items.MANNEQUIN_LEGS,
+                            xi.items.MANNEQUIN_FEET
+                        })
                     then
                         return quest:progressEvent(309)
                     end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Imperial_Whitegate.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Imperial_Whitegate.lua
@@ -21,11 +21,17 @@ end
 entity.onTrigger = function(player, npc)
     local noWeapons = player:getEquipID(xi.slot.MAIN) == 0 and player:getEquipID(xi.slot.SUB) == 0
 
-    if player:getCurrentMission(xi.mission.log_id.TOAU) == xi.mission.id.toau.IMPERIAL_CORONATION and
-        whitegateShared.doRoyalPalaceArmorCheck(player) and noWeapons then
+    if
+        player:getCurrentMission(xi.mission.log_id.TOAU) == xi.mission.id.toau.IMPERIAL_CORONATION and
+        whitegateShared.doRoyalPalaceArmorCheck(player) and
+        noWeapons
+    then
         player:startEvent(3140, xi.besieged.getMercenaryRank(player), player:getTitle(), 0, 0, 0, 0, 0, 0, 0)
-    elseif player:getCurrentMission(xi.mission.log_id.TOAU) >= xi.mission.id.toau.IMPERIAL_CORONATION and
-        whitegateShared.doRoyalPalaceArmorCheck(player) and noWeapons then
+    elseif
+        player:getCurrentMission(xi.mission.log_id.TOAU) >= xi.mission.id.toau.IMPERIAL_CORONATION and
+        whitegateShared.doRoyalPalaceArmorCheck(player) and
+        noWeapons
+    then
         local ring = player:getCharVar("TOAU_RINGTIME")
         local standard = player:hasItem(129)
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kaduru-Haiduru.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kaduru-Haiduru.lua
@@ -13,10 +13,13 @@ local function canUse_KaduruHaiduru_Service(player)
     local shihuDanhuDate = player:getCharVar("ShihuDanhu_TP_date")
 
     -- Kaduru-Haiduru can be used unless the following are true.
-    if (shihuDanhuEncounters > 1 and os.time() < shihuDanhuDate) or
-        (os.time() < caughtUsingShihuDanhuDate) then
+    if
+        (shihuDanhuEncounters > 1 and os.time() < shihuDanhuDate) or
+        os.time() < caughtUsingShihuDanhuDate
+    then
         return false
     end
+
     return true
 end
 

--- a/scripts/zones/AlTaieu/npcs/qm_jailer_of_hope.lua
+++ b/scripts/zones/AlTaieu/npcs/qm_jailer_of_hope.lua
@@ -10,13 +10,13 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     -- JAILER OF HOPE
-    if (
+    if
         not GetMobByID(ID.mob.JAILER_OF_HOPE):isSpawned() and
         trade:hasItemQty(1850, 1) and -- first_virtue
         trade:hasItemQty(1851, 1) and -- deed_of_placidity
         trade:hasItemQty(1852, 1) and -- high-quality_phuabo_organ
         trade:getItemCount() == 3
-    ) then
+    then
         player:tradeComplete()
         SpawnMob(ID.mob.JAILER_OF_HOPE):updateClaim(player)
     end

--- a/scripts/zones/AlTaieu/npcs/qm_jailer_of_prudence.lua
+++ b/scripts/zones/AlTaieu/npcs/qm_jailer_of_prudence.lua
@@ -10,14 +10,14 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     -- JAILER OF PRUDENCE
-    if (
+    if
         not GetMobByID(ID.mob.JAILER_OF_PRUDENCE_1):isSpawned() and
         not GetMobByID(ID.mob.JAILER_OF_PRUDENCE_2):isSpawned() and
         trade:hasItemQty(1856, 1) and -- third_virtue
         trade:hasItemQty(1870, 1) and -- deed_of_sensibility
         trade:hasItemQty(1871, 1) and -- high-quality_hpemde_organ
         trade:getItemCount() == 3
-    ) then
+    then
         player:tradeComplete()
         SpawnMob(ID.mob.JAILER_OF_PRUDENCE_1):updateClaim(player) -- Spawn Jailer of Prudence 1
         SpawnMob(ID.mob.JAILER_OF_PRUDENCE_2)                     -- Spawn Jailer of Prudence 2 unclaimed

--- a/scripts/zones/Altar_Room/Zone.lua
+++ b/scripts/zones/Altar_Room/Zone.lua
@@ -19,8 +19,11 @@ zoneObject.onZoneIn = function(player, prevZone)
 
     if player:getCharVar("FickblixCS") == 1 and player:getNation() ~= xi.nation.SANDORIA then
         cs = 10000
-    elseif player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST) == QUEST_AVAILABLE and
-        player:getMainLvl() >= 60 and player:getCharVar("moraldecline") <= os.time() then
+    elseif
+        player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST) == QUEST_AVAILABLE and
+        player:getMainLvl() >= 60 and
+        player:getCharVar("moraldecline") <= os.time()
+    then
         cs = 46
     elseif player:getCharVar("moral") == 4 and head == 15202 then -- Yagudo Headgear
         cs = 47

--- a/scripts/zones/Altar_Room/mobs/Yagudo_Avatar.lua
+++ b/scripts/zones/Altar_Room/mobs/Yagudo_Avatar.lua
@@ -11,11 +11,14 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST) == QUEST_ACCEPTED and
-        player:getCharVar("moral") == 5 then
+    if
+        player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST) == QUEST_ACCEPTED and
+        player:getCharVar("moral") == 5
+    then
         player:setCharVar("moral", 6)
         player:delKeyItem(xi.ki.VAULT_QUIPUS)
     end
+
     for i = ID.mob.YAGUDO_AVATAR + 1, ID.mob.YAGUDO_AVATAR + 8 do
         DespawnMob(i)
     end

--- a/scripts/zones/Altar_Room/npcs/Stone_Lid.lua
+++ b/scripts/zones/Altar_Room/npcs/Stone_Lid.lua
@@ -47,10 +47,9 @@ entity.onEventFinish = function(player, csid, option)
             ID.mob.LAA_YAKU_THE_AUSTERE,
             ID.mob.POO_YOZO_THE_BABBLER,
         }
+
         local npc = GetNPCByID(ID.npc.STONE_LID)
-        if npcUtil.popFromQM(player, npc, mobs, {
-            hide = 1
-        }) then
+        if npcUtil.popFromQM(player, npc, mobs, { hide = 1 }) then
             player:messageSpecial(ID.text.DRAWS_NEAR)
         end
     elseif csid == 49 then

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -47,14 +47,20 @@ entity.onMobFight = function(mob, target)
             mob:setLocalVar("changeTime", mob:getBattleTime())
             mob:setLocalVar("changeHP", mob:getHP() / 1000)
         -- subanimation 1 is flight, so check if she should land
-        elseif (mob:getAnimationSub() == 1 and (mob:getHP() / 1000 <= changeHP - 10 or
-                mob:getBattleTime() - changeTime > 120)) then
+        elseif
+            mob:getAnimationSub() == 1 and
+            (mob:getHP() / 1000 <= changeHP - 10 or
+            mob:getBattleTime() - changeTime > 120)
+        then
             mob:useMobAbility(1282)
             mob:setLocalVar("changeTime", mob:getBattleTime())
             mob:setLocalVar("changeHP", mob:getHP() / 1000)
         -- subanimation 2 is grounded mode, so check if she should take off
-        elseif (mob:getAnimationSub() == 2 and (mob:getHP() / 1000 <= changeHP - 10 or
-                mob:getBattleTime() - changeTime > 120)) then
+        elseif
+            mob:getAnimationSub() == 2 and
+            (mob:getHP() / 1000 <= changeHP - 10 or
+            mob:getBattleTime() - changeTime > 120)
+        then
             mob:setAnimationSub(1)
             mob:addStatusEffectEx(xi.effect.ALL_MISS, 0, 1, 0, 0)
             mob:SetMobSkillAttack(730)

--- a/scripts/zones/Bastok_Markets/npcs/Degenhard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Degenhard.lua
@@ -12,8 +12,10 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEYOND_INFINITY) >= QUEST_ACCEPTED and
-        npcUtil.tradeHasExactly(trade, { xi.items.SEASONING_STONE, xi.items.FOSSILIZED_BONE, xi.items.FOSSILIZED_FANG }) then
+    if
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEYOND_INFINITY) >= QUEST_ACCEPTED and
+        npcUtil.tradeHasExactly(trade, { xi.items.SEASONING_STONE, xi.items.FOSSILIZED_BONE, xi.items.FOSSILIZED_FANG })
+    then
         player:startEvent(15)
     end
 end

--- a/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
@@ -121,10 +121,11 @@ entity.onTrigger = function(player, npc)
 
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
-    if (bastokMissions   == 0xFFFFFFFE and
+    if
+        bastokMissions   == 0xFFFFFFFE and
         bastokQuests     == 0xFFFFFFFE and
         otherQuests      == 0xFFFFFFFE and
-        seekersOfAdoulin == 0xFFFFFFFE)
+        seekersOfAdoulin == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.
     end

--- a/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
@@ -28,9 +28,11 @@ end
 entity.onMobFight = function(mob, target)
     -- Every 25% of its HP Tuchulcha will bury itself under the sand
     -- accompanied by use of the ability Sandpit
-    if (mob:getHPP() < 75 and mob:getLocalVar('Sandpits') == 0)
-    or (mob:getHPP() < 50 and mob:getLocalVar('Sandpits') == 1)
-    or (mob:getHPP() < 25 and mob:getLocalVar('Sandpits') == 2) then
+    if
+        (mob:getHPP() < 75 and mob:getLocalVar('Sandpits') == 0) or
+        (mob:getHPP() < 50 and mob:getLocalVar('Sandpits') == 1) or
+        (mob:getHPP() < 25 and mob:getLocalVar('Sandpits') == 2)
+    then
         mob:setLocalVar('Sandpits', mob:getLocalVar('Sandpits') + 1)
         mob:useMobAbility(276)
         mob:timer(4000, function(tuchulcha)

--- a/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
@@ -18,8 +18,11 @@ end
 entity.onTrigger = function(player, npc)
     if (xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
         local hasStone = xi.abyssea.getHeldTraverserStones(player)
-        if (hasStone >= 1 and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED
-        and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_FLUTTERY_FIEND) == QUEST_AVAILABLE) then
+        if
+            hasStone >= 1 and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_FLUTTERY_FIEND) == QUEST_AVAILABLE
+        then
             player:startEvent(62)
         else
             player:startEvent(61, 0, 1) -- No param = no entry.

--- a/scripts/zones/Empyreal_Paradox/bcnms/apocalypse_nigh.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/apocalypse_nigh.lua
@@ -31,7 +31,10 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and player:getCharVar('ApocalypseNigh') == 4 then
+        if
+            player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
+            player:getCharVar('ApocalypseNigh') == 4
+        then
             player:setCharVar('ApocalypseNigh', 5)
             player:setCharVar("Apoc_Nigh_Reward", getMidnight())
             player:startEvent(7)

--- a/scripts/zones/FeiYin/npcs/Seed_Afterglow.lua
+++ b/scripts/zones/FeiYin/npcs/Seed_Afterglow.lua
@@ -31,14 +31,14 @@ entity.onTrigger = function(player, npc)
     local progressMask         = player:getCharVar("SEED_AFTERGLOW_MASK")
     local intensity            = player:getCharVar("SEED_AFTERGLOW_INTENSITY")
 
-    if (
+    if
         player:hasKeyItem(xi.ki.MARK_OF_SEED) or
         player:hasKeyItem(xi.ki.AZURE_KEY) or
         player:hasKeyItem(xi.ki.IVORY_KEY) or
         os.time() < player:getCharVar("LastAzureKey") or
         os.time() < player:getCharVar("LastIvoryKey") or
         aCrystallineProphecy < xi.mission.id.acp.THOSE_WHO_LURK_IN_SHADOWS_II
-    ) then
+    then
         player:messageSpecial(ID.text.SOFTLY_SHIMMERING_LIGHT)
 
     elseif (needToZone and not player:hasStatusEffect(xi.effect.MARK_OF_SEED)) then

--- a/scripts/zones/FeiYin/npcs/qm1.lua
+++ b/scripts/zones/FeiYin/npcs/qm1.lua
@@ -11,12 +11,12 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (
+    if
         player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.PIEUJE_S_DECISION) == QUEST_ACCEPTED and
         npcUtil.tradeHas(trade, 1098) and -- Tavnazia Bell
         not player:hasItem(13842) and -- Tavnazian Mask
         not GetMobByID(ID.mob.ALTEDOUR_I_TAVNAZIA):isSpawned()
-    ) then
+    then
         player:confirmTrade()
         player:messageSpecial(ID.text.SENSE_OF_FOREBODING)
         SpawnMob(ID.mob.ALTEDOUR_I_TAVNAZIA):updateClaim(player)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
@@ -13,23 +13,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     if player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.GARDEN_OF_ANTIQUITY and player:getCharVar("PromathiaStatus") == 3 then
         player:startEvent(1)
-    elseif player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-        player:getCharVar('ApocalypseNigh') == 2 then
+    elseif
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
+        player:getCharVar('ApocalypseNigh') == 2
+    then
         player:startEvent(4)
     else
         player:startEvent(52)
     end
-    return 1
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
     if (csid == 52 and option == 1) then
         player:setPos(-419.995, 0, 248.483, 191, 35); -- To The Garden of RuHmet
     elseif csid == 4 then

--- a/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
@@ -18,8 +18,11 @@ end
 entity.onTrigger = function(player, npc)
     if (xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
         local hasStone = xi.abyssea.getHeldTraverserStones(player)
-        if (hasStone >= 1 and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED
-        and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_GOLDSTRUCK_GIGAS) == QUEST_AVAILABLE) then
+        if
+            hasStone >= 1 and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_GOLDSTRUCK_GIGAS) == QUEST_AVAILABLE
+        then
             player:startEvent(9)
         else
             player:startEvent(218, 0, 1) -- No param = no entry.

--- a/scripts/zones/Lower_Jeuno/npcs/Aldo.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Aldo.lua
@@ -12,8 +12,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-        player:getCharVar('ApocalypseNigh') == 5 and player:getRank(player:getNation()) >= 5 then
+    if
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
+        player:getCharVar('ApocalypseNigh') == 5 and
+        player:getRank(player:getNation()) >= 5
+    then
         player:startEvent(10057)
     elseif player:getCharVar('ApocalypseNigh') == 6 then
         player:startEvent(10058)

--- a/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Chululu.lua
@@ -176,11 +176,13 @@ entity.onEventFinish = function(player, csid, option)
         player:setLocalVar("Cardstemp", 1)
 
     elseif csid == 10114 then
-        if npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.ALL_IN_THE_CARDS, {
-            gil = 600,
-            title = xi.title.CARD_COLLECTOR,
-            var = { "AllInTheCards_date" }
-        }) then
+        if
+            npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.ALL_IN_THE_CARDS, {
+                gil = 600,
+                title = xi.title.CARD_COLLECTOR,
+                var = { "AllInTheCards_date" }
+            })
+        then
             player:confirmTrade()
         end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Leshy.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Leshy.lua
@@ -29,13 +29,13 @@ entity.onMobRoam = function(mob)
     local offset = ph - ID.mob.LESHY_OFFSET
     if (offset >= 0 and offset <= 7) then
         local nm = GetMobByID(ID.mob.COLORFUL_LESHY)
-        if (
+        if
             not nm:isSpawned() and
             not GetMobByID(ID.mob.COLORFUL_LESHY + 1):isSpawned() and
             os.time() > nm:getLocalVar("timeToGrow") and
             nm:getLocalVar("phIndex") == 0 and
             math.random(1, 20) == 1 -- this prevents the same Leshy from growing every cycle
-        ) then
+        then
             local p = mob:getPos()
             DisallowRespawn(ph, true)
             DespawnMob(ph)

--- a/scripts/zones/Metalworks/npcs/Alois.lua
+++ b/scripts/zones/Metalworks/npcs/Alois.lua
@@ -23,11 +23,13 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 805 then
-        if npcUtil.completeQuest(
-            player,
-            xi.quest.log_id.BASTOK,
-            xi.quest.id.bastok.FADED_PROMISES,
-            { item = 17775, xi.title.ASSASSIN_REJECT, var = { "FadedPromises" }, fame = 10 })
+        if
+            npcUtil.completeQuest(
+                player,
+                xi.quest.log_id.BASTOK,
+                xi.quest.id.bastok.FADED_PROMISES,
+                { item = 17775, xi.title.ASSASSIN_REJECT, var = { "FadedPromises" }, fame = 10 }
+            )
         then
             player:delKeyItem(xi.ki.DIARY_OF_MUKUNDA)
         end

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -38,13 +38,17 @@ entity.onMobFight = function(mob, target)
             --and record the time this phase was started
             mob:setLocalVar("changeTime", mob:getBattleTime())
         -- subanimation 1 is flight, so check if he should land
-        elseif (mob:getAnimationSub() == 1 and
-                mob:getBattleTime() - changeTime > 120) then
+        elseif
+            mob:getAnimationSub() == 1 and
+            mob:getBattleTime() - changeTime > 120
+        then
             mob:useMobAbility(1302)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         -- subanimation 2 is grounded mode, so check if he should take off
-        elseif (mob:getAnimationSub() == 2 and
-                mob:getBattleTime() - changeTime > 120) then
+        elseif
+            mob:getAnimationSub() == 2 and
+            mob:getBattleTime() - changeTime > 120
+        then
             mob:setAnimationSub(1)
             mob:addStatusEffectEx(xi.effect.ALL_MISS, 0, 1, 0, 0)
             mob:SetMobSkillAttack(731)

--- a/scripts/zones/Norg/npcs/Comitiolus.lua
+++ b/scripts/zones/Norg/npcs/Comitiolus.lua
@@ -10,8 +10,9 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHasExactly(trade, { 1695, 4297, 4506 }) -- Habaneros, Black Curry, Mutton Tortilla
-        and player:getCharVar("TuningOut_Progress") == 6
+    if
+        npcUtil.tradeHasExactly(trade, { 1695, 4297, 4506 }) and -- Habaneros, Black Curry, Mutton Tortilla
+        player:getCharVar("TuningOut_Progress") == 6
     then
         player:startEvent(207, 0, 1695) -- Receives spicy food, mentions only one of them
     end

--- a/scripts/zones/Norg/npcs/Gilgamesh.lua
+++ b/scripts/zones/Norg/npcs/Gilgamesh.lua
@@ -14,8 +14,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
-        player:getCharVar('ApocalypseNigh') == 6 and player:getCharVar('Apoc_Nigh_RewardCS1') == 0 then
+    if
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH) == QUEST_ACCEPTED and
+        player:getCharVar('ApocalypseNigh') == 6 and
+        player:getCharVar('Apoc_Nigh_RewardCS1') == 0
+    then
         player:startEvent(232, 252)
     elseif player:getCharVar('Apoc_Nigh_RewardCS1') == 1 then
         player:startEvent(234, 252)
@@ -48,10 +51,12 @@ entity.onEventFinish = function(player, csid, option)
         end
 
         if reward ~= 0 then
-            if npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH, {
-                item = reward,
-                var = { "ApocalypseNigh", "Apoc_Nigh_Reward", "Apoc_Nigh_RewardCS1" }
-            }) then
+            if
+                npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH, {
+                    item = reward,
+                    var = { "ApocalypseNigh", "Apoc_Nigh_Reward", "Apoc_Nigh_RewardCS1" }
+                })
+            then
                 player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.DAWN)
                 player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE)
                 player:setCharVar("PromathiaStatus", 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
@@ -31,8 +31,9 @@ entity.onTrigger = function(player, npc)
 
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
-    if (addonScenarios    == 0xFFFFFFFE and
-        seekersOfAdoulin  == 0xFFFFFFFE)
+    if
+        addonScenarios    == 0xFFFFFFFE and
+        seekersOfAdoulin  == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Vamorcote.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Vamorcote.lua
@@ -23,7 +23,8 @@ entity.onTrigger = function(player, npc)
     -- Look at the "The Setting Sun" quest status and San d'Oria player's fame
     local theSettingSun = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_SETTING_SUN)
 
-    if theSettingSun == QUEST_AVAILABLE  and
+    if
+        theSettingSun == QUEST_AVAILABLE and
         player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 5 and
         player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL) ~= QUEST_COMPLETED
     then

--- a/scripts/zones/Port_Bastok/npcs/Dalba.lua
+++ b/scripts/zones/Port_Bastok/npcs/Dalba.lua
@@ -131,11 +131,12 @@ entity.onTrigger = function(player, npc)
 
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
-    if (bastokMissions    == 0xFFFFFFFE and
+    if
+        bastokMissions    == 0xFFFFFFFE and
         bastokQuests      == 0xFFFFFFFE and
         otherQuests       == 0xFFFFFFFE and
         promathiaMissions == 0xFFFFFFFE and
-        addonScenarios    == 0xFFFFFFFE)
+        addonScenarios    == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.
     end

--- a/scripts/zones/Port_Bastok/npcs/Raifa.lua
+++ b/scripts/zones/Port_Bastok/npcs/Raifa.lua
@@ -40,13 +40,16 @@ entity.onEventFinish = function(player, csid, option)
             player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.ECO_WARRIOR)
         end
         player:setCharVar("EcoStatus", 101) -- EcoStatus var:  1 to 3 for sandy // 101 to 103 for bastok // 201 to 203 for windurst
-    elseif csid == 282 and npcUtil.completeQuest(player, xi.quest.log_id.BASTOK, xi.quest.id.bastok.ECO_WARRIOR, {
-        gil = 5000,
-        item = 4198,
-        title = xi.title.CERULEAN_SOLDIER,
-        fame = 80,
-        var = "EcoStatus"
-    }) then
+    elseif
+        csid == 282 and
+        npcUtil.completeQuest(player, xi.quest.log_id.BASTOK, xi.quest.id.bastok.ECO_WARRIOR, {
+            gil = 5000,
+            item = 4198,
+            title = xi.title.CERULEAN_SOLDIER,
+            fame = 80,
+            var = "EcoStatus"
+        })
+    then
         player:delKeyItem(xi.ki.INDIGESTED_ORE)
         player:setCharVar("EcoReset", getConquestTally())
     end

--- a/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
@@ -13,8 +13,13 @@ local ID = require("scripts/zones/Port_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.CHASING_QUOTAS) == QUEST_ACCEPTED and player:getCharVar("ChasingQuotas_Progress") == 0 and
-        trade:getItemCount() == 1 and trade:hasItemQty(12494, 1) and trade:getGil() == 0) then -- Trading gold hairpin only
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.CHASING_QUOTAS) == QUEST_ACCEPTED and
+        player:getCharVar("ChasingQuotas_Progress") == 0 and
+        trade:getItemCount() == 1 and
+        trade:hasItemQty(12494, 1) and
+        trade:getGil() == 0
+    then -- Trading gold hairpin only
             player:tradeComplete()
             player:startEvent(17)
     end

--- a/scripts/zones/Rabao/npcs/Leodarion.lua
+++ b/scripts/zones/Rabao/npcs/Leodarion.lua
@@ -71,7 +71,8 @@ entity.onEventFinish = function(player, csid, option)
         player:delKeyItem(xi.ki.OLD_TRICK_BOX)
         player:setCharVar("trueWillCS", 2)
     elseif (csid == 99) then
-        if npcUtil.completeQuest(player, xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL, {
+        if
+            npcUtil.completeQuest(player, xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL, {
                 item = 13782, -- Ninja Chainmail
                 fameArea = xi.quest.fame_area.NORG,
                 title = xi.title.PARAGON_OF_NINJA_EXCELLENCE,

--- a/scripts/zones/Sacrarium/mobs/Mariselles_Pupil.lua
+++ b/scripts/zones/Sacrarium/mobs/Mariselles_Pupil.lua
@@ -22,9 +22,10 @@ end
 
 entity.onMobFight = function(mob, target)
     local teleTime = mob:getLocalVar('teleTime')
-    if mob:getBattleTime() - teleTime > 30 and
-       mob:getBattleTime() > 59 and
-       mob:actionQueueEmpty()
+    if
+        mob:getBattleTime() - teleTime > 30 and
+        mob:getBattleTime() > 59 and
+        mob:actionQueueEmpty()
     then
         local profLocation = mob:getLocalVar('spawnLocation')
         local randomPosition = math.random(1, 9)

--- a/scripts/zones/Sacrarium/mobs/Old_Professor_Mariselle.lua
+++ b/scripts/zones/Sacrarium/mobs/Old_Professor_Mariselle.lua
@@ -50,9 +50,10 @@ entity.onMobFight = function(mob, target)
     end
 
     local teleTime = mob:getLocalVar('teleTime')
-    if mob:getBattleTime() - teleTime > 30 and
-       mob:getBattleTime() > 59 and
-       mob:actionQueueEmpty()
+    if
+        mob:getBattleTime() - teleTime > 30 and
+        mob:getBattleTime() > 59 and
+        mob:actionQueueEmpty()
     then
         local profLocation = mob:getLocalVar('spawnLocation')
         local randomPosition = math.random(1, 9)

--- a/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
@@ -40,13 +40,16 @@ entity.onEventFinish = function(player, csid, option)
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ECO_WARRIOR)
         end
         player:setCharVar("EcoStatus", 1) -- EcoStatus var:  1 to 3 for sandy // 101 to 103 for bastok // 201 to 203 for windurst
-    elseif csid == 681 and npcUtil.completeQuest(player, xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ECO_WARRIOR, {
-        gil = 5000,
-        item = 4198,
-        title = xi.title.VERMILLION_VENTURER,
-        fame = 80,
-        var = "EcoStatus"
-    }) then
+    elseif
+        csid == 681 and
+        npcUtil.completeQuest(player, xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.ECO_WARRIOR, {
+            gil = 5000,
+            item = 4198,
+            title = xi.title.VERMILLION_VENTURER,
+            fame = 80,
+            var = "EcoStatus"
+        })
+    then
         player:delKeyItem(xi.ki.INDIGESTED_STALAGMITE)
         player:setCharVar("EcoReset", getConquestTally())
     end

--- a/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
+++ b/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
@@ -8,7 +8,8 @@ local ID = require("scripts/zones/Temenos/IDs")
 local entity = {}
 
 entity.onMobEngaged = function(mob, target)
-    if GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 5):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 6):isDead() and
+    if
+        GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 5):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 6):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 7):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 8):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 9):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 10):isDead()
     then
@@ -28,7 +29,9 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 2):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_C_CRATE[3]):setStatus(xi.status.NORMAL)

--- a/scripts/zones/Temenos/mobs/Airi.lua
+++ b/scripts/zones/Temenos/mobs/Airi.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 3):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 4):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 5):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Enhanced_Ahriman.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Ahriman.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 4):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Enhanced_Dragon.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Dragon.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 5):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Enhanced_Vulture.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Vulture.lua
@@ -17,7 +17,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_W_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_W_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 4):isDead() and GetMobByID(ID.mob.TEMENOS_W_MOB[7] + 5):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Goblin_Fencer.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Fencer.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 4):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Goblin_Theurgist.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Theurgist.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 4):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Goblin_Warlord.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Warlord.lua
@@ -9,7 +9,8 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[7]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 3):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[7] + 4):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Iruci.lua
+++ b/scripts/zones/Temenos/mobs/Iruci.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 3):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 4):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 5):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Light_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Light_Elemental.lua
@@ -22,12 +22,18 @@ entity.onMobDeath = function(mob, player, optParams)
         switch (mob:getID()): caseof
         {
             [ID.mob.TEMENOS_C_MOB[2] + 1] = function()
-                if GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 2):isDead() then
+                if
+                    GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and
+                    GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 2):isDead()
+                then
                     GetNPCByID(ID.npc.TEMENOS_C_CRATE[2]):setStatus(xi.status.NORMAL)
                 end
             end,
             [ID.mob.TEMENOS_C_MOB[2] + 2] = function()
-                if GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 1):isDead() then
+                if
+                    GetMobByID(ID.mob.TEMENOS_C_MOB[2]):isDead() and
+                    GetMobByID(ID.mob.TEMENOS_C_MOB[2] + 1):isDead()
+                then
                     GetNPCByID(ID.npc.TEMENOS_C_CRATE[2]):setStatus(xi.status.NORMAL)
                 end
             end,

--- a/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
+++ b/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
@@ -8,7 +8,8 @@ local ID = require("scripts/zones/Temenos/IDs")
 local entity = {}
 
 entity.onMobEngaged = function(mob, target)
-    if GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 12):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 13):isDead() and
+    if
+        GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 12):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 13):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 14):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 15):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 16):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 17):isDead()
     then
@@ -28,7 +29,9 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 2):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_C_CRATE[3]):setStatus(xi.status.NORMAL)

--- a/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
+++ b/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
@@ -8,7 +8,8 @@ local ID = require("scripts/zones/Temenos/IDs")
 local entity = {}
 
 entity.onMobEngaged = function(mob, target)
-    if GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 18):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 19):isDead() and
+    if
+        GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 18):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 19):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 20):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 21):isDead() and
         GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 22):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 23):isDead()
     then
@@ -28,7 +29,9 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[3] + 2):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_C_CRATE[3]):setStatus(xi.status.NORMAL)

--- a/scripts/zones/Temenos/mobs/Praetorian_Guard_CCCXI.lua
+++ b/scripts/zones/Temenos/mobs/Praetorian_Guard_CCCXI.lua
@@ -11,7 +11,9 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 2):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5]):setStatus(xi.status.NORMAL)

--- a/scripts/zones/Temenos/mobs/Praetorian_Guard_CCXX.lua
+++ b/scripts/zones/Temenos/mobs/Praetorian_Guard_CCXX.lua
@@ -11,7 +11,9 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 2):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 2):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 3):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5]):setStatus(xi.status.NORMAL)

--- a/scripts/zones/Temenos/mobs/Praetorian_Guard_CXLVIII.lua
+++ b/scripts/zones/Temenos/mobs/Praetorian_Guard_CXLVIII.lua
@@ -11,13 +11,16 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 3):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5]):setStatus(xi.status.NORMAL)
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5] + 1):setStatus(xi.status.NORMAL)
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5] + 2):setStatus(xi.status.NORMAL)
         end
+
         if GetNPCByID(ID.npc.TEMENOS_N_GATE[5]):getAnimation() == xi.animation.CLOSE_DOOR then
             xi.limbus.handleDoors(mob:getBattlefield(), true, ID.npc.TEMENOS_N_GATE[5])
         end

--- a/scripts/zones/Temenos/mobs/Praetorian_Guard_LXXIII.lua
+++ b/scripts/zones/Temenos/mobs/Praetorian_Guard_LXXIII.lua
@@ -11,13 +11,16 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 2):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5]):isDead() and
+            GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 2):isDead() and
             GetMobByID(ID.mob.TEMENOS_N_MOB[5] + 3):isDead()
         then
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5]):setStatus(xi.status.NORMAL)
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5] + 1):setStatus(xi.status.NORMAL)
             GetNPCByID(ID.npc.TEMENOS_N_CRATE[5] + 2):setStatus(xi.status.NORMAL)
         end
+
         if GetNPCByID(ID.npc.TEMENOS_N_GATE[5]):getAnimation() == xi.animation.CLOSE_DOOR then
             xi.limbus.handleDoors(mob:getBattlefield(), true, ID.npc.TEMENOS_N_GATE[5])
         end

--- a/scripts/zones/Temenos/mobs/Temenos_Cleaner.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Cleaner.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 3):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 4):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 5):isDead()
         then

--- a/scripts/zones/Temenos/mobs/Temenos_Weapon.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Weapon.lua
@@ -15,7 +15,8 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     if optParams.isKiller or optParams.noKiller then
-        if GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
+        if
+            GetMobByID(ID.mob.TEMENOS_C_MOB[1]):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 1):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 2):isDead() and GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 4):isDead() and
             GetMobByID(ID.mob.TEMENOS_C_MOB[1] + 5):isDead()
         then

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
@@ -19,11 +19,13 @@ entity.onTrade = function(player, npc, trade)
 
     if (aLittleKnowledge == QUEST_ACCEPTED and aLittleKnowledgeProgress == 1) then
         if (trade:hasItemQty(2550, 12) and trade:getGil() == 0 and trade:getItemCount() == 12) then
-            if( player:getMainJob() == xi.job.BLM or
+            if
+                player:getMainJob() == xi.job.BLM or
                 player:getMainJob() == xi.job.RDM or
                 player:getMainJob() == xi.job.SMN or
-                player:getMainJob() == xi.job.BLU) then
-                player:startEvent(12, 1)
+                player:getMainJob() == xi.job.BLU
+            then
+               player:startEvent(12, 1)
             else
                 player:startEvent(12)
             end
@@ -49,10 +51,12 @@ entity.onTrigger = function(player, npc)
     elseif (aLittleKnowledgeProgress == 1 and aLittleKnowledge == QUEST_ACCEPTED) then
         player:startEvent(11)
     elseif (aLittleKnowledgeProgress == 2 and aLittleKnowledge == QUEST_ACCEPTED) then
-        if (player:hasStatusEffect(xi.effect.MANAFONT) or
+        if
+            player:hasStatusEffect(xi.effect.MANAFONT) or
             player:hasStatusEffect(xi.effect.CHAINSPELL) or
             player:hasStatusEffect(xi.effect.ASTRAL_FLOW) or
-            player:hasStatusEffect(xi.effect.AZURE_LORE)) then
+            player:hasStatusEffect(xi.effect.AZURE_LORE)
+        then
             player:startEvent(14)
         else
             player:startEvent(13)

--- a/scripts/zones/Throne_Room/mobs/Shadow_Lord.lua
+++ b/scripts/zones/Throne_Room/mobs/Shadow_Lord.lua
@@ -35,8 +35,11 @@ entity.onMobFight = function(mob, target)
                 mob:setLocalVar("changeTime", mob:getBattleTime())
                 mob:setLocalVar("changeHP", mob:getHP())
             -- subanimation 2 is physical mode, so check if he should change into magic mode
-            elseif (mob:getAnimationSub() == 2 and (mob:getHP() <= changeHP - 1000 or
-                    mob:getBattleTime() - changeTime > 300)) then
+            elseif
+                mob:getAnimationSub() == 2 and
+                (mob:getHP() <= changeHP - 1000 or
+                mob:getBattleTime() - changeTime > 300)
+            then
                 mob:setAnimationSub(1)
                 mob:delStatusEffect(xi.effect.PHYSICAL_SHIELD)
                 mob:addStatusEffectEx(xi.effect.MAGIC_SHIELD, 0, 1, 0, 0)
@@ -46,8 +49,11 @@ entity.onMobFight = function(mob, target)
                 mob:setLocalVar("changeTime", mob:getBattleTime())
                 mob:setLocalVar("changeHP", mob:getHP())
             -- subanimation 1 is magic mode, so check if he should change into physical mode
-            elseif (mob:getAnimationSub() == 1 and (mob:getHP() <= changeHP - 1000 or
-                    mob:getBattleTime() - changeTime > 300)) then
+            elseif
+                mob:getAnimationSub() == 1 and
+                (mob:getHP() <= changeHP - 1000 or
+                mob:getBattleTime() - changeTime > 300)
+            then
                 -- and use an ability before changing
                 mob:useMobAbility(673)
                 mob:setAnimationSub(2)

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -32,8 +32,10 @@ entity.onMobFight = function(mob, target)
             -- and record the time this phase was started
             mob:setLocalVar("changeTime", mob:getBattleTime())
         -- subanimation 1 is flight, so check if he should land
-        elseif (mob:getAnimationSub() == 1 and
-                mob:getBattleTime() - changeTime > 30) then
+        elseif
+            mob:getAnimationSub() == 1 and
+            mob:getBattleTime() - changeTime > 30
+        then
             mob:useMobAbility(1292)
             mob:setLocalVar("changeTime", mob:getBattleTime())
         -- subanimation 2 is grounded mode, so check if he should take off

--- a/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
@@ -19,8 +19,11 @@ entity.onTrigger = function(player, npc)
     if (xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
         local hasStone = xi.abyssea.getHeldTraverserStones(player)
 
-        if (hasStone >= 1 and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED
-        and player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_DELECTABLE_DEMON) == QUEST_AVAILABLE) then
+        if
+            hasStone >= 1 and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.DAWN_OF_DEATH) == QUEST_ACCEPTED and
+            player:getQuestStatus(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_DELECTABLE_DEMON) == QUEST_AVAILABLE
+        then
             player:startEvent(56)
         else
             player:startEvent(55, 0, 1) -- No param = no entry.

--- a/scripts/zones/Wajaom_Woodlands/mobs/Zoraal_Jas_Pkuucha.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Zoraal_Jas_Pkuucha.lua
@@ -27,11 +27,11 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if (
+    if
         mob:getHPP() <= mob:getLocalVar("whenToPopZoraal") and
         not GetMobByID(ID.mob.PERCIPIENT_ZORAAL_JA):isSpawned() and
         mob:getLocalVar("hasPoppedZoraal") == 0
-    ) then
+    then
         GetMobByID(ID.mob.PERCIPIENT_ZORAAL_JA):setSpawn(mob:getXPos() + math.random(-2, 2), mob:getYPos(), mob:getZPos() + math.random(-2, 2))
         SpawnMob(ID.mob.PERCIPIENT_ZORAAL_JA):updateEnmity(target)
         mob:setHP(mob:getMaxHP())

--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -66,8 +66,10 @@ entity.onTrigger = function(player, npc)
 
     if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 6)) then
         player:startEvent(498)
-    elseif (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and
-        player:getCharVar("ClassReunionProgress") == 3) then
+    elseif
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CLASS_REUNION) == QUEST_ACCEPTED and
+        player:getCharVar("ClassReunionProgress") == 3
+    then
         player:startEvent(409) -- she mentions that Sunny-Pabonny left for San d'Oria
 
     -- Trust

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -55,8 +55,9 @@ local function getFenrirRewardMask(player)
 end
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHasExactly(trade, { 1696, 1697, 1698 }) -- Magicked Steel Ingot, Spruce Lumber, Extra-fine File
-        and player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN) == QUEST_ACCEPTED
+    if
+        npcUtil.tradeHasExactly(trade, { 1696, 1697, 1698 }) and -- Magicked Steel Ingot, Spruce Lumber, Extra-fine File
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN) == QUEST_ACCEPTED
     then
         player:startEvent(886)
     end
@@ -69,9 +70,10 @@ entity.onTrigger = function(player, npc)
     local turmoil = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
 
     -- Tuning In
-    if tuningIn == QUEST_AVAILABLE
-        and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 4
-        and (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.DISTANT_BELIEFS or player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE))
+    if
+        tuningIn == QUEST_AVAILABLE and
+        player:getFameLevel(xi.quest.fame_area.WINDURST) >= 4 and
+        (player:getCurrentMission(xi.mission.log_id.COP) >= xi.mission.id.cop.DISTANT_BELIEFS or player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE))
     then
         player:startEvent(884, 0, 1696, 1697, 1698) -- Magicked Steel Ingot, Spruce Lumber, Extra-fine File
 
@@ -83,11 +85,13 @@ entity.onTrigger = function(player, npc)
         player:startEvent(897) -- Finishing dialogue
 
     -- The Moonlit Path and Other Fenrir Stuff!
-    elseif (moonlitPath == QUEST_AVAILABLE and
+    elseif
+        moonlitPath == QUEST_AVAILABLE and
         player:getFameLevel(xi.quest.fame_area.WINDURST) >= 6 and
         player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 6 and
         player:getFameLevel(xi.quest.fame_area.BASTOK) >= 6 and
-        player:getFameLevel(xi.quest.fame_area.NORG) >= 4) then -- Fenrir flag event
+        player:getFameLevel(xi.quest.fame_area.NORG) >= 4
+    then -- Fenrir flag event
 
         player:startEvent(842, 0, 1125)
     elseif (moonlitPath == QUEST_ACCEPTED) then
@@ -95,8 +99,12 @@ entity.onTrigger = function(player, npc)
             player:startEvent(845, 0, 1125, 334)
         elseif (player:hasKeyItem(xi.ki.WHISPER_OF_THE_MOON)) then -- First turn-in
             local availRewards = 0
-            if not player:hasKeyItem(xi.ki.TRAINERS_WHISTLE) or
-                player:hasKeyItem(xi.ki.FENRIR_WHISTLE) then availRewards = availRewards + 128; end -- Mount Pact
+            if
+                not player:hasKeyItem(xi.ki.TRAINERS_WHISTLE) or
+                player:hasKeyItem(xi.ki.FENRIR_WHISTLE)
+            then
+                availRewards = availRewards + 128
+            end -- Mount Pact
 
             player:startEvent(846, 0, 13399, 1208, 1125, availRewards, 18165, 13572)
         elseif hasAvatarWhispers(player) then
@@ -191,10 +199,13 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 884 then
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN)
 
-    elseif csid == 886 and npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN, {
-        gil = 4000,
-        title = xi.title.FINE_TUNER,
-    }) then
+    elseif
+        csid == 886 and
+        npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_IN, {
+            gil = 4000,
+            title = xi.title.FINE_TUNER,
+        })
+    then
         player:tradeComplete()
 
     -- Tuning Out
@@ -202,10 +213,13 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("TuningOut_Progress", 1)
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_OUT)
 
-    elseif csid == 897 and npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_OUT, {
-        item = 15180, -- Cache-Nez
-        title = xi.title.FRIEND_OF_THE_HELMED,
-    }) then
+    elseif
+        csid == 897 and
+        npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.TUNING_OUT, {
+            item = 15180, -- Cache-Nez
+            title = xi.title.FRIEND_OF_THE_HELMED,
+        })
+    then
         player:setCharVar("TuningOut_Progress", 0) -- zero when quest is done
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
@@ -41,14 +41,17 @@ entity.onEventFinish = function(player, csid, option)
             player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.ECO_WARRIOR)
         end
         player:setCharVar("EcoStatus", 201) -- EcoStatus var:  1 to 3 for sandy // 101 to 103 for bastok // 201 to 203 for windurst
-    elseif csid == 822 and npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.ECO_WARRIOR, {
-        gil = 5000,
-        item = 4198,
-        title = xi.title.EMERALD_EXTERMINATOR,
-        fame = 80,
-        fameArea = xi.quest.fame_area.WINDURST,
-        var = "EcoStatus"
-    }) then
+    elseif
+        csid == 822 and
+        npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.ECO_WARRIOR, {
+            gil = 5000,
+            item = 4198,
+            title = xi.title.EMERALD_EXTERMINATOR,
+            fame = 80,
+            fameArea = xi.quest.fame_area.WINDURST,
+            var = "EcoStatus"
+        })
+    then
         player:delKeyItem(xi.ki.INDIGESTED_MEAT)
         player:setCharVar("EcoReset", getConquestTally())
     end

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Hampu-Kampu.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Hampu-Kampu.lua
@@ -38,10 +38,12 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 174 then -- Option doesn't matter as NPC will take key item if yes or no
-        if npcUtil.completeQuest(player, xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.SAY_IT_WITH_A_HANDBAG, {
-            item = 19110, -- Trainee's Needle
-            var = "sayItWithAHandbagCS"
-        }) then
+        if
+            npcUtil.completeQuest(player, xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.SAY_IT_WITH_A_HANDBAG, {
+                item = 19110, -- Trainee's Needle
+                var = "sayItWithAHandbagCS"
+            })
+        then
             player:delKeyItem(xi.ki.REPAIRED_HANDBAG)
             player:setCharVar("sayItWithAHandbagBonusCS", 1)
         end

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Rohn_Ehlbalna.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Rohn_Ehlbalna.lua
@@ -10,8 +10,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.REDEEMING_ROCKS) == QUEST_ACCEPTED and
-        player:getCharVar("RedeemingRocksProg") == 1 then
+    if
+        player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.REDEEMING_ROCKS) == QUEST_ACCEPTED and
+        player:getCharVar("RedeemingRocksProg") == 1
+    then
         player:startEvent(114) -- 2nd CS quest "Redeeming Rocks"
     else
         player:startEvent(440)

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -44,13 +44,17 @@ end
 
 entity.onTrade = function(player, npc, trade)
     -- THE KIND CARDIAN
-    if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_KIND_CARDIAN) == QUEST_ACCEPTED and
-        npcUtil.tradeHas(trade, 969) then
+    if
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_KIND_CARDIAN) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 969)
+    then
         player:startEvent(397)
 
         -- CAN CARDIANS CRY?
-    elseif player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED and
-        npcUtil.tradeHas(trade, 551) then
+    elseif
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY) == QUEST_ACCEPTED and
+        npcUtil.tradeHas(trade, 551)
+    then
         player:startEvent(325, 0, 20000, 5000)
     end
 end
@@ -103,9 +107,10 @@ entity.onEventFinish = function(player, csid, option)
         -- CAN CARDIANS CRY?
     elseif csid == 319 then
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY)
-    elseif csid == 325 and npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY, {
-        gil = 5000
-    }) then
+    elseif
+        csid == 325 and
+        npcUtil.completeQuest(player, xi.quest.log_id.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY, { gil = 5000 })
+    then
         player:confirmTrade()
 
         -- TRUST

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -88,7 +88,9 @@ entity.onTrigger = function(player, npc)
         player:startEvent(865, 0, 0, 0, trustMemory(player), 0, 0, 0, trustFlag)
 
     -- ROCK RACKETEER (Mihgo's Amigo follow-up)
-    elseif mihgosAmigo == QUEST_COMPLETED and rockRacketeer == QUEST_AVAILABLE and
+    elseif
+        mihgosAmigo == QUEST_COMPLETED and
+        rockRacketeer == QUEST_AVAILABLE and
         player:getFameLevel(xi.quest.fame_area.WINDURST) >= 3
     then
         if player:needToZone() then

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm2.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm2.lua
@@ -38,7 +38,8 @@ end
 entity.onTrigger = function(player, npc)
     local tuningOutProgress = player:getCharVar("TuningOut_Progress")
 
-    if tuningOutProgress == 4
+    if
+        tuningOutProgress == 4
         and npc:getLocalVar("QuestPlayer") == player:getID()
         and npc:getLocalVar("NasusKilled") == 5
     then -- player killed 5 Nasus and was the one to pop


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Requires conditionals to follow one of the following formats:
```
if
   condition and
   condition2
then
```
or
`if condition then`

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed, CI should pass
<!-- Clear and detailed steps to test your changes here -->
