### PR TITLE
Change lua binding isZoneVisited to hasVisitedZone

### DIFF
--- a/scripts/globals/items/custom_gilet_+1.lua
+++ b/scripts/globals/items/custom_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/custom_top_+1.lua
+++ b/scripts/globals/items/custom_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/ducal_guards_ring.lua
+++ b/scripts/globals/items/ducal_guards_ring.lua
@@ -10,7 +10,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if not target:isZoneVisited(243) then
+    if not target:hasVisitedZone(243) then
         result = 56
     end
     return result

--- a/scripts/globals/items/elder_gilet_+1.lua
+++ b/scripts/globals/items/elder_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/federation_stables_scarf.lua
+++ b/scripts/globals/items/federation_stables_scarf.lua
@@ -10,7 +10,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if not target:isZoneVisited(241) then
+    if not target:hasVisitedZone(241) then
         result = 56
     end
     return result

--- a/scripts/globals/items/kingdom_stables_collar.lua
+++ b/scripts/globals/items/kingdom_stables_collar.lua
@@ -10,7 +10,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if not target:isZoneVisited(230) then
+    if not target:hasVisitedZone(230) then
         result = 56
     end
     return result

--- a/scripts/globals/items/magna_gilet_+1.lua
+++ b/scripts/globals/items/magna_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/magna_top_+1.lua
+++ b/scripts/globals/items/magna_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/nexus_cape.lua
+++ b/scripts/globals/items/nexus_cape.lua
@@ -123,7 +123,7 @@ itemObject.onItemCheck = function(target)
             }
             -- Make sure we can actually tele to that zone..
             for _, validZone in ipairs(validZoneList) do
-                if validZone == leaderZone and target:isZoneVisited(validZone) then
+                if validZone == leaderZone and target:hasVisitedZone(validZone) then
                     result = 0
                 end
             end

--- a/scripts/globals/items/republic_stables_medal.lua
+++ b/scripts/globals/items/republic_stables_medal.lua
@@ -12,7 +12,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if not target:isZoneVisited(xi.zone.BASTOK_MINES) then
+    if not target:hasVisitedZone(xi.zone.BASTOK_MINES) then
         result = xi.msg.basic.ITEM_UNABLE_TO_USE_2
     end
     return result

--- a/scripts/globals/items/savage_top_+1.lua
+++ b/scripts/globals/items/savage_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/shadow_lord_shirt.lua
+++ b/scripts/globals/items/shadow_lord_shirt.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 itemObject.onItemCheck = function(target)
     local result = 0
     -- Need retail verification: Is having set foot in the zone a requirement?
-    if not target:isZoneVisited(162) then
+    if not target:hasVisitedZone(162) then
         result = 56
     end
     return result

--- a/scripts/globals/items/tidal_talisman.lua
+++ b/scripts/globals/items/tidal_talisman.lua
@@ -36,7 +36,7 @@ itemObject.onItemCheck = function(target)
 
     if
         teleportData[zoneId] and
-        target:isZoneVisited(teleportData[zoneId][5])
+        target:hasVisitedZone(teleportData[zoneId][5])
     then
         return 0
     end

--- a/scripts/globals/items/wonder_maillot_+1.lua
+++ b/scripts/globals/items/wonder_maillot_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/scripts/globals/items/wonder_top_+1.lua
+++ b/scripts/globals/items/wonder_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:isZoneVisited(4) == false then
+    if target:hasVisitedZone(4) == false then
         result = 56
     end
     return result

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2345,13 +2345,13 @@ auto CLuaBaseEntity::getZoneName() -> const char*
 }
 
 /************************************************************************
- *  Function: isZoneVisited()
+ *  Function: hasVisitedZone()
  *  Purpose : Returns true if a player has ever visited the zone
- *  Example : if not target:isZoneVisited(xi.zone.BIBIKI_BAY) then
+ *  Example : if not target:hasVisitedZone(xi.zone.BIBIKI_BAY) then
  *  Notes   : Mainly used for teleport items (like to Bibiki Bay)
  ************************************************************************/
 
-bool CLuaBaseEntity::isZoneVisited(uint16 zone)
+bool CLuaBaseEntity::hasVisitedZone(uint16 zone)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
@@ -14704,7 +14704,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getZone", CLuaBaseEntity::getZone);
     SOL_REGISTER("getZoneID", CLuaBaseEntity::getZoneID);
     SOL_REGISTER("getZoneName", CLuaBaseEntity::getZoneName);
-    SOL_REGISTER("isZoneVisited", CLuaBaseEntity::isZoneVisited);
+    SOL_REGISTER("hasVisitedZone", CLuaBaseEntity::hasVisitedZone);
     SOL_REGISTER("getPreviousZone", CLuaBaseEntity::getPreviousZone);
     SOL_REGISTER("getCurrentRegion", CLuaBaseEntity::getCurrentRegion);
     SOL_REGISTER("getContinentID", CLuaBaseEntity::getContinentID);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -171,7 +171,7 @@ public:
     auto   getZone(sol::object const& arg0) -> std::optional<CLuaZone>; // Get Entity zone
     uint16 getZoneID();                                                 // Get Entity zone ID
     auto   getZoneName() -> const char*;                                // Get Entity zone name
-    bool   isZoneVisited(uint16 zone);                                  // true если указанная зона посещалась персонажем ранее
+    bool   hasVisitedZone(uint16 zone);                                 // true if player has previously entered zone
     uint16 getPreviousZone();                                           // Get Entity previous zone
     uint8  getCurrentRegion();                                          // Get Entity conquest region
     uint8  getContinentID();                                            // узнаем континент, на котором находится сущность


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Applies similar language style of other functions in CLuaBaseEntity to the isZoneVisited function.  This allows for more natural language understanding in a condition where it is used.

Example:
`if player:hasVisitedZone(xi.zone.BIBIKI_BAY)` parses much more easily than `if player:isZoneVisited(xi.zone.BIBIKI_BAY)`

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed.
<!-- Clear and detailed steps to test your changes here -->
