### PR TITLE
Fix getstats treasure hunter and battletime

### DIFF
--- a/scripts/commands/getstats.lua
+++ b/scripts/commands/getstats.lua
@@ -58,9 +58,9 @@ function onTrigger(player)
         target:getName(), target:getMod(xi.mod.TREASURE_HUNTER)), xi.msg.channel.SYSTEM_3)
     elseif targetType == xi.objType.PET then
         -- not needed yet, but we don't want to run MOB so just die in empty conditionals
-    elseif targetType ~= xi.objType.TRUST then
+    elseif targetType == xi.objType.TRUST then
         -- see above
-    elseif targetType ~= xi.objType.FELLOW then
+    elseif targetType == xi.objType.FELLOW then
         -- see above
     elseif targetType == xi.objType.MOB then
         player:PrintToPlayer(string.format("Mob's current Treasure Hunter Tier: %i", target:getTHlevel()), xi.msg.channel.SYSTEM_3)


### PR DESCRIPTION
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes conditional checks in getstats that would cause th level and battle time to not be printed

## Steps to test these changes

Target a mob and use !getstats. Should show th level and battle time
