### PR TITLE
Pet Level Restriction Interactions

### DIFF
--- a/sql/char_stats.sql
+++ b/sql/char_stats.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS `char_stats` (
   `slvl` tinyint(2) unsigned NOT NULL DEFAULT '1',
   `pet_id` smallint(3) unsigned NOT NULL DEFAULT '0',
   `pet_type` smallint(3) unsigned NOT NULL DEFAULT '0',
+  `pet_level` smallint(3) unsigned NOT NULL DEFAULT '0',
   `pet_hp` smallint(4) unsigned NOT NULL DEFAULT '0',
   `pet_mp` smallint(4) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`charid`)

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -579,14 +579,6 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             // allies targid >= 0x700
             if (PEntity->targid >= 0x700)
             {
-                if (auto* PPetEntity = dynamic_cast<CPetEntity*>(PEntity))
-                {
-                    if (PPetEntity->isAlive() && PPetEntity->PAI->IsSpawned())
-                    {
-                        PPetEntity->Die();
-                    }
-                }
-
                 if (auto* PMobEntity = dynamic_cast<CMobEntity*>(PEntity))
                 {
                     if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
@@ -594,11 +586,6 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                         m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                     }
                 }
-
-                PEntity->status = STATUS_TYPE::DISAPPEAR;
-                // Remove from battlefield so the dynamic entity can cleanup and clear it's dynamic entity ID
-                PEntity->PBattlefield = nullptr;
-                return found;
             }
             else
             {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -173,6 +173,7 @@ struct PetInfo_t
     bool     respawnPet; // used for spawning pet on zone
     uint8    petID;      // id as in wyvern(48) , carbuncle(8) ect..
     PET_TYPE petType;    // type of pet being transfered
+    uint8    petLevel;   // level the pet was spawned with
     int16    petHP;      // pets hp
     int16    petMP;
     float    petTP; // pets tp

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -49,6 +49,7 @@ CPetEntity::CPetEntity(PET_TYPE petType)
     allegiance              = ALLEGIANCE_TYPE::PLAYER;
     m_MobSkillList          = 0;
     m_PetID                 = 0;
+    m_spawnLevel            = 0;
     m_IsClaimable           = false;
     m_bReleaseTargIDOnDeath = true;
     spawnAnimation          = SPAWN_ANIMATION::SPECIAL; // Initial spawn has the special spawn-in animation
@@ -61,6 +62,16 @@ CPetEntity::~CPetEntity() = default;
 PET_TYPE CPetEntity::getPetType()
 {
     return m_PetType;
+}
+
+uint8 CPetEntity::getSpawnLevel()
+{
+    return m_spawnLevel;
+}
+
+void CPetEntity::setSpawnLevel(uint8 level)
+{
+    m_spawnLevel = level;
 }
 
 bool CPetEntity::isBstPet()

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -53,6 +53,8 @@ public:
     ~CPetEntity();                // деструктор
 
     PET_TYPE     getPetType();
+    uint8        getSpawnLevel();
+    void         setSpawnLevel(uint8 level);
     bool         isBstPet();
     uint32       m_PetID;
     std::string  GetScriptName();
@@ -66,7 +68,8 @@ public:
     void         OnPetSkillFinished(CPetSkillState& state, action_t& action);
 
 private:
-    PET_TYPE m_PetType; // the type of pet e.g. avatar/wyvern/jugpet etc
+    PET_TYPE m_PetType;    // the type of pet e.g. avatar/wyvern/jugpet etc
+    uint8    m_spawnLevel; // The level the pet was spawned at
 };
 
 #endif

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -663,7 +663,7 @@ namespace charutils
         }
 
         fmtQuery = "SELECT nameflags, mjob, sjob, hp, mp, mhflag, title, bazaar_message, zoning, "
-                   "pet_id, pet_type, pet_hp, pet_mp "
+                   "pet_id, pet_type, pet_hp, pet_mp, pet_level "
                    "FROM char_stats WHERE charid = %u;";
 
         ret          = sql->Query(fmtQuery, PChar->id);
@@ -702,6 +702,7 @@ namespace charutils
                 PChar->petZoningInfo.petID      = sql->GetUIntData(9);
                 PChar->petZoningInfo.petMP      = sql->GetIntData(12);
                 PChar->petZoningInfo.petType    = static_cast<PET_TYPE>(sql->GetUIntData(10));
+                PChar->petZoningInfo.petLevel   = sql->GetUIntData(13);
                 PChar->petZoningInfo.respawnPet = true;
             }
         }
