### PR TITLE
[chore] Remove some outer parentheses from NPC script conditions

### DIFF
--- a/scripts/commands/cs.lua
+++ b/scripts/commands/cs.lua
@@ -16,7 +16,7 @@ end
 
 function onTrigger(player, csid, op1, op2, op3, op4, op5, op6, op7, op8, texttable)
     -- validate csid
-    if (csid == nil) then
+    if csid == nil then
         error(player, "You must enter a cutscene id.")
         return
     end

--- a/scripts/commands/cs2.lua
+++ b/scripts/commands/cs2.lua
@@ -16,7 +16,7 @@ end
 
 function onTrigger(player, csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8)
     -- validate csid
-    if (csid == nil) then
+    if csid == nil then
         error(player, "You must enter a cutscene id.")
         return
     end

--- a/scripts/zones/Attohwa_Chasm/npcs/Cradle_of_Rebirth.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Cradle_of_Rebirth.lua
@@ -9,7 +9,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     -- Trade Flaxen Pouch
     if (trade:hasItemQty(1777, 1) and trade:getItemCount() == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1778) -- Parradamo Stones
         else
             player:tradeComplete()

--- a/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
@@ -46,7 +46,7 @@ entity.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MIASMA_FILTER)
         player:setCharVar("[ENM]MiasmaFilter", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif (csid == 13) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1777) -- Flaxen Pouch
             return
         else

--- a/scripts/zones/Bastok_Markets/npcs/Umberto.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Umberto.lua
@@ -22,7 +22,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 473 then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 5674)
         else
             player:addItem(5674)

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Loussaire.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Loussaire.lua
@@ -179,7 +179,7 @@ entity.onEventFinish = function(player, csid, option)
         local firstKI  = player:getLocalVar("firstKI")
         local secondKI = player:getLocalVar("secondKI")
 
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, itemid)
 
         else

--- a/scripts/zones/Beadeaux/npcs/Haggleblix.lua
+++ b/scripts/zones/Beadeaux/npcs/Haggleblix.lua
@@ -149,7 +149,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- singles to hundos
     elseif (csid == 135) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -159,7 +159,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- hundos to 10k pieces
     elseif (csid == 136) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -187,7 +187,7 @@ entity.onEventFinish = function(player, csid, option)
     -- bought item from shop
     elseif (csid == 137) then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Bibiki_Bay/npcs/Warmachine.lua
+++ b/scripts/zones/Bibiki_Bay/npcs/Warmachine.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
 
     -- COP mission
     if (player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DAWN and player:getCharVar("COP_3-taru_story") == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, coloredDrop)
         else
             player:setCharVar("ColoredDrop", coloredDrop)
@@ -32,7 +32,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if (csid == 43) then
         local coloredDropID = player:getCharVar("ColoredDrop")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, coloredDropID)
         else
             player:addItem(coloredDropID)

--- a/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
@@ -148,7 +148,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- singles to hundos
     elseif (csid == 55) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -158,7 +158,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- hundos to 10k pieces
     elseif (csid == 56) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -186,7 +186,7 @@ entity.onEventFinish = function(player, csid, option)
     -- bought item from shop
     elseif (csid == 57) then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
@@ -320,19 +320,19 @@ entity.onEventFinish = function(player, csid, option)
     local reward = player:getCharVar("RELIC_IN_PROGRESS")
 
     -- User is cancelling a relic.  Null everything out, it never happened.
-    if (csid == 87 and option == 666) then
+    if csid == 87 and option == 666 then
         player:setCharVar("RELIC_IN_PROGRESS", 0)
         player:setCharVar("RELIC_DUE_AT", 0)
         player:setCharVar("RELIC_MAKE_ANOTHER", 0)
         player:setCharVar("RELIC_CONQUEST_WAIT", 0)
 
         -- User is okay with making a relic they cannot possibly accept
-    elseif (csid == 20 and option == 1) then
+    elseif csid == 20 and option == 1 then
         player:setCharVar("RELIC_MAKE_ANOTHER", 1)
 
         -- Picking up a finished relic stage 1>2 and 2>3.
-    elseif ((csid == 16 or csid == 19) and reward ~= 0) then
-        if (player:getFreeSlotsCount() < 1) then
+    elseif (csid == 16 or csid == 19) and reward ~= 0 then
+        if player:getFreeSlotsCount() < 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, reward + 1)
         else
             player:addItem(reward + 1)
@@ -343,8 +343,8 @@ entity.onEventFinish = function(player, csid, option)
             player:setCharVar("RELIC_CONQUEST_WAIT", getConquestTally())
         end
         -- Picking up a finished relic stage 3>4.
-    elseif (csid == 52 and reward ~= 0) then
-        if (player:getFreeSlotsCount() < 1) then
+    elseif csid == 52 and reward ~= 0 then
+        if player:getFreeSlotsCount() < 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, reward + 1)
         else
             player:addItem(reward + 1)

--- a/scripts/zones/Castle_Zvahl_Keep/npcs/_4i5.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/npcs/_4i5.lua
@@ -11,7 +11,10 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.RECOLLECTIONS) == QUEST_ACCEPTED and player:getCharVar("recollectionsQuest") == 2) then
+    if
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.RECOLLECTIONS) == QUEST_ACCEPTED and
+        player:getCharVar("recollectionsQuest") == 2
+    then
         if (trade:hasItemQty(1106, 1) and trade:getItemCount() == 1) then
             player:startEvent(8, 1106)
         end
@@ -28,14 +31,12 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 8) then
+    if csid == 8 then
         player:tradeComplete()
         player:setCharVar("recollectionsQuest", 3)
         player:addKeyItem(xi.ki.FOE_FINDER_MK_I)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.FOE_FINDER_MK_I)
     end
-
 end
 
 return entity

--- a/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Chalvatot.lua
@@ -65,13 +65,13 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- CIRCLE OF TIME
-    if (csid == 99 and option == 0) then
+    if csid == 99 and option == 0 then
         player:setCharVar("circleTime", 6)
-    elseif ((csid == 98 or csid == 99) and option == 1) then
+    elseif (csid == 98 or csid == 99) and option == 1 then
         player:setCharVar("circleTime", 7)
         player:addKeyItem(xi.ki.MOON_RING)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MOON_RING)
-    elseif (csid == 96) then
+    elseif csid == 96 then
         if (player:getFreeSlotsCount() ~= 0) then
             player:addItem(12647)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 12647)
@@ -83,13 +83,13 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- LURE OF THE WILDCAT
-    elseif (csid == 561) then
+    elseif csid == 561 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 19, true))
 
     -- HER MAJESTY'S GARDEN
-    elseif (csid == 84 and option == 1) then
+    elseif csid == 84 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HER_MAJESTY_S_GARDEN)
-    elseif (csid == 83) then
+    elseif csid == 83 then
         player:tradeComplete()
         player:addKeyItem(xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAP_OF_THE_NORTHLANDS_AREA)

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -76,8 +76,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 88) then
-        if (player:getFreeSlotsCount() == 0) then
+    if csid == 88 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14095)
         else
             if (player:getMainJob() == xi.job.PLD) then
@@ -94,7 +94,7 @@ entity.onEventFinish = function(player, csid, option)
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.UNDER_OATH)
         player:setCharVar("UnderOathCS", 0)
     elseif (csid == 89) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12644)
         else
             player:addItem(12644)

--- a/scripts/zones/Davoi/npcs/Lootblox.lua
+++ b/scripts/zones/Davoi/npcs/Lootblox.lua
@@ -148,7 +148,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- singles to hundos
     elseif (csid == 135) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
             player:tradeComplete()
@@ -158,7 +158,7 @@ entity.onEventFinish = function(player, csid, option)
 
     -- hundos to 10k pieces
     elseif (csid == 136) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
             player:tradeComplete()
@@ -186,7 +186,7 @@ entity.onEventFinish = function(player, csid, option)
     -- bought item from shop
     elseif (csid == 137) then
         local item = player:getLocalVar("hundoItemBought")
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             player:tradeComplete()

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
@@ -35,7 +35,7 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar('ApocalypseNigh', 3)
         player:setPos(-419.995, 0, 248.483, 191, 35)
     elseif csid == 1 then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14672)
         else
             if (player:addItem(14672)) then

--- a/scripts/zones/Kazham/npcs/Dodmos.lua
+++ b/scripts/zones/Kazham/npcs/Dodmos.lua
@@ -43,7 +43,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 286 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1544) --Mini tuning fork
         else
             player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE)
@@ -51,7 +51,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1544)
         end
     elseif (csid == 290 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1544) --Mini tuning fork
         else
             player:addItem(1544)

--- a/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
+++ b/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
@@ -35,7 +35,7 @@ entity.onEventFinish = function(player, csid, option)
     if (csid == 191) then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.PERSONAL_HYGIENE)
     elseif (csid == 193) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13247)
         else
             player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.PERSONAL_HYGIENE)

--- a/scripts/zones/Kazham/npcs/Hari_Pakhroib.lua
+++ b/scripts/zones/Kazham/npcs/Hari_Pakhroib.lua
@@ -19,21 +19,21 @@ entity.onTrigger = function(player, npc)
     local pfame = player:getFameLevel(xi.quest.fame_area.WINDURST)
     local needToZone = player:needToZone()
 
-    if (guardian == QUEST_ACCEPTED) then
-        if (pamamas == 1) then
+    if guardian == QUEST_ACCEPTED then
+        if pamamas == 1 then
             player:startEvent(71) --Finish Quest
         else
             player:startEvent(69, 0, 4596) --Reminder Dialogue
         end
-    elseif (guardian == QUEST_AVAILABLE and pfame >= 7) then
+    elseif guardian == QUEST_AVAILABLE and pfame >= 7 then
         player:startEvent(68, 4596, 4596, 4596) --Start Quest
-    elseif (guardian == QUEST_COMPLETED and needToZone == false) then
-        if (pamamas == 2) then
+    elseif guardian == QUEST_COMPLETED and not needToZone then
+        if pamamas == 2 then
             player:startEvent(71) --Finish quest dialogue (no different csid between initial and repeats)
         else
             player:startEvent(72) --Dialogue for after completion of quest
         end
-    elseif (guardian == QUEST_COMPLETED and needToZone == true) then
+    elseif guardian == QUEST_COMPLETED and needToZone then
         player:startEvent(72)
     else
         player:startEvent(84) --Standard Dialogue
@@ -44,12 +44,12 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 68 and option == 1) then
+    if csid == 68 and option == 1 then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.GREETINGS_TO_THE_GUARDIAN)
         player:setCharVar("PamamaVar", 0)
-    elseif (csid == 71) then
+    elseif csid == 71 then
         local pamamas = player:getCharVar("PamamaVar")
-        if (pamamas == 1) then --First completion of quest; set title, complete quest, and give higher fame
+        if pamamas == 1 then --First completion of quest; set title, complete quest, and give higher fame
             player:addGil(xi.settings.main.GIL_RATE * 5000)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 5000)
             player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.GREETINGS_TO_THE_GUARDIAN)
@@ -57,7 +57,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addTitle(xi.title.KAZHAM_CALLER)
             player:setCharVar("PamamaVar", 0)
             player:needToZone(true)
