### PR TITLE
[core] Update pet/trust despawn animation logic to match retail, fix pets having green names

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -529,11 +529,11 @@ bool CAIContainer::QueueEmpty()
     return ActionQueue.isEmpty();
 }
 
-bool CAIContainer::Internal_Despawn()
+bool CAIContainer::Internal_Despawn(bool instantDespawn)
 {
     if (!IsCurrentState<CDespawnState>() && !IsCurrentState<CRespawnState>())
     {
-        return ForceChangeState<CDespawnState>(PEntity);
+        return ForceChangeState<CDespawnState>(PEntity, instantDespawn);
     }
     return false;
 }

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -77,7 +77,7 @@ public:
     bool Internal_Die(duration);
     bool Internal_Raise();
     bool Internal_UseItem(uint16 targetid, uint8 loc, uint8 slotid);
-    bool Internal_Despawn();
+    bool Internal_Despawn(bool instantDespawn = false);
     bool Internal_Respawn(duration _duration);
 
     void    Reset();

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -26,18 +26,13 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../zone.h"
 #include "../ai_container.h"
 
-CDespawnState::CDespawnState(CBaseEntity* _PEntity, duration spawnTime)
+CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
 : CState(_PEntity, _PEntity->targid)
 {
-    if (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behaviour & BEHAVIOUR_NO_DESPAWN))
+    if (!instantDespawn && (_PEntity->status != STATUS_TYPE::DISAPPEAR && !(static_cast<CMobEntity*>(_PEntity)->m_Behaviour & BEHAVIOUR_NO_DESPAWN)))
     {
         _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, new CEntityAnimationPacket(_PEntity, _PEntity, CEntityAnimationPacket::Fade_Out));
     }
-}
-
-CDespawnState::CDespawnState(CBaseEntity* _PEntity)
-: CDespawnState(_PEntity, 0s)
-{
 }
 
 bool CDespawnState::Update(time_point tick)

--- a/src/map/ai/states/despawn_state.h
+++ b/src/map/ai/states/despawn_state.h
@@ -27,8 +27,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 class CDespawnState : public CState
 {
 public:
-    CDespawnState(CBaseEntity* PEntity);
-    CDespawnState(CBaseEntity* PEntity, duration spawnTime);
+    CDespawnState(CBaseEntity* PEntity, bool instantDespawn);
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override;
     virtual bool CanChangeState() override;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -415,7 +415,7 @@ bool CCharEntity::isNewPlayer() const
 
 void CCharEntity::setPetZoningInfo()
 {
-    if (PPet->objtype == TYPE_PET)
+    if (PPet && PPet->objtype == TYPE_PET)
     {
         switch (((CPetEntity*)PPet)->getPetType())
         {
@@ -436,6 +436,7 @@ void CCharEntity::setPetZoningInfo()
             default:
                 break;
         }
+        petZoningInfo.respawnPet = true;
     }
 }
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -51,6 +51,7 @@ CPetEntity::CPetEntity(PET_TYPE petType)
     m_PetID                 = 0;
     m_IsClaimable           = false;
     m_bReleaseTargIDOnDeath = true;
+    spawnAnimation          = SPAWN_ANIMATION::SPECIAL; // Initial spawn has the special spawn-in animation
 
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CPetController>(this), std::make_unique<CTargetFind>(this));
 }
