### PR TITLE
[core] Fix mutex race condition in watchdog on cleanup

### DIFF
--- a/src/common/watchdog.cpp
+++ b/src/common/watchdog.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2022 LandSandBoat Dev Teams
@@ -38,7 +38,10 @@ Watchdog::~Watchdog()
 
         m_running = false;
         m_stopCondition.notify_all();
+    }
 
+    if (m_watchdog.joinable())
+    {
         m_watchdog.join();
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix mutex race condition where a thread join will never join because it's waiting for a lock that will never unlock via going out of scope

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

run xi_connect/xi_map, issue "exit" on the console and see it exit normally