### PR TITLE
[core] [lua] [sql] DRG Jump audit + a few other DRG related things

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -3671,6 +3671,7 @@ xi.items =
     ORPHIC_EGG                      = 18256,
     BIBIKI_SEASHELL                 = 18257,
     THROWING_TOMAHAWK               = 18258,
+    ANGON                           = 18259,
     CAESTUS                         = 18263,
     SPHARAI                         = 18264,
     BATARDEAU                       = 18269,

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Dragoon Job Utilities
 -----------------------------------
-require("scripts/globals/settings")
 require("scripts/globals/ability")
-require("scripts/globals/status")
-require("scripts/globals/msg")
-require("scripts/globals/weaponskills")
+require("scripts/globals/items")
 require("scripts/globals/jobpoints")
+require("scripts/globals/msg")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/weaponskills")
 -----------------------------------
 xi = xi or {}
 xi.job_utils = xi.job_utils or {}
@@ -165,10 +166,10 @@ end
 xi.job_utils.dragoon.abilityCheckAngon = function(player, target, ability)
     local id = player:getEquipID(xi.slot.AMMO)
 
-    if id == 18259 then
+    if id == xi.items.ANGON then
         return 0, 0
     else
-        return xi.msg.basic.UNABLE_TO_USE_JA, 0
+        return xi.msg.basic.CANNOT_PERFORM, 0
     end
 end
 

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -16,14 +16,12 @@ xi.job_utils.dragoon = xi.job_utils.dragoon or {}
 
 -- Returns a table of WS Parameters common to all damage-dealing jumps
 local function getJumpWSParams(player, atkMultiplier, tpMultiplier)
-    local ftp = 1 + (player:getStat(xi.mod.VIT) / 256)
-
     local params =
     {
         numHits = 1,
-        ftp100 = ftp,
-        ftp200 = ftp,
-        ftp300 = ftp,
+        ftp100  = 1,
+        ftp200  = 1,
+        ftp300  = 1,
 
         str_wsc = 0.0,
         dex_wsc = 0.0,
@@ -77,7 +75,7 @@ end
 -- Generic Function for damage-based Jumps
 local function performWSJump(player, target, action, params)
     local taChar = player:getTrickAttackChar(target)
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, params, 0, action, true, taChar)
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, params, 1000, action, true, taChar)
     local totalHits = tpHits + extraHits
 
     if totalHits > 0 then
@@ -222,7 +220,14 @@ end
 
 xi.job_utils.dragoon.useJump = function(player, target, ability, action)
     local atkMultiplier = (player:getMod(xi.mod.JUMP_ATT_BONUS) + 100) / 100
-    local params = getJumpWSParams(player, atkMultiplier, nil)
+    local params = getJumpWSParams(player, atkMultiplier, 0)
+
+    -- Only "Jump" and not others get the fTP VIT bonus
+    local ftp = 1 + (player:getStat(xi.mod.VIT) / 256)
+    params.ftp100 = ftp
+    params.ftp200 = ftp
+    params.ftp300 = ftp
+
     local damage, totalHits = performWSJump(player, target, action, params)
 
     -- Under Spirit Surge, Jump also decreases target defense by 20% for 60 seconds
@@ -401,7 +406,7 @@ end
 
 xi.job_utils.dragoon.useSpiritJump = function(player, target, ability, action)
     local atkMultiplier = (player:getMod(xi.mod.JUMP_ATT_BONUS) + 100) / 100
-    local params = getJumpWSParams(player, atkMultiplier, nil)
+    local params = getJumpWSParams(player, atkMultiplier, 0)
     local damage, _ = performWSJump(player, target, action, params)
 
     -- Reduce 99% of total accumulated enmity

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -15,7 +15,7 @@ xi.job_utils.dragoon = xi.job_utils.dragoon or {}
 -----------------------------------
 
 -- Returns a table of WS Parameters common to all damage-dealing jumps
