### PR TITLE
[login] Fix lookup of BANNED_WORDS_LIST

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -839,8 +839,8 @@ int32 lobbyview_parse(int32 fd)
                     }
 
                     // (optional) Check if the name contains any words on the bad word list
-                    auto badWordsList = lua["xi"]["settings"]["login"]["BANNED_WORDS_LIST"].get<sol::table>();
-                    if (badWordsList.valid())
+                    auto loginSettingsTable = lua["xi"]["settings"]["login"].get<sol::table>();
+                    if (auto badWordsList = loginSettingsTable.get_or<sol::table>("BANNED_WORDS_LIST", sol::lua_nil); badWordsList.valid())
                     {
                         auto potentialName = to_upper(nameStr);
                         for (auto entry : badWordsList)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

If BANNED_WORDS_LIST isn't present, we would previously silently crash. We should be looking up xi.settings.login and then do a secondary lookup for the list which is prepared to fail.

## Steps to test these changes

Make a new character, with or without BANNED_WORDS_LIST  present in login.lua