### PR TITLE
Change "Lightning Breath" for Wyvern's to apply proper type of damage

### DIFF
--- a/scripts/globals/abilities/pets/lightning_breath.lua
+++ b/scripts/globals/abilities/pets/lightning_breath.lua
@@ -33,7 +33,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     pet:setTP(0)
 
     local dmg = AbilityFinalAdjustments(dmgmod, pet, skill, target, xi.attackType.BREATH, xi.damageType.LIGHTNING, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    target:takeDamage(dmg, pet, xi.attackType.BREATH, xi.damageType.FIRE)
+    target:takeDamage(dmg, pet, xi.attackType.BREATH, xi.damageType.LIGHTNING)
     return dmg
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It corrects the Elemental Breath "Lightning Breath" to have the right type. I checked all the other breaths and they seem to have the right typing. 

## Steps to test these changes

1. Summon Wyvern
2. Ensure that "Lightning Breath" is applying lightning dmg