### PR TITLE
[ci] Make Check_Checkboxes job more robust

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees:
 
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
-
+**_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
 - [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
 - [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees:
 
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
-
+**_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my issue will be ignored.
 - [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
 - [ ] I have searched existing [issues](https://github.com/LandSandBoat/server/issues) to see if the issue has already been opened, and I have checked the commit log to see if the issue has been resolved since my server was last updated.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 <!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
 <!-- (it should look like this: - [x] I have ...) -->
-
 **_I affirm:_**
-
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
 - [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
 - [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -33,17 +33,19 @@ jobs:
                 type_name = "report"
             }
 
+            // Remove block comments
+            body_text = body_text.replaceAll(/<!--.*-->/g, "")
+
             console.log(`github.event_name: ${event_type}`)
             console.log(`body_text: ${body_text}`)
             console.log(`type_name: ${type_name}`)
 
             // Count the filled in checkboxes:
-            // 1x in the comment example
             // 1x pre-filled
             // 2x to be filled
-            // Minimum total: 4
+            // Minimum total: 3
             const checkbox_count = count_instances(body_text, "[x]")
-            if (checkbox_count < 4)
+            if (checkbox_count < 3)
             {
                 console.log(`Found ${checkbox_count} completed checkboxes. Leaving a reminder comment.`)
                 github.rest.issues.createComment({


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Previously this job was reliant on the block comments in the template, which users may or may not remove. This regex's them out so we only have to check against 3 checkboxes.

## Steps to test these changes

N/A
