### PR TITLE
[Fix] Shimering Circle anti-cheat checks that prevented progress to Sky zone

### DIFF
--- a/scripts/zones/Hall_of_the_Gods/npcs/Shimmering_Circle.lua
+++ b/scripts/zones/Hall_of_the_Gods/npcs/Shimmering_Circle.lua
@@ -13,20 +13,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local roz = player:getCurrentMission(xi.mission.log_id.ZILART)
-    local rozStat = player:getMissionStatus(xi.mission.log_id.ZILART)
-
     if player:getZPos() < 200 then
-        if
-            roz ~= xi.mission.id.zilart.NONE and
-            (
-                roz > xi.mission.id.zilart.THE_GATE_OF_THE_GODS or
-                (
-                    roz == xi.mission.id.zilart.THE_GATE_OF_THE_GODS and
-                    rozStat > 0
-                )
-            )
-        then
+        if player:getCurrentMission(xi.mission.log_id.ZILART) >= xi.mission.id.zilart.THE_GATE_OF_THE_GODS then
             player:startEvent(10)
         else
             player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes a check that prevented the npc from reacting properly (allowing teleportation) when it should.

## Steps to test these changes

Progress through this missions normally.
