### PR TITLE
Set zero block rate on non players when mobmod not applied

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1853,6 +1853,10 @@ namespace battleutils
                     return blockRate;
                 }
             }
+            else // No block mobmod, so zero rate
+            {
+                return 0;
+            }
         }
         else
         {


### PR DESCRIPTION
Fixes #3084

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [:crossed_fingers:] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Winter and I saw there is a tiny chance mobs will try to block if this wasn't explicitly zero. So we're returning zero now.

## Steps to test these changes
Give self lots of acc, immortal a lv one bunny, swing for an hour and notice bunny never takes half damage (default shield block is 50%)
