### PR TITLE
[chore] Remove explicit boolean comparisons from Lua conditions

### DIFF
--- a/scripts/commands/exec.lua
+++ b/scripts/commands/exec.lua
@@ -39,9 +39,9 @@ function onTrigger(player, str)
     end
 
     -- Execute the string..
-    local status, err1 = pcall(scriptObj)
-    if status == false then
-        player:PrintToPlayer("Error calling: " .. str .. "\n" .. err1)
+    local successfullyExecuted, errorMessage = pcall(scriptObj)
+    if not successfullyExecuted then
+        player:PrintToPlayer("Error calling: " .. str .. "\n" .. errorMessage)
     end
 
     -- Restore the os table..

--- a/scripts/commands/setmobmod.lua
+++ b/scripts/commands/setmobmod.lua
@@ -35,7 +35,7 @@ function onTrigger(player, modifier, amount)
         return
     end
 
-    if target:isMob() == false then
+    if not target:isMob() then
         error(player, "No valid target found. Place cursor on a mob. ")
         return
     end

--- a/scripts/globals/abilities/divine_waltz.lua
+++ b/scripts/globals/abilities/divine_waltz.lua
@@ -42,7 +42,7 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     -- Only remove TP if the player doesn't have Trance, and only deduct once instead of for each target.
-    if player:getID() == target:getID() and player:hasStatusEffect(xi.effect.TRANCE) == false then
+    if player:getID() == target:getID() and not player:hasStatusEffect(xi.effect.TRANCE) then
         player:delTP(400)
     end
 

--- a/scripts/globals/abilities/divine_waltz_ii.lua
+++ b/scripts/globals/abilities/divine_waltz_ii.lua
@@ -42,7 +42,7 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     -- Only remove TP if the player doesn't have Trance, and only deduct once instead of for each target.
-    if player:getID() == target:getID() and player:hasStatusEffect(xi.effect.TRANCE) == false then
+    if player:getID() == target:getID() and not player:hasStatusEffect(xi.effect.TRANCE) then
         player:delTP(800)
     end
 

--- a/scripts/globals/abilities/feral_howl.lua
+++ b/scripts/globals/abilities/feral_howl.lua
@@ -19,7 +19,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     local feralHowlMod = player:getMod(xi.mod.FERAL_HOWL_DURATION)
     local duration = 10
 
-    if target:hasStatusEffect(xi.effect.TERROR) == true or target:hasStatusEffect(xi.effect.STUN) == true then -- effect already on, or target stunned, do nothing
+    if target:hasStatusEffect(xi.effect.TERROR) or target:hasStatusEffect(xi.effect.STUN) then -- effect already on, or target stunned, do nothing
     -- reserved for miss based on target already having stun or terror effect active
     else
         -- Calculate duration.

--- a/scripts/globals/abilities/pets/flame_breath.lua
+++ b/scripts/globals/abilities/pets/flame_breath.lua
@@ -20,7 +20,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/frost_breath.lua
+++ b/scripts/globals/abilities/pets/frost_breath.lua
@@ -5,7 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/mobskills")
 require("scripts/globals/ability")
-
 -----------------------------------
 local abilityObject = {}
 
@@ -21,7 +20,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) -1 ) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/gust_breath.lua
+++ b/scripts/globals/abilities/pets/gust_breath.lua
@@ -20,7 +20,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/healing_breath.lua
+++ b/scripts/globals/abilities/pets/healing_breath.lua
@@ -24,7 +24,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
     local master = pet:getMaster()
     local deep = 0
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = 50 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 5
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/healing_breath_ii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_ii.lua
@@ -24,7 +24,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
     local master = pet:getMaster()
     local deep = 0
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = 50 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 5
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/healing_breath_iii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_iii.lua
@@ -30,7 +30,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
     local master = pet:getMaster()
     local deep = 0
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = 50 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 5
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/healing_breath_iv.lua
+++ b/scripts/globals/abilities/pets/healing_breath_iv.lua
@@ -29,7 +29,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
     local master = pet:getMaster()
     local deep = 0
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = 50 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 5
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/hydro_breath.lua
+++ b/scripts/globals/abilities/pets/hydro_breath.lua
@@ -21,7 +21,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/lightning_breath.lua
+++ b/scripts/globals/abilities/pets/lightning_breath.lua
@@ -21,7 +21,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/sand_breath.lua
+++ b/scripts/globals/abilities/pets/sand_breath.lua
@@ -21,7 +21,7 @@ abilityObject.onUseAbility = function(pet, target, skill, action)
     -- 0.25 for each merit after the first
     -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
     local deep = 1
-    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) == true then
+    if pet:hasStatusEffect(xi.effect.MAGIC_ATK_BOOST) then
         deep = deep + 1 + (master:getMerit(xi.merit.DEEP_BREATHING) - 1) * 0.25
         pet:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
     end

--- a/scripts/globals/abilities/pets/somnolence.lua
+++ b/scripts/globals/abilities/pets/somnolence.lua
@@ -29,7 +29,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     duration = duration * resist
 
-    if duration > 0 and target:hasStatusEffect(xi.effect.WEIGHT) == false then
+    if duration > 0 and not target:hasStatusEffect(xi.effect.WEIGHT) then
         target:addStatusEffect(xi.effect.WEIGHT, 50, 0, duration)
     end
 

--- a/scripts/globals/abilities/repair.lua
+++ b/scripts/globals/abilities/repair.lua
@@ -101,7 +101,7 @@ abilityObject.onUseAbility = function(player, target, ability)
 
     local diff = petMaxHP - petCurrentHP
 
-    if (diff < totalHealing) then
+    if diff < totalHealing then
         totalHealing = diff
     end
 

--- a/scripts/globals/abilities/shadowbind.lua
+++ b/scripts/globals/abilities/shadowbind.lua
@@ -37,7 +37,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     end
 
      -- TODO: Acc penalty for /RNG, acc vs. mob level?
-    if math.random(0, 99) >= target:getMod(xi.mod.BINDRES) and target:hasStatusEffect(xi.effect.BIND) == false then
+    if math.random(0, 99) >= target:getMod(xi.mod.BINDRES) and not target:hasStatusEffect(xi.effect.BIND) then
         target:addStatusEffect(xi.effect.BIND, 0, 0, duration)
         ability:setMsg(xi.msg.basic.IS_EFFECT) -- Target is bound.
     else

--- a/scripts/globals/abilities/spectral_jig.lua
+++ b/scripts/globals/abilities/spectral_jig.lua
@@ -23,7 +23,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     local durationMultiplier = 1.0 + utils.clamp(player:getMod(xi.mod.JIG_DURATION), 0, 50) / 100
     local finalDuration = math.floor(baseDuration * durationMultiplier * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER)
 
-    if player:hasStatusEffect(xi.effect.SNEAK) == false then
+    if not player:hasStatusEffect(xi.effect.SNEAK) then
         player:addStatusEffect(xi.effect.SNEAK, 0, 10, finalDuration)
         player:addStatusEffect(xi.effect.INVISIBLE, 0, 10, finalDuration)
         ability:setMsg(xi.msg.basic.SPECTRAL_JIG) -- Gains the effect of sneak and invisible

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -164,10 +164,9 @@ end
 
 -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
 function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, action, taChar, wsParams, skill)
-
     -- Determine cratio and ccritratio
     local ignoredDef = 0
-    if wsParams.ignoresDef ~= nil and wsParams.ignoresDef == true then
+    if wsParams.ignoresDef then
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
     local cratio, ccritratio = getMeleeCRatio(attacker, target, wsParams, ignoredDef)
@@ -252,7 +251,7 @@ end
 function doAutoRangedWeaponskill(attacker, target, wsID, wsParams, tp, primaryMsg, skill, action)
     -- Determine cratio and ccritratio
     local ignoredDef = 0
-    if wsParams.ignoresDef ~= nil and wsParams.ignoresDef == true then
+    if wsParams.ignoresDef then
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
     local cratio, ccritratio = getRangedCRatio(attacker, target, wsParams, ignoredDef)

--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -60,7 +60,7 @@ effectObject.onEffectTick = function(target, effect)
 
     if healtime > 2 then
         -- curse II also known as "zombie"
-        if not(target:hasStatusEffect(xi.effect.DISEASE)) and target:hasStatusEffect(xi.effect.PLAGUE) == false and target:hasStatusEffect(xi.effect.CURSE_II) == false then
+        if not target:hasStatusEffect(xi.effect.DISEASE) and not target:hasStatusEffect(xi.effect.PLAGUE) and not target:hasStatusEffect(xi.effect.CURSE_II) then
             local healHP = 0
             if target:getContinentID() == 1 and target:hasStatusEffect(xi.effect.SIGNET) then
                 healHP = 10 + (3 * math.floor(target:getMainLvl() / 10)) + (healtime - 2) * (1 + math.floor(target:getMaxHP() / 300)) + target:getMod(xi.mod.HPHEAL)

--- a/scripts/globals/effects/mark_of_seed.lua
+++ b/scripts/globals/effects/mark_of_seed.lua
@@ -29,7 +29,7 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    if target:hasKeyItem(xi.ki.MARK_OF_SEED) == false and target:hasKeyItem(xi.ki.AZURE_KEY) == false then
+    if not target:hasKeyItem(xi.ki.MARK_OF_SEED) and not target:hasKeyItem(xi.ki.AZURE_KEY) then
         target:messageSpecial(ID.text.MARK_OF_SEED_HAS_VANISHED)
     end
     target:setCharVar("SEED_AFTERGLOW_TIMER", 0)

--- a/scripts/globals/events/harvest_festivals.lua
+++ b/scripts/globals/events/harvest_festivals.lua
@@ -41,13 +41,13 @@ local function halloweenItemsCheck(player)
     -- Checks for HQ Upgrade
     for ri = 1, #reward_list do
         if headSlot == reward_list[ri] or mainHand == reward_list[ri] then
-            if headSlot == pumpkinHead and player:hasItem(13917) == false then
+            if headSlot == pumpkinHead and not player:hasItem(13917) then
                 reward = 13917 -- Horror Head
-            elseif headSlot == pumpkinHead2 and player:hasItem(15177) == false then
+            elseif headSlot == pumpkinHead2 and not player:hasItem(15177) then
                 reward = 15177 -- Horror Head II
-            elseif mainHand == trickStaff and player:hasItem(17566) == false then
+            elseif mainHand == trickStaff and not player:hasItem(17566) then
                 reward =  17566 -- Treat Staff
-            elseif mainHand == trickStaff2 and player:hasItem(17588) == false then
+            elseif mainHand == trickStaff2 and not player:hasItem(17588) then
                 reward = 17588 -- Treat Staff II
             end
             return reward

--- a/scripts/globals/events/harvest_festivals.lua
+++ b/scripts/globals/events/harvest_festivals.lua
@@ -59,7 +59,7 @@ local function halloweenItemsCheck(player)
 
     while cnt ~= 0 do
         local picked = reward_list[math.random(1, #reward_list)]
-        if player:hasItem(picked) == false then
+        if not player:hasItem(picked) then
             reward = picked
             cnt = 0
         else

--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -368,7 +368,7 @@ xi.instance.onEventUpdate = function(player, csid, option)
         for _, v in pairs(party) do
             if v:getID() ~= player:getID() then
                 -- Check entry requirements for party
-                if checkEntryReqs(v, instanceId) == false then
+                if not checkEntryReqs(v, instanceId) then
                     player:messageText(npc, ID.text.MEMBER_NO_REQS, false)
                     player:instanceEntry(npc, 1)
                     return false

--- a/scripts/globals/interaction/action_util.lua
+++ b/scripts/globals/interaction/action_util.lua
@@ -105,7 +105,7 @@ function actionUtil.parseActionDef(actionDef)
         if door == nil then
             door = actionDef.door
         end
-        if door == true then
+        if door then
             action:openDoor()
         end
     end

--- a/scripts/globals/interaction/actions/sequence.lua
+++ b/scripts/globals/interaction/actions/sequence.lua
@@ -81,7 +81,7 @@ function Sequence.performSequenceAction(action, player, targetEntity)
 
     elseif action.perform then
         -- Not a sequence-only action, so delegate responsibility to the corresponding action class
-        if action:perform(player, targetEntity) ~= false then
+        if action:perform(player, targetEntity) then
             Sequence.performSequenceAction(action.__nextAction, player, targetEntity)
         end
     end

--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -235,9 +235,11 @@ local function runHandlersInData(data, player, secondLevelKey, thirdLevelKey, ar
     end
 
     local secondLevelTable = data[player:getZoneID()]
-    if not secondLevelTable
-        or not secondLevelTable[secondLevelKey]
-        or not secondLevelTable[secondLevelKey][thirdLevelKey] then
+    if
+        not secondLevelTable or
+        not secondLevelTable[secondLevelKey] or
+        not secondLevelTable[secondLevelKey][thirdLevelKey]
+    then
         return { }
     end
 
@@ -377,8 +379,9 @@ local function onHandler(data, secondLevelKey, thirdLevelKey, args, fallbackHand
     end
 
     -- Prioritize important actions from the handler system if applicable
-    if not fallbackHandler
-        or (#actions > 0 -- only prioritize if there's actually actions to do
+    if
+        not fallbackHandler or
+        (#actions > 0 -- only prioritize if there's actually actions to do
             and (secondLevelKey == 'onZoneIn' -- play onZoneIn cs if given
                 or priority > Action.Priority.Event -- prioritize this if event is important enough
                 or player:getLocalVar(fallbackVar) == 0) -- alternate between trying handler system and fallback handler
@@ -395,9 +398,10 @@ local function onHandler(data, secondLevelKey, thirdLevelKey, args, fallbackHand
 
     -- Fall back to side-loaded handler from other lua file
     local result = fallbackHandler(unpack(args))
-    if player:isInEvent() or player:didGetMessage() -- Fallback handler triggered something
-        or (result == -1 and thirdLevelKey == 'onTrigger')  -- Doors return -1 to open
-        or (result ~= nil and result ~= -1 and secondLevelKey == 'onZoneIn') -- onZoneIn returns a csid if any, else -1
+    if
+        player:isInEvent() or player:didGetMessage() or -- Fallback handler triggered something
+        (result == -1 and thirdLevelKey == 'onTrigger') or  -- Doors return -1 to open
+        (result ~= nil and result ~= -1 and secondLevelKey == 'onZoneIn') -- onZoneIn returns a csid if any, else -1
     then
         return result
     end

--- a/scripts/globals/items/alchemists_belt.lua
+++ b/scripts/globals/items/alchemists_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
         result = 242
     end
     return result

--- a/scripts/globals/items/antidote.lua
+++ b/scripts/globals/items/antidote.lua
@@ -12,7 +12,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.POISON) == true then
+    if target:hasStatusEffect(xi.effect.POISON) then
         target:delStatusEffect(xi.effect.POISON)
     end
 end

--- a/scripts/globals/items/blacksmiths_belt.lua
+++ b/scripts/globals/items/blacksmiths_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
         result = 237
     end
     return result

--- a/scripts/globals/items/boneworkers_belt.lua
+++ b/scripts/globals/items/boneworkers_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
         result = 241
     end
     return result

--- a/scripts/globals/items/bottle_of_antacid.lua
+++ b/scripts/globals/items/bottle_of_antacid.lua
@@ -12,9 +12,9 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.FOOD) == true then
+    if target:hasStatusEffect(xi.effect.FOOD) then
         target:delStatusEffect(xi.effect.FOOD)
-    elseif target:hasStatusEffect(xi.effect.FIELD_SUPPORT_FOOD) == true then
+    elseif target:hasStatusEffect(xi.effect.FIELD_SUPPORT_FOOD) then
         target:delStatusEffect(xi.effect.FIELD_SUPPORT_FOOD)
     end
 end

--- a/scripts/globals/items/breath_mantle.lua
+++ b/scripts/globals/items/breath_mantle.lua
@@ -19,7 +19,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) == true then
+    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
         target:delStatusEffect(xi.effect.ENCHANTMENT)
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15486)
     else

--- a/scripts/globals/items/carpenters_belt.lua
+++ b/scripts/globals/items/carpenters_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
         result = 236
     end
     return result

--- a/scripts/globals/items/culinarians_belt.lua
+++ b/scripts/globals/items/culinarians_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.COOKING_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
         result = 243
     end
     return result

--- a/scripts/globals/items/custom_gilet_+1.lua
+++ b/scripts/globals/items/custom_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/custom_top_+1.lua
+++ b/scripts/globals/items/custom_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/elder_gilet_+1.lua
+++ b/scripts/globals/items/elder_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/flask_of_echo_drops.lua
+++ b/scripts/globals/items/flask_of_echo_drops.lua
@@ -12,7 +12,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.SILENCE) == true then
+    if target:hasStatusEffect(xi.effect.SILENCE) then
         target:delStatusEffect(xi.effect.SILENCE)
     end
 end

--- a/scripts/globals/items/flask_of_eye_drops.lua
+++ b/scripts/globals/items/flask_of_eye_drops.lua
@@ -12,7 +12,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.BLINDNESS) == true then
+    if target:hasStatusEffect(xi.effect.BLINDNESS) then
         target:delStatusEffect(xi.effect.BLINDNESS)
     end
 end

--- a/scripts/globals/items/goldsmiths_belt.lua
+++ b/scripts/globals/items/goldsmiths_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
         result = 238
     end
     return result

--- a/scripts/globals/items/high_breath_mantle.lua
+++ b/scripts/globals/items/high_breath_mantle.lua
@@ -19,7 +19,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) == true then
+    if target:hasStatusEffect(xi.effect.ENCHANTMENT) then
         target:delStatusEffect(xi.effect.ENCHANTMENT)
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 1800, 15487)
     else

--- a/scripts/globals/items/kinkobo.lua
+++ b/scripts/globals/items/kinkobo.lua
@@ -14,7 +14,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) == false then
+    if not target:hasStatusEffect(xi.effect.ENCHANTMENT) then
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 3600, 17592)
     end
 end

--- a/scripts/globals/items/magna_gilet_+1.lua
+++ b/scripts/globals/items/magna_gilet_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/magna_top_+1.lua
+++ b/scripts/globals/items/magna_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/messhikimaru.lua
+++ b/scripts/globals/items/messhikimaru.lua
@@ -14,7 +14,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) == false then
+    if not target:hasStatusEffect(xi.effect.ENCHANTMENT) then
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 600, 17826)
     end
 end

--- a/scripts/globals/items/poisona_ring.lua
+++ b/scripts/globals/items/poisona_ring.lua
@@ -12,7 +12,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.POISON) == true then
+    if target:hasStatusEffect(xi.effect.POISON) then
         target:delStatusEffect(xi.effect.POISON)
     end
 end

--- a/scripts/globals/items/remedy.lua
+++ b/scripts/globals/items/remedy.lua
@@ -14,21 +14,21 @@ end
 
 itemObject.onItemUse = function(target)
 
-    if target:hasStatusEffect(xi.effect.SILENCE) == true then
+    if target:hasStatusEffect(xi.effect.SILENCE) then
         target:delStatusEffect(xi.effect.SILENCE)
     end
-    if target:hasStatusEffect(xi.effect.BLINDNESS) == true then
+    if target:hasStatusEffect(xi.effect.BLINDNESS) then
         target:delStatusEffect(xi.effect.BLINDNESS)
     end
-    if target:hasStatusEffect(xi.effect.POISON) == true then
+    if target:hasStatusEffect(xi.effect.POISON) then
         target:delStatusEffect(xi.effect.POISON)
     end
-    if target:hasStatusEffect(xi.effect.PARALYSIS) == true then
+    if target:hasStatusEffect(xi.effect.PARALYSIS) then
         target:delStatusEffect(xi.effect.PARALYSIS)
     end
 
     local rDisease = math.random(1, 2) -- Disease is not garunteed to be cured, 1 means removed 2 means fail. 50% chance
-    if rDisease == 1 and target:hasStatusEffect(xi.effect.DISEASE) == true then
+    if rDisease == 1 and target:hasStatusEffect(xi.effect.DISEASE) then
         target:delStatusEffect(xi.effect.DISEASE)
     end
 end

--- a/scripts/globals/items/savage_top_+1.lua
+++ b/scripts/globals/items/savage_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/talaria.lua
+++ b/scripts/globals/items/talaria.lua
@@ -14,7 +14,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.ENCHANTMENT) == false then
+    if not target:hasStatusEffect(xi.effect.ENCHANTMENT) then
         target:addStatusEffect(xi.effect.ENCHANTMENT, 0, 0, 3600, 11403)
     end
 end

--- a/scripts/globals/items/tanners_belt.lua
+++ b/scripts/globals/items/tanners_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
         result = 240
     end
     return result

--- a/scripts/globals/items/teleport_ring_altep.lua
+++ b/scripts/globals/items/teleport_ring_altep.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.ALTEPA_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.ALTEPA_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/teleport_ring_dem.lua
+++ b/scripts/globals/items/teleport_ring_dem.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.DEM_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.DEM_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/teleport_ring_holla.lua
+++ b/scripts/globals/items/teleport_ring_holla.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.HOLLA_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.HOLLA_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/teleport_ring_mea.lua
+++ b/scripts/globals/items/teleport_ring_mea.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.MEA_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.MEA_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/teleport_ring_vahzl.lua
+++ b/scripts/globals/items/teleport_ring_vahzl.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.VAHZL_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.VAHZL_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/teleport_ring_yhoat.lua
+++ b/scripts/globals/items/teleport_ring_yhoat.lua
@@ -11,7 +11,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasKeyItem(xi.ki.YHOATOR_GATE_CRYSTAL) == false then
+    if not target:hasKeyItem(xi.ki.YHOATOR_GATE_CRYSTAL) then
         result = 445
     end
     return result