@@ -162,7 +163,17 @@ void CPetEntity::FadeOut()
 void CPetEntity::Die()
 {
     PAI->ClearStateStack();
-    PAI->Internal_Die(0s);
+
+    // master is zoning, don't go to death state, instead despawn instantly
+    if (health.hp > 0 && PMaster && PMaster->objtype == TYPE_PC && static_cast<CCharEntity*>(PMaster)->petZoningInfo.respawnPet)
+    {
+        PAI->Internal_Despawn(true);
+    }
+    else
+    {
+        PAI->Internal_Die(0s);
+    }
+
     luautils::OnMobDeath(this, nullptr);
 
     // NOTE: This is purposefully calling CBattleEntity's impl.

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -53,6 +53,7 @@ CTrustEntity::CTrustEntity(CCharEntity* PChar)
     m_MovementType          = MELEE_RANGE;
     m_IsClaimable           = false;
     m_bReleaseTargIDOnDeath = true;
+    spawnAnimation          = SPAWN_ANIMATION::SPECIAL; // Initial spawn has the special spawn-in animation
 
     PAI = std::make_unique<CAIContainer>(this, std::make_unique<CPathFind>(this), std::make_unique<CTrustController>(PChar, this),
                                          std::make_unique<CTargetFind>(this));

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -68,10 +68,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         case ENTITY_SPAWN:
         {
             updatemask = UPDATE_ALL_MOB;
-            if (PEntity->objtype == TYPE_PET)
-            {
-                ref<uint8>(0x28) = 0x04;
-            }
+
             if (PEntity->look.size == MODEL_EQUIPPED || PEntity->look.size == MODEL_CHOCOBO)
             {
                 updatemask = 0x57;

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -166,7 +166,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
                 }
                 ref<uint8>(0x28) |= PMob->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR) ? 0x10 : 0x00;
                 ref<uint8>(0x28) |= PMob->health.hp > 0 && PMob->animation == ANIMATION_DEATH ? 0x08 : 0;
-                ref<uint8>(0x28) |= PMob->status == STATUS_TYPE::NORMAL ? 0x40 : 0; // Make the entity triggerable
+                ref<uint8>(0x28) |= PMob->status == STATUS_TYPE::NORMAL && PMob->objtype == TYPE_MOB ? 0x40 : 0; // Make the entity triggerable if a mob and normal status
                 ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);
                 ref<uint8>(0x2B) = PEntity->namevis;
             }

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -920,6 +920,11 @@ namespace petutils
                 PPet->PInstance = PMaster->PInstance;
             }
 
+            if (spawningFromZone)
+            {
+                PPet->spawnAnimation = SPAWN_ANIMATION::NORMAL; // Don't play special spawn animation on zone in
+            }
+
             PMaster->loc.zone->InsertPET(PPet);
 
             PPet->Spawn();
@@ -962,7 +967,7 @@ namespace petutils
             // apply stats from previous zone if this pet is being transferred
             if (spawningFromZone)
             {
-                PPet->health.tp = (int16) static_cast<CCharEntity*>(PMaster)->petZoningInfo.petTP;
+                PPet->health.tp = static_cast<uint16>(static_cast<CCharEntity*>(PMaster)->petZoningInfo.petTP);
                 PPet->health.hp = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petHP;
                 PPet->health.mp = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petMP;
             }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -181,6 +181,9 @@ void CZoneEntities::InsertPET(CBaseEntity* PPet)
                 PCurrentChar->updateEntityPacket(PPet, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
         }
+
+        PPet->spawnAnimation = SPAWN_ANIMATION::NORMAL; // Turn off special spawn animation
+
         return;
     }
     ShowError("CZone::InsertPET : entity is null");
@@ -223,6 +226,9 @@ void CZoneEntities::InsertTRUST(CBaseEntity* PTrust)
                 PCurrentChar->updateEntityPacket(PTrust, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
         }
+
+        PTrust->spawnAnimation = SPAWN_ANIMATION::NORMAL; // Turn off special spawn animation
+
         return;
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

From my commit:

* This implements the following about pet/trust spawn/despawn animations:
    Only the first spawn animation of a pet/trust plays the "special" animation.
    Zoning (pets only) doesn't play the "die" animation. Trusts still "die" as they are not stored on zone.
    This means pets only disappear on zoning now, as expected.

    * "Special animations" include:

    Wyvern "from the sky" spawn in animation
    Avatar glow + crest effects on the ground
    Automaton "appear" animation with the effect
    Trust summon effect

    * GEO bubbles are not effected as they only have one spawn in animation.

In addition, fixes pets having green names.

## Steps to test these changes

2box, have one character summon an avatar, have the other run to 50' of the avatar and see it despawn. walk back in range and see if not have the "special" spawn animation and simply appear.

Have the summoner zone, and see the avatar despawn instead of die.
Repeat for Wyverns, automatons.

For trusts the above is true except the "die" animation is used on zone.
