### PR TITLE
[dbtool] Fix express update

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -309,8 +309,10 @@ def fetch_files(express=False):
             )
             if len(sql_diffs) > 0:
                 for diff in sql_diffs:
-                    import_files.append(from_server_path("sql/" + diff))
-                express_enabled = True
+                    if os.path.exists(from_server_path(diff.b_path)):
+                        import_files.append(from_server_path(diff.b_path))
+                if len(import_files) > 0:
+                    express_enabled = True
             else:
                 express_enabled = False
                 if (
@@ -339,7 +341,9 @@ def fetch_files(express=False):
     backups.sort()
     import_files.sort()
     try:
-        import_files.append(import_files.pop(import_files.index("triggers.sql")))
+        import_files.append(
+            import_files.pop(import_files.index(from_server_path("sql/triggers.sql")))
+        )
     except:  # lgtm [py/catch-base-exception]
         pass
     fetch_module_files()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fixes an issue where we were adding the diff object itself rather than the path it holds. Also some more verifying that everything is valid (e.g. a diff of a deleted file shouldn't be imported). Fixes triggers being the last import.

## Steps to test these changes

- Change a SQL file (example zone_settings.sql change one of the zoneip entries) and commit the change.
- Run dbtool, see express update for zone_settings.
- `git reset --hard HEAD~1`
- Delete a SQL file and commit the change.
- Run dbtool, express update not enabled.
- `git reset --hard HEAD~1`
- Run dbtool, select Update (option 1).
- See triggers.sql at the bottom of the list, abort update.
