### PR TITLE
[ci] Use pull_request_target trigger for comment job

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,16 +1,15 @@
 name: "github"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   issues:
     types: [opened]
 
-permissions: write-all
-
 jobs:
   Check_Checkboxes:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/github-script@v6
         with:
@@ -24,7 +23,7 @@ jobs:
             var   body_text  = ""
             var   type_name  = ""
 
-            if (event_type === "pull_request")
+            if (event_type === "pull_request_target")
             {
                 body_text = context.payload.pull_request.body
                 type_name = "PR"
@@ -56,7 +55,6 @@ jobs:
                     repo: context.repo.repo,
                     body: `✨ Thanks for the ${type_name}! ✨\n\nThis is a friendly automated reminder that the maintainers won't look at your ${type_name} until you've properly completed all of the checkboxes in the pre-filled template.`
                  })
-                console.log(result)
             }
             else
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`pull_request` trigger only works from inside this repo. `pull_request_target` is apparently whats needed when PRs come from forks.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
https://github.com/sbertix/ComposableRequest/blob/130a78d3ad03f382372f5d1a1eca1483ff8582d9/.github/workflows/pull_request.yml
https://stackoverflow.com/questions/67665951/github-action-cant-comment-on-pr

https://github.com/zach2good/server/pull/2

## Steps to test these changes

N/A