### PR TITLE
Battle ID to isolate fights

### DIFF
--- a/scripts/battlefields/Apollyon/se_apollyon.lua
+++ b/scripts/battlefields/Apollyon/se_apollyon.lua
@@ -277,7 +277,7 @@ content.groups =
         setup = function(battlefield, mobs)
             for _, mob in ipairs(mobs) do
                 -- Prevent boss from being targetable until first mob Flying_Spear is killed
-                mob:setUntargetable(true)
+                mob:setBattleID(1)
                 mob:setStatus(xi.status.NORMAL)
                 mob:setMobMod(xi.mobMod.NO_AGGRO, 1)
                 mob:setMobMod(xi.mobMod.NO_LINK, 1)
@@ -300,7 +300,7 @@ content.groups =
             boss:setMod(xi.mod.UDMGPHYS, (8 - count) * -1000)
             if count == 1 then
                 -- Make the boss become targetable after the first kill
-                boss:setUntargetable(false)
+                boss:setBattleID(0)
                 boss:setStatus(xi.status.MOB)
                 boss:setMobMod(xi.mobMod.NO_AGGRO, 0)
                 boss:setMobMod(xi.mobMod.NO_LINK, 0)

--- a/scripts/battlefields/Temenos/temenos_eastern_towern.lua
+++ b/scripts/battlefields/Temenos/temenos_eastern_towern.lua
@@ -253,7 +253,12 @@ content.paths =
 content.groups =
 {
     {
-        mobs = { "Armoury_Crate_Eastern" }
+        mobs = { "Armoury_Crate_Eastern" },
+        setup = function(battlefield, crates)
+            for _, crate in ipairs(crates) do
+                crate:setBattleID(1) -- Different battle ID prevents the crate from being hit by AOEs
+            end
+        end
     },
 
     {

--- a/scripts/battlefields/Temenos/temenos_western_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_western_tower.lua
@@ -256,7 +256,12 @@ content.paths =
 content.groups =
 {
     {
-        mobs = { "Armoury_Crate_Western" }
+        mobs = { "Armoury_Crate_Western" },
+        setup = function(battlefield, crates)
+            for _, crate in ipairs(crates) do
+                crate:setBattleID(1) -- Different battle ID prevents the crate from being hit by AOEs
+            end
+        end
     },
 
     {

--- a/scripts/globals/limbus.lua
+++ b/scripts/globals/limbus.lua
@@ -326,6 +326,7 @@ function Limbus:onBattlefieldInitialise(battlefield)
         for i, crateID in ipairs(ID.npc.RECOVER_CRATES) do
             local crate = GetEntityByID(crateID)
             xi.limbus.hideCrate(crate)
+            crate:setBattleID(1) -- Different battle ID prevents the crate from being hit by AOEs
             crate:addListener("ON_TRIGGER", "TRIGGER_RECOVER_CRATE", utils.bind(self.handleOpenRecoverCrate, self))
         end
     end

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1364,7 +1364,7 @@ INSERT INTO `mob_skills` VALUES (1527,1086,'laser_shower',4,10.0,2000,1500,4,0,0
 INSERT INTO `mob_skills` VALUES (1528,1087,'floodlight',2,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1529,1089,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Proto-Omega
 INSERT INTO `mob_skills` VALUES (1530,1088,'stun_cannon',4,20.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,3000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,0,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1532,1124,'pod_ejection',0,7.0,4500,1,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1533,1117,'pile_pitch',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1534,1118,'guided_missile',2,5.0,2000,1500,4,0,0,0,0,0,0);

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -73,7 +73,8 @@ bool CMobController::TryDeaggro()
     // target is no longer valid, so wipe them from our enmity list
     if (!PTarget || PTarget->isDead() || PTarget->isMounted() || PTarget->loc.zone->GetID() != PMob->loc.zone->GetID() ||
         PMob->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect() ||
-        PMob->allegiance == PTarget->allegiance || CheckDetection(PTarget) || CheckHide(PTarget) || CheckLock(PTarget))
+        PMob->allegiance == PTarget->allegiance || CheckDetection(PTarget) || CheckHide(PTarget) || CheckLock(PTarget) ||
+        PMob->getBattleID() != PTarget->getBattleID())
     {
         if (PTarget)
         {
@@ -1097,6 +1098,11 @@ bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
     TracyZoneScoped;
     TracyZoneIString(PMob->GetName());
     TracyZoneIString(PTarget->GetName());
+
+    if (PMob->getBattleID() != PTarget->getBattleID())
+    {
+        return false;
+    }
 
     // Don't aggro I'm neutral
     if ((PMob->getMobMod(MOBMOD_ALWAYS_AGGRO) == 0 && !PMob->m_Aggro) || PMob->m_neutral || PMob->isDead())

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -117,7 +117,8 @@ bool CPetController::TryDeaggro()
 
     // target is no longer valid, so wipe them from our enmity list
     if (PTarget->isDead() || PTarget->isMounted() || PTarget->loc.zone->GetID() != PPet->loc.zone->GetID() ||
-        PPet->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect())
+        PPet->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect() ||
+        PPet->getBattleID() != PTarget->getBattleID())
     {
         return true;
     }

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -429,7 +429,8 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
     }
 
     if (m_PBattleEntity->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect() ||
-        m_PBattleEntity->PBattlefield != PTarget->PBattlefield || m_PBattleEntity->PInstance != PTarget->PInstance)
+        m_PBattleEntity->PBattlefield != PTarget->PBattlefield || m_PBattleEntity->PInstance != PTarget->PInstance ||
+        m_PBattleEntity->getBattleID() != PTarget->getBattleID())
     {
         return false;
     }
@@ -585,7 +586,7 @@ CBattleEntity* CTargetFind::getValidTarget(uint16 actionTargetID, uint16 validTa
         return m_PBattleEntity->PPet;
     }
 
-    if (PTarget->ValidTarget(m_PBattleEntity, validTargetFlags))
+    if (m_PBattleEntity->getBattleID() == PTarget->getBattleID() && PTarget->ValidTarget(m_PBattleEntity, validTargetFlags))
     {
         return PTarget;
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1338,6 +1338,7 @@ void CBattleEntity::Spawn()
     HideName(false);
     CBaseEntity::Spawn();
     m_OwnerID.clean();
+    setBattleID(0);
 }
 
 void CBattleEntity::Die()

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2033,6 +2033,16 @@ duration CBattleEntity::GetBattleTime()
     return server_clock::now() - m_battleStartTime;
 }
 
+void CBattleEntity::setBattleID(uint16 battleID)
+{
+    m_battleID = battleID;
+}
+
+uint16 CBattleEntity::getBattleID()
+{
+    return m_battleID;
+}
+
 void CBattleEntity::Tick(time_point /*unused*/)
 {
     TracyZoneScoped;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -732,6 +732,9 @@ public:
     void     SetBattleStartTime(time_point);
     duration GetBattleTime();
 
+    void   setBattleID(uint16 battleID);
+    uint16 getBattleID();
+
     virtual void Tick(time_point) override;
     virtual void PostTick() override;
 
@@ -778,6 +781,7 @@ private:
     uint8      m_slvl; // ТЕКУЩИЙ уровень дополнительной профессии
     uint16     m_battleTarget{ 0 };
     time_point m_battleStartTime;
+    uint16     m_battleID = 0; // Current battle the entity is participating in. Battle ID must match in order for entities to interact with each other.
 
     std::unordered_map<Mod, int16, EnumClassHash>                                                m_modStat;     // массив модификаторов
     std::unordered_map<Mod, int16, EnumClassHash>                                                m_modStatSave; // saved state

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9769,6 +9769,36 @@ void CLuaBaseEntity::wakeUp()
 }
 
 /************************************************************************
+ *  Function: setBattleID()
+ *  Purpose : Sets the battle ID on the entity. Only entities with the same battle ID can interact with each other.
+ *  Example : target:setBattleID(1)
+ *  Notes   : Default value for battle ID is 0.
+ ************************************************************************/
+
+void CLuaBaseEntity::setBattleID(uint16 battleID)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    PEntity->setBattleID(battleID);
+}
+
+/************************************************************************
+ *  Function: getBattleID()
+ *  Purpose : Gets the battle ID on the entity
+ *  Example : target:getBattleID()
+ *  Notes   :
+ ************************************************************************/
+
+uint16 CLuaBaseEntity::getBattleID()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
+    return PEntity->getBattleID();
+}
+
+/************************************************************************
  *  Function: recalculateStats()
  *  Purpose : Recalculate the total Stats for a PC (force update)
  *  Example : target:recalculateStats()
@@ -15052,6 +15082,9 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("canChangeState", CLuaBaseEntity::canChangeState);
 
     SOL_REGISTER("wakeUp", CLuaBaseEntity::wakeUp);
+
+    SOL_REGISTER("setBattleID", CLuaBaseEntity::setBattleID);
+    SOL_REGISTER("getBattleID", CLuaBaseEntity::getBattleID);
 
     SOL_REGISTER("recalculateStats", CLuaBaseEntity::recalculateStats);
     SOL_REGISTER("checkImbuedItems", CLuaBaseEntity::checkImbuedItems);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -562,6 +562,9 @@ public:
 
     void wakeUp(); // wakes target if necessary
 
+    void   setBattleID(uint16 battleID);
+    uint16 getBattleID();
+
     void recalculateStats();
     bool checkImbuedItems();
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -911,6 +911,7 @@ namespace petutils
             PMaster->StatusEffectContainer->CopyConfrontationEffect(PPet);
 
             PPet->PMaster = PMaster;
+            PPet->setBattleID(PMaster->getBattleID());
 
             if (PMaster->PBattlefield)
             {

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -356,6 +356,7 @@ namespace trustutils
         CTrustEntity* PTrust = LoadTrust(PMaster, TrustID);
         PMaster->PTrusts.insert(PMaster->PTrusts.end(), PTrust);
         PMaster->StatusEffectContainer->CopyConfrontationEffect(PTrust);
+        PTrust->setBattleID(PMaster->getBattleID());
 
         if (PMaster->PBattlefield)
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

This introduces a battle ID on the entities which only allows battle interactions to occur between entities with the same battle ID. This can be used for an assortment of content such as Garrison, Pirate's Chart Quest, and anywhere we don't want battle interactions to occur.

## Steps to test these changes

Target any mob and input `!exec target:setBattleID(1)` and that mob will no longer be interactable. You can do the same with yourself and then you will be able to interact with only that mob and no other mobs. Use `!exec target:setBattleID(0)` to reset to default.