-        elseif (pamamas == 2) then --Repeats of quest; give only gil and less fame
+        elseif pamamas == 2 then --Repeats of quest; give only gil and less fame
             player:addGil(xi.settings.main.GIL_RATE * 5000)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 5000)
             player:addFame(xi.quest.fame_area.WINDURST, 30)

--- a/scripts/zones/Kazham/npcs/Rauteinot.lua
+++ b/scripts/zones/Kazham/npcs/Rauteinot.lua
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RAUTEINOTS_PARCEL)
         player:tradeComplete()
     elseif (csid == 141) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4728)
         else
             player:setCharVar("MissionaryManVar", 0)

--- a/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
@@ -16,7 +16,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+    if xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30 then
         local hasStone = xi.abyssea.getHeldTraverserStones(player)
         if
             hasStone >= 1 and
@@ -36,11 +36,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 9) then
+    if csid == 9 then
         player:addQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_GOLDSTRUCK_GIGAS)
-    elseif (csid == 10) then
+    elseif csid == 10 then
         -- Killed Briareus
-    elseif (csid == 218 and option == 1) then
+    elseif csid == 218 and option == 1 then
         player:setPos(-480, 0, 794, 62, 132)
     end
 end

--- a/scripts/zones/Metalworks/npcs/Ayame.lua
+++ b/scripts/zones/Metalworks/npcs/Ayame.lua
@@ -9,9 +9,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCharVar("FadedPromises") == 1) then
+    if player:getCharVar("FadedPromises") == 1 then
         player:startEvent(803)
-    elseif (player:getCharVar("FadedPromises") == 3) then
+    elseif player:getCharVar("FadedPromises") == 3 then
         player:startEvent(804)
     end
 end
@@ -20,9 +20,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 803 and option == 1) then
+    if csid == 803 and option == 1 then
         player:setCharVar("FadedPromises", 2)
-    elseif (csid == 804) then
+    elseif csid == 804 then
         player:setCharVar("FadedPromises", 4)
     end
 end

--- a/scripts/zones/Metalworks/npcs/Ferghus.lua
+++ b/scripts/zones/Metalworks/npcs/Ferghus.lua
@@ -15,9 +15,9 @@ entity.onTrigger = function(player, npc)
     local tooManyChefs = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TOO_MANY_CHEFS)
     local pFame = player:getFameLevel(xi.quest.fame_area.BASTOK)
 
-    if (tooManyChefs == QUEST_AVAILABLE and pFame >= 5) then
+    if tooManyChefs == QUEST_AVAILABLE and pFame >= 5 then
         player:startEvent(946) -- Start Quest "Too Many Chefs"
-    elseif (player:getCharVar("TOO_MANY_CHEFS") == 4) then -- after trade to Leonhardt
+    elseif player:getCharVar("TOO_MANY_CHEFS") == 4 then -- after trade to Leonhardt
         player:startEvent(947)
     else
         player:startEvent(420) -- Standard
@@ -28,10 +28,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 946 and option == 0) then
+    if csid == 946 and option == 0 then
         player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TOO_MANY_CHEFS)
         player:setCharVar("TOO_MANY_CHEFS", 1)
-    elseif (csid == 947) then
+    elseif csid == 947 then
         player:setCharVar("TOO_MANY_CHEFS", 5)
     end
 end

--- a/scripts/zones/Metalworks/npcs/Leonhardt.lua
+++ b/scripts/zones/Metalworks/npcs/Leonhardt.lua
@@ -6,7 +6,7 @@
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getCharVar("TOO_MANY_CHEFS") == 3) then
+    if player:getCharVar("TOO_MANY_CHEFS") == 3 then
         if trade:hasItemQty(2527, 1) then -- Trade Red Oven Mitt
             player:tradeComplete()
             player:startEvent(950)
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCharVar("TOO_MANY_CHEFS") == 1) then
+    if player:getCharVar("TOO_MANY_CHEFS") == 1 then
         player:startEvent(948) -- part 2 Too Many Chefs
     else
         player:startEvent(945) -- standard
@@ -26,9 +26,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 948) then
+    if csid == 948 then
         player:setCharVar("TOO_MANY_CHEFS", 2)
-    elseif (csid == 950) then
+    elseif csid == 950 then
         player:setCharVar("TOO_MANY_CHEFS", 4)
     end
 end

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -116,15 +116,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
-    if (csid == 800) then
+    if csid == 800 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
-    if (csid == 800) then
+    if csid == 800 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
-    elseif (csid == 801) then
+    elseif csid == 801 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end
 end

--- a/scripts/zones/Metalworks/npcs/Udine_AMAN.lua
+++ b/scripts/zones/Metalworks/npcs/Udine_AMAN.lua
@@ -10,11 +10,11 @@ end
 
 entity.onTrigger = function(player, npc)
     local var = 0
-    if (player:getMentor() == false) then
-        if (player:getMainLvl() >= 30 and player:getPlaytime() >= 648000) then
+    if not player:getMentor() then
+        if player:getMainLvl() >= 30 and player:getPlaytime() >= 648000 then
             var = 1
         end
-    elseif (player:getMentor() == true) then
+    elseif player:getMentor() then
         var = 2
     end
     player:startEvent(826, var)
@@ -24,7 +24,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 826 and option == 0) then
+    if csid == 826 and option == 0 then
         player:setMentor(true)
     end
 end

--- a/scripts/zones/Metalworks/npcs/relic.lua
+++ b/scripts/zones/Metalworks/npcs/relic.lua
@@ -10,7 +10,7 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getCharVar("RELIC_IN_PROGRESS") == xi.items.FERDINAND and npcUtil.tradeHas(trade, { xi.items.TEN_THOUSAND_BYNE_BILL, xi.items.ETHEREAL_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.FERDINAND })) then -- currency, shard, necropsyche, stage 4
+    if player:getCharVar("RELIC_IN_PROGRESS") == xi.items.FERDINAND and npcUtil.tradeHas(trade, { xi.items.TEN_THOUSAND_BYNE_BILL, xi.items.ETHEREAL_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.FERDINAND }) then -- currency, shard, necropsyche, stage 4
         player:startEvent(843, xi.items.ANNIHILATOR)
     end
 end
@@ -23,7 +23,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 843 and npcUtil.giveItem(player, { xi.items.ANNIHILATOR, { xi.items.ONE_HUNDRED_BYNE_BILL, 30 } })) then
+    if csid == 843 and npcUtil.giveItem(player, { xi.items.ANNIHILATOR, { xi.items.ONE_HUNDRED_BYNE_BILL, 30 } }) then
         player:confirmTrade()
         player:setCharVar("RELIC_IN_PROGRESS", 0)
     end

--- a/scripts/zones/Mhaura/npcs/Lacia.lua
+++ b/scripts/zones/Mhaura/npcs/Lacia.lua
@@ -42,7 +42,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 10025 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1548) --Mini tuning fork
         else
             player:addQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING)
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1548)
         end
     elseif (csid == 10029 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1548) --Mini tuning fork
         else
             player:addItem(1548)

--- a/scripts/zones/Norg/npcs/Mamaulabion.lua
+++ b/scripts/zones/Norg/npcs/Mamaulabion.lua
@@ -118,7 +118,7 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("MamaMia_date", getMidnight())
 
     elseif (csid == 197) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14625) -- Evokers Ring
         else
             player:addItem(14625) -- Evokers Ring

--- a/scripts/zones/Norg/npcs/Ryoma.lua
+++ b/scripts/zones/Norg/npcs/Ryoma.lua
@@ -49,16 +49,16 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 95) then
+    if csid == 95 then
         player:addKeyItem(xi.ki.SEALED_DAGGER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SEALED_DAGGER)
         player:delKeyItem(xi.ki.STRANGELY_SHAPED_CORAL)
         player:setCharVar("AyameAndKaede_Event", 4)
-    elseif (csid == 133) then
+    elseif csid == 133 then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TWENTY_IN_PIRATE_YEARS)
         player:setCharVar("twentyInPirateYearsCS", 1)
-    elseif (csid == 134) then
-        if (player:getFreeSlotsCount() <= 1) then
+    elseif csid == 134 then
+        if player:getFreeSlotsCount() <= 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17771)
         else
             player:delKeyItem(xi.ki.TRICK_BOX)
@@ -71,11 +71,11 @@ entity.onEventFinish = function(player, csid, option)
             player:addFame(xi.quest.fame_area.NORG, 30)
             player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TWENTY_IN_PIRATE_YEARS)
         end
-    elseif (csid == 135) then
+    elseif csid == 135 then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX)
-    elseif (csid == 136) then
+    elseif csid == 136 then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL)
-    elseif (csid == 137) then
+    elseif csid == 137 then
         player:setCharVar("trueWillCS", 1)
     end
 end

--- a/scripts/zones/Norg/npcs/Verctissa.lua
+++ b/scripts/zones/Norg/npcs/Verctissa.lua
@@ -43,7 +43,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 199 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1549) --Mini tuning fork
         else
             player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER)
@@ -51,7 +51,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1549)
         end
     elseif (csid == 203 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1549) --Mini tuning fork
         else
             player:addItem(1549)

--- a/scripts/zones/Northern_San_dOria/npcs/Abioleget.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Abioleget.lua
@@ -47,7 +47,7 @@ end
 entity.onEventFinish = function(player, csid, option)
 
     if (csid == 600) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13465)
         else
             player:addItem(13465)

--- a/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
@@ -88,7 +88,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif (csid == 45 and option == 0) then
         player:setCharVar("sharpeningTheSwordCS", 1)
     elseif (csid == 44) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17643)
         else
             player:delKeyItem(xi.ki.ORDELLE_WHETSTONE)

--- a/scripts/zones/Northern_San_dOria/npcs/Alphollon_C_Meriard.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Alphollon_C_Meriard.lua
@@ -27,7 +27,7 @@ entity.onTrade = function(player, npc, trade)
             end
         end
 
-        if (reward ~= 0) then
+        if reward ~= 0 then
             --Trade pair for a nice reward.
             player:startEvent(720, item, reward)
             player:setCharVar("reward", reward)
@@ -43,9 +43,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 720) then
+    if csid == 720 then
         local reward = player:getCharVar("reward")
-        if (reward ~= 0) then
+        if reward ~= 0 then
             player:tradeComplete()
             player:addItem(reward)
             player:setCharVar("reward", 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -116,15 +116,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
-    if (csid == 731) then
+    if csid == 731 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
-    if (csid == 731) then
+    if csid == 731 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 1, "guild_woodworking", keyitems, items)
-    elseif (csid == 732) then
+    elseif csid == 732 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Anilla.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Anilla.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 6)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 6)
+    then
         player:startEvent(808)
     else
         player:startEvent(586)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 808) then
+    if csid == 808 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 6, true))
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
@@ -38,7 +38,7 @@ entity.onEventFinish = function(player, csid, option)
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TROUBLE_AT_THE_SLUICE)
         player:setCharVar("troubleAtTheSluiceVar", 1)
     elseif (csid == 56) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16706) -- Heavy Axe
         else
             player:tradeComplete()

--- a/scripts/zones/Northern_San_dOria/npcs/Bertenont.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Bertenont.lua
@@ -16,7 +16,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 9)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 9)
+    then
         player:startEvent(809)
     else
         player:showText(npc, ID.text.BERTENONT_DIALOG)
