### PR TITLE
[dbtool] Refactor to allow running from other directories like repo root

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -12,30 +12,45 @@ import pathlib
 # Pre-flight sanity checks
 def preflight_exit():
     # If double clicked on Windows: pause with an input so the user can read the error...
-    if os.name == 'nt' and 'PROMPT' not in os.environ:
-        input('Press ENTER to continue...')
+    if os.name == "nt" and "PROMPT" not in os.environ:
+        input("Press ENTER to continue...")
     exit(-1)
+
 
 # - git should installed and available
 try:
     subprocess.call(["git"], stdout=subprocess.PIPE)
-except: # lgtm [py/catch-base-exception]
-    print("ERROR: Make sure git is installed and available on your system's PATH environment variable.")
+except:  # lgtm [py/catch-base-exception]
+    print(
+        "ERROR: Make sure git is installed and available on your system's PATH environment variable."
+    )
     preflight_exit()
 
 # If launching from somewhere that isnt <root>/tools/, figure out where dbtool.py is located, and the server root.
 dbtool_dir_path = os.path.normpath(os.path.realpath(os.path.dirname(__file__)))
 server_dir_path = os.path.normpath(os.path.realpath(os.path.dirname(dbtool_dir_path)))
 
+
 def from_dbtool_path(path):
     return os.path.normpath(os.path.join(dbtool_dir_path, path))
+
 
 def from_server_path(path):
     return os.path.normpath(os.path.join(server_dir_path, path))
 
+
 # - Repo should be checked out as a git repo, not as plain files
-if not subprocess.call(['git', '-C', server_dir_path, 'status'], stderr=subprocess.STDOUT, stdout = open(os.devnull, 'w')) == 0:
-    print("ERROR: The project must be checked out as a git repo (using git clone, or similar).")
+if (
+    not subprocess.call(
+        ["git", "-C", server_dir_path, "status"],
+        stderr=subprocess.STDOUT,
+        stdout=open(os.devnull, "w"),
+    )
+    == 0
+):
+    print(
+        "ERROR: The project must be checked out as a git repo (using git clone, or similar)."
+    )
     preflight_exit()
 
 # External Deps (requirements.txt)
@@ -48,61 +63,69 @@ try:
 except Exception as e:
     print("ERROR: Exception occured while importing external dependencies:")
     print(e)
-    print("Ensure you've run/re-run the command you use to install python dependencies (ex: pip install --upgrade -r requirements.txt)")
+    print(
+        "Ensure you've run/re-run the command you use to install python dependencies (ex: pip install --upgrade -r requirements.txt)"
+    )
     preflight_exit()
+
 
 def print_red(str):
     print(colorama.Fore.RED + str)
 
+
 def print_green(str):
     print(colorama.Fore.GREEN + str)
 
+
 def populate_migrations():
     migration_list = []
-    for file in sorted(os.scandir(from_dbtool_path("migrations")), key=lambda e: e.name):
+    for file in sorted(
+        os.scandir(from_dbtool_path("migrations")), key=lambda e: e.name
+    ):
         if file.name.endswith(".py") and file.name != "utils.py":
             name = file.name.replace(".py", "")
             module = importlib.import_module("migrations." + name)
             migration_list.append(module)
     return migration_list
 
+
 # Migrations are automatically scraped from the migrations folder
 migrations = populate_migrations()
 
 # These are the 'protected' files
 player_data = [
-    'accounts.sql',
-    'accounts_banned.sql',
-    'auction_house.sql',
-    'char_blacklist.sql',
-    'char_chocobos.sql',
-    'char_effects.sql',
-    'char_equip.sql',
-    'char_equip_saved.sql',
-    'char_exp.sql',
-    'char_history.sql',
-    'char_inventory.sql',
-    'char_jobs.sql',
-    'char_job_points.sql',
-    'char_look.sql',
-    'char_merit.sql',
-    'char_pet.sql',
-    'char_points.sql',
-    'char_profile.sql',
-    'char_skills.sql',
-    'char_spells.sql',
-    'char_stats.sql',
-    'char_storage.sql',
-    'char_style.sql',
-    'char_unlocks.sql',
-    'char_vars.sql',
-    'chars.sql',
-    'conquest_system.sql',
-    'delivery_box.sql',
-    'ip_exceptions.sql',
-    'linkshells.sql',
-    'server_variables.sql',
-    'unity_system.sql',
+    "accounts.sql",
+    "accounts_banned.sql",
+    "auction_house.sql",
+    "char_blacklist.sql",
+    "char_chocobos.sql",
+    "char_effects.sql",
+    "char_equip.sql",
+    "char_equip_saved.sql",
+    "char_exp.sql",
+    "char_history.sql",
+    "char_inventory.sql",
+    "char_jobs.sql",
+    "char_job_points.sql",
+    "char_look.sql",
+    "char_merit.sql",
+    "char_pet.sql",
+    "char_points.sql",
+    "char_profile.sql",
+    "char_skills.sql",
+    "char_spells.sql",
+    "char_stats.sql",
+    "char_storage.sql",
+    "char_style.sql",
+    "char_unlocks.sql",
+    "char_vars.sql",
+    "chars.sql",
+    "conquest_system.sql",
+    "delivery_box.sql",
+    "ip_exceptions.sql",
+    "linkshells.sql",
+    "server_variables.sql",
+    "unity_system.sql",
 ]
 
 import_files = []
@@ -116,71 +139,78 @@ password = None
 db = None
 cur = None
 repo = Repo(server_dir_path)
-db_ver = ''
+db_ver = ""
 current_client = None
 release_version = None
 release_client = None
 express_enabled = False
 auto_backup = 0
 auto_update_client = True
-mysql_bin = ''
-mysql_env = shutil.which('mysql')
+mysql_bin = ""
+mysql_env = shutil.which("mysql")
 if mysql_env:
