### PR TITLE
[core] Reset deaggro time when switching targets after deaggro

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -29,8 +29,8 @@ xi.settings.map =
     -- Game settings
     -- --------------------------------
 
-    --  PacketGuard will block and report any packets that aren't in the allow-list for a
-    --  player's current state.
+    -- PacketGuard will block and report any packets that aren't in the allow-list for a
+    -- player's current state.
     PACKETGUARD_ENABLED = true,
 
     -- Minimal number of 0x3A packets which uses for detect lightluggage (set 0 for disable)
@@ -39,7 +39,7 @@ xi.settings.map =
     -- Enable or disable Recycle Bin (Set to false for items to be dropped immediately)
     ENABLE_ITEM_RECYCLE_BIN = true,
 
-    --  AH fee structure, defaults are retail.
+    -- AH fee structure, defaults are retail.
     AH_BASE_FEE_SINGLE = 1,
     AH_BASE_FEE_STACKS = 4,
     AH_TAX_RATE_SINGLE = 1.0,
@@ -56,12 +56,12 @@ xi.settings.map =
     EXP_LOSS_RATE           = 1.0,
     EXP_PARTY_GAP_PENALTIES = true,
 
-    --  Capacity Point Settings
+    -- Capacity Point Settings
     CAPACITY_RATE = 1.0,
 
     -- Determines Vana'diel time epoch (886/1/1 Firesday)
-    --  current timestamp - vanadiel_time_epoch = vana'diel time
-    --  0 defaults to SE epoch 1009810800 (JP midnight 1/1/2002)
+    -- current timestamp - vanadiel_time_epoch = vana'diel time
+    -- 0 defaults to SE epoch 1009810800 (JP midnight 1/1/2002)
     -- safe range is 1 - current timestamp
     VANADIEL_TIME_EPOCH = 0,
 
@@ -84,7 +84,7 @@ xi.settings.map =
     WS_POINTS_BASE = 1,
 
     -- Weaponskill points per skillchain element - whole numbers only, retail is 1
-    --  (tier 3 sc's have 4 elements, plus 1 for the ws itself, giving 5 points to the closer).
+    -- (tier 3 sc's have 4 elements, plus 1 for the ws itself, giving 5 points to the closer).
     WS_POINTS_SKILLCHAIN = 1,
 
     -- Enable/disable jobs other than BST and RNG having widescan
@@ -155,7 +155,7 @@ xi.settings.map =
     -- Sets the fraction of MP a subjob provides to the main job. Retail is half and this acts as a divisor so default is 2
     SJ_MP_DIVISOR = 2.0,
 
-    --  Modify ratio of subjob-to-mainjob
+    -- Modify ratio of subjob-to-mainjob
     -- 0            = no subjobs
     -- 1            = 1/2   (default, 75/37, 99/49)
     -- 2            = 2/3   (75/50, 99/66)
@@ -192,8 +192,11 @@ xi.settings.map =
     -- Maximum total bonus gil that can be dropped. Default 9999 gil.
     MAX_GIL_BONUS = 9999,
 
-    --  Allow mobs to walk back home instead of despawning
+    -- Allow mobs to walk back home instead of despawning
     MOB_NO_DESPAWN = false,
+
+    -- Adds extra time to mob despawn in seconds. Base time is 25s, so a setting of 5 here would be a total of 30 seconds.
+    MOB_ADDITIONAL_TIME_TO_DEAGGRO = 0,
 
     -- Allows parry, block, and guard to skill up regardless of the action occuring.
     -- This did not happen in previous eras
@@ -208,8 +211,8 @@ xi.settings.map =
     LV_CAP_MISSION_BCNM = 0,
 
     -- Max allowed merits points players can hold
-    --  10 classic
-    --  30 abyssea
+    -- 10 classic
+    -- 30 abyssea
     MAX_MERIT_POINTS = 30,
 
     -- Minimum time between uses of yell command (in seconds).
@@ -243,10 +246,10 @@ xi.settings.map =
     -- Set to 1 to completely disable auto-jailing offenders
     ANTICHEAT_JAIL_DISABLE = false,
 
-    --  Gobbie Mystery Box settings
+    -- Gobbie Mystery Box settings
     DAILY_TALLY_AMOUNT = 10,
     DAILY_TALLY_LIMIT  = 50000,
-    
+
     -- Enable/disable keeping jug pets through zoning
     KEEP_JUGPET_THROUGH_ZONING = false,
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -80,7 +80,17 @@ bool CMobController::TryDeaggro()
             PMob->PEnmityContainer->Clear(PTarget->id);
         }
         PTarget = PMob->PEnmityContainer->GetHighestEnmity();
-        PMob->SetBattleTargetID(PTarget ? PTarget->targid : 0);
+        if (PTarget)
+        {
+            PMob->SetBattleTargetID(PTarget->targid);
+            // Reset deaggro time so that the mob is given time to actually try to path towards the new highest enmity target
+            TapDeaggroTime();
+        }
+        else
+        {
+            PMob->SetBattleTargetID(0);
+        }
+
         return TryDeaggro();
     }
 
@@ -150,7 +160,8 @@ bool CMobController::CheckDetection(CBattleEntity* PTarget)
         TapDeaggroTime();
     }
 
-    return PMob->CanDeaggro() && (m_Tick >= m_DeaggroTime + 25s);
+    auto additionalDeaggroTime = std::chrono::seconds(settings::get<uint32>("map.MOB_ADDITIONAL_TIME_TO_DEAGGRO"));
+    return PMob->CanDeaggro() && (m_Tick >= m_DeaggroTime + 25s + additionalDeaggroTime);
 }
 
 void CMobController::TryLink()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes #3046
Adds a setting to increase deaggro time

## Steps to test these changes

3box and flash a mob on one char, gravity on another, have them run opposite directions, have a 3rd character autofollow the mob

observe the mob follow the player that flashed first, give up after about 25 seconds and then turn around to try to chase the other player and then give up after about 25 seconds. This better matches retail behavior.