@@ -27,7 +30,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 809) then
+    if csid == 809 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 9, true))
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Castilchat.lua
@@ -13,7 +13,12 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local count = trade:getItemCount()
-    if (trade:hasItemQty(1545, 1) and player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_ACCEPTED and player:getMainJob() == xi.job.SMN and count == 1) then -- Trade mini fork of ice
+    if
+        trade:hasItemQty(1545, 1) and
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_ACCEPTED and
+        player:getMainJob() == xi.job.SMN and
+        count == 1
+    then -- Trade mini fork of ice
         player:startEvent(734, 0, 1545, 4, 20)
     end
 end
@@ -21,17 +26,22 @@ end
 entity.onTrigger = function(player, npc)
     local trialSizeByIce = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE)
 
-    if (player:getMainLvl() >= 20 and player:getMainJob() == xi.job.SMN and trialSizeByIce == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2) then -- Requires player to be Summoner at least lvl 20
+    if
+        player:getMainLvl() >= 20 and
+        player:getMainJob() == xi.job.SMN and
+        trialSizeByIce == QUEST_AVAILABLE and
+        player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2
+    then -- Requires player to be Summoner at least lvl 20
         player:startEvent(733, 0, 1545, 4, 20)     --mini tuning fork of ice, zone, level
-    elseif (trialSizeByIce == QUEST_ACCEPTED) then
+    elseif trialSizeByIce == QUEST_ACCEPTED then
         local iceFork = player:hasItem(1545)
 
-        if (iceFork) then
+        if iceFork then
             player:startEvent(708) --Dialogue given to remind player to be prepared
         else
             player:startEvent(737, 0, 1545, 4, 20) -- Need another mini tuning fork
         end
-    elseif (trialSizeByIce == QUEST_COMPLETED) then
+    elseif trialSizeByIce == QUEST_COMPLETED then
         player:startEvent(736) -- Defeated Avatar
     else
         player:startEvent(711) -- Standard dialog
@@ -42,22 +52,22 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 733 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+    if csid == 733 and option == 1 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1545)
         else
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE)
             player:addItem(1545)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1545)
         end
-    elseif (csid == 734 and option == 0 or csid == 737) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 734 and option == 0 or csid == 737 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1545)
         else
             player:addItem(1545)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1545)
         end
-    elseif (csid == 734 and option == 1) then
+    elseif csid == 734 and option == 1 then
         xi.teleport.to(player, xi.teleport.id.CLOISTER_OF_FROST)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Charlaimagnat.lua
@@ -15,11 +15,21 @@ end
 entity.onTrigger = function(player, npc)
     local theMissingPiece = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.THE_MISSING_PIECE)
 
-    if (theMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC) and player:hasKeyItem(xi.ki.LETTER_FROM_ALFESAR)) then
+    if
+        theMissingPiece == QUEST_ACCEPTED and
+        player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC) and
+        player:hasKeyItem(xi.ki.LETTER_FROM_ALFESAR)
+    then
         player:startEvent(703) -- Continuing the Quest
-    elseif (theMissingPiece == QUEST_ACCEPTED and os.time() < player:getCharVar("TheMissingPiece_date")) then
+    elseif
+        theMissingPiece == QUEST_ACCEPTED and
+        os.time() < player:getCharVar("TheMissingPiece_date")
+    then
         player:startEvent(704) -- didn't wait a day yet
-    elseif (theMissingPiece == QUEST_ACCEPTED and os.time() >= player:getCharVar("TheMissingPiece_date")) then
+    elseif
+        theMissingPiece == QUEST_ACCEPTED and
+        os.time() >= player:getCharVar("TheMissingPiece_date")
+    then
         player:startEvent(705) -- Quest Completed
     else
         player:startEvent(702) -- standard dialogue
@@ -30,13 +40,13 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 703) then
+    if csid == 703 then
         player:setCharVar("TheMissingPiece_date", os.time() + 60)
         player:addTitle(xi.title.ACQUIRER_OF_ANCIENT_ARCANUM)
         player:delKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
         player:delKeyItem(xi.ki.LETTER_FROM_ALFESAR)
-    elseif (csid == 705) then
-        if (player:getFreeSlotsCount() == 0) then -- does the player have space
+    elseif csid == 705 then
+        if player:getFreeSlotsCount() == 0 then -- does the player have space
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4729)
         else -- give player teleport-altep
             player:addItem(4729)

--- a/scripts/zones/Northern_San_dOria/npcs/Commojourt.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Commojourt.lua
@@ -11,7 +11,7 @@ end
 entity.onTrigger = function(player, npc)
     local rand = math.random(1, 2)
 
-    if (rand == 1) then
+    if rand == 1 then
         player:startEvent(653)
     else
         player:startEvent(657)

--- a/scripts/zones/Northern_San_dOria/npcs/Emeige_AMAN.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Emeige_AMAN.lua
@@ -10,11 +10,11 @@ end
 
 entity.onTrigger = function(player, npc)
     local var = 0
-    if (player:getMentor() == false) then
-        if (player:getMainLvl() >= 30 and player:getPlaytime() >= 648000) then
+    if not player:getMentor() then
+        if player:getMainLvl() >= 30 and player:getPlaytime() >= 648000 then
             var = 1
         end
-    elseif (player:getMentor() == true) then
+    elseif player:getMentor() then
         var = 2
     end
     player:startEvent(739, var)
@@ -24,7 +24,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 739 and option == 0) then
+    if csid == 739 and option == 0 then
         player:setMentor(true)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Eperdur.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Eperdur.lua
@@ -44,7 +44,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 680 then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4732)
         else
             player:addTitle(xi.title.PILGRIM_TO_MEA)

--- a/scripts/zones/Northern_San_dOria/npcs/Giaunne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Giaunne.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 5)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 5)
+    then
         player:startEvent(805)
     else
         player:startEvent(667)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 805) then
+    if csid == 805 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 5, true))
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
@@ -18,31 +18,43 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByIce = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE)
-    local whisperOfFrost = player:hasKeyItem(xi.ki.WHISPER_OF_FROST)
     local classReunion = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CLASS_REUNION)
     local classReunionProgress = player:getCharVar("ClassReunionProgress")
 
     -----------------------------------
     -- Class Reunion
-    if (classReunion == 1 and classReunionProgress == 4) then
+    if classReunion == 1 and classReunionProgress == 4 then
         player:startEvent(713, 0, 1171, 0, 0, 0, 0, 0, 0) -- he gives you an ice pendulum and wants you to go to Cloister of Frost
-    elseif (classReunion == 1 and classReunionProgress == 5 and player:hasItem(1171) == false) then
+    elseif classReunion == 1 and classReunionProgress == 5 and not player:hasItem(1171) then
         player:startEvent(712, 0, 1171, 0, 0, 0, 0, 0, 0) -- lost the ice pendulum need another one
     -----------------------------------
-    elseif ((trialByIce == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 6) or (trialByIce == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByIce_date"))) then
+    elseif
+        (trialByIce == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 6) or
+        (trialByIce == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByIce_date"))
+    then
         player:startEvent(706, 0, xi.ki.TUNING_FORK_OF_ICE) -- Start and restart quest "Trial by ice"
-    elseif (trialByIce == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_ICE) == false and whisperOfFrost == false) then
+    elseif
+        trialByIce == QUEST_ACCEPTED and
+        not player:hasKeyItem(xi.ki.TUNING_FORK_OF_ICE) and
+        not player:hasKeyItem(xi.ki.WHISPER_OF_FROST)
+    then
         player:startEvent(718, 0, xi.ki.TUNING_FORK_OF_ICE) -- Defeat against Shiva : Need new Fork
-    elseif (trialByIce == QUEST_ACCEPTED and whisperOfFrost == false) then
+    elseif
+        trialByIce == QUEST_ACCEPTED and
+        not player:hasKeyItem(xi.ki.WHISPER_OF_FROST)
+    then
         player:startEvent(707, 0, xi.ki.TUNING_FORK_OF_ICE, 4)
-    elseif (trialByIce == QUEST_ACCEPTED and whisperOfFrost) then
+    elseif
+        trialByIce == QUEST_ACCEPTED and
+        player:hasKeyItem(xi.ki.WHISPER_OF_FROST)
+    then
         local numitem = 0
 
-        if (player:hasItem(17492)) then numitem = numitem + 1; end  -- Shiva's Claws
-        if (player:hasItem(13242)) then numitem = numitem + 2; end  -- Ice Belt
-        if (player:hasItem(13561)) then numitem = numitem + 4; end  -- Ice Ring
-        if (player:hasItem(1207)) then numitem = numitem + 8; end   -- Rust 'B' Gone
-        if (player:hasSpell(302)) then numitem = numitem + 32; end  -- Ability to summon Shiva
+        if player:hasItem(17492) then numitem = numitem + 1 end  -- Shiva's Claws
+        if player:hasItem(13242) then numitem = numitem + 2 end  -- Ice Belt
+        if player:hasItem(13561) then numitem = numitem + 4 end  -- Ice Ring
+        if player:hasItem(1207) then numitem = numitem + 8 end   -- Rust 'B' Gone
+        if player:hasSpell(302) then numitem = numitem + 32 end  -- Ability to summon Shiva
 
         player:startEvent(709, 0, xi.ki.TUNING_FORK_OF_ICE, 4, 0, numitem)
     else
@@ -54,32 +66,32 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 706 and option == 1) then
-        if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE) == QUEST_COMPLETED) then
+    if csid == 706 and option == 1 then
+        if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE) == QUEST_COMPLETED then
             player:delQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE)
         end
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE)
         player:setCharVar("TrialByIce_date", 0)
         player:addKeyItem(xi.ki.TUNING_FORK_OF_ICE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TUNING_FORK_OF_ICE)
-    elseif (csid == 718) then
+    elseif csid == 718 then
         player:addKeyItem(xi.ki.TUNING_FORK_OF_ICE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TUNING_FORK_OF_ICE)
-    elseif (csid == 709) then
+    elseif csid == 709 then
         local item = 0
-        if (option == 1) then item = 17492         -- Shiva's Claws
-        elseif (option == 2) then item = 13242  -- Ice Belt
-        elseif (option == 3) then item = 13561  -- Ice Ring
-        elseif (option == 4) then item = 1207     -- Rust 'B' Gone
+        if option == 1 then item = 17492         -- Shiva's Claws
+        elseif option == 2 then item = 13242  -- Ice Belt
+        elseif option == 3 then item = 13561  -- Ice Ring
+        elseif option == 4 then item = 1207     -- Rust 'B' Gone
         end
 
-        if (player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6)) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
-            if (option == 5) then
+            if option == 5 then
                 player:addGil(xi.settings.main.GIL_RATE * 10000)
                 player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 10000) -- Gil
-            elseif (option == 6) then
+            elseif option == 6 then
                 player:addSpell(302) -- Avatar
                 player:messageSpecial(ID.text.SHIVA_UNLOCKED, 0, 0, 4)
             else
@@ -92,8 +104,8 @@ entity.onEventFinish = function(player, csid, option)
             player:addFame(xi.quest.fame_area.SANDORIA, 30)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TRIAL_BY_ICE)
         end
-    elseif (csid == 713 or csid == 712) then
-        if (player:getFreeSlotsCount() ~= 0) then
+    elseif csid == 713 or csid == 712 then
+        if player:getFreeSlotsCount() ~= 0 then
             player:addItem(1171)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1171)
             player:setCharVar("ClassReunionProgress", 5)