-    mysql_bin = os.path.dirname(mysql_env).replace('\\','/')
-    if mysql_bin[-1] != '/':
-        mysql_bin = mysql_bin + '/'
-if os.name == 'nt':
-    exe = '.exe'
+    mysql_bin = os.path.dirname(mysql_env).replace("\\", "/")
+    if mysql_bin[-1] != "/":
+        mysql_bin = mysql_bin + "/"
+if os.name == "nt":
+    exe = ".exe"
 else:
-    exe = ''
-log_errors = ' 2>>error.log'
+    exe = ""
+log_errors = " 2>>error.log"
 colorama.init(autoreset=True)
 
 # Redirect errors through this to hide annoying password warning
 def fetch_errors():
     try:
-        with open(from_dbtool_path('error.log')) as f:
+        with open(from_dbtool_path("error.log")) as f:
             while True:
                 line = f.readline()
-                if not line: break
-                if 'Using a password on the command line interface can be insecure.' in line:
+                if not line:
+                    break
+                if (
+                    "Using a password on the command line interface can be insecure."
+                    in line
+                ):
                     continue
                 print_red(line)
-        os.remove(from_dbtool_path('error.log'))
-    except: # lgtm [py/catch-base-exception]
+        os.remove(from_dbtool_path("error.log"))
+    except:  # lgtm [py/catch-base-exception]
         return
+
 
 def fetch_credentials():
     global database, host, port, login, password
     credentials = {}
 
     # Grab mysql credentials
-    filename = from_server_path('settings/default/network.lua')
-    if from_server_path('settings/network.lua'):
-        filename = from_server_path('settings/network.lua')
+    filename = from_server_path("settings/default/network.lua")
+    if from_server_path("settings/network.lua"):
+        filename = from_server_path("settings/network.lua")
 
     try:
         with open(filename) as f:
             while True:
                 line = f.readline()
-                if not line: break
+                if not line:
+                    break
                 if "SQL_" in line:
-                    line = line.replace(',', '').replace('\"', '').replace('\n', '')
+                    line = line.replace(",", "").replace('"', "").replace("\n", "")
                     parts = line.split("=")
                     type = parts[0].strip()
                     val = parts[1].strip()
                     credentials[type] = val
 
-        database = os.getenv('XI_NETWORK_SQL_DATABASE') or credentials['SQL_DATABASE']
-        host = os.getenv('XI_NETWORK_SQL_HOST') or credentials['SQL_HOST']
-        port = os.getenv('XI_NETWORK_SQL_PORT') or int(credentials['SQL_PORT'])
-        login = os.getenv('XI_NETWORK_SQL_LOGIN') or credentials['SQL_LOGIN']
-        password = os.getenv('XI_NETWORK_SQL_PASSWORD') or credentials['SQL_PASSWORD']
-    except: # lgtm [py/catch-base-exception]
-        print_red('Error fetching credentials.\nCheck settings/network.lua.')
+        database = os.getenv("XI_NETWORK_SQL_DATABASE") or credentials["SQL_DATABASE"]
+        host = os.getenv("XI_NETWORK_SQL_HOST") or credentials["SQL_HOST"]
+        port = os.getenv("XI_NETWORK_SQL_PORT") or int(credentials["SQL_PORT"])
+        login = os.getenv("XI_NETWORK_SQL_LOGIN") or credentials["SQL_LOGIN"]
+        password = os.getenv("XI_NETWORK_SQL_PASSWORD") or credentials["SQL_PASSWORD"]
+    except:  # lgtm [py/catch-base-exception]
+        print_red("Error fetching credentials.\nCheck settings/network.lua.")
         return False
 
     return True
+
 
 def fetch_versions():
     global current_client, release_version, release_client
@@ -188,72 +218,83 @@ def fetch_versions():
 
     try:
         release_version = repo.git.rev_parse(repo.head.object.hexsha, short=4)
-    except: # lgtm [py/catch-base-exception]
-        print_red('Unable to read current version hash.')
+    except:  # lgtm [py/catch-base-exception]
+        print_red("Unable to read current version hash.")
 
     try:
-        with open(from_server_path('settings/default/login.lua')) as f:
+        with open(from_server_path("settings/default/login.lua")) as f:
             while True:
                 line = f.readline()
-                if not line: break
+                if not line:
+                    break
                 match = re.match(r'\s+?CLIENT_VER =\s+"(\S+)"', line)
                 if match:
                     release_client = match.group(1)
-    except: # lgtm [py/catch-base-exception]
-        print_red('Unable to read settings/default/login.lua.')
+    except:  # lgtm [py/catch-base-exception]
+        print_red("Unable to read settings/default/login.lua.")
 
-    if os.path.exists(from_server_path('settings/login.lua')):
+    if os.path.exists(from_server_path("settings/login.lua")):
         try:
-            with open(from_server_path('settings/login.lua')) as f:
+            with open(from_server_path("settings/login.lua")) as f:
                 while True:
                     line = f.readline()
-                    if not line: break
+                    if not line:
+                        break
                     match = re.match(r'\s+?CLIENT_VER =\s+"(\S+)"', line)
                     if match:
                         current_client = match.group(1)
-        except: # lgtm [py/catch-base-exception]
-            print_red('Unable to read settings/login.lua')
+        except:  # lgtm [py/catch-base-exception]
+            print_red("Unable to read settings/login.lua")
 
     if db_ver and release_version:
         fetch_files(True)
     else:
         fetch_files()
 
+
 def fetch_configs():
     global mysql_bin, auto_backup, auto_update_client, db_ver
     try:
-        with open(from_dbtool_path('config.yaml')) as file:
+        with open(from_dbtool_path("config.yaml")) as file:
             configs = yaml.full_load(file)
             for config in configs:
                 for key, value in config.items():