--- a/scripts/globals/items/vial_of_tincture.lua
+++ b/scripts/globals/items/vial_of_tincture.lua
@@ -12,11 +12,11 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.PLAGUE) == true then
+    if target:hasStatusEffect(xi.effect.PLAGUE) then
         target:delStatusEffect(xi.effect.PLAGUE)
     end
 
-    if target:hasStatusEffect(xi.effect.DISEASE) == true then
+    if target:hasStatusEffect(xi.effect.DISEASE) then
         target:delStatusEffect(xi.effect.DISEASE)
     end
 end

--- a/scripts/globals/items/weavers_belt.lua
+++ b/scripts/globals/items/weavers_belt.lua
@@ -14,7 +14,7 @@ local itemObject = {}
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) == true then
+    if target:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
         result = 239
     end
     return result

--- a/scripts/globals/items/wonder_maillot_+1.lua
+++ b/scripts/globals/items/wonder_maillot_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/items/wonder_top_+1.lua
+++ b/scripts/globals/items/wonder_top_+1.lua
@@ -9,7 +9,7 @@ require("scripts/globals/teleports")
 
 itemObject.onItemCheck = function(target)
     local result = 0
-    if target:hasVisitedZone(4) == false then
+    if not target:hasVisitedZone(4) then
         result = 56
     end
     return result

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -177,7 +177,7 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
         effectpower = effectpower * (caster:getSubLvl() / target:getMainLvl())
     end
 
-    if target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) == false then
+    if not target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) then
         -- no effect or otherwise prevented
         if caster:getID() == target:getID() then                  -- dead code? you can't roll if the same roll is already active. There is no known buff that would prevent a corsair roll.
             currentAbility:setMsg(xi.msg.basic.ROLL_MAIN_FAIL)    -- no effect for the COR rolling if they had the buff already

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -379,7 +379,7 @@ xi.job_utils.dragoon.useAngon = function(player, target, ability)
     local typeEffect = xi.effect.DEFENSE_DOWN
     local duration = 15 + player:getMerit(xi.merit.ANGON) -- This will return 30 sec at one investment because merit power is 15.
 
-    if target:addStatusEffect(typeEffect, 20, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, 20, 0, duration) then
         ability:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -360,7 +360,7 @@ xi.magian.magianOnTrigger = function(player, npc, EVENT_IDS)
     if EVENT_IDS[1] and player:getMainLvl() < 75 then
         player:startEvent(EVENT_IDS[1]) -- can't take a trial before lvl 75
 
-    elseif player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) == false then
+    elseif not player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) then
         player:startEvent(EVENT_IDS[2]) -- player can start magian for the first time
 
     else
@@ -380,7 +380,7 @@ xi.magian.magianOnTrade = function(player, npc, trade, TYPE, EVENT_IDS)
 
     player:setLocalVar("storeItemId", itemId)
 
-    if player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) == true and trade:getSlotCount() == 1 then
+    if player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) and trade:getSlotCount() == 1 then
         if not next(matchId) and item:isType(TYPE) then
             player:setLocalVar("invalidItem", 1)
             player:startEvent(EVENT_IDS[4], 0, 0, 0, 0, 0, 0, 0, utils.MAX_UINT32) -- invalid weapon

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -555,7 +555,7 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
                 local trialId = bit.rshift(option, 8)
                 local t = GetMagianTrial(trialId)
 
-                if player:hasItem(t.rewardItem) and rareItems[t.rewardItem] == true then
+                if player:hasItem(t.rewardItem) and rareItems[t.rewardItem] then
                     player:updateEvent(1)
                 else
                     player:updateEvent(0)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -963,9 +963,9 @@ function addBonusesAbility(caster, ele, target, dmg, params)
         mdefBarBonus = target:getStatusEffect(xi.magic.barSpell[ele]):getSubPower()
     end
 
-    if params ~= nil and params.bonusmab ~= nil and params.includemab == true then
+    if params ~= nil and params.bonusmab ~= nil and params.includemab then
         mab = (100 + caster:getMod(xi.mod.MATT) + params.bonusmab) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
-    elseif params == nil or (params ~= nil and params.includemab == true) then
+    elseif params == nil or (params ~= nil and params.includemab) then
         mab = (100 + caster:getMod(xi.mod.MATT)) / (100 + target:getMod(xi.mod.MDEF) + mdefBarBonus)
     end
 

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -373,7 +373,7 @@ function getCureFinal(caster, spell, basecure, minCure, isBlueMagic)
     end
 
     local rapture = 1
-    if isBlueMagic == false then --rapture doesn't affect BLU cures as they're not white magic
+    if not isBlueMagic then --rapture doesn't affect BLU cures as they're not white magic
         if caster:hasStatusEffect(xi.effect.RAPTURE) then
             rapture = 1.5 + caster:getMod(xi.mod.RAPTURE_AMOUNT) / 100
             caster:delStatusEffectSilent(xi.effect.RAPTURE)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -995,7 +995,7 @@ end
 
 function getElementalDebuffDOT(INT)
     local DOT = 0
-    if INT<= 39 then
+    if INT <= 39 then
         DOT = 1
     elseif INT <= 69 then
         DOT = 2

--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -53,7 +53,7 @@ end
 function FormMagicBurst(ele, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
     if resonance ~= nil and resonance:getTier() > 0 then -- Resonance exists, ignore it if its tier 0
-        if doesSpellElementMatchResonance(ele, resonance) == true then
+        if doesSpellElementMatchResonance(ele, resonance) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance
@@ -65,7 +65,7 @@ function MobFormMagicBurst(element, target)
     local resonance = target:getStatusEffect(xi.effect.SKILLCHAIN)
 
     if resonance ~= nil and resonance:getTier() > 0 then -- Resonance exists, ignore it if its tier 0
-        if doesMobSpellElementMatchResonance(element, resonance) == true then
+        if doesMobSpellElementMatchResonance(element, resonance) then
             return resonance:getTier(), resonance:getSubPower()
         end
     end -- if resonance

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -565,7 +565,7 @@ xi.mobskills.mobFinalAdjustments = function(dmg, mob, skill, target, attackType,
         target:delStatusEffect(xi.effect.THIRD_EYE)
     end
 
-    if attackType == xi.attackType.PHYSICAL and skill:isSingle() == false then
+    if attackType == xi.attackType.PHYSICAL and not skill:isSingle() then
         target:delStatusEffect(xi.effect.THIRD_EYE)
     end
 
@@ -647,7 +647,7 @@ end
 -- end
 
 xi.mobskills.mobDrainMove = function(mob, target, drainType, drain, attackType, damageType)
-    if target:isUndead() == false then
+    if not target:isUndead() then
         if drainType == xi.mobskills.drainType.MP then
             -- can't go over limited mp
             if target:getMP() < drain then

--- a/scripts/globals/mobskills/gregale_wing.lua
+++ b/scripts/globals/mobskills/gregale_wing.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         return 1
     elseif mob:getAnimationSub() == 1 then
         return 1
-    elseif target:isBehind(mob, 48) == true then
+    elseif target:isBehind(mob, 48) then
         return 1
     end
     return 0

--- a/scripts/globals/mobskills/horrid_roar_2.lua
+++ b/scripts/globals/mobskills/horrid_roar_2.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     elseif mob:getAnimationSub() == 1 then
         return 1

--- a/scripts/globals/mobskills/horrid_roar_3.lua
+++ b/scripts/globals/mobskills/horrid_roar_3.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         return 1
     elseif mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) then
         return 1
-    elseif target:isBehind(mob, 48) == true then
+    elseif target:isBehind(mob, 48) then
         return 1
     elseif mob:getAnimationSub() == 1 then
         return 1

--- a/scripts/globals/mobskills/kick_out.lua
+++ b/scripts/globals/mobskills/kick_out.lua
@@ -14,7 +14,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == false then
+    if not target:isBehind(mob, 48) then
         return 1
     end
     return 0

--- a/scripts/globals/mobskills/lava_spit.lua
+++ b/scripts/globals/mobskills/lava_spit.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     end
   end
 
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/lodesong.lua
+++ b/scripts/globals/mobskills/lodesong.lua
@@ -11,7 +11,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     -- can only used if not silenced
-    if mob:getMainJob() == xi.job.BRD and mob:hasStatusEffect(xi.effect.SILENCE) == false then
+    if mob:getMainJob() == xi.job.BRD and not mob:hasStatusEffect(xi.effect.SILENCE) then
         return 0
     end
     return 1

--- a/scripts/globals/mobskills/plague_swipe.lua
+++ b/scripts/globals/mobskills/plague_swipe.lua
@@ -14,7 +14,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     -- TODO: Replace this when there's a better method than isFacingTheSameDirection() aka isBehind
-    if target:isBehind(mob) == false then
+    if not target:isBehind(mob) then
         return 1
     end
     return 0

--- a/scripts/globals/mobskills/scorching_lash.lua
+++ b/scripts/globals/mobskills/scorching_lash.lua
@@ -24,7 +24,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         end
     end
 
-    if target:isBehind(mob, 48) == false then
+    if not target:isBehind(mob, 48) then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/serpentine_tail.lua
+++ b/scripts/globals/mobskills/serpentine_tail.lua
@@ -22,7 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
             return 1
         end
     elseif mob:getFamily() == 313 then -- Tinnin
-        if mob:getAnimationSub() < 2 and target:isBehind(mob, 48) == true then
+        if mob:getAnimationSub() < 2 and target:isBehind(mob, 48) then
             return 0
         else
             return 1

--- a/scripts/globals/mobskills/shock_wave.lua
+++ b/scripts/globals/mobskills/shock_wave.lua
@@ -10,7 +10,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     end
 

--- a/scripts/globals/mobskills/sulfurous_breath.lua
+++ b/scripts/globals/mobskills/sulfurous_breath.lua
@@ -10,7 +10,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/sweeping_flail.lua
+++ b/scripts/globals/mobskills/sweeping_flail.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 55) == false then
+    if not target:isBehind(mob, 55) then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/tebbad_wing.lua
+++ b/scripts/globals/mobskills/tebbad_wing.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
         return 1
     elseif mob:getAnimationSub() == 1 then
         return 1
-    elseif target:isBehind(mob, 48) == true then
+    elseif target:isBehind(mob, 48) then
         return 1
     end
     return 0

--- a/scripts/globals/mobskills/tempest_wing.lua
+++ b/scripts/globals/mobskills/tempest_wing.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 55) == true then
+    if target:isBehind(mob, 55) then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/thornsong.lua
+++ b/scripts/globals/mobskills/thornsong.lua
@@ -15,7 +15,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     -- can only use if not silenced
-    if mob:getMainJob() == xi.job.BRD and mob:hasStatusEffect(xi.effect.SILENCE) == false then
+    if mob:getMainJob() == xi.job.BRD and not mob:hasStatusEffect(xi.effect.SILENCE) then
         return 0
     end
     return 1

--- a/scripts/globals/mobskills/typhoon_wing.lua
+++ b/scripts/globals/mobskills/typhoon_wing.lua
@@ -15,7 +15,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     elseif mob:getAnimationSub() ~= 0 then
         return 1

--- a/scripts/globals/mobskills/voidsong.lua
+++ b/scripts/globals/mobskills/voidsong.lua
@@ -16,7 +16,7 @@ local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     -- can only used if not silenced
-    if mob:getMainJob() == xi.job.BRD and mob:hasStatusEffect(xi.effect.SILENCE) == false then
+    if mob:getMainJob() == xi.job.BRD and not mob:hasStatusEffect(xi.effect.SILENCE) then
         return 0
     end
     return 1

--- a/scripts/globals/mobskills/wild_horn.lua
+++ b/scripts/globals/mobskills/wild_horn.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) == true then
+    if target:isBehind(mob, 48) then
         return 1
     end
     return 0

--- a/scripts/globals/spells/black/impact.lua
+++ b/scripts/globals/spells/black/impact.lua
@@ -36,31 +36,31 @@ spellObject.onSpellCast = function(caster, target, spell)
     local mndLoss = ((target:getStat(xi.mod.MND) / 100) * 20)
     local chrLoss = ((target:getStat(xi.mod.CHR) / 100) * 20)
 
-    if target:hasStatusEffect(xi.effect.STR_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.STR_DOWN) then
         target:addStatusEffect(xi.effect.STR_DOWN, strLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.DEX_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.DEX_DOWN) then
         target:addStatusEffect(xi.effect.DEX_DOWN, dexLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.VIT_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.VIT_DOWN) then
         target:addStatusEffect(xi.effect.VIT_DOWN, vitLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.AGI_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.AGI_DOWN) then
         target:addStatusEffect(xi.effect.AGI_DOWN, agiLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.INT_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.INT_DOWN) then
         target:addStatusEffect(xi.effect.INT_DOWN, intLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.MND_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.MND_DOWN) then
         target:addStatusEffect(xi.effect.MND_DOWN, mndLoss, 0, duration)
     end
 
-    if target:hasStatusEffect(xi.effect.CHR_DOWN) == false then
+    if not target:hasStatusEffect(xi.effect.CHR_DOWN) then
         target:addStatusEffect(xi.effect.CHR_DOWN, chrLoss, 0, duration)
     end
 

--- a/scripts/globals/spells/black/meteor.lua
+++ b/scripts/globals/spells/black/meteor.lua
@@ -15,7 +15,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
    -- The client blocks the spell via menus, but it can still be cast via text commands, so we have to block it here, albiet with the wrong message.
     if caster:isMob() then
         return 0
-    elseif caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) == true then
+    elseif caster:hasStatusEffect(xi.effect.ELEMENTAL_SEAL) then
         return 0
     else
         return xi.msg.basic.STATUS_PREVENTS

--- a/scripts/globals/spells/blue/amplification.lua
+++ b/scripts/globals/spells/blue/amplification.lua
@@ -41,9 +41,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffectOne, power, 0, duration) == false and target:addStatusEffect(typeEffectTwo, power, 0, duration) == false then -- both statuses fail to apply
+    if
+        not target:addStatusEffect(typeEffectOne, power, 0, duration) and
+        not target:addStatusEffect(typeEffectTwo, power, 0, duration)
+    then
+        -- both statuses fail to apply
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    elseif target:addStatusEffect(typeEffectOne, power, 0, duration) == false then -- the first status fails to apply
+    elseif not target:addStatusEffect(typeEffectOne, power, 0, duration) then -- the first status fails to apply
         target:addStatusEffect(typeEffectTwo, power, 0, duration)
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
         returnEffect = typeEffectTwo

--- a/scripts/globals/spells/blue/battery_charge.lua
+++ b/scripts/globals/spells/blue/battery_charge.lua
@@ -43,7 +43,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         target:delStatusEffect(xi.effect.REFRESH)
     end
 
-    if target:addStatusEffect(typeEffect, power, 3, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 3, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/cocoon.lua
+++ b/scripts/globals/spells/blue/cocoon.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/feather_barrier.lua
+++ b/scripts/globals/spells/blue/feather_barrier.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/memento_mori.lua
+++ b/scripts/globals/spells/blue/memento_mori.lua
@@ -38,7 +38,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/occultation.lua
+++ b/scripts/globals/spells/blue/occultation.lua
@@ -44,7 +44,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/plasma_charge.lua
+++ b/scripts/globals/spells/blue/plasma_charge.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/regeneration.lua
+++ b/scripts/globals/spells/blue/regeneration.lua
@@ -43,7 +43,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         target:delStatusEffect(xi.effect.REGEN)
     end
 
-    if target:addStatusEffect(typeEffect, power, 3, duration, 0, 0, 0) == false then
+    if not target:addStatusEffect(typeEffect, power, 3, duration, 0, 0, 0) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/saline_coat.lua
+++ b/scripts/globals/spells/blue/saline_coat.lua
@@ -39,7 +39,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/triumphant_roar.lua
+++ b/scripts/globals/spells/blue/triumphant_roar.lua
@@ -38,7 +38,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 1, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 1, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/blue/warm-up.lua
+++ b/scripts/globals/spells/blue/warm-up.lua
@@ -41,9 +41,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffectOne, power, 0, duration) == false and target:addStatusEffect(typeEffectTwo, power, 0, duration) == false then -- both statuses fail to apply
+    if
+        not target:addStatusEffect(typeEffectOne, power, 0, duration) and
+        not target:addStatusEffect(typeEffectTwo, power, 0, duration)
+    then
+        -- both statuses fail to apply
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
-    elseif target:addStatusEffect(typeEffectOne, power, 0, duration) == false then -- the first status fails to apply
+    elseif not target:addStatusEffect(typeEffectOne, power, 0, duration) then -- the first status fails to apply
         target:addStatusEffect(typeEffectTwo, power, 0, duration)
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
         returnEffect = typeEffectTwo

