### PR TITLE
[core] Fix exit issues with Watchdog and ConsoleService

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,11 +1,12 @@
+# add_subdirectory(lua) # Handled globally
+# add_subdirectory(mysql) # Handled globally
+# add_subdirectory(zmq) # Handled globally
+
 add_subdirectory(concurrentqueue)
 add_subdirectory(detour)
-# add_subdirectory(lua) # Handled globally 
-# add_subdirectory(mysql) # Handled globally
 add_subdirectory(recast)
 add_subdirectory(sol)
 add_subdirectory(spdlog)
-# add_subdirectory(zmq) # Handled globally
 
 # CPM Modules
 CPMAddPackage(
@@ -26,6 +27,13 @@ CPMAddPackage(
         "EFSW_INSTALL OFF"
 ) # defines: efsw
 
+# TODO: std::jthread lands in C++20. Remove this once all compilers for all platforms implement.
+CPMAddPackage(
+    NAME jthread-lite
+    GITHUB_REPOSITORY martinmoene/jthread-lite
+    GIT_TAG 5332bbd46dcba5f028a844795cc0931e9f2ffdf4
+) # defines: jthread-lite
+
 set(EXTERNAL_LIBS
     concurrentqueue
     mariadbclient
@@ -35,6 +43,7 @@ set(EXTERNAL_LIBS
     sol2_single
     argparse
     efsw
+    jthread-lite
 )
 
 if (WIN32)

--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -11,6 +11,7 @@ xi.settings = xi.settings or {}
 
 xi.settings.logging =
 {
+    DEBUG_SOCKETS        = false,
     DEBUG_NAVMESH        = false,
     DEBUG_PACKETS        = false,
     DEBUG_ACTIONS        = false,

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -43,8 +43,8 @@ public:
     virtual void Tick();
 
 protected:
-    std::string m_ServerName;
-    bool        m_IsRunning;
+    std::string       m_ServerName;
+    std::atomic<bool> m_IsRunning;
 
     std::unique_ptr<argparse::ArgumentParser> gArgParser;
     std::unique_ptr<ConsoleService>           gConsoleService;

--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -22,8 +22,83 @@
 #include "console_service.h"
 
 #ifdef _WIN32
-#include <Windows.h> // ReadConsoleInput et al
+#include <conio.h>
+#include <io.h>
+#include <windows.h>
+#define isatty  _isatty
+#define getchar _getch
+#else
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #endif
+
+// https://stackoverflow.com/a/71992965
+bool stdinHasData()
+{
+#if defined(_WIN32)
+    // this works by harnessing Windows' black magic:
+    return _kbhit();
+#else
+    // using a timeout of 0 so we aren't waiting:
+    struct timespec timeout
+    {
+        0l, 0l
+    };
+
+    // create a file descriptor set
+    fd_set fds{};
+
+    // initialize the fd_set to 0
+    FD_ZERO(&fds);
+    // set the fd_set to target file descriptor 0 (STDIN)
+    FD_SET(0, &fds);
+
+    // pselect the number of file descriptors that are ready, since
+    // we're only passing in 1 file descriptor, it will return either
+    // a 0 if STDIN isn't ready, or a 1 if it is.
+    return pselect(0 + 1, &fds, nullptr, nullptr, &timeout, nullptr) == 1;
+#endif
+}
+
+bool getLine(std::string& line)
+{
+    // If there is data on stdin we can call _getch() knowing that it won't block!
+    // This makes this routine non-blocking.
+    if (!stdinHasData())
+    {
+        return false;
+    }
+
+    auto keyCharacter = static_cast<char>(getchar());
+    if (keyCharacter == '\r')
+    {
+        fmt::print("\n"); // Windows needs \r\n for newlines in the console, but the enter key is only \r.
+        return true;
+    }
+    if (keyCharacter == '\n')
+    {
+        return true;
+    }
+
+    if (keyCharacter == '\b')
+    {
+        fmt::print("\b \b"); // move cursor left, overwrite with space, move cursor left
+        if (line.size() > 0)
+        {
+            line.pop_back(); // remove last char in buffer if any
+        }
+        return false;
+    }
+
+    fmt::print("{:c}", keyCharacter); // echo character back to console, apparently using ReadConsoleInput & GetStdHandle prevents echo?
+    if (std::isprint(keyCharacter))
+    {
+        line += keyCharacter;
+    }
+
+    return false;
+}
 
 ConsoleService::ConsoleService()
 {
@@ -65,22 +140,20 @@ ConsoleService::ConsoleService()
     {
         ShowInfo("Console input thread is ready...");
         ShowInfo("Type 'help' for a list of available commands.");
-        m_consoleInputThread = std::thread([&]()
+        m_consoleInputThread = nonstd::jthread([&]()
         {
-            auto lastInputTime = server_clock::now();
+            std::string line;
 
             while (m_consoleThreadRun)
             {
-                if ((server_clock::now() - lastInputTime) > 1s)
+                std::unique_lock<std::mutex> lock(m_consoleInputBottleneck);
+
+                // https://en.cppreference.com/w/cpp/thread/condition_variable/wait_for
+                if (!m_consoleStopCondition.wait_for(lock, 50ms, [&]{ return !m_consoleThreadRun; }))
                 {
-                    std::lock_guard lock(m_consoleInputBottleneck);
-                    std::string line;
-
-                    line = getLine();
-
-                    if (!m_consoleThreadRun)
+                    if (!getLine(line))
                     {
-                        break;
+                        continue;
                     }
 
                     std::istringstream stream(line);
@@ -106,11 +179,12 @@ ConsoleService::ConsoleService()
                         }
                         else
                         {
-                            fmt::print("> Unknown command.\n");
+                            fmt::print(fmt::format("> Unknown command: {}\n", inputs[0]));
                         }
                     }
+
+                    line = std::string();
                 }
-                std::this_thread::sleep_for(250ms); // TODO: Do this better
             };
             fmt::print("Console input thread exiting...\n");
         });
@@ -120,91 +194,20 @@ ConsoleService::ConsoleService()
 
 ConsoleService::~ConsoleService()
 {
-    m_consoleThreadRun = false;
-
-    if (m_consoleInputThread.joinable())
-    {
-        m_consoleInputThread.join();
-    }
+    stop();
+    m_consoleStopCondition.notify_all();
 }
 
 // NOTE: If you capture things in this function, make sure they're protected (locked or atomic)!
 // NOTE: If you're going to print, use fmt::print, rather than ShowInfo etc.
 void ConsoleService::RegisterCommand(std::string const& name, std::string const& description, std::function<void(std::vector<std::string>)> func)
 {
-    std::lock_guard lock(m_consoleInputBottleneck);
+    std::lock_guard<std::mutex> lock(m_consoleInputBottleneck);
+
     m_commands[name] = ConsoleCommand{ name, description, func };
 }
 
 void ConsoleService::stop()
 {
     m_consoleThreadRun = false;
-}
-
-std::string ConsoleService::getLine()
-{
-    std::string line;
-
-// Windows doesn't have a proper poll that works for stdin, but we can use some win32 API on the console...
-#ifdef _WIN32
-    INPUT_RECORD record;
-    DWORD        numEvents;
-
-    while (m_consoleThreadRun)
-    {
-        if (!ReadConsoleInput(GetStdHandle(STD_INPUT_HANDLE), &record, 1, &numEvents))
-        {
-            continue; // this is an error state, does this happen in the real world?
-        }
-
-        if (record.EventType != KEY_EVENT)
-        {
-            continue;
-        }
-
-        if (record.Event.KeyEvent.bKeyDown) // only take input on keydown, not key up
-        {
-            WCHAR keyCharacter = record.Event.KeyEvent.uChar.UnicodeChar;
-
-            if (keyCharacter == '\b')
-            {
-                fmt::print("\b \b"); // move cursor left, overwrite with space, move cursor left
-                if (line.size() > 0)
-                {
-                    line.pop_back(); // remove last char in buffer if any
-                }
-                continue;
-            }
-
-            fmt::print("{:c}", keyCharacter); // echo character back to console, apparently using ReadConsoleInput & GetStdHandle prevents echo?
-            if (keyCharacter == '\r')
-            {
-                fmt::print("\n"); // Windows needs \r\n for newlines in the console, but the enter key is only \r.
-                break;
-            }
-
-            if (std::isprint(keyCharacter))
-            {
-                line += keyCharacter;
-            }
-        }
-    }
-// Linux has a proper polling system for stdin
-#else
-    struct pollfd pollFileDescriptor = { STDIN_FILENO, POLLIN, 0 };
-    int           hasData            = 0;
-
-    // poll() can return -1 when stdin is bad, is this a real-world error condition?
-    while (hasData == 0 && m_consoleThreadRun)
-    {
-        // poll for 1000ms. This doesn't seem to have significant overhead.
-        hasData = poll(&pollFileDescriptor, 1, 1000);
-        if (hasData == 1)
-        {
-            std::getline(std::cin, line);
-        }
-    }
-#endif
-
-    return line;
 }

--- a/src/common/console_service.h
+++ b/src/common/console_service.h
@@ -25,23 +25,18 @@
 #pragma once
 
 #include <any>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <thread>
 
+#include <nonstd/jthread.hpp>
+
 #include "logging.h"
 #include "taskmgr.h"
 #include "tracy.h"
 #include "utils.h"
-
-#ifdef WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <poll.h>
-#include <unistd.h>
-#endif
 
 class ConsoleService
 {
@@ -67,13 +62,12 @@ public:
     void stop();
 
 private:
-    std::thread       m_consoleInputThread;
-    std::mutex        m_consoleInputBottleneck;
-    std::atomic<bool> m_consoleThreadRun = true;
+    std::mutex              m_consoleInputBottleneck;
+    std::atomic<bool>       m_consoleThreadRun = true;
+    nonstd::jthread         m_consoleInputThread;
+    std::condition_variable m_consoleStopCondition;
 
     std::unordered_map<std::string, ConsoleCommand> m_commands;
-
-    std::string getLine();
 };
 
 #endif // _CONSOLE_SERVICE_H_

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -232,7 +232,6 @@ int main(int argc, char** argv)
         duration next = std::chrono::milliseconds(200);
 
         // clang-format off
-        ShowInfo("Setting up main tick watchdog thread");
         auto watchdog = Watchdog(2000ms, [&]()
         {
             ShowCritical("Process main tick has taken 2000ms or more. Are you debugging or stuck in a loop?");

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -61,6 +61,7 @@ namespace logging
 #define ShowCritical(...) { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_CRITICAL(spdlog::get("critical"), _msgStr); }
 
 // Debug Loggers
+#define DebugSockets(...)  { if (settings::get<bool>("logging.DEBUG_SOCKETS"))   { ShowDebug(__VA_ARGS__); } }
 #define DebugNavmesh(...)  { if (settings::get<bool>("logging.DEBUG_NAVMESH"))   { ShowDebug(__VA_ARGS__); } }
 #define DebugPackets(...)  { if (settings::get<bool>("logging.DEBUG_PACKETS"))   { ShowDebug(__VA_ARGS__); } }
 #define DebugActions(...)  { if (settings::get<bool>("logging.DEBUG_ACTIONS"))   { ShowDebug(__VA_ARGS__); } }

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -1100,9 +1100,9 @@ void set_eof(int32 fd)
 int create_session(int fd, RecvFunc func_recv, SendFunc func_send, ParseFunc func_parse)
 {
     TracyZoneScoped;
-#ifdef _DEBUG
-    ShowDebug(fmt::format("create_session fd: {}", fd).c_str());
-#endif // _DEBUG
+
+    DebugSockets(fmt::format("create_session fd: {}", fd).c_str());
+
     sessions[fd] = std::make_unique<socket_data>(func_recv, func_send, func_parse);
 
     sessions[fd]->rdata.reserve(RFIFO_SIZE);
@@ -1117,9 +1117,7 @@ int delete_session(int fd)
 {
     TracyZoneScoped;
 
-#ifdef _DEBUG
-    ShowDebug(fmt::format("delete_session fd: {}", fd).c_str());
-#endif // _DEBUG
+    DebugSockets(fmt::format("delete_session fd: {}", fd).c_str());
 
     if (fd <= 0 || fd >= FD_SETSIZE)
     {
@@ -1143,11 +1141,7 @@ int delete_session(int fd)
 
     fd_max = std::distance(result, sessions.rend());
 
-#ifdef _DEBUG
-    ShowDebug(fmt::format("Resizing fd_max from {} to {}.", old_fd_max, fd_max).c_str());
-#else
-    std::ignore = old_fd_max;
-#endif // _DEBUG
+    DebugSockets(fmt::format("Resizing fd_max from {} to {}.", old_fd_max, fd_max).c_str());
 
     return 0;
 }

--- a/src/common/watchdog.cpp
+++ b/src/common/watchdog.cpp
@@ -27,34 +27,30 @@ Watchdog::Watchdog(duration timeout, std::function<void()> callback)
 , m_lastUpdate(server_clock::now())
 , m_running(true)
 {
-    m_watchdog = std::thread(&Watchdog::_innerFunc, this);
+    m_watchdog = nonstd::jthread(&Watchdog::_innerFunc, this);
 }
 
 Watchdog::~Watchdog()
 {
     if (m_running)
     {
-        std::unique_lock<std::mutex> lock(m_bottlneck);
+        std::unique_lock<std::mutex> lock(m_bottleneck);
 
         m_running = false;
         m_stopCondition.notify_all();
-    }
-
-    if (m_watchdog.joinable())
-    {
-        m_watchdog.join();
     }
 }
 
 void Watchdog::update()
 {
-    std::unique_lock<std::mutex> lock(m_bottlneck);
+    std::unique_lock<std::mutex> lock(m_bottleneck);
+
     m_lastUpdate = server_clock::now();
 }
 
 void Watchdog::_innerFunc()
 {
-    std::unique_lock<std::mutex> lock(m_bottlneck);
+    std::unique_lock<std::mutex> lock(m_bottleneck);
 
     while ((server_clock::now() - m_lastUpdate) < m_timeout)
     {

--- a/src/common/watchdog.h
+++ b/src/common/watchdog.h
@@ -26,7 +26,8 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
-#include <thread>
+
+#include <nonstd/jthread.hpp>
 
 class Watchdog
 {
@@ -45,8 +46,8 @@ private:
     voidFunc_t m_callback;
     time_point m_lastUpdate;
 
-    std::thread             m_watchdog;
+    nonstd::jthread         m_watchdog;
     std::atomic_bool        m_running;
-    std::mutex              m_bottlneck;
+    std::mutex              m_bottleneck;
     std::condition_variable m_stopCondition;
 };

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -93,7 +93,7 @@ int32 lobbydata_parse(int32 fd)
         char* buff = &sessions[fd]->rdata[0];
         if (ref<uint8>(buff, 0) == 0x0d)
         {
-            ShowDebug("Posible Crash Attempt from IP: <%s>", ip2str(sessions[fd]->client_addr));
+            ShowWarning("Possible Crash Attempt from IP: <%s>", ip2str(sessions[fd]->client_addr));
         }
         ShowDebug("lobbydata_parse:Incoming Packet: <%x> from ip:<%s>", ref<uint8>(buff, 0), ip2str(sd->client_addr));
 
@@ -979,7 +979,6 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
     if (sql->Query(Query, charid, createchar->m_look.face, createchar->m_look.race, createchar->m_look.size) == SQL_ERROR)
     {
         ShowDebug("lobby_cLook: char<%s>, charid: %u", createchar->m_name, charid);
-
         return -1;
     }
 
@@ -988,7 +987,6 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
     if (sql->Query(Query, charid, createchar->m_mjob) == SQL_ERROR)
     {
         ShowDebug("lobby_cStats: charid: %u", charid);
-
         return -1;
     }
 

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -206,9 +206,9 @@ int do_sockets(fd_set* rfd, duration next)
     for (int i = 0; i < (int)rfd->fd_count; ++i)
     {
         int fd = sock2fd(rfd->fd_array[i]);
-#ifdef _DEBUG
-        ShowDebug(fmt::format("select fd: {}", i).c_str());
-#endif // _DEBUG
+
+        DebugSockets(fmt::format("select fd: {}", i).c_str());
+
         if (sessions[fd])
         {
             sessions[fd]->func_recv(fd);

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -190,7 +190,7 @@ target_include_directories(xi_map
         ${module_include_dirs}
 )
 
-target_precompile_headers(xi_map PUBLIC pch.h)
+target_precompile_headers(xi_map PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/pch.h)
 
 if(TRACY_ENABLE)
     target_link_libraries(xi_map PUBLIC tracy_client)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -69,6 +69,10 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
 
+#ifdef WIN32
+#include <io.h>
+#endif
+
 #ifdef TRACY_ENABLE
 void* operator new(std::size_t count)
 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Introduces `nonstd::jthread`; a C++11 shim for C++20's `std::jthread`. This is a thread that joins on its own destruction. Very handy.
* Replaces the `this_thread::sleep` calls inside ConsoleService with a `condition_variable`
* Refactors getLine's impls to constantly poll and retrieve individual letters the command line in a non-blocking way
* Introduced DEBUG_SOCKETS flag, to hide the incorrectly marked "only log on debug" messages about fds in sockets

## Steps to test these changes

On Windows and Linux:
- Start xi_connect
- CTRL+C -> You should exit gracefully

- Start xi_connect
- Type exit -> You should exit gracefully