-local function getJumpWSParams(player, atkMultiplier, tpMultiplier)
+local function getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
     local params =
     {
         numHits = 1,
@@ -44,12 +44,14 @@ local function getJumpWSParams(player, atkMultiplier, tpMultiplier)
         atk200 = atkMultiplier,
         atk300 = atkMultiplier,
 
-        bonusTP = player:getMod(xi.mod.JUMP_TP_BONUS),
-        targetTPMult = tpMultiplier,
+        bonusTP = 0,
+        targetTPMult = 0,
+        attackerTPMult = tpMultiplier,
         hitsHigh = true,
+        isJump = true,
     }
 
-    if player:getMod(xi.mod.FORCE_JUMP_CRIT) > 0 then
+    if player:getMod(xi.mod.FORCE_JUMP_CRIT) > 0 or forceCrit then
         params.crit100 = 1.0
         params.crit200 = 1.0
         params.crit300 = 1.0
@@ -73,23 +75,51 @@ local function hasWyvern(player)
 end
 
 -- Generic Function for damage-based Jumps
-local function performWSJump(player, target, action, params)
+local function performWSJump(player, target, action, params, abilityID)
     local taChar = player:getTrickAttackChar(target)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, params, 1000, action, true, taChar)
     local totalHits = tpHits + extraHits
+    local specEffect = 0x00
 
     if totalHits > 0 then
-        if criticalHit then
-            action:speceffect(target:getID(), 38)
+
+        if target:getHP() <= 0 then
+            specEffect = bit.bor(specEffect, 0x01) -- Add in "killed target" bit
         end
 
+        if criticalHit then -- set crit bit
+            specEffect = bit.bor(specEffect, 0x02)
+        end
+
+        if abilityID == xi.jobAbility.SOUL_JUMP or abilityID == xi.jobAbility.SPIRIT_JUMP then
+            specEffect = bit.bor(specEffect, 0x04) -- Add in Soul/Spirit bit
+        end
+
+        -- TODO: process additional effects such as Delphinius, Pteroslaver Mail +2/3, Hebo's Spear, enspells, other weapon built-in add effects
+
+        action:speceffect(target:getID(), specEffect)
         action:messageID(target:getID(), xi.msg.basic.USES_JA_TAKE_DAMAGE)
-        action:speceffect(target:getID(), 32)
     else
         action:messageID(target:getID(), xi.msg.basic.JA_MISS_2)
-        action:speceffect(target:getID(), 0)
+        action:speceffect(target:getID(), specEffect)
     end
 
+    -- Jumps add JUMP_TP_BONUS regardless of 0 dmg or miss and is affected by Store TP but not the target's subtle blow
+    local storeTPModifier = (100 + player:getMod(xi.mod.STORETP)) / 100
+    local extraTP = player:getMod(xi.mod.JUMP_TP_BONUS)
+
+    -- Spirit jump specific TP bonus
+    if abilityID == xi.jobAbility.SPIRIT_JUMP then
+        extraTP = extraTP + player:getMod(xi.mod.JUMP_SPIRIT_TP_BONUS)
+    end
+
+    player:addTP(math.floor(extraTP * storeTPModifier))
+
+    -- https://www.bg-wiki.com/ffxi/Fly_High_(Ability)
+    if player:hasStatusEffect(xi.effect.FLY_HIGH) then
+        local flyHighJumpRecast = 10
+        action:setRecast(flyHighJumpRecast)
+    end
     return damage, totalHits
 end
 
@@ -194,7 +224,7 @@ xi.job_utils.dragoon.useSpiritSurge = function(player, target, ability)
 
     target:despawnPet()
 
-    -- All Jump recast times are reset
+    -- All Jump recast times are reset, but not Spirit/Soul jump
     target:resetRecast(xi.recast.ABILITY, 158) -- Jump
     target:resetRecast(xi.recast.ABILITY, 159) -- High Jump
     target:resetRecast(xi.recast.ABILITY, 160) -- Super Jump
@@ -220,7 +250,7 @@ end
 
 xi.job_utils.dragoon.useJump = function(player, target, ability, action)
     local atkMultiplier = (player:getMod(xi.mod.JUMP_ATT_BONUS) + 100) / 100
-    local params = getJumpWSParams(player, atkMultiplier, 0)
+    local params = getJumpWSParams(player, atkMultiplier, 1, false)
 
     -- Only "Jump" and not others get the fTP VIT bonus
     local ftp = 1 + (player:getStat(xi.mod.VIT) / 256)