--- a/scripts/globals/spells/blue/zephyr_mantle.lua
+++ b/scripts/globals/spells/blue/zephyr_mantle.lua
@@ -37,7 +37,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if target:addStatusEffect(typeEffect, power, 0, duration) == false then
+    if not target:addStatusEffect(typeEffect, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -209,7 +209,7 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
     -----------------------------------
     -- STEP 1: baseSpellDamage (V)
     -----------------------------------
-    if caster:isPC() and xi.settings.main.USE_OLD_MAGIC_DAMAGE == false then
+    if caster:isPC() and not xi.settings.main.USE_OLD_MAGIC_DAMAGE then
         baseSpellDamage = pTable[spellId][vPC] -- vPC
     else
         baseSpellDamage = pTable[spellId][vNPC] -- vNPC

--- a/scripts/globals/spells/doom.lua
+++ b/scripts/globals/spells/doom.lua
@@ -14,7 +14,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local effect = xi.effect.DOOM
-    if target:hasStatusEffect(effect) == false then
+    if not target:hasStatusEffect(effect) then
         spell:setMsg(xi.msg.basic.MAGIC_ENFEEB) -- gains effect
         target:addStatusEffect(effect, 10, 3, 30)
     else

--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -179,7 +179,7 @@ xi.spells.enhancing.calculateSongPower = function(caster, target, spell, spellId
     end
 
     -- Additional Potency from Status Effects.
-    if soulVoicePower == true then -- Soul Voice/Macarato affects Power.
+    if soulVoicePower then -- Soul Voice/Macarato affects Power.
         if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
             power = math.floor(power * 2)
         elseif caster:hasStatusEffect(xi.effect.MARCATO) then

--- a/scripts/globals/spells/enhancing_song.lua
+++ b/scripts/globals/spells/enhancing_song.lua
@@ -218,7 +218,7 @@ xi.spells.enhancing.calculateSongDuration = function(caster, target, spell, inst
     end
 
     -- Additional duration from Status Effects.
-    if soulVoicePower == false then -- Soul Voice/Macarato doesn't affect potency, so it affects Duration.
+    if not soulVoicePower then -- Soul Voice/Macarato doesn't affect potency, so it affects Duration.
         if caster:hasStatusEffect(xi.effect.SOUL_VOICE) then
             duration = math.floor(duration * 2)
         elseif caster:hasStatusEffect(xi.effect.MARCATO) then

--- a/scripts/globals/spells/white/cura.lua
+++ b/scripts/globals/spells/white/cura.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 10
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = -10
@@ -70,7 +70,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         end
     end
 
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         basecure = getBaseCureOld(power, divisor, constant)
     else
         basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cura_ii.lua
+++ b/scripts/globals/spells/white/cura_ii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 60
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = 20
@@ -70,7 +70,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         end
     end
 
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         basecure = getBaseCureOld(power, divisor, constant)
     else
         basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cura_iii.lua
+++ b/scripts/globals/spells/white/cura_iii.lua
@@ -30,7 +30,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 130
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = 70
@@ -66,7 +66,7 @@ spellObject.onSpellCast = function(caster, target, spell)
         end
     end
 
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         basecure = getBaseCureOld(power, divisor, constant)
     else
         basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure.lua
+++ b/scripts/globals/spells/white/cure.lua
@@ -23,7 +23,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 10
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = -10
@@ -64,13 +64,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     end
 
     if isValidHealTarget(caster, target) then
-        if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+        if xi.settings.main.USE_OLD_CURE_FORMULA then
             basecure = getBaseCureOld(power, divisor, constant)
         else
             basecure = getBaseCure(power, divisor, constant, basepower)
         end
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -125,7 +125,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure_ii.lua
+++ b/scripts/globals/spells/white/cure_ii.lua
@@ -23,7 +23,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 60
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = 20
@@ -64,13 +64,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     end
 
     if isValidHealTarget(caster, target) then
-        if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+        if xi.settings.main.USE_OLD_CURE_FORMULA then
             basecure = getBaseCureOld(power, divisor, constant)
         else
             basecure = getBaseCure(power, divisor, constant, basepower)
         end
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -123,7 +123,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure_iii.lua
+++ b/scripts/globals/spells/white/cure_iii.lua
@@ -23,7 +23,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 130
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 1
         constant = 70
@@ -60,13 +60,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     end
 
     if isValidHealTarget(caster, target) then
-        if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+        if xi.settings.main.USE_OLD_CURE_FORMULA then
             basecure = getBaseCureOld(power, divisor, constant)
         else
             basecure = getBaseCure(power, divisor, constant, basepower)
         end
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -119,7 +119,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure_iv.lua
+++ b/scripts/globals/spells/white/cure_iv.lua
@@ -22,7 +22,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 270
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 0.6666
         constant = 165
@@ -58,13 +58,13 @@ spellObject.onSpellCast = function(caster, target, spell)
         end
     end
     if isValidHealTarget(caster, target) then
-        if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+        if xi.settings.main.USE_OLD_CURE_FORMULA then
             basecure = getBaseCureOld(power, divisor, constant)
         else
             basecure = getBaseCure(power, divisor, constant, basepower)
         end
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -116,7 +116,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure_v.lua
+++ b/scripts/globals/spells/white/cure_v.lua
@@ -23,7 +23,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local final = 0
 
     local minCure = 450
-    if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+    if xi.settings.main.USE_OLD_CURE_FORMULA then
         power = getCurePowerOld(caster)
         divisor = 0.6666
         constant = 330
@@ -68,13 +68,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     end
 
     if isValidHealTarget(caster, target) then -- e.g. is a PC and not a monster (?)
-        if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+        if xi.settings.main.USE_OLD_CURE_FORMULA then
             basecure = getBaseCureOld(power, divisor, constant)
         else
             basecure = getBaseCure(power, divisor, constant, basepower)
         end
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -127,7 +127,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/cure_vi.lua
+++ b/scripts/globals/spells/white/cure_vi.lua
@@ -53,7 +53,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if isValidHealTarget(caster, target) then
         basecure = getBaseCure(power, divisor, constant, basepower)
         final = getCureFinal(caster, spell, basecure, minCure, false)
-        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and target:hasStatusEffect(xi.effect.STONESKIN) == false then
+        if caster:hasStatusEffect(xi.effect.AFFLATUS_SOLACE) and not target:hasStatusEffect(xi.effect.STONESKIN) then
             local solaceStoneskin = 0
             local equippedBody = caster:getEquipID(xi.slot.BODY)
             if equippedBody == 11186 then
@@ -106,7 +106,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         else
             -- e.g. monsters healing themselves.
-            if xi.settings.main.USE_OLD_CURE_FORMULA == true then
+            if xi.settings.main.USE_OLD_CURE_FORMULA then
                 basecure = getBaseCureOld(power, divisor, constant)
             else
                 basecure = getBaseCure(power, divisor, constant, basepower)

--- a/scripts/globals/spells/white/sacrifice.lua
+++ b/scripts/globals/spells/white/sacrifice.lua
@@ -22,7 +22,7 @@ spellObject.onSpellCast = function(caster, target, spell)
             local statusEffect = target:getStatusEffect(effect)
 
             -- only add it to me if I don't have it
-            if caster:hasStatusEffect(effect) == false then
+            if not caster:hasStatusEffect(effect) then
                 caster:addStatusEffect(effect, statusEffect:getPower(), statusEffect:getTickCount(), statusEffect:getDuration())
             end
 

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1551,7 +1551,7 @@ xi.treasure.onTrade = function(player, npc, trade, chestType)
             end
         end
         local gilAmount = math.random(info.gil[2], info.gil[3])
-        local gil = gilAmount/#membersInZone
+        local gil = gilAmount / #membersInZone
         for i = 1, #membersInZone do
             membersInZone[i]:addGil(gil)
             membersInZone[i]:messageSpecial(ID.text.GIL_OBTAINED, gil)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -635,7 +635,7 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     -- Determine cratio and ccritratio
     local ignoredDef = 0
 
-    if wsParams.ignoresDef ~= nil and wsParams.ignoresDef == true then
+    if wsParams.ignoresDef then
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
     local cratio, ccritratio = cMeleeRatio(attacker, target, wsParams, ignoredDef, tp)
@@ -704,7 +704,7 @@ end
     -- Determine cratio and ccritratio
     local ignoredDef = 0
 
-    if wsParams.ignoresDef ~= nil and wsParams.ignoresDef == true then
+    if wsParams.ignoresDef then
         ignoredDef = calculatedIgnoredDef(tp, target:getStat(xi.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
 

--- a/scripts/globals/weaponskills/armor_break.lua
+++ b/scripts/globals/weaponskills/armor_break.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
         local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end

--- a/scripts/globals/weaponskills/blade_retsu.lua
+++ b/scripts/globals/weaponskills/blade_retsu.lua
@@ -33,7 +33,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
-    if damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
         local duration = (tp / 1000 * 30) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         -- paralyze proc based on lvl difference
         local power = 30 + (player:getMainLvl() - target:getMainLvl()) * 3

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
         local duration = (75 + (tp / 1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 10, 0, duration)
     end

--- a/scripts/globals/weaponskills/bora_axe.lua
+++ b/scripts/globals/weaponskills/bora_axe.lua
@@ -38,7 +38,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
-    if damage > 0 and target:hasStatusEffect(xi.effect.BIND) == false and chance then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.BIND) and chance then
         local duration = 20 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/brainshaker.lua
+++ b/scripts/globals/weaponskills/brainshaker.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
         local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -38,7 +38,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
         local duration = (45 + (tp / 1000 * 45)) * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0)
         target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration)
     end

--- a/scripts/globals/weaponskills/flat_blade.lua
+++ b/scripts/globals/weaponskills/flat_blade.lua
@@ -35,7 +35,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
-    if damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false and chance then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) and chance then
         local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -35,16 +35,16 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     if damage > 0 then
         local duration = (tp / 1000 * 30) + 60
-        if target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false then
+        if not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
             target:addStatusEffect(xi.effect.DEFENSE_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0))
         end
-        if target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false then
+        if not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
             target:addStatusEffect(xi.effect.ATTACK_DOWN, 12.5, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0))
         end
-        if target:hasStatusEffect(xi.effect.EVASION_DOWN) == false then
+        if not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
             target:addStatusEffect(xi.effect.EVASION_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0))
         end
-        if target:hasStatusEffect(xi.effect.ACCURACY_DOWN) == false then
+        if not target:hasStatusEffect(xi.effect.ACCURACY_DOWN) then
             target:addStatusEffect(xi.effect.ACCURACY_DOWN, 20, 0, duration * applyResistanceAddEffect(player, target, xi.magic.ele.EARTH, 0))
         end
     end

--- a/scripts/globals/weaponskills/glory_slash.lua
+++ b/scripts/globals/weaponskills/glory_slash.lua
@@ -30,7 +30,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
         local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/guillotine.lua
+++ b/scripts/globals/weaponskills/guillotine.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.SILENCE) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.SILENCE) then
         local duration = (30 + (tp / 1000 * 30)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/herculean_slash.lua
+++ b/scripts/globals/weaponskills/herculean_slash.lua
@@ -32,7 +32,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
         local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end

--- a/scripts/globals/weaponskills/infernal_scythe.lua
+++ b/scripts/globals/weaponskills/infernal_scythe.lua
@@ -31,7 +31,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
         local duration = (tp / 1000 * 180) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
     end

--- a/scripts/globals/weaponskills/leg_sweep.lua
+++ b/scripts/globals/weaponskills/leg_sweep.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local chance = (tp-1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if damage > 0 and chance then
-        if target:hasStatusEffect(xi.effect.STUN) == false then
+        if not target:hasStatusEffect(xi.effect.STUN) then
             local duration = 4 * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
             target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
         end

--- a/scripts/globals/weaponskills/nightmare_scythe.lua
+++ b/scripts/globals/weaponskills/nightmare_scythe.lua
@@ -33,7 +33,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.BLINDNESS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.BLINDNESS) then
         local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.BLINDNESS, 15, 0, duration)
     end

--- a/scripts/globals/weaponskills/numbing_shot.lua
+++ b/scripts/globals/weaponskills/numbing_shot.lua
@@ -32,7 +32,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
         local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 30, 0, duration)
     end

--- a/scripts/globals/weaponskills/sanguine_blade.lua
+++ b/scripts/globals/weaponskills/sanguine_blade.lua
@@ -49,7 +49,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if target:isUndead() == false then
+    if not target:isUndead() then
         player:addHP((damage / 100) * drain)
     end
 

--- a/scripts/globals/weaponskills/shadowstitch.lua
+++ b/scripts/globals/weaponskills/shadowstitch.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     if damage > 0 then
         local chance = (tp - 1000) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0) > math.random() * 150
-        if target:hasStatusEffect(xi.effect.BIND) == false and chance then
+        if not target:hasStatusEffect(xi.effect.BIND) and chance then
             local duration = (5 + (tp / 1000 * 5)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
             target:addStatusEffect(xi.effect.BIND, 1, 0, duration)
         end

--- a/scripts/globals/weaponskills/shattersoul.lua
+++ b/scripts/globals/weaponskills/shattersoul.lua
@@ -38,7 +38,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.MAGIC_DEF_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.MAGIC_DEF_DOWN) then
         target:addStatusEffect(xi.effect.MAGIC_DEF_DOWN, 10, 0, 120)
     end
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/shell_crusher.lua
+++ b/scripts/globals/weaponskills/shell_crusher.lua
@@ -34,12 +34,11 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
         local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end
     return tpHits, extraHits, criticalHit, damage
-
 end
 
 return weaponskillObject

--- a/scripts/globals/weaponskills/shield_break.lua
+++ b/scripts/globals/weaponskills/shield_break.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.EVASION_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.EVASION_DOWN) then
         local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.EVASION_DOWN, 40, 0, duration)
     end

--- a/scripts/globals/weaponskills/shijin_spiral.lua
+++ b/scripts/globals/weaponskills/shijin_spiral.lua
@@ -38,7 +38,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     if damage > 0 then
         local duration = (tp / 1000) + 4
-        if target:hasStatusEffect(xi.effect.PLAGUE) == false then
+        if not target:hasStatusEffect(xi.effect.PLAGUE) then
             target:addStatusEffect(xi.effect.PLAGUE, 5, 0, duration)
         end
     end

--- a/scripts/globals/weaponskills/shockwave.lua
+++ b/scripts/globals/weaponskills/shockwave.lua
@@ -28,7 +28,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.atk100 = 1; params.atk200 = 1; params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.SLEEP_I) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.SLEEP_I) then
         local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/shoulder_tackle.lua
+++ b/scripts/globals/weaponskills/shoulder_tackle.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         params.vit_wsc = 1.0
     end
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
         local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/skullbreaker.lua
+++ b/scripts/globals/weaponskills/skullbreaker.lua
@@ -32,7 +32,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         params.str_wsc = 1.0
     end
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.INT_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.INT_DOWN) then
         target:addStatusEffect(xi.effect.INT_DOWN, 10, 0, 140)
     end
 

--- a/scripts/globals/weaponskills/smash_axe.lua
+++ b/scripts/globals/weaponskills/smash_axe.lua
@@ -33,7 +33,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.STUN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.STUN) then
         local duration = (tp / 500) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0)
         target:addStatusEffect(xi.effect.STUN, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/sniper_shot.lua
+++ b/scripts/globals/weaponskills/sniper_shot.lua
@@ -32,7 +32,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.INT_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.INT_DOWN) then
         target:addStatusEffect(xi.effect.INT_DOWN, 10, 0, 140)
     end
 

--- a/scripts/globals/weaponskills/stardiver.lua
+++ b/scripts/globals/weaponskills/stardiver.lua
@@ -34,7 +34,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN) then
         target:addStatusEffect(xi.effect.CRIT_HIT_EVASION_DOWN, 5, 0, 60)
     end
 

--- a/scripts/globals/weaponskills/tachi_ageha.lua
+++ b/scripts/globals/weaponskills/tachi_ageha.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.DEFENSE_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.DEFENSE_DOWN) then
         local duration = (tp / 1000 * 60) * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, 25, 0, duration)
     end

--- a/scripts/globals/weaponskills/tachi_gekko.lua
+++ b/scripts/globals/weaponskills/tachi_gekko.lua
@@ -35,7 +35,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     -- Silence duration changed from 60 to 45 as per bg-wiki: http://www.bg-wiki.com/bg/Tachi:_Gekko
-    if damage > 0 and target:hasStatusEffect(xi.effect.SILENCE) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.SILENCE) then
         local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.WIND, 0)
         target:addStatusEffect(xi.effect.SILENCE, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/tachi_hobaku.lua
+++ b/scripts/globals/weaponskills/tachi_hobaku.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local chance = (tp - 1000) * applyResistanceAddEffect(player, target, xi.magic.ele.LIGHTNING, 0) > math.random() * 150
     if damage > 0 and chance then
-        if target:hasStatusEffect(xi.effect.STUN) == false then
+        if not target:hasStatusEffect(xi.effect.STUN) then
             target:addStatusEffect(xi.effect.STUN, 1, 0, 4)
         end
     end

--- a/scripts/globals/weaponskills/tachi_kasha.lua
+++ b/scripts/globals/weaponskills/tachi_kasha.lua
@@ -38,7 +38,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.PARALYSIS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.PARALYSIS) then
         local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.ICE, 0)
         target:addStatusEffect(xi.effect.PARALYSIS, 25, 0, duration)
     end

--- a/scripts/globals/weaponskills/tachi_yukikaze.lua
+++ b/scripts/globals/weaponskills/tachi_yukikaze.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.BLINDNESS) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.BLINDNESS) then
         local duration = 60 * applyResistanceAddEffect(player, target, xi.magic.ele.DARK, 0)
         target:addStatusEffect(xi.effect.BLINDNESS, 25, 0, duration)
     end

--- a/scripts/globals/weaponskills/uriel_blade.lua
+++ b/scripts/globals/weaponskills/uriel_blade.lua
@@ -28,7 +28,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.FLASH) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.FLASH) then
     target:addStatusEffect(xi.effect.FLASH, 200, 0, 15)
     end
 

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -35,7 +35,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
         local duration = (30 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 3, 0, duration)
     end

--- a/scripts/globals/weaponskills/wasp_sting.lua
+++ b/scripts/globals/weaponskills/wasp_sting.lua
@@ -33,7 +33,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.POISON) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.POISON) then
         local duration = (75 + (tp / 1000 * 15)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.POISON, 1, 0, duration)
     end

--- a/scripts/globals/weaponskills/weapon_break.lua
+++ b/scripts/globals/weaponskills/weapon_break.lua
@@ -36,7 +36,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if damage > 0 and target:hasStatusEffect(xi.effect.ATTACK_DOWN) == false then
+    if damage > 0 and not target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
         local duration = (120 + (tp / 1000 * 60)) * applyResistanceAddEffect(player, target, xi.magic.ele.WATER, 0)
         target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, duration)
     end

--- a/scripts/missions/windurst/2_2_A_Testing_Time.lua
+++ b/scripts/missions/windurst/2_2_A_Testing_Time.lua
@@ -48,12 +48,12 @@ local assessment = function(player, npc)
     local completed = player:hasCompletedMission(mission.areaId, mission.missionId)
 
     -- player took too long to speak under requirements in time, so they fail mission
-    if (completed == false and secondsPassed > 3456) or (completed and secondsPassed > 6912) then
+    if (not completed and secondsPassed > 3456) or (completed and secondsPassed > 6912) then
         return mission:progressEvent(202)
     end
 
     -- handle the events for first-time doing the mission
-    if completed == false and secondsPassed > 3312 then
+    if not completed and secondsPassed > 3312 then
         local event = 198
 
         if killCount >= 35 then

--- a/scripts/quests/otherAreas/RQ6_The_Clue.lua
+++ b/scripts/quests/otherAreas/RQ6_The_Clue.lua
@@ -110,7 +110,7 @@ quest.sections =
                         local count      = trade:getItemCount()
                         local crawlerEgg = trade:hasItemQty(xi.items.CRAWLER_EGG, trade:getItemCount())
 
-                        if crawlerEgg == true and count < 4 then
+                        if crawlerEgg and count < 4 then
                             return quest:event(93)
                         end
                     end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(638, 4, skillLevel, 1, 511, 187, 0, 7, 2184)
         else
             player:startEvent(638, 4, skillLevel, 1, 511, 5662, 6955, 7, 2184)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Imperial_Whitegate.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Imperial_Whitegate.lua
@@ -32,9 +32,7 @@ entity.onTrigger = function(player, npc)
         whitegateShared.doRoyalPalaceArmorCheck(player) and
         noWeapons
     then
-        local ring = player:getCharVar("TOAU_RINGTIME")
-        local standard = player:hasItem(129)
-
+        local ring      = player:getCharVar("TOAU_RINGTIME")
         local ringParam = 0
 
         if ring == 0 then
@@ -42,8 +40,7 @@ entity.onTrigger = function(player, npc)
         end
 
         local standardParam = 0
-
-        if standard == false then
+        if not player:hasItem(129) then
             standardParam = 1
         end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
@@ -16,7 +16,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if npcUtil.tradeHas(trade, 2184) then
-            if player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
                 player:confirmTrade()
                 player:startEvent(643, 8, 0, 0, 0, 188, 0, 6, 0)
             else
@@ -31,7 +31,7 @@ entity.onTrigger = function(player, npc)
     -- local skillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(642, 8, 0, 0, 511, 1, 0, 0, 2184)
         else
             player:startEvent(642, 8, 0, 0, 511, 1, 19267, 0, 2184)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(638, 4, skillLevel, 2, 511, 0, 0, 7, 2184)
         else
             player:startEvent(638, 4, skillLevel, 2, 511, 5662, 7154, 7, 2184)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
@@ -16,7 +16,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if npcUtil.tradeHas(trade, 2184) then
-            if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
                 player:confirmTrade()
                 player:startEvent(637, 17160, 1, 19405, 21215, 30030, 0, 7, 0)
             else

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Justice.lua
@@ -14,7 +14,7 @@ entity.onMobFight = function(mob, target)
     if os.time() - popTime > 60 then
         local alreadyPopped = false
         for Xzomit = mob:getID() + 1, mob:getID() + 6 do
-            if alreadyPopped == true then
+            if alreadyPopped then
                 break
             else
                 if not GetMobByID(Xzomit):isSpawned() then

--- a/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(229, 8, 0, 0, 0, 188, 0, 4, 0)
             else