-                    if key == 'mysql_bin':
-                        if value != '':
+                    if key == "mysql_bin":
+                        if value != "":
                             mysql_bin = value
-                    if key == 'auto_backup':
+                    if key == "auto_backup":
                         auto_backup = int(value)
-                    if key == 'auto_update_client':
+                    if key == "auto_update_client":
                         auto_update_client = bool(value)
-                    if key == 'db_ver':
+                    if key == "db_ver":
                         db_ver = value
-    except: # lgtm [py/catch-base-exception]
+    except:  # lgtm [py/catch-base-exception]
         write_configs()
 
+
 def write_configs():
-    with open(from_dbtool_path('config.yaml'), 'w') as file:
-        dump = [{'mysql_bin' : mysql_bin}, {'auto_backup' : auto_backup}, {'auto_update_client' : auto_update_client}, {'db_ver' : db_ver}]
+    with open(from_dbtool_path("config.yaml"), "w") as file:
+        dump = [
+            {"mysql_bin": mysql_bin},
+            {"auto_backup": auto_backup},
+            {"auto_update_client": auto_update_client},
+            {"db_ver": db_ver},
+        ]
         yaml.dump(dump, file)
 
+
 def fetch_module_files():
-    with open(from_server_path('modules/init.txt'), 'r') as file:
+    with open(from_server_path("modules/init.txt"), "r") as file:
         for line in file.readlines():
-            if not line.startswith('#') and line.strip() and not line in ['\n', '\r\n']:
+            if not line.startswith("#") and line.strip() and not line in ["\n", "\r\n"]:
                 line = from_server_path("modules/" + line.strip())
                 if pathlib.Path(line).is_dir():
-                    for filename in pathlib.Path(line).glob('**/*.sql'):
-                        import_files.append(str(filename).replace('\\', '/'))
+                    for filename in pathlib.Path(line).glob("**/*.sql"):
+                        import_files.append(str(filename).replace("\\", "/"))
                 else:
                     if line.endswith(".sql"):
-                        import_files.append(str(line).replace('\\', '/'))
+                        import_files.append(str(line).replace("\\", "/"))
+
 
 def check_protected():
     global import_protected, express_enabled
@@ -262,119 +303,170 @@ def check_protected():
     import_protected.clear()
     for table in player_data:
         import_protected.append("'" + table[:-4] + "'")
-    cur.execute("SELECT TABLE_NAME FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = '{}' AND `TABLE_NAME` IN ({})".format(database,', '.join(import_protected)))
+    cur.execute(
+        "SELECT TABLE_NAME FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = '{}' AND `TABLE_NAME` IN ({})".format(
+            database, ", ".join(import_protected)
+        )
+    )
     tables = cur.fetchall()
     import_protected.clear()
     for value in tables:
-        import_protected.append(''.join(value) + '.sql')
+        import_protected.append("".join(value) + ".sql")
     import_protected = [value for value in player_data if value not in import_protected]
     if import_protected:
         express_enabled = True
+
 
 def fetch_files(express=False):
     import_files.clear()
     if express:
         try:
             global express_enabled
-            sql_diffs = repo.commit(db_ver).diff(release_version, paths=from_server_path('sql/'))
+            sql_diffs = repo.commit(db_ver).diff(
+                release_version, paths=from_server_path("sql/")
+            )
             if len(sql_diffs) > 0:
                 for diff in sql_diffs:
-                    import_files.append(from_server_path('sql/' + diff))
+                    import_files.append(from_server_path("sql/" + diff))
                 express_enabled = True
             else:
                 express_enabled = False
-                if len(repo.commit(db_ver).diff(release_version,paths=from_server_path('tools/migrations'))) > 0:
+                if (
+                    len(
+                        repo.commit(db_ver).diff(
+                            release_version, paths=from_server_path("tools/migrations")
+                        )
+                    )
+                    > 0
+                ):
                     express_enabled = True
-        except: # lgtm [py/catch-base-exception]
-            print_red('Error checking diffs.\nCheck that hash is valid in config.yaml.')
+        except:  # lgtm [py/catch-base-exception]
+            print_red("Error checking diffs.\nCheck that hash is valid in config.yaml.")
     else:
-        for (_, _, filenames) in os.walk(from_server_path('sql/')):
+        for (_, _, filenames) in os.walk(from_server_path("sql/")):
             for filename in filenames:
-                import_files.append(from_server_path('sql/' + filename))
+                import_files.append(from_server_path("sql/" + filename))
             break
     check_protected()
     backups.clear()
-    for (_, _, filenames) in os.walk(from_server_path('sql/backups/')):
+    for (_, _, filenames) in os.walk(from_server_path("sql/backups/")):
         for file in filenames:
-            if not '.gitignore' in file:
-                backups.append(from_server_path('sql/backups/' + file))
+            if not ".gitignore" in file:
+                backups.append(from_server_path("sql/backups/" + file))
         break
     backups.sort()
     import_files.sort()
     try:
-        import_files.append(import_files.pop(import_files.index('triggers.sql')))
-    except: # lgtm [py/catch-base-exception]
+        import_files.append(import_files.pop(import_files.index("triggers.sql")))
+    except:  # lgtm [py/catch-base-exception]
         pass
     fetch_module_files()
+
 
 def write_version(silent=False):
     global db_ver
     update_client = auto_update_client
     if not silent and current_client != release_client:
-        update_client = input('Update client version? [y/N] ').lower() == 'y'
+        update_client = input("Update client version? [y/N] ").lower() == "y"
     update_client = update_client and release_client
     db_ver = release_version
     write_configs()
 
