### PR TITLE
Battlefield Exit Race

### DIFF
--- a/scripts/battlefields/Apollyon/central_apollyon.lua
+++ b/scripts/battlefields/Apollyon/central_apollyon.lua
@@ -27,7 +27,6 @@ local content = Limbus:new({
     entryNpc         = '_12i',
     requiredKeyItems = { xi.ki.COSMO_CLEANSE, { xi.ki.RED_CARD, xi.ki.BLACK_CARD }, message = ID.text.YOU_INSERT_THE_CARD_POLISHED },
     requiredItems    = { xi.items.SMALT_CHIP, xi.items.SMOKY_CHIP, xi.items.CHARCOAL_CHIP, xi.items.MAGENTA_CHIP },
-    title            = xi.title.APOLLYON_RAVAGER,
     name             = "CENTRAL_APOLLYON",
 })
 

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -769,12 +769,19 @@ function Battlefield:onEntryEventUpdate(player, csid, option, npc)
 end
 
 function Battlefield.redirectEventCall(eventName, player, csid, option)
+    local battlefieldID = 0
     local battlefield = player:getBattlefield()
-    if not battlefield then
+    if battlefield then
+        battlefieldID = battlefield:getID()
+    else
+        battlefieldID = player:getLocalVar("battlefieldID")
+    end
+
+    if battlefieldID == 0 then
         return
     end
 
-    local content = xi.battlefield.contents[battlefield:getID()]
+    local content = xi.battlefield.contents[battlefieldID]
     content[eventName](content, player, csid, option)
 end
 
@@ -890,6 +897,8 @@ function Battlefield:onBattlefieldStatusChange(battlefield, players, status)
 end
 
 function Battlefield:onBattlefieldEnter(player, battlefield)
+    player:setLocalVar("battlefieldID", battlefield:getID())
+
     local initiatorId, _ = battlefield:getInitiator()
     if #self.requiredKeyItems > 0 and ((not self.requiredKeyItems.onlyInitiator) or player:getID() == initiatorId) then
 

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -29,9 +29,9 @@ function onBattlefieldHandlerInitialise(zone)
     return default
 end
 
-xi.battlefield = {}
-xi.battlefield.contents = {}
-xi.battlefield.contentsByZone = {}
+xi.battlefield = xi.battlefield or {}
+xi.battlefield.contents = xi.battlefield.contents or {}
+xi.battlefield.contentsByZone = xi.battlefield.contentsByZone or {}
 
 xi.battlefield.status =
 {

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -104,4 +104,10 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.STUN)
 end
 
+entity.onMobDeath = function(mob, player, optParams)
+    if player then
+        player:addTitle(xi.title.APOLLYON_RAVAGER)
+    end
+end
+
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There was an race with leaving a battlefield. If the player's CS did not finish fast enough then the battlefield would be cleaned up first. Consequently the player's battlefield couldn't be found and some finish events such as onBattlefieldWin wouldn't be called. This is fixed by tracking the battlefield ID in a local var.

Additional changes includes keeping `xi.battlefield` around when reloading.
Fixes https://github.com/LandSandBoat/server/issues/3157

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