@@ -31,7 +31,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
             player:startEvent(228, 8, skillLevel, 0, 511, 188, 0, 4, 2184)
         else
             player:startEvent(228, 8, skillLevel, 0, 511, 188, 7127, 4, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Macici.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Macici.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(233, 8, 0, 0, 0, 188, 0, 2, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(232, 8, skillLevel, 0, 511, 188, 0, 2, 2184)
         else
             player:startEvent(232, 8, skillLevel, 0, 511, 188, 6566, 2, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(225, 8, 0, 0, 0, 188, 0, 6, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
             player:startEvent(224, 8, skillLevel, 0, 511, 188, 0, 6, 2184)
         else
             player:startEvent(224, 8, skillLevel, 0, 511, 188, 7121, 6, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(223, 8, 0, 0, 0, 188, 0, 8, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(222, 8, skillLevel, 0, 511, 188, 0, 8, 2184)
         else
             player:startEvent(222, 8, skillLevel, 0, 511, 188, 7121, 8, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(231, 8, 0, 0, 0, 188, 0, 3, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(230, 8, skillLevel, 0, 511, 188, 0, 3, 2184)
         else
             player:startEvent(230, 8, skillLevel, 0, 511, 188, 7101, 3, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(235, 8, 0, 0, 0, 188, 0, 1, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(234, 8, skillLevel, 0, 511, 188, 0, 1, 2184)
         else
             player:startEvent(234, 8, skillLevel, 0, 511, 188, 7055, 1, 2184)

--- a/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 
     if guildMember == 1 then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
-            if player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false then
+            if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
                 player:tradeComplete()
                 player:startEvent(227, 8, 0, 0, 0, 188, 0, 5, 0)
             else
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(226, 8, skillLevel, 0, 511, 188, 0, 5, 2184)
         else
             player:startEvent(226, 8, skillLevel, 0, 511, 188, 7127, 5, 2184)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20u.lua
@@ -69,7 +69,7 @@ entity.onEventFinish = function(player, csid, option, target)
 end
 
 entity.onInstanceCreated = function(player, target, instance)
-    if (instance) then
+    if instance then
         player:setInstance(instance)
         player:instanceEntry(target, 4)
         player:delKeyItem(xi.ki.REMNANTS_PERMIT)

--- a/scripts/zones/Arrapago_Reef/npcs/Meyaada.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Meyaada.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     -- ASSAULT
     if toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM then
         local IPpoint = player:getCurrency("imperial_standing")
-        if player:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false then
+        if player:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS) and not player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) then
             player:startEvent(223, 50, IPpoint)
         else
             player:startEvent(7)

--- a/scripts/zones/Arrapago_Reef/npcs/_jic.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jic.lua
@@ -50,7 +50,7 @@ entity.onEventUpdate = function(player, csid, option, target)
 
     local party = player:getParty()
 
-    if (party ~= nil) then
+    if party ~= nil then
         for i, v in pairs(party) do
             if not v:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS and v:getCurrentAssault() == assaultid) then
                 player:messageText(target, ID.text.MEMBER_NO_REQS, false)

--- a/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Astrologer.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Astrologer.lua
@@ -58,9 +58,9 @@ entity.onMobFight = function(mob, target)
         isBusy = true -- is set to true if mob is in any stage of using a mobskill or casting a spell
     end
 
-    if mob:isFollowingPath() == false then
+    if not mob:isFollowingPath() then
         if os.time() - runTime > 10 then
-            if mob:actionQueueEmpty() == true and isBusy == false then
+            if mob:actionQueueEmpty() and not isBusy then
                 if mob:getLocalVar("run") <= 1 then
                     mob:setLocalVar("run", 1)
                     mob:setLocalVar("runTime", os.time())

--- a/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
@@ -47,7 +47,7 @@ entity.onMobFight = function(mob, target)
     if mob:isFollowingPath() == false and (os.time() - runTime > 20) then
         mob:setLocalVar("runTime", os.time())
         entity.onMobRoamAction(mob)
-    elseif mob:isFollowingPath() == true then
+    elseif mob:isFollowingPath() then
         if os.time() - popTime > 7 then
             mobPet:updateEnmity(target)
             mobPet:setPos(mobPos.x, mobPos.y, mobPos.z, mobPos.rot)

--- a/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
+++ b/scripts/zones/Arrapago_Remnants/mobs/Qiqirn_Treasure_Hunter.lua
@@ -14,7 +14,7 @@ entity.onMobRoamAction = function(mob)
     local stage = instance:getStage()
     local prog = instance:getProgress()
 
-    if mob:isFollowingPath() == false then
+    if not mob:isFollowingPath() then
         mob:setSpeed(40)
         mob:pathThrough(ID.points[stage][prog].route, 9)
     end
@@ -44,7 +44,7 @@ entity.onMobFight = function(mob, target)
     --    isBusy = true -- is set to true if mob is in any stage of using a mobskill or casting a spell
     -- end
 
-    if mob:isFollowingPath() == false and (os.time() - runTime > 20) then
+    if not mob:isFollowingPath() and (os.time() - runTime > 20) then
         mob:setLocalVar("runTime", os.time())
         entity.onMobRoamAction(mob)
     elseif mob:isFollowingPath() then

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -26,7 +26,7 @@ entity.onMobFight = function(mob, target)
         end
     end
 
-    if mob:hasStatusEffect(xi.effect.MIGHTY_STRIKES) == false and mob:actionQueueEmpty() == true then
+    if mob:hasStatusEffect(xi.effect.MIGHTY_STRIKES) == false and mob:actionQueueEmpty() then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
         local changeHP = mob:getLocalVar("changeHP")

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -20,13 +20,13 @@ entity.onMobFight = function(mob, target)
 
     -- Gains a large attack boost when health is under 25% which cannot be Dispelled.
     if mob:getHP() < ((mob:getMaxHP() / 10) * 2.5) then
-        if mob:hasStatusEffect(xi.effect.ATTACK_BOOST) == false then
+        if not mob:hasStatusEffect(xi.effect.ATTACK_BOOST) then
             mob:addStatusEffect(xi.effect.ATTACK_BOOST, 75, 0, 0)
             mob:getStatusEffect(xi.effect.ATTACK_BOOST):setFlag(xi.effectFlag.DEATH)
         end
     end
 
-    if mob:hasStatusEffect(xi.effect.MIGHTY_STRIKES) == false and mob:actionQueueEmpty() then
+    if not mob:hasStatusEffect(xi.effect.MIGHTY_STRIKES) and mob:actionQueueEmpty() then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
         local changeHP = mob:getLocalVar("changeHP")

--- a/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
             -- Both Vanadiel time and unix timestamps are based on seconds. Add the difference to the event.
             player:startEvent(14, VanadielTime() + (miasmaFilterCD - os.time()))
         else
-            if player:hasItem(1778) == true or player:hasItem(1777) then -- Parradamo Stones, Flaxen Pouch
+            if player:hasItem(1778) or player:hasItem(1777) then -- Parradamo Stones, Flaxen Pouch
                 player:startEvent(15)
             else
                 player:startEvent(13)

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
@@ -159,7 +159,7 @@ entity.onMobFight = function(mob, target)
     end
 
     -- Check for time limit, too
-    if os.time() > depopTime and mob:actionQueueEmpty() == true then
+    if os.time() > depopTime and mob:actionQueueEmpty() then
         for i = 0, 1 do
             for j = 1, 8 do
                 if pets[i][j]:isSpawned() then

--- a/scripts/zones/Bastok_Markets/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Bastok_Markets/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(679)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(680)
     elseif assistChannelProgress == nil then
         player:startEvent(680, 128)

--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0)
         else
             player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 28674, 0, 0)

--- a/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
@@ -135,7 +135,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if player:delGil(10) == false then
+    if not player:delGil(10) then
         player:setLocalVar("Lamepaue_PlayCutscene", 2)  -- Cancel the cutscene.
         player:updateEvent(0)
     else

--- a/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(304, skillCap, skillLevel, 2, 201, player:getGil(), 0, 9, 0)
         else
             player:startEvent(304, skillCap, skillLevel, 2, 201, player:getGil(), 6975, 9, 0)

--- a/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(303, skillCap, skillLevel, 1, 201, player:getGil(), 0, 3, 0)
         else
             player:startEvent(303, skillCap, skillLevel, 1, 201, player:getGil(), 7054, 3, 0)

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Adelbrecht.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Adelbrecht.lua
@@ -31,14 +31,12 @@ entity.onTrigger = function(player, npc)
     -- 0 = none, 1 = San d'Oria Iron Rams, 2 = Bastok Fighting Fourth, 3 = Windurst Cobras
 
     local theFightingFourth = player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.THE_FIGHTING_FOURTH)
-    local blueLetter = player:hasKeyItem(xi.ki.BLUE_RECOMMENDATION_LETTER)
-    local battleRations = player:hasKeyItem(xi.ki.BATTLE_RATIONS)
 
-    if theFightingFourth == QUEST_AVAILABLE and blueLetter == true then
+    if theFightingFourth == QUEST_AVAILABLE and player:hasKeyItem(xi.ki.BLUE_RECOMMENDATION_LETTER) then
         player:startEvent(139)
     elseif theFightingFourth == QUEST_AVAILABLE and player:getCharVar("BLUE_R_LETTER_USED") == 1 then
         player:startEvent(139)
-    elseif theFightingFourth == QUEST_ACCEPTED and battleRations == true then
+    elseif theFightingFourth == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.BATTLE_RATIONS) then
         player:startEvent(140)
     elseif theFightingFourth == QUEST_ACCEPTED and player:getCharVar("THE_FIGHTING_FOURTH") == 1 then
         player:startEvent(141)

--- a/scripts/zones/Bastok_Mines/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Bastok_Mines/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(668)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(669)
     elseif assistChannelProgress == nil then
         player:startEvent(669, 128)

--- a/scripts/zones/Bastok_Mines/npcs/Azima.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Azima.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost        = xi.crafting.getAdvImageSupportCost(player, xi.skill.ALCHEMY)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(122, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0) -- Event doesn't work
         else
             player:startEvent(122, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0x6FE2, 0, 0)

--- a/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel  = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(124, skillCap, skillLevel, 2, 201, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(124, skillCap, skillLevel, 2, 201, player:getGil(), 7009, 4095, 0)

--- a/scripts/zones/Bastok_Mines/npcs/Titus.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Titus.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel  = player:getSkillLevel(xi.skill.ALCHEMY)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(123, skillCap, skillLevel, 1, 137, player:getGil(), 0, 0, 0)
         else
             player:startEvent(123, skillCap, skillLevel, 1, 137, player:getGil(), 6758, 0, 0)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Bounty_Hunter.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Bounty_Hunter.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Digger.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Digger.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Furrier.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Furrier.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Gambler.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Gambler.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Leecher.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Leecher.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Mugger.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Mugger.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Pathfinder.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Pathfinder.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Shaman.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Shaman.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Batallia_Downs/mobs/Goblin_Smithy.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Goblin_Smithy.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 74, 2, xi.regime.type.FIELDS)
-    if xi.settings.main.ENABLE_ACP == 1 and player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) == false and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
+    if xi.settings.main.ENABLE_ACP == 1 and not player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD) and player:getCurrentMission(xi.mission.log_id.ACP) >= xi.mission.id.acp.THE_ECHO_AWAKENS then
         -- Guesstimating 15% chance
         if math.random(1, 100) >= 85 then
             player:addKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)

--- a/scripts/zones/Bhaflau_Thickets/npcs/Daswil.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/Daswil.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     -- ASSAULT
     if toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM then
         local IPpoint = player:getCurrency("imperial_standing")
-        if player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false then
+        if player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) and not player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) then
             player:startEvent(512, 50, IPpoint)
         else
             player:startEvent(7)

--- a/scripts/zones/Caedarva_Mire/npcs/Nahshib.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Nahshib.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     -- ASSAULT
     if toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM then
         local IPpoint = player:getCurrency("imperial_standing")
-        if player:hasKeyItem(xi.ki.PERIQIA_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false then
+        if player:hasKeyItem(xi.ki.PERIQIA_ASSAULT_ORDERS) and not player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) then
             player:startEvent(148, 50, IPpoint)
         else
             player:startEvent(7)

--- a/scripts/zones/Caedarva_Mire/npcs/Nareema.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Nareema.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     -- ASSAULT
     if toauMission >= xi.mission.id.toau.PRESIDENT_SALAHEEM then
         local IPpoint = player:getCurrency("imperial_standing")
-        if player:hasKeyItem(xi.ki.LEUJAOAM_ASSAULT_ORDERS) and player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) == false then
+        if player:hasKeyItem(xi.ki.LEUJAOAM_ASSAULT_ORDERS) and not player:hasKeyItem(xi.ki.ASSAULT_ARMBAND) then
             player:startEvent(149, 50, IPpoint)
         else
             player:startEvent(7, 1)

--- a/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Rahal.lua
@@ -17,7 +17,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local crestProgress = player:getCharVar("TheHolyCrest_Event")
-    local remedyKI = player:hasKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
+    local hasDragonCurseRemedy = player:hasKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
     local stalkerQuest = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.KNIGHT_STALKER)
     local stalkerProgress = player:getCharVar("KnightStalker_Progress")
     local wildcatSandy = player:getCharVar("WildcatSandy")
@@ -28,9 +28,9 @@ entity.onTrigger = function(player, npc)
     then
         player:startEvent(559)
     -- Need to speak with Rahal to get Dragon Curse Remedy
-    elseif crestProgress == 5 and remedyKI == false then
+    elseif crestProgress == 5 and not hasDragonCurseRemedy then
         player:startEvent(60) -- Gives key item
-    elseif crestProgress == 5 and remedyKI == true then
+    elseif crestProgress == 5 and hasDragonCurseRemedy then
         player:startEvent(122) -- Reminder to go to Gelsba
 
     -- Completed AF2, AF3 available, and currently on DRG.  No level check, since they cleared AF2.

--- a/scripts/zones/Crawlers_Nest_[S]/npcs/Kalsu-Kalasu.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/npcs/Kalsu-Kalasu.lua
@@ -21,9 +21,9 @@ entity.onTrigger = function(player, npc)
             -- message for other nations missing
             player:startEvent(3)
         end
-    elseif player:hasKeyItem(xi.ki.GREEN_RECOMMENDATION_LETTER) == true then
+    elseif player:hasKeyItem(xi.ki.GREEN_RECOMMENDATION_LETTER) then
         player:startEvent(2)
-    elseif player:hasKeyItem(xi.ki.GREEN_RECOMMENDATION_LETTER) == false then
+    elseif not player:hasKeyItem(xi.ki.GREEN_RECOMMENDATION_LETTER) then
         player:startEvent(1)
     end
 end

--- a/scripts/zones/Davoi/npcs/Disused_Well.lua
+++ b/scripts/zones/Davoi/npcs/Disused_Well.lua
@@ -13,7 +13,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.KNIGHTS_SOUL) == false and player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) and player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) then
+    if not player:hasKeyItem(xi.ki.KNIGHTS_SOUL) and player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) and player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) then
         player:addKeyItem(xi.ki.KNIGHTS_SOUL)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.KNIGHTS_SOUL)
     else

--- a/scripts/zones/Davoi/npcs/qm1.lua
+++ b/scripts/zones/Davoi/npcs/qm1.lua
@@ -18,7 +18,7 @@ end
 entity.onTrigger = function(player, npc)
     local toCureaCough = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TO_CURE_A_COUGH)
 
-    if toCureaCough == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.THYME_MOSS) == false then
+    if toCureaCough == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.THYME_MOSS) then
         player:addKeyItem(xi.ki.THYME_MOSS)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.THYME_MOSS)
     end

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Indescript_Markings.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/npcs/Indescript_Markings.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
     player:delStatusEffect(xi.effect.SNEAK)
 
     -- SCH AF Quest - Boots
-    if loafersQuestProgress > 0 and loafersQuestProgress < 3 and player:hasKeyItem(xi.ki.RAFFLESIA_DREAMSPIT) == false then
+    if loafersQuestProgress > 0 and loafersQuestProgress < 3 and not player:hasKeyItem(xi.ki.RAFFLESIA_DREAMSPIT) then
 
         player:addKeyItem(xi.ki.RAFFLESIA_DREAMSPIT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.RAFFLESIA_DREAMSPIT)

--- a/scripts/zones/Garlaige_Citadel/npcs/Mashira.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/Mashira.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.RUBBISH_DAY) == QUEST_ACCEPTED and player:getCharVar("RubbishDayVar") == 0 then
         player:startEvent(11, 1) -- For the quest "Rubbish day"
     elseif player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.MAKING_AMENS) == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.BROKEN_WAND) == true then
+        if player:hasKeyItem(xi.ki.BROKEN_WAND) then
             player:startEvent(11, 3)
         else player:startEvent(11, 0) -- Making Amens dialogue
         end

--- a/scripts/zones/Garlaige_Citadel/npcs/_5kr.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/_5kr.lua
@@ -12,7 +12,7 @@ local ID = require("scripts/zones/Garlaige_Citadel/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(502, 1) == true and trade:getItemCount() == 1 then -- Garlaige Key (Not Chest/Coffer)
+    if trade:hasItemQty(502, 1) and trade:getItemCount() == 1 then -- Garlaige Key (Not Chest/Coffer)
         player:startEvent(4) -- Open the door
     end
 end

--- a/scripts/zones/Gusgen_Mines/npcs/qm3.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm3.lua
@@ -17,10 +17,10 @@ end
 entity.onTrigger = function(player, npc)
     local healingTheLand = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.HEALING_THE_LAND)
 
-    if healingTheLand == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) == true then
+    if healingTheLand == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) then
         player:delKeyItem(xi.ki.SEAL_OF_BANISHING)
         player:messageSpecial(ID.text.FOUND_LOCATION_SEAL, xi.ki.SEAL_OF_BANISHING)
-    elseif healingTheLand == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) == false then
+    elseif healingTheLand == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) then
         player:messageSpecial(ID.text.IS_ON_THIS_SEAL, xi.ki.SEAL_OF_BANISHING)
     else
         player:messageSpecial(ID.text.LETTERS_IS_WRITTEN_HERE)

--- a/scripts/zones/Kazham/npcs/Dodmos.lua
+++ b/scripts/zones/Kazham/npcs/Dodmos.lua
@@ -24,9 +24,9 @@ entity.onTrigger = function(player, npc)
     if player:getMainLvl() >= 20 and player:getMainJob() == xi.job.SMN and trialSizeFire == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 then --Requires player to be Summoner at least lvl 20
         player:startEvent(286, 0, 1544, 0, 20)     --mini tuning fork, zone, level
     elseif trialSizeFire == QUEST_ACCEPTED then
-        local fireFork = player:hasItem(1544)
+        local hasFireFork = player:hasItem(1544)
 
-        if fireFork == true then
+        if hasFireFork then
             player:startEvent(272) --Dialogue given to remind player to be prepared
         else
             player:startEvent(290, 0, 1544, 0, 20) --Need another mini tuning fork

--- a/scripts/zones/Kazham/npcs/Dodmos.lua
+++ b/scripts/zones/Kazham/npcs/Dodmos.lua
@@ -13,7 +13,7 @@ local ID = require("scripts/zones/Kazham/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(1544, 1) == true and player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE) == QUEST_ACCEPTED and player:getMainJob() == xi.job.SMN then
+    if trade:hasItemQty(1544, 1) and player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE) == QUEST_ACCEPTED and player:getMainJob() == xi.job.SMN then
         player:startEvent(287, 0, 1544, 0, 20)
     end
 end

--- a/scripts/zones/Kazham/npcs/Magriffon.lua
+++ b/scripts/zones/Kazham/npcs/Magriffon.lua
@@ -54,7 +54,7 @@ entity.onTrigger = function(player, npc)
     elseif evenmoreTravelsStatus == QUEST_ACCEPTED and player:getCharVar("EVEN_MORE_GULLIBLES_PROGRESS") == 2 then
         player:startEvent(152, 0, 1144, 256)
     elseif gulliblesTravelsStatus == QUEST_COMPLETED then
-        if evenmoreTravelsStatus == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 7 and player:needToZone() == false then
+        if evenmoreTravelsStatus == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 7 and not player:needToZone() then
         player:startEvent(148, 0, 256, 0, 0, 35000)
         else
             player:startEvent(147)

--- a/scripts/zones/Kazham/npcs/Rauteinot.lua
+++ b/scripts/zones/Kazham/npcs/Rauteinot.lua
@@ -13,7 +13,7 @@ local ID = require("scripts/zones/Kazham/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if player:getCharVar("MissionaryManVar") == 1 and trade:hasItemQty(1146, 1) == true and trade:getItemCount() == 1 then
+    if player:getCharVar("MissionaryManVar") == 1 and trade:hasItemQty(1146, 1) and trade:getItemCount() == 1 then
         player:startEvent(139) -- Trading elshimo marble
     end
 end

--- a/scripts/zones/Kazham/npcs/Ronta-Onta.lua
+++ b/scripts/zones/Kazham/npcs/Ronta-Onta.lua
@@ -17,15 +17,15 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByFire = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_FIRE)
-    local whisperOfFlames = player:hasKeyItem(xi.ki.WHISPER_OF_FLAMES)
+    local hasWhisperOfFlames = player:hasKeyItem(xi.ki.WHISPER_OF_FLAMES)
 
     if (trialByFire == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 6) or (trialByFire == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByFire_date")) then
         player:startEvent(270, 0, xi.ki.TUNING_FORK_OF_FIRE) -- Start and restart quest "Trial by Fire"
-    elseif trialByFire == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_FIRE) == false and whisperOfFlames == false then
+    elseif trialByFire == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.TUNING_FORK_OF_FIRE) and not hasWhisperOfFlames then
         player:startEvent(285, 0, xi.ki.TUNING_FORK_OF_FIRE) -- Defeat against Ifrit : Need new Fork
-    elseif trialByFire == QUEST_ACCEPTED and whisperOfFlames == false then
+    elseif trialByFire == QUEST_ACCEPTED and not hasWhisperOfFlames then
         player:startEvent(271, 0, xi.ki.TUNING_FORK_OF_FIRE, 0)
-    elseif trialByFire == QUEST_ACCEPTED and whisperOfFlames then
+    elseif trialByFire == QUEST_ACCEPTED and hasWhisperOfFlames then
         local numitem = 0
 
         if player:hasItem(17665) then

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_MR.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_MR.lua
@@ -36,9 +36,7 @@ entity.onMobEngaged = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    local charm = mob:getLocalVar("Charm")
-
-    if (charm == 0 and mob:getHPP() <  50) then
+    if mob:getLocalVar("Charm") == 0 and mob:getHPP() <  50 then
         mob:useMobAbility(710)
         mob:setLocalVar("Charm", 1)
     end

--- a/scripts/zones/La_Theine_Plateau/npcs/Faurbellant.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Faurbellant.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
     if gates == QUEST_COMPLETED then
         player:showText(npc, ID.text.FAURBELLANT_4)
     elseif gates == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WIND) == true then
+        if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WIND) then
             player:showText(npc, ID.text.FAURBELLANT_2, 0, xi.ki.SCRIPTURE_OF_WIND)
             player:delKeyItem(xi.ki.SCRIPTURE_OF_WIND)
             player:addKeyItem(xi.ki.SCRIPTURE_OF_WATER)

--- a/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
@@ -16,7 +16,7 @@ entity.onTrade = function(player, npc, trade)
 
     if
         totalNPC == 1023 and
-        trade:hasItemQty(555, 1) == true and
+        trade:hasItemQty(555, 1) and
         trade:getItemCount() == 1
     then
         player:startEvent(231) -- Ending quest "save the clock tower"
@@ -24,12 +24,12 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local airshipKI         = player:hasKeyItem(xi.ki.AIRSHIP_PASS)
+    local hasAirshipKI      = player:hasKeyItem(xi.ki.AIRSHIP_PASS)
     local saveTheClockTower = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SAVE_THE_CLOCK_TOWER)
     local npcNumber         = player:getCharVar("saveTheClockTowerVar") -- Quest step & number of npc
 
     if
-        airshipKI == false and
+        not hasAirshipKI and
         saveTheClockTower == QUEST_ACCEPTED and
         npcNumber >= 1 and
         npcNumber <= 11
@@ -37,7 +37,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(230, 4, 10) -- airship + petition help/restart
 
     elseif
-        airshipKI == true and
+        hasAirshipKI and
         saveTheClockTower == QUEST_ACCEPTED and
         npcNumber >= 1 and
         npcNumber <= 11
@@ -45,20 +45,20 @@ entity.onTrigger = function(player, npc)
         player:startEvent(230, 6, 10) -- petition help/restart
 
     elseif
-        airshipKI == false and
+        not hasAirshipKI and
         saveTheClockTower == QUEST_ACCEPTED and
         npcNumber == 0
     then
         player:startEvent(230, 8, 10) -- airship + petition
 
     elseif