-    if os.path.exists(from_server_path('settings/login.lua')):
+    if os.path.exists(from_server_path("settings/login.lua")):
         try:
             if current_client != release_client:
-                for line in fileinput.input(from_server_path('settings/login.lua'), inplace=True):
-                    match = re.match(r'\s+?CLIENT_VER =\s+(\S+)', line)
+                for line in fileinput.input(
+                    from_server_path("settings/login.lua"), inplace=True
+                ):
+                    match = re.match(r"\s+?CLIENT_VER =\s+(\S+)", line)
                     if match:
                         line = '    CLIENT_VER = "' + release_client + '",\n'
-                    print(line, end='')
+                    print(line, end="")
             else:
                 update_client = False
             if update_client:
-                print_green('Updated client version!')
+                print_green("Updated client version!")
             fetch_versions()
-        except: # lgtm [py/catch-base-exception]
+        except:  # lgtm [py/catch-base-exception]
             fileinput.close()
-            print_red('Error writing version.')
+            print_red("Error writing version.")
+
 
 def import_file(file):
-    file = os.path.normpath(file).replace('\\','/')
+    file = os.path.normpath(file).replace("\\", "/")
 
     if not os.path.exists(file):
-        print_red(f'Trying to import file that does not exist ({file}), or is an incomplete path.')
+        print_red(
+            f"Trying to import file that does not exist ({file}), or is an incomplete path."
+        )
         return
 
-    print('Importing ' + file)
-    query = 'SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0; SOURCE {}; SET unique_checks=1; SET foreign_key_checks=1; COMMIT;'.format(file)
+    print("Importing " + file)
+    query = "SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0; SOURCE {}; SET unique_checks=1; SET foreign_key_checks=1; COMMIT;".format(
+        file
+    )
 
-    result = subprocess.run([
-        '{}mysql{}'.format(mysql_bin, exe),
-        '-h', host,
-        '-P', str(port),
-        '-u', login,
-        '-p{}'.format(password),
-        database,
-        '-e', query],
-        capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "{}mysql{}".format(mysql_bin, exe),
+            "-h",
+            host,
+            "-P",
+            str(port),
+            "-u",
+            login,
+            "-p{}".format(password),
+            database,
+            "-e",
+            query,
+        ],
+        capture_output=True,
+        text=True,
+    )
 
     for line in result.stderr.splitlines():
         # Safe to ignore this warning
-        if 'Using a password on the command line interface can be insecure' not in line:
+        if "Using a password on the command line interface can be insecure" not in line:
             print_red(line)
+
 
 def connect():
     global db, cur
     try:
-        db = mariadb.connect(host=host,
-                user=login,
-                passwd=password,
-                db=database,
-                port=port)
+        db = mariadb.connect(
+            host=host, user=login, passwd=password, db=database, port=port
+        )
         cur = db.cursor()
     except mariadb.Error as err:
         if err.errno == mariadb.constants.ERR.ER_ACCESS_DENIED_ERROR:
-            print_red('Incorrect mysql_login or mysql_password, update settings/network.lua.')
+            print_red(
+                "Incorrect mysql_login or mysql_password, update settings/network.lua."
+            )
             close()
         elif err.errno == mariadb.constants.ERR.ER_BAD_DB_ERROR:
-            print_red('Database ' + database + ' does not exist.')
-            if input('Would you like to create new database: ' + database + '? [y/N] ').lower() == 'y':
-                create_command = '"' + mysql_bin + 'mysqladmin' + exe + '" -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' CREATE ' + database
+            print_red("Database " + database + " does not exist.")
+            if (
+                input(
+                    "Would you like to create new database: " + database + "? [y/N] "
+                ).lower()
+                == "y"
+            ):
+                create_command = (
+                    '"'
+                    + mysql_bin
+                    + "mysqladmin"
+                    + exe
+                    + '" -h '
+                    + host
+                    + " -P "
+                    + str(port)
+                    + " -u "
+                    + login
+                    + " -p"
+                    + password
+                    + " CREATE "
+                    + database
+                )
                 os.system(create_command + log_errors)
                 fetch_errors()
                 setup_db()
@@ -387,47 +479,120 @@ def connect():
 
     return True
 
+
 def close():
     if db:
-        print('Closing connection...')
+        print("Closing connection...")
         cur.close()
         db.close()
     time.sleep(0.5)
     quit()
 
+
 def setup_db():
     fetch_files()
     for sql_file in import_files:
         import_file(sql_file)
-    print_green('Finished importing!')
+    print_green("Finished importing!")
     write_version()
 
-def backup_db(silent=False,lite=False):
-    if silent or input('Would you like to backup your database? [y/N] ').lower() == 'y':
+
+def backup_db(silent=False, lite=False):
+    if silent or input("Would you like to backup your database? [y/N] ").lower() == "y":
         if not silent:
-            lite = input('Would you like to only backup protected tables? [y/N] ').lower() == 'y'
+            lite = (
+                input("Would you like to only backup protected tables? [y/N] ").lower()
+                == "y"
+            )
         if lite:
-            tables = ' '
+            tables = " "
             for table in player_data:
-                tables += table[:-4] + ' '
-            dumpcmd = '"' + mysql_bin + 'mysqldump' + exe + '" --hex-blob --add-drop-trigger -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' ' + database +\
-                tables + '> ' + server_dir_path + '/sql/backups/' + database + '-' + time.strftime('%Y%m%d-%H%M%S') + '-lite.sql'
+                tables += table[:-4] + " "
+            dumpcmd = (
+                '"'
+                + mysql_bin
+                + "mysqldump"
+                + exe
+                + '" --hex-blob --add-drop-trigger -h '
+                + host
+                + " -P "
+                + str(port)
+                + " -u "
+                + login
+                + " -p"
+                + password
+                + " "
+                + database
+                + tables
+                + "> "
+                + server_dir_path
+                + "/sql/backups/"
+                + database
+                + "-"
+                + time.strftime("%Y%m%d-%H%M%S")
+                + "-lite.sql"
+            )
         else:
             if db_ver:
