### PR TITLE
Remove outer parens from additional NPC lua scripts

### DIFF
--- a/scripts/zones/Bastok_Markets_[S]/npcs/Gentle_Tiger.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Gentle_Tiger.lua
@@ -14,14 +14,14 @@ end
 entity.onTrigger = function(player, npc)
     local onSabbatical = player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.ON_SABBATICAL)
     local onSabbaticalProgress = player:getCharVar("OnSabbatical")
-    if (onSabbatical == QUEST_ACCEPTED) then
-        if (onSabbaticalProgress == 1) then
+    if onSabbatical == QUEST_ACCEPTED then
+        if onSabbaticalProgress == 1 then
             player:startEvent(46)
         else
             player:startEvent(47)
         end
-    elseif (player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.FIRES_OF_DISCONTENT) == QUEST_ACCEPTED) then
-        if (player:getCharVar("FiresOfDiscProg") == 5) then
+    elseif player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.FIRES_OF_DISCONTENT) == QUEST_ACCEPTED then
+        if player:getCharVar("FiresOfDiscProg") == 5 then
             player:startEvent(160)
         else
             player:startEvent(161)
@@ -36,9 +36,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 46) then
+    if csid == 46 then
         player:setCharVar("OnSabbatical", 2)
-    elseif (csid == 160) then
+    elseif csid == 160 then
         player:setCharVar("FiresOfDiscProg", 6)
     end
 end

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Loussaire.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Loussaire.lua
@@ -29,7 +29,7 @@ entity.onTrigger = function(player, npc)
     local gownQuestProgress    = player:getCharVar("AF_SCH_BODY")
     local afProgress           = player:getCharVar("AF_Loussaire")
 
-    if (player:getCharVar("AF_SCH_COMPLETE") == 0) then
+    if player:getCharVar("AF_SCH_COMPLETE") == 0 then
 
         -- They have a piece in progress.
         if
@@ -43,17 +43,16 @@ entity.onTrigger = function(player, npc)
                 gownQuestProgress == 2
             )
         then
-
             local itemid   = 14580 -- Scholar's Gown
             local firstKI  = xi.ki.PEISTE_DUNG
             local secondKI = xi.ki.SAMPLE_OF_GRAUBERG_CHERT
 
-            if (loafersQuestProgress == 1 or loafersQuestProgress == 2) then
+            if loafersQuestProgress == 1 or loafersQuestProgress == 2 then
                 itemid   = 15748 -- Scholar's Loafers
                 firstKI  = xi.ki.RAFFLESIA_DREAMSPIT
                 secondKI = xi.ki.DROGAROGAN_BONEMEAL
 
-            elseif (pantsQuestProgress == 1 or pantsQuestProgress == 2) then
+            elseif pantsQuestProgress == 1 or pantsQuestProgress == 2 then
                 itemid   = 16311 -- Scholar's Pants
                 firstKI  = xi.ki.SLUG_MUCUS
                 secondKI = xi.ki.DJINN_EMBER
@@ -62,42 +61,41 @@ entity.onTrigger = function(player, npc)
             player:startEvent(50, itemid, firstKI, secondKI)
 
         -- Nothing in progress and meet the starting requirements.
-        elseif (downwardHelix == QUEST_COMPLETED and mJob == xi.job.SCH and mLvl >= xi.settings.main.AF2_QUEST_LEVEL) then
-
+        elseif downwardHelix == QUEST_COMPLETED and mJob == xi.job.SCH and mLvl >= xi.settings.main.AF2_QUEST_LEVEL then
             -- If a player has completed any of the paths, it will be a different cutscene.
             local counter = 0
-            if (loafersQuestProgress == 4) then
+            if loafersQuestProgress == 4 then
                 counter = counter + 1
             end
-            if (pantsQuestProgress == 4) then
+            if pantsQuestProgress == 4 then
                 counter = counter + 1
             end
-            if (gownQuestProgress == 4) then
+            if gownQuestProgress == 4 then
                 counter = counter + 1
             end
 
             -- Controls which CS to give the player based on completed paths.
             local cutsceneID = 51
-            if (counter == 1) then
+            if counter == 1 then
                 cutsceneID = 52
-            elseif (counter == 2) then
+            elseif counter == 2 then
                 cutsceneID = 54
             end
 
             -- Check Key Items and give them their dynamic event.
-            if (player:hasKeyItem(xi.ki.RAFFLESIA_DREAMSPIT) and player:hasKeyItem(xi.ki.DROGAROGAN_BONEMEAL) and loafersQuestProgress == 3) then -- Scholar's Loafers
+            if player:hasKeyItem(xi.ki.RAFFLESIA_DREAMSPIT) and player:hasKeyItem(xi.ki.DROGAROGAN_BONEMEAL) and loafersQuestProgress == 3 then -- Scholar's Loafers
                 player:startEvent(cutsceneID, 15748)
                 player:setLocalVar("item", 15748)
                 player:setLocalVar("firstKI", xi.ki.RAFFLESIA_DREAMSPIT)
                 player:setLocalVar("secondKI", xi.ki.DROGAROGAN_BONEMEAL)
 
-            elseif (player:hasKeyItem(xi.ki.SLUG_MUCUS) and player:hasKeyItem(xi.ki.DJINN_EMBER) and pantsQuestProgress == 3) then -- Scholar's Pants
+            elseif player:hasKeyItem(xi.ki.SLUG_MUCUS) and player:hasKeyItem(xi.ki.DJINN_EMBER) and pantsQuestProgress == 3 then -- Scholar's Pants
                 player:startEvent(cutsceneID, 16311)
                 player:setLocalVar("item", 16311)
                 player:setLocalVar("firstKI", xi.ki.SLUG_MUCUS)
                 player:setLocalVar("secondKI", xi.ki.DJINN_EMBER)
 
-            elseif (player:hasKeyItem(xi.ki.PEISTE_DUNG) and player:hasKeyItem(xi.ki.SAMPLE_OF_GRAUBERG_CHERT) and gownQuestProgress == 3) then -- Scholar's Gown
+            elseif player:hasKeyItem(xi.ki.PEISTE_DUNG) and player:hasKeyItem(xi.ki.SAMPLE_OF_GRAUBERG_CHERT) and gownQuestProgress == 3 then -- Scholar's Gown
                 player:startEvent(cutsceneID, 14580)
                 player:setLocalVar("item", 14580)
                 player:setLocalVar("firstKI", xi.ki.PEISTE_DUNG)
@@ -105,26 +103,25 @@ entity.onTrigger = function(player, npc)
 
             -- Show them the normal Menu to select from.
             else
-
                 local params = 0 -- Controls which items to hide (Binary - 0XXX)
 
                 -- Scholar's Loafers
-                if (loafersQuestProgress ~= 0) then
+                if loafersQuestProgress ~= 0 then
                     params = 1
                 end
 
                 -- Scholar's Pants
-                if (pantsQuestProgress ~= 0) then
+                if pantsQuestProgress ~= 0 then
                     params = params + 2
                 end
 
                 -- Scholar's Gown
-                if (gownQuestProgress ~= 0) then
+                if gownQuestProgress ~= 0 then
                     params = params + 4
                 end
 
-                if (params < 8) then
-                    if (afProgress > 0) then
+                if params < 8 then
+                    if afProgress > 0 then
                         player:startEvent(53, params) -- Shorter CS than 49
                     else
                         player:startEvent(49, params)
@@ -139,42 +136,42 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if (csid == 49 or csid == 53) then
+    if csid == 49 or csid == 53 then
         -- Display Loafers
-        if (option == 2) then
+        if option == 2 then
             player:updateEvent(option, xi.ki.RAFFLESIA_DREAMSPIT, xi.ki.DROGAROGAN_BONEMEAL, 0, 0, 0, 0, 0)
 
         -- Display Pants
-        elseif (option == 4) then
+        elseif option == 4 then
             player:updateEvent(option, xi.ki.SLUG_MUCUS, xi.ki.DJINN_EMBER, 0, 0, 0, 0, 0)
 
         -- Display Gown
-        elseif (option == 6) then
+        elseif option == 6 then
             player:updateEvent(option, xi.ki.PEISTE_DUNG, xi.ki.SAMPLE_OF_GRAUBERG_CHERT, 0, 0, 0, 0, 0)
 
         -- Confirm Loafers
-        elseif (option == 1) then
+        elseif option == 1 then
             player:setCharVar("AF_SCH_BOOTS", 1)
 
         -- Confirm Pants
-        elseif (option == 3) then
+        elseif option == 3 then
             player:setCharVar("AF_SCH_PANTS", 1)
 
         -- Confirm Gown
-        elseif (option == 5) then
+        elseif option == 5 then
             player:setCharVar("AF_SCH_BODY", 1)
 
-        elseif (option > 7) then
+        elseif option > 7 then
             player:PrintToPlayer("There was an error in the CS. Inform your Server Admin/GM.")
         end
     end
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 49 and option == 0) then
+    if csid == 49 and option == 0 then
         player:setCharVar("AF_Loussaire", 1)
 
-    elseif (csid == 51 or csid == 52 or csid == 54) then
+    elseif csid == 51 or csid == 52 or csid == 54 then
         local itemid   = player:getLocalVar("item")
         local firstKI  = player:getLocalVar("firstKI")
         local secondKI = player:getLocalVar("secondKI")
@@ -189,16 +186,16 @@ entity.onEventFinish = function(player, csid, option)
             player:setLocalVar("secondKI", 0)
 
             -- Flag the path complete
-            if (itemid == 15748) then
+            if itemid == 15748 then
                 player:setCharVar("AF_SCH_BOOTS", 4)
-            elseif (itemid == 16311) then
+            elseif itemid == 16311 then
                 player:setCharVar("AF_SCH_PANTS", 4)
             else
                 player:setCharVar("AF_SCH_BODY", 4)
             end
 
             local afProgress = player:getCharVar("AF_Loussaire")
-            if (afProgress == 3) then
+            if afProgress == 3 then
 
                 -- They are done. Clean-up
                 player:setCharVar("AF_SCH_BOOTS",    0)

--- a/scripts/zones/Bhaflau_Thickets/npcs/Daswil.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/Daswil.lua
@@ -20,9 +20,9 @@ entity.onTrigger = function(player, npc)
     local toauMission = player:getCurrentMission(xi.mission.log_id.TOAU)
 
     -- ASSAULT
-    if (toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM) then
+    if toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM then
         local IPpoint = player:getCurrency("imperial_standing")
-        if (player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false) then
+        if player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false then
             player:startEvent(512, 50, IPpoint)
         else
             player:startEvent(7)
@@ -40,7 +40,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- ASSAULT
-    if (csid == 512 and option == 1) then
+    if csid == 512 and option == 1 then
         player:delCurrency("imperial_standing", 50)
         player:addKeyItem(xi.ki.ASSAULT_ARMBAND)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ASSAULT_ARMBAND)

--- a/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
@@ -36,11 +36,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 62) then
+    if csid == 62 then
         player:addQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_FLUTTERY_FIEND)
-    elseif (csid == 63) then
+    elseif csid == 63 then
         -- Killed Itzpapalotl
-    elseif (csid == 61 and option == 1) then
+    elseif csid == 61 and option == 1 then
         player:setPos(-140, 20, -181, 131, 215)
     end
 end

--- a/scripts/zones/Carpenters_Landing/npcs/relic.lua
+++ b/scripts/zones/Carpenters_Landing/npcs/relic.lua
@@ -10,7 +10,7 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getCharVar("RELIC_IN_PROGRESS") == xi.items.ANCILE and npcUtil.tradeHas(trade, { xi.items.RANPERRE_GOLDPIECE, xi.items.SUPERNAL_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.ANCILE })) then -- currency, shard, necropsyche, stage 4
+    if player:getCharVar("RELIC_IN_PROGRESS") == xi.items.ANCILE and npcUtil.tradeHas(trade, { xi.items.RANPERRE_GOLDPIECE, xi.items.SUPERNAL_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.ANCILE }) then -- currency, shard, necropsyche, stage 4
         player:startEvent(44, xi.items.AEGIS)
     end
 end
@@ -23,7 +23,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 44 and npcUtil.giveItem(player, { xi.items.AEGIS, { xi.items.MONTIONT_SILVERPIECE, 30 } })) then
+    if csid == 44 and npcUtil.giveItem(player, { xi.items.AEGIS, { xi.items.MONTIONT_SILVERPIECE, 30 } }) then
         player:confirmTrade()
         player:setCharVar("RELIC_IN_PROGRESS", 0)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
@@ -48,22 +48,25 @@ entity.onTrade = function(player, npc, trade)
     local gil = trade:getGil()
     local count = trade:getItemCount()
 