-        airshipKI == true and
+        hasAirshipKI and
         saveTheClockTower == QUEST_ACCEPTED and
         npcNumber == 0
     then
         player:startEvent(230, 10, 10) -- petition
 
-    elseif airshipKI == false then
+    elseif not hasAirshipKI then
         player:startEvent(230, 12) -- airship
 
     else

--- a/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
@@ -79,7 +79,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 230 and option == 10 then
-        if player:hasKeyItem(xi.ki.AIRSHIP_PASS) == true then
+        if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.AIRSHIP_PASS)
         end
     elseif csid == 230 and option == 20 then
@@ -93,7 +93,7 @@ entity.onEventFinish = function(player, csid, option)
             player:setCharVar("saveTheClockTowerNPCz2", 0)
         end
     elseif csid == 230 and option == 30 then
-        if player:hasItem(555) == true then
+        if player:hasItem(555) then
             player:messageSpecial(ID.text.ITEM_OBTAINED, 555)
             player:setCharVar("saveTheClockTowerVar", 1)
             player:setCharVar("saveTheClockTowerNPCz1", 0)

--- a/scripts/zones/Lower_Jeuno/npcs/Domenic.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Domenic.lua
@@ -13,7 +13,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEYOND_INFINITY) == true then
+    if player:hasCompletedQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEYOND_INFINITY) then
         player:startEvent(10115, player:getGil())
     else
         player:startEvent(10116)

--- a/scripts/zones/Lower_Jeuno/npcs/Garnev.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Garnev.lua
@@ -14,7 +14,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.DEAL_WITH_TENSHODO) == QUEST_ACCEPTED and
-        trade:hasItemQty(554, 1) == true and
+        trade:hasItemQty(554, 1) and
         trade:getItemCount() == 1
     then
         player:startEvent(166) -- Ending quest

--- a/scripts/zones/Lower_Jeuno/npcs/Kurou-Morou.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Kurou-Morou.lua
@@ -15,15 +15,15 @@ entity.onTrade = function(player, npc, trade)
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.YOUR_CRYSTAL_BALL) == QUEST_ACCEPTED and
         trade:getItemCount() == 1
     then
-        if trade:hasItemQty(557, 1) == true then
+        if trade:hasItemQty(557, 1) then
             player:startEvent(192) -- CS for ahriman lens trade; Trading the lens to Kurou-Morou is optional
-        elseif trade:hasItemQty(556, 1) == true then
+        elseif trade:hasItemQty(556, 1) then
             player:startEvent(196) -- Trade divination sphere, finish quest
         end
 
     elseif
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.NEVER_TO_RETURN) == QUEST_ACCEPTED and
-        trade:hasItemQty(12507, 1) == true and
+        trade:hasItemQty(12507, 1) and
         trade:getItemCount() == 1
     then
         player:startEvent(203) -- Finish "Never to return" quest

--- a/scripts/zones/Lower_Jeuno/npcs/Panta-Putta.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Panta-Putta.lua
@@ -17,7 +17,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local theWonderMagicSet = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_WONDER_MAGIC_SET)
-    local wonderMagicSetKI  = player:hasKeyItem(xi.ki.WONDER_MAGIC_SET)
+    local hasWonderMagicSet = player:hasKeyItem(xi.ki.WONDER_MAGIC_SET)
     local theKindCardian    = player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.THE_KIND_CARDIAN)
 
     if
@@ -28,11 +28,11 @@ entity.onTrigger = function(player, npc)
 
     elseif
         theWonderMagicSet == QUEST_ACCEPTED and
-        wonderMagicSetKI == false
+        not hasWonderMagicSet
     then
         player:startEvent(55) -- During quest "The wonder magic set"
 
-    elseif wonderMagicSetKI == true then
+    elseif hasWonderMagicSet then
         player:startEvent(33) -- Finish quest "The wonder magic set"
 
     elseif

--- a/scripts/zones/Lower_Jeuno/npcs/Teigero-Bangero.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Teigero-Bangero.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if
-        trade:hasItemQty(555, 1) == true and
+        trade:hasItemQty(555, 1) and
         trade:getItemCount() == 1
     then
         local a = player:getCharVar("saveTheClockTowerNPCz2") -- NPC Zone2

--- a/scripts/zones/Lower_Jeuno/npcs/Vola.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Vola.lua
@@ -15,9 +15,9 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.FISTFUL_OF_FURY) == QUEST_ACCEPTED and
-        trade:hasItemQty(1012, 1) == true and
-        trade:hasItemQty(1013, 1) == true and
-        trade:hasItemQty(1014, 1) == true and
+        trade:hasItemQty(1012, 1) and
+        trade:hasItemQty(1013, 1) and
+        trade:hasItemQty(1014, 1) and
         trade:getItemCount() == 3
     then
         player:startEvent(213) -- Finish Quest "Fistful of Fury"

--- a/scripts/zones/Lower_Jeuno/npcs/Zauko.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Zauko.lua
@@ -18,7 +18,7 @@ entity.onTrade = function(player, npc, trade)
 
     ----- Save The Clock Tower Quest -----
     if
-        trade:hasItemQty(555, 1) == true and
+        trade:hasItemQty(555, 1) and
         trade:getItemCount() == 1
     then
         local a = player:getCharVar("saveTheClockTowerNPCz2") -- NPC Zone2

--- a/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
@@ -67,7 +67,7 @@ entity.onTrigger = function(player, npc)
         end
 
     elseif
-        player:needToZone() == false and
+        not player:needToZone() and
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.SAVE_MY_SON) == QUEST_COMPLETED and
         saveMySon == 2
     then

--- a/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
@@ -52,7 +52,7 @@ entity.onTrigger = function(player, npc)
     if player:getCharVar("BeatAroundTheBushin") == 1 then
         player:startEvent(155) -- Start Quest "Beat around the Bushin"
 
-    elseif player:hasKeyItem(xi.ki.TENSHODO_MEMBERS_CARD) == true then
+    elseif player:hasKeyItem(xi.ki.TENSHODO_MEMBERS_CARD) then
         player:startEvent(105) -- Open the door
 
     else

--- a/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6tc.lua
@@ -18,28 +18,28 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEAT_AROUND_THE_BUSHIN) == QUEST_ACCEPTED then
         if
-            trade:hasItemQty(1526, 1) == true and
+            trade:hasItemQty(1526, 1) and
             trade:getItemCount() == 1 and
             player:getCharVar("BeatAroundTheBushin") == 2
         then
             player:startEvent(156) -- After trade Wyrm Beard
 
         elseif
-            trade:hasItemQty(1527, 1) == true and
+            trade:hasItemQty(1527, 1) and
             trade:getItemCount() == 1 and
             player:getCharVar("BeatAroundTheBushin") == 4
         then
             player:startEvent(157) -- After trade Behemoth Tongue
 
         elseif
-            trade:hasItemQty(1525, 1) == true and
+            trade:hasItemQty(1525, 1) and
             trade:getItemCount() == 1 and
             player:getCharVar("BeatAroundTheBushin") == 6
         then
             player:startEvent(158) -- After trade Adamantoise Egg
 
         elseif
-            trade:hasItemQty(13202, 1) == true and
+            trade:hasItemQty(13202, 1) and
             trade:getItemCount() == 1 and
             player:getCharVar("BeatAroundTheBushin") == 7
         then

--- a/scripts/zones/Mamook/mobs/Chamrosh.lua
+++ b/scripts/zones/Mamook/mobs/Chamrosh.lua
@@ -27,7 +27,7 @@ entity.onMobFight = function(mob, target)
     local spell = mob:getLocalVar("COPY_SPELL")
     local changeTime = mob:getLocalVar("changeTime")
 
-    if spell > 0 and mob:hasStatusEffect(xi.effect.SILENCE) == false then
+    if spell > 0 and not mob:hasStatusEffect(xi.effect.SILENCE) then
         if delay >= 3 then
             mob:castSpell(spell)
             mob:setLocalVar("COPY_SPELL", 0)

--- a/scripts/zones/Metalworks/npcs/Hugues.lua
+++ b/scripts/zones/Metalworks/npcs/Hugues.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(104, skillCap, skillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(104, skillCap, skillLevel, 1, 207, player:getGil(), 7101, 4095, 0)

--- a/scripts/zones/Metalworks/npcs/Romero.lua
+++ b/scripts/zones/Metalworks/npcs/Romero.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(105, skillCap, skillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else
             player:startEvent(105, skillCap, skillLevel, 2, 207, player:getGil(), 7127, 0, 0)

--- a/scripts/zones/Metalworks/npcs/Wise_Owl.lua
+++ b/scripts/zones/Metalworks/npcs/Wise_Owl.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(103, cost, skillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(103, cost, skillLevel, 0, 207, player:getGil(), 28721, 4095, 0)

--- a/scripts/zones/Mhaura/npcs/Lacia.lua
+++ b/scripts/zones/Mhaura/npcs/Lacia.lua
@@ -12,7 +12,7 @@ local ID = require("scripts/zones/Mhaura/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(1548, 1) == true and player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING) == QUEST_ACCEPTED and player:getMainJob() == xi.job.SMN then
+    if trade:hasItemQty(1548, 1) and player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING) == QUEST_ACCEPTED and player:getMainJob() == xi.job.SMN then
         player:startEvent(10026, 0, 1548, 5, 20)
     end
 end

--- a/scripts/zones/Mhaura/npcs/Lacia.lua
+++ b/scripts/zones/Mhaura/npcs/Lacia.lua
@@ -23,9 +23,9 @@ entity.onTrigger = function(player, npc)
     if player:getMainLvl() >= 20 and player:getMainJob() == xi.job.SMN and trialSizeLightning == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 then --Requires player to be Summoner at least lvl 20
         player:startEvent(10025, 0, 1548, 5, 20)     --mini tuning fork of lightning, zone, level
     elseif trialSizeLightning == QUEST_ACCEPTED then
-        local lightningFork = player:hasItem(1548)
+        local hasLightningFork = player:hasItem(1548)
 
-        if lightningFork == true then
+        if hasLightningFork then
             player:startEvent(10018) --Dialogue given to remind player to be prepared
         else
             player:startEvent(10029, 0, 1548, 5, 20) --Need another mini tuning fork

--- a/scripts/zones/Mhaura/npcs/Ripapa.lua
+++ b/scripts/zones/Mhaura/npcs/Ripapa.lua
@@ -18,7 +18,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByLightning = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.TRIAL_BY_LIGHTNING)
-    local whisperOfStorms = player:hasKeyItem(xi.ki.WHISPER_OF_STORMS)
+    local hasWhisperOfStorms = player:hasKeyItem(xi.ki.WHISPER_OF_STORMS)
     local carbuncleDebacle = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CARBUNCLE_DEBACLE)
     local carbuncleDebacleProgress = player:getCharVar("CarbuncleDebacleProgress")
 
@@ -26,17 +26,17 @@ entity.onTrigger = function(player, npc)
     -- Carbunlce Debacle
     if carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 2 then
         player:startEvent(10022) -- get the lighning pendulum lets go to Cloister of Storms
-    elseif carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 3 and player:hasItem(1172) == false then
+    elseif carbuncleDebacle == QUEST_ACCEPTED and carbuncleDebacleProgress == 3 and not player:hasItem(1172) then
         player:startEvent(10023, 0, 1172, 0, 0, 0, 0, 0, 0) -- "lost the pendulum?"
     -----------------------------------
     -- Trial by Lightning
     elseif (trialByLightning == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 6) or (trialByLightning == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByLightning_date")) then
         player:startEvent(10016, 0, xi.ki.TUNING_FORK_OF_LIGHTNING) -- Start and restart quest "Trial by Lightning"
-    elseif trialByLightning == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_LIGHTNING) == false and whisperOfStorms == false then
+    elseif trialByLightning == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.TUNING_FORK_OF_LIGHTNING) and not hasWhisperOfStorms then
         player:startEvent(10024, 0, xi.ki.TUNING_FORK_OF_LIGHTNING) -- Defeat against Ramuh : Need new Fork
-    elseif trialByLightning == QUEST_ACCEPTED and whisperOfStorms == false then
+    elseif trialByLightning == QUEST_ACCEPTED and not hasWhisperOfStorms then
         player:startEvent(10017, 0, xi.ki.TUNING_FORK_OF_LIGHTNING, 5)
-    elseif trialByLightning == QUEST_ACCEPTED and whisperOfStorms then
+    elseif trialByLightning == QUEST_ACCEPTED and hasWhisperOfStorms then
         local numitem = 0
 
         if player:hasItem(17531) then

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -18,7 +18,7 @@ entity.onMobFight = function(mob, target)
         return
     end
 
-    if mob:hasStatusEffect(xi.effect.INVINCIBLE) == false and mob:actionQueueEmpty() then
+    if not mob:hasStatusEffect(xi.effect.INVINCIBLE) and mob:actionQueueEmpty() then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
 

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -18,7 +18,7 @@ entity.onMobFight = function(mob, target)
         return
     end
 
-    if mob:hasStatusEffect(xi.effect.INVINCIBLE) == false and mob:actionQueueEmpty() == true then
+    if mob:hasStatusEffect(xi.effect.INVINCIBLE) == false and mob:actionQueueEmpty() then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
 

--- a/scripts/zones/Norg/npcs/Edal-Tahdal.lua
+++ b/scripts/zones/Norg/npcs/Edal-Tahdal.lua
@@ -18,15 +18,15 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByWater = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.TRIAL_BY_WATER)
-    local whisperOfTides = player:hasKeyItem(xi.ki.WHISPER_OF_TIDES)
+    local hasWhisperOfTides = player:hasKeyItem(xi.ki.WHISPER_OF_TIDES)
 
     if (trialByWater == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.NORG) >= 4) or (trialByWater == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByWater_date")) then
         player:startEvent(109, 0, xi.ki.TUNING_FORK_OF_WATER) -- Start and restart quest "Trial by Water"
-    elseif trialByWater == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_WATER) == false and whisperOfTides == false then
+    elseif trialByWater == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.TUNING_FORK_OF_WATER) and not hasWhisperOfTides then
         player:startEvent(190, 0, xi.ki.TUNING_FORK_OF_WATER) -- Defeat against Avatar : Need new Fork
-    elseif trialByWater == QUEST_ACCEPTED and whisperOfTides == false then
+    elseif trialByWater == QUEST_ACCEPTED and not hasWhisperOfTides then
         player:startEvent(110, 0, xi.ki.TUNING_FORK_OF_WATER, 2)
-    elseif trialByWater == QUEST_ACCEPTED and whisperOfTides then
+    elseif trialByWater == QUEST_ACCEPTED and hasWhisperOfTides then
         local numitem = 0
 
         if player:hasItem(17439) then

--- a/scripts/zones/Norg/npcs/Keal.lua
+++ b/scripts/zones/Norg/npcs/Keal.lua
@@ -76,12 +76,11 @@ end
 entity.onTrigger = function(player, npc)
     local vault = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.ITS_NOT_YOUR_VAULT)
     local mLvl = player:getMainLvl()
-    local ironBox = player:hasKeyItem(xi.ki.SEALED_IRON_BOX)
 
     if vault == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.NORG) >= 3 and mLvl >= 5 then
         player:startEvent(36, xi.ki.SEALED_IRON_BOX) -- Start quest
     elseif vault == QUEST_ACCEPTED then
-        if ironBox == true then
+        if player:hasKeyItem(xi.ki.SEALED_IRON_BOX) then
             player:startEvent(38) -- Finish quest
         else
             player:startEvent(37, xi.ki.MAP_OF_SEA_SERPENT_GROTTO) -- Reminder/Directions Dialogue

--- a/scripts/zones/Norg/npcs/Laisrean.lua
+++ b/scripts/zones/Norg/npcs/Laisrean.lua
@@ -18,12 +18,11 @@ end
 entity.onTrigger = function(player, npc)
     local stash = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.THE_SAHAGINS_STASH)
     local mLvl = player:getMainLvl()
-    local seaStatue = player:hasKeyItem(xi.ki.SEA_SERPENT_STATUE)
 
     if stash == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.NORG) >= 4 and mLvl >= 5 then
         player:startEvent(33) -- Start quest
     elseif stash == QUEST_ACCEPTED then
-        if seaStatue == true then
+        if player:hasKeyItem(xi.ki.SEA_SERPENT_STATUE) then
             player:startEvent(35, xi.ki.SEA_SERPENT_STATUE) -- Finish quest
         else
             player:startEvent(34) -- Reminder Dialogue

--- a/scripts/zones/Norg/npcs/Ryoma.lua
+++ b/scripts/zones/Norg/npcs/Ryoma.lua
@@ -34,7 +34,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(133) -- Start Quest "20 in Pirate Years"
     elseif twentyInPirateYears == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TRICK_BOX) then
         player:startEvent(134) -- Finish Quest "20 in Pirate Years"
-    elseif twentyInPirateYears == QUEST_COMPLETED and illTakeTheBigBox == QUEST_AVAILABLE and mJob == xi.job.NIN and mLvl >= 50 and player:needToZone() == false then
+    elseif twentyInPirateYears == QUEST_COMPLETED and illTakeTheBigBox == QUEST_AVAILABLE and mJob == xi.job.NIN and mLvl >= 50 and not player:needToZone() then
         player:startEvent(135) -- Start Quest "I'll Take the Big Box"
     elseif illTakeTheBigBox == QUEST_COMPLETED and trueWill == QUEST_AVAILABLE then
         player:startEvent(136) -- Start Quest "True Will"

--- a/scripts/zones/Norg/npcs/Shivivi.lua
+++ b/scripts/zones/Norg/npcs/Shivivi.lua
@@ -67,7 +67,7 @@ entity.onTrigger = function(player, npc)
     local DampScroll = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.SECRET_OF_THE_DAMP_SCROLL)
     local mLvl = player:getMainLvl()
 
-    if DampScroll == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.NORG) >= 3 and mLvl >= 10 and player:hasItem(1210) == true then
+    if DampScroll == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.NORG) >= 3 and mLvl >= 10 and player:hasItem(1210) then
         player:startEvent(31, 1210) -- Start the quest
     elseif DampScroll == QUEST_ACCEPTED then
         player:startEvent(32) -- Reminder Dialogue

--- a/scripts/zones/Northern_San_dOria/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(996)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(997)
     elseif assistChannelProgress == nil then
         player:startEvent(997, 128)

--- a/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
@@ -33,7 +33,7 @@ entity.onTrigger = function(player, npc)
     local mLvl = player:getMainLvl()
     local mJob = player:getMainJob()
     -- Check if they have key item "Ordelle whetStone"
-    local ordelleWhetstone = player:hasKeyItem(xi.ki.ORDELLE_WHETSTONE)
+    local hasOrdelleWhetstone = player:hasKeyItem(xi.ki.ORDELLE_WHETSTONE)
     local sharpeningTheSwordCS = player:getCharVar("sharpeningTheSwordCS")
     local aBoysDreamCS = player:getCharVar("aBoysDreamCS")
 
@@ -46,9 +46,9 @@ entity.onTrigger = function(player, npc)
         elseif mJob == xi.job.PLD and mLvl >= 40 and sharpeningTheSwordCS == 1 then
             player:startEvent(43) -- Start Quest "Sharpening the Sword"
         end
-    elseif sharpeningTheSword == QUEST_ACCEPTED and ordelleWhetstone == false then
+    elseif sharpeningTheSword == QUEST_ACCEPTED and not hasOrdelleWhetstone then
         player:startEvent(42) -- During Quest "Sharpening the Sword"
-    elseif sharpeningTheSword == QUEST_ACCEPTED and ordelleWhetstone == true then
+    elseif sharpeningTheSword == QUEST_ACCEPTED and hasOrdelleWhetstone then
         player:startEvent(44) -- Finish Quest "Sharpening the Sword"
     -- "A Boy's Dream" Quest Dialogs
     elseif aBoysDream == QUEST_AVAILABLE and mJob == xi.job.PLD and mLvl >= 50 then

--- a/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(624, skillCap, skillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(624, skillCap, skillLevel, 1, 207, player:getGil(), 7127, 4095, 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(630, skillCap, skillLevel, 2, 205, player:getGil(), 0, 90, 0)
         else
             player:startEvent(630, skillCap, skillLevel, 2, 205, player:getGil(), 7054, 90, 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Belgidiveau.lua
@@ -17,13 +17,13 @@ end
 
 entity.onTrigger = function(player, npc)
     local troubleAtTheSluice = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TROUBLE_AT_THE_SLUICE)
-    local neutralizerKI = player:hasKeyItem(xi.ki.NEUTRALIZER)
+    local hasNeutralizerKI = player:hasKeyItem(xi.ki.NEUTRALIZER)
 
     if troubleAtTheSluice == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 3 then
         player:startEvent(57)
-    elseif troubleAtTheSluice == QUEST_ACCEPTED and neutralizerKI == false then
+    elseif troubleAtTheSluice == QUEST_ACCEPTED and not hasNeutralizerKI then
         player:startEvent(55)
-    elseif neutralizerKI then
+    elseif hasNeutralizerKI then
         player:startEvent(56)
     else
         player:startEvent(585)

--- a/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
@@ -30,14 +30,13 @@ end
 entity.onTrigger = function(player, npc)
     -- "Blackmail" quest status
     local blackMail = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.BLACKMAIL)
-    local envelope = player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE)
     local sanFame = player:getFameLevel(xi.quest.fame_area.SANDORIA)
     local homeRank = player:getRank(player:getNation())
     local questState = player:getCharVar("BlackMailQuest")
 
     if blackMail == QUEST_AVAILABLE and sanFame >= 3 and homeRank >= 3 then
         player:startEvent(643) -- 643 gives me letter