@@ -228,7 +258,7 @@ xi.job_utils.dragoon.useJump = function(player, target, ability, action)
     params.ftp200 = ftp
     params.ftp300 = ftp
 
-    local damage, totalHits = performWSJump(player, target, action, params)
+    local damage, totalHits = performWSJump(player, target, action, params, ability:getID())
 
     -- Under Spirit Surge, Jump also decreases target defense by 20% for 60 seconds
     if
@@ -335,8 +365,8 @@ xi.job_utils.dragoon.useSpiritLink = function(player, target, ability)
 end
 
 xi.job_utils.dragoon.useHighJump = function(player, target, ability, action)
-    local params = getJumpWSParams(player, 1, 0)
-    local damage, totalHits = performWSJump(player, target, action, params)
+    local params = getJumpWSParams(player, 1, 1, false)
+    local damage, totalHits = performWSJump(player, target, action, params, ability:getID())
 
     if target:isMob() then
         local enmityShed = 50
@@ -352,7 +382,8 @@ xi.job_utils.dragoon.useHighJump = function(player, target, ability, action)
         player:hasStatusEffect(xi.effect.SPIRIT_SURGE)
     then
         -- Under Spirit Surge, High Jump reduces TP of target
-        target:delTP(damage * 0.2)
+        -- https://www.bg-wiki.com/ffxi/Spirit_Surge
+        target:delTP(damage * 2)
     end
 
     return damage
@@ -406,25 +437,40 @@ end
 
 xi.job_utils.dragoon.useSpiritJump = function(player, target, ability, action)
     local atkMultiplier = (player:getMod(xi.mod.JUMP_ATT_BONUS) + 100) / 100
-    local params = getJumpWSParams(player, atkMultiplier, 0)
-    local damage, _ = performWSJump(player, target, action, params)
+    atkMultiplier = atkMultiplier + (player:getMod(xi.mod.JUMP_SOUL_SPIRIT_ATT_BONUS)) / 100
 
-    -- Reduce 99% of total accumulated enmity
-    if target:isMob() then
-        target:lowerEnmity(player, 99)
+    local tpMultiplier = 1
+    local forceCrit = false
+
+    -- https://www.bg-wiki.com/ffxi/Spirit_Jump
+    if hasWyvern(player) then
+        tpMultiplier = 2
+        atkMultiplier = atkMultiplier + 0.25
+        forceCrit = true
     end
+
+    local params = getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
+    local damage, _ = performWSJump(player, target, action, params, ability:getID())
 
     return damage
 end
 
 xi.job_utils.dragoon.useSoulJump = function(player, target, ability, action)
-    local params = getJumpWSParams(player, 1, 0)
-    local damage, _ = performWSJump(player, target, action, params)
+    local atkMultiplier = (player:getMod(xi.mod.JUMP_ATT_BONUS) + 100) / 100
+    atkMultiplier = atkMultiplier + (player:getMod(xi.mod.JUMP_SOUL_SPIRIT_ATT_BONUS)) / 100
 
-    -- Reduce 99% of total accumulated enmity
-    if target:isMob() then
-        target:lowerEnmity(player, 99)
+    local tpMultiplier = 1
+    local forceCrit = false
+
+    -- https://www.bg-wiki.com/ffxi/Soul_Jump
+    if hasWyvern(player) then
+        tpMultiplier = 3
+        atkMultiplier = atkMultiplier + 0.5
+        forceCrit = true
     end
+
+    local params = getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
+    local damage, _ = performWSJump(player, target, action, params, ability:getID())
 
     return damage
 end
@@ -434,5 +480,12 @@ xi.job_utils.dragoon.useDragonBreaker = function(player, target, ability)
 end
 
 xi.job_utils.dragoon.useFlyHigh = function(player, target, ability)
