### PR TITLE
[misc] Update the wording for issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,10 @@ assignees:
 
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
-- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
-- [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated
-- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
+
+- [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
+- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
+- [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.
 
 ## OS / platform the server is running (if known)
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,9 +8,10 @@ assignees:
 
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
-- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
-- [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated
-- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
+
+- [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
+- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
+- [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.
 
 ## Describe the feature
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
+
 **_I affirm:_**
-- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
-- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
-- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits
+
+- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
+- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
+- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.
 
 ## What does this pull request do?
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

The previous wordings referred to 'this example' which was visible in the text while editing, but not on the main page while viewing. This makes it more obvious what happens if you don't fill in the boxes.

Also adds an obvious link to the Code of Conduct alongside the Contributing Guide.

A couple of little grammar bits too.

## Steps to test these changes

Remember you can look at these changes and press the 'page' button to get a preview of the actual output:
<img width="187" alt="image" src="https://user-images.githubusercontent.com/1389729/199472104-f06cbda3-123f-430a-bdf5-5458f3788a5b.png">
