### PR TITLE
[tools] Only check resolved filename when checking protected tables

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -520,7 +520,7 @@ def update_db(silent=False, express=False):
         if import_files:
             print_green("The following files will be imported:")
             for sql_file in import_files:
-                if sql_file not in player_data:
+                if pathlib.Path(sql_file).name not in player_data:
                     print(os.path.normpath(sql_file).replace("\\", "/"))
     if silent or input("Proceed with update? [y/N] ").lower() == "y":
         for sql_file in import_protected:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Updates dbtool to check the filename only of protected tables

## Steps to test these changes

use dbtool and don't see attempted import of accounts, chars, etc after first import of said tables
