### PR TITLE
[core] Adjust beastmen's seal drop check to not include mobs that have <= -100% exp modifier

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1027,7 +1027,8 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     ZONE_TYPE zoneType  = zoneutils::GetZone(PChar->getZone())->GetType();
     bool      validZone = zoneType != ZONE_TYPE::BATTLEFIELD && zoneType != ZONE_TYPE::DYNAMIS;
 
-    if (!getMobMod(MOBMOD_NO_DROPS) && validZone && charutils::CheckMob(m_HiPCLvl, GetMLevel()) > EMobDifficulty::TooWeak)
+    // Check if mob can drop seals -- mobmod to disable drops, zone type isnt battlefield/dynamis, mob is stronger than Too Weak, or mobmod for EXP bonus is -100 or lower (-100% exp)
+    if (!getMobMod(MOBMOD_NO_DROPS) && validZone && charutils::CheckMob(m_HiPCLvl, GetMLevel()) > EMobDifficulty::TooWeak && getMobMod(MOBMOD_EXP_BONUS) > -100)
     {
         // check for seal drops
         /* MobLvl >= 1 = Beastmen Seals ID=1126


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Adds check to not drop seals if MOBMOD_EXP_BONUS <= -100
The intent was to prevent Limbus mobs from dropping the seals, but this in effect makes any intentionally zero-exp mob not drop them.
## Steps to test these changes
Go to limbus, kill a bunch of stuff and never get a seal drop.
Go outside of limbus, kill stuff that grants exp outside a battlefields and get seal drops.