--- a/scripts/zones/Northern_San_dOria/npcs/Lotine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Lotine.lua
@@ -11,7 +11,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local rand = math.random(1, 2)
-    if (rand == 1) then
+    if rand == 1 then
         player:startEvent(652)
     else
         player:startEvent(656)

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -116,15 +116,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
-    if (csid == 729) then
+    if csid == 729 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
-    if (csid == 729) then
+    if csid == 729 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 2, "guild_smithing", keyitems, items)
-    elseif (csid == 730) then
+    elseif csid == 730 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Miaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Miaux.lua
@@ -19,21 +19,21 @@ entity.onTrigger = function(player, npc)
     local aCraftsmansWork = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_CRAFTSMAN_S_WORK)
     local quotasStatus    = player:getCharVar("ChasingQuotas_Progress")
 
-    if (player:getMainJob() == xi.job.DRG and player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and aCraftsmansWork == QUEST_AVAILABLE) then
-        if (player:getCharVar("has_seen_drgaf1_quest_already") == 0) then
+    if player:getMainJob() == xi.job.DRG and player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and aCraftsmansWork == QUEST_AVAILABLE then
+        if player:getCharVar("has_seen_drgaf1_quest_already") == 0 then
             player:startEvent(73)
         else -- If player has seen the big cut scene, give them a smaller one.
             player:startEvent(71)
         end
-    elseif (aCraftsmansWork == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.ALTEPA_POLISHING_STONE) == false) then
+    elseif aCraftsmansWork == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.ALTEPA_POLISHING_STONE) then
         player:startEvent(69)
-    elseif (aCraftsmansWork == QUEST_ACCEPTED) then
+    elseif aCraftsmansWork == QUEST_ACCEPTED then
             player:startEvent(70)
-    elseif (quotasStatus == 2) then
+    elseif quotasStatus == 2 then
         player:startEvent(67) -- I found this earring.
-    elseif (quotasStatus == 3 or quotasStatus == 4) then
+    elseif quotasStatus == 3 or quotasStatus == 4 then
         player:startEvent(68) -- Post-earring, move along.
-    elseif (quotasStatus >= 5) then
+    elseif quotasStatus >= 5 then
         player:startEvent(66) -- The earring was helpful?
     else
         player:startEvent(11)
@@ -44,14 +44,14 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 73 and option == 0) then -- first part of long CS -- declines questgiver
+    if csid == 73 and option == 0 then -- first part of long CS -- declines questgiver
         player:setCharVar("has_seen_drgaf1_quest_already", 1)
-    elseif ((csid == 73 or csid == 71) and option == 1) then
+    elseif (csid == 73 or csid == 71) and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_CRAFTSMAN_S_WORK)
         player:setCharVar("has_seen_drgaf1_quest_already", 0)
         player:setCharVar("aCraftsmanWork", 1)
-    elseif (csid == 70) then -- This is only if player has Altepa Polishing Stone
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 70 then -- This is only if player has Altepa Polishing Stone
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16887)-- Peregrine (DRG AF1)
         else
             player:setCharVar("aCraftsmanWork", 0)
@@ -61,7 +61,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addFame(xi.quest.fame_area.SANDORIA, 20)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_CRAFTSMAN_S_WORK)
         end
-    elseif (csid == 67) then
+    elseif csid == 67 then
         player:addKeyItem(xi.ki.SHINY_EARRING)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SHINY_EARRING)
         player:setCharVar("ChasingQuotas_Progress", 3)

--- a/scripts/zones/Northern_San_dOria/npcs/Phairupegiont.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Phairupegiont.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 8)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 8)
+    then
         player:startEvent(806)
     else
         player:startEvent(663)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 806) then
+    if csid == 806 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 8, true))
     end
 end

--- a/scripts/zones/Port_Bastok/npcs/Dulsie.lua
+++ b/scripts/zones/Port_Bastok/npcs/Dulsie.lua
@@ -10,11 +10,9 @@ local ID = require("scripts/zones/Port_Bastok/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-
-    if (trade:hasItemQty(536, 1) and trade:getItemCount() == 1) then
+    if trade:hasItemQty(536, 1) and trade:getItemCount() == 1 then
         player:startEvent(8)
     end
-
 end
 
 entity.onTrigger = function(player, npc)
@@ -25,13 +23,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 8) then
+    if csid == 8 then
         player:tradeComplete()
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 50)
     end
-
 end
 
 return entity

--- a/scripts/zones/Port_Bastok/npcs/Ferrol.lua
+++ b/scripts/zones/Port_Bastok/npcs/Ferrol.lua
@@ -42,7 +42,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 297 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1547) --Mini tuning fork
         else
             player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH)
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1547)
         end
     elseif (csid == 301 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1547) --Mini tuning fork
         else
             player:addItem(1547)

--- a/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
@@ -103,7 +103,7 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("ChasingQuotas_Progress", 2)
         player:setCharVar("ChasingQuotas_date", 0)
     elseif (csid == 15) then
-        if (player:getFreeSlotsCount() < 1) then
+        if player:getFreeSlotsCount() < 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14227)
         else
             player:delKeyItem(xi.ki.RANCHURIOMES_LEGACY)

--- a/scripts/zones/Port_San_dOria/npcs/Cherlodeau.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Cherlodeau.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 12)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 12)
+    then
         player:startEvent(748)
     else
         player:startEvent(590)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 748) then
+    if csid == 748 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 12, true))
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
@@ -59,7 +59,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 303) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17386)
         else
             player:tradeComplete()

--- a/scripts/zones/Port_San_dOria/npcs/Joulet.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Joulet.lua
@@ -61,7 +61,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 307) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17386)
         else
             player:tradeComplete()

--- a/scripts/zones/Port_San_dOria/npcs/Perdiouvilet.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Perdiouvilet.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 10)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 10)
+    then
         player:startEvent(750)
     else
         player:startEvent(762)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 750) then
+    if csid == 750 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 10, true))
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Pomilla.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Pomilla.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 11)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 11)
+    then
         player:startEvent(749)
     else
         player:startEvent(562)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 749) then
+    if csid == 749 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 11, true))
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
@@ -12,11 +12,18 @@ entity.onTrade = function(player, npc, trade)
     local letterRed = player:getCharVar("LeleroonsLetterRed")
 
     -- gold chain, velvet cloth, red grass cloth, sailcloth
-    if (letterRed == 2 and trade:getItemCount() == 4 and trade:hasItemQty(761, 1) and trade:hasItemQty(828, 1) and trade:hasItemQty(1829, 1) and trade:hasItemQty(1997, 1)) then
+    if
+        letterRed == 2 and
+        trade:getItemCount() == 4 and
+        trade:hasItemQty(761, 1) and
+        trade:hasItemQty(828, 1) and
+        trade:hasItemQty(1829, 1) and
+        trade:hasItemQty(1997, 1)
+    then
         player:startEvent(755) -- accepts materials, now bring me imperial gold piece
 
     -- imperial gold piece
-    elseif (letterRed == 3 and trade:getItemCount() == 1 and trade:hasItemQty(2187, 1)) then
+    elseif letterRed == 3 and trade:getItemCount() == 1 and trade:hasItemQty(2187, 1) then
         player:startEvent(760) -- accepts gold piece, now wait for next vana'diel day
 
     end
@@ -24,19 +31,19 @@ end
 
 entity.onTrigger = function(player, npc)
     local letterRed = player:getCharVar("LeleroonsLetterRed")
-    if (player:hasKeyItem(xi.ki.LELEROONS_LETTER_RED)) then
+    if player:hasKeyItem(xi.ki.LELEROONS_LETTER_RED) then
         player:startEvent(753) -- accept letter, now bring me four items
-    elseif (letterRed == 2) then
+    elseif letterRed == 2 then
         player:startEvent(754) -- i'm waiting for four items
-    elseif (letterRed == 3) then
+    elseif letterRed == 3 then
         player:startEvent(761) -- i'm waiting for imperial gold piece
-    elseif (letterRed == 4) then
-        if (vanaDay() > player:getCharVar("corAfSubmitDay")) then
+    elseif letterRed == 4 then
+        if vanaDay() > player:getCharVar("corAfSubmitDay") then
             player:startEvent(756) -- here's your cor frac
         else
             player:startEvent(757) -- patience. need to wait for vana'diel day
         end
-    elseif (letterRed == 5) then
+    elseif letterRed == 5 then
         player:startEvent(758) -- are you caring for your corsair's frac?
     else
         player:startEvent(759) -- default dialog
@@ -47,17 +54,17 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 753) then
+    if csid == 753 then
         player:setCharVar("LeleroonsLetterRed", 2)
         player:delKeyItem(xi.ki.LELEROONS_LETTER_RED)
-    elseif (csid == 755) then
+    elseif csid == 755 then
         player:tradeComplete()
         player:setCharVar("LeleroonsLetterRed", 3)
-    elseif (csid == 760) then
+    elseif csid == 760 then
         player:tradeComplete()
         player:setCharVar("LeleroonsLetterRed", 4)
         player:setCharVar("corAfSubmitDay", vanaDay())
-    elseif (csid == 756) then
+    elseif csid == 756 then
         player:setCharVar("LeleroonsLetterRed", 5)
         player:addItem(14522) -- corsair's frac
         player:messageSpecial(ID.text.ITEM_OBTAINED, 14522)

--- a/scripts/zones/Port_Windurst/npcs/Kuroido-Moido.lua
+++ b/scripts/zones/Port_Windurst/npcs/Kuroido-Moido.lua
@@ -49,7 +49,7 @@ entity.onTrigger = function(player, npc)
         end
     else
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(225)   -- Standard Conversation
         else
             player:startEvent(226)   -- Standard Conversation

--- a/scripts/zones/Port_Windurst/npcs/Ohruru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Ohruru.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
 -- ======== FOR TESTING ONLY ==========-----
 --    if (player:getCharVar("QuestCatchItIfYouCan_var") == 0 and player:hasStatusEffect(xi.effect.MUTE) == false and player:hasStatusEffect(xi.effect.BANE) == false and player:hasStatusEffect(xi.effect.PLAGUE) == false) then
 --        rand = math.random(1, 3)
---        if (rand == 1) then
+--        if rand == 1 then
 --            player:addStatusEffect(xi.effect.MUTE, 0, 0, 100)
 --        elseif (rand == 2) then
 --            player:addStatusEffect(xi.effect.BANE, 0, 0, 100)
@@ -55,7 +55,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(255) -- CATCH IT IF YOU CAN: After Quest
     elseif (catch == 1 and player:hasStatusEffect(xi.effect.MUTE) == false and player:hasStatusEffect(xi.effect.BANE) == false and player:hasStatusEffect(xi.effect.PLAGUE) == false) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(248) -- CATCH IT IF YOU CAN: During Quest 1
         else
             player:startEvent(251) -- CATCH IT IF YOU CAN: During Quest 2

--- a/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
+++ b/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
@@ -77,7 +77,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif (csid == 10009 and option == 1) then
         local crystal = 4101 -- water crystal
 
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, crystal)
         else
             player:addItem(crystal)

