### PR TITLE
[Fix][Interaction] RDM AF2 Quest progression bug when interacting with QM

### DIFF
--- a/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
+++ b/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
@@ -111,13 +111,17 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') >= 2 then
-                        if player:hasKeyItem(xi.ki.CRAWLER_BLOOD) and player:hasKeyItem(xi.ki.OLD_BOOTS) then
-                            return quest:progressEvent(4) -- Loose key items. Start boot purification.
-                        else
+                        if quest:getVar(player, 'Time') > 0 then
                             if quest:getVar(player, 'Time') <= os.time() then
                                 return quest:progressEvent(5) -- Quest complete.
                             else
                                 return quest:messageSpecial(crawlersID.text.EQUIPMENT_NOT_PURIFIED) -- Purification incomplete.
+                            end
+                        else
+                            if player:hasKeyItem(xi.ki.CRAWLER_BLOOD) and player:hasKeyItem(xi.ki.OLD_BOOTS) then
+                                return quest:progressEvent(4) -- Loose key items. Start boot purification.
+                            else
+                                return quest:messageSpecial(crawlersID.text.SOMEONE_HAS_BEEN_DIGGING_HERE)
                             end
                         end
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

When examining the qm, it would immediately end the quest if not in possesion of the cawler blood KI.
This PR fixes this profression problem.

## Steps to test these changes

Run the quest. Examine the qm before obtaining the crawler blood KI and after obtaining the old boots KI. Quest should not end.
