### PR TITLE
Clean nomad_cap script and make it use a table

### DIFF
--- a/scripts/globals/items/nomad_cap.lua
+++ b/scripts/globals/items/nomad_cap.lua
@@ -1,9 +1,20 @@
 -----------------------------------
---  ID: 16119
---  Nomad Cap
---  Transports the user to their Home Nation
+-- ID: 16119
+-- Nomad Cap
+-- Transports the user to their Home Nation
+-- TODO: Confirm wiki claims of random zone destinations among a same nation.
+-----------------------------------
+require("scripts/globals/zone")
 -----------------------------------
 local itemObject = {}
+
+local pos =
+{
+    -- Content  [Nation] = {   x,   y,  z, rot, zone },
+    [xi.nation.SANDORIA] = { 126,   0,  -1, 122, 231 },
+    [xi.nation.BASTOK  ] = { 106,   0, -71, 130, 234 },
+    [xi.nation.WINDURST] = { 197, -12, 224,  65, 240 },
+}
 
 itemObject.onItemCheck = function(target)
     return 0
@@ -11,19 +22,8 @@ end
 
 itemObject.onItemUse = function(target)
     local nation = target:getNation(target)
-    if (nation == 0) then -- San d'Oria
-        target:setPos(126, 0, -1, 122, 231)
-        return
-    end
-    if (nation == 1) then -- Bastok
-        target:setPos(106, 0, -71, 130, 234)
-        return
-    end
-    if (nation == 2) then -- Windurst
-        target:setPos(197, -12, 224, 65, 240)
-        return
-    end
-    print( "Unable to fetch target's nation." )
+
+    target:setPos(unpack(pos[nation]))
 end
 
 return itemObject


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the elseif chain with a table. No actual functionality changes.

## Steps to test these changes

Use nomad cap