-    if (player:hasKeyItem(xi.ki.VIAL_OF_SHROUDED_SAND)) then
+    if player:hasKeyItem(xi.ki.VIAL_OF_SHROUDED_SAND) then
 
         -- buy prismatic hourglass
-        if (gil == xi.settings.main.PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(xi.ki.PRISMATIC_HOURGLASS)) then
+        if
+            gil == xi.settings.main.PRISMATIC_HOURGLASS_COST and count == 1 and
+            not player:hasKeyItem(xi.ki.PRISMATIC_HOURGLASS)
+        then
             player:startEvent(54)
 
         -- return timeless hourglass for refund
-        elseif (count == 1 and trade:hasItemQty(timelessHourglassID, 1)) then
+        elseif count == 1 and trade:hasItemQty(timelessHourglassID, 1) then
             player:startEvent(97)
 
         -- currency exchanges
-        elseif (count == xi.settings.main.CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], xi.settings.main.CURRENCY_EXCHANGE_RATE)) then
+        elseif count == xi.settings.main.CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1], xi.settings.main.CURRENCY_EXCHANGE_RATE) then
             player:startEvent(55, xi.settings.main.CURRENCY_EXCHANGE_RATE)
-        elseif (count == xi.settings.main.CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], xi.settings.main.CURRENCY_EXCHANGE_RATE)) then
+        elseif count == xi.settings.main.CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2], xi.settings.main.CURRENCY_EXCHANGE_RATE) then
             player:startEvent(56, xi.settings.main.CURRENCY_EXCHANGE_RATE)
-        elseif (count == 1 and trade:hasItemQty(currency[3], 1)) then
+        elseif count == 1 and trade:hasItemQty(currency[3], 1) then
             player:startEvent(58, currency[3], currency[2], xi.settings.main.CURRENCY_EXCHANGE_RATE)
 
         -- shop
@@ -85,7 +88,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:hasKeyItem(xi.ki.VIAL_OF_SHROUDED_SAND)) then
+    if player:hasKeyItem(xi.ki.VIAL_OF_SHROUDED_SAND) then
         player:startEvent(53, currency[1], xi.settings.main.CURRENCY_EXCHANGE_RATE, currency[2], xi.settings.main.CURRENCY_EXCHANGE_RATE, currency[3], xi.settings.main.PRISMATIC_HOURGLASS_COST, timelessHourglassID, xi.settings.main.TIMELESS_HOURGLASS_COST)
     else
         player:startEvent(50)
@@ -93,33 +96,33 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if (csid == 53) then
+    if csid == 53 then
 
         -- asking about hourglasses
-        if (option == 1) then
-            if (not player:hasItem(timelessHourglassID)) then
+        if option == 1 then
+            if not player:hasItem(timelessHourglassID) then
                 -- must figure out what changes here to prevent the additional dialog
                 -- player:updateEvent(?)
             end
 
         -- shop
-        elseif (option == 2) then
+        elseif option == 2 then
             player:updateEvent(unpack(shop, 1, 8))
-        elseif (option == 3) then
+        elseif option == 3 then
             player:updateEvent(unpack(shop, 9, 14))
 
         -- offer to trade down from a 10k
-        elseif (option == 10) then
+        elseif option == 10 then
             player:updateEvent(currency[3], currency[2], xi.settings.main.CURRENCY_EXCHANGE_RATE)
 
         -- main menu (param1 = dynamis map bitmask, param2 = gil)
-        elseif (option == 11) then
+        elseif option == 11 then
             player:updateEvent(xi.dynamis.getDynamisMapList(player), player:getGil())
 
         -- maps
-        elseif (maps[option] ~= nil) then
+        elseif maps[option] ~= nil then
             local price = maps[option]
-            if (price > player:getGil()) then
+            if price > player:getGil() then
                 player:messageSpecial(ID.text.NOT_ENOUGH_GIL)
             else
                 player:delGil(price)
@@ -135,19 +138,19 @@ end
 entity.onEventFinish = function(player, csid, option)
 
     -- bought prismatic hourglass
-    if (csid == 54) then
+    if csid == 54 then
         player:tradeComplete()
         player:addKeyItem(xi.ki.PRISMATIC_HOURGLASS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.PRISMATIC_HOURGLASS)
 
     -- refund timeless hourglass
-    elseif (csid == 97) then
+    elseif csid == 97 then
         player:tradeComplete()
         player:addGil(xi.settings.main.TIMELESS_HOURGLASS_COST)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.TIMELESS_HOURGLASS_COST)
 
     -- singles to hundos
-    elseif (csid == 55) then
+    elseif csid == 55 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
         else
@@ -157,7 +160,7 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- hundos to 10k pieces
-    elseif (csid == 56) then
+    elseif csid == 56 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[3])
         else
@@ -167,7 +170,7 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- 10k pieces to hundos
-    elseif (csid == 58) then
+    elseif csid == 58 then
         local slotsReq = math.ceil(xi.settings.main.CURRENCY_EXCHANGE_RATE / 99)
         if (player:getFreeSlotsCount() < slotsReq) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, currency[2])
@@ -184,7 +187,7 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- bought item from shop
-    elseif (csid == 57) then
+    elseif csid == 57 then
         local item = player:getLocalVar("hundoItemBought")
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)

--- a/scripts/zones/Castle_Oztroja/npcs/relic.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/relic.lua
@@ -10,7 +10,7 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getCharVar("RELIC_IN_PROGRESS") == xi.items.CAESTUS and npcUtil.tradeHas(trade, { xi.items.TEN_THOUSAND_BYNE_BILL, xi.items.MYSTIC_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.CAESTUS })) then -- currency, shard, necropsyche, stage 4
+    if player:getCharVar("RELIC_IN_PROGRESS") == xi.items.CAESTUS and npcUtil.tradeHas(trade, { xi.items.TEN_THOUSAND_BYNE_BILL, xi.items.MYSTIC_FRAGMENT, xi.items.SHARD_OF_NECROPSYCHE, xi.items.CAESTUS }) then -- currency, shard, necropsyche, stage 4
         player:startEvent(59, xi.items.SPHARAI)
     end
 end
@@ -23,7 +23,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 59 and npcUtil.giveItem(player, { xi.items.SPHARAI, { xi.items.ONE_HUNDRED_BYNE_BILL, 30 } })) then
+    if csid == 59 and npcUtil.giveItem(player, { xi.items.SPHARAI, { xi.items.ONE_HUNDRED_BYNE_BILL, 30 } }) then
         player:confirmTrade()
         player:setCharVar("RELIC_IN_PROGRESS", 0)
     end

--- a/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
@@ -38,7 +38,7 @@ entity.onTrigger = function(player, npc)
         player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.CHASING_QUOTAS) == QUEST_COMPLETED and
         stalkerQuest == QUEST_AVAILABLE and player:getMainJob() == xi.job.DRG
     then
-        if (player:getCharVar("KnightStalker_Declined") == 0) then
+        if player:getCharVar("KnightStalker_Declined") == 0 then
             player:startEvent(121) -- Start AF3
         else
             player:startEvent(120) -- Short version if they previously declined
@@ -67,25 +67,25 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 60) then
+    if csid == 60 then
         player:addKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.DRAGON_CURSE_REMEDY)
-    elseif (csid == 559) then
+    elseif csid == 559 then
         player:setCharVar("WildcatSandy", utils.mask.setBit(player:getCharVar("WildcatSandy"), 17, true))
-    elseif (csid == 121) then
-        if (option == 1) then
+    elseif csid == 121 then
+        if option == 1 then
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER)
         else
             player:setCharVar("KnightStalker_Declined", 1)
         end
-    elseif (csid == 120 and option == 1) then
+    elseif csid == 120 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER)
         player:setCharVar("KnightStalker_Declined", 0)
-    elseif (csid == 78) then
+    elseif csid == 78 then
         player:setCharVar("KnightStalker_Progress", 2)
-    elseif (csid == 110) then
+    elseif csid == 110 then
         player:setCharVar("KnightStalker_Progress", 4)
-    elseif (csid == 118) then
+    elseif csid == 118 then
         player:setCharVar("KnightStalker_Option2", 0)
     end
 end

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -90,10 +90,10 @@ entity.onEventFinish = function(player, csid, option)
             player:addFame(xi.quest.fame_area.SANDORIA, 40)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_BOY_S_DREAM)
         end
-    elseif (csid == 90 and option == 1) then
+    elseif csid == 90 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.UNDER_OATH)
         player:setCharVar("UnderOathCS", 0)
-    elseif (csid == 89) then
+    elseif csid == 89 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12644)
         else

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h1.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h1.lua
@@ -41,9 +41,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 551) then
+    if csid == 551 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.PRELUDE_OF_BLACK_AND_WHITE)
-    elseif (csid == 552) then
+    elseif csid == 552 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.PIEUJE_S_DECISION)
     end
 end

--- a/scripts/zones/Crawlers_Nest_[S]/npcs/Tucker.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/npcs/Tucker.lua
@@ -12,13 +12,13 @@ entity.onTrade = function(player, npc, trade)
     local aLittleKnowledgeProgress = player:getCharVar("ALittleKnowledge")
     local sheetsofVellumProgress = player:getCharVar("SheetsofVellum")
 
-    if (aLittleKnowledge == QUEST_ACCEPTED and aLittleKnowledgeProgress == 1 and sheetsofVellumProgress > 0 and sheetsofVellumProgress < 4) then
-        if (trade:hasItemQty(4365, 48) and trade:getGil() == 0 and trade:getItemCount() == 48) then
-            if (sheetsofVellumProgress == 1) then
+    if aLittleKnowledge == QUEST_ACCEPTED and aLittleKnowledgeProgress == 1 and sheetsofVellumProgress > 0 and sheetsofVellumProgress < 4 then
+        if trade:hasItemQty(4365, 48) and trade:getGil() == 0 and trade:getItemCount() == 48 then
+            if sheetsofVellumProgress == 1 then
                 player:startEvent(8)
-            elseif (sheetsofVellumProgress == 2) then
+            elseif sheetsofVellumProgress == 2 then
                 player:startEvent(10)
-            elseif (sheetsofVellumProgress == 3) then
+            elseif sheetsofVellumProgress == 3 then
                 player:startEvent(11)
             end
         end
@@ -30,12 +30,12 @@ entity.onTrigger = function(player, npc)
     local aLittleKnowledgeProgress = player:getCharVar("ALittleKnowledge")
     local sheetsofVellumProgress = player:getCharVar("SheetsofVellum")
 
-    if (aLittleKnowledge == QUEST_ACCEPTED and aLittleKnowledgeProgress == 1) then
-        if (sheetsofVellumProgress == 1) then
+    if aLittleKnowledge == QUEST_ACCEPTED and aLittleKnowledgeProgress == 1 then
+        if sheetsofVellumProgress == 1 then
             player:startEvent(7)
-        elseif (sheetsofVellumProgress == 2 or sheetsofVellumProgress == 3) then
+        elseif sheetsofVellumProgress == 2 or sheetsofVellumProgress == 3 then
             player:startEvent(9)
-        elseif (sheetsofVellumProgress == 4) then
+        elseif sheetsofVellumProgress == 4 then
             player:startEvent(12)
         else
             player:startEvent(6)
@@ -47,10 +47,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 6) then
+    if csid == 6 then
         player:setCharVar("SheetsofVellum", 1)
-    elseif (csid == 8) then
-        if (player:getFreeSlotsCount() > 0) then
+    elseif csid == 8 then
+        if player:getFreeSlotsCount() > 0 then
             player:tradeComplete()
             player:addItem(2550, 4)
             player:messageSpecial(ID.text.ITEM_OBTAINED + 9, 2550, 4)
@@ -58,8 +58,8 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 2550)
         end
-    elseif (csid == 10) then
-        if (player:getFreeSlotsCount() > 0) then
+    elseif csid == 10 then
+        if player:getFreeSlotsCount() > 0 then
             player:tradeComplete()
             player:addItem(2550, 4)
             player:messageSpecial(ID.text.ITEM_OBTAINED + 9, 2550, 4)
@@ -67,8 +67,8 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 2550)
         end
-    elseif (csid == 11) then
-        if (player:getFreeSlotsCount() > 0) then
+    elseif csid == 11 then
+        if player:getFreeSlotsCount() > 0 then
             player:tradeComplete()
             player:addItem(2550, 4)
             player:messageSpecial(ID.text.ITEM_OBTAINED + 9, 2550, 4)

