### PR TITLE
[dbtool] Stop protected tables being imported

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -526,7 +526,7 @@ def update_db(silent=False, express=False):
         for sql_file in import_protected:
             import_file(sql_file)
         for sql_file in import_files:
-            if sql_file not in player_data:
+            if pathlib.Path(sql_file).name not in player_data:
                 import_file(sql_file)
         print_green("Finished importing!")
         express_enabled = False


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Good find in #3085! That prevents protected tables from being listed but still allows them to import. This should fix that, hopefully no disasters caused by this.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
