### PR TITLE
Refactor dynamic targid generation

### DIFF
--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -232,27 +232,8 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
     // NOTE: Mob allegiance is the default for NPCs
     PEntity->allegiance = static_cast<ALLEGIANCE_TYPE>(table.get_or<uint8>("allegiance", ALLEGIANCE_TYPE::MOB));
 
-    uint16 ZoneID = m_pLuaZone->GetID();
+    m_pLuaZone->GetZoneEntities()->AssignDynamicTargIDandLongID(PEntity);
 
-    // TODO: Wrap this entity in a unique_ptr that will free this dynamic targ ID
-    //       on despawn/destruction
-    // TODO: The tracking of these IDs is pretty bad also, fix that in zone_entities
-    PEntity->targid = m_pLuaZone->GetZoneEntities()->GetNewDynamicTargID();
-    if (PEntity->targid >= 0x900)
-    {
-        ShowError("CLuaZone::insertDynamicEntity : targid is high (03hX), update packets will be ignored", PEntity->targid);
-    }
-
-    m_pLuaZone->GetZoneEntities()->dynamicTargIds.insert(PEntity->targid);
-
-    PEntity->id = 0x1000000 + (ZoneID << 12) + PEntity->targid;
-    // Add 0x100 if targid is >= 0x800 -- observed on retail.
-    if (PEntity->targid >= 0x800)
-    {
-        PEntity->id += 0x100;
-    }
-
-    PEntity->loc.zone       = m_pLuaZone;
     PEntity->loc.p.rotation = table.get_or<uint8>("rotation", 0);
     PEntity->loc.p.x        = table.get_or<float>("x", 0.01);
     PEntity->loc.p.y        = table.get_or<float>("y", 0.01);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1382,24 +1382,10 @@ Usage:
                 CZone* newZone = zoneutils::GetZone(zoneID);
 
                 // Get dynamic targid
-                PMob->targid = newZone->GetZoneEntities()->GetNewDynamicTargID();
+                newZone->GetZoneEntities()->AssignDynamicTargIDandLongID(PMob);
 
-                // Insert ally's new targid into zone's dynamic entity list
-                newZone->GetZoneEntities()->dynamicTargIds.insert(PMob->targid);
                 // Ensure dynamic targid is released on death
                 PMob->m_bReleaseTargIDOnDeath = true;
-
-                // Calculate ID based off targID
-                PMob->id = 0x1000000 + (zoneID << 12) + PMob->targid;
-
-                // Add 0x100 if targid is >= 0x800 -- observed on retail.
-                if (PMob->targid >= 0x800)
-                {
-                    PMob->id += 0x100;
-                }
-
-                // assign new zone
-                PMob->loc.zone = newZone;
 
                 // Insert ally into zone's mob list. TODO: Do we need to assign party for allies?
                 newZone->GetZoneEntities()->m_mobList[PMob->targid] = PMob;

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -77,7 +77,7 @@ public:
     bool         CharListEmpty() const;
 
     uint16 GetNewCharTargID();
-    uint16 GetNewDynamicTargID();
+    void   AssignDynamicTargIDandLongID(CBaseEntity* PEntity);
 
     EntityList_t m_allyList;
     EntityList_t m_mobList; // список всех MOBs в зоне


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I saw this (https://github.com/LandSandBoat/server/pull/3140) and noticed we've started to have the exact same snippet appear in a lot of places. I've refactored them into a single helper. I did this for:

- Assigning dynamic targids, the 0x100 offset, insertion into the dynamic targid list, and the resultant long id

## Steps to test these changes

Everything should work as normal