### PR TITLE
[core] Fix issue with setting blank onMobDeath functions in Dynamic Entities

### DIFF
--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -464,7 +464,7 @@ xi.garrison.tick = function(npc)
     local allNPCsDead = true
     for _, entityId in pairs(zoneData.npcs) do
         local entity = GetMobByID(entityId)
-        if entity:isAlive() then
+        if entity and entity:isAlive() then
             allNPCsDead = false
         end
     end
@@ -473,7 +473,7 @@ xi.garrison.tick = function(npc)
     for _, entityId in pairs(zoneData.players) do
         local entity = GetPlayerByID(entityId)
         -- TODO: Only check valid players
-        if entity:isAlive() then
+        if entity and entity:isAlive() then
             allPlayersDead = false
         end
     end
@@ -481,7 +481,7 @@ xi.garrison.tick = function(npc)
     local allMobsDead = true
     for _, entityId in pairs(zoneData.mobs) do
         local entity = GetMobByID(entityId)
-        if entity:isAlive() then
+        if entity and entity:isAlive() then
             allMobsDead = false
         end
     end

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -339,7 +339,9 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         auto onMobDeath = table["onMobDeath"].get<sol::function>();
         if (!onMobDeath.valid())
         {
-            cacheEntry["onMobDeath"] = []() {}; // Empty func
+            // TODO: Using an empty C++ lambda here wasn't working.
+            // Figure out why and fix.
+            cacheEntry["onMobDeath"] = lua.safe_script("return function() end");
         }
 
         m_pLuaZone->InsertMOB(PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

I was getting very vague errors while spawning these mobs with blank onMobDeath functions, so this fixes that.

Also a little bit of stuff for garrison.

## Steps to test these changes

Spawn a wave in Garrison, see no errors at the start, or when the helpers die
