### PR TITLE
[core] add Sekkanoki functionality to mobskill_state.cpp 

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -84,12 +84,11 @@ CMobSkill* CMobSkillState::GetSkill()
 
 void CMobSkillState::SpendCost()
 {
-    auto tp = 0;
     if (!m_PSkill->isTpFreeSkill())
     {
         if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEKKANOKI))
         {
-            tp = m_PEntity->addTP(-1000);
+            m_spentTP = m_PEntity->addTP(-1000);
             m_PEntity->StatusEffectContainer->DelStatusEffect(EFFECT_SEKKANOKI);
         }
         else
@@ -97,9 +96,7 @@ void CMobSkillState::SpendCost()
             m_spentTP            = m_PEntity->health.tp;
             m_PEntity->health.tp = 0;
         }
-    }    
-
-    m_spentTP = tp;
+    }
 }
 
 bool CMobSkillState::Update(time_point tick)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -96,7 +96,7 @@ void CMobSkillState::SpendCost()
         m_PEntity->health.tp = 0;
     }
 
-    m_spent = tp;
+    m_spentTP = tp;
 }
 
 bool CMobSkillState::Update(time_point tick)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -95,6 +95,8 @@ void CMobSkillState::SpendCost()
         m_spentTP            = m_PEntity->health.tp;
         m_PEntity->health.tp = 0;
     }
+
+    m_spent = tp;
 }
 
 bool CMobSkillState::Update(time_point tick)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -84,7 +84,13 @@ CMobSkill* CMobSkillState::GetSkill()
 
 void CMobSkillState::SpendCost()
 {
-    if (!m_PSkill->isTpFreeSkill())
+    auto tp = 0;
+    if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEKKANOKI))
+    {
+        tp = m_PEntity->addTP(-1000);
+        m_PEntity->StatusEffectContainer->DelStatusEffect(EFFECT_SEKKANOKI);
+    }
+    else if (!m_PSkill->isTpFreeSkill())
     {
         m_spentTP            = m_PEntity->health.tp;
         m_PEntity->health.tp = 0;

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -85,16 +85,19 @@ CMobSkill* CMobSkillState::GetSkill()
 void CMobSkillState::SpendCost()
 {
     auto tp = 0;
-    if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEKKANOKI))
+    if (!m_PSkill->isTpFreeSkill())
     {
-        tp = m_PEntity->addTP(-1000);
-        m_PEntity->StatusEffectContainer->DelStatusEffect(EFFECT_SEKKANOKI);
-    }
-    else if (!m_PSkill->isTpFreeSkill())
-    {
-        m_spentTP            = m_PEntity->health.tp;
-        m_PEntity->health.tp = 0;
-    }
+        if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEKKANOKI))
+        {
+            tp = m_PEntity->addTP(-1000);
+            m_PEntity->StatusEffectContainer->DelStatusEffect(EFFECT_SEKKANOKI);
+        }
+        else
+        {
+            m_spentTP            = m_PEntity->health.tp;
+            m_PEntity->health.tp = 0;
+        }
+    }    
 
     m_spentTP = tp;
 }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

- Creates functionality for Sekkanoki for mobskills. This is primarily so that trusts can utilize the ability through gambits. Videos below.
- video 1 : Sekkanoki prior to code. WS depletes to 0 regardless of status.
    - https://user-images.githubusercontent.com/99501957/197692301-efd20bb4-e387-4962-806c-71e49d364f12.mov

- video 2 : Sekkanoki after update. Uses 1000 tp and saves 2000 for self skillchain
    - https://user-images.githubusercontent.com/99501957/197692629-2031a9b1-9cc3-4668-9f29-e4bfc7e0f67a.mov

<!-- Describe what your PR doe

s here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1. load in changes.
2. clean and rebuild server to apply core changes
3.  load up a SAM trust spell lua (AAGK is who I used) with :
     - mob:addSimpleGambit(ai.t.SELF, ai.c.TP_GTE, 2000, ai.r.JA, ai.s.SPECIFIC, xi.ja.SEKKANOKI)
     - mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 3000)
5. engage in combat and use !tp 2000 to trigger the ability.
6. use !tp 3000 to trigger WS use. (and self skillchain!)