--- a/scripts/zones/Rabao/npcs/Agado-Pugado.lua
+++ b/scripts/zones/Rabao/npcs/Agado-Pugado.lua
@@ -17,36 +17,48 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByWind = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND)
-    local whisperOfGales = player:hasKeyItem(xi.ki.WHISPER_OF_GALES)
     local carbuncleDebacle = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CARBUNCLE_DEBACLE)
     local carbuncleDebacleProgress = player:getCharVar("CarbuncleDebacleProgress")
 
     -----------------------------------
     -- Carbuncle Debacle
-    if (carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 5 and player:hasKeyItem(xi.ki.DAZE_BREAKER_CHARM) == true) then
+    if carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 5 and player:hasKeyItem(xi.ki.DAZE_BREAKER_CHARM) then
         player:startEvent(86) -- get the wind pendulum, lets go to Cloister of Gales
-    elseif (carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 6) then
-        if (player:hasItem(1174) == false) then
+    elseif carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 6 then
+        if not player:hasItem(1174) then
             player:startEvent(87, 0, 1174, 0, 0, 0, 0, 0, 0) -- "lost the pendulum?" This one too~???
         else
             player:startEvent(88) -- reminder to go to Cloister of Gales
         end
     -----------------------------------
     -- Trial by Wind
-    elseif ((trialByWind == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SELBINA_RABAO) >= 5) or (trialByWind == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByWind_date"))) then
+    elseif
+        (trialByWind == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SELBINA_RABAO) >= 5) or
+        (trialByWind == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByWind_date"))
+    then
         player:startEvent(66, 0, 331) -- Start and restart quest "Trial by Wind"
-    elseif (trialByWind == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_WIND) == false and whisperOfGales == false) then
+    elseif
+        trialByWind == QUEST_ACCEPTED and
+        not player:hasKeyItem(xi.ki.TUNING_FORK_OF_WIND) and
+        not player:hasKeyItem(xi.ki.WHISPER_OF_GALES)
+    then
         player:startEvent(107, 0, 331) -- Defeat against Avatar : Need new Fork
-    elseif (trialByWind == QUEST_ACCEPTED and whisperOfGales == false) then
+    elseif
+        trialByWind == QUEST_ACCEPTED and
+        not player:hasKeyItem(xi.ki.WHISPER_OF_GALES)
+    then
         player:startEvent(67, 0, 331, 3)
-    elseif (trialByWind == QUEST_ACCEPTED and whisperOfGales) then
+    elseif
+        trialByWind == QUEST_ACCEPTED and
+        player:hasKeyItem(xi.ki.WHISPER_OF_GALES)
+    then
         local numitem = 0
 
-        if (player:hasItem(17627)) then numitem = numitem + 1; end  -- Garuda's Dagger
-        if (player:hasItem(13243)) then numitem = numitem + 2; end  -- Wind Belt
-        if (player:hasItem(13562)) then numitem = numitem + 4; end  -- Wind Ring
-        if (player:hasItem(1202)) then numitem = numitem + 8; end   -- Bubbly Water
-        if (player:hasSpell(301)) then numitem = numitem + 32; end  -- Ability to summon Garuda
+        if player:hasItem(17627) then numitem = numitem + 1 end  -- Garuda's Dagger
+        if player:hasItem(13243) then numitem = numitem + 2 end  -- Wind Belt
+        if player:hasItem(13562) then numitem = numitem + 4 end  -- Wind Ring
+        if player:hasItem(1202) then numitem = numitem + 8 end   -- Bubbly Water
+        if player:hasSpell(301) then numitem = numitem + 32 end  -- Ability to summon Garuda
 
         player:startEvent(69, 0, 331, 3, 0, numitem)
     else
@@ -58,32 +70,32 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 66 and option == 1) then
-        if (player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND) == QUEST_COMPLETED) then
+    if csid == 66 and option == 1 then
+        if player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND) == QUEST_COMPLETED then
             player:delQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND)
         end
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND)
         player:setCharVar("TrialByWind_date", 0)
         player:addKeyItem(xi.ki.TUNING_FORK_OF_WIND)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TUNING_FORK_OF_WIND)
-    elseif (csid == 107) then
+    elseif csid == 107 then
         player:addKeyItem(xi.ki.TUNING_FORK_OF_WIND)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TUNING_FORK_OF_WIND)
-    elseif (csid == 69) then
+    elseif csid == 69 then
         local item = 0
-        if (option == 1) then item = 17627         -- Garuda's Dagger
-        elseif (option == 2) then item = 13243  -- Wind Belt
-        elseif (option == 3) then item = 13562  -- Wind Ring
-        elseif (option == 4) then item = 1202     -- Bubbly Water
+        if option == 1 then item = 17627         -- Garuda's Dagger
+        elseif option == 2 then item = 13243  -- Wind Belt
+        elseif option == 3 then item = 13562  -- Wind Ring
+        elseif option == 4 then item = 1202     -- Bubbly Water
         end
 
-        if (player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6)) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
-            if (option == 5) then
+            if option == 5 then
                 player:addGil(xi.settings.main.GIL_RATE * 10000)
                 player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 10000) -- Gil
-            elseif (option == 6) then
+            elseif option == 6 then
                 player:addSpell(301) -- Garuda Spell
                 player:messageSpecial(ID.text.GARUDA_UNLOCKED, 0, 0, 3)
             else
@@ -96,8 +108,8 @@ entity.onEventFinish = function(player, csid, option)
             player:addFame(xi.quest.fame_area.SELBINA_RABAO, 30)
             player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WIND)
         end
-    elseif (csid == 86 or csid == 87) then
-        if (player:getFreeSlotsCount() ~= 0) then
+    elseif csid == 86 or csid == 87 then
+        if player:getFreeSlotsCount() ~= 0 then
             player:addItem(1174)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1174)
             player:setCharVar("CarbuncleDebacleProgress", 6)

--- a/scripts/zones/Rabao/npcs/Leodarion.lua
+++ b/scripts/zones/Rabao/npcs/Leodarion.lua
@@ -15,36 +15,39 @@ local ID = require("scripts/zones/Rabao/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX) == QUEST_ACCEPTED and player:getCharVar("illTakeTheBigBoxCS") == 2) then
-        if (trade:hasItemQty(17098, 1) and trade:getItemCount() == 1) then -- Trade Oak Pole
+    if
+        player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX) == QUEST_ACCEPTED and
+        player:getCharVar("illTakeTheBigBoxCS") == 2
+    then
+        if trade:hasItemQty(17098, 1) and trade:getItemCount() == 1 then -- Trade Oak Pole
             player:startEvent(92)
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX) == QUEST_ACCEPTED) then
+    if player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.I_LL_TAKE_THE_BIG_BOX) == QUEST_ACCEPTED then
         local illTakeTheBigBoxCS = player:getCharVar("illTakeTheBigBoxCS")
 
-        if (illTakeTheBigBoxCS == 1) then
+        if illTakeTheBigBoxCS == 1 then
             player:startEvent(90)
-        elseif (illTakeTheBigBoxCS == 2) then
+        elseif illTakeTheBigBoxCS == 2 then
             player:startEvent(91)
-        elseif (illTakeTheBigBoxCS == 3 and VanadielDayOfTheYear() == player:getCharVar("illTakeTheBigBox_Timer")) then
+        elseif illTakeTheBigBoxCS == 3 and VanadielDayOfTheYear() == player:getCharVar("illTakeTheBigBox_Timer") then
             player:startEvent(93)
-        elseif (illTakeTheBigBoxCS == 3) then
+        elseif illTakeTheBigBoxCS == 3 then
             player:startEvent(94)
-        elseif (illTakeTheBigBoxCS == 4) then
+        elseif illTakeTheBigBoxCS == 4 then
             player:startEvent(95)
         end
-    elseif (player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED) then
+    elseif player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
         local trueWillCS = player:getCharVar("trueWillCS")
 
-        if (trueWillCS == 1) then
+        if trueWillCS == 1 then
             player:startEvent(97)
-        elseif (trueWillCS == 2 and player:hasKeyItem(xi.ki.LARGE_TRICK_BOX) == false) then
+        elseif trueWillCS == 2 and not player:hasKeyItem(xi.ki.LARGE_TRICK_BOX) then
             player:startEvent(98)
-        elseif (player:hasKeyItem(xi.ki.LARGE_TRICK_BOX)) then
+        elseif player:hasKeyItem(xi.ki.LARGE_TRICK_BOX) then
             player:startEvent(99)
         end
     else
@@ -56,21 +59,21 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 90) then
+    if csid == 90 then
         player:setCharVar("illTakeTheBigBoxCS", 2)
-    elseif (csid == 92) then
+    elseif csid == 92 then
         player:tradeComplete()
         player:setCharVar("illTakeTheBigBox_Timer", VanadielDayOfTheYear())
         player:setCharVar("illTakeTheBigBoxCS", 3)
-    elseif (csid == 94) then
+    elseif csid == 94 then
         player:setCharVar("illTakeTheBigBox_Timer", 0)
         player:setCharVar("illTakeTheBigBoxCS", 4)
         player:addKeyItem(xi.ki.SEANCE_STAFF)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SEANCE_STAFF)
-    elseif (csid == 97) then
+    elseif csid == 97 then
         player:delKeyItem(xi.ki.OLD_TRICK_BOX)
         player:setCharVar("trueWillCS", 2)
-    elseif (csid == 99) then
+    elseif csid == 99 then
         if
             npcUtil.completeQuest(player, xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRUE_WILL, {
                 item = 13782, -- Ninja Chainmail

--- a/scripts/zones/Rabao/npcs/Rahi_Fohlatti.lua
+++ b/scripts/zones/Rabao/npcs/Rahi_Fohlatti.lua
@@ -42,7 +42,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 108 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1546) --Mini tuning fork
         else
             player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WIND)
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 1546)
         end
     elseif (csid == 112 and option == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1546) --Mini tuning fork
         else
             player:addItem(1546)

--- a/scripts/zones/Ranguemont_Pass/npcs/Waters_of_Oblivion.lua
+++ b/scripts/zones/Ranguemont_Pass/npcs/Waters_of_Oblivion.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
     then
         player:messageSpecial(ID.text.SENSE_OF_FOREBODING)
         SpawnMob(ID.mob.TROS):updateClaim(player)
-    elseif (player:hasKeyItem(xi.ki.MERTAIRES_BRACELET) and trosKilled == 1) then
+    elseif player:hasKeyItem(xi.ki.MERTAIRES_BRACELET) and trosKilled == 1 then
         player:startEvent(8) -- Finish Quest "Painful Memory"
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
@@ -35,8 +35,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 8) then
-        if (npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.PAINFUL_MEMORY, { item = 16766 })) then
+    if csid == 8 then
+        if npcUtil.completeQuest(player, xi.quest.log_id.JEUNO, xi.quest.id.jeuno.PAINFUL_MEMORY, { item = 16766 }) then
             player:delKeyItem(xi.ki.MERTAIRES_BRACELET)
             player:setCharVar("TrosKilled", 0)
             player:setCharVar("Tros_Timer", 0)

--- a/scripts/zones/Southern_San_dOria/npcs/Ailevia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ailevia.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     -- Adventurer coupon
-    if (trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true) then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) then
         player:startEvent(655)
     end
 end
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 655) then
+    if csid == 655 then
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 50)

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -109,15 +109,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, target)
-    if (csid == 690) then
+    if csid == 690 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, target)
-    if (csid == 690) then
+    if csid == 690 then
         xi.crafting.unionRepresentativeTriggerFinish(player, option, target, 5, "guild_leathercraft", keyitems, items)