--- a/scripts/zones/Giddeus/npcs/Altar_of_Offerings.lua
+++ b/scripts/zones/Giddeus/npcs/Altar_of_Offerings.lua
@@ -17,7 +17,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local crisisstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.A_CRISIS_IN_THE_MAKING)
-    if (crisisstatus >= 1 and player:getCharVar("QuestCrisisMaking_var") == 1) then
+    if crisisstatus >= 1 and player:getCharVar("QuestCrisisMaking_var") == 1 then
         player:startEvent(53) -- A Crisis in the Making: Receive Offering
     else
         player:startEvent(60) -- Standard Message
@@ -28,7 +28,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 53 and option == 1) then
+    if csid == 53 and option == 1 then
         player:addKeyItem(39, xi.ki.OFF_OFFERING)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.OFF_OFFERING)
         player:setCharVar("QuestCrisisMaking_var", 2)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
@@ -29,7 +29,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 52 and option == 1) then
+    if csid == 52 and option == 1 then
         player:setPos(-419.995, 0, 248.483, 191, 35); -- To The Garden of RuHmet
     elseif csid == 4 then
         player:setCharVar('ApocalypseNigh', 3)
@@ -38,7 +38,7 @@ entity.onEventFinish = function(player, csid, option)
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14672)
         else
-            if (player:addItem(14672)) then
+            if player:addItem(14672) then
                 player:setCharVar("PromathiaStatus", 0)
                 player:completeMission(xi.mission.log_id.COP, xi.mission.id.cop.GARDEN_OF_ANTIQUITY)
                 player:addMission(xi.mission.log_id.COP, xi.mission.id.cop.A_FATE_DECIDED)

--- a/scripts/zones/Misareaux_Coast/npcs/Swirling_Vortex.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Swirling_Vortex.lua
@@ -19,11 +19,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 554 and option == 1) then
+    if csid == 554 and option == 1 then
         xi.teleport.to(player, xi.teleport.id.QUFIM_VORTEX)
     end
-
 end
 
 return entity

--- a/scripts/zones/Northern_San_dOria/npcs/Abioleget.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Abioleget.lua
@@ -14,10 +14,10 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     local sermonQuest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_VICASQUE_S_SERMON)
 
-    if (sermonQuest == QUEST_ACCEPTED) then
+    if sermonQuest == QUEST_ACCEPTED then
         local gil = trade:getGil()
         local count = trade:getItemCount()
-        if (gil == 70 and count == 1) then
+        if gil == 70 and count == 1 then
             player:tradeComplete()
             player:startEvent(591)
         end
@@ -27,10 +27,10 @@ end
 entity.onTrigger = function(player, npc)
     local sermonQuest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_VICASQUE_S_SERMON)
 
-    if (sermonQuest == QUEST_AVAILABLE) then
+    if sermonQuest == QUEST_AVAILABLE then
         player:startEvent(589)
-    elseif (sermonQuest == QUEST_ACCEPTED) then
-        if (player:getCharVar("sermonQuestVar") == 1) then
+    elseif sermonQuest == QUEST_ACCEPTED then
+        if player:getCharVar("sermonQuestVar") == 1 then
             player:tradeComplete()
             player:startEvent(600)
         else
@@ -45,8 +45,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 600) then
+    if csid == 600 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 13465)
         else
@@ -57,9 +56,9 @@ entity.onEventFinish = function(player, csid, option)
             player:setCharVar("sermonQuestVar", 0)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_VICASQUE_S_SERMON )
         end
-    elseif (csid == 589) then
+    elseif csid == 589 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_VICASQUE_S_SERMON )
-    elseif (csid == 591) then
+    elseif csid == 591 then
         player:addItem(618)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 618)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
             player:startEvent(624, skillCap, skillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(624, skillCap, skillLevel, 1, 207, player:getGil(), 7127, 4095, 0)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 624 and option == 1) then
+    if csid == 624 and option == 1 then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 1, 1)
         player:addStatusEffect(xi.effect.WOODWORKING_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
             player:startEvent(630, skillCap, skillLevel, 2, 205, player:getGil(), 0, 90, 0)
         else
             player:startEvent(630, skillCap, skillLevel, 2, 205, player:getGil(), 7054, 90, 0)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 630 and option == 1) then
+    if csid == 630 and option == 1 then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 2, 2)
         player:addStatusEffect(xi.effect.SMITHING_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
@@ -34,10 +34,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 57 and option == 0) then
+    if csid == 57 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TROUBLE_AT_THE_SLUICE)
         player:setCharVar("troubleAtTheSluiceVar", 1)
-    elseif (csid == 56) then
+    elseif csid == 56 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16706) -- Heavy Axe
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
@@ -12,28 +12,30 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local new_nation = xi.nation.SANDORIA
     local old_nation = player:getNation()
     local rank = GetNationRank(new_nation)
 
-    if (old_nation == new_nation) then
+    if old_nation == new_nation then
         player:startEvent(608, 0, 0, 0, old_nation)
-    elseif (player:getCurrentMission(old_nation) ~= xi.mission.id.nation.NONE or player:getMissionStatus(player:getNation()) ~= 0) then
+    elseif
+        player:getCurrentMission(old_nation) ~= xi.mission.id.nation.NONE or
+        player:getMissionStatus(player:getNation()) ~= 0
+    then
         player:startEvent(607, 0, 0, 0, new_nation)
-    elseif (old_nation ~= new_nation) then
+    elseif old_nation ~= new_nation then
         local has_gil = 0
         local cost = 0
 
-        if (rank == 1) then
+        if rank == 1 then
             cost = 40000
-        elseif (rank == 2) then
+        elseif rank == 2 then
             cost = 12000
-        elseif (rank == 3) then
+        elseif rank == 3 then
             cost = 4000
         end
 
-        if (player:getGil() >= cost) then
+        if player:getGil() >= cost then
             has_gil = 1
         end
 
@@ -45,17 +47,16 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 606 and option == 1) then
+    if csid == 606 and option == 1 then
         local new_nation = xi.nation.SANDORIA
         local rank = GetNationRank(new_nation)
         local cost = 0
 
-        if (rank == 1) then
+        if rank == 1 then
             cost = 40000
-        elseif (rank == 2) then
+        elseif rank == 2 then
             cost = 12000
-        elseif (rank == 3) then
+        elseif rank == 3 then
             cost = 4000
         end
 
@@ -63,7 +64,6 @@ entity.onEventFinish = function(player, csid, option)
         player:setGil(player:getGil() - cost)
         player:setRankPoints(0)
     end
-
 end
 
 return entity

--- a/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
@@ -17,11 +17,11 @@ entity.onTrade = function(player, npc, trade)
     local black = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
     local questState = player:getCharVar("BlackMailQuest")
 
-    if (black == QUEST_ACCEPTED and questState == 2 or black == QUEST_COMPLETED) then
+    if black == QUEST_ACCEPTED and questState == 2 or black == QUEST_COMPLETED then
         local count = trade:getItemCount()
         local carta = trade:hasItemQty(530, 1)
 
-        if (carta == true and count == 1) then
+        if carta == true and count == 1 then
             player:startEvent(648, 0, 530) --648
         end
     end
@@ -35,15 +35,15 @@ entity.onTrigger = function(player, npc)
     local homeRank = player:getRank(player:getNation())
     local questState = player:getCharVar("BlackMailQuest")
 
-    if (blackMail == QUEST_AVAILABLE and sanFame >= 3 and homeRank >= 3) then
+    if blackMail == QUEST_AVAILABLE and sanFame >= 3 and homeRank >= 3 then
         player:startEvent(643) -- 643 gives me letter
-    elseif (blackMail == QUEST_ACCEPTED and envelope == true) then
+    elseif blackMail == QUEST_ACCEPTED and envelope == true then
         player:startEvent(645)  -- 645 recap, take envelope!
 
-    elseif (blackMail == QUEST_ACCEPTED and questState == 1) then
+    elseif blackMail == QUEST_ACCEPTED and questState == 1 then
         player:startEvent(646, 0, 530) --646  after giving letter to H, needs param
 
-    elseif (blackMail == QUEST_ACCEPTED and questState == 2) then
+    elseif blackMail == QUEST_ACCEPTED and questState == 2 then
         player:startEvent(647, 0, 530) --647 recap of 646
 
     else
@@ -60,13 +60,13 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 643) then
+    if csid == 643 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
         player:addKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SUSPICIOUS_ENVELOPE)
-    elseif (csid == 646 and option == 1) then
+    elseif csid == 646 and option == 1 then
         player:setCharVar("BlackMailQuest", 2)
-    elseif (csid == 648) then
+    elseif csid == 648 then
         player:tradeComplete()
         player:addGil(xi.settings.main.GIL_RATE * 900)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 900)
@@ -76,7 +76,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addFame(xi.quest.fame_area.SANDORIA, 5)
         end
-    elseif (csid == 40 and option == 1) then
+    elseif csid == 40 and option == 1 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
             player:startEvent(628, cost, skillLevel, 0, 205, player:getGil(), 0, 0, 0)
         else
             player:startEvent(628, cost, skillLevel, 0, 205, player:getGil(), 28721, 4095, 0)
@@ -35,7 +35,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
-    if (csid == 628 and option == 1) then
+    if csid == 628 and option == 1 then
         player:delGil(cost)
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 2, 0)
         player:addStatusEffect(xi.effect.SMITHING_IMAGERY, 3, 0, 480)

--- a/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
@@ -9,7 +9,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true) then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
         player:startEvent(631)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()
@@ -24,7 +24,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 631) then
+    if csid == 631 then
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 50)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Morjean.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Morjean.lua
@@ -15,11 +15,11 @@ end
 entity.onTrigger = function(player, npc)
     local theHolyCrest = player:getCharVar("TheHolyCrest_Event")
 
-    if (theHolyCrest == 2) then
+    if theHolyCrest == 2 then
         player:startEvent(65)
-    elseif ((theHolyCrest == 3 and player:hasItem(1159)) or theHolyCrest == 4) then -- Wyvern Egg
+    elseif (theHolyCrest == 3 and player:hasItem(1159)) or theHolyCrest == 4 then -- Wyvern Egg
         player:startEvent(62)
-    elseif (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II) == QUEST_ACCEPTED) then
+    elseif player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II) == QUEST_ACCEPTED then
         player:startEvent(602)
     else
         player:startEvent(601)
@@ -30,10 +30,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 65) then
+    if csid == 65 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_HOLY_CREST)
         player:setCharVar("TheHolyCrest_Event", 3)
-    elseif (csid == 62 and option == 0) then
+    elseif csid == 62 and option == 0 then
         player:setCharVar("TheHolyCrest_Event", 4)
     end
 end

--- a/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
             player:startEvent(629, skillCap, skillLevel, 1, 205, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(629, skillCap, skillLevel, 1, 205, player:getGil(), 7128, 4095, 0)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 629 and option == 1) then
