### PR TITLE
[core] Add basic Lua RPC between zones over ZMQ

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -149,6 +149,10 @@ enum MSGSERVTYPE : uint8
     // gm commands
     MSG_SEND_TO_ZONE,
     MSG_SEND_TO_ENTITY,
+
+    // rpc
+    MSG_RPC_SEND, // sent by sender -> reciever
+    MSG_RPC_RECV, // sent by reciever -> sender
 };
 
 constexpr auto msgTypeToStr = [](uint8 msgtype)
@@ -191,6 +195,10 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_SEND_TO_ZONE";
         case MSG_SEND_TO_ENTITY:
             return "MSG_SEND_TO_ENTITY";
+        case MSG_RPC_SEND:
+            return "MSG_RPC_SEND";
+        case MSG_RPC_RECV:
+            return "MSG_RPC_RECV";
         default:
             return "Unknown";
     };

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -143,6 +143,8 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
         case MSG_SEND_TO_ENTITY:
         case MSG_LUA_FUNCTION:
+        case MSG_RPC_SEND:
+        case MSG_RPC_RECV:
         {
             const char* query = "SELECT zoneip, zoneport FROM zone_settings WHERE zoneid = %d;";
             ret               = zmqSql->Query(query, ref<uint16>((uint8*)extra->data(), 2));

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -53,6 +53,8 @@ namespace message
     moodycamel::ConcurrentQueue<chat_message_t> outgoing_queue;
     moodycamel::ConcurrentQueue<chat_message_t> incoming_queue;
 
+    std::unordered_map<uint64_t, sol::function> replyMap;
+
     void send_queue()
     {
         TracyZoneScoped;
@@ -184,11 +186,13 @@ namespace message
             }
             case MSG_CHAT_YELL:
             {
+                // clang-format off
                 zoneutils::ForEachZone([&packet, &extra](CZone* PZone)
-                                       {
+                {
                     if (PZone->CanUseMisc(MISC_YELL))
                     {
-                        PZone->ForEachChar([&packet, &extra](CCharEntity* PChar) {
+                        PZone->ForEachChar([&packet, &extra](CCharEntity* PChar)
+                        {
                             // don't push to sender
                             if (PChar->id != ref<uint32>((uint8*)extra.data(), 0))
                             {
@@ -198,17 +202,24 @@ namespace message
                                 PChar->pushPacket(newPacket);
                             }
                         });
-                    } });
+                    }
+                });
+                // clang-format on
                 break;
             }
             case MSG_CHAT_SERVMES:
             {
+                // clang-format off
                 zoneutils::ForEachZone([&packet](CZone* PZone)
-                                       { PZone->ForEachChar([&packet](CCharEntity* PChar)
-                                                            {
+                {
+                    PZone->ForEachChar([&packet](CCharEntity* PChar)
+                    {
                         CBasicPacket* newPacket = new CBasicPacket();
                         memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                        PChar->pushPacket(newPacket); }); });
+                        PChar->pushPacket(newPacket);
+                    });
+                });
+                // clang-format on
                 break;
             }
             case MSG_PT_INVITE:
@@ -341,7 +352,6 @@ namespace message
                                            { ((CCharEntity*)PMember)->ReloadPartyInc(); });
                     }
                 }
-
                 break;
             }
             case MSG_PT_DISBAND:
@@ -562,8 +572,8 @@ namespace message
                     sol::error err = result;
                     ShowError("MSG_LUA_FUNCTION: error: %s: %s", err.what(), str.c_str());
                 }
+                break;
             }
-            break;
             case MSG_CHARVAR_UPDATE:
             {
                 uint8* data   = (uint8*)extra.data();
@@ -580,6 +590,63 @@ namespace message
                     ShowDebug(fmt::format("Updating charvar for {} ({}): {} = {}", player->GetName(), charId, varName, value));
                     player->updateCharVarCache(varName, value);
                 }