-    elseif (csid == 691) then
+    elseif csid == 691 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Amutiyaal.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Amutiyaal.lua
@@ -79,12 +79,12 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 812) then
+    if csid == 812 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT)
         player:setCharVar("WildcatSandy", 0)
         player:addKeyItem(xi.ki.RED_SENTINEL_BADGE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RED_SENTINEL_BADGE)
-    elseif (csid == 815) then
+    elseif csid == 815 then
         player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT)
         player:addFame(xi.quest.fame_area.SANDORIA, 150)
         player:setCharVar("WildcatSandy", 0)
@@ -92,7 +92,7 @@ entity.onEventFinish = function(player, csid, option)
         player:addKeyItem(xi.ki.RED_INVITATION_CARD)
         player:messageSpecial(ID.text.KEYITEM_LOST, xi.ki.RED_SENTINEL_BADGE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RED_INVITATION_CARD)
-    elseif (csid == 881) then
+    elseif csid == 881 then
         player:tradeComplete()
         xi.teleport.to(player, xi.teleport.id.WHITEGATE)
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
@@ -42,7 +42,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 541 and option == 0) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 567) -- Well Water
         else
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRAVE_CONCERNS)

--- a/scripts/zones/Southern_San_dOria/npcs/Authere.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Authere.lua
@@ -15,9 +15,12 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 1)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 1)
+    then
         player:startEvent(809)
-    elseif (player:getCharVar("BrothersCS") == 1) then
+    elseif player:getCharVar("BrothersCS") == 1 then
         player:startEvent(597)  -- brothers cs
     else
         player:startEvent(605)  -- when i grow up im gonna fight like trion
@@ -28,9 +31,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 809) then
+    if csid == 809 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 1, true))
-    elseif (csid == 597) then
+    elseif csid == 597 then
         player:setCharVar("BrothersCS", 0)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Daggao.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Daggao.lua
@@ -15,11 +15,14 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 0)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 0)
+    then
         player:startEvent(810)
-    elseif (player:getCharVar("peaceForTheSpiritCS") == 3) then
+    elseif player:getCharVar("peaceForTheSpiritCS") == 3 then
         player:startEvent(72)
-    elseif (player:getCharVar("peaceForTheSpiritCS") == 5) then
+    elseif player:getCharVar("peaceForTheSpiritCS") == 5 then
         player:startEvent(73)
     else
         player:startEvent(60)
@@ -30,9 +33,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 810) then
+    if csid == 810 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 0, true))
-    elseif (csid == 72) then
+    elseif csid == 72 then
         player:setCharVar("peaceForTheSpiritCS", 4)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Deraquien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Deraquien.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 4)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 4)
+    then
         player:startEvent(811)
     else
         player:startEvent(18)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 811) then
+    if csid == 811 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 4, true))
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Femitte.lua
@@ -19,13 +19,16 @@ entity.onTrigger = function(player, npc)
     local distantLoyalties = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 3)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 3)
+    then
         player:startEvent(807)
-    elseif (player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 4 and distantLoyalties == 0) then
+    elseif player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 4 and distantLoyalties == 0 then
         player:startEvent(663)
-    elseif (distantLoyalties == 1 and distantLoyaltiesProgress == 1) then
+    elseif distantLoyalties == 1 and distantLoyaltiesProgress == 1 then
         player:startEvent(664)
-    elseif (distantLoyalties == 1 and distantLoyaltiesProgress == 4 and player:hasKeyItem(xi.ki.MYTHRIL_HEARTS)) then
+    elseif distantLoyalties == 1 and distantLoyaltiesProgress == 4 and player:hasKeyItem(xi.ki.MYTHRIL_HEARTS) then
         player:startEvent(665)
     else
         player:startEvent(661)
@@ -36,15 +39,15 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 807) then
+    if csid == 807 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 3, true))
-    elseif (csid == 663 and option == 0) then
+    elseif csid == 663 and option == 0 then
         player:addKeyItem(xi.ki.GOLDSMITHING_ORDER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.GOLDSMITHING_ORDER)
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.DISTANT_LOYALTIES)
         player:setCharVar("DistantLoyaltiesProgress", 1)
-    elseif (csid == 665) then
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 665 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13585)
         else
             player:delKeyItem(xi.ki.MYTHRIL_HEARTS)

--- a/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
@@ -39,7 +39,7 @@ entity.onEventFinish = function(player, csid, option)
         player:addKeyItem(xi.ki.WEAPONS_ORDER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.WEAPONS_ORDER)
     elseif (csid == 607) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17090) -- Elm Staff
         else
             player:addTitle(xi.title.ARMS_TRADER)

--- a/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Hinaree.lua
@@ -12,7 +12,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 3 and player:getCharVar("Promathia_kill_day") < os.time() and player:getCharVar("COP_louverance_story") == 0 ) then
+    if
+        player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DAWN and
+        player:getCharVar("PromathiaStatus") == 3 and
+        player:getCharVar("Promathia_kill_day") < os.time() and
+        player:getCharVar("COP_louverance_story") == 0
+    then
         player:startEvent(757)
     end
 end
@@ -21,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 757) then
+    if csid == 757 then
         player:setCharVar("COP_louverance_story", 1)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Paouala.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Paouala.lua
@@ -13,8 +13,8 @@ local ID = require("scripts/zones/Southern_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SLEEPLESS_NIGHTS) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(4527, 1) and trade:getItemCount() == 1) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SLEEPLESS_NIGHTS) == QUEST_ACCEPTED then
+        if trade:hasItemQty(4527, 1) and trade:getItemCount() == 1 then
             player:startEvent(84)
         end
     end
@@ -23,11 +23,11 @@ end
 entity.onTrigger = function(player, npc)
     local sleeplessNights = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SLEEPLESS_NIGHTS)
 
-    if (player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 and sleeplessNights == QUEST_AVAILABLE) then
+    if player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 and sleeplessNights == QUEST_AVAILABLE then
         player:startEvent(85)
-    elseif (sleeplessNights == QUEST_ACCEPTED) then
+    elseif sleeplessNights == QUEST_ACCEPTED then
         player:startEvent(83)
-    elseif (sleeplessNights == QUEST_COMPLETED) then
+    elseif sleeplessNights == QUEST_COMPLETED then
         player:startEvent(81)
     else
         player:startEvent(82)
@@ -38,9 +38,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 85 and option == 1) then
+    if csid == 85 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.SLEEPLESS_NIGHTS)
-    elseif (csid == 84) then
+    elseif csid == 84 then
         player:tradeComplete()
         player:addTitle(xi.title.SHEEPS_MILK_DELIVERER)
         player:addGil(xi.settings.main.GIL_RATE * 5000)

--- a/scripts/zones/Southern_San_dOria/npcs/Parvipon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Parvipon.lua
@@ -11,8 +11,8 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING) ~= QUEST_AVAILABLE) then
-        if (trade:hasItemQty(856, 3) and trade:getItemCount() == 3) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING) ~= QUEST_AVAILABLE then
+        if trade:hasItemQty(856, 3) and trade:getItemCount() == 3 then
             player:startEvent(89)
         end
     end
@@ -21,7 +21,7 @@ end
 entity.onTrigger = function(player, npc)
     local theMerchantsBidding = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING)
 
-    if (theMerchantsBidding == QUEST_AVAILABLE) then
+    if theMerchantsBidding == QUEST_AVAILABLE then
         player:startEvent(90)
     else
         player:startEvent(88)
@@ -32,13 +32,13 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 90 and option == 1) then
+    if csid == 90 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING)
-    elseif (csid == 89) then
+    elseif csid == 89 then
         player:tradeComplete()
         player:addGil(xi.settings.main.GIL_RATE * 120)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 120)
-        if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING) == QUEST_ACCEPTED) then
+        if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING) == QUEST_ACCEPTED then
             player:addFame(xi.quest.fame_area.SANDORIA, 30)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MERCHANT_S_BIDDING)
         else

--- a/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rouva.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatSandy = player:getCharVar("WildcatSandy")
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatSandy, 2)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatSandy, 2)
+    then
         player:startEvent(808)
     else
         player:startEvent(664)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 808) then
+    if csid == 808 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 2, true))
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false) then
+    if guildMember == 1 then
+        if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(652, skillCap, skillLevel, 2, 239, player:getGil(), 0, 0, 0)
         else
             player:startEvent(652, skillCap, skillLevel, 2, 239, player:getGil(), 7075, 0, 0)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 652 and option == 1) then
+    if csid == 652 and option == 1 then
         player:messageSpecial(ID.text.LEATHER_SUPPORT, 0, 5, 2)
         player:addStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Vemalpeau.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Vemalpeau.lua
@@ -14,13 +14,19 @@ end
 
 entity.onTrigger = function(player, npc)
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.UNDER_OATH) == QUEST_ACCEPTED and player:getCharVar("UnderOathCS") == 0) then   -- Quest: Under Oath - PLD AF3
+    if
+        player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.UNDER_OATH) == QUEST_ACCEPTED and
+        player:getCharVar("UnderOathCS") == 0
+    then   -- Quest: Under Oath - PLD AF3
         player:startEvent(7) --Under Oath - mentions the boy missing
-    elseif (player:getCharVar("UnderOathCS") == 3 and player:hasKeyItem(xi.ki.MIQUES_PAINTBRUSH)) then
+    elseif
+        player:getCharVar("UnderOathCS") == 3 and
+        player:hasKeyItem(xi.ki.MIQUES_PAINTBRUSH)
+    then
         player:startEvent(5) --Under Oath - upset about the paintbrush
-    elseif (player:getCharVar("UnderOathCS") == 4 and player:hasKeyItem(xi.ki.STRANGE_SHEET_OF_PAPER)) then
+    elseif player:getCharVar("UnderOathCS") == 4 and player:hasKeyItem(xi.ki.STRANGE_SHEET_OF_PAPER) then
         player:startEvent(3) -- Under Oath - mentions commanding officer
-    elseif (player:getCharVar("UnderOathCS") == 9 and player:hasKeyItem(xi.ki.KNIGHTS_CONFESSION)) then
+    elseif player:getCharVar("UnderOathCS") == 9 and player:hasKeyItem(xi.ki.KNIGHTS_CONFESSION) then
         player:startEvent(2) -- Under Oath - Thanks you and concludes quest
     else
         player:startEvent(1)
@@ -31,17 +37,15 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 7) then
+    if csid == 7 then
         player:setCharVar("UnderOathCS", 1)
-    elseif (csid == 5) then
+    elseif csid == 5 then
         player:setCharVar("UnderOathCS", 4)
         player:delKeyItem(xi.ki.MIQUES_PAINTBRUSH)
-    elseif (csid == 2) then
+    elseif csid == 2 then
         player:setCharVar("UnderOathCS", 0)
         player:delKeyItem(xi.ki.KNIGHTS_CONFESSION)
     end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/_6eo.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/_6eo.lua
@@ -25,7 +25,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if (csid == 63) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 751)
         else
             player:completeQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE)

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
@@ -118,7 +118,7 @@ entity.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ULBRECHTS_SEALED_LETTER)
         player:setCharVar("OnSabbatical", 1)
     elseif (csid == 20) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED)
         else
             player:delKeyItem(xi.ki.ULBRECHTS_SEALED_LETTER)