+    if csid == 629 and option == 1 then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 2, 1)
         player:addStatusEffect(xi.effect.SMITHING_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
             player:startEvent(625, skillCap, skillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else
             player:startEvent(625, skillCap, skillLevel, 2, 207, player:getGil(), 6857, 0, 0)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 625 and option == 1) then
+    if csid == 625 and option == 1 then
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 1, 2)
         player:addStatusEffect(xi.effect.WOODWORKING_IMAGERY, 1, 0, 120)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
             player:startEvent(623, cost, skillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(623, cost, skillLevel, 0, 207, player:getGil(), 28482, 4095, 0)
@@ -35,7 +35,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
-    if (csid == 623 and option == 1) then
+    if csid == 623 and option == 1 then
         player:delGil(cost)
         player:messageSpecial(ID.text.IMAGE_SUPPORT, 0, 1, 0)
         player:addStatusEffect(xi.effect.WOODWORKING_IMAGERY, 3, 0, 480)

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -60,7 +60,7 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
     if csid == 1 then
         player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif (csid == 71) then
+    elseif csid == 71 then
         player:setPos(0, 0, 0, 0, 224)
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
@@ -36,42 +36,42 @@ entity.onTrigger = function(player, npc)
         player:startEvent(24)
 
     -- Chasing Quotas (DRG AF2)
-    elseif (quotasStatus == QUEST_AVAILABLE and player:getMainJob() == xi.job.DRG and player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and quotasNo == 0) then
+    elseif quotasStatus == QUEST_AVAILABLE and player:getMainJob() == xi.job.DRG and player:getMainLvl() >= xi.settings.main.AF1_QUEST_LEVEL and quotasNo == 0 then
         player:startEvent(18) -- Long version of quest start
-    elseif (quotasNo == 1) then
+    elseif quotasNo == 1 then
         player:startEvent(14) -- Short version for those that said no.
-    elseif (quotasStatus == QUEST_ACCEPTED and quotasProgress == 0) then
+    elseif quotasStatus == QUEST_ACCEPTED and quotasProgress == 0 then
         player:startEvent(13) -- Reminder to bring Gold Hairpin
-    elseif (quotasProgress == 1) then
+    elseif quotasProgress == 1 then
         if (player:getCharVar("ChasingQuotas_date") > os.time()) then
             player:startEvent(3) -- Fluff cutscene because you haven't waited a day
         else
             player:startEvent(7) -- Boss got mugged
         end
-    elseif (quotasProgress == 2) then
+    elseif quotasProgress == 2 then
         player:startEvent(8) -- Go investigate
-    elseif (quotasProgress == 3) then
+    elseif quotasProgress == 3 then
         player:startEvent(6) -- Earring is a clue, non-required CS
-    elseif (quotasProgress == 4 or quotasProgress == 5) then
+    elseif quotasProgress == 4 or quotasProgress == 5 then
         player:startEvent(9) -- Fluff text until Ceraulian is necessary again
-    elseif (quotasProgress == 6) then
+    elseif quotasProgress == 6 then
         player:startEvent(15) -- End of AF2
 
-    elseif (quotasStatus == QUEST_COMPLETED and stalkerStatus == QUEST_AVAILABLE) then
+    elseif quotasStatus == QUEST_COMPLETED and stalkerStatus == QUEST_AVAILABLE then
         player:startEvent(16) -- Fluff text until DRG AF3
 
     -- Knight Stalker (DRG AF3)
-    elseif (stalkerStatus == QUEST_ACCEPTED and stalkerProgress == 0) then
+    elseif stalkerStatus == QUEST_ACCEPTED and stalkerProgress == 0 then
         player:startEvent(19) -- Fetch the last Dragoon's helmet
-    elseif (stalkerProgress == 1) then
-        if (player:hasKeyItem(xi.ki.CHALLENGE_TO_THE_ROYAL_KNIGHTS) == false) then
+    elseif stalkerProgress == 1 then
+        if player:hasKeyItem(xi.ki.CHALLENGE_TO_THE_ROYAL_KNIGHTS) == false then
             player:startEvent(23) -- Reminder to get helmet
         else
             player:startEvent(20) -- Response if you try to turn in the challenge to Ceraulian
         end
-    elseif (player:getCharVar("KnightStalker_Option1") == 1) then
+    elseif player:getCharVar("KnightStalker_Option1") == 1 then
         player:startEvent(22)
-    elseif (stalkerStatus == QUEST_COMPLETED) then
+    elseif stalkerStatus == QUEST_COMPLETED then
         player:startEvent(21)
 
     else
@@ -83,26 +83,26 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 24) then
+    if csid == 24 then
         player:setCharVar("TheHolyCrest_Event", 1)
 
     -- Chasing Quotas (DRG AF2)
-    elseif (csid == 18) then
+    elseif csid == 18 then
         if option == 0 then
             player:setCharVar("ChasingQuotas_No", 1)
         else
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.CHASING_QUOTAS)
         end
-    elseif (csid == 14 and option == 1) then
+    elseif csid == 14 and option == 1 then
         player:setCharVar("ChasingQuotas_No", 0)
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.CHASING_QUOTAS)
-    elseif (csid == 17) then
+    elseif csid == 17 then
         player:setCharVar("ChasingQuotas_Progress", 1)
         player:setCharVar("ChasingQuotas_date", os.time() + 60)
-    elseif (csid == 7) then
+    elseif csid == 7 then
         player:setCharVar("ChasingQuotas_Progress", 2)
         player:setCharVar("ChasingQuotas_date", 0)
-    elseif (csid == 15) then
+    elseif csid == 15 then
         if player:getFreeSlotsCount() < 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 14227)
         else
@@ -115,9 +115,9 @@ entity.onEventFinish = function(player, csid, option)
         end
 
         -- Knight Stalker (DRG AF3)
-    elseif (csid == 19) then
+    elseif csid == 19 then
         player:setCharVar("KnightStalker_Progress", 1)
-    elseif (csid == 22) then
+    elseif csid == 22 then
         player:setCharVar("KnightStalker_Option1", 0)
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
@@ -11,7 +11,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true) then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
         player:startEvent(612)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 612) then
+    if csid == 612 then
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 50)
     end
 end

--- a/scripts/zones/Port_San_dOria/npcs/Vounebariont.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Vounebariont.lua
@@ -11,36 +11,31 @@ local ID = require("scripts/zones/Port_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS) ~= QUEST_AVAILABLE) then
-        if (trade:hasItemQty(889, 5) and trade:getItemCount() == 5) then -- Trade Beetle Shell
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS) ~= QUEST_AVAILABLE then
+        if trade:hasItemQty(889, 5) and trade:getItemCount() == 5 then -- Trade Beetle Shell
             player:startEvent(514)
         end
     end
-
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2) then
+    if player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 then
         player:startEvent(516)
     else
         player:startEvent(568)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 516) then
+    if csid == 516 then
         if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS) == QUEST_AVAILABLE) then
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS)
         end
-    elseif (csid == 514) then
-        if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS) == QUEST_ACCEPTED) then
+    elseif csid == 514 then
+        if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS) == QUEST_ACCEPTED then
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THICK_SHELLS)
             player:addFame(xi.quest.fame_area.SANDORIA, 30)
         else
@@ -52,7 +47,6 @@ entity.onEventFinish = function(player, csid, option)
         player:addGil(xi.settings.main.GIL_RATE * 750)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 750)
     end
-
 end
 
 return entity

--- a/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
+++ b/scripts/zones/Port_Windurst/npcs/Chipmy-Popmy.lua
@@ -28,7 +28,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 619) then
+    if csid == 619 then
         player:setCharVar("COP_3-taru_story", 1)
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Choyi_Totlihpa.lua
+++ b/scripts/zones/Port_Windurst/npcs/Choyi_Totlihpa.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 17)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 17) then
         player:startEvent(622)
     else
         player:startEvent(215)
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 622) then
+    if csid == 622 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 17, true))
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Kunchichi.lua
+++ b/scripts/zones/Port_Windurst/npcs/Kunchichi.lua
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 623) then
+    if csid == 623 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 15, true))
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Three_of_Clubs.lua
+++ b/scripts/zones/Port_Windurst/npcs/Three_of_Clubs.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 18)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 18) then
         player:startEvent(625)
     else
         player:startEvent(222)
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 625) then
+    if csid == 625 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 18, true))
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Yaman-Hachuman.lua
+++ b/scripts/zones/Port_Windurst/npcs/Yaman-Hachuman.lua
@@ -18,11 +18,11 @@ entity.onTrigger = function(player, npc)
     local wonderWands = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDER_WANDS)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 16)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 16) then
         player:startEvent(624)
-    elseif (wonderWands == QUEST_ACCEPTED) then
+    elseif wonderWands == QUEST_ACCEPTED then
         player:startEvent(256, 0, 0, 0, 17061)
-    elseif (wonderWands == QUEST_COMPLETED) then
+    elseif wonderWands == QUEST_COMPLETED then
         player:startEvent(268)
     else
         player:startEvent(233)
@@ -33,7 +33,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 624) then
+    if csid == 624 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 16, true))
     end
 end

--- a/scripts/zones/Qulun_Dome/npcs/_440.lua
+++ b/scripts/zones/Qulun_Dome/npcs/_440.lua
@@ -27,11 +27,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
     if (csid == 50 or csid == 51) and option == 1 then
         player:messageSpecial(ID.text.THE_3_ITEMS_GLOW_FAINTLY, xi.ki.SILVER_BELL, xi.ki.CORUSCANT_ROSARY, xi.ki.BLACK_MATINEE_NECKLACE)
     end
-
 end
 
 return entity

--- a/scripts/zones/Rabao/npcs/Alfesar.lua
+++ b/scripts/zones/Rabao/npcs/Alfesar.lua
@@ -18,13 +18,13 @@ entity.onTrigger = function(player, npc)
     local theMissingPiece = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.THE_MISSING_PIECE)
     local fame = player:getFameLevel(xi.quest.fame_area.SELBINA_RABAO)
 
-    if (theMissingPiece == QUEST_AVAILABLE and fame >= 4) then -- start quest
+    if theMissingPiece == QUEST_AVAILABLE and fame >= 4 then -- start quest
         player:startEvent(6)
-    elseif (theMissingPiece == QUEST_ACCEPTED and not(player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT))) then -- talk to again with quest activated
+    elseif theMissingPiece == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT) then -- talk to again with quest activated
         player:startEvent(7)
-    elseif (theMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)) then -- successfully retrieve key item
+    elseif theMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT) then -- successfully retrieve key item
         player:startEvent(8)
-    elseif (theMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)) then -- They got their Key items. tell them to goto sandy
+    elseif theMissingPiece == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC) then -- They got their Key items. tell them to goto sandy
         player:startEvent(9)
     else
         player:startEvent(52) -- standard dialogue
@@ -35,9 +35,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 6) then
+    if csid == 6 then
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.THE_MISSING_PIECE)
-    elseif (csid == 8) then -- give the player the key items he needs to complete the quest
+    elseif csid == 8 then -- give the player the key items he needs to complete the quest
         player:addKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
         player:addKeyItem(xi.ki.LETTER_FROM_ALFESAR)
         player:delKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)

--- a/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
@@ -12,8 +12,8 @@ require("scripts/globals/titles")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRAVE_CONCERNS) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(547, 1) and trade:getItemCount() == 1 and player:getCharVar("OfferingWaterOK") == 1) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRAVE_CONCERNS) == QUEST_ACCEPTED then
+        if trade:hasItemQty(547, 1) and trade:getItemCount() == 1 and player:getCharVar("OfferingWaterOK") == 1 then
             player:startEvent(624)
         end
     end
@@ -24,13 +24,13 @@ entity.onTrigger = function(player, npc)
     local wellWater = player:hasItem(567) -- Well Water
     local waterskin = player:hasItem(547) -- Tomb Waterskin
 
-    if (tomb == QUEST_AVAILABLE) then
+    if tomb == QUEST_AVAILABLE then
         player:startEvent(541)
-    elseif (tomb == QUEST_ACCEPTED and wellWater == false and player:getCharVar("OfferingWaterOK") == 0) then
+    elseif tomb == QUEST_ACCEPTED and wellWater == false and player:getCharVar("OfferingWaterOK") == 0 then
         player:startEvent(622)
-    elseif (tomb == QUEST_ACCEPTED and waterskin == true and player:getCharVar("OfferingWaterOK") == 0) then
+    elseif tomb == QUEST_ACCEPTED and waterskin == true and player:getCharVar("OfferingWaterOK") == 0 then
         player:startEvent(623)
-    elseif (tomb == QUEST_COMPLETED) then
+    elseif tomb == QUEST_COMPLETED then
         player:startEvent(558)
     else
         player:startEvent(540)
@@ -41,7 +41,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 541 and option == 0) then
+    if csid == 541 and option == 0 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 567) -- Well Water
         else
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option)
             player:addItem(567)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 567) -- Well Water
         end
-    elseif (csid == 624) then
+    elseif csid == 624 then
         player:tradeComplete()
         player:setCharVar("OfferingWaterOK", 0)
         player:addTitle(xi.title.ROYAL_GRAVE_KEEPER)

--- a/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
@@ -14,8 +14,8 @@ require("scripts/globals/titles")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(940, 1) and trade:getItemCount() == 1) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST) == QUEST_ACCEPTED then
+        if trade:hasItemQty(940, 1) and trade:getItemCount() == 1 then
             player:startEvent(617)
         end
     end
@@ -27,44 +27,44 @@ entity.onTrigger = function(player, npc)
     local aSquiresTestII = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II)
     local aKnightsTest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_KNIGHT_S_TEST)
 
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER) == QUEST_ACCEPTED and player:getCharVar("KnightStalker_Progress") == 2) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER) == QUEST_ACCEPTED and player:getCharVar("KnightStalker_Progress") == 2 then
         player:startEvent(63) -- DRG AF3 cutscene, doesn't appear to have a follow up.
-    elseif (lvl < 7) then
+    elseif lvl < 7 then
         player:startEvent(668)
-    elseif (lvl >= 7 and aSquiresTest ~= QUEST_COMPLETED) then
-        if (aSquiresTest == 0) then
-            if (player:getCharVar("SquiresTest") == 1) then
+    elseif lvl >= 7 and aSquiresTest ~= QUEST_COMPLETED then
+        if aSquiresTest == 0 then
+            if player:getCharVar("SquiresTest") == 1 then
                 player:startEvent(631)
             else
                 player:startEvent(616)
             end