-    elseif blackMail == QUEST_ACCEPTED and envelope == true then
+    elseif blackMail == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SUSPICIOUS_ENVELOPE) then
         player:startEvent(645)  -- 645 recap, take envelope!
 
     elseif blackMail == QUEST_ACCEPTED and questState == 1 then

--- a/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Dauperiat.lua
@@ -18,10 +18,7 @@ entity.onTrade = function(player, npc, trade)
     local questState = player:getCharVar("BlackMailQuest")
 
     if black == QUEST_ACCEPTED and questState == 2 or black == QUEST_COMPLETED then
-        local count = trade:getItemCount()
-        local carta = trade:hasItemQty(530, 1)
-
-        if carta == true and count == 1 then
+        if trade:hasItemQty(530, 1) and trade:getItemCount() == 1 then
             player:startEvent(648, 0, 530) --648
         end
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
@@ -42,7 +42,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if player:delGil(10) == false then
+    if not player:delGil(10) then
         player:setLocalVar("Durogg_PlayCutscene", 2)  -- Cancel the cutscene.
         player:updateEvent(0)
     else

--- a/scripts/zones/Northern_San_dOria/npcs/Eperdur.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Eperdur.lua
@@ -26,13 +26,13 @@ entity.onTrigger = function(player, npc)
         player:startEvent(681) -- Start quest "Healing the Land"
     elseif healingTheLand == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) then
         player:startEvent(682) -- During quest "Healing the Land"
-    elseif healingTheLand == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) == false then
+    elseif healingTheLand == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.SEAL_OF_BANISHING) then
         player:startEvent(683) -- Finish quest "Healing the Land"
     elseif healingTheLand == QUEST_COMPLETED and sorceryOfTheNorth == QUEST_AVAILABLE and player:needToZone() then
         player:startEvent(684) -- New standard dialog after "Healing the Land"
-    elseif healingTheLand == QUEST_COMPLETED and sorceryOfTheNorth == QUEST_AVAILABLE and player:needToZone() == false then
+    elseif healingTheLand == QUEST_COMPLETED and sorceryOfTheNorth == QUEST_AVAILABLE and not player:needToZone() then
         player:startEvent(685) -- Start quest "Sorcery of the North"
-    elseif sorceryOfTheNorth == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.FEIYIN_MAGIC_TOME) == false then
+    elseif sorceryOfTheNorth == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.FEIYIN_MAGIC_TOME) then
         player:startEvent(686) -- During quest "Sorcery of the North"
     elseif sorceryOfTheNorth == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.FEIYIN_MAGIC_TOME) then
         player:startEvent(687) -- Finish quest "Sorcery of the North"

--- a/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(628, cost, skillLevel, 0, 205, player:getGil(), 0, 0, 0)
         else
             player:startEvent(628, cost, skillLevel, 0, 205, player:getGil(), 28721, 4095, 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Matildie.lua
@@ -9,7 +9,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) then
         player:startEvent(631)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()

--- a/scripts/zones/Northern_San_dOria/npcs/Olbergieut.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Olbergieut.lua
@@ -17,9 +17,8 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-
     local gates = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
-    if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WATER) == true then
+    if player:hasKeyItem(xi.ki.SCRIPTURE_OF_WATER) then
         player:startEvent(620)
     elseif gates == QUEST_ACCEPTED then
         player:showText(npc, ID.text.OLBERGIEUT_DIALOG, xi.ki.SCRIPTURE_OF_WIND)
@@ -28,14 +27,12 @@ entity.onTrigger = function(player, npc)
     else
         player:startEvent(612)
     end
-
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-
     if csid == 619 and option == 0 then
         player:addQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GATES_TO_PARADISE)
         player:addKeyItem(xi.ki.SCRIPTURE_OF_WIND)
@@ -52,7 +49,6 @@ entity.onEventFinish = function(player, csid, option)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 13584)
         end
     end
-
 end
 
 return entity

--- a/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(629, skillCap, skillLevel, 1, 205, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(629, skillCap, skillLevel, 1, 205, player:getGil(), 7128, 4095, 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(625, skillCap, skillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else
             player:startEvent(625, skillCap, skillLevel, 2, 207, player:getGil(), 6857, 0, 0)

--- a/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(623, cost, skillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else
             player:startEvent(623, cost, skillLevel, 0, 207, player:getGil(), 28482, 4095, 0)

--- a/scripts/zones/Nyzul_Isle/npcs/Runic_Lamp.lua
+++ b/scripts/zones/Nyzul_Isle/npcs/Runic_Lamp.lua
@@ -178,7 +178,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             end
 
             -- Finish.
-            if winCondition == true then
+            if winCondition then
                 instance:setLocalVar("procedureTime", os.time() + 6)
                 npc:timer(6000, function(npcLamp)
                     instance:setLocalVar("lampsCorrect", 0)

--- a/scripts/zones/Periqia/instances/shades_of_vengeance.lua
+++ b/scripts/zones/Periqia/instances/shades_of_vengeance.lua
@@ -59,7 +59,7 @@ instanceObject.onInstanceFailure = function(instance)
 end
 
 instanceObject.onInstanceProgressUpdate = function(instance, progress)
-    if progress >= 10 and instance:completed() == false then
+    if progress >= 10 and not instance:completed() then
         instance:complete()
     end
 end

--- a/scripts/zones/Port_Bastok/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Port_Bastok/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(470)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(471)
     elseif assistChannelProgress == nil then
         player:startEvent(471, 128)

--- a/scripts/zones/Port_Bastok/npcs/Carmelo.lua
+++ b/scripts/zones/Port_Bastok/npcs/Carmelo.lua
@@ -26,11 +26,11 @@ entity.onTrigger = function(player, npc)
         player:startEvent(271)
     elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress == 3 then
         player:startEvent(272)
-    elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress == 4 and player:needToZone() == true then
+    elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress == 4 and player:needToZone() then
         player:startEvent(273)
-    elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress == 4 and player:needToZone() == false then
+    elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress == 4 and not player:needToZone() then
         player:startEvent(274)
-    elseif loversInTheDusk == QUEST_AVAILABLE and aTestOfTrueLove == QUEST_COMPLETED and player:needToZone() == false then
+    elseif loversInTheDusk == QUEST_AVAILABLE and aTestOfTrueLove == QUEST_COMPLETED and not player:needToZone() then
         player:startEvent(275)
     elseif loversInTheDusk == QUEST_ACCEPTED then
         player:startEvent(276)

--- a/scripts/zones/Port_Bastok/npcs/Carmelo.lua
+++ b/scripts/zones/Port_Bastok/npcs/Carmelo.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
     local aTestOfTrueLoveProgress = player:getCharVar("ATestOfTrueLoveProgress")
     local loversInTheDusk = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.LOVERS_IN_THE_DUSK)
 
-    if player:getFameLevel(xi.quest.fame_area.BASTOK) >= 7 and aTestOfTrueLove == QUEST_AVAILABLE and loveAndIce == QUEST_COMPLETED and player:needToZone() == false then
+    if player:getFameLevel(xi.quest.fame_area.BASTOK) >= 7 and aTestOfTrueLove == QUEST_AVAILABLE and loveAndIce == QUEST_COMPLETED and not player:needToZone() then
         player:startEvent(270)
     elseif aTestOfTrueLove == QUEST_ACCEPTED and aTestOfTrueLoveProgress < 3 then
         player:startEvent(271)

--- a/scripts/zones/Port_Bastok/npcs/Dalba.lua
+++ b/scripts/zones/Port_Bastok/npcs/Dalba.lua
@@ -145,7 +145,7 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
-    if player:delGil(10) == false then
+    if not player:delGil(10) then
         player:setLocalVar("Dalba_PlayCutscene", 2)  -- Cancel the cutscene.
         player:updateEvent(0)
     else

--- a/scripts/zones/Port_Bastok/npcs/Ensetsu.lua
+++ b/scripts/zones/Port_Bastok/npcs/Ensetsu.lua
@@ -23,9 +23,9 @@ entity.onTrigger = function(player, npc)
     if ayameAndKaede == QUEST_ACCEPTED then
         local questStatus = player:getCharVar("AyameAndKaede_Event")
 
-        if (questStatus == 1 or questStatus == 2) and player:hasKeyItem(xi.ki.STRANGELY_SHAPED_CORAL) == false then
+        if (questStatus == 1 or questStatus == 2) and not player:hasKeyItem(xi.ki.STRANGELY_SHAPED_CORAL) then
             player:startEvent(242)
-        elseif questStatus == 2 and player:hasKeyItem(xi.ki.STRANGELY_SHAPED_CORAL) == true then
+        elseif questStatus == 2 and player:hasKeyItem(xi.ki.STRANGELY_SHAPED_CORAL) then
             player:startEvent(245)
         elseif questStatus == 3 then
             player:startEvent(243)

--- a/scripts/zones/Port_Bastok/npcs/Juroro.lua
+++ b/scripts/zones/Port_Bastok/npcs/Juroro.lua
@@ -16,15 +16,15 @@ end
 
 entity.onTrigger = function(player, npc)
     local trialByEarth = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TRIAL_BY_EARTH)
-    local whisperOfTremors = player:hasKeyItem(xi.ki.WHISPER_OF_TREMORS)
+    local hasWhisperOfTremors = player:hasKeyItem(xi.ki.WHISPER_OF_TREMORS)
 
     if (trialByEarth == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.BASTOK) >= 6) or (trialByEarth == QUEST_COMPLETED and os.time() > player:getCharVar("TrialByEarth_date")) then
         player:startEvent(249, 0, xi.ki.TUNING_FORK_OF_EARTH) -- Start and restart quest "Trial by Earth"
-    elseif trialByEarth == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.TUNING_FORK_OF_EARTH) == false and whisperOfTremors == false then
+    elseif trialByEarth == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.TUNING_FORK_OF_EARTH) and not hasWhisperOfTremors then
         player:startEvent(284, 0, xi.ki.TUNING_FORK_OF_EARTH) -- Defeat against Titan : Need new Fork
-    elseif trialByEarth == QUEST_ACCEPTED and whisperOfTremors == false then
+    elseif trialByEarth == QUEST_ACCEPTED and not hasWhisperOfTremors then
         player:startEvent(250, 0, xi.ki.TUNING_FORK_OF_EARTH, 1)
-    elseif trialByEarth == QUEST_ACCEPTED and whisperOfTremors then
+    elseif trialByEarth == QUEST_ACCEPTED and hasWhisperOfTremors then
         local numitem = 0
 
         if player:hasItem(17438) then

--- a/scripts/zones/Port_Bastok/npcs/_6k8.lua
+++ b/scripts/zones/Port_Bastok/npcs/_6k8.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.AIRSHIP_PASS) == true and player:getGil() >= 200 then
+    if player:hasKeyItem(xi.ki.AIRSHIP_PASS) and player:getGil() >= 200 then
         player:startEvent(141)
     else
         player:startEvent(142)

--- a/scripts/zones/Port_Jeuno/npcs/Guddal.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Guddal.lua
@@ -12,9 +12,9 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if not player:hasKeyItem(xi.ki.AIRSHIP_PASS_FOR_KAZHAM) then
         if
-            trade:hasItemQty(1024, 1) == true and
-            trade:hasItemQty(1025, 1) == true and
-            trade:hasItemQty(1026, 1) == true and
+            trade:hasItemQty(1024, 1) and
+            trade:hasItemQty(1025, 1) and
+            trade:hasItemQty(1026, 1) and
             trade:getGil() == 0 and
             trade:getItemCount() == 3
         then

--- a/scripts/zones/Port_Jeuno/npcs/Karl.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Karl.lua
@@ -15,7 +15,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.CHILD_S_PLAY) == QUEST_ACCEPTED and
-        trade:hasItemQty(776, 1) == true and
+        trade:hasItemQty(776, 1) and
         trade:getItemCount() == 1
     then
         player:startEvent(1) -- Finish quest

--- a/scripts/zones/Port_Jeuno/npcs/Pitantimand.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Pitantimand.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if
-        trade:hasItemQty(555, 1) == true and
+        trade:hasItemQty(555, 1) and
         trade:getItemCount() == 1
     then
         local a = player:getCharVar("saveTheClockTowerNPCz2") -- NPC Zone2

--- a/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
@@ -13,13 +13,13 @@ local ID = require("scripts/zones/Port_Jeuno/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local count       = trade:getItemCount()
-    local sLux        = trade:hasItemQty(2740, 1)
-    local sLuna       = trade:hasItemQty(2741, 1)
-    local sAstrum     = trade:hasItemQty(2742, 1)
-    local acpMission  = player:getCurrentMission(xi.mission.log_id.ACP)
-    local crimsonKey  = player:hasKeyItem(xi.ki.CRIMSON_KEY)
-    local lastCrimson = player:getCharVar("LastCrimsonKey") -- When last Crimson key was obtained
+    local count         = trade:getItemCount()
+    local sLux          = trade:hasItemQty(2740, 1)
+    local sLuna         = trade:hasItemQty(2741, 1)
+    local sAstrum       = trade:hasItemQty(2742, 1)
+    local acpMission    = player:getCurrentMission(xi.mission.log_id.ACP)
+    local hasCrimsonKey = player:hasKeyItem(xi.ki.CRIMSON_KEY)
+    local lastCrimson   = player:getCharVar("LastCrimsonKey") -- When last Crimson key was obtained
 
     if
         xi.settings.main.ENABLE_ACP == 0 and
@@ -37,7 +37,7 @@ entity.onTrade = function(player, npc, trade)
             sAstrum and
             count == 3 and
             acpMission >= xi.mission.id.acp.GATHERER_OF_LIGHT_I and
-            crimsonKey == false and
+            not hasCrimsonKey and
             os.time() > lastCrimson
         then -- and timer stuff here) then
             player:tradeComplete()
@@ -51,7 +51,7 @@ entity.onTrade = function(player, npc, trade)
             sLuna and
             sAstrum and
             count == 3 and
-            (os.time() <= lastCrimson or crimsonKey == true)
+            (os.time() <= lastCrimson or hasCrimsonKey)
         then
             player:messageSpecial(ID.text.DRYEYES_3, xi.ki.CRIMSON_KEY)
         -- White Coral Key:
@@ -77,12 +77,12 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local acpMission   = player:getCurrentMission(xi.mission.log_id.ACP)
-    local salad        = player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)
-    local juice        = player:hasKeyItem(xi.ki.JUG_OF_GREASY_GOBLIN_JUICE)
-    local grub         = player:hasKeyItem(xi.ki.CHUNK_OF_SMOKED_GOBLIN_GRUB)
-    local viridianKey  = player:hasKeyItem(xi.ki.VIRIDIAN_KEY)
-    local lastViridian = player:getCharVar("LastViridianKey") -- When last Viridian key was obtained
+    local acpMission     = player:getCurrentMission(xi.mission.log_id.ACP)
+    local salad          = player:hasKeyItem(xi.ki.BOWL_OF_BLAND_GOBLIN_SALAD)
+    local juice          = player:hasKeyItem(xi.ki.JUG_OF_GREASY_GOBLIN_JUICE)
+    local grub           = player:hasKeyItem(xi.ki.CHUNK_OF_SMOKED_GOBLIN_GRUB)
+    local hasViridianKey = player:hasKeyItem(xi.ki.VIRIDIAN_KEY)
+    local lastViridian   = player:getCharVar("LastViridianKey") -- When last Viridian key was obtained
 
     if csid == 323 then
         if option == 1 then
@@ -93,7 +93,7 @@ entity.onEventFinish = function(player, csid, option)
                 juice and
                 grub and
                 acpMission >= xi.mission.id.acp.GATHERER_OF_LIGHT_I and
-                viridianKey == false and
+                not hasViridianKey and
                 os.time() > lastViridian
             then
                 player:addKeyItem(xi.ki.VIRIDIAN_KEY)
@@ -106,7 +106,7 @@ entity.onEventFinish = function(player, csid, option)
 
             elseif
                 os.time() <= lastViridian or
-                viridianKey == true
+                hasViridianKey
             then
                 player:messageSpecial(ID.text.DRYEYES_3, xi.ki.VIRIDIAN_KEY)
 

--- a/scripts/zones/Port_Jeuno/npcs/_6u4.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6u4.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     if
-        player:hasKeyItem(xi.ki.AIRSHIP_PASS) == true and
+        player:hasKeyItem(xi.ki.AIRSHIP_PASS) and
         player:getGil() >= 200
     then
         player:startEvent(38)

--- a/scripts/zones/Port_Jeuno/npcs/_6ua.lua
+++ b/scripts/zones/Port_Jeuno/npcs/_6ua.lua
@@ -12,7 +12,7 @@ end
 
 entity.onTrigger = function(player, npc)
     if
-        player:hasKeyItem(xi.ki.AIRSHIP_PASS) == true and
+        player:hasKeyItem(xi.ki.AIRSHIP_PASS) and
         player:getGil() >= 200
     then
         player:startEvent(36)

--- a/scripts/zones/Port_San_dOria/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Port_San_dOria/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(826)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(827)
     elseif assistChannelProgress == nil then
         player:startEvent(827, 128)

--- a/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
@@ -8,10 +8,7 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local count = trade:getItemCount()
-    local auctionParcel = trade:hasItemQty(594, 1)
-
-    if auctionParcel == true and count == 1 then
+    if trade:hasItemQty(594, 1) and trade:getItemCount() == 1 then
         local theBrugaireConsortium = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM)
         if theBrugaireConsortium == 1 then
             player:tradeComplete()

--- a/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ceraulian.lua
@@ -64,7 +64,7 @@ entity.onTrigger = function(player, npc)
     elseif stalkerStatus == QUEST_ACCEPTED and stalkerProgress == 0 then
         player:startEvent(19) -- Fetch the last Dragoon's helmet
     elseif stalkerProgress == 1 then
-        if player:hasKeyItem(xi.ki.CHALLENGE_TO_THE_ROYAL_KNIGHTS) == false then
+        if not player:hasKeyItem(xi.ki.CHALLENGE_TO_THE_ROYAL_KNIGHTS) then
             player:startEvent(23) -- Reminder to get helmet
         else
             player:startEvent(20) -- Response if you try to turn in the challenge to Ceraulian

--- a/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
@@ -18,13 +18,13 @@ entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED then
         if count == 1 and trade:getGil() == 100 then  -- pay to replace package
             local prog = player:getCharVar("TheBrugaireConsortium-Parcels")
-            if prog == 10 and player:hasItem(593) == false then
+            if prog == 10 and not player:hasItem(593) then
                 player:startEvent(608)
                 player:setCharVar("TheBrugaireConsortium-Parcels", 11)
-            elseif prog == 20 and player:hasItem(594) == false then
+            elseif prog == 20 and not player:hasItem(594) then
                 player:startEvent(609)
                 player:setCharVar("TheBrugaireConsortium-Parcels", 21)
-            elseif prog == 30 and player:hasItem(595) == false then
+            elseif prog == 30 and not player:hasItem(595) then
                 player:startEvent(610)
                 player:setCharVar("TheBrugaireConsortium-Parcels", 31)
             end

--- a/scripts/zones/Port_San_dOria/npcs/Nogelle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Nogelle.lua
@@ -12,10 +12,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.LUFET_S_LAKE_SALT) == QUEST_ACCEPTED then
-        local count = trade:getItemCount()
-        local lufetSalt = trade:hasItemQty(1019, 3)
-
-        if lufetSalt == true and count == 3 then
+        if trade:hasItemQty(1019, 3) and trade:getItemCount() == 3 then
             player:tradeComplete()
             player:addFame(xi.quest.fame_area.SANDORIA, 30)
             player:addGil(xi.settings.main.GIL_RATE * 600)

--- a/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Teilsa.lua
@@ -11,7 +11,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) then
         player:startEvent(612)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()

--- a/scripts/zones/Port_San_dOria/npcs/Thierride.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Thierride.lua
@@ -14,9 +14,7 @@ local ID = require("scripts/zones/Port_San_dOria/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local count = trade:getItemCount()
-
-    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED and trade:hasItemQty(595, 1) == true and count == 1 then
+    if player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED and trade:hasItemQty(595, 1) and trade:getItemCount() == 1 then
         player:tradeComplete()
         player:startEvent(539)
         player:setCharVar("TheBrugaireConsortium-Parcels", 31)

--- a/scripts/zones/Port_Windurst/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Port_Windurst/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(934)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(935)
     elseif assistChannelProgress == nil then
         player:startEvent(935, 128)

--- a/scripts/zones/Port_Windurst/npcs/Degong.lua
+++ b/scripts/zones/Port_Windurst/npcs/Degong.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10013, skillCap, skillLevel, 2, 239, player:getGil(), 0, 30, 0) -- p1 = skill level
         else
             player:startEvent(10013, skillCap, skillLevel, 2, 239, player:getGil(), 19293, 30, 0)

--- a/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
+++ b/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.FISHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10012, skillCap, skillLevel, 1, 239, player:getGil(), 0, 0, 0) -- p1 = skill level
         else
             player:startEvent(10012, skillCap, skillLevel, 1, 239, player:getGil(), 19194, 4031, 0)

