### PR TITLE
Add Red Ghost (A) functions

### DIFF
--- a/scripts/zones/Abyssea-Attohwa/npcs/Red_Ghost.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/Red_Ghost.lua
@@ -1,0 +1,21 @@
+--------------------------------------------
+-- NPC: Red Ghost
+-- Zone: Abyssea - Attohwa
+-- !pos 23 -0.744 126 215
+--------------------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    player:startEvent(389)
+end
+
+entity.onEventUpdate = function(player, csid, option, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+end
+
+return entity


### PR DESCRIPTION
Adds Red Ghosts ability to move players to the top level where conflux 8 is at.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adds Red Ghosts ability to move players to the top level where conflux 8 is at.
## Steps to test these changes

go to abyssea - attohwa and use red ghost to get to the top level where conflux 8 is at,
<!-- Clear and detailed steps to test your changes here -->