+                break;
+            }
+            case MSG_RPC_SEND:
+            {
+                // Extract data
+                uint8*   data     = (uint8*)extra.data();
+                uint16   sendZone = ref<uint16>(data, 2); // here
+                uint16   recvZone = ref<uint16>(data, 4); // origin
+                uint64_t slotKey  = ref<uint64_t>(data, 6);
+                uint16   strSize  = ref<uint16>(data, 14);
+                auto     sendStr  = std::string(data + 16, data + 16 + strSize);
+
+                // Execute Lua & collect payload
+                std::string payload = "";
+                auto        result  = lua.safe_script(sendStr);
+                if (result.valid() && result.return_count())
+                {
+                    payload = result.get<std::string>(0);
+                }
+
+                // Reply w/ payload
+                std::vector<uint8> packetData(16 + payload.size() + 1);
+
+                ref<uint16>(packetData.data(), 2)   = recvZone; // origin
+                ref<uint16>(packetData.data(), 4)   = sendZone; // here
+                ref<uint64_t>(packetData.data(), 6) = slotKey;
+
+                ref<uint16>(packetData.data(), 14) = (uint16)payload.size();
+                std::memcpy(packetData.data() + 16, payload.data(), payload.size());
+
+                packetData[packetData.size() - 1] = '\0';
+
+                message::send(MSG_RPC_RECV, packetData.data(), packetData.size());
+
+                break;
+            }
+            case MSG_RPC_RECV:
+            {
+                uint8* data = (uint8*)extra.data();
+                // No need for any of the zone id data now
+                uint64_t slotKey = ref<uint64_t>(data, 6);
+                uint16   strSize = ref<uint16>(data, 14);
+                auto     payload = std::string(data + 16, data + 16 + strSize);
+
+                auto maybeEntry = replyMap.find(slotKey);
+                if (maybeEntry != replyMap.end())
+                {
+                    auto& recvFunc = maybeEntry->second;
+                    auto  result   = recvFunc(payload);
+                    if (!result.valid())
+                    {
+                        sol::error err = result;
+                        ShowError("message::parse::MSG_RPC_RECV: %s", err.what());
+                    }
+                    replyMap.erase(slotKey);
+                }
+
                 break;
             }
             default:
@@ -776,5 +843,24 @@ namespace message
         TracyZoneScoped;
 
         send(charutils::getCharIdFromName(playerName), packet);
+    }
+
+    void rpc_send(uint16 sendZone, uint16 recvZone, std::string const& sendStr, sol::function recvFunc)
+    {
+        uint64_t slotKey  = std::chrono::duration_cast<std::chrono::microseconds>(hires_clock::now().time_since_epoch()).count();
+        replyMap[slotKey] = recvFunc;
+
+        std::vector<uint8> packetData(16 + sendStr.size() + 1);
+
+        ref<uint16>(packetData.data(), 2)   = recvZone; // destination
+        ref<uint16>(packetData.data(), 4)   = sendZone; // origin
+        ref<uint64_t>(packetData.data(), 6) = slotKey;
+
+        ref<uint16>(packetData.data(), 14) = (uint16)sendStr.size();
+        std::memcpy(packetData.data() + 16, sendStr.data(), sendStr.size());
+
+        packetData[packetData.size() - 1] = '\0';
+
+        message::send(MSG_RPC_SEND, packetData.data(), packetData.size());
     }
 }; // namespace message

--- a/src/map/message.h
+++ b/src/map/message.h
@@ -20,6 +20,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 */
 
 #include "common/cbasetypes.h"
+#include "common/lua.h"
 #include "common/mmo.h"
 #include "common/socket.h"
 #include "common/sql.h"
@@ -75,6 +76,8 @@ namespace message
     void send(uint32 playerId, CBasicPacket* packet);
     void send(std::string const& playerName, CBasicPacket* packet);
     void send_charvar_update(uint32 charId, std::string const& varName, uint32 value);
+    void rpc_send(uint16 sendZone, uint16 recvZone, std::string const& sendStr, sol::function recvFunc);
+
     void close();
 
     // For use on the zmq thread


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Puts in some groundwork for RPC between zones. This seems mainly useful for folks implementing era dynamis across processes. Was fun to figure out and implement.

<img width="260" alt="image" src="https://user-images.githubusercontent.com/1389729/199626220-63ac92e8-f22e-41af-9229-88f992c9bfb4.png">

## Steps to test these changes

Not hooked up yet, but here was my test code (and plans)

```cpp
    // TODO: Hook this up to lua_zone
    /*
    local RPC_GetZoneLocalVar = function(zone, targetZoneId, localVar, callback)
        zone:rpc_send(targetZoneId,
            "return GetZone(" .. targetZoneId .. "):getLocalVar('" .. localVar .. "')",
            callback)
    end

    RPC_GetZoneLocalVar(zone, xi.zone.DYNAMIS_BASTOK, "DYNAMIS_TOKEN",
        function(payload)
            print('DYNAMIS_TOKEN: ' .. tonumber(payload))
        end)
    */
    message::rpc_send(
        ZONE_BASTOK_MARKETS,
        ZONE_DYNAMIS_BASTOK,
        "print('executing on reciever'); print('sending payload: hello from the other side!'); return 'hello from the other side!'",
        lua.script("return function(payload) print('executing on sender'); print('got payload: ' .. payload); end"));
```

Which produced:

```
[11/03/22 00:13:49:984][map][debug] Message: Received message MSG_RPC_SEND (18) from message server (message::parse:89)
[11/03/22 00:13:49:984][map][lua] executing on reciever (lua_print:153)
[11/03/22 00:13:49:984][map][lua] sending payload: hello from the other side! (lua_print:153)
[11/03/22 00:13:50:989][map][debug] Message: Received message MSG_RPC_RECV (19) from message server (message::parse:89)
[11/03/22 00:13:50:989][map][lua] executing on sender (lua_print:153)
[11/03/22 00:13:50:989][map][lua] got payload: hello from the other side! (lua_print:153)
```