-                dumpcmd = '"' + mysql_bin + 'mysqldump' + exe + '" --hex-blob --add-drop-trigger -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' ' + database +\
-                    ' > ' + server_dir_path + '/sql/backups/' + database + '-' + time.strftime('%Y%m%d-%H%M%S') + '-' + db_ver + '.sql'
+                dumpcmd = (
+                    '"'
+                    + mysql_bin
+                    + "mysqldump"
+                    + exe
+                    + '" --hex-blob --add-drop-trigger -h '
+                    + host
+                    + " -P "
+                    + str(port)
+                    + " -u "
+                    + login
+                    + " -p"
+                    + password
+                    + " "
+                    + database
+                    + " > "
+                    + server_dir_path
+                    + "/sql/backups/"
+                    + database
+                    + "-"
+                    + time.strftime("%Y%m%d-%H%M%S")
+                    + "-"
+                    + db_ver
+                    + ".sql"
+                )
             else:
-                dumpcmd = '"' + mysql_bin + 'mysqldump' + exe + '" --hex-blob --add-drop-trigger -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' ' + database +\
-                    ' > ' + server_dir_path + '/sql/backups/' + database + time.strftime('%Y%m%d-%H%M%S') + '-full.sql'
+                dumpcmd = (
+                    '"'
+                    + mysql_bin
+                    + "mysqldump"
+                    + exe
+                    + '" --hex-blob --add-drop-trigger -h '
+                    + host
+                    + " -P "
+                    + str(port)
+                    + " -u "
+                    + login
+                    + " -p"
+                    + password
+                    + " "
+                    + database
+                    + " > "
+                    + server_dir_path
+                    + "/sql/backups/"
+                    + database
+                    + time.strftime("%Y%m%d-%H%M%S")
+                    + "-full.sql"
+                )
         os.system(dumpcmd + log_errors)
         fetch_errors()
-        print_green('Database saved!')
+        print_green("Database saved!")
         time.sleep(0.5)
+
 
 def express_update(silent=False):
     update_db(silent, True)
 
-def update_db(silent=False,express=False):
+
+def update_db(silent=False, express=False):
     global express_enabled
     if not silent or auto_backup:
         backup_db(silent, auto_backup == 2)
@@ -435,220 +600,375 @@ def update_db(silent=False,express=False):
         fetch_files()
     if not silent:
         if import_protected:
-            print_green('The following PROTECTED tables could not be found and will be imported:')
+            print_green(
+                "The following PROTECTED tables could not be found and will be imported:"
+            )
             for sql_file in import_protected:
                 print(sql_file)
         if import_files:
-            print_green('The following files will be imported:')
+            print_green("The following files will be imported:")
             for sql_file in import_files:
                 if sql_file not in player_data:
-                    print(os.path.normpath(sql_file).replace('\\', '/'))
-    if silent or input('Proceed with update? [y/N] ').lower() == 'y':
+                    print(os.path.normpath(sql_file).replace("\\", "/"))
+    if silent or input("Proceed with update? [y/N] ").lower() == "y":
         for sql_file in import_protected:
             import_file(sql_file)
         for sql_file in import_files:
             if sql_file not in player_data:
                 import_file(sql_file)
-        print_green('Finished importing!')
+        print_green("Finished importing!")
         express_enabled = False
         run_all_migrations(silent or express)
         write_version(silent)
 
+
 def adjust_mysql_bin():
     global mysql_bin
     while True:
-        choice = input('Please enter the path to your MySQL bin directory or press enter to check PATH.\ne.g. C:\\Program Files\\MariaDB 10.6\\bin\\\n> ').replace('\\', '/')
-        if choice == '':
-            mysql_file = shutil.which('mysql')
+        choice = input(
+            "Please enter the path to your MySQL bin directory or press enter to check PATH.\ne.g. C:\\Program Files\\MariaDB 10.6\\bin\\\n> "
+        ).replace("\\", "/")
+        if choice == "":
+            mysql_file = shutil.which("mysql")
             if not mysql_file:
                 continue
-            choice = os.path.dirname(mysql_file).replace('\\','/')
-        if choice and choice[-1] != '/':
-            choice = choice + '/'
-        if os.path.exists(choice + 'mysql' + exe):
+            choice = os.path.dirname(mysql_file).replace("\\", "/")
+        if choice and choice[-1] != "/":
+            choice = choice + "/"
+        if os.path.exists(choice + "mysql" + exe):
             mysql_bin = choice
             break
+
 
 def adjust_auto_backup():
     global auto_backup
     while True:
-        choice = input('Would you like a backup to automatically be created when running an update from the command line? [y/n] ')
-        if choice == 'y':
-            choice = input('Would you like to only automatically backup protected tables? [y/N] ')
-            if choice == 'y':
+        choice = input(
+            "Would you like a backup to automatically be created when running an update from the command line? [y/n] "
+        )
+        if choice == "y":
+            choice = input(
+                "Would you like to only automatically backup protected tables? [y/N] "
+            )
+            if choice == "y":
                 auto_backup = 2
                 break
             else:
                 auto_backup = 1
                 break
-        elif choice == 'n':
+        elif choice == "n":
             auto_backup = 0
             break
         bad_selection()
 
+
 def adjust_auto_update_client():
     global auto_update_client
     while True:
-        choice = input('Would you like to automatically update the client version when running an update from the command line? [y/n] ')
-        if choice == 'y':
+        choice = input(
+            "Would you like to automatically update the client version when running an update from the command line? [y/n] "
+        )
+        if choice == "y":
             auto_update_client = True
             break