@@ -135,7 +135,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif (csid == 25) then
         player:setCharVar("DownwardHelix", 2)
     elseif (csid == 27) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED)
         else
             player:completeQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.DOWNWARD_HELIX)

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Turbulent_Storm.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Turbulent_Storm.lua
@@ -16,16 +16,16 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCampaignAllegiance() > 0) then
-        if (player:getCampaignAllegiance() == 2) then
+    if player:getCampaignAllegiance() > 0 then
+        if player:getCampaignAllegiance() == 2 then
             player:startEvent(9)
         else
             -- message for other nations missing
             player:startEvent(9)
         end
-    elseif (player:hasKeyItem(xi.ki.RED_RECOMMENDATION_LETTER) == true) then
+    elseif player:hasKeyItem(xi.ki.RED_RECOMMENDATION_LETTER) then
         player:startEvent(8)
-    elseif (player:hasKeyItem(xi.ki.RED_RECOMMENDATION_LETTER) == false) then
+    elseif not player:hasKeyItem(xi.ki.RED_RECOMMENDATION_LETTER) then
         player:startEvent(7)
     end
 end
@@ -34,7 +34,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 7 and option == 0) then
+    if csid == 7 and option == 0 then
         player:addKeyItem(xi.ki.BLUE_RECOMMENDATION_LETTER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BLUE_RECOMMENDATION_LETTER)
     end

--- a/scripts/zones/Uleguerand_Range/npcs/Chamnaet_Spring.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Chamnaet_Spring.lua
@@ -12,7 +12,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     -- Trade Cotton Pouch
     if (trade:hasItemQty(1779, 1) and trade:getItemCount() == 1) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1780) -- Chamnaet Ice
         else
             player:tradeComplete()

--- a/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
@@ -45,7 +45,7 @@ entity.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ZEPHYR_FAN)
         player:setCharVar("[ENM]ZephyrFan", os.time() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif (csid == 14) then
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 1779) -- Cotton Pouch
             return
         else

--- a/scripts/zones/Western_Adoulin/npcs/Clautaire.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clautaire.lua
@@ -17,15 +17,15 @@ end
 
 entity.onTrigger = function(player, npc)
     local finao = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.FAILURE_IS_NOT_AN_OPTION)
-    if (finao == QUEST_ACCEPTED) then
-        if (player:hasKeyItem(xi.ki.HUNK_OF_BEDROCK)) then
+    if finao == QUEST_ACCEPTED then
+        if player:hasKeyItem(xi.ki.HUNK_OF_BEDROCK) then
             -- Finishing Quest: 'F.A.I.L.ure Is Not an Option'
             player:startEvent(76)
         else
             -- Dialgoue during Quest: 'F.A.I.L.ure Is Not an Option'
             player:startEvent(77)
         end
-    elseif ((finao == QUEST_AVAILABLE) and (player:getFameLevel(xi.quest.fame_area.ADOULIN) >= 4) and player:hasKeyItem(xi.ki.FAIL_BADGE)) then
+    elseif finao == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.ADOULIN) >= 4 and player:hasKeyItem(xi.ki.FAIL_BADGE) then
         -- Starting Quest: 'F.A.I.L.ure Is Not an Option'
         player:startEvent(78)
     else
@@ -38,10 +38,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 78) then
+    if csid == 78 then
         -- Starting Quest: 'F.A.I.L.ure Is Not an Option'
         player:addQuest(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.FAILURE_IS_NOT_AN_OPTION)
-    elseif (csid == 76) then
+    elseif csid == 76 then
         -- Finishing Quest: 'F.A.I.L.ure Is Not an Option'
         player:delKeyItem(xi.ki.HUNK_OF_BEDROCK)
         player:completeQuest(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.FAILURE_IS_NOT_AN_OPTION)

--- a/scripts/zones/Windurst_Walls/npcs/Raamimi.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Raamimi.lua
@@ -18,13 +18,13 @@ entity.onTrigger = function(player, npc)
     local toBee = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
     local toBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if (toBeeOrNotStatus == 10 and toBee == QUEST_AVAILABLE) then
+    if toBeeOrNotStatus == 10 and toBee == QUEST_AVAILABLE then
         player:startEvent(67) -- Quest Started - He gives you honey
-    elseif (toBee == QUEST_ACCEPTED) then
+    elseif toBee == QUEST_ACCEPTED then
         player:startEvent(68) -- After honey is given to player...... but before 5th hondy is given to Zayhi
-    elseif (toBee == QUEST_COMPLETED and toBeeOrNotStatus == 5) then
+    elseif toBee == QUEST_COMPLETED and toBeeOrNotStatus == 5 then
         player:startEvent(80) -- Quest Finish - Gives Mulsum
-    elseif (toBee == QUEST_COMPLETED and toBeeOrNotStatus == 0 and player:needToZone()) then
+    elseif toBee == QUEST_COMPLETED and toBeeOrNotStatus == 0 and player:needToZone() then
         player:startEvent(79) -- After Quest but before zoning "it's certainly gotten quiet around here..."
     else
         player:startEvent(296)
@@ -42,16 +42,16 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 67) then
-        if (player:getFreeSlotsCount() == 0) then
+    if csid == 67 then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4370) -- Cannot give Honey because player Inventory is full
         else
             player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE)
             player:addItem(4370)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4370) -- Gives player Honey x1
         end
-    elseif (csid == 80) then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
-        if (player:getFreeSlotsCount() == 0) then
+    elseif csid == 80 then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 4156) -- Cannot give Mulsum because player Inventory is full
         else
             player:setCharVar("ToBeeOrNot_var", 0)

--- a/scripts/zones/Windurst_Waters/npcs/Amagusa-Chigurusa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Amagusa-Chigurusa.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 12)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatWindurst, 12)
+    then
         player:startEvent(937)
     else
         player:startEvent(562)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 937) then
+    if csid == 937 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 12, true))
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Door_House.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Door_House.lua
@@ -11,15 +11,22 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local npcID = npc:getID()
-    if (npcID == ID.npc.LELEROON_GREEN_DOOR) then
+    if npcID == ID.npc.LELEROON_GREEN_DOOR then
         local letterGreen = player:getCharVar("LeleroonsLetterGreen")
 
         -- gold thread, karakul leather, red grass cloth, wamoura silk
-        if (letterGreen == 2 and trade:getItemCount() == 4 and trade:hasItemQty(823, 1) and trade:hasItemQty(879, 1) and trade:hasItemQty(1829, 1) and trade:hasItemQty(2304, 1)) then
+        if
+            letterGreen == 2 and
+            trade:getItemCount() == 4 and
+            trade:hasItemQty(823, 1) and
+            trade:hasItemQty(879, 1) and
+            trade:hasItemQty(1829, 1) and
+            trade:hasItemQty(2304, 1)
+        then
             player:startEvent(943) -- accepts materials, now bring me 4 imperial mythril pieces
 
         -- 4 imperial mythril pieces
-        elseif (letterGreen == 3 and trade:getItemCount() == 4 and trade:hasItemQty(2186, 4)) then
+        elseif letterGreen == 3 and trade:getItemCount() == 4 and trade:hasItemQty(2186, 4) then
             player:startEvent(946) -- accepts mythril pieces, now wait for next vana'diel day
 
         end
@@ -28,16 +35,16 @@ end
 
 entity.onTrigger = function(player, npc)
     local npcID = npc:getID()
-    if (npcID == ID.npc.LELEROON_GREEN_DOOR) then
+    if npcID == ID.npc.LELEROON_GREEN_DOOR then
         local letterGreen = player:getCharVar("LeleroonsLetterGreen")
-        if (player:hasKeyItem(xi.ki.LELEROONS_LETTER_GREEN)) then
+        if player:hasKeyItem(xi.ki.LELEROONS_LETTER_GREEN) then
             player:startEvent(941) -- accept letter, now bring me four items
-        elseif (letterGreen == 2) then
+        elseif letterGreen == 2 then
             player:startEvent(942) -- i'm waiting for four items
-        elseif (letterGreen == 3) then
+        elseif letterGreen == 3 then
             player:startEvent(954) -- i'm waiting for 4 imperial mythril pieces
-        elseif (letterGreen == 4) then
-            if (vanaDay() > player:getCharVar("corAfSubmitDay")) then
+        elseif letterGreen == 4 then
+            if vanaDay() > player:getCharVar("corAfSubmitDay") then
                 player:startEvent(944) -- here's your cor gants
             else
                 player:startEvent(945) -- patience. need to wait for vana'diel day
@@ -50,17 +57,17 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 941) then
+    if csid == 941 then
         player:setCharVar("LeleroonsLetterGreen", 2)
         player:delKeyItem(xi.ki.LELEROONS_LETTER_GREEN)
-    elseif (csid == 943) then
+    elseif csid == 943 then
         player:tradeComplete()
         player:setCharVar("LeleroonsletterGreen", 3)
-    elseif (csid == 946) then
+    elseif csid == 946 then
         player:tradeComplete()
         player:setCharVar("LeleroonsletterGreen", 4)
         player:setCharVar("corAfSubmitDay", vanaDay())
-    elseif (csid == 944) then
+    elseif csid == 944 then
         player:setCharVar("LeleroonsletterGreen", 5)
         player:addItem(14929) -- corsair's gants
         player:messageSpecial(ID.text.ITEM_OBTAINED, 14929)

--- a/scripts/zones/Windurst_Waters/npcs/Funpo-Shipo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Funpo-Shipo.lua
@@ -27,7 +27,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 13)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatWindurst, 13)
+    then
         player:startEvent(938)
     else
         player:startEvent(576)
@@ -38,7 +41,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 938) then
+    if csid == 938 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 13, true))
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
     local fame = player:getFameLevel(xi.quest.fame_area.WINDURST)
     if (wonderingstatus == QUEST_AVAILABLE and fame >= 5) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(633)          -- WONDERING_MINSTREL: Before Quest
         else
             player:startEvent(634)          -- WONDERING_MINSTREL: Quest Start
@@ -42,7 +42,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(611)             -- Singing 1 (daytime < 6 or daytime >= 18)
         else
             local rand = math.random(1, 2)
-            if (rand == 1) then
+            if rand == 1 then
                 player:startEvent(610)          -- Standard Conversation 1 (daytime)
             else
                 player:startEvent(615)             -- Standard Conversation 2 (daytime)
@@ -58,7 +58,7 @@ entity.onEventFinish = function(player, csid, option)
     if (csid == 634) then    -- WONDERING_MINSTREL: Quest Start
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
     elseif (csid == 638) then  -- WONDERING_MINSTREL: Quest Finish
-        if (player:getFreeSlotsCount() == 0) then
+        if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17349)
         else
             player:tradeComplete()

--- a/scripts/zones/Windurst_Waters/npcs/Lago-Charago.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lago-Charago.lua
@@ -15,7 +15,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 11)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatWindurst, 11)
+    then
         player:startEvent(940)
     else
         player:startEvent(300)
@@ -26,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 940) then
+    if csid == 940 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 11, true))
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -94,10 +94,10 @@ entity.onTrigger = function(player, npc)
     then -- Fenrir flag event
 
         player:startEvent(842, 0, 1125)