-        elseif (aSquiresTest == QUEST_ACCEPTED) then
+        elseif aSquiresTest == QUEST_ACCEPTED then
             player:startEvent(667)
         end
-    elseif (lvl >= 7 and lvl < 15) then
+    elseif lvl >= 7 and lvl < 15 then
         player:startEvent(671)
-    elseif (lvl >= 15 and aSquiresTestII ~= QUEST_COMPLETED) then
+    elseif lvl >= 15 and aSquiresTestII ~= QUEST_COMPLETED then
         local stalactiteDew = player:hasKeyItem(xi.ki.STALACTITE_DEW)
 
-        if (aSquiresTestII == QUEST_AVAILABLE) then
+        if aSquiresTestII == QUEST_AVAILABLE then
             player:startEvent(625)
-        elseif (aSquiresTestII == QUEST_ACCEPTED and stalactiteDew == false) then
+        elseif aSquiresTestII == QUEST_ACCEPTED and stalactiteDew == false then
             player:startEvent(630)
-        elseif (stalactiteDew) then
+        elseif stalactiteDew then
             player:startEvent(626)
         else
             player:startEvent(667)
         end
-    elseif (lvl >= 15 and lvl < 30) then
+    elseif lvl >= 15 and lvl < 30 then
         player:startEvent(670)
-    elseif (lvl >= 30 and aKnightsTest ~= QUEST_COMPLETED) then
-        if (aKnightsTest == 0) then
-            if (player:getCharVar("KnightsTest_Event") == 1) then
+    elseif lvl >= 30 and aKnightsTest ~= QUEST_COMPLETED then
+        if aKnightsTest == 0 then
+            if player:getCharVar("KnightsTest_Event") == 1 then
                 player:startEvent(635)
             else
                 player:startEvent(627)
             end
-        elseif (player:hasKeyItem(xi.ki.KNIGHTS_SOUL)) then
+        elseif player:hasKeyItem(xi.ki.KNIGHTS_SOUL) then
             player:startEvent(628)
         else
             player:startEvent(669)
@@ -75,17 +75,17 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 616) then
-        if (option == 0) then
+    if csid == 616 then
+        if option == 0 then
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST)
         else
             player:setCharVar("SquiresTest_Event", 1)
         end
-    elseif (csid == 631 and option == 0) then
+    elseif csid == 631 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST)
         player:setCharVar("SquiresTest_Event", 0)
-    elseif (csid == 617) then
-        if (player:getFreeSlotsCount(0) >= 1) then
+    elseif csid == 617 then
+        if player:getFreeSlotsCount(0) >= 1 then
             player:tradeComplete()
             player:addTitle(xi.title.KNIGHT_IN_TRAINING)
             player:addItem(16565)
@@ -95,9 +95,9 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16565) -- Spatha
         end
-    elseif (csid == 625 or csid == 630) then
+    elseif csid == 625 or csid == 630 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II)
-    elseif (csid == 626) then
+    elseif csid == 626 then
         player:tradeComplete()
         player:addTitle(xi.title.SPELUNKER)
         player:delKeyItem(xi.ki.STALACTITE_DEW)
@@ -105,21 +105,21 @@ entity.onEventFinish = function(player, csid, option)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.SQUIRE_CERTIFICATE)
         player:addFame(xi.quest.fame_area.SANDORIA, 30)
         player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II)
-    elseif (csid == 627) then
-        if (option == 0) then
+    elseif csid == 627 then
+        if option == 0 then
             player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_KNIGHT_S_TEST)
             player:addKeyItem(xi.ki.BOOK_OF_TASKS)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BOOK_OF_TASKS)
         else
             player:setCharVar("KnightsTest_Event", 1)
         end
-    elseif (csid == 635 and option == 0) then
+    elseif csid == 635 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_KNIGHT_S_TEST)
         player:addKeyItem(xi.ki.BOOK_OF_TASKS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BOOK_OF_TASKS)
         player:setCharVar("KnightsTest_Event", 0)
-    elseif (csid == 628) then
-        if (player:getFreeSlotsCount(0) >= 1) then
+    elseif csid == 628 then
+        if player:getFreeSlotsCount(0) >= 1 then
             player:addTitle(xi.title.TRIED_AND_TESTED_KNIGHT)
             player:delKeyItem(xi.ki.KNIGHTS_SOUL)
             player:delKeyItem(xi.ki.BOOK_OF_TASKS)
@@ -134,7 +134,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 12306) -- Kite Shield
         end
-    elseif (csid == 63) then
+    elseif csid == 63 then
         player:setCharVar("KnightStalker_Progress", 3)
     end
 

--- a/scripts/zones/Southern_San_dOria/npcs/Baunise.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Baunise.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) == false) then
+    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) == false then
         player:startEvent(634)
     else
         player:showText(npc, 7817)-- nothing to report
@@ -26,12 +26,10 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 634) then
+    if csid == 634 then
         player:addKeyItem(xi.ki.BOOK_OF_THE_WEST)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BOOK_OF_THE_WEST)
     end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/npcs/Blendare.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Blendare.lua
@@ -14,15 +14,13 @@ end
 
 entity.onTrigger = function(player, npc)
     player:startEvent(606)  -- my brother always takes my sweets
---    player:startEvent(598)   --did nothing no speech or text
---    player:startEvent(945)    --black screen and hang
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 606) then
+    if csid == 606 then
         player:setCharVar("BrothersCS", 1)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
@@ -13,26 +13,22 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) == false) then
+    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) == false then
         player:startEvent(633)
     else
         player:showText(npc, 7817) -- nothing to report
 
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 633) then
+    if csid == 633 then
         player:addKeyItem(xi.ki.BOOK_OF_THE_EAST)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.BOOK_OF_THE_EAST)
     end
-
 end
 --- for future use
     -- player:startEvent(847) --are you the chicks owner

--- a/scripts/zones/Southern_San_dOria/npcs/Chanpau.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Chanpau.lua
@@ -12,9 +12,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II) == QUEST_ACCEPTED) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_SQUIRE_S_TEST_II) == QUEST_ACCEPTED then
         player:startEvent(629)
-    elseif (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_COMPLETED) then
+    elseif player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_COMPLETED then
         local fired = player:getCharVar("Fired")
 
         if fired == 1 then
@@ -31,7 +31,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 505) then
+    if csid == 505 then
         player:setCharVar("Fired", 1)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
@@ -18,17 +18,17 @@ entity.onTrigger = function(player, npc)
 --    player:startEvent(51)  -- it says what i dont beleive you -- under oath
 --    player:startEvent(19)  -- thanks for your help i have to tell trion -- under oath
 --     player:startEvent(77)    -- a boys dream
-    if (player:getCharVar("aBoysDreamCS") == 2) then
+    if player:getCharVar("aBoysDreamCS") == 2 then
         player:startEvent(50)
-    elseif (player:getCharVar("aBoysDreamCS") >= 7) then
+    elseif player:getCharVar("aBoysDreamCS") >= 7 then
         player:startEvent(32)
-    elseif (player:getCharVar("UnderOathCS") == 4 and player:hasKeyItem(xi.ki.STRANGE_SHEET_OF_PAPER)) then
+    elseif player:getCharVar("UnderOathCS") == 4 and player:hasKeyItem(xi.ki.STRANGE_SHEET_OF_PAPER) then
         player:startEvent(77)
-    elseif (player:getCharVar("UnderOathCS") == 5) then
+    elseif player:getCharVar("UnderOathCS") == 5 then
         player:startEvent(79)
-    elseif (player:hasKeyItem(xi.ki.KNIGHTS_CONFESSION) and player:getCharVar("UnderOathCS") == 6) then
+    elseif player:hasKeyItem(xi.ki.KNIGHTS_CONFESSION) and player:getCharVar("UnderOathCS") == 6 then
         player:startEvent(51)
-    elseif (player:getCharVar("UnderOathCS") == 8) then
+    elseif player:getCharVar("UnderOathCS") == 8 then
         player:startEvent(19)
     else
         player:startEvent(76)
@@ -40,11 +40,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 50) then
+    if csid == 50 then
         player:setCharVar("aBoysDreamCS", 3)
-    elseif (csid == 32 and player:getCharVar("aBoysDreamCS") == 7) then
+    elseif csid == 32 and player:getCharVar("aBoysDreamCS") == 7 then
         player:setCharVar("aBoysDreamCS", 8)
-    elseif (csid == 77) then
+    elseif csid == 77 then
         player:setCharVar("UnderOathCS", 5)
     end
 end

--- a/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
@@ -16,13 +16,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local quest_fas = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.FATHER_AND_SON)      -- 1st Quest in Series
     local quest_poa = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_PURCHASE_OF_ARMS)  -- 2nd Quest in Series
 
-    if (player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 and quest_fas == QUEST_COMPLETED and quest_poa == QUEST_AVAILABLE) then
+    if player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 and quest_fas == QUEST_COMPLETED and quest_poa == QUEST_AVAILABLE then
         player:startEvent(594)  -- Start quest A Purchase of Arms
-    elseif (quest_poa == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.WEAPONS_RECEIPT) == true) then
+    elseif quest_poa == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.WEAPONS_RECEIPT) == true then
         player:startEvent(607) -- Finish A Purchase of Arms quest
     else
         player:startEvent(593)  -- Standard Dialog
@@ -33,12 +32,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 594 and option == 0) then
+    if csid == 594 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_PURCHASE_OF_ARMS)
         player:addKeyItem(xi.ki.WEAPONS_ORDER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.WEAPONS_ORDER)
-    elseif (csid == 607) then
+    elseif csid == 607 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17090) -- Elm Staff
         else
@@ -50,7 +48,6 @@ entity.onEventFinish = function(player, csid, option)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.A_PURCHASE_OF_ARMS)
         end
     end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/npcs/Maugie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Maugie.lua
@@ -16,15 +16,15 @@ end
 
 entity.onTrigger = function(player, npc)
     local grimySignpost = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRIMY_SIGNPOSTS)
-    if (grimySignpost == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2) then
+    if grimySignpost == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 then
         player:startEvent(45)
-    elseif (grimySignpost == QUEST_ACCEPTED) then
-        if (player:getCharVar("CleanSignPost") == 15) then
+    elseif grimySignpost == QUEST_ACCEPTED then
+        if player:getCharVar("CleanSignPost") == 15 then
             player:startEvent(44)
         else
             player:startEvent(43)
         end
-    elseif (grimySignpost == QUEST_COMPLETED) then
+    elseif grimySignpost == QUEST_COMPLETED then
         player:startEvent(42)
     else
         player:startEvent(46) -- default text
@@ -35,9 +35,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 45 and option == 0) then
+    if csid == 45 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRIMY_SIGNPOSTS)
-    elseif (csid == 44) then
+    elseif csid == 44 then
         player:setCharVar("CleanSignPost", 0)
         player:addFame(xi.quest.fame_area.SANDORIA, 30)
         player:addGil(xi.settings.main.GIL_RATE * 1500)

--- a/scripts/zones/Southern_San_dOria/npcs/Nenne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Nenne.lua
@@ -17,28 +17,25 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local medicineWoman = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_MEDICINE_WOMAN)
     local toCureaCough = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TO_CURE_A_COUGH)
 
-    if (toCureaCough == QUEST_AVAILABLE and player:getCharVar("toCureaCough") == 0 and medicineWoman == QUEST_COMPLETED) then
+    if toCureaCough == QUEST_AVAILABLE and player:getCharVar("toCureaCough") == 0 and medicineWoman == QUEST_COMPLETED then
         player:startEvent(538)
-    elseif (player:hasKeyItem(xi.ki.COUGH_MEDICINE) == true) then
+    elseif player:hasKeyItem(xi.ki.COUGH_MEDICINE) == true then
         player:startEvent(647)
     else
         player:startEvent(584)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 538) then
+    if csid == 538 then
         player:setCharVar("toCureaCough", 1)
-    elseif (csid == 647) then
+    elseif csid == 647 then
         player:addTitle(xi.title.A_MOSS_KIND_PERSON)
         player:setCharVar("toCureaCough", 0)
         player:delKeyItem(xi.ki.COUGH_MEDICINE)
@@ -47,7 +44,6 @@ entity.onEventFinish = function(player, csid, option)
         player:addFame(xi.quest.fame_area.SANDORIA, 30)
         player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TO_CURE_A_COUGH)
     end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
@@ -17,8 +17,8 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false) then
+    if guildMember == 1 then
+        if player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false then
             player:startEvent(650, cost, skillLevel, 0, 239, player:getGil(), 0, 0, 0)
         else
             player:startEvent(650, cost, skillLevel, 0, 239, player:getGil(), 28727, 0, 0)