--- a/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Hakkuru-Rinkuru.lua
@@ -43,10 +43,10 @@ entity.onTrigger = function(player, npc)
             player:startEvent(274, 0, 937) -- MAKING AMENDS + ANIMAL GLUE: Quest Start
     elseif makingAmends == QUEST_ACCEPTED then
             player:startEvent(275, 0, 937) -- MAKING AMENDS + ANIMAL GLUE: Quest Objective Reminder
-    elseif makingAmends == QUEST_COMPLETED and needToZone == true then
+    elseif makingAmends == QUEST_COMPLETED and needToZone then
             player:startEvent(278) -- MAKING AMENDS: After Quest
 --End Making Amends Section; Begin Wonder Wands Section
-    elseif makingAmends == QUEST_COMPLETED and makingAmens == QUEST_COMPLETED and wonderWands == QUEST_AVAILABLE and pFame >= 5 and needToZone == false then
+    elseif makingAmends == QUEST_COMPLETED and makingAmens == QUEST_COMPLETED and wonderWands == QUEST_AVAILABLE and pFame >= 5 and not needToZone then
             player:startEvent(259) --Starts Wonder Wands
     elseif wonderWands == QUEST_ACCEPTED then
             player:startEvent(260) --Reminder for Wonder Wands

--- a/scripts/zones/Port_Windurst/npcs/Jack_of_Clubs.lua
+++ b/scripts/zones/Port_Windurst/npcs/Jack_of_Clubs.lua
@@ -9,7 +9,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) then
         player:startEvent(10008, xi.settings.main.GIL_RATE * 50)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()

--- a/scripts/zones/Port_Windurst/npcs/Ohruru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Ohruru.lua
@@ -20,7 +20,7 @@ end
 entity.onTrigger = function(player, npc)
 --    player:delQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CATCH_IT_IF_YOU_CAN) -- ======== FOR TESTING ONLY ==========-----
 -- ======== FOR TESTING ONLY ==========-----
---    if player:getCharVar("QuestCatchItIfYouCan_var") == 0 and player:hasStatusEffect(xi.effect.MUTE) == false and player:hasStatusEffect(xi.effect.BANE) == false and player:hasStatusEffect(xi.effect.PLAGUE) == false then
+--    if player:getCharVar("QuestCatchItIfYouCan_var") == 0 and not player:hasStatusEffect(xi.effect.MUTE) and not player:hasStatusEffect(xi.effect.BANE) and not player:hasStatusEffect(xi.effect.PLAGUE) then
 --        rand = math.random(1, 3)
 --        if rand == 1 then
 --            player:addStatusEffect(xi.effect.MUTE, 0, 0, 100)
@@ -49,11 +49,11 @@ entity.onTrigger = function(player, npc)
             player:startEvent(231) -- CATCH IT IF YOU CAN: Before Quest 2
         end
 
-    elseif catch >= 1 and (player:hasStatusEffect(xi.effect.MUTE) == true or player:hasStatusEffect(xi.effect.BANE) == true or player:hasStatusEffect(xi.effect.PLAGUE) == true) then
+    elseif catch >= 1 and (player:hasStatusEffect(xi.effect.MUTE) or player:hasStatusEffect(xi.effect.BANE) or player:hasStatusEffect(xi.effect.PLAGUE)) then
         player:startEvent(246) -- CATCH IT IF YOU CAN: Quest Turn In 1
     elseif catch >= 1 and player:needToZone() then
         player:startEvent(255) -- CATCH IT IF YOU CAN: After Quest
-    elseif catch == 1 and player:hasStatusEffect(xi.effect.MUTE) == false and player:hasStatusEffect(xi.effect.BANE) == false and player:hasStatusEffect(xi.effect.PLAGUE) == false then
+    elseif catch == 1 and not player:hasStatusEffect(xi.effect.MUTE) and not player:hasStatusEffect(xi.effect.BANE) and not player:hasStatusEffect(xi.effect.PLAGUE) then
         local rand = math.random(1, 2)
         if rand == 1 then
             player:startEvent(248) -- CATCH IT IF YOU CAN: During Quest 1

--- a/scripts/zones/Port_Windurst/npcs/Ohruru.lua
+++ b/scripts/zones/Port_Windurst/npcs/Ohruru.lua
@@ -75,15 +75,15 @@ entity.onEventFinish = function(player, csid, option)
         player:addQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CATCH_IT_IF_YOU_CAN)
     elseif csid == 246 and option == 0 then
         player:needToZone(true)
-        if player:hasStatusEffect(xi.effect.MUTE) == true then
+        if player:hasStatusEffect(xi.effect.MUTE) then
             player:delStatusEffect(xi.effect.MUTE)
             player:addGil(xi.settings.main.GIL_RATE * 1000)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 1000)
-        elseif player:hasStatusEffect(xi.effect.BANE) == true then
+        elseif player:hasStatusEffect(xi.effect.BANE) then
             player:delStatusEffect(xi.effect.BANE)
             player:addGil(xi.settings.main.GIL_RATE * 1200)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 1200)
-        elseif player:hasStatusEffect(xi.effect.PLAGUE) == true then
+        elseif player:hasStatusEffect(xi.effect.PLAGUE) then
             player:delStatusEffect(xi.effect.PLAGUE)
             player:addGil(xi.settings.main.GIL_RATE * 1500)
             player:messageSpecial(ID.text.GIL_OBTAINED, xi.settings.main.GIL_RATE * 1500)

--- a/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
+++ b/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.FISHING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.FISHING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10011, cost, skillLevel, 0, 239, player:getGil(), 0, 0, 0) -- p1 = skill level
         else
             player:startEvent(10011, cost, skillLevel, 0, 239, player:getGil(), 38586, 30, 0)

--- a/scripts/zones/Port_Windurst/npcs/Sigismund.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sigismund.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local starstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.TO_CATCH_A_FALLING_STAR)
-    if starstatus == 1 and trade:hasItemQty(546, 1) == true and trade:getItemCount() == 1 and trade:getGil() == 0 then
+    if starstatus == 1 and trade:hasItemQty(546, 1) and trade:getItemCount() == 1 and trade:getGil() == 0 then
         player:startEvent(199) -- Quest Finish
     end
 end

--- a/scripts/zones/Port_Windurst/npcs/Tokaka.lua
+++ b/scripts/zones/Port_Windurst/npcs/Tokaka.lua
@@ -12,11 +12,8 @@ entity.onTrade = function(player, npc, trade)
     local tokakaSpokenTo = player:getCharVar("TokakaSpokenTo")
     local needToZone     = player:needToZone()
 
-    if tokakaSpokenTo == 1 and needToZone == false then
-        local count = trade:getItemCount()
-        local bastoreSardine = trade:hasItemQty(4360, 1)
-
-        if bastoreSardine == true and count == 1 then
+    if tokakaSpokenTo == 1 and not needToZone then
+        if trade:hasItemQty(4360, 1) and trade:getItemCount() == 1 then
             player:startEvent(210, xi.settings.main.GIL_RATE * 70, 4360)
         end
     end

--- a/scripts/zones/PsoXja/npcs/_i97.lua
+++ b/scripts/zones/PsoXja/npcs/_i97.lua
@@ -13,7 +13,7 @@ end
 
 entity.onTrigger = function(player, npc)
     local posZ = player:getZPos()
-    if player:hasKeyItem(xi.ki.PSOXJA_PASS) == true and posZ >= 25 then
+    if player:hasKeyItem(xi.ki.PSOXJA_PASS) and posZ >= 25 then
         player:startEvent(14)
     elseif posZ < 25 then
         player:startEvent(17)

--- a/scripts/zones/Qulun_Dome/npcs/The_Mute.lua
+++ b/scripts/zones/Qulun_Dome/npcs/The_Mute.lua
@@ -11,7 +11,7 @@ end
 entity.onTrigger = function(player, npc)
     local duration = math.random(600, 900)
 
-    if player:hasStatusEffect(xi.effect.SILENCE) == false then
+    if not player:hasStatusEffect(xi.effect.SILENCE) then
         player:addStatusEffect(xi.effect.SILENCE, 0, 0, duration)
     end
 end

--- a/scripts/zones/Rabao/npcs/Irmilant.lua
+++ b/scripts/zones/Rabao/npcs/Irmilant.lua
@@ -28,9 +28,9 @@ entity.onTrigger = function(player, npc)
     local ImmortalLuShang = player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.THE_IMMORTAL_LU_SHANG)
     local indomitableTimer = player:getCharVar("IndomitableSpiritTimer")
 
-    if player:hasItem(489) == true and (ImmortalLuShang == QUEST_AVAILABLE or ImmortalLuShang == QUEST_COMPLETED) then
+    if player:hasItem(489) and (ImmortalLuShang == QUEST_AVAILABLE or ImmortalLuShang == QUEST_COMPLETED) then
         player:startEvent(77) --Offer the quest if the player has the broken rod
-    elseif player:hasKeyItem(xi.ki.SERPENT_RUMORS) == true and Indomitable == QUEST_AVAILABLE then
+    elseif player:hasKeyItem(xi.ki.SERPENT_RUMORS) and Indomitable == QUEST_AVAILABLE then
         player:startEvent(131) --Begins Indomitable Spirit
     elseif indomitableTimer ~= 0 and indomitableTimer > os.time() then
         player:startEvent(133) --Asks the player to wait (next CQ tally)

--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
@@ -48,7 +48,7 @@ entity.onMobFight = function(mob, target)
         end
     end
 
-    if mob:actionQueueEmpty() == true and not isBusy then -- the last check prevents multiple Mega/Gigaflares from being called at the same time.
+    if mob:actionQueueEmpty() and not isBusy then -- the last check prevents multiple Mega/Gigaflares from being called at the same time.
         if megaFlareQueue > 0 then
             mob:SetMobAbilityEnabled(false) -- disable all other actions until Megaflare is used successfully
             mob:SetMagicCastingEnabled(false)

--- a/scripts/zones/RuLude_Gardens/npcs/Magian_Moogle_Green.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Magian_Moogle_Green.lua
@@ -36,17 +36,13 @@ entity.onTrigger = function(player, npc)
         return
     end
 
-    local learnerLog = player:hasKeyItem(xi.ki.MAGIAN_LEARNERS_LOG)
-    local trialLog = player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG)
-
     if player:getMainLvl() < 30 then
         player:startEvent(10151)
-
     elseif
         player:getCharVar("MetGreenMagianMog") == 0 and
-        learnerLog == false
+        not player:hasKeyItem(xi.ki.MAGIAN_LEARNERS_LOG)
     then
-        if trialLog == false then
+        if not player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) then
             player:startEvent(10160, 0)
         else
             player:startEvent(10160, 1)

--- a/scripts/zones/RuLude_Gardens/npcs/Magian_Moogle_Green.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Magian_Moogle_Green.lua
@@ -61,7 +61,7 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 10160 and option == 1 then
-        if player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) == false then
+        if not player:hasKeyItem(xi.ki.MAGIAN_TRIAL_LOG) then
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAGIAN_LEARNERS_LOG)
             player:addKeyItem(xi.ki.MAGIAN_LEARNERS_LOG)
         end

--- a/scripts/zones/RuLude_Gardens/npcs/Radeivepart.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Radeivepart.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if
-        trade:hasItemQty(555, 1) == true and
+        trade:hasItemQty(555, 1) and
         trade:getGil() == 0 and
         trade:getItemCount() == 1
     then
@@ -45,7 +45,7 @@ entity.onTrade = function(player, npc, trade)
 
     elseif player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.NORTHWARD) == QUEST_ACCEPTED then
         if
-            trade:hasItemQty(16522, 1) == true and
+            trade:hasItemQty(16522, 1) and
             trade:getGil() == 0 and
             trade:getItemCount() == 1
         then
@@ -81,7 +81,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 61 then
         player:completeQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.NORTHWARD)
         player:addTitle(xi.title.ENVOY_TO_THE_NORTH)
-        if player:hasKeyItem(xi.ki.MAP_OF_CASTLE_ZVAHL) == false then
+        if not player:hasKeyItem(xi.ki.MAP_OF_CASTLE_ZVAHL) then
             player:addKeyItem(xi.ki.MAP_OF_CASTLE_ZVAHL)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAP_OF_CASTLE_ZVAHL)
         end

--- a/scripts/zones/Sauromugue_Champaign_[S]/npcs/Bulwark_Gate.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/npcs/Bulwark_Gate.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.KNOT_QUITE_THERE) == QUEST_ACCEPTED and player:getCharVar("KnotQuiteThere") == 1 then
-        if trade:hasItemQty(2562, 1) == true and trade:getGil() == 0 and trade:getItemCount() == 1 then
+        if trade:hasItemQty(2562, 1) and trade:getGil() == 0 and trade:getItemCount() == 1 then
             player:startEvent(106)
         end
     end

--- a/scripts/zones/Sealions_Den/helpers/TenzenFunctions.lua
+++ b/scripts/zones/Sealions_Den/helpers/TenzenFunctions.lua
@@ -112,7 +112,7 @@ end
 tenzenFunctions.riceBall = function(mob, target, busyState)
     local battlefield = mob:getBattlefield()
     if
-        mob:actionQueueEmpty() == true and
+        mob:actionQueueEmpty() and
         not busyState
     then
         if

--- a/scripts/zones/Sealions_Den/mobs/Tenzen.lua
+++ b/scripts/zones/Sealions_Den/mobs/Tenzen.lua
@@ -72,7 +72,7 @@ entity.onMobFight = function(mob, target)
 
     -- scripted sequence of weaponskills in order to potentially create the level 4 skillchain cosmic elucidation
     if
-        mob:actionQueueEmpty() == true and
+        mob:actionQueueEmpty() and
         not isBusy
     then
         tenzenFunctions.wsSequence(mob)

--- a/scripts/zones/Southern_San_dOria/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(3617)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(3618)
     elseif assistChannelProgress == nil then
         player:startEvent(3618, 128)

--- a/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
     if player:getCharVar("DiaryPage") == 3 or toCureaCough == QUEST_ACCEPTED then
         if player:hasKeyItem(xi.ki.THYME_MOSS) == false and player:hasKeyItem(xi.ki.COUGH_MEDICINE) == false then
             player:startEvent(645) -- need thyme moss for cough med
-        elseif player:hasKeyItem(xi.ki.THYME_MOSS) == true then
+        elseif player:hasKeyItem(xi.ki.THYME_MOSS) then
             player:startEvent(646) -- receive cough med for Nenne
         end
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Amaura.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local toCureaCough = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.TO_CURE_A_COUGH)
 
     if player:getCharVar("DiaryPage") == 3 or toCureaCough == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.THYME_MOSS) == false and player:hasKeyItem(xi.ki.COUGH_MEDICINE) == false then
+        if not player:hasKeyItem(xi.ki.THYME_MOSS) and not player:hasKeyItem(xi.ki.COUGH_MEDICINE) then
             player:startEvent(645) -- need thyme moss for cough med
         elseif player:hasKeyItem(xi.ki.THYME_MOSS) then
             player:startEvent(646) -- receive cough med for Nenne

--- a/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Andecia.lua
@@ -21,14 +21,12 @@ end
 
 entity.onTrigger = function(player, npc)
     local tomb = player:getQuestStatus(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.GRAVE_CONCERNS)
-    local wellWater = player:hasItem(567) -- Well Water
-    local waterskin = player:hasItem(547) -- Tomb Waterskin
 
     if tomb == QUEST_AVAILABLE then
         player:startEvent(541)
-    elseif tomb == QUEST_ACCEPTED and wellWater == false and player:getCharVar("OfferingWaterOK") == 0 then
+    elseif tomb == QUEST_ACCEPTED and not player:hasItem(567) and player:getCharVar("OfferingWaterOK") == 0 then
         player:startEvent(622)
-    elseif tomb == QUEST_ACCEPTED and waterskin == true and player:getCharVar("OfferingWaterOK") == 0 then
+    elseif tomb == QUEST_ACCEPTED and player:hasItem(547) and player:getCharVar("OfferingWaterOK") == 0 then
         player:startEvent(623)
     elseif tomb == QUEST_COMPLETED then
         player:startEvent(558)

--- a/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Balasiel.lua
@@ -44,13 +44,13 @@ entity.onTrigger = function(player, npc)
     elseif lvl >= 7 and lvl < 15 then
         player:startEvent(671)
     elseif lvl >= 15 and aSquiresTestII ~= QUEST_COMPLETED then
-        local stalactiteDew = player:hasKeyItem(xi.ki.STALACTITE_DEW)
+        local hasStalactiteDew = player:hasKeyItem(xi.ki.STALACTITE_DEW)
 
         if aSquiresTestII == QUEST_AVAILABLE then
             player:startEvent(625)
-        elseif aSquiresTestII == QUEST_ACCEPTED and stalactiteDew == false then
+        elseif aSquiresTestII == QUEST_ACCEPTED and not hasStalactiteDew then
             player:startEvent(630)
-        elseif stalactiteDew then
+        elseif hasStalactiteDew then
             player:startEvent(626)
         else
             player:startEvent(667)

--- a/scripts/zones/Southern_San_dOria/npcs/Baunise.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Baunise.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) == false then
+    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and not player:hasKeyItem(xi.ki.BOOK_OF_THE_WEST) then
         player:startEvent(634)
     else
         player:showText(npc, 7817)-- nothing to report

--- a/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Cahaurme.lua
@@ -13,7 +13,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) == false then
+    if player:hasKeyItem(xi.ki.BOOK_OF_TASKS) and not player:hasKeyItem(xi.ki.BOOK_OF_THE_EAST) then
         player:startEvent(633)
     else
         player:showText(npc, 7817) -- nothing to report

--- a/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Helbort.lua
@@ -21,7 +21,7 @@ entity.onTrigger = function(player, npc)
 
     if player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 2 and quest_fas == QUEST_COMPLETED and quest_poa == QUEST_AVAILABLE then
         player:startEvent(594)  -- Start quest A Purchase of Arms
-    elseif quest_poa == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.WEAPONS_RECEIPT) == true then
+    elseif quest_poa == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.WEAPONS_RECEIPT) then
         player:startEvent(607) -- Finish A Purchase of Arms quest
     else
         player:startEvent(593)  -- Standard Dialog

--- a/scripts/zones/Southern_San_dOria/npcs/Nenne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Nenne.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
 
     if toCureaCough == QUEST_AVAILABLE and player:getCharVar("toCureaCough") == 0 and medicineWoman == QUEST_COMPLETED then
         player:startEvent(538)
-    elseif player:hasKeyItem(xi.ki.COUGH_MEDICINE) == true then
+    elseif player:hasKeyItem(xi.ki.COUGH_MEDICINE) then
         player:startEvent(647)
     else
         player:startEvent(584)

--- a/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
@@ -18,7 +18,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(650, cost, skillLevel, 0, 239, player:getGil(), 0, 0, 0)
         else
             player:startEvent(650, cost, skillLevel, 0, 239, player:getGil(), 28727, 0, 0)

--- a/scripts/zones/Southern_San_dOria/npcs/Rolandienne.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Rolandienne.lua
@@ -18,7 +18,7 @@ end
 entity.onTrigger = function(player, npc)
     if player:getEminenceProgress(1) then
         player:startEvent(993)
-    elseif player:hasKeyItem(xi.ki.MEMORANDOLL) == false then
+    elseif not player:hasKeyItem(xi.ki.MEMORANDOLL) then
         player:startEvent(994)
     else
         player:triggerRoeEvent(xi.roe.triggers.talkToRoeNpc)

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
@@ -20,7 +20,7 @@ entity.onTrade = function(player, npc, trade)
     if lufetSalt and cnt == 1 and beansAhoy == QUEST_ACCEPTED then
         if player:getCharVar("BeansAhoy") == 0 then
             player:startEvent(337) -- Traded the Correct Item Dialogue (NOTE: You have to trade the Salts one at according to wiki)
-        elseif player:needsToZone() == false then
+        elseif not player:needToZone() then
             player:startEvent(340) -- Quest Complete Dialogue
         end
     else
@@ -51,7 +51,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 337 then
         player:tradeComplete()
         player:setCharVar("BeansAhoy", 1)
-        player:needsToZone(true)
+        player:needToZone(true)
     elseif csid == 340 or csid == 342 then
         if player:hasItem(5704, 1) or player:getFreeSlotsCount() < 1 then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 5704)

--- a/scripts/zones/Tavnazian_Safehold/npcs/qm_unforgiven.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/qm_unforgiven.lua
@@ -16,7 +16,7 @@ end
 entity.onTrigger = function(player, npc)
     local unforgiven = player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.UNFORGIVEN)
 
-    if unforgiven == QUEST_ACCEPTED and player:hasKeyItem(xi.ki.ALABASTER_HAIRPIN) == false then
+    if unforgiven == QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.ALABASTER_HAIRPIN) then
         player:addKeyItem(xi.ki.ALABASTER_HAIRPIN)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ALABASTER_HAIRPIN) -- ALABASTER HAIRPIN for Unforgiven Quest
     end

--- a/scripts/zones/The_Ashu_Talif/instances/the_black_coffin.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/the_black_coffin.lua
@@ -54,7 +54,7 @@ instanceObject.onInstanceProgressUpdate = function(instance, progress)
         for i, mob in pairs(ID.mob[2]) do
             SpawnMob(mob, instance)
         end
