### PR TITLE
Ensure that patrolling is only done while roaming

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../entities/baseentity.h"
 #include "../../entities/mobentity.h"
 #include "../../zone.h"
+#include "../ai_container.h"
 #include "lua/luautils.h"
 
 namespace
@@ -653,7 +654,7 @@ void CPathFind::FinishedPath()
             Clear();
         }
     }
-    else if (IsPatrolling())
+    else if (IsPatrolling() && m_POwner->PAI->IsRoaming())
     {
         m_currentPoint = 0;
         m_currentTurn  = 0;


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This fixes an issue where mobs will path very oddly while engaged if they patrol while roaming. The mob will finish pathing to the battle target and then start to path back some causing it to sometimes not attack at all or seemingly run away.

## Steps to test these changes

```
!addkeyitem red_card
!addkeyitem cosmo_cleanse
!pos -600 -0.5 -600 38
```

Mobs on floor one of Apollyon NW will patrol about. If you aggro one it should path properly while attempting to melee you and if you die it'll resume its patrol.