### PR TITLE
Handle Automaton exceeding elemental capacity

### DIFF
--- a/scripts/globals/abilities/activate.lua
+++ b/scripts/globals/abilities/activate.lua
@@ -18,6 +18,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         return xi.msg.basic.ALREADY_HAS_A_PET, 0
     elseif not player:canUseMisc(xi.zoneMisc.PET) then
         return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
+    elseif player:isExceedingElementalCapacity() then
+        return xi.msg.basic.AUTO_EXCEEDS_CAPACITY, 0
     else
         return 0, 0
     end

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -300,6 +300,7 @@ xi.msg.basic =
     COVER_FAILURE          = 312, -- The <player>'s attempt to cover has no effect.
 
     -- PUP
+    AUTO_EXCEEDS_CAPACITY  = 745, -- Your automaton exceeds one or more elemental capacity values and cannot be activated.
     AUTO_OVERLOAD_CHANCE   = 798, -- The <pet>'s overload chance is <number>%.
     AUTO_OVERLOADED        = 799, -- The <pet>'s overload chance is <number>%. The <pet> is overloaded!
     PROVOKE_SWITCH         = 418, -- The <actor> uses <action> on <target>. The <target> switches to <actor>!

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -105,6 +105,27 @@ uint8 CAutomatonEntity::getElementCapacity(uint8 element)
     return m_ElementEquip[element];
 }
 
+uint8 CAutomatonEntity::getElementalCapacityBonus()
+{
+    return m_elementalCapacityBonus;
+}
+
+void CAutomatonEntity::setElementalCapacityBonus(uint8 bonus)
+{
+    if (bonus == m_elementalCapacityBonus)
+    {
+        return;
+    }
+
+    int8 difference = static_cast<int8>(bonus) - m_elementalCapacityBonus;
+    for (size_t i = 0; i < m_ElementMax.size(); ++i)
+    {
+        m_ElementMax[i] += difference;
+    }
+
+    m_elementalCapacityBonus = bonus;
+}
+
 void CAutomatonEntity::burdenTick()
 {
     for (auto&& burden : m_Burden)

--- a/src/map/entities/automatonentity.h
+++ b/src/map/entities/automatonentity.h
@@ -77,6 +77,9 @@ public:
     uint8 getElementMax(uint8 element);
     uint8 getElementCapacity(uint8 element);
 
+    uint8 getElementalCapacityBonus();
+    void  setElementalCapacityBonus(uint8 bonus);
+
     void  burdenTick();
     auto  getBurden() -> std::array<uint8, 8>;
     void  setAllBurden(uint8 burden);
@@ -96,6 +99,7 @@ public:
 
 private:
     std::array<uint8, 8> m_Burden{};
+    uint8                m_elementalCapacityBonus = 0;
 };
 
 #endif

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -729,6 +729,7 @@ public:
     void  removeAllManeuvers();
     void  updateAttachments();
     void  reduceBurden(float percentReduction, sol::object const& intReductionObj);
+    bool  isExceedingElementalCapacity();
 
     auto   getAllRuneEffects() -> sol::table;
     uint8  getActiveRuneCount();

--- a/src/map/packets/char_job_extra.cpp
+++ b/src/map/packets/char_job_extra.cpp
@@ -125,6 +125,6 @@ CCharJobExtraPacket::CCharJobExtraPacket(CCharEntity* PChar, bool mjob)
         ref<uint16>(0x98) = PChar->PAutomaton->stats.CHR;
         ref<uint16>(0x9A) = PChar->PAutomaton->getMod(Mod::CHR);
 
-        ref<uint8>(0x9C) = 0; // extra elemental capacity from gifts
+        ref<uint8>(0x9C) = PChar->getMod(Mod::AUTO_ELEM_CAPACITY);
     }
 }

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -137,6 +137,8 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_COUNTER_ABS_BY_SHADOW = 14,  /* The <player>'s attack is countered by the <target>. .. of <player>'s shadows absorbs the damage and disappears. */
     /* THF */
     MSGBASIC_TREASURE_HUNTER_UP = 603, /* Additional effect: Treasure Hunter effectiveness against <target> increases to .. */
+    /* PUP */
+    MSGBASIC_AUTO_EXCEEDS_CAPACITY = 745, /* Your automaton exceeds one or more elemental capacity values and cannot be activated. */
     /* DNC */
     MSGBASIC_NO_FINISHINGMOVES = 524,
     /* TRUST & ALTER EGO */

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -845,12 +845,14 @@ namespace charutils
         charutils::LoadInventory(PChar);
 
         CalculateStats(PChar);
-        blueutils::LoadSetSpells(PChar);
-        puppetutils::LoadAutomaton(PChar);
         BuildingCharSkillsTable(PChar);
         BuildingCharAbilityTable(PChar);
         BuildingCharTraitsTable(PChar);
         jobpointutils::RefreshGiftMods(PChar);
+
+        // Order matters as these use merits and JP gifts
+        blueutils::LoadSetSpells(PChar);
+        puppetutils::LoadAutomaton(PChar);
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);
 

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -88,20 +88,21 @@ namespace puppetutils
                         tempEquip.Attachments[i] = 0;
                     }
 
-                    int16 elemCapacityBonus = 0 + PChar->getMod(Mod::AUTO_ELEM_CAPACITY);
-
                     for (int i = 0; i < 6; i++)
                     {
-                        PChar->PAutomaton->setElementMax(i, 5 + elemCapacityBonus);
+                        PChar->PAutomaton->setElementMax(i, 5);
                     }
-                    PChar->PAutomaton->setElementMax(6, 3 + elemCapacityBonus);
-                    PChar->PAutomaton->setElementMax(7, 3 + elemCapacityBonus);
+                    PChar->PAutomaton->setElementMax(6, 3);
+                    PChar->PAutomaton->setElementMax(7, 3);
 
                     for (int i = 0; i < 8; i++)
                     {
                         PChar->PAutomaton->m_ElementEquip[i] = 0;
                     }
                 }
+
+                // Add the elemental bonus before we set the head and frame
+                PChar->PAutomaton->setElementalCapacityBonus(PChar->getMod(Mod::AUTO_ELEM_CAPACITY));
 
                 setHead(PChar, tempEquip.Head);
                 setFrame(PChar, tempEquip.Frame);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Handle Automaton exceeding elemental capacity
 - When going under level restriction and exceeding elemental capacity the automaton is dismissed
 - When exceeding elemental capacity player cannot activate automaton

This also fixes an issue with BLU JP gift `JP_BLUE_MAGIC_POINT_BONUS` is not applied properly when loading a character.

## Steps to test these changes

1. Run the following commands in game.
```
!changejob pup 99
!addkeyitem job_breaker
!setjobpoints 100
!addallattachments
```
2. Spend all of your JP in a MH and you should get the PUP 100JP gift giving you +2 elemental capacity.
3. Go to your favorite field/dungeon zone. 
4. Equip your automaton to use up all of one element (should be something like 8/8)
5. Activate your automaton
6. `!addeffect level_restriction 40`
7. At this point your automaton should be deactivated but, assuming your Automaton is full HP, your Activate should reset.
8. Try to use Activate and it should error saying you are exceeding elemental capacity.
9. Remove attachments to not exceed elemental capacity anymore.
10. Try to Activate and it should now summon your Automaton.

You can play around with other similar scenarios and use `!deleffect level_restriction` to remove the level restriction.