-        elif choice == 'n':
+        elif choice == "n":
             auto_update_client = False
             break
         bad_selection()
 
+
 def run_all_migrations(silent=False):
     migrations_needed = []
-    print_green('Checking migrations...')
+    print_green("Checking migrations...")
     for migration in migrations:
         check_migration(migration, migrations_needed, silent)
     if len(migrations_needed) > 0:
         if not silent:
-            if input('Migrations required!\nRun missing migrations? [y/N] ').lower() != 'y':
+            if (
+                input("Migrations required!\nRun missing migrations? [y/N] ").lower()
+                != "y"
+            ):
                 return
             else:
                 backup_db()
-        if os.path.exists(from_dbtool_path('migration_errors.log')):
-            os.remove(from_dbtool_path('migration_errors.log'))
+        if os.path.exists(from_dbtool_path("migration_errors.log")):
+            os.remove(from_dbtool_path("migration_errors.log"))
         for migration in migrations_needed:
-            print('Running migrations for ' + migration.migration_name() + '...')
+            print("Running migrations for " + migration.migration_name() + "...")
             migration.migrate(cur, db)
-        print_green('Finished migrations!')
-        if os.path.exists(from_dbtool_path('migration_errors.log')):
-            print_red('There were errors with some migrations, this likely means one or more characters \n'
-                'have corrupt data in some field. See migration_errors.log for more details.')
+        print_green("Finished migrations!")
+        if os.path.exists(from_dbtool_path("migration_errors.log")):
+            print_red(
+                "There were errors with some migrations, this likely means one or more characters \n"
+                "have corrupt data in some field. See migration_errors.log for more details."
+            )
         time.sleep(0.5)
     else:
-        print_green('No migrations required.')
+        print_green("No migrations required.")
         time.sleep(0.5)
+
 
 def check_migration(migration, migrations_needed, silent=False):
     migration.check_preconditions(cur)
     if not migration.needs_to_run(cur):
         if not silent:
-            print_red('[' + colorama.Fore.GREEN + '*' + colorama.Fore.RED + '] ' + colorama.Style.RESET_ALL + migration.migration_name())
+            print_red(
+                "["
+                + colorama.Fore.GREEN
+                + "*"
+                + colorama.Fore.RED
+                + "] "
+                + colorama.Style.RESET_ALL
+                + migration.migration_name()
+            )
         return
     migrations_needed.append(migration)
     if not silent:
-        print_red('[ ] ' + colorama.Style.RESET_ALL + migration.migration_name())
+        print_red("[ ] " + colorama.Style.RESET_ALL + migration.migration_name())
+
 
 def restore_backup():
     backup_db()
     fetch_files()
     while len(backups):
         for i, backup in enumerate(backups):
-            print_green(str(i + 1) + colorama.Style.RESET_ALL + '. ' + backup.replace('\\','/'))
-        choice = input('Choose a number to import, or type "delete #" to delete a file.\n> ')
+            print_green(
+                str(i + 1) + colorama.Style.RESET_ALL + ". " + backup.replace("\\", "/")
+            )
+        choice = input(
+            'Choose a number to import, or type "delete #" to delete a file.\n> '
+        )
         if choice.isnumeric():
             choice = int(choice)
             if 0 < choice < len(backups) + 1:
-                backup_file = backups[choice - 1].replace('\\','/')
+                backup_file = backups[choice - 1].replace("\\", "/")
                 print(colorama.ansi.clear_screen())
-                print_red('If this is a full backup created by this tool, it is recommended to manually change \n'
-                    'the DB_VER in config.yaml to the hash sequence in the filename, after \n'
-                    'the database name and the timestamp, so that express update functions properly.')
-                if input('Import ' + backup_file + '? [y/N] ').lower() == 'y':
+                print_red(
+                    "If this is a full backup created by this tool, it is recommended to manually change \n"
+                    "the DB_VER in config.yaml to the hash sequence in the filename, after \n"
+                    "the database name and the timestamp, so that express update functions properly."
+                )
+                if input("Import " + backup_file + "? [y/N] ").lower() == "y":
                     import_file(backup_file)
-                    print_green('Finished importing!')
+                    print_green("Finished importing!")
                     break
             else:
                 bad_selection()
         else:
-            choice = re.match(r'^delete (\d+)$', choice)
+            choice = re.match(r"^delete (\d+)$", choice)
             if choice:
                 choice = int(choice.group(1))
                 if 0 < choice < len(backups) + 1:
                     backup_file = backups[choice - 1]
                     print(colorama.ansi.clear_screen())
-                    if input('Delete ' + backup_file + '? [y/N] ').lower() == 'y':
-                        os.remove(from_server_path('sql/backups/') + backup_file)
-                        print_green('Deleted ' + backup_file + '!')
+                    if input("Delete " + backup_file + "? [y/N] ").lower() == "y":
+                        os.remove(from_server_path("sql/backups/") + backup_file)
+                        print_green("Deleted " + backup_file + "!")
                         fetch_files()
                 else:
                     bad_selection()
             else:
                 return
 
+
 def reset_db():
     backup_db()
-    print_red('Are you sure you want to reset your database to default?')
+    print_red("Are you sure you want to reset your database to default?")
     choice = input('Type "reset ' + database + '" to confirm.\n> ')
-    choice = re.match(r'^reset (\w+)$', choice)
+    choice = re.match(r"^reset (\w+)$", choice)
     if choice and choice.group(1) == database:
         setup_db()
 
+
 def bad_selection():
-    print_red('Invalid selection.')
+    print_red("Invalid selection.")
     time.sleep(0.5)
 
+
 def menu():
