### PR TITLE
Fix ID reference in Dark Legacy quest

### DIFF
--- a/scripts/quests/bastok/Dark_Legacy.lua
+++ b/scripts/quests/bastok/Dark_Legacy.lua
@@ -128,7 +128,7 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 2
                     then
                         player:confirmTrade()
-                        SpawnMob(ID.mob.VAA_HUJA_THE_ERUDITE):updateClaim(player)
+                        SpawnMob(giddeusID.mob.VAA_HUJA_THE_ERUDITE):updateClaim(player)
 
                         return quest:messageSpecial(giddeusID.text.SENSE_OF_FOREBODING)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes invalid ID variable reference for SpawnMob call in Dark Legacy
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Follow quest guide, see NM pop appropriately.
<!-- Clear and detailed steps to test your changes here -->