@@ -5051,11 +5052,11 @@ namespace charutils
 
         const char* Query = "UPDATE char_stats "
                             "SET hp = %u, mp = %u, nameflags = %u, mhflag = %u, mjob = %u, sjob = %u, "
-                            "pet_id = %u, pet_type = %u, pet_hp = %u, pet_mp = %u "
+                            "pet_id = %u, pet_type = %u, pet_hp = %u, pet_mp = %u, pet_level = %u "
                             "WHERE charid = %u;";
 
         sql->Query(Query, PChar->health.hp, PChar->health.mp, PChar->nameflags.flags, PChar->profile.mhflag, PChar->GetMJob(), PChar->GetSJob(),
-                   PChar->petZoningInfo.petID, static_cast<uint8>(PChar->petZoningInfo.petType), PChar->petZoningInfo.petHP, PChar->petZoningInfo.petMP, PChar->id);
+                   PChar->petZoningInfo.petID, static_cast<uint8>(PChar->petZoningInfo.petType), PChar->petZoningInfo.petHP, PChar->petZoningInfo.petMP, PChar->petZoningInfo.petLevel, PChar->id);
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -884,6 +884,299 @@ namespace petutils
         }
     }
 
+    void CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        uint32 petID    = PPet->m_PetID;
+        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
+                                        { return t->PetID == petID; });
+
+        uint8 mLvl = PMaster->GetMLevel();
+
+        if (PMaster->GetMJob() == JOB_SMN)
+        {
+            mLvl += PMaster->getMod(Mod::AVATAR_LVL_BONUS);
+
+            if (petID == PETID_CARBUNCLE)
+            {
+                mLvl += PMaster->getMod(Mod::CARBUNCLE_LVL_BONUS);
+            }
+            else if (petID == PETID_CAIT_SITH)
+            {
+                mLvl += PMaster->getMod(Mod::CAIT_SITH_LVL_BONUS);
+            }
+            PPet->SetMLevel(mLvl);
+        }
+        else if (PMaster->GetSJob() == JOB_SMN)
+        {
+            PPet->SetMLevel(PMaster->GetSLevel());
+        }
+        else
+        { // should never happen
+            ShowDebug("%s summoned an avatar but is not SMN main or SMN sub! Please report. ", PMaster->GetName());
+            PPet->SetMLevel(1);
+        }
+
+        LoadAvatarStats(PMaster, PPet); // follows PC calcs (w/o SJ)
+
+        PPet->m_SpellListContainer = mobSpellList::GetMobSpellList(PPetData->spellList);
+
+        PPet->setModifier(Mod::DMGPHYS, -5000); //-50% PDT
+
+        PPet->setModifier(Mod::CRIT_DMG_INCREASE, 8); // Avatars have Crit Att Bonus II for +8 crit dmg
+
+        if (mLvl >= 70)
+        {
+            PPet->setModifier(Mod::MATT, 32);
+        }
+        else if (mLvl >= 50)
+        {
+            PPet->setModifier(Mod::MATT, 28);
+        }
+        else if (mLvl >= 30)
+        {
+            PPet->setModifier(Mod::MATT, 24);
+        }
+        else if (mLvl >= 10)
+        {
+            PPet->setModifier(Mod::MATT, 20);
+        }
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
+
+        if (petID == PETID_FENRIR)
+        {
+            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0 * (280.0f / 60.0f))));
+        }
+
+        // In a 2014 update SE updated Avatar base damage
+        // Based on testing this value appears to be Level now instead of Level * 0.74f
+        uint16 weaponDamage = 1 + mLvl;
+        if (petID == PETID_CARBUNCLE || petID == PETID_CAIT_SITH)
+        {
+            weaponDamage = static_cast<uint16>(floor(mLvl * 0.9f));
+        }
+
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage(weaponDamage);
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (PPetData->cmbDelay / 60.0f))));
+        // Set B+ weapon skill (assumed capped for level derp)
+        // attack is madly high for avatars (roughly x2)
+        PPet->setModifier(Mod::ATT, 2 * battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, mLvl > 99 ? 99 : mLvl));
+        PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, mLvl > 99 ? 99 : mLvl));
+        // Set E evasion and def
+        PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_THROWING, JOB_WHM, mLvl > 99 ? 99 : mLvl));
+        PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_THROWING, JOB_WHM, mLvl > 99 ? 99 : mLvl));
+        // cap all magic skills so they play nice with spell scripts
+        for (int i = SKILL_DIVINE_MAGIC; i <= SKILL_BLUE_MAGIC; i++)
+        {
+            uint16 maxSkill = battleutils::GetMaxSkill((SKILLTYPE)i, PPet->GetMJob(), mLvl > 99 ? 99 : mLvl);
+            if (maxSkill != 0)
+            {
+                PPet->WorkingSkills.skill[i] = maxSkill;
+            }
+            else // if the mob is WAR/BLM and can cast spell
+            {
+                // set skill as high as main level, so their spells won't get resisted
+                uint16 maxSubSkill = battleutils::GetMaxSkill((SKILLTYPE)i, PPet->GetSJob(), mLvl > 99 ? 99 : mLvl);
+
+                if (maxSubSkill != 0)
+                {
+                    PPet->WorkingSkills.skill[i] = maxSubSkill;
+                }
+            }
+        }
+
+        if (PMaster->objtype == TYPE_PC)
+        {
+            CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
+            PPet->addModifier(Mod::MATT, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_MAGICAL_ATTACK, PChar));
+            PPet->addModifier(Mod::ATT, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_PHYSICAL_ATTACK, PChar));
+            PPet->addModifier(Mod::MACC, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_MAGICAL_ACCURACY, PChar));
+            PPet->addModifier(Mod::ACC, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_PHYSICAL_ACCURACY, PChar));
+
+            PPet->addModifier(Mod::ACC, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_ACC_BONUS));
+            PPet->addModifier(Mod::MACC, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_MAGIC_ACC_BONUS));
+            PPet->addModifier(Mod::ATT, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_PHYS_ATK_BONUS) * 2);
+            PPet->addModifier(Mod::MAGIC_DAMAGE, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_MAGIC_DMG_BONUS) * 5);
+            PPet->addModifier(Mod::BP_DAMAGE, PChar->PJobPoints->GetJobPointValue(JP_BLOOD_PACT_DMG_BONUS) * 3);
+        }
+
+        PMaster->setModifier(Mod::AVATAR_PERPETUATION, PerpetuationCost(petID, mLvl));
+
+        FinalizePetStatistics(PMaster, PPet);
+    }
+
+    void CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        // set the wyvern job based on master's SJ
+        if (PMaster->GetSJob() != JOB_NON)
+        {
+            PPet->SetSJob(PMaster->GetSJob());
+        }
+
+        PPet->SetMJob(JOB_DRG);
+        // https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#About_the_Wyvern
+        uint8 mLvl = PMaster->GetMLevel();
+        uint8 iLvl = std::clamp(charutils::getMainhandItemLevel(static_cast<CCharEntity*>(PMaster)) - 99, 0, 20);
+
+        PPet->SetMLevel(mLvl + iLvl + PMaster->getMod(Mod::WYVERN_LVL_BONUS));
+
+        LoadAvatarStats(PMaster, PPet);                                                                               // follows PC calcs (w/o SJ)
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); // 320 delay
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(1 + floor(mLvl * 0.9f)));
+        // Set A+ weapon skill
+        PPet->setModifier(Mod::ATT, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+        PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+        // Set D evasion and def
+        PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+        PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
+
+        // Job Point: Wyvern Max HP
+        if (PMaster->objtype == TYPE_PC)
+        {
+            uint8 jpValue = static_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_WYVERN_MAX_HP_BONUS);
+            if (jpValue > 0)
+            {
+                PPet->addModifier(Mod::HP, jpValue * 10);
+            }
+
+            if (PMaster->GetMJob() == JOBTYPE::JOB_DRG)
+            {
+                PPet->addModifier(Mod::ACC, PMaster->getMod(Mod::PET_ACC_EVA));
+                PPet->addModifier(Mod::EVA, PMaster->getMod(Mod::PET_ACC_EVA));
+                PPet->addModifier(Mod::MACC, PMaster->getMod(Mod::PET_MACC_MEVA));
+                PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
+            }
+        }
+
+        FinalizePetStatistics(PMaster, PPet);
+    }
+
+    void CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        uint32 petID    = PPet->m_PetID;
+        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
+                                        { return t->PetID == petID; });
+
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
+        // Get the Jug pet cap level
+        uint8 highestLvl = PPetData->maxLevel;
+
+        // Increase the pet's level cal by the bonus given by BEAST AFFINITY merits.
+        CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
+        highestLvl += PChar->PMeritPoints->GetMeritValue(MERIT_BEAST_AFFINITY, PChar);
+
+        // And cap it to the master's level or weapon ilvl, whichever is greater
+        auto capLevel = std::max(PMaster->GetMLevel(), PMaster->m_Weapons[SLOT_MAIN]->getILvl());
+        if (highestLvl > capLevel)
+        {
+            highestLvl = capLevel;
+        }
+
+        // Randomize: 0-2 lvls lower, less Monster Gloves(+1/+2) bonus
+        highestLvl -= xirand::GetRandomNumber(3 - std::clamp<int16>(PChar->getMod(Mod::JUG_LEVEL_RANGE), 0, 2));
+
+        PPet->SetMLevel(std::min(PPet->getSpawnLevel(), highestLvl));
+        LoadJugStats(PPet, PPetData); // follow monster calcs (w/o SJ)
+
+        FinalizePetStatistics(PMaster, PPet);
+    }
+
+    void CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
+        switch (PAutomaton->getFrame())
+        {
+            default: // case FRAME_HARLEQUIN:
+                PPet->SetMJob(JOB_WAR);
+                PPet->SetSJob(JOB_RDM);
+                break;
+            case FRAME_VALOREDGE:
+                PPet->SetMJob(JOB_PLD);
+                PPet->SetSJob(JOB_WAR);
+                break;
+            case FRAME_SHARPSHOT:
+                PPet->SetMJob(JOB_RNG);
+                PPet->SetSJob(JOB_PUP);
+                break;
+            case FRAME_STORMWAKER:
+                PPet->SetMJob(JOB_RDM);
+                PPet->SetSJob(JOB_WHM);
+                break;
+        }
+
+        // TEMP: should be MLevel when unsummoned, and PUP level when summoned
+        uint8 mainLevel = PMaster->GetMJob() == JOB_PUP ? PMaster->GetMLevel() + PMaster->getMod(Mod::AUTOMATON_LVL_BONUS) : PMaster->GetSLevel();
+        PPet->SetMLevel(mainLevel);
+        PPet->SetSLevel(mainLevel / 2); // Todo: SetSLevel() already reduces the level?
+
+        LoadAutomatonStats(static_cast<CCharEntity*>(PMaster), PPet, g_PPetList.at(PPet->m_PetID)); // temp
+
+        if (PMaster->objtype == TYPE_PC)
+        {
+            CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
+            PPet->addModifier(Mod::ATTP, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
+            PPet->addModifier(Mod::DEFP, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
+            PPet->addModifier(Mod::MATT, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
+            PPet->addModifier(Mod::ACC, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
+            PPet->addModifier(Mod::RACC, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
+            PPet->addModifier(Mod::EVA, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
+            PPet->addModifier(Mod::MDEF, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
+        }
+
+        FinalizePetStatistics(PMaster, PPet);
+    }
+
+    void CalculateLoupanStats(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        PPet->SetMLevel(PMaster->GetMLevel());
+        PPet->health.maxhp = (uint32)floor((250 * PPet->GetMLevel()) / 15);
+
+        if (PMaster->StatusEffectContainer->HasStatusEffect(EFFECT_BOLSTER))
+        {
+            uint8 bolsterJPVal = dynamic_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_BOLSTER_EFFECT);
+            PPet->health.maxhp += (uint32)floor(PPet->health.maxhp * (0.03 * bolsterJPVal));
+        }
+
+        PPet->health.hp = PPet->health.maxhp;
+
+        // This sets the correct visual size for the luopan as pets currently
+        // do not make use of the entity flags in the database
+        // TODO: make pets use entity flags
+        PPet->m_flags = 0x0000008B;
+        // Just sit, do nothing
+        PPet->speed = 0;
+
+        FinalizePetStatistics(PMaster, PPet);
+    }
+
+    void FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet)
+    {
+        // set C magic evasion
+        PPet->setModifier(Mod::MEVA, battleutils::GetMaxSkill(SKILL_ELEMENTAL_MAGIC, JOB_RDM, PPet->GetMLevel() > 99 ? 99 : PPet->GetMLevel()));
+        PPet->health.tp = 0;
+        PMaster->applyPetModifiers(PPet);
+        PPet->UpdateHealth();
+        PPet->health.hp = PPet->GetMaxHP();
+        PPet->health.mp = PPet->GetMaxMP();
+
+        // Stout Servant - Can't really tie it ot a real mod since it applies to the pet
+        if (CCharEntity* PCharMaster = dynamic_cast<CCharEntity*>(PMaster))
+        {
+            if (charutils::hasTrait(PCharMaster, TRAIT_STOUT_SERVANT))
+            {
+                for (CTrait* trait : PCharMaster->TraitList)
+                {
+                    if (trait->getID() == TRAIT_STOUT_SERVANT)
+                    {
+                        PPet->addModifier(Mod::DMG, -(trait->getValue() * 100));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     /************************************************************************
      *                                                                      *
      *                                                                      *
@@ -1396,10 +1689,8 @@ namespace petutils
         XI_DEBUG_BREAK_IF(PMaster == nullptr);
         XI_DEBUG_BREAK_IF(PetID >= MAX_PETID);
 
-        Pet_t* PPetData = new Pet_t();
-
-        PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)
-                                 { return t->PetID == PetID; });
+        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)
+                                        { return t->PetID == PetID; });
 
         if (PMaster->GetMJob() != JOB_DRG && PetID == PETID_WYVERN)
         {
@@ -1535,301 +1826,35 @@ namespace petutils
         PPet->m_Element = PPetData->m_Element;
         PPet->m_PetID   = PPetData->PetID;
 
-        uint8 spawnLevel = UINT8_MAX;
-        if (spawningFromZone)
-        {
-            spawnLevel = static_cast<uint8>(static_cast<CCharEntity*>(PMaster)->petZoningInfo.petLevel);
-        }
-
         if (PPet->getPetType() == PET_TYPE::AVATAR)
         {
-            uint8 mLvl = PMaster->GetMLevel();
-
-            if (PMaster->GetMJob() == JOB_SMN)
-            {
-                mLvl += PMaster->getMod(Mod::AVATAR_LVL_BONUS);
-
-                if (PetID == PETID_CARBUNCLE)
-                {
-                    mLvl += PMaster->getMod(Mod::CARBUNCLE_LVL_BONUS);
-                }
-                else if (PetID == PETID_CAIT_SITH)
-                {
-                    mLvl += PMaster->getMod(Mod::CAIT_SITH_LVL_BONUS);
-                }
-                PPet->SetMLevel(std::min(spawnLevel, mLvl));
-            }
-            else if (PMaster->GetSJob() == JOB_SMN)
-            {
-                PPet->SetMLevel(std::min(spawnLevel, PMaster->GetSLevel()));
-            }
-            else
-            { // should never happen
-                ShowDebug("%s summoned an avatar but is not SMN main or SMN sub! Please report. ", PMaster->GetName());
-                PPet->SetMLevel(1);
-            }
-
-            LoadAvatarStats(PMaster, PPet); // follows PC calcs (w/o SJ)
-
-            PPet->m_SpellListContainer = mobSpellList::GetMobSpellList(PPetData->spellList);
-
-            PPet->setModifier(Mod::DMGPHYS, -5000); //-50% PDT
-
-            PPet->setModifier(Mod::CRIT_DMG_INCREASE, 8); // Avatars have Crit Att Bonus II for +8 crit dmg
-
-            if (mLvl >= 70)
-            {
-                PPet->setModifier(Mod::MATT, 32);
-            }
-            else if (mLvl >= 50)
-            {
-                PPet->setModifier(Mod::MATT, 28);
-            }
-            else if (mLvl >= 30)
-            {
-                PPet->setModifier(Mod::MATT, 24);
-            }
-            else if (mLvl >= 10)
-            {
-                PPet->setModifier(Mod::MATT, 20);
-            }
-            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
-
-            if (PetID == PETID_FENRIR)
-            {
-                static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0 * (280.0f / 60.0f))));
-            }
-
-            // In a 2014 update SE updated Avatar base damage
-            // Based on testing this value appears to be Level now instead of Level * 0.74f
-            uint16 weaponDamage = 1 + mLvl;
-            if (PetID == PETID_CARBUNCLE || PetID == PETID_CAIT_SITH)
-            {
-                weaponDamage = static_cast<uint16>(floor(mLvl * 0.9f));
-            }
-
-            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage(weaponDamage);
-            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (PPetData->cmbDelay / 60.0f))));
-            // Set B+ weapon skill (assumed capped for level derp)
-            // attack is madly high for avatars (roughly x2)
-            PPet->setModifier(Mod::ATT, 2 * battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, mLvl > 99 ? 99 : mLvl));
-            PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_CLUB, JOB_WHM, mLvl > 99 ? 99 : mLvl));
-            // Set E evasion and def
-            PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_THROWING, JOB_WHM, mLvl > 99 ? 99 : mLvl));
-            PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_THROWING, JOB_WHM, mLvl > 99 ? 99 : mLvl));
-            // cap all magic skills so they play nice with spell scripts
-            for (int i = SKILL_DIVINE_MAGIC; i <= SKILL_BLUE_MAGIC; i++)
-            {
-                uint16 maxSkill = battleutils::GetMaxSkill((SKILLTYPE)i, PPet->GetMJob(), mLvl > 99 ? 99 : mLvl);
-                if (maxSkill != 0)
-                {
-                    PPet->WorkingSkills.skill[i] = maxSkill;
-                }
-                else // if the mob is WAR/BLM and can cast spell
-                {
-                    // set skill as high as main level, so their spells won't get resisted
-                    uint16 maxSubSkill = battleutils::GetMaxSkill((SKILLTYPE)i, PPet->GetSJob(), mLvl > 99 ? 99 : mLvl);
-
-                    if (maxSubSkill != 0)
-                    {
-                        PPet->WorkingSkills.skill[i] = maxSubSkill;
-                    }
-                }
-            }
-
-            if (PMaster->objtype == TYPE_PC)
-            {
-                CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
-                PPet->addModifier(Mod::MATT, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_MAGICAL_ATTACK, PChar));
-                PPet->addModifier(Mod::ATT, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_PHYSICAL_ATTACK, PChar));
-                PPet->addModifier(Mod::MACC, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_MAGICAL_ACCURACY, PChar));
-                PPet->addModifier(Mod::ACC, PChar->PMeritPoints->GetMeritValue(MERIT_AVATAR_PHYSICAL_ACCURACY, PChar));
-
-                PPet->addModifier(Mod::ACC, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_ACC_BONUS));
-                PPet->addModifier(Mod::MACC, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_MAGIC_ACC_BONUS));
-                PPet->addModifier(Mod::ATT, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_PHYS_ATK_BONUS) * 2);
-                PPet->addModifier(Mod::MAGIC_DAMAGE, PChar->PJobPoints->GetJobPointValue(JP_SUMMON_MAGIC_DMG_BONUS) * 5);
-                PPet->addModifier(Mod::BP_DAMAGE, PChar->PJobPoints->GetJobPointValue(JP_BLOOD_PACT_DMG_BONUS) * 3);
-            }
-
-            PMaster->addModifier(Mod::AVATAR_PERPETUATION, PerpetuationCost(PetID, mLvl));
+            CalculateAvatarStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::JUG_PET)
         {
-            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
-            static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
-            // Get the Jug pet cap level
-            uint8 highestLvl = PPetData->maxLevel;
-
-            // Increase the pet's level cal by the bonus given by BEAST AFFINITY merits.
-            CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
-            highestLvl += PChar->PMeritPoints->GetMeritValue(MERIT_BEAST_AFFINITY, PChar);
-
-            // And cap it to the master's level or weapon ilvl, whichever is greater
-            auto capLevel = std::max(PMaster->GetMLevel(), PMaster->m_Weapons[SLOT_MAIN]->getILvl());
-            if (highestLvl > capLevel)
-            {
-                highestLvl = capLevel;
-            }
-
-            // Randomize: 0-2 lvls lower, less Monster Gloves(+1/+2) bonus
-            highestLvl -= xirand::GetRandomNumber(3 - std::clamp<int16>(PChar->getMod(Mod::JUG_LEVEL_RANGE), 0, 2));
-
-            PPet->SetMLevel(std::min(spawnLevel, highestLvl));
-            LoadJugStats(PPet, PPetData); // follow monster calcs (w/o SJ)
+            uint8 spawnLevel = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petLevel;
+            PPet->setSpawnLevel(spawnLevel > 0 ? spawnLevel : UINT8_MAX);
+            CalculateJugPetStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::WYVERN)
         {
-            LoadWyvernStatistics(PMaster, PPet, false);
+            CalculateWyvernStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::AUTOMATON && PMaster->objtype == TYPE_PC)
         {
-            CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
-            switch (PAutomaton->getFrame())
-            {
-                default: // case FRAME_HARLEQUIN:
-                    PPet->SetMJob(JOB_WAR);
-                    PPet->SetSJob(JOB_RDM);
-                    break;
-                case FRAME_VALOREDGE:
-                    PPet->SetMJob(JOB_PLD);
-                    PPet->SetSJob(JOB_WAR);
-                    break;
-                case FRAME_SHARPSHOT:
-                    PPet->SetMJob(JOB_RNG);
-                    PPet->SetSJob(JOB_PUP);
-                    break;
-                case FRAME_STORMWAKER:
-                    PPet->SetMJob(JOB_RDM);
-                    PPet->SetSJob(JOB_WHM);
-                    break;
-            }
-
-            // TEMP: should be MLevel when unsummoned, and PUP level when summoned
-            uint8 mainLevel = PMaster->GetMJob() == JOB_PUP ? PMaster->GetMLevel() + PMaster->getMod(Mod::AUTOMATON_LVL_BONUS) : PMaster->GetSLevel();
-            mainLevel       = std::min<uint8>(spawnLevel, mainLevel);
-            PPet->SetMLevel(mainLevel);
-            PPet->SetSLevel(mainLevel / 2); // Todo: SetSLevel() already reduces the level?
-
-            LoadAutomatonStats(static_cast<CCharEntity*>(PMaster), PPet, g_PPetList.at(PetID)); // temp
-
-            if (PMaster->objtype == TYPE_PC)
-            {
-                CCharEntity* PChar = static_cast<CCharEntity*>(PMaster);
-                PPet->addModifier(Mod::ATTP, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
-                PPet->addModifier(Mod::DEFP, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
-                PPet->addModifier(Mod::MATT, PChar->PMeritPoints->GetMeritValue(MERIT_OPTIMIZATION, PChar));
-                PPet->addModifier(Mod::ACC, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
-                PPet->addModifier(Mod::RACC, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
-                PPet->addModifier(Mod::EVA, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
-                PPet->addModifier(Mod::MDEF, PChar->PMeritPoints->GetMeritValue(MERIT_FINE_TUNING, PChar));
-            }
+            CalculateAutomatonStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::LUOPAN && PMaster->objtype == TYPE_PC)
         {
-            PPet->SetMLevel(std::min(spawnLevel, PMaster->GetMLevel()));
-            PPet->health.maxhp = (uint32)floor((250 * spawnLevel) / 15);
-
-            if (PMaster->StatusEffectContainer->HasStatusEffect(EFFECT_BOLSTER))
-            {
-                uint8 bolsterJPVal = dynamic_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_BOLSTER_EFFECT);
-                PPet->health.maxhp += (uint32)floor(PPet->health.maxhp * (0.03 * bolsterJPVal));
-            }
-
-            PPet->health.hp = PPet->health.maxhp;
-
-            // This sets the correct visual size for the luopan as pets currently
-            // do not make use of the entity flags in the database
-            // TODO: make pets use entity flags
-            PPet->m_flags = 0x0000008B;
-            // Just sit, do nothing
-            PPet->speed = 0;
+            CalculateLoupanStats(PMaster, PPet);
         }
 
-        FinalizePetStatistics(PMaster, PPet);
         PPet->setSpawnLevel(PPet->GetMLevel());
         PPet->status        = STATUS_TYPE::NORMAL;
         PPet->m_ModelRadius = PPetData->radius;
         PPet->m_EcoSystem   = PPetData->EcoSystem;
 
         PMaster->PPet = PPet;
-    }
-
-    void LoadWyvernStatistics(CBattleEntity* PMaster, CPetEntity* PPet, bool finalize)
-    {
-        // set the wyvern job based on master's SJ
-        if (PMaster->GetSJob() != JOB_NON)
-        {
-            PPet->SetSJob(PMaster->GetSJob());
-        }
-
-        PPet->SetMJob(JOB_DRG);
-        // https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#About_the_Wyvern
-        uint8 mLvl = PMaster->GetMLevel();
-        uint8 iLvl = std::clamp(charutils::getMainhandItemLevel(static_cast<CCharEntity*>(PMaster)) - 99, 0, 20);
-
-        PPet->SetMLevel(mLvl + iLvl + PMaster->getMod(Mod::WYVERN_LVL_BONUS));
-
-        LoadAvatarStats(PMaster, PPet);                                                                               // follows PC calcs (w/o SJ)
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); // 320 delay
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
-        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(1 + floor(mLvl * 0.9f)));
-        // Set A+ weapon skill
-        PPet->setModifier(Mod::ATT, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-        PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-        // Set D evasion and def
-        PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-        PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
-
-        // Job Point: Wyvern Max HP
-        if (PMaster->objtype == TYPE_PC)
-        {
-            uint8 jpValue = static_cast<CCharEntity*>(PMaster)->PJobPoints->GetJobPointValue(JP_WYVERN_MAX_HP_BONUS);
-            if (jpValue > 0)
-            {
-                PPet->addModifier(Mod::HP, jpValue * 10);
-            }
-
-            if (PMaster->GetMJob() == JOBTYPE::JOB_DRG)
-            {
-                PPet->addModifier(Mod::ACC, PMaster->getMod(Mod::PET_ACC_EVA));
-                PPet->addModifier(Mod::EVA, PMaster->getMod(Mod::PET_ACC_EVA));
-                PPet->addModifier(Mod::MACC, PMaster->getMod(Mod::PET_MACC_MEVA));
-                PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
-            }
-        }
-
-        if (finalize)
-        {
-            FinalizePetStatistics(PMaster, PPet);
-        }
-    }
-
-    void FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet)
-    {
-        // set C magic evasion
-        PPet->setModifier(Mod::MEVA, battleutils::GetMaxSkill(SKILL_ELEMENTAL_MAGIC, JOB_RDM, PPet->GetMLevel() > 99 ? 99 : PPet->GetMLevel()));
-        PPet->health.tp = 0;
-        PMaster->applyPetModifiers(PPet);
-        PPet->UpdateHealth();
-        PPet->health.hp = PPet->GetMaxHP();
-        PPet->health.mp = PPet->GetMaxMP();
-
-        // Stout Servant - Can't really tie it ot a real mod since it applies to the pet
-        if (CCharEntity* PCharMaster = dynamic_cast<CCharEntity*>(PMaster))
-        {
-            if (charutils::hasTrait(PCharMaster, TRAIT_STOUT_SERVANT))
-            {
-                for (CTrait* trait : PCharMaster->TraitList)
-                {
-                    if (trait->getID() == TRAIT_STOUT_SERVANT)
-                    {
-                        PPet->addModifier(Mod::DMG, -(trait->getValue() * 100));
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     bool CheckPetModType(CBattleEntity* PPet, PetModType petmod)

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -78,7 +78,11 @@ namespace petutils
     int16 PerpetuationCost(uint32 id, uint8 level);
     void  Familiar(CBattleEntity* PPet);
     void  LoadPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone);
-    void  LoadWyvernStatistics(CBattleEntity* PMaster, CPetEntity* PPet, bool finalize);
+    void  CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void  CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void  CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void  CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void  CalculateLoupanStats(CBattleEntity* PMaster, CPetEntity* PPet);
     void  FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet);
     bool  CheckPetModType(CBattleEntity* PPet, PetModType petmod);
 }; // namespace petutils

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -78,13 +78,17 @@ namespace petutils
     int16 PerpetuationCost(uint32 id, uint8 level);
     void  Familiar(CBattleEntity* PPet);
     void  LoadPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone);
-    void  CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void  CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void  CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void  CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void  CalculateLoupanStats(CBattleEntity* PMaster, CPetEntity* PPet);
-    void  FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet);
-    bool  CheckPetModType(CBattleEntity* PPet, PetModType petmod);
+
+    void CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void CalculateWyvernStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void CalculateAutomatonStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void CalculateLoupanStats(CBattleEntity* PMaster, CPetEntity* PPet);
+    void FinalizePetStatistics(CBattleEntity* PMaster, CPetEntity* PPet);
+
+    void SetupPetWithMaster(CBattleEntity* PMaster, CPetEntity* PPet);
+
+    bool CheckPetModType(CBattleEntity* PPet, PetModType petmod);
 }; // namespace petutils
 
 #endif

--- a/tools/migrations/032_pet_level_column.py
+++ b/tools/migrations/032_pet_level_column.py
@@ -1,0 +1,24 @@
+def migration_name():
+    return "Adding Pet Level column for char_stats"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure column doesn't already exist.
+    cur.execute("SHOW COLUMNS FROM char_stats LIKE 'pet_level';")
+
+    row = cur.fetchone()
+    if row:
+        return False
+
+    return True
+
+
+def migrate(cur, db):
+    cur.execute(
+        "ALTER TABLE `char_stats` ADD COLUMN `pet_level` smallint(3) unsigned NOT NULL DEFAULT '0';"
+    )
+    db.commit()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/255
Pets will now change their level to reflect the master's level.

These changes primarily focus around handling pets with level restrictions.
- Add a `pet_level` column to `char_stats` that stores `petZoningInfo.petLevel`. This is currently only used for BST jugs. Initially there was some thought that all pets would stay at the level they were summoned at when not under level restriction but that only seems to be the case for jug pets.
- Refactor pet stat calculations to their own functions
- Handle level restrictions with pets including resetting them and recalculating stats

I'm working on an additional change to fix Automaton activation which does involve level restrictions but I decided it is a big enough change to warrant its own PR.

Thanks to Meloetta and @WinterSolstice8 for helping verify all of these interactions on retail!

## Steps to test these changes

Change your job to any pet job.
```
!changejob pup 75
!changejob smn 75
!changejob drg 75
!changejob bst 75
```
To apply and remove a level restriction use as well as check your pet stats.
```
/checkparam (on your pet)
!addeffect level_restriction 40
/checkparam (on your pet)
!deleffect level_restriction
/checkparam (on your pet)
```