@@ -34,7 +34,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
-    if (csid == 650 and option == 1) then
+    if csid == 650 and option == 1 then
         player:delGil(cost)
         player:messageSpecial(ID.text.LEATHER_SUPPORT, 0, 5, 0)
         player:addStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY, 3, 0, 480)

--- a/scripts/zones/Southern_San_dOria/npcs/Taumila.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Taumila.lua
@@ -13,51 +13,45 @@ local ID = require("scripts/zones/Southern_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-
-    if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH) ~= QUEST_AVAILABLE) then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH) ~= QUEST_AVAILABLE then
         if (trade:hasItemQty(884, 3) and trade:getItemCount() == 3) then
             player:startEvent(572)
         end
     end
-
 end
 
 entity.onTrigger = function(player, npc)
-
     local tigersTeeth = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH)
 
-    if (player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 3 and tigersTeeth == QUEST_AVAILABLE) then
+    if player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 3 and tigersTeeth == QUEST_AVAILABLE then
         player:startEvent(574)
-    elseif (tigersTeeth == QUEST_ACCEPTED) then
+    elseif tigersTeeth == QUEST_ACCEPTED then
         player:startEvent(575)
-    elseif (tigersTeeth == QUEST_COMPLETED) then
+    elseif tigersTeeth == QUEST_COMPLETED then
         player:startEvent(573)
     else
         player:startEvent(571)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 574 and option == 0) then
+    if csid == 574 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH)
-    elseif (csid == 572) then
+    elseif csid == 572 then
         player:tradeComplete()
         player:addTitle(xi.title.FANG_FINDER)
         player:addGil(xi.settings.main.GIL_RATE * 2100)
         player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 2100)
-        if (player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH) == QUEST_ACCEPTED) then
+        if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH) == QUEST_ACCEPTED then
             player:addFame(xi.quest.fame_area.SANDORIA, 30)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TIGER_S_TEETH)
         else
             player:addFame(xi.quest.fame_area.SANDORIA, 5)
         end
     end
-
 end
 
 return entity

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/_6eo.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/_6eo.lua
@@ -14,8 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == QUEST_ACCEPTED and player:getCharVar("KnotQuiteThere") == 3) then
+    if player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == QUEST_ACCEPTED and player:getCharVar("KnotQuiteThere") == 3 then
         player:startEvent(63)
     end
 end
@@ -24,7 +23,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 63) then
+    if csid == 63 then
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 751)
         else

--- a/scripts/zones/Tavnazian_Safehold/npcs/_0qa.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/_0qa.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 5) then
+    if player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DAWN and player:getCharVar("PromathiaStatus") == 5 then
         player:startEvent(543)
     end
 end
@@ -21,7 +21,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 543) then
+    if csid == 543 then
         player:setCharVar("PromathiaStatus", 6)
     end
 end

--- a/scripts/zones/The_Colosseum/npcs/_1e9.lua
+++ b/scripts/zones/The_Colosseum/npcs/_1e9.lua
@@ -16,7 +16,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 51 and option == 1) then
+    if csid == 51 and option == 1 then
         player:setPos(79.981, 0, -104.897, 190, 50)
     end
 end

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
 
     -- Count keyitems
     for i = xi.ki.SHARD_OF_APATHY, xi.ki.SHARD_OF_RAGE do
-        if (player:hasKeyItem(i) == true) then
+        if player:hasKeyItem(i) == true then
             aaKeyitems = aaKeyitems + 1
         end
     end
@@ -38,21 +38,21 @@ entity.onTrigger = function(player, npc)
         end
     end
 
-    if (currentZM == xi.mission.id.zilart.ARK_ANGELS and zmProgress == 1 and divineStatus < 2) then -- Reminder CS/starts Divine Might (per Wiki)
+    if currentZM == xi.mission.id.zilart.ARK_ANGELS and zmProgress == 1 and divineStatus < 2 then -- Reminder CS/starts Divine Might (per Wiki)
         player:startEvent(54, 917, 1408, 1550)
-    elseif (currentZM >= xi.mission.id.zilart.ARK_ANGELS and dmStatus == QUEST_AVAILABLE and aaKeyitems > 0) then -- Alternative cutscene for those that have done one or more AA fight
+    elseif currentZM >= xi.mission.id.zilart.ARK_ANGELS and dmStatus == QUEST_AVAILABLE and aaKeyitems > 0 then -- Alternative cutscene for those that have done one or more AA fight
         player:startEvent(56, 917, 1408, 1550)
-    elseif (dmStatus == QUEST_ACCEPTED and divineStatus >= 2) then -- CS when player has completed Divine might, award earring
+    elseif dmStatus == QUEST_ACCEPTED and divineStatus >= 2 then -- CS when player has completed Divine might, award earring
         player:startEvent(55, 14739, 14740, 14741, 14742, 14743)
-    elseif (dmStatus == QUEST_COMPLETED and dmEarrings < xi.settings.main.NUMBER_OF_DM_EARRINGS and dmRepeat ~= QUEST_ACCEPTED) then -- You threw away old Earring, start the repeat quest
+    elseif dmStatus == QUEST_COMPLETED and dmEarrings < xi.settings.main.NUMBER_OF_DM_EARRINGS and dmRepeat ~= QUEST_ACCEPTED then -- You threw away old Earring, start the repeat quest
         player:startEvent(57, player:getCharVar("DM_Earring"))
-    elseif (dmRepeat == QUEST_ACCEPTED and divineStatus < 2) then
-        if (moonOre == false) then
+    elseif dmRepeat == QUEST_ACCEPTED and divineStatus < 2 then
+        if moonOre == false then
             player:startEvent(58) -- Reminder for Moonlight Ore
         else
             player:startEvent(56, 917, 1408, 1550) -- Reminder for Ark Pentasphere
         end
-    elseif (dmRepeat == QUEST_ACCEPTED and divineStatus == 2 and moonOre == true) then -- Repeat turn in
+    elseif dmRepeat == QUEST_ACCEPTED and divineStatus == 2 and moonOre == true then -- Repeat turn in
         player:startEvent(59)
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY) -- Need some kind of feedback
@@ -60,37 +60,38 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if ((csid == 55 or csid == 59) and option == 2) then
+    if (csid == 55 or csid == 59) and option == 2 then
         player:updateEvent(14739, 14740, 14741, 14742, 14743)
     end
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if ((csid == 54 or csid == 56) and player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT) == QUEST_AVAILABLE) then -- Flag Divine Might
+    if (csid == 54 or csid == 56) and player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT) == QUEST_AVAILABLE then -- Flag Divine Might
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT)
 
-    elseif (csid == 57) then -- Divine Might Repeat
+    elseif csid == 57 then -- Divine Might Repeat
         player:delQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT)
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT)
 
-    elseif (csid == 55 or csid == 59) then -- Turning in Divine Might or Repeat
+    elseif csid == 55 or csid == 59 then -- Turning in Divine Might or Repeat
         local reward = 0
-        if (option == 1) then
+        if option == 1 then
             reward = 14739 -- Suppanomimi
-        elseif (option == 2) then
+        elseif option == 2 then
             reward = 14740 -- Knight's Earring
-        elseif (option == 3) then
+        elseif option == 3 then
             reward = 14741 -- Abyssal Earring
-        elseif (option == 4) then
+        elseif option == 4 then
             reward = 14742 -- Beastly Earring
-        elseif (option == 5) then
+        elseif option == 5 then
             reward = 14743 -- Bushinomimi
         end
-        if (reward ~= 0) then
-            if (player:getFreeSlotsCount() >= 1 and player:hasItem(reward) == false) then
+
+        if reward ~= 0 then
+            if player:getFreeSlotsCount() >= 1 and player:hasItem(reward) == false then
                 player:addItem(reward)
                 player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
-                if (csid == 55) then
+                if csid == 55 then
                     player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT)
                 else
                     player:completeQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT)

--- a/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
@@ -16,7 +16,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if (xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+    if xi.settings.main.ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30 then
         local hasStone = xi.abyssea.getHeldTraverserStones(player)
 
         if
@@ -37,11 +37,11 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 56) then
+    if csid == 56 then
         player:addQuest(xi.quest.log_id.ABYSSEA, xi.quest.id.abyssea.A_DELECTABLE_DEMON)
-    elseif (csid == 57) then
+    elseif csid == 57 then
         -- Killed Cirein-croin
-    elseif (csid == 55 and option == 1) then
+    elseif csid == 55 and option == 1 then
         player:setPos(670, -15, 318, 119, 216)
     end
 end

--- a/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
@@ -17,11 +17,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 502 and option == 1) then
+    if csid == 502 and option == 1 then
         player:setPos(-37, 1, -56, 0, 50)
     end
-
 end
 
 return entity

--- a/scripts/zones/Wajaom_Woodlands/npcs/_1f1.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/_1f1.lua
@@ -11,24 +11,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
-    if (player:hasKeyItem(xi.ki.SICKLEMOON_SALT)) then
+    if player:hasKeyItem(xi.ki.SICKLEMOON_SALT) then
         player:startEvent(514)
     else
         player:startEvent(516)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
-    if (csid == 514 and option == 1) then
+    if csid == 514 and option == 1 then
         player:delKeyItem(xi.ki.SICKLEMOON_SALT)
     end
-
 end
 
 return entity

--- a/scripts/zones/Western_Adoulin/npcs/Barenngo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Barenngo.lua
@@ -14,10 +14,10 @@ end
 
 entity.onTrigger = function(player, npc)
     local DELM = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.DONT_EVER_LEAF_ME)
-    if ((DELM == QUEST_ACCEPTED) and (player:getCharVar("DELM_Barenngo_Branch") < 1)) then
+    if DELM == QUEST_ACCEPTED and player:getCharVar("DELM_Barenngo_Branch") < 1 then
         -- Progresses Quest: 'Dont Ever Leaf Me'
         player:startEvent(5015)
-    elseif ((DELM == QUEST_ACCEPTED) and (player:getCharVar("DELM_Barenngo_Branch") < 2)) then
+    elseif DELM == QUEST_ACCEPTED and player:getCharVar("DELM_Barenngo_Branch") < 2 then
         -- Reminds player of hint for Quest: 'Dont Ever Leaf Me'
         player:startEvent(5016)
     else
@@ -30,7 +30,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 5015) then
+    if csid == 5015 then
         -- Progresses Quest: 'Dont Ever Leaf Me'
         player:setCharVar("DELM_Barenngo_Branch", 1)
     end

--- a/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
@@ -18,11 +18,11 @@ entity.onTrade = function(player, npc, trade)
     local vvc = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.VEGETABLE_VEGETABLE_CRISIS)
 
     -- DO NOT GO INTO THE LIGHT (Urunday Lumber, Damascus Ingot, Fire Crystal)
-    if (dngitl == QUEST_ACCEPTED and player:getCharVar("DNGITL_Status") == 3 and npcUtil.tradeHas(trade, { 3927, 658, 4096 })) then
+    if dngitl == QUEST_ACCEPTED and player:getCharVar("DNGITL_Status") == 3 and npcUtil.tradeHas(trade, { 3927, 658, 4096 }) then
         player:startEvent(5076)
 
     -- VEGETABLE VEGETABLE CRISIS (Urunday Lumber, Midrium Ingot, Raaz Leather)
-    elseif (vvc == QUEST_ACCEPTED and player:getCharVar("VVC_Status") == 1 and npcUtil.tradeHas(trade, { 3927, 3919, 8708 })) then
+    elseif vvc == QUEST_ACCEPTED and player:getCharVar("VVC_Status") == 1 and npcUtil.tradeHas(trade, { 3927, 3919, 8708 }) then
         player:startEvent(5089)
     end
 end
@@ -32,15 +32,15 @@ entity.onTrigger = function(player, npc)
     local vvc = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.VEGETABLE_VEGETABLE_CRISIS)
 
     -- DO NOT GO INTO THE LIGHT
-    if (dngitl == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.INVENTORS_COALITION_PICKAXE)) then
+    if dngitl == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.INVENTORS_COALITION_PICKAXE) then
         player:startEvent(5077)
 
     -- VEGETABLE VEGETABLE CRISIS
-    elseif (vvc == QUEST_ACCEPTED and player:getCharVar("VVC_Status") == 1) then
+    elseif vvc == QUEST_ACCEPTED and player:getCharVar("VVC_Status") == 1 then
         player:startEvent(5088)
 
     -- STANDARD DIALOGS
-    elseif (player:getCurrentMission(xi.mission.log_id.SOA) >= xi.mission.id.soa.LIFE_ON_THE_FRONTIER) then
+    elseif player:getCurrentMission(xi.mission.log_id.SOA) >= xi.mission.id.soa.LIFE_ON_THE_FRONTIER then
         player:startEvent(588) -- Standard dialogue
     else
         player:startEvent(531) -- Dialogue prior to joining colonization effort
