### PR TITLE
Jug pet and other pet fixes

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -40,7 +40,7 @@ void CPetController::Tick(time_point tick)
     TracyZoneScoped;
     TracyZoneIString(PPet->GetName());
 
-    if (PPet->isCharmed && tick > PPet->charmTime)
+    if (PPet->shouldDespawn(tick))
     {
         petutils::DespawnPet(PPet->PMaster);
         return;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -433,11 +433,13 @@ void CCharEntity::setPetZoningInfo()
         case PET_TYPE::AVATAR:
         case PET_TYPE::AUTOMATON:
         case PET_TYPE::WYVERN:
-            petZoningInfo.petLevel = PPetEntity->getSpawnLevel();
-            petZoningInfo.petHP    = PPet->health.hp;
-            petZoningInfo.petTP    = PPet->health.tp;
-            petZoningInfo.petMP    = PPet->health.mp;
-            petZoningInfo.petType  = PPetEntity->getPetType();
+            petZoningInfo.petLevel     = PPetEntity->getSpawnLevel();
+            petZoningInfo.petHP        = PPet->health.hp;
+            petZoningInfo.petTP        = PPet->health.tp;
+            petZoningInfo.petMP        = PPet->health.mp;
+            petZoningInfo.petType      = PPetEntity->getPetType();
+            petZoningInfo.jugSpawnTime = ((CPetEntity*)PPet)->getJugSpawnTime();
+            petZoningInfo.jugDuration  = ((CPetEntity*)PPet)->getJugDuration();
             break;
         default:
             break;
@@ -449,12 +451,14 @@ void CCharEntity::setPetZoningInfo()
 void CCharEntity::resetPetZoningInfo()
 {
     // reset the petZoning info
-    petZoningInfo.petLevel   = 0;
-    petZoningInfo.petHP      = 0;
-    petZoningInfo.petTP      = 0;
-    petZoningInfo.petMP      = 0;
-    petZoningInfo.respawnPet = false;
-    petZoningInfo.petType    = PET_TYPE::AVATAR;
+    petZoningInfo.petLevel     = 0;
+    petZoningInfo.petHP        = 0;
+    petZoningInfo.petTP        = 0;
+    petZoningInfo.petMP        = 0;
+    petZoningInfo.respawnPet   = false;
+    petZoningInfo.petType      = PET_TYPE::AVATAR;
+    petZoningInfo.jugSpawnTime = 0;
+    petZoningInfo.jugDuration  = 0;
 }
 /************************************************************************
  *

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -170,13 +170,15 @@ struct teleport_t
 
 struct PetInfo_t
 {
-    bool     respawnPet; // used for spawning pet on zone
-    uint8    petID;      // id as in wyvern(48) , carbuncle(8) ect..
-    PET_TYPE petType;    // type of pet being transfered
-    uint8    petLevel;   // level the pet was spawned with
-    int16    petHP;      // pets hp
-    int16    petMP;
-    float    petTP; // pets tp
+    bool     respawnPet;   // used for spawning pet on zone
+    int32    jugSpawnTime; // Keeps track of original spawn time in seconds since epoch
+    int32    jugDuration;  // Number of seconds a jug pet should last after its original spawn time
+    uint8    petID;        // id as in wyvern(48) , carbuncle(8) ect..
+    PET_TYPE petType;      // type of pet being transfered
+    uint8    petLevel;     // level the pet was spawned with
+    int16    petHP;        // pets hp
+    int16    petMP;        // pets mp
+    float    petTP;        // pets tp
 };
 
 struct AuctionHistory_t

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -55,6 +55,9 @@ public:
     PET_TYPE     getPetType();
     uint8        getSpawnLevel();
     void         setSpawnLevel(uint8 level);
+    int32        getJugSpawnTime();             // initial spawn time (in seconds since epoch) of this pet if it's a jug pet
+    int32        getJugDuration();              // duration of this jug pet in seconds
+    void         setJugDuration(int32 seconds); // sets the duration of this jug pet in seconds
     bool         isBstPet();
     uint32       m_PetID;
     std::string  GetScriptName();
@@ -63,13 +66,20 @@ public:
     virtual void FadeOut() override;
     virtual void Die() override;
     virtual void Spawn() override;
+    bool         shouldPersistThroughZone();     // if true, zoning should not cause a currently active pet to despawn
+    bool         shouldDespawn(time_point tick); // if true, the pet should despawn at this point in time
+    void         loadPetZoningInfo();            // loads info from previous zone (hp / mp / tp / spawn time). This MUST be called after Spawn()
     virtual void OnAbility(CAbilityState&, action_t&) override;
     virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
     void         OnPetSkillFinished(CPetSkillState& state, action_t& action);
 
 private:
-    PET_TYPE m_PetType;    // the type of pet e.g. avatar/wyvern/jugpet etc
-    uint8    m_spawnLevel; // The level the pet was spawned at
+    PET_TYPE   m_PetType;      // the type of pet e.g. avatar/wyvern/jugpet etc
+    uint8      m_spawnLevel;   // The level the pet was spawned at
+    time_point m_jugSpawnTime; // original spawn time of a jug pet
+    duration   m_jugDuration;  // Time before the jug is despawned after being called
+
+    void setJugSpawnTime(int32 spawnTime); // sets the initial spawn time of this pet in seconds since epoch
 };
 
 #endif

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -523,7 +523,17 @@ void SmallPacket0x00D(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (PChar->PPet != nullptr)
         {
-            PChar->setPetZoningInfo();
+            if (auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet))
+            {
+                if (PPetEntity->shouldPersistThroughZone())
+                {
+                    PChar->setPetZoningInfo();
+                }
+                else
+                {
+                    PChar->resetPetZoningInfo();
+                }
+            }
         }
 
         PSession->shuttingDown = 1;
@@ -3679,8 +3689,17 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
     // handle pets on zone
     if (PChar->PPet != nullptr)
     {
-        PChar->setPetZoningInfo();
-        petutils::DespawnPet(PChar);
+        if (auto* PPetEntity = dynamic_cast<CPetEntity*>(PChar->PPet))
+        {
+            if (PPetEntity->shouldPersistThroughZone())
+            {
+                PChar->setPetZoningInfo();
+            }
+            else
+            {
+                PChar->resetPetZoningInfo();
+            }
+        }
     }
 
     uint32 zoneLineID    = data.ref<uint32>(0x04);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -698,12 +698,17 @@ namespace charutils
             int16 petHP = sql->GetUIntData(11);
             if (petHP)
             {
-                PChar->petZoningInfo.petHP      = petHP;
-                PChar->petZoningInfo.petID      = sql->GetUIntData(9);
-                PChar->petZoningInfo.petMP      = sql->GetIntData(12);
-                PChar->petZoningInfo.petType    = static_cast<PET_TYPE>(sql->GetUIntData(10));
-                PChar->petZoningInfo.petLevel   = sql->GetUIntData(13);
-                PChar->petZoningInfo.respawnPet = true;
+                PChar->petZoningInfo.petHP        = petHP;
+                PChar->petZoningInfo.petID        = sql->GetUIntData(9);
+                PChar->petZoningInfo.petMP        = sql->GetIntData(12);
+                PChar->petZoningInfo.petType      = static_cast<PET_TYPE>(sql->GetUIntData(10));
+                PChar->petZoningInfo.petLevel     = sql->GetUIntData(13);
+                PChar->petZoningInfo.respawnPet   = true;
+                PChar->petZoningInfo.jugSpawnTime = PChar->getCharVar("jug-pet-spawn-time");
+                PChar->petZoningInfo.jugDuration  = PChar->getCharVar("jug-duration-seconds");
+
+                // clear the charvars used for jug state
+                PChar->clearCharVarsWithPrefix("jug-");
             }
         }
 
@@ -5057,6 +5062,11 @@ namespace charutils
 
         sql->Query(Query, PChar->health.hp, PChar->health.mp, PChar->nameflags.flags, PChar->profile.mhflag, PChar->GetMJob(), PChar->GetSJob(),
                    PChar->petZoningInfo.petID, static_cast<uint8>(PChar->petZoningInfo.petType), PChar->petZoningInfo.petHP, PChar->petZoningInfo.petMP, PChar->petZoningInfo.petLevel, PChar->id);
+
+        // These two are jug only variables. We should probably move pet char stats into its own table, but in the meantime
+        // we use charvars for jug specific things
+        PChar->setCharVar("jug-pet-spawn-time", PChar->petZoningInfo.jugSpawnTime);
+        PChar->setCharVar("jug-duration-seconds", PChar->petZoningInfo.jugDuration);
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1266,12 +1266,11 @@ namespace petutils
             {
                 SetupPetWithMaster(PMaster, PPet);
             }
+
             // apply stats from previous zone if this pet is being transferred
             if (spawningFromZone)
             {
-                PPet->health.tp = static_cast<uint16>(static_cast<CCharEntity*>(PMaster)->petZoningInfo.petTP);
-                PPet->health.hp = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petHP;
-                PPet->health.mp = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petMP;
+                PPet->loadPetZoningInfo();
             }
         }
         else if (PMaster->objtype == TYPE_PC)
@@ -1352,6 +1351,7 @@ namespace petutils
 
     void DetachPet(CBattleEntity* PMaster)
     {
+        XI_DEBUG_BREAK_IF(PMaster == nullptr);
         XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
         XI_DEBUG_BREAK_IF(PMaster->objtype != TYPE_PC);
 
@@ -1451,6 +1451,7 @@ namespace petutils
 
     void DespawnPet(CBattleEntity* PMaster)
     {
+        XI_DEBUG_BREAK_IF(PMaster == nullptr);
         XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
 
         petutils::DetachPet(PMaster);
@@ -1839,6 +1840,7 @@ namespace petutils
         {
             uint8 spawnLevel = static_cast<CCharEntity*>(PMaster)->petZoningInfo.petLevel;
             PPet->setSpawnLevel(spawnLevel > 0 ? spawnLevel : UINT8_MAX);
+            PPet->setJugDuration(static_cast<int32>(PPetData->time));
             CalculateJugPetStats(PMaster, PPet);
         }
         else if (PPet->getPetType() == PET_TYPE::WYVERN)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes jug pet and automaton persistence through zone
- Despawns jug pet after the time specified in pet_list
- Closes https://github.com/HorizonFFXI/HorizonXI-Issues/issues/368

## Steps to test these changes

Set a pet "time" column in pet_list to a low number like 30.
Summon that pet by using the proper jug. Observe it despawn after 30 seconds.
Try zoning while pet is up. Pet should reappear in the other zone with the same HP it had. Pet should still despawn 30 secs after call beast was used.
