### PR TITLE
[lua] Regional NPC Rank Fixes

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -597,9 +597,10 @@ xi.conquest.toggleRegionalNPCs = function(zone)
             { GetNationRank(xi.nation.WINDURST), xi.zone.WINDURST_WOODS },
         }
 
-        table.sort(rankings, function (a, b) return a[1] > b[1] end)
+        table.sort(rankings, function (a, b) return a[1] < b[1] end)
 
         local firstPlaceZone = rankings[1][2]
+        local secondPlaceZone = rankings[2][2]
 
         if firstPlaceZone == zone:getID() then
             print("Making regional conquest NPCs available in: " .. zone:getName())
@@ -615,7 +616,11 @@ xi.conquest.toggleRegionalNPCs = function(zone)
 
                     -- If there is a clear winner, and not a tie,
                     -- show the NPCs
-                    if id == firstPlaceZone and not IsConquestAlliance() then
+                    if
+                        id == firstPlaceZone and
+                        not (IsConquestAlliance() or
+                        (firstPlaceZone == secondPlaceZone))
+                    then
                         entity:setStatus(xi.status.NORMAL)
                     end
                 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
- Fixes Regional NPCs being shown in the Rank 3 nation when there is a tie for first
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixes: https://github.com/LandSandBoat/server/issues/3051
## Steps to test these changes
- Open Region Info -> Conquest
- Check rankings
- When there is a tie check regional NPC locations in each City (They should not be there):
!gotoid 17719424
!gotoid 17743966
!gotoid 17764525

<!-- Clear and detailed steps to test your changes here -->
