### PR TITLE
Fix out of bounds gardening crash and aura effect calculations

### DIFF
--- a/src/map/utils/gardenutils.cpp
+++ b/src/map/utils/gardenutils.cpp
@@ -254,10 +254,12 @@ namespace gardenutils
                     CItem* PItemContained = PContainer->GetItem(slotID);
                     if (PItemContained != nullptr && PItemContained->isType(ITEM_FURNISHING))
                     {
-                        CItemFurnishing* PFurniture = static_cast<CItemFurnishing*>(PItemContained);
-                        if (PFurniture->isInstalled())
+                        auto PFurniture = dynamic_cast<CItemFurnishing*>(PItemContained);
+                        if (PFurniture && PFurniture->isInstalled())
                         {
-                            auras[PFurniture->getElement()] += PFurniture->getAura();
+                            // -1 because element values range from 1-8
+                            // Converts from lua 1 based index to c/c++ 0 based index
+                            auras[PFurniture->getElement() - 1] += PFurniture->getAura();
                         }
                     }
                 }
@@ -267,10 +269,7 @@ namespace gardenutils
             uint16 dominantAura = 0;
             for (uint8 elementID = 0; elementID < 8; ++elementID)
             {
-                if (elements[elementID] > dominantAura)
-                {
-                    dominantAura = elements[elementID];
-                }
+                dominantAura = std::max(auras[elementID], dominantAura);
             }
             strength += dominantAura / 10;
         }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes out of bounds crash when harvesting with furniture of dark element are installed
- Fixes dominant aura calculation
- Closes https://github.com/AirSkyBoat/AirSkyBoat/issues/578

## Steps to test these changes

1. Install the following furniture:
- star globe (itemId 139)
- oak table (itemId 24)
- brass flowerpot (itemId 217)

2. Either wait a few days for the plan to mature, or run the following query:

`UPDATE char_inventory set extra = X'0A40000007250805160000007DF63D264A94492600000000' WHERE charid='<your-char-id>' AND itemId='217'`

Replace <your-char-id> by the chard_id of your character
Note that this query will set any flowerpot anywhere in the character bags as planted and mature. This is fine for testing and shouldn't break anything.

3. In your mog house, harvest the plant in the brass flowerpot. Should not crash and should yield goodies.