-    elseif progress >= 10 and instance:completed() == false then
+    elseif progress >= 10 and not instance:completed() then
         local ally = GetMobByID(ID.mob.GESSHO, instance)
         if ally:isAlive() then
             ally:setLocalVar("ready", 2)

--- a/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Captain.lua
+++ b/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Captain.lua
@@ -13,7 +13,7 @@ end
 entity.onMobFight = function(mob, target)
     -- The captain gives up at <= 20% HP. Everyone disengages
     local instance = mob:getInstance()
-    if mob:getHPP() <= 20 and instance:completed() == false then
+    if mob:getHPP() <= 20 and not instance:completed() then
         instance:complete()
     end
 

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_BLM.lua
@@ -71,7 +71,7 @@ entity.onMobFight = function(mob, target)
     end
 
     if
-        mob:actionQueueEmpty() == true and
+        mob:actionQueueEmpty() and
         not isBusy
     then -- dont change forms while charging Optic Induration
         if

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixzdei_RDM.lua
@@ -71,7 +71,7 @@ entity.onMobFight = function(mob, target)
     end
 
     if
-        mob:actionQueueEmpty() == true and
+        mob:actionQueueEmpty() and
         not isBusy
     then -- dont change forms while charging Optic Induration
         if

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/_0zu.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/_0zu.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.BRAND_OF_DAWN) == false then
+    if not player:hasKeyItem(xi.ki.BRAND_OF_DAWN) then
         player:startEvent(110)
     end
 

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/_0zv.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/_0zv.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.BRAND_OF_TWILIGHT) == false then
+    if not player:hasKeyItem(xi.ki.BRAND_OF_TWILIGHT) then
         player:startEvent(111)
     end
 

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Seiryu.lua
@@ -7,7 +7,7 @@ require("scripts/globals/status")
 local entity = {}
 
 entity.onMobMagicPrepare = function(mob, target, spellId)
-    if mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) == false then
+    if not mob:hasStatusEffect(xi.effect.HUNDRED_FISTS, 0) then
         local rnd = math.random()
         if rnd < 0.5 then
             return 186 -- aeroga 3

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
 
     -- Count keyitems
     for i = xi.ki.SHARD_OF_APATHY, xi.ki.SHARD_OF_RAGE do
-        if player:hasKeyItem(i) == true then
+        if player:hasKeyItem(i) then
             aaKeyitems = aaKeyitems + 1
         end
     end

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
@@ -22,7 +22,7 @@ entity.onTrigger = function(player, npc)
     local aaKeyitems = 0
     local dmEarrings = 0
     local divineStatus = player:getCharVar("DivineMight")
-    local moonOre = player:hasKeyItem(xi.ki.MOONLIGHT_ORE)
+    local hasMoonOre = player:hasKeyItem(xi.ki.MOONLIGHT_ORE)
 
     -- Count keyitems
     for i = xi.ki.SHARD_OF_APATHY, xi.ki.SHARD_OF_RAGE do
@@ -47,12 +47,12 @@ entity.onTrigger = function(player, npc)
     elseif dmStatus == QUEST_COMPLETED and dmEarrings < xi.settings.main.NUMBER_OF_DM_EARRINGS and dmRepeat ~= QUEST_ACCEPTED then -- You threw away old Earring, start the repeat quest
         player:startEvent(57, player:getCharVar("DM_Earring"))
     elseif dmRepeat == QUEST_ACCEPTED and divineStatus < 2 then
-        if moonOre == false then
+        if not hasMoonOre then
             player:startEvent(58) -- Reminder for Moonlight Ore
         else
             player:startEvent(56, 917, 1408, 1550) -- Reminder for Ark Pentasphere
         end
-    elseif dmRepeat == QUEST_ACCEPTED and divineStatus == 2 and moonOre == true then -- Repeat turn in
+    elseif dmRepeat == QUEST_ACCEPTED and divineStatus == 2 and hasMoonOre then -- Repeat turn in
         player:startEvent(59)
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY) -- Need some kind of feedback

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/blank_divine_might.lua
@@ -88,7 +88,7 @@ entity.onEventFinish = function(player, csid, option)
         end
 
         if reward ~= 0 then
-            if player:getFreeSlotsCount() >= 1 and player:hasItem(reward) == false then
+            if player:getFreeSlotsCount() >= 1 and not player:hasItem(reward) then
                 player:addItem(reward)
                 player:messageSpecial(ID.text.ITEM_OBTAINED, reward)
                 if csid == 55 then

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -13,7 +13,7 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) == false and mob:actionQueueEmpty() == true then
+    if not mob:hasStatusEffect(xi.effect.BLOOD_WEAPON) and mob:actionQueueEmpty() then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
 

--- a/scripts/zones/Uleguerand_Range/npcs/Eternal_Ice.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Eternal_Ice.lua
@@ -15,7 +15,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:hasKeyItem(xi.ki.MYSTIC_ICE) == false then
+    if not player:hasKeyItem(xi.ki.MYSTIC_ICE) then
         player:addKeyItem(xi.ki.MYSTIC_ICE)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MYSTIC_ICE)
     else

--- a/scripts/zones/Uleguerand_Range/npcs/Fissure.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Fissure.lua
@@ -17,7 +17,7 @@ end
 entity.onTrigger = function(player, npc)
     local z = player:getZPos()
 
-    if player:hasKeyItem(xi.ki.MYSTIC_ICE) == true then
+    if player:hasKeyItem(xi.ki.MYSTIC_ICE) then
         if z > -200 and z < -150 then                -- southern Fissure (J-9)
             player:startEvent(2, xi.ki.MYSTIC_ICE)
         elseif z > 200 and z < 250 then            -- middle Fissure (K-7)

--- a/scripts/zones/Upper_Jeuno/npcs/Collet.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Collet.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(555, 1) == true and trade:getItemCount() == 1 then
+    if trade:hasItemQty(555, 1) and trade:getItemCount() == 1 then
         local a = player:getCharVar("saveTheClockTowerNPCz1") -- NPC zone1
         if
             a == 0 or

--- a/scripts/zones/Upper_Jeuno/npcs/Constance.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Constance.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(555, 1) == true and trade:getItemCount() == 1 then
+    if trade:hasItemQty(555, 1) and trade:getItemCount() == 1 then
         local a = player:getCharVar("saveTheClockTowerNPCz1") -- NPC Part1
         if
             a == 0 or

--- a/scripts/zones/Upper_Jeuno/npcs/Ilumida.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Ilumida.lua
@@ -29,7 +29,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(201) --asks player again, SearchingForTheRightWords accept/deny
 
     elseif searchingForWords == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.MOONDROP) == true then
+        if player:hasKeyItem(xi.ki.MOONDROP) then
             player:startEvent(198)
         else
             player:startEvent(199) -- SearchingForTheRightWords quest accepted dialog

--- a/scripts/zones/Upper_Jeuno/npcs/Monberaux.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Monberaux.lua
@@ -15,7 +15,7 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(555, 1) == true and trade:getItemCount() == 1 then
+    if trade:hasItemQty(555, 1) and trade:getItemCount() == 1 then
         local a = player:getCharVar("saveTheClockTowerNPCz1") -- NPC Part1
         if
             a == 0 or

--- a/scripts/zones/Upper_Jeuno/npcs/Souren.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Souren.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(555, 1) == true and trade:getItemCount() == 1 then
+    if trade:hasItemQty(555, 1) and trade:getItemCount() == 1 then
         local a = player:getCharVar("saveTheClockTowerNPCz1") -- NPC Part1
         if
             a == 0 or

--- a/scripts/zones/Upper_Jeuno/npcs/Zuber.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Zuber.lua
@@ -7,7 +7,7 @@
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:hasItemQty(555, 1) == true and trade:getItemCount() == 1 then
+    if trade:hasItemQty(555, 1) and trade:getItemCount() == 1 then
         local a = player:getCharVar("saveTheClockTowerNPCz2") -- NPC Zone2
         if
             a == 0 or

--- a/scripts/zones/Upper_Jeuno/npcs/_6s2.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/_6s2.lua
@@ -30,7 +30,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(118) -- Start short cs quest with option "a clock most delicate"
 
     elseif aClockMostdelicate == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.CLOCK_TOWER_OIL) == true then
+        if player:hasKeyItem(xi.ki.CLOCK_TOWER_OIL) then
             player:startEvent(202) -- Ending quest "a clock most delicate"
         else
             player:startEvent(117) -- During quest "a clock most delicate"

--- a/scripts/zones/VeLugannon_Palace/npcs/qm1.lua
+++ b/scripts/zones/VeLugannon_Palace/npcs/qm1.lua
@@ -13,7 +13,7 @@ end
 entity.onTrigger = function(player, npc)
     local hideTime = 0
 
-    if player:hasItem(16575) == false and player:getFreeSlotsCount() >= 1 then
+    if not player:hasItem(16575) and player:getFreeSlotsCount() >= 1 then
         player:addItem(16575)
         player:messageSpecial(ID.text.ITEM_OBTAINED, 16575) -- Curtana
 

--- a/scripts/zones/Vunkerl_Inlet_[S]/npcs/Indescript_Markings.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/npcs/Indescript_Markings.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     player:delStatusEffect(xi.effect.SNEAK)
 
     -- SCH AF Quest - Legs
-    if pantsQuestProgress > 0 and pantsQuestProgress < 3 and player:hasKeyItem(xi.ki.DJINN_EMBER) == false then
+    if pantsQuestProgress > 0 and pantsQuestProgress < 3 and not player:hasKeyItem(xi.ki.DJINN_EMBER) then
         player:addKeyItem(xi.ki.DJINN_EMBER)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.DJINN_EMBER)
         player:setCharVar("AF_SCH_PANTS", pantsQuestProgress + 1)

--- a/scripts/zones/Western_Adoulin/npcs/Eternal_Flame.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Eternal_Flame.lua
@@ -18,7 +18,7 @@ end
 entity.onTrigger = function(player, npc)
     if player:getEminenceProgress(1) then
         player:startEvent(5079)
-    elseif player:hasKeyItem(xi.ki.MEMORANDOLL) == false then
+    elseif not player:hasKeyItem(xi.ki.MEMORANDOLL) then
         player:startEvent(5080)
     else
         player:triggerRoeEvent(xi.roe.triggers.talkToRoeNpc)

--- a/scripts/zones/Windurst_Walls/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Windurst_Walls/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(563)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(564)
     elseif assistChannelProgress == nil then
         player:startEvent(564, 128)

--- a/scripts/zones/Windurst_Waters/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Windurst_Waters/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(1162)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(1163)
     elseif assistChannelProgress == nil then
         player:startEvent(1163, 128)

--- a/scripts/zones/Windurst_Waters/npcs/Chamama.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Chamama.lua
@@ -14,10 +14,8 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local inAPickle = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.IN_A_PICKLE)
-    local count = trade:getItemCount()
-    local gil = trade:getGil()
 
-    if (inAPickle == QUEST_ACCEPTED or inAPickle == QUEST_COMPLETED) and trade:hasItemQty(583, 1) == true and count == 1 and gil == 0 then
+    if (inAPickle == QUEST_ACCEPTED or inAPickle == QUEST_COMPLETED) and trade:hasItemQty(583, 1) and trade:getItemCount() == 1 and trade:getGil() == 0 then
         local rand = math.random(1, 4)
         if rand <= 2 then
             if inAPickle == QUEST_ACCEPTED then
@@ -39,7 +37,7 @@ entity.onTrigger = function(player, npc)
     local inAPickle = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.IN_A_PICKLE)
     local needToZone = player:needToZone()
 
-    if inAPickle == QUEST_AVAILABLE and needToZone == false then
+    if inAPickle == QUEST_AVAILABLE and not needToZone then
         local rand = math.random(1, 2)
         if rand == 1 then
             player:startEvent(654, 0, 4444) -- IN A PICKLE + RARAB TAIL: Quest Begin
@@ -50,7 +48,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(655, 0, 4444) -- IN A PICKLE + RARAB TAIL: Quest Objective Reminder
     elseif inAPickle == QUEST_COMPLETED and needToZone then
         player:startEvent(660) -- IN A PICKLE: After Quest
-    elseif inAPickle == QUEST_COMPLETED and needToZone == false and player:getCharVar("QuestInAPickle_var") ~= 1 then
+    elseif inAPickle == QUEST_COMPLETED and not needToZone and player:getCharVar("QuestInAPickle_var") ~= 1 then
         local rand = math.random(1, 2)
         if rand == 1 then
             player:startEvent(661) -- IN A PICKLE: Repeatable Quest Begin

--- a/scripts/zones/Windurst_Waters/npcs/Gantineux.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Gantineux.lua
@@ -21,9 +21,9 @@ entity.onTrigger = function(player, npc)
     if actingInGoodFaith == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 4 and player:getMainLvl() >= 10 then
         player:startEvent(10019) -- Start quest "Acting in Good Faith"
     elseif actingInGoodFaith == QUEST_ACCEPTED then
-        if player:hasKeyItem(xi.ki.SPIRIT_INCENSE) == true then
+        if player:hasKeyItem(xi.ki.SPIRIT_INCENSE) then
             player:startEvent(10020) -- During quest "Acting in Good Faith" (with Spirit Incense KI)
-        elseif player:hasKeyItem(xi.ki.GANTINEUXS_LETTER) == true then
+        elseif player:hasKeyItem(xi.ki.GANTINEUXS_LETTER) then
             player:startEvent(10022) --  During quest "Acting in Good Faith" (with Gantineux's Letter)
         else
             player:startEvent(10021) -- During quest "Acting in Good Faith" (before Gantineux's Letter)

--- a/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10017, skillCap, skillLevel, 2, 495, player:getGil(), 0, 4095, 0) -- p1 = skill level
         else
             player:startEvent(10017, skillCap, skillLevel, 2, 495, player:getGil(), 7094, 4095, 0)

--- a/scripts/zones/Windurst_Waters/npcs/Jack_of_Hearts.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jack_of_Hearts.lua
@@ -9,7 +9,7 @@ require("scripts/globals/settings")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) == true then
+    if trade:getItemCount() == 1 and trade:hasItemQty(536, 1) then
         player:startEvent(10012, xi.settings.main.GIL_RATE * 50)
         player:addGil(xi.settings.main.GIL_RATE * 50)
         player:tradeComplete()

--- a/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10016, skillCap, skillLevel, 1, 495, player:getGil(), 0, 4095, 0) -- p1 = skill level
         else
             player:startEvent(10016, skillCap, skillLevel, 1, 495, player:getGil(), 7180, 4095, 0)

--- a/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jatan-Paratan.lua
@@ -14,7 +14,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     local wonderingstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.WONDERING_MINSTREL)
-    if wonderingstatus == 1 and trade:hasItemQty(718, 1) == true and trade:getItemCount() == 1 and player:getCharVar("QuestWonderingMin_var") == 1 then
+    if wonderingstatus == 1 and trade:hasItemQty(718, 1) and trade:getItemCount() == 1 and player:getCharVar("QuestWonderingMin_var") == 1 then
         player:startEvent(638)                 -- WONDERING_MINSTREL: Quest Finish
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.COOKING)
 
     if guildMember == 1 then
-        if player:hasStatusEffect(xi.effect.COOKING_IMAGERY) == false then
+        if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10015, cost, skillLevel, 0, 495, player:getGil(), 0, 0, 0) -- p1 = skill level
         else
             player:startEvent(10015, cost, skillLevel, 0, 495, player:getGil(), 28589, 0, 0)

--- a/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
         end
     elseif reapstatus == QUEST_COMPLETED and player:needToZone() then
         player:startEvent(478)                              -- REAP WHAT YOU SOW: After Quest
-    elseif reapstatus == QUEST_COMPLETED and player:needToZone() == false and player:getCharVar("QuestReapSow_var") == 0 then
+    elseif reapstatus == QUEST_COMPLETED and not player:needToZone() and player:getCharVar("QuestReapSow_var") == 0 then
         local rand = math.random(1, 2)
         if rand == 1 then
             player:startEvent(479, 0, 4565, 572)                -- REAP WHAT YOU SOW + HERB SEEDS: REPEATABLE QUEST START

--- a/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mashuu-Ajuu.lua
@@ -16,9 +16,9 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     local reapstatus = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.REAP_WHAT_YOU_SOW)
     if reapstatus >= 1 and trade:getItemCount() == 1 and trade:getGil() == 0 then
-        if trade:hasItemQty(4565, 1) == true then
+        if trade:hasItemQty(4565, 1) then
             player:startEvent(475, 500, 131)                     -- REAP WHAT YOU SOW + GIL: Quest Turn In: Sobbing Fungus turned in
-        elseif trade:hasItemQty(4566, 1) == true then
+        elseif trade:hasItemQty(4566, 1) then
             player:startEvent(477, 700)                     -- REAP WHAT YOU SOW + GIL + Stationary Set: Deathball turned in
         end
     end

--- a/scripts/zones/Windurst_Waters/npcs/Maysoon.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Maysoon.lua
@@ -13,7 +13,7 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.HOIST_THE_JELLY_ROGER) == QUEST_ACCEPTED then
-        if trade:hasItemQty(4508, 1) == true and trade:getGil() == 0 and trade:getItemCount() == 1 then
+        if trade:hasItemQty(4508, 1) and trade:getGil() == 0 and trade:getItemCount() == 1 then
             player:startEvent(10001) -- Finish quest "Hoist the Jelly, Roger"
         end
     end

--- a/scripts/zones/Windurst_Waters/npcs/Ranpi-Monpi.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ranpi-Monpi.lua
@@ -43,7 +43,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(557)                             -- new dialog before finish of quest
 
     -- A Crisis in the Making
-    elseif crisisstatus == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 and player:needToZone() == false then -- A Crisis in the Making + ITEM: Quest Offer
+    elseif crisisstatus == QUEST_AVAILABLE and player:getFameLevel(xi.quest.fame_area.WINDURST) >= 2 and not player:needToZone() then -- A Crisis in the Making + ITEM: Quest Offer
         player:startEvent(258, 0, 625)
     elseif crisisstatus == QUEST_ACCEPTED then
         local prog = player:getCharVar("QuestCrisisMaking_var")
@@ -52,7 +52,7 @@ entity.onTrigger = function(player, npc)
         elseif prog == 2 then -- A Crisis in the Making: Quest Finish
             player:startEvent(267)
         end
-    elseif crisisstatus == QUEST_COMPLETED and player:needToZone() == false and player:getCharVar("QuestCrisisMaking_var") == 0 then  -- A Crisis in the Making + ITEM: Repeatable Quest Offer
+    elseif crisisstatus == QUEST_COMPLETED and not player:needToZone() and player:getCharVar("QuestCrisisMaking_var") == 0 then  -- A Crisis in the Making + ITEM: Repeatable Quest Offer
         player:startEvent(259, 0, 625)
     elseif crisisstatus == QUEST_COMPLETED and player:getCharVar("QuestCrisisMaking_var") == 1 then  -- A Crisis in the Making: Quest Objective Reminder
         player:startEvent(262, 0, 625)

--- a/scripts/zones/Windurst_Woods/npcs/AMAN_Liaison.lua
+++ b/scripts/zones/Windurst_Woods/npcs/AMAN_Liaison.lua
@@ -16,7 +16,7 @@ entity.onTrigger = function(player, npc)
 
     if firstStepForwardCompleted and assistChannelCompleted then
         player:startEvent(980)
-    elseif firstStepForwardCompleted == false then
+    elseif not firstStepForwardCompleted then
         player:startEvent(981)
     elseif assistChannelProgress == nil then
         player:startEvent(981, 128)

--- a/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Fhelm_Jobeizat.lua
@@ -19,7 +19,7 @@ end
 entity.onTrigger = function(player, npc)
     if player:getEminenceProgress(1) then
         player:startEvent(848, 0, player:getGil())
-    elseif player:hasKeyItem(xi.ki.MEMORANDOLL) == false then
+    elseif not player:hasKeyItem(xi.ki.MEMORANDOLL) then
         player:startEvent(849)
     else
         player:triggerRoeEvent(xi.roe.triggers.talkToRoeNpc)

--- a/scripts/zones/Windurst_Woods/npcs/Kopua-Mobua_AMAN.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopua-Mobua_AMAN.lua
@@ -11,11 +11,11 @@ end
 
 entity.onTrigger = function(player, npc)
     local var = 0
-    if player:getMentor() == false then
+    if not player:getMentor() then
         if player:getMainLvl() >= 30 and player:getPlaytime() >= 648000 then
             var = 1
         end
-    elseif player:getMentor() == true then
+    elseif player:getMentor() then
         var = 2
     end
     player:startEvent(10026, var)

--- a/tools/ci/check_lua_binding_usage.py
+++ b/tools/ci/check_lua_binding_usage.py
@@ -78,7 +78,6 @@ def main():
     function_names.append("onBattlefieldLoss")
     function_names.append("onBattlefieldWipe")
     function_names.append("handleWipe")
-    function_names.append("needsToZone")
     function_names.append("unsetVarBit")
     function_names.append("addVar")
     function_names.append("getLocaLVar")


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes instances of comparing variables and functions to `true` or `false` in preparation for a CI requirement.  Functions that return bool, and boolean variables should be named appropriately to be readable using `not` or, in the case of true, by itself.

Example:
`if not player:hasKeyItem(...)` is preferred over `if player:hasKeyItem(...) == true`

Search pattern: `== true|== false|~= true|~= false`
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed
<!-- Clear and detailed steps to test your changes here -->
