### PR TITLE
Refining Battlefield Group Initialization

### DIFF
--- a/scripts/battlefields/Apollyon/cs_apollyon.lua
+++ b/scripts/battlefields/Apollyon/cs_apollyon.lua
@@ -1,8 +1,9 @@
 -----------------------------------
 -- Area: Apollyon
--- Name: SE Apollyon
+-- Name: CS Apollyon
 -- !addkeyitem black_card
 -- !addkeyitem cosmo_cleanse
+-- !additem 2127
 -- !pos 600 -0.5 -600 38
 -----------------------------------
 local ID = require("scripts/zones/Apollyon/IDs")
@@ -177,7 +178,7 @@ content.groups =
         isParty = true,
         superlink = true,
         spawned = false,
-        setup = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.CARNAGECHIEF_JACKBODOKK),
+        initialize = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.CARNAGECHIEF_JACKBODOKK),
     },
 
     {
@@ -208,7 +209,7 @@ content.groups =
         isParty = true,
         superlink = true,
         spawned = false,
-        setup = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.NAQBA_CHIRURGEON),
+        initialize = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.NAQBA_CHIRURGEON),
     },
 
     {
@@ -239,7 +240,7 @@ content.groups =
         isParty = true,
         superlink = true,
         spawned = false,
-        setup = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.DEE_WAPA_THE_DESOLATOR),
+        initialize = utils.bind(setupSharedHate, ID.CS_APOLLYON.mob.DEE_WAPA_THE_DESOLATOR),
     },
 
     {

--- a/scripts/battlefields/Apollyon/nw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/nw_apollyon.lua
@@ -36,7 +36,7 @@ function content:onBattlefieldInitialise(battlefield)
     end
 end
 
-local enpowerBoss = function(battlefield, mobs)
+local empowerBoss = function(battlefield, mobs)
     local boss = mobs[1]
     boss:addMod(xi.mod.ATTP, 100)
     boss:addMod(xi.mod.ACC, 50)
@@ -243,7 +243,7 @@ content.groups =
             [xi.mod.BINDRES] = -25,
         },
 
-        setup = enpowerBoss,
+        setup = empowerBoss,
         death = function(battlefield, mob, count)
             xi.limbus.spawnFrom(mob, ID.NW_APOLLYON.npc.ITEM_CRATES[1])
         end,
@@ -277,7 +277,7 @@ content.groups =
             [xi.mod.SLEEPRES] = -25,
         },
 
-        setup = enpowerBoss,
+        setup = empowerBoss,
         death = function(battlefield, mob, count)
             xi.limbus.spawnFrom(mob, ID.NW_APOLLYON.npc.ITEM_CRATES[2])
         end,
@@ -305,7 +305,7 @@ content.groups =
     {
         mobs = { "Millenary_Mossback" },
         stationary = true,
-        setup = enpowerBoss,
+        setup = empowerBoss,
         death = function(battlefield, mob, count)
             xi.limbus.spawnFrom(mob, ID.NW_APOLLYON.npc.ITEM_CRATES[3])
         end,
@@ -339,7 +339,7 @@ content.groups =
             [xi.mod.BINDRES] = -25,
         },
 
-        setup = enpowerBoss,
+        setup = empowerBoss,
         death = function(battlefield, mob, count)
             xi.limbus.spawnFrom(mob, ID.NW_APOLLYON.npc.ITEM_CRATES[4])
         end,
@@ -373,7 +373,7 @@ content.groups =
             [xi.mobMod.SEVERE_SPELL_CHANCE] = 100,
         },
 
-        setup = enpowerBoss,
+        setup = empowerBoss,
         death = function(battlefield, mob, count)
             npcUtil.showCrate(GetNPCByID(ID.NW_APOLLYON.npc.LOOT_CRATE))
         end,

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -935,7 +935,12 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 
                 if (group.deathCallback.valid())
                 {
-                    group.deathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity), group.deathCount);
+                    auto result = group.deathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity), group.deathCount);
+                    if (!result.valid())
+                    {
+                        sol::error err = result;
+                        ShowError("Error in battlefield %s group.death: %s", this->GetName(), err.what());
+                    }
                 }
 
                 if (group.allDeathCallback.valid() && group.deathCount >= group.mobIds.size())
@@ -953,13 +958,23 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 
                     if (deathCount == group.mobIds.size())
                     {
-                        group.allDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                        auto result = group.allDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                        if (!result.valid())
+                        {
+                            sol::error err = result;
+                            ShowError("Error in battlefield %s group.allDeath: %s", this->GetName(), err.what());
+                        }
                     }
                 }
 
                 if (group.randomDeathCallback.valid() && mobId == group.randomMobId)
                 {
-                    group.randomDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                    auto result = group.randomDeathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity));
+                    if (!result.valid())
+                    {
+                        sol::error err = result;
+                        ShowError("Error in battlefield %s group.randomDeath: %s", this->GetName(), err.what());
+                    }
                 }
                 break;
             }

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -125,6 +125,7 @@ struct BattlefieldGroup
     sol::function       deathCallback;
     sol::function       randomDeathCallback;
     sol::function       allDeathCallback;
+    sol::function       setupCallback;
     uint8               deathCount  = 0;
     uint32              randomMobId = 0;
 };


### PR DESCRIPTION
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Better solution for setting up battlefield groups to support repeating mobs in groups. If a group would repeat mobs from a previous group then it would wipe all modifiers setup during `spawn()`.

Now it will initialize all groups by setting up their modifiers and saves them. This includes a new `initialize` callback. Once **all** groups are initialized then it will spawn the mobs and finally call the `setup` callback which does not save the modifiers afterwards.

## Steps to test these changes

```
-- !addkeyitem black_card
-- !addkeyitem cosmo_cleanse
-- !additem 2127
-- !pos 600 -0.5 -600 38
```

Trade Metal Chip and enter CS Apollyon. Inside target Dee Wapa and use `!getmod IMPACT_SDT` and it should be `2000`. Before this change it would be set to 0.