@@ -52,13 +52,13 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- DO NOT GO INTO THE LIGHT
-    if (csid == 5076) then
+    if csid == 5076 then
         player:confirmTrade()
         npcUtil.giveKeyItem(player, xi.ki.INVENTORS_COALITION_PICKAXE)
         player:setCharVar("DNGITL_Status", 0)
 
     -- VEGETABLE VEGETABLE CRISIS
-    elseif (csid == 5089) then
+    elseif csid == 5089 then
         player:confirmTrade()
         player:setCharVar("VVC_Status", 2)
         player:setCharVar("VVC_Gameday_Wait", vanaDay())

--- a/scripts/zones/Western_Adoulin/npcs/Defliaa.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Defliaa.lua
@@ -15,10 +15,10 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     -- ALL THE WAY TO THE BANK
-    if (player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE)) then
+    if player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE) then
         local paidDefliaa = utils.mask.getBit(player:getCharVar("ATWTTB_Payments"), 0)
 
-        if (not paidDefliaa and npcUtil.tradeHas( trade, { { "gil", 19440 } })) then
+        if not paidDefliaa and npcUtil.tradeHas( trade, { { "gil", 19440 } }) then
             player:startEvent(5069)
         end
     end
@@ -44,7 +44,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- ALL THE WAY TO THE BANK
-    if (csid == 5069) then
+    if csid == 5069 then
         player:confirmTrade()
         player:setCharVar("ATWTTB_Payments", utils.mask.setBit(player:getCharVar("ATWTTB_Payments"), 0, true))
         if utils.mask.isFull(player:getCharVar("ATWTTB_Payments"), 5) then

--- a/scripts/zones/Western_Adoulin/npcs/Dewalt.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dewalt.lua
@@ -14,10 +14,10 @@ end
 
 entity.onTrigger = function(player, npc)
     local DELM = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.DONT_EVER_LEAF_ME)
-    if ((DELM == QUEST_ACCEPTED) and (player:getCharVar("DELM_Dewalt_Branch") < 1)) then
+    if DELM == QUEST_ACCEPTED and player:getCharVar("DELM_Dewalt_Branch") < 1 then
         -- Progresses Quest: 'Dont Ever Leaf Me'
         player:startEvent(5013)
-    elseif ((DELM == QUEST_ACCEPTED) and (player:getCharVar("DELM_Dewalt_Branch") < 2)) then
+    elseif DELM == QUEST_ACCEPTED and player:getCharVar("DELM_Dewalt_Branch") < 2 then
         -- Reminds player of hint for Quest: 'Dont Ever Leaf Me'
         player:startEvent(5014)
     else
@@ -30,7 +30,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 5013) then
+    if csid == 5013 then
         -- Progresses Quest: 'Dont Ever Leaf Me'
         player:setCharVar("DELM_Dewalt_Branch", 1)
     end

--- a/scripts/zones/Western_Adoulin/npcs/Flapano.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Flapano.lua
@@ -19,17 +19,17 @@ entity.onTrade = function(player, npc, trade)
     local exoticDelicacies = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.EXOTIC_DELICACIES)
 
     -- ALL THE WAY TO THE BANK
-    if (player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE) and npcUtil.tradeHas( trade, { { "gil", 5600 } } )) then
+    if player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE) and npcUtil.tradeHas(trade, { { "gil", 5600 } }) then
         local paidFlapano = utils.mask.getBit(player:getCharVar("ATWTTB_Payments"), 2)
-        if (not paidFlapano) then
+        if not paidFlapano then
             player:startEvent(5071)
         end
 
     -- EXOTIC DELICACIES
-    elseif (exoticDelicacies == QUEST_ACCEPTED) then
-        if (npcUtil.tradeHas( trade, { 3916, 5949, { 5954, 2 } })) then
+    elseif exoticDelicacies == QUEST_ACCEPTED then
+        if npcUtil.tradeHas( trade, { 3916, 5949, { 5954, 2 } }) then
             player:startEvent(2861)
-        elseif (npcUtil.tradeHas(trade, 5974) or npcUtil.tradeHas(trade, 5975)) then
+        elseif npcUtil.tradeHas(trade, 5974) or npcUtil.tradeHas(trade, 5975) then
             player:startEvent(2862)
         end
     end
@@ -40,15 +40,15 @@ entity.onTrigger = function(player, npc)
     local exoticDelicacies = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.EXOTIC_DELICACIES)
 
     -- THE WEATHERSPOON WAR
-    if (theWeatherspoonWar == QUEST_ACCEPTED and player:getCharVar("Weatherspoon_War_Status") == 6) then
+    if theWeatherspoonWar == QUEST_ACCEPTED and player:getCharVar("Weatherspoon_War_Status") == 6 then
         player:startEvent(191)
 
     -- EXOTIC DELICACIES
     -- Flapano offers his quest every other time the player talks to him
-    elseif (exoticDelicacies ~= QUEST_COMPLETED and player:getCharVar("Flapano_Odd_Even") == 0) then
-        if (exoticDelicacies == QUEST_AVAILABLE) then
+    elseif exoticDelicacies ~= QUEST_COMPLETED and player:getCharVar("Flapano_Odd_Even") == 0 then
+        if exoticDelicacies == QUEST_AVAILABLE then
             player:startEvent(2860)
-        elseif (exoticDelicacies == QUEST_ACCEPTED) then
+        elseif exoticDelicacies == QUEST_ACCEPTED then
             player:startEvent(2863)
         end
 
@@ -69,7 +69,7 @@ entity.onTrigger = function(player, npc)
         }
         xi.shop.general(player, stock)
 
-        if (exoticDelicacies ~= QUEST_COMPLETED) then
+        if exoticDelicacies ~= QUEST_COMPLETED then
             player:setCharVar("Flapano_Odd_Even", 0)
         end
     end
@@ -80,7 +80,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- ALL THE WAY TO THE BANK
-    if (csid == 5071) then
+    if csid == 5071 then
         player:confirmTrade()
         player:setCharVar("ATWTTB_Payments", utils.mask.setBit(player:getCharVar("ATWTTB_Payments"), 2, true))
         if utils.mask.isFull(player:getCharVar("ATWTTB_Payments"), 5) then
@@ -88,10 +88,10 @@ entity.onEventFinish = function(player, csid, option)
         end
 
     -- EXOTIC DELICACIES
-    elseif (csid == 2860 and option == 1) then
+    elseif csid == 2860 and option == 1 then
         player:addQuest(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.EXOTIC_DELICACIES)
-    elseif (csid == 2861) then
-        if (npcUtil.completeQuest(player, xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.EXOTIC_DELICACIES, { bayld = 500, item = 5975, xp = 1000 })) then
+    elseif csid == 2861 then
+        if npcUtil.completeQuest(player, xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.EXOTIC_DELICACIES, { bayld = 500, item = 5975, xp = 1000 }) then
             player:confirmTrade()
             player:setCharVar("Flapano_Odd_Even", 0)
         end

--- a/scripts/zones/Western_Adoulin/npcs/Gontrain.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Gontrain.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local raptorRapture = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.RAPTOR_RAPTURE)
 
-    if ((raptorRapture == QUEST_ACCEPTED) and (player:getCharVar("Raptor_Rapture_Status") == 4)) then
+    if raptorRapture == QUEST_ACCEPTED and player:getCharVar("Raptor_Rapture_Status") == 4 then
         -- Progresses Quest: 'Raptor Rapture', speaking to Ilney.
         player:startEvent(5034)
     else
@@ -28,7 +28,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 5034) then
+    if csid == 5034 then
         -- Progresses Quest: 'Raptor Rapture', spoke to Ilney.
         player:setCharVar("Raptor_Rapture_Status", 5)
     end

--- a/scripts/zones/Western_Adoulin/npcs/Hujette.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Hujette.lua
@@ -16,9 +16,9 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     -- ALL THE WAY TO THE BANK
-    if (player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE)) then
+    if player:hasKeyItem(xi.ki.TARUTARU_SAUCE_INVOICE) then
         local paidHujette = utils.mask.getBit(player:getCharVar("ATWTTB_Payments"), 1)
-        if ((not paidHujette) and npcUtil.tradeHas( trade, { { "gil", 3000 } })) then
+        if not paidHujette and npcUtil.tradeHas(trade, { { "gil", 3000 } }) then
             player:startEvent(5070)
         end
     end
@@ -42,7 +42,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     -- ALL THE WAY TO THE BANK
-    if (csid == 5070) then
+    if csid == 5070 then
         player:confirmTrade()
         player:setCharVar("ATWTTB_Payments", utils.mask.setBit(player:getCharVar("ATWTTB_Payments"), 2, true))
         if utils.mask.isFull(player:getCharVar("ATWTTB_Payments"), 5) then

--- a/scripts/zones/Western_Adoulin/npcs/Nikkhail.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nikkhail.lua
@@ -17,12 +17,11 @@ end
 
 entity.onTrigger = function(player, npc)
     local atfta = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.A_THIRST_FOR_THE_AGES)
-    local atftaNeedKI = ((player:getCharVar("ATFTA_Status") < 2) and (not player:hasKeyItem(xi.ki.COPY_OF_THE_ALLIANCE_AGREEMENT)))
-
+    local atftaNeedKI = player:getCharVar("ATFTA_Status") < 2 and not player:hasKeyItem(xi.ki.COPY_OF_THE_ALLIANCE_AGREEMENT)
     local soaMission = player:getCurrentMission(xi.mission.log_id.SOA)
 
-    if (soaMission >= xi.mission.id.soa.LIFE_ON_THE_FRONTIER) then
-        if ((atfta == QUEST_ACCEPTED) and atftaNeedKI) then
+    if soaMission >= xi.mission.id.soa.LIFE_ON_THE_FRONTIER then
+        if atfta == QUEST_ACCEPTED and atftaNeedKI then
             -- Progresses Quest: 'A Thirst for the Ages'
             player:startEvent(5053)
         else
@@ -39,7 +38,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 5053) then
+    if csid == 5053 then
         -- Progresses Quest: 'A Thirst for the Ages'
         player:addKeyItem(xi.ki.COPY_OF_THE_ALLIANCE_AGREEMENT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.COPY_OF_THE_ALLIANCE_AGREEMENT)

--- a/scripts/zones/Western_Adoulin/npcs/Pagnelle.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Pagnelle.lua
@@ -18,8 +18,8 @@ entity.onTrigger = function(player, npc)
     local raptorRapture = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.RAPTOR_RAPTURE)
     local raptorRaptureStatus = player:getCharVar("Raptor_Rapture_Status")
 
-    if (raptorRapture == QUEST_AVAILABLE) then
-        if (raptorRaptureStatus < 3) then
+    if raptorRapture == QUEST_AVAILABLE then
+        if raptorRaptureStatus < 3 then
             -- Starts chain of events for the introduction CS for Quest: 'Raptor Rapture'.
             -- If player somehow doesn't finish the chain of events, they can just talk to Pagnelle again to retry.
             player:setCharVar("Raptor_Rapture_Status", 1)
@@ -29,31 +29,31 @@ entity.onTrigger = function(player, npc)
             -- Offers Quest: 'Raptor Rapture' if player has yet to accept it.
             player:startEvent(5061)
         end
-    elseif (raptorRapture == QUEST_ACCEPTED) then
-        if (raptorRaptureStatus == 4) then
+    elseif raptorRapture == QUEST_ACCEPTED then
+        if raptorRaptureStatus == 4 then
             -- Reminder during Quest: 'Raptor Rapture', speak to Ilney.
             player:startEvent(5033)
-        elseif (raptorRaptureStatus == 5) then
+        elseif raptorRaptureStatus == 5 then
             -- Progresses Quest: 'Raptor Rapture', spoke to Ilney.
             player:startEvent(5035)
-        elseif (raptorRaptureStatus == 6) then
+        elseif raptorRaptureStatus == 6 then
             local hasRockberries = player:hasKeyItem(xi.ki.ROCKBERRY1) and player:hasKeyItem(xi.ki.ROCKBERRY2) and player:hasKeyItem(xi.ki.ROCKBERRY3)
-            if (hasRockberries) then
+            if hasRockberries then
                 -- Progresses Quest: 'Raptor Rapture', turning in rockberries.
                 player:startEvent(5037)
             else
                 -- Reminder during Quest: 'Raptor Rapture', bring rockberries.
                 player:startEvent(5036)
             end
-        elseif (raptorRaptureStatus == 7) then
+        elseif raptorRaptureStatus == 7 then
             -- Reminder during Quest: 'Raptor Rapture', go to Rala.
             player:startEvent(5038)
