### PR TITLE
Make Jidra adds in Apollyon SW randomly target

### DIFF
--- a/scripts/battlefields/Apollyon/sw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/sw_apollyon.lua
@@ -307,7 +307,9 @@ content.groups =
             local add = GetMobByID(addID)
             add:setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos(), mob:getRotPos())
             SpawnMob(addID)
-            local target = mob:getTarget()
+
+            local enmityList = mob:getEnmityList()
+            local target = utils.randomEntry(enmityList)["entity"]
             if target ~= nil then
                 add:updateEnmity(target)
             end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/303
Jidra spawn a mob when they die and this add should randomly aggro a player on the enmity list rather than go after the current Jidra target.

https://www.bg-wiki.com/ffxi/Jidra

## Steps to test these changes

```
-- !addkeyitem red_card
-- !addkeyitem cosmo_cleanse
-- !pos -600 -0.5 -600 38
```
Once inside use `!cs 208` to advance to the second floor and from there you can kill the Jidra and see they properly aggro randomly. This does require two players to truly see this at play.