-    elseif (moonlitPath == QUEST_ACCEPTED) then
+    elseif moonlitPath == QUEST_ACCEPTED then
         if (player:hasKeyItem(xi.ki.MOON_BAUBLE)) then -- Default text after acquiring moon bauble and before fighting Fenrir
             player:startEvent(845, 0, 1125, 334)
-        elseif (player:hasKeyItem(xi.ki.WHISPER_OF_THE_MOON)) then -- First turn-in
+        elseif player:hasKeyItem(xi.ki.WHISPER_OF_THE_MOON) then -- First turn-in
             local availRewards = 0
             if
                 not player:hasKeyItem(xi.ki.TRAINERS_WHISTLE) or
@@ -113,10 +113,10 @@ entity.onTrigger = function(player, npc)
         else -- Talked to after flag without the whispers
             player:startEvent(843, 0, 1125)
         end
-    elseif (moonlitPath == QUEST_COMPLETED) then
-        if (player:hasKeyItem(xi.ki.MOON_BAUBLE)) then -- Default text after acquiring moon bauble and before fighting Fenrir
+    elseif moonlitPath == QUEST_COMPLETED then
+        if player:hasKeyItem(xi.ki.MOON_BAUBLE) then -- Default text after acquiring moon bauble and before fighting Fenrir
             player:startEvent(845, 0, 1125, 334)
-        elseif (player:hasKeyItem(xi.ki.WHISPER_OF_THE_MOON)) then -- Repeat turn-in
+        elseif player:hasKeyItem(xi.ki.WHISPER_OF_THE_MOON) then -- Repeat turn-in
             local availRewards = getFenrirRewardMask(player)
 
             player:startEvent(850, 0, 13399, 1208, 1125, availRewards, 18165, 13572)
@@ -139,9 +139,9 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- Moonlit Path and Other Fenrir Stuff
-    if (csid == 842 and option == 2) then
+    if csid == 842 and option == 2 then
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_MOONLIT_PATH)
-    elseif (csid == 844) then
+    elseif csid == 844 then
         player:addKeyItem(xi.ki.MOON_BAUBLE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MOON_BAUBLE)
         player:delKeyItem(xi.ki.WHISPER_OF_FLAMES)
@@ -158,17 +158,17 @@ entity.onEventFinish = function(player, csid, option)
         player:delQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TRIAL_BY_LIGHTNING)
     elseif csid == 846 or csid == 850 then -- Turn-in event
         local reward = 0
-        if (option == 1) then reward = 18165 -- Fenrir's Stone
-        elseif (option == 2) then reward = 13572 -- Fenrir's Cape
-        elseif (option == 3) then reward = 13138 -- Fenrir's Torque
-        elseif (option == 4) then reward = 13399 -- Fenrir's Earring
-        elseif (option == 5) then reward = 1208 -- Ancient's Key
-        elseif (option == 6) then
+        if option == 1 then reward = 18165 -- Fenrir's Stone
+        elseif option == 2 then reward = 13572 -- Fenrir's Cape
+        elseif option == 3 then reward = 13138 -- Fenrir's Torque
+        elseif option == 4 then reward = 13399 -- Fenrir's Earring
+        elseif option == 5 then reward = 1208 -- Ancient's Key
+        elseif option == 6 then
             player:addGil(xi.settings.main.GIL_RATE * 15000)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 15000) -- Gil
-        elseif (option == 7) then
+        elseif option == 7 then
             player:addSpell(297) -- Pact
-        elseif (option == 8) then
+        elseif option == 8 then
             player:addKeyItem(xi.ki.FENRIR_WHISTLE)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.FENRIR_WHISTLE)
             -- Pact as Mount

--- a/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
@@ -29,12 +29,12 @@ entity.onTrigger = function(player, npc)
 
     if (reapstatus == QUEST_AVAILABLE) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(463, 0, 4565, 572)                 -- REAP WHAT YOU SOW + HERB SEEDS: QUEST START
         end
     elseif (reapstatus == QUEST_ACCEPTED) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(464, 0, 4565, 572)                  -- REAP WHAT YOU SOW + HERB SEEDS: OBJECTIVE REMINDER
         else
             player:startEvent(476)                          -- Another Conversation During Quest
@@ -43,12 +43,12 @@ entity.onTrigger = function(player, npc)
         player:startEvent(478)                              -- REAP WHAT YOU SOW: After Quest
     elseif (reapstatus == QUEST_COMPLETED and player:needToZone() == false and player:getCharVar("QuestReapSow_var") == 0) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(479, 0, 4565, 572)                -- REAP WHAT YOU SOW + HERB SEEDS: REPEATABLE QUEST START
         end
     elseif (reapstatus == QUEST_COMPLETED and player:getCharVar("QuestReapSow_var") == 1) then
         local rand = math.random(1, 2)
-        if (rand == 1) then
+        if rand == 1 then
             player:startEvent(464, 0, 4565, 572)                  -- REAP WHAT YOU SOW + HERB SEEDS: OBJECTIVE REMINDER
         else
             player:startEvent(476)                          -- Another Conversation During Quest

--- a/scripts/zones/Windurst_Waters/npcs/Npopo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Npopo.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Area: Windurst Waters
 --  NPC: Npopo
--- Type: Standard NPC
 -- !pos -35.464 -5.999 239.120 238
 -----------------------------------
 require("scripts/globals/quests")
@@ -15,7 +14,10 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 10)) then
+    if
+        player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and
+        not utils.mask.getBit(wildcatWindurst, 10)
+    then
         player:startEvent(936)
     else
         player:startEvent(269)
@@ -26,7 +28,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 936) then
+    if csid == 936 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 10, true))
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
@@ -17,14 +17,14 @@ entity.onTrade = function(player, npc, trade)
     local turmoil = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
     local count = trade:getItemCount()
 
-    if (turmoil == QUEST_ACCEPTED) then
-        if (count == 3 and trade:getGil() == 0 and trade:hasItemQty(906, 3) == true) then --Check that all 3 items have been traded
+    if turmoil == QUEST_ACCEPTED then
+        if count == 3 and trade:getGil() == 0 and trade:hasItemQty(906, 3) then --Check that all 3 items have been traded
             player:startEvent(791)
         else
             player:startEvent(786, 4500, 267, 906) -- Reminder of needed items
         end
-    elseif (turmoil == QUEST_COMPLETED) then
-        if (count == 3 and trade:getGil() == 0 and trade:hasItemQty(906, 3) == true) then --Check that all 3 items have been traded
+    elseif turmoil == QUEST_COMPLETED then
+        if count == 3 and trade:getGil() == 0 and trade:hasItemQty(906, 3) then --Check that all 3 items have been traded
             player:startEvent(791)
         else
             player:startEvent(795, 4500, 0, 906) -- Reminder of needed items for repeated quest
@@ -40,8 +40,8 @@ entity.onTrigger = function(player, npc)
     local flowerProgress = player:getCharVar("FLOWER_PROGRESS")
     local blueRibbonBlues = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.BLUE_RIBBON_BLUES)
 
-    if ((sayFlowers == QUEST_ACCEPTED or sayFlowers == QUEST_COMPLETED) and flowerProgress == 1) then
-        if (needToZone) then
+    if (sayFlowers == QUEST_ACCEPTED or sayFlowers == QUEST_COMPLETED) and flowerProgress == 1 then
+        if needToZone then
             player:startEvent(518)
         elseif (player:getCharVar("FLOWER_PROGRESS") == 2) then
             player:startEvent(517, 0, 0, 0, 0, 950)
@@ -50,11 +50,11 @@ entity.onTrigger = function(player, npc)
         end
 
     -- Begin Toraimarai Turmoil Section
-    elseif blueRibbonBlues == QUEST_COMPLETED and turmoil == QUEST_AVAILABLE and pfame >= 6 and needToZone == false then
+    elseif blueRibbonBlues == QUEST_COMPLETED and turmoil == QUEST_AVAILABLE and pfame >= 6 and not needToZone then
         player:startEvent(785, 4500, 267, 906)
-    elseif (turmoil == QUEST_ACCEPTED) then
+    elseif turmoil == QUEST_ACCEPTED then
         player:startEvent(786, 4500, 267, 906) -- Reminder of needed items
-    elseif (turmoil == QUEST_COMPLETED) then
+    elseif turmoil == QUEST_COMPLETED then
         player:startEvent(795, 4500, 0, 906) -- Allows player to initiate repeat of Toraimarai Turmoil
     end
 end
@@ -76,27 +76,27 @@ entity.onEventFinish = function(player, csid, option)
     -- Check Missions first (priority?)
     local turmoil = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
 
-    if (csid == 785 and option == 1) then -- Adds Toraimarai turmoil
+    if csid == 785 and option == 1 then -- Adds Toraimarai turmoil
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RHINOSTERY_CERTIFICATE)
         player:addKeyItem(xi.ki.RHINOSTERY_CERTIFICATE) -- Rhinostery Certificate
-    elseif (csid == 791 and turmoil == QUEST_ACCEPTED) then -- Completes Toraimarai turmoil - first time
+    elseif csid == 791 and turmoil == QUEST_ACCEPTED then -- Completes Toraimarai turmoil - first time
         player:addGil(xi.settings.main.GIL_RATE * 4500)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 4500)
         player:completeQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TORAIMARAI_TURMOIL)
         player:addFame(xi.quest.fame_area.WINDURST, 100)
         player:addTitle(xi.title.CERTIFIED_RHINOSTERY_VENTURER)
         player:tradeComplete()
-    elseif (csid == 791 and turmoil == 2) then -- Completes Toraimarai turmoil - repeats
+    elseif csid == 791 and turmoil == 2 then -- Completes Toraimarai turmoil - repeats
         player:addGil(xi.settings.main.GIL_RATE * 4500)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 4500)
         player:addFame(xi.quest.fame_area.WINDURST, 50)
         player:tradeComplete()
-    elseif (csid == 516) then
-        if (option < 7) then
+    elseif csid == 516 then
+        if option < 7 then
             local choice = flowerList[option]
-            if (choice and player:getGil() >= choice.gil) then
-                if (player:getFreeSlotsCount() > 0) then
+            if choice and player:getGil() >= choice.gil then
+                if player:getFreeSlotsCount() > 0 then
                     player:addItem(choice.itemid)
                     player:messageSpecial(ID.text.ITEM_OBTAINED, choice.itemid)
                     player:delGil(choice.gil)
@@ -107,7 +107,7 @@ entity.onEventFinish = function(player, csid, option)
             else
                 player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
             end
-        elseif (option == 7) then
+        elseif option == 7 then
             player:setCharVar("FLOWER_PROGRESS", 2)
         end
     end

--- a/scripts/zones/Windurst_Waters/npcs/Ranpi-Monpi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ranpi-Monpi.lua
@@ -61,7 +61,7 @@ entity.onTrigger = function(player, npc)
     else
     --Standard dialogs
         local rand = math.random(1, 3)
-        if (rand == 1) then  -- STANDARD CONVO: sings song about ingredients
+        if rand == 1 then  -- STANDARD CONVO: sings song about ingredients
             player:startEvent(249)
         elseif (rand == 2) then   -- STANDARD CONVO 2: sings song about ingredients
             player:startEvent(251)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Begins to remove outer parentheses from conditions in NPC scripts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed
<!-- Clear and detailed steps to test your changes here -->