+    -- All Jump recast times are reset
+    target:resetRecast(xi.recast.ABILITY, 158) -- Jump
+    target:resetRecast(xi.recast.ABILITY, 159) -- High Jump
+    target:resetRecast(xi.recast.ABILITY, 160) -- Super Jump
+    target:resetRecast(xi.recast.ABILITY, 166) -- Spirit Jump
+    target:resetRecast(xi.recast.ABILITY, 167) -- Soul Jump
+
     player:addStatusEffect(xi.effect.FLY_HIGH, 14, 0, 30)
 end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1361,9 +1361,13 @@ xi.mod =
     STEALTH                         = 358,
     RAPID_SHOT                      = 359,
     CHARM_TIME                      = 360,
-    JUMP_TP_BONUS                   = 361,
-    JUMP_ATT_BONUS                  = 362,
-    HIGH_JUMP_ENMITY_REDUCTION      = 363,
+    JUMP_TP_BONUS                   = 361,  -- bonus tp player receives when using jump
+    JUMP_SPIRIT_TP_BONUS            = 285,  -- bonus tp player receives when using jump for spirit jump only
+    JUMP_ATT_BONUS                  = 362,  -- ATT% bonus for all jumps
+    JUMP_SOUL_SPIRIT_ATT_BONUS      = 286,  -- ATT% bonus for Soul & Spirit jump only
+    JUMP_ACC_BONUS                  = 936,  -- accuracy bonus for all jumps
+    JUMP_DOUBLE_ATTACK              = 888,  -- DA% bonus for all jumps
+    HIGH_JUMP_ENMITY_REDUCTION      = 363,  -- for gear that reduces more enmity from high jump
     REWARD_HP_BONUS                 = 364,
     SNAP_SHOT                       = 365,
 
@@ -1648,7 +1652,7 @@ xi.mod =
     AUGMENTS_AURA_STEAL             = 889, -- 20% chance of 2 effects to be dispelled or stolen per merit level
     AUGMENTS_CONSPIRATOR            = 912, -- Applies Conspirator benefits to player at the top of the hate list
     JUG_LEVEL_RANGE                 = 564, -- Decreases the level range of spawned jug pets. Maxes out at 2.
-    FORCE_JUMP_CRIT                 = 828, -- Critical hit rate bonus for jump and high jump
+    FORCE_JUMP_CRIT                 = 828, -- Force critical hit for all jumps
     QUICK_DRAW_DMG_PERCENT          = 834, -- Percentage increase to QD damage
 
     -- Crafting food effects

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -903,7 +903,9 @@ function takeWeaponskillDamage(defender, attacker, wsParams, primaryMsg, attack,
     end
 
     local targetTPMult = wsParams.targetTPMult or 1
-    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult)
+    local attackerTPMult = wsParams.attackerTPMult or 1
+
+    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult)
     if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then
         if finaldmg >= 0 then
             action:param(defender:getID(), math.abs(finaldmg))

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -165,7 +165,8 @@ local function accVariesWithTP(hitrate, acc, tp, a1, a2, a3)
     return hrate
 end
 
-local function getMultiAttacks(attacker, target, numHits)
+local function getMultiAttacks(attacker, target, wsParams)
+    local numHits = wsParams.numHits
     local bonusHits = 0
     local multiChances = 1
     local doubleRate = (attacker:getMod(xi.mod.DOUBLE_ATTACK) + attacker:getMerit(xi.merit.DOUBLE_ATTACK_RATE)) / 100
@@ -173,6 +174,12 @@ local function getMultiAttacks(attacker, target, numHits)
     local quadRate = attacker:getMod(xi.mod.QUAD_ATTACK) / 100
     local oaThriceRate = attacker:getMod(xi.mod.MYTHIC_OCC_ATT_THRICE) / 100
     local oaTwiceRate = attacker:getMod(xi.mod.MYTHIC_OCC_ATT_TWICE) / 100
+
+    local isJump = wsParams.isJump or false
+
+    if isJump then
+        doubleRate = doubleRate + attacker:getMod(xi.mod.JUMP_DOUBLE_ATTACK)
+    end
 
     -- Add Ambush Augments to Triple Attack
     if attacker:hasTrait(76) and attacker:isBehind(target, 23) then -- TRAIT_AMBUSH
