### PR TITLE
Resolving a few issues with Proto-Omega

### DIFF
--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -49,8 +49,11 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.REGAIN, 50)
     mob:setMod(xi.mod.REGEN, 25)
     mob:setBehaviour(bit.bor(mob:getBehaviour(), xi.behavior.NO_TURN))
-    mob:setLocalVar("formTime", os.time() + 120)
     quadrupedForm(mob)
+end
+
+entity.onMobEngaged = function(mob, target)
+    mob:setLocalVar("formTime", os.time() + 120)
 end
 
 entity.onMobFight = function(mob, target)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2442,7 +2442,6 @@ INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1533); -- pile_pitch
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1534); -- guided_missile
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1535); -- hyper_pulse
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1536); -- target_analysis
-INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1537); -- discharger
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1538); -- ion_efflux
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1539); -- rear_lasers
 INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1259);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1368,7 +1368,7 @@ INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,0,0,4,0,0,0,0,
 INSERT INTO `mob_skills` VALUES (1532,1124,'pod_ejection',0,7.0,4500,1,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1533,1117,'pile_pitch',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1534,1118,'guided_missile',2,5.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1535,1119,'hyper_pulse',0,10.0,2000,1500,4,0,0,0,0,0,0); -- Omega
+INSERT INTO `mob_skills` VALUES (1535,1119,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Omega
 INSERT INTO `mob_skills` VALUES (1536,1120,'target_analysis',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1537,1121,'discharger',0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1538,1122,'ion_efflux',4,10.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/327
Resolving a few issues with Proto-Omega
 - Should switch form 2 minutes after being engaged
 - Does not use Discharger skill
 - Make all versions of Hyper Pulse be AoE

## Steps to test these changes

```
!addkeyitem black_card
!addkeyitem cosmo_cleanse
!additem 1909
!additem 1910
!additem 1987
!additem 1988
!pos 600 -0.5 -600 38
```

Wait 2 minutes before engaging Proto-Omega and it shouldn't switch forms until 2 minutes into the fight.
Feed it TP with `!tp 3000`.