-    print(colorama.Fore.GREEN + 'o' + colorama.Fore.RED + '---------------------------------------' + colorama.Fore.GREEN + 'o\n' + colorama.Fore.RED +
-          '| ' + colorama.Style.RESET_ALL + 'LandSandBoat Database Management Tool' + colorama.Fore.RED + ' |\n'
-          '| ' + colorama.Style.RESET_ALL + str('Connected to ' + database).center(37) + colorama.Fore.RED + ' |')
+    print(
+        colorama.Fore.GREEN
+        + "o"
+        + colorama.Fore.RED
+        + "---------------------------------------"
+        + colorama.Fore.GREEN
+        + "o\n"
+        + colorama.Fore.RED
+        + "| "
+        + colorama.Style.RESET_ALL
+        + "LandSandBoat Database Management Tool"
+        + colorama.Fore.RED
+        + " |\n"
+        "| "
+        + colorama.Style.RESET_ALL
+        + str("Connected to " + database).center(37)
+        + colorama.Fore.RED
+        + " |"
+    )
     if db_ver:
-        print(colorama.Fore.RED + '| ' + colorama.Style.RESET_ALL + str('#' + db_ver).center(37) + colorama.Fore.RED + ' |')
-    print(colorama.Fore.GREEN + 'o' + colorama.Fore.RED + '---------------------------------------' + colorama.Fore.GREEN + 'o')
+        print(
+            colorama.Fore.RED
+            + "| "
+            + colorama.Style.RESET_ALL
+            + str("#" + db_ver).center(37)
+            + colorama.Fore.RED
+            + " |"
+        )
+    print(
+        colorama.Fore.GREEN
+        + "o"
+        + colorama.Fore.RED
+        + "---------------------------------------"
+        + colorama.Fore.GREEN
+        + "o"
+    )
     if express_enabled:
-        print(colorama.Fore.RED + '|' + colorama.Fore.GREEN + 'e' + colorama.Style.RESET_ALL + '. Express Update ' + str('(#' + release_version + ')').ljust(21) + colorama.Fore.RED + '|')
-    print(colorama.Fore.RED + '|' + colorama.Fore.GREEN + '1' + colorama.Style.RESET_ALL + '. Update DB                           ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + '2' + colorama.Style.RESET_ALL + '. Check migrations                    ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + '3' + colorama.Style.RESET_ALL + '. Backup                              ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + '4' + colorama.Style.RESET_ALL + '. Restore/Import                      ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + 'r' + colorama.Style.RESET_ALL + '. Reset DB                            ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + 't' + colorama.Style.RESET_ALL + '. Tasks                               ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + 's' + colorama.Style.RESET_ALL + '. Settings                            ' + colorama.Fore.RED + '|\n'
-          '|' + colorama.Fore.GREEN + 'q' + colorama.Style.RESET_ALL + '. Quit                                ' + colorama.Fore.RED + '|\n'
-          + colorama.Fore.GREEN + 'o' + colorama.Fore.RED + '---------------------------------------' + colorama.Fore.GREEN + 'o')
+        print(
+            colorama.Fore.RED
+            + "|"
+            + colorama.Fore.GREEN
+            + "e"
+            + colorama.Style.RESET_ALL
+            + ". Express Update "
+            + str("(#" + release_version + ")").ljust(21)
+            + colorama.Fore.RED
+            + "|"
+        )
+    print(
+        colorama.Fore.RED
+        + "|"
+        + colorama.Fore.GREEN
+        + "1"
+        + colorama.Style.RESET_ALL
+        + ". Update DB                           "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "2"
+        + colorama.Style.RESET_ALL
+        + ". Check migrations                    "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "3"
+        + colorama.Style.RESET_ALL
+        + ". Backup                              "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "4"
+        + colorama.Style.RESET_ALL
+        + ". Restore/Import                      "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "r"
+        + colorama.Style.RESET_ALL
+        + ". Reset DB                            "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "t"
+        + colorama.Style.RESET_ALL
+        + ". Tasks                               "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "s"
+        + colorama.Style.RESET_ALL
+        + ". Settings                            "
+        + colorama.Fore.RED
+        + "|\n"
+        "|"
+        + colorama.Fore.GREEN
+        + "q"
+        + colorama.Style.RESET_ALL
+        + ". Quit                                "
+        + colorama.Fore.RED
+        + "|\n"
+        + colorama.Fore.GREEN
+        + "o"
+        + colorama.Fore.RED
+        + "---------------------------------------"
+        + colorama.Fore.GREEN
+        + "o"
+    )
+
 
 def settings():
     fetch_configs()
-    print_green('Current MySQL bin location: ' + colorama.Style.RESET_ALL + mysql_bin)
-    if input('Change this location? [y/N] ').lower() == 'y':
+    print_green("Current MySQL bin location: " + colorama.Style.RESET_ALL + mysql_bin)
+    if input("Change this location? [y/N] ").lower() == "y":
         adjust_mysql_bin()
-    print_green('Automatic backup for command line updates: ' + colorama.Style.RESET_ALL + str(bool(auto_backup)))
-    if input('Change this? [y/N] ').lower() == 'y':
+    print_green(
+        "Automatic backup for command line updates: "
+        + colorama.Style.RESET_ALL
+        + str(bool(auto_backup))
+    )
+    if input("Change this? [y/N] ").lower() == "y":
         adjust_auto_backup()
-    print_green('Automatic client version update for command line updates: ' + colorama.Style.RESET_ALL + str(auto_update_client))
-    if input('Change this? [y/N] ').lower() == 'y':
+    print_green(
+        "Automatic client version update for command line updates: "
+        + colorama.Style.RESET_ALL
+        + str(auto_update_client)
+    )
+    if input("Change this? [y/N] ").lower() == "y":
         adjust_auto_update_client()
     write_configs()
+
 
 # TODO: Hook this up to a menu option
 def set_external_ip(ip_str):
     global mysql_bin, exe
 