@@ -593,7 +600,7 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
     -- Calculate additional hits if a multiHit WS (or we're supposed to get a DA/TA/QA proc from main hit)
     dmg = mainBase * ftp
     local hitsDone = 1
-    local numHits = getMultiAttacks(attacker, target, wsParams.numHits)
+    local numHits = getMultiAttacks(attacker, target, wsParams)
 
     while hitsDone < numHits and finaldmg < targetHp do -- numHits is hits in the base WS _and_ DA/TA/QA procs during those hits
         hitdmg, calcParams = getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
@@ -675,9 +682,18 @@ function doPhysicalWeaponskill(attacker, target, wsID, wsParams, tp, action, pri
     calcParams.flourishEffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
     calcParams.fencerBonus = fencerBonus(attacker)
     calcParams.bonusTP = wsParams.bonusTP or 0
-    calcParams.bonusfTP = gorgetBeltFTP or 0
-    calcParams.bonusAcc = (gorgetBeltAcc or 0) + attacker:getMod(xi.mod.WSACC)
-    calcParams.bonusWSmods = wsParams.bonusWSmods or 0
+
+    local isJump = wsParams.isJump or false
+    if isJump then
+        calcParams.bonusfTP = 0
+        calcParams.bonusAcc = attacker:getMod(xi.mod.JUMP_ACC_BONUS)
+        calcParams.bonusWSmods = 0
+    else
+        calcParams.bonusfTP = gorgetBeltFTP or 0
+        calcParams.bonusAcc = (gorgetBeltAcc or 0) + attacker:getMod(xi.mod.WSACC)
+        calcParams.bonusWSmods = wsParams.bonusWSmods or 0
+    end
+
     calcParams.hitRate = getHitRate(attacker, target, false, calcParams.bonusAcc)
     calcParams.skillType = attack.weaponType
 
@@ -904,6 +920,13 @@ function takeWeaponskillDamage(defender, attacker, wsParams, primaryMsg, attack,
 
     local targetTPMult = wsParams.targetTPMult or 1
     local attackerTPMult = wsParams.attackerTPMult or 1
+    local isJump = wsParams.isJump or false
+
+    -- DA/TA/QA/OaT/Oa2-3 etc give full TP return per hit on Jumps
+    if isJump then
+        attackerTPMult = attackerTPMult * (wsResults.tpHitsLanded + wsResults.extraHitsLanded)
+        wsResults.extraHitsLanded = 0
+    end
 
     finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult)
     if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -259,6 +259,8 @@ uint16 CAbility::getAoEMsg() const
 {
     switch (m_message)
     {
+        case 150: // Ancient Circle
+            return m_message + 1;
         case 185:
             return 264;
         case 186:

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1484,9 +1484,11 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
                 if (value < 0)
                 {
-                    actionTarget.messageID = ability::GetAbsorbMessage(prevMsg);
+                    actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
                     actionTarget.param     = -actionTarget.param;
                 }
+
+                prevMsg = actionTarget.messageID;
 
                 state.ApplyEnmity();
             }

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -173,9 +173,11 @@ void CTrustEntity::OnAbility(CAbilityState& state, action_t& action)
 
                 if (value < 0)
                 {
-                    actionTarget.messageID = ability::GetAbsorbMessage(prevMsg);
+                    actionTarget.messageID = ability::GetAbsorbMessage(actionTarget.messageID);
                     actionTarget.param     = -actionTarget.param;
                 }
+
+                prevMsg = actionTarget.messageID;
 
                 state.ApplyEnmity();
             }

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -465,10 +465,14 @@ enum class Mod
 
     // Dragoon
     ANCIENT_CIRCLE_DURATION    = 859,  // Ancient Circle extended duration in seconds
-    JUMP_TP_BONUS              = 361,  // bonus tp player receives when using jump (must be divided by 10)
-    JUMP_ATT_BONUS             = 362,  // ATT% bonus for jump + high jump
+    JUMP_TP_BONUS              = 361,  // bonus tp player receives when using jump
+    JUMP_SPIRIT_TP_BONUS       = 285,  // bonus tp player receives when using jump for spirit jump only
+    JUMP_ATT_BONUS             = 362,  // ATT% bonus for all jumps
+    JUMP_SOUL_SPIRIT_ATT_BONUS = 286,  // ATT% bonus for Soul & Spirit jump only
+    JUMP_ACC_BONUS             = 936,  // accuracy bonus for all jumps
+    JUMP_DOUBLE_ATTACK         = 888,  // DA% bonus for all jumps
     HIGH_JUMP_ENMITY_REDUCTION = 363,  // for gear that reduces more enmity from high jump
-    FORCE_JUMP_CRIT            = 828,  // Critical hit rate bonus for jump and high jump
+    FORCE_JUMP_CRIT            = 828,  // Force critical hit for all jumps
     WYVERN_EFFECTIVE_BREATH    = 829,  // Increases the threshold for triggering healing breath/offensive breath more inclined to pick elemental weakness
     WYVERN_SUBJOB_TRAITS       = 974,  // Adds subjob traits to wyvern on spawn
     WYVERN_BREATH_MACC         = 986,  // Increases accuracy of wyvern's breath. adds 10 magic accuracy per merit to the trait Strafe
@@ -925,9 +929,7 @@ enum class Mod
     // 138 to 143
     // 156 to 159
     // 192 to 223
-    // 261 to 286
-    // 888
-    // 936
+    // 261 to 284
     //
     // SPARE = 1071, and onward
 };

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2430,8 +2430,8 @@ namespace battleutils
             if (primary)
             // Calculate TP Return from WS
             {
-                standbyTp = ((int16)(((tpMultiplier * baseTp) + bonusTP) *
-                                     (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
+                standbyTp = bonusTP + ((int16)((tpMultiplier * baseTp) *
+                                               (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
             }
 
             // account for attacker's subtle blow which reduces the baseTP gain for the defender


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

dragoon.lua:
   * Implement Soul/Spirit jump force crit, attack bonus, extra TP when Wyvern is out
    * Update specEffect to match retail bits with retail testing
    * Move Jump TP bonus to performWSJump, instead of feeding it through the weaponskill system
    * Fly High now properly resets Jump timers
    * When jumps are used with Fly High active, their timers are set to 10 seconds.
    * Correct Spirit Surge high jump to reduce TP of target by damage * 2, not damage * .02
    * Remove enmity removal from Soul/Spirit jump (they are just 1 CE & 0 VE actions)
    * Fix jump fTP VIT bonus not applying correctly
    * Add various mods:
    ** Spirit Jump TP bonus
    ** Soul & Spirit Jump Attack Bonus
    ** Jump accuracy bonus
    ** Jump Double Attack bonus
    
weaponskills.lua:
* Add better support for Jumps
    * Gives full TP return to every hit of a jump
    * Add Jump Double attack support
    * Add Jump Accuracy support

A few message updates for Ancient Circle, fix AoE messages on JA that depended on CAbility::getAoEMsg()
Fix logspam when Jump is used
Correct Angon message when angon isn't equipped to match retail, remove magic number for Angon
Add AoE message case for Ancient Circle
Fix extra TP gain from hits that doesn't match retail during weaponskills

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Test Jump TP bonus:
!setmod STORETP 34
!setmod JUMP_TP_BONUS 71
!setmod JUMP_SPIRIT_TP_BONUS 70

with a 492 delay weapon:
* Spirit Jump should return exactly 555 tp on a single hit with your wyvern out, and 371 without
* Soul Jump should return exactly 645 tp on a single hit with your wyvern out, and 278 without
* Jump and High Jump should return 278 tp on a single hit

Test Jump Double Attack:
set mods above
!setmod JUMP_DOUBLE_ATTACK 100
* Spirit Jump should return exactly 922 tp on a DA with your wyvern out, and 555 without
* Soul Jump should return exactly 1195 tp on a DA with your wyvern out, and 426 without
* Jump and High jump should return exactly 426 TP

Test Fly High:
use all jump timers, use fly high, see them all reset
use jumps, see all jumps have a timer of 10s during duration of fly high

Test Jump VIT bonus:
!setmod VIT 999
use normal jump, see it do ludicrous damage compared to high jump which does not have the fTP bonus

Ancient Circle aoe message should look as follows:
![image](https://user-images.githubusercontent.com/60417494/200198078-2ade8355-ca55-451f-a6d8-b5c0f81efd46.png)