-        elseif (raptorRaptureStatus == 8) then
+        elseif raptorRaptureStatus == 8 then
             -- Finishes Quest: 'Raptor Rapture'
             player:startEvent(5039)
         end
     else
-        if (player:needToZone()) then
+        if player:needToZone() then
             -- Dialogue after finishing Quest: 'Raptor Rapture', before zoning
             player:startEvent(5040)
         else
@@ -67,23 +67,23 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 5032) then
+    if csid == 5032 then
         -- Warps player to Rala Waterways to continue intrductory CS for Quest: 'Raptor Rapture'
         player:setPos(0, 0, 0, 0, 258)
-    elseif ((csid == 5061) and (option == 1)) then
+    elseif csid == 5061 and option == 1 then
         -- Starts Quest: 'Raptor Rapture'
         player:addQuest(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.RAPTOR_RAPTURE)
         player:setCharVar("Raptor_Rapture_Status", 4)
-    elseif (csid == 5035) then
+    elseif csid == 5035 then
         -- Progresses Quest: 'Raptor Rapture', spoke to Ilney, now need rockberries.
         player:setCharVar("Raptor_Rapture_Status", 6)
-    elseif (csid == 5037) then
+    elseif csid == 5037 then
         -- Progresses Quest: 'Raptor Rapture', brought rockberries, now need to go to Rala.
         player:delKeyItem(xi.ki.ROCKBERRY1)
         player:delKeyItem(xi.ki.ROCKBERRY2)
         player:delKeyItem(xi.ki.ROCKBERRY3)
         player:setCharVar("Raptor_Rapture_Status", 7)
-    elseif (csid == 5039) then
+    elseif csid == 5039 then
         -- Finishing Quest: 'Raptor Rapture'
         player:setCharVar("Raptor_Rapture_Status", 0)
         player:completeQuest(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.RAPTOR_RAPTURE)

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -22,17 +22,17 @@ entity.onTrigger = function(player, npc)
     local tomath = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON)
     local fertileGround = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.FERTILE_GROUND)
     local waywardWaypoints = player:getQuestStatus(xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.WAYWARD_WAYPOINTS)
-    waywardWaypoints = (waywardWaypoints == QUEST_ACCEPTED) and (player:getCharVar("WW_Need_Shipilolo") > 0)
+    waywardWaypoints = waywardWaypoints == QUEST_ACCEPTED and player:getCharVar("WW_Need_Shipilolo") > 0
     local soaMission = player:getCurrentMission(xi.mission.log_id.SOA)
 
     if (soaMission >= xi.mission.id.soa.LIFE_ON_THE_FRONTIER) then
-        if ((tomath == QUEST_ACCEPTED) and player:hasKeyItem(xi.ki.BROKEN_HARPOON)) then
+        if tomath == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.BROKEN_HARPOON) then
             -- Progresses Quest: 'The Old Man and the Harpoon'
             player:startEvent(2543)
-        elseif ((fertileGround == QUEST_ACCEPTED) and (not player:hasKeyItem(xi.ki.BOTTLE_OF_FERTILIZER_X))) then
+        elseif fertileGround == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.BOTTLE_OF_FERTILIZER_X) then
             -- Progresses Quest: 'Fertile Ground'
             player:startEvent(2850)
-        elseif (waywardWaypoints and (not player:hasKeyItem(xi.ki.WAYPOINT_RECALIBRATION_KIT))) then
+        elseif waywardWaypoints and not player:hasKeyItem(xi.ki.WAYPOINT_RECALIBRATION_KIT) then
             -- Progresses Quest: 'Wayward Waypoints'
             player:startEvent(79)
         else
@@ -49,15 +49,15 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 2543) then
+    if csid == 2543 then
         -- Progresses Quest: 'The Old Man and the Harpoon'
         player:delKeyItem(xi.ki.BROKEN_HARPOON)
         player:addKeyItem(xi.ki.EXTRAVAGANT_HARPOON)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.EXTRAVAGANT_HARPOON)
-    elseif (csid == 2850) then
+    elseif csid == 2850 then
         -- Progresses Quest: 'Fertile Ground'
         player:addKeyItem(xi.ki.BOTTLE_OF_FERTILIZER_X)
-    elseif (csid == 79) then
+    elseif csid == 79 then
         player:addKeyItem(xi.ki.WAYPOINT_RECALIBRATION_KIT)
         player:setCharVar("WW_Need_Shipilolo", 0)
     end

--- a/scripts/zones/Windurst_Walls/npcs/Chomomo.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Chomomo.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 8)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 8) then
         player:startEvent(499)
     else
         player:startEvent(325)
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 499) then
+    if csid == 499 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 8, true))
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Moan-Maon.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Moan-Maon.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 7)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 7) then
         player:startEvent(497)
     else
         player:startEvent(307)
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 497) then
+    if csid == 497 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 7, true))
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Naih_Arihmepp.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Naih_Arihmepp.lua
@@ -29,7 +29,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 9)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 9) then
         player:startEvent(500)
     else
         player:startEvent(326)
@@ -40,7 +40,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 500) then
+    if csid == 500 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 9, true))
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Yoriri.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Yoriri.lua
@@ -15,7 +15,7 @@ end
 entity.onTrigger = function(player, npc)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 5)) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.LURE_OF_THE_WILDCAT) == QUEST_ACCEPTED and not utils.mask.getBit(wildcatWindurst, 5) then
         player:startEvent(496)
     else
         player:startEvent(313)
@@ -26,7 +26,7 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 496) then
+    if csid == 496 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 5, true))
     end
 end

--- a/scripts/zones/Windurst_Walls/npcs/Zayhi-Bauhi.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zayhi-Bauhi.lua
@@ -11,18 +11,18 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if (player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(4370, 1) and trade:getItemCount() == 1) then
+    if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_BEE_OR_NOT_TO_BEE) == QUEST_ACCEPTED then
+        if trade:hasItemQty(4370, 1) and trade:getItemCount() == 1 then
             local toBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
-            if (toBeeOrNotStatus == 10) then
+            if toBeeOrNotStatus == 10 then
                 player:startEvent(69) -- After Honey#1: Clearing throat
-            elseif (toBeeOrNotStatus == 1) then
+            elseif toBeeOrNotStatus == 1 then
                 player:startEvent(70) -- After Honey#2: Tries to speak again... coughs
-            elseif (toBeeOrNotStatus == 2) then
+            elseif toBeeOrNotStatus == 2 then
                 player:startEvent(73) -- After Honey#3: Tries to speak again... coughs..asked for more Honey
-            elseif (toBeeOrNotStatus == 3) then
+            elseif toBeeOrNotStatus == 3 then
                 player:startEvent(74) -- After Honey#4: Feels like its getting a lot better but there is still iritaion
-            elseif (toBeeOrNotStatus == 4) then
+            elseif toBeeOrNotStatus == 4 then
                 player:startEvent(75) -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey
             end
         end
@@ -34,19 +34,22 @@ entity.onTrigger = function(player, npc)
     local postmanKOsTwice = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.THE_POSTMAN_ALWAYS_KO_S_TWICE)
     local toBeeOrNotStatus = player:getCharVar("ToBeeOrNot_var")
 
-    if ((player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 and postmanKOsTwice == QUEST_COMPLETED and toBee == QUEST_AVAILABLE) or (toBee == QUEST_ACCEPTED and toBeeOrNotStatus == 10)) then
+    if
+        (player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 and postmanKOsTwice == QUEST_COMPLETED and toBee == QUEST_AVAILABLE) or
+        (toBee == QUEST_ACCEPTED and toBeeOrNotStatus == 10)
+    then
         player:startEvent(64)   -- Just Before Quest Start "Too Bee or Not Too Be" (Speech given with lots of coughing)
-    elseif (toBee == QUEST_ACCEPTED) then
-        if (toBeeOrNotStatus == 1) then
+    elseif toBee == QUEST_ACCEPTED then
+        if toBeeOrNotStatus == 1 then
             player:startEvent(69) -- After Honey#1: Clearing throat
-        elseif (toBeeOrNotStatus == 2) then
+        elseif toBeeOrNotStatus == 2 then
             player:startEvent(70) -- After Honey#2: Tries to speak again... coughs
-        elseif (toBeeOrNotStatus == 3) then
+        elseif toBeeOrNotStatus == 3 then
             player:startEvent(73) -- After Honey#3: Tries to speak again... coughs..asked for more Honey
-        elseif (toBeeOrNotStatus == 4) then
+        elseif toBeeOrNotStatus == 4 then
             player:startEvent(74) -- After Honey#4: Feels like its getting a lot better but there is still iritaion
         end
-    elseif (toBee == QUEST_COMPLETED and player:needToZone()) then
+    elseif toBee == QUEST_COMPLETED and player:needToZone() then
         player:startEvent(78) -- ToBee After Quest Finish but before zone (tooth still hurts)
     else
         player:startEvent(299) -- Normal speech
@@ -67,21 +70,21 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 64) then
+    if csid == 64 then
         player:setCharVar("ToBeeOrNot_var", 10)
-    elseif (csid == 69) then -- After Honey#1: Clearing throat
+    elseif csid == 69 then -- After Honey#1: Clearing throat
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 1)
-    elseif (csid == 70) then -- After Honey#2: Tries to speak again... coughs
+    elseif csid == 70 then -- After Honey#2: Tries to speak again... coughs
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 2)
-    elseif (csid == 73) then -- After Honey#3: Tries to speak again... coughs..asked for more Honey
+    elseif csid == 73 then -- After Honey#3: Tries to speak again... coughs..asked for more Honey
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 3)
-    elseif (csid == 74) then -- After Honey#4: Feels like its getting a lot better but there is still iritaion
+    elseif csid == 74 then -- After Honey#4: Feels like its getting a lot better but there is still iritaion
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 4)
-    elseif (csid == 75) then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
+    elseif csid == 75 then -- After Honey#5: ToBee quest Finish (tooth hurts from all the Honey)
         player:tradeComplete()
         player:setCharVar("ToBeeOrNot_var", 5)
         player:addFame(xi.quest.fame_area.WINDURST, 30)

--- a/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
@@ -14,31 +14,29 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local wonderingstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
-    if (wonderingstatus == 1 and trade:hasItemQty(718, 1) == true and trade:getItemCount() == 1 and player:getCharVar("QuestWonderingMin_var") == 1) then
+    if wonderingstatus == 1 and trade:hasItemQty(718, 1) == true and trade:getItemCount() == 1 and player:getCharVar("QuestWonderingMin_var") == 1 then
         player:startEvent(638)                 -- WONDERING_MINSTREL: Quest Finish
     end
 end
 
 entity.onTrigger = function(player, npc)
-
-            --        player:delQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
-
+    -- player:delQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
     local wonderingstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
     local fame = player:getFameLevel(xi.quest.fame_area.WINDURST)
-    if (wonderingstatus == QUEST_AVAILABLE and fame >= 5) then
+    if wonderingstatus == QUEST_AVAILABLE and fame >= 5 then
         local rand = math.random(1, 2)
         if rand == 1 then
             player:startEvent(633)          -- WONDERING_MINSTREL: Before Quest
         else
             player:startEvent(634)          -- WONDERING_MINSTREL: Quest Start
         end
-    elseif (wonderingstatus == QUEST_ACCEPTED) then
+    elseif wonderingstatus == QUEST_ACCEPTED then
         player:startEvent(635)                 -- WONDERING_MINSTREL: During Quest
-    elseif (wonderingstatus == QUEST_COMPLETED and player:needToZone()) then
+    elseif wonderingstatus == QUEST_COMPLETED and player:needToZone() then
         player:startEvent(639)                 -- WONDERING_MINSTREL: After Quest
     else
         local hour = VanadielHour()
-        if (hour >= 18 or hour <= 6) then
+        if hour >= 18 or hour <= 6 then
             player:startEvent(611)             -- Singing 1 (daytime < 6 or daytime >= 18)
         else
             local rand = math.random(1, 2)
@@ -55,9 +53,9 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if (csid == 634) then    -- WONDERING_MINSTREL: Quest Start
+    if csid == 634 then    -- WONDERING_MINSTREL: Quest Start
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
-    elseif (csid == 638) then  -- WONDERING_MINSTREL: Quest Finish
+    elseif csid == 638 then  -- WONDERING_MINSTREL: Quest Finish
         if player:getFreeSlotsCount() == 0 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 17349)
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Applies formatting rules for parentheses for more NPC lua scripts.  This is going to be a long-term effort with just under 1700 lines remaining.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed.
<!-- Clear and detailed steps to test your changes here -->