-    query = f'UPDATE zone_settings SET zoneip = \'{ip_str}\';'
+    query = f"UPDATE zone_settings SET zoneip = '{ip_str}';"
 
     print("Executing query:")
     print(query)
 
-    result = subprocess.run([
-        '{}mysql{}'.format(mysql_bin, exe),
-        '-h', host,
-        '-P', str(port),
-        '-u', login,
-        '-p{}'.format(password),
-        database,
-        '-e', query],
-        capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "{}mysql{}".format(mysql_bin, exe),
+            "-h",
+            host,
+            "-P",
+            str(port),
+            "-u",
+            login,
+            "-p{}".format(password),
+            database,
+            "-e",
+            query,
+        ],
+        capture_output=True,
+        text=True,
+    )
 
     for line in result.stderr.splitlines():
         # Safe to ignore this warning
-        if 'Using a password on the command line interface can be insecure' not in line:
+        if "Using a password on the command line interface can be insecure" not in line:
             print_red(line)
 
+
 def tasks():
-    if input('Make server public-facing? [y/N] ').lower() == 'y':
+    if input("Make server public-facing? [y/N] ").lower() == "y":
         import urllib.request
-        external_ip = urllib.request.urlopen('https://ident.me').read().decode('utf8')
-        print_green(f'Detected your public-facing IP as: {external_ip}')
-        if input('Is this correct? [y/N] ').lower() == 'y':
+
+        external_ip = urllib.request.urlopen("https://ident.me").read().decode("utf8")
+        print_green(f"Detected your public-facing IP as: {external_ip}")
+        if input("Is this correct? [y/N] ").lower() == "y":
             set_external_ip(external_ip)
         else:
-            external_ip = input('Please enter your public-facing IP: ')
+            external_ip = input("Please enter your public-facing IP: ")
             if len(external_ip.strip()) > 0:
                 set_external_ip(external_ip)
+
 
 def main():
     try:
@@ -656,31 +976,36 @@ def main():
         if fetch_credentials() == False:
             return
         fetch_configs()
-        #Check MySQL path/availability
-        if not os.path.exists(mysql_bin + 'mysql' + exe):
+        # Check MySQL path/availability
+        if not os.path.exists(mysql_bin + "mysql" + exe):
             adjust_mysql_bin()
             write_configs()
         fetch_versions()
-        #CLI args
+        # CLI args
         if len(sys.argv) > 1:
             arg1 = str(sys.argv[1])
-            if 'backup' == arg1:
-                if len(sys.argv) > 2 and str(sys.argv[2]) == 'lite':
-                    backup_db(True,True)
+            if "backup" == arg1:
+                if len(sys.argv) > 2 and str(sys.argv[2]) == "lite":
+                    backup_db(True, True)
                 else:
                     backup_db(True)
                 return
-            elif 'migrate' == arg1:
+            elif "migrate" == arg1:
                 if connect() != False:
                     run_all_migrations(True)
                     close()
                 return
-            elif 'update' == arg1:
+            elif "update" == arg1:
                 full_update = False
-                if len(sys.argv) > 2 and str(sys.argv[2]) == 'full':
+                if len(sys.argv) > 2 and str(sys.argv[2]) == "full":
                     full_update = True
-                if db_ver and release_version and not express_enabled and not full_update:
-                    print_green('Database is up to date.')
+                if (
+                    db_ver
+                    and release_version
+                    and not express_enabled
+                    and not full_update
+                ):
+                    print_green("Database is up to date.")
                     return
                 if connect() != False:
                     if express_enabled and not full_update:
@@ -689,33 +1014,48 @@ def main():
                         update_db(True)
                     close()
                 return
-            elif 'setup' == arg1:
+            elif "setup" == arg1:
                 if len(sys.argv) > 2 and str(sys.argv[2]) == database:
-                    create_command = '"' + mysql_bin + 'mysqladmin' + exe + '" -h ' + host + ' -P ' + str(port) + ' -u ' + login + ' -p' + password + ' CREATE ' + database
+                    create_command = (
+                        '"'
+                        + mysql_bin
+                        + "mysqladmin"
+                        + exe
+                        + '" -h '
+                        + host
+                        + " -P "
+                        + str(port)
+                        + " -u "
+                        + login
+                        + " -p"
+                        + password
+                        + " CREATE "
+                        + database
+                    )
                     os.system(create_command + log_errors)
                     fetch_errors()
                     setup_db()
                 return
-        #Main loop
+        # Main loop
         print(colorama.ansi.clear_screen())
         connect()
         actions = {
-            '1': update_db,
-            '2': run_all_migrations,
-            '3': backup_db,
-            '4': restore_backup,
-            'r': reset_db,
-            't': tasks,
-            's': settings
+            "1": update_db,
+            "2": run_all_migrations,
+            "3": backup_db,
+            "4": restore_backup,
+            "r": reset_db,
+            "t": tasks,
+            "s": settings,
         }
         while cur:
             menu()
-            selection = input('> ').lower()
+            selection = input("> ").lower()
 
             print(colorama.ansi.clear_screen())
-            if 'q' == selection:
+            if "q" == selection:
                 close()
-            if 'e' == selection and express_enabled:
+            if "e" == selection and express_enabled:
                 express_update()
                 continue
             use_tool = actions.get(selection, bad_selection)
@@ -727,5 +1067,6 @@ def main():
         except SystemExit:
             os._exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

As part of https://github.com/LandSandBoat/server/issues/2240, one of the issues is to remove the requirement for dbtool to always be run from <root>/tools. This does that.

## Steps to test these changes

Use dbtool as normal, but launch it from `<root>/tools`, or `<root>`, or `<root>/scripts/globals` and make sure everything works as expected.
