### PR TITLE
[chore] Convert zone position checks to multiline condition

### DIFF
--- a/scripts/zones/Abdhaljs_Isle-Purgonorgo/Zone.lua
+++ b/scripts/zones/Abdhaljs_Isle-Purgonorgo/Zone.lua
@@ -13,7 +13,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
     player:addKeyItem(xi.ki.MAP_OF_ABDH_ISLE_PURGONORGO)
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(521.600, -3.000, 563.000, 64)
     end
     return cs

--- a/scripts/zones/Abyssea-Altepa/Zone.lua
+++ b/scripts/zones/Abyssea-Altepa/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(435, 0, 320, 136)
     end
 

--- a/scripts/zones/Abyssea-Attohwa/Zone.lua
+++ b/scripts/zones/Abyssea-Attohwa/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-134, -20, -182, 108)
     end
 

--- a/scripts/zones/Abyssea-Empyreal_Paradox/Zone.lua
+++ b/scripts/zones/Abyssea-Empyreal_Paradox/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(540, -500, -565, 64)
     end
 

--- a/scripts/zones/Abyssea-Grauberg/Zone.lua
+++ b/scripts/zones/Abyssea-Grauberg/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-555, 31, -760, 0)
     end
 

--- a/scripts/zones/Abyssea-Konschtat/Zone.lua
+++ b/scripts/zones/Abyssea-Konschtat/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
     -- Note: in retail even tractor lands you back at searing ward, will handle later.
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(153, -72, -840, 140)
     end
 

--- a/scripts/zones/Abyssea-La_Theine/Zone.lua
+++ b/scripts/zones/Abyssea-La_Theine/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-480.5, -0.5, 794, 62)
     end
 

--- a/scripts/zones/Abyssea-Misareaux/Zone.lua
+++ b/scripts/zones/Abyssea-Misareaux/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(670, -15, 318, 119)
     end
 

--- a/scripts/zones/Abyssea-Tahrongi/Zone.lua
+++ b/scripts/zones/Abyssea-Tahrongi/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-24, 44, -678, 240)
     end
 

--- a/scripts/zones/Abyssea-Uleguerand/Zone.lua
+++ b/scripts/zones/Abyssea-Uleguerand/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-238, -40, -520.5, 0)
     end
 

--- a/scripts/zones/Abyssea-Vunkerl/Zone.lua
+++ b/scripts/zones/Abyssea-Vunkerl/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-351, -46.750, 699.5, 10)
     end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -24,7 +24,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI then
             cs = 201
         elseif prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI then

--- a/scripts/zones/AlTaieu/Zone.lua
+++ b/scripts/zones/AlTaieu/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-25, -1 , -620 , 33)
     end
 

--- a/scripts/zones/Al_Zahbi/Zone.lua
+++ b/scripts/zones/Al_Zahbi/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) + 37
         player:setPos(position, 0, -62, 192)
     end

--- a/scripts/zones/Altar_Room/Zone.lua
+++ b/scripts/zones/Altar_Room/Zone.lua
@@ -31,7 +31,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         cs = 51
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-247.998, 12.609, -100.008, 128)
     end
 

--- a/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
@@ -36,7 +36,11 @@ end
 
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.ARRAPAGO_REMNANTS then
             player:setPos(-579, 0.05, -100, 192)
         else

--- a/scripts/zones/Arrapago_Reef/Zone.lua
+++ b/scripts/zones/Arrapago_Reef/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-456, -3, -405, 64)
     end
 

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -49,7 +49,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-194.487, -13.766, 338.704, 141)
     end
 

--- a/scripts/zones/Aydeewa_Subterrane/Zone.lua
+++ b/scripts/zones/Aydeewa_Subterrane/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(356.503, -0.364, -179.607, 122)
     end
 

--- a/scripts/zones/Balgas_Dais/Zone.lua
+++ b/scripts/zones/Balgas_Dais/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(317.842, -126.158, 380.143, 127)
     end
 

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -25,7 +25,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
     end

--- a/scripts/zones/Bastok_Markets_[S]/Zone.lua
+++ b/scripts/zones/Bastok_Markets_[S]/Zone.lua
@@ -16,7 +16,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
     end

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -30,7 +30,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) - 75
         player:setPos(116, 0.99, position, 127)
     end

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -49,7 +49,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-693.609, -14.583, 173.59, 30)
     end
 

--- a/scripts/zones/Batallia_Downs_[S]/Zone.lua
+++ b/scripts/zones/Batallia_Downs_[S]/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-500.451, -39.71, 504.894, 39)
     end
 

--- a/scripts/zones/Beadeaux/Zone.lua
+++ b/scripts/zones/Beadeaux/Zone.lua
@@ -34,7 +34,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(387.382, 38.029, 19.694, 3)
     end
 

--- a/scripts/zones/Beadeaux_[S]/Zone.lua
+++ b/scripts/zones/Beadeaux_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-297.109, 0.008, 96.002, 252)
     end
 

--- a/scripts/zones/Bearclaw_Pinnacle/Zone.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-680, 16, -540, 129)
     end
 

--- a/scripts/zones/Beaucedine_Glacier/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier/Zone.lua
@@ -23,7 +23,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setPos(-284.751, -39.923, -422.948, 235)
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-247.911, -82.165, 260.207, 248)
     end
 

--- a/scripts/zones/Beaucedine_Glacier_[S]/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-180, -81.85, 280, 44)
     end
 

--- a/scripts/zones/Behemoths_Dominion/Zone.lua
+++ b/scripts/zones/Behemoths_Dominion/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(358.134, 24.806, -60.001, 123)
     end
 

--- a/scripts/zones/Bhaflau_Thickets/Zone.lua
+++ b/scripts/zones/Bhaflau_Thickets/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-100, -13.5, -479.514, 60)
     end
 

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.MANACLIPPER then
             cs = xi.manaclipper.onZoneIn(player)
         else

--- a/scripts/zones/Boneyard_Gully/Zone.lua
+++ b/scripts/zones/Boneyard_Gully/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-709.508, 18.066, 456.241, 24)
     end
 

--- a/scripts/zones/Bostaunieux_Oubliette/Zone.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(99.978, -25.647, 72.867, 61)
     end
 

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -30,7 +30,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-276.529, 16.403, -324.519, 14)
     end
 

--- a/scripts/zones/Caedarva_Mire/Zone.lua
+++ b/scripts/zones/Caedarva_Mire/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(339.996, 2.5, -721.286, 200)
     end
 

--- a/scripts/zones/Cape_Teriggan/Zone.lua
+++ b/scripts/zones/Cape_Teriggan/Zone.lua
@@ -28,7 +28,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(315.644, -1.517, -60.633, 108)
     end
 

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -24,7 +24,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(6.509, -9.163, -819.333, 239)
     end
 

--- a/scripts/zones/Castle_Oztroja/Zone.lua
+++ b/scripts/zones/Castle_Oztroja/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-162.895, 22.136, -139.923, 2)
     end
 

--- a/scripts/zones/Castle_Oztroja_[S]/Zone.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/Zone.lua
@@ -37,7 +37,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-239.447, -1.813, -19.98, 250)
     end
 

--- a/scripts/zones/Castle_Zvahl_Baileys/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/Zone.lua
@@ -40,7 +40,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-181.969, -35.542, 19.995, 254)
     end
 

--- a/scripts/zones/Castle_Zvahl_Baileys_[S]/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(412.024, -12, -20.047, 128)
     end
 

--- a/scripts/zones/Castle_Zvahl_Keep_[S]/Zone.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-555.996, -71.691, 60, 255)
     end
 

--- a/scripts/zones/Ceizak_Battlegrounds/Zone.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(431, 0, 178, 110)
     end
 

--- a/scripts/zones/Celennia_Memorial_Library/Zone.lua
+++ b/scripts/zones/Celennia_Memorial_Library/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-96, -2, -87, 94)
     end
 

--- a/scripts/zones/Chamber_of_Oracles/Zone.lua
+++ b/scripts/zones/Chamber_of_Oracles/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-177.804, -2.765, -37.893, 179)
     end
 

--- a/scripts/zones/Chateau_dOraguille/Zone.lua
+++ b/scripts/zones/Chateau_dOraguille/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(14.872, 8.918, 24.002, 255)
     end
 

--- a/scripts/zones/Cirdas_Caverns/Zone.lua
+++ b/scripts/zones/Cirdas_Caverns/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-180, 30, -314, 203)
     end
 

--- a/scripts/zones/Cloister_of_Flames/Zone.lua
+++ b/scripts/zones/Cloister_of_Flames/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-698.729, -1.045, -646.659, 184)
     end
 

--- a/scripts/zones/Cloister_of_Frost/Zone.lua
+++ b/scripts/zones/Cloister_of_Frost/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(499.993, -1.696, 523.343, 194)
     end
 

--- a/scripts/zones/Cloister_of_Gales/Zone.lua
+++ b/scripts/zones/Cloister_of_Gales/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-399.541, -1.697, -420, 252)
     end
 

--- a/scripts/zones/Cloister_of_Storms/Zone.lua
+++ b/scripts/zones/Cloister_of_Storms/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(517.957, -18.013, 540.045, 0)
     end
 

--- a/scripts/zones/Cloister_of_Tides/Zone.lua
+++ b/scripts/zones/Cloister_of_Tides/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(564.776, 34.297, 500.819, 250)
     end
 

--- a/scripts/zones/Cloister_of_Tremors/Zone.lua
+++ b/scripts/zones/Cloister_of_Tremors/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-636.001, -16.563, -500.023, 205)
     end
 

--- a/scripts/zones/Crawlers_Nest/Zone.lua
+++ b/scripts/zones/Crawlers_Nest/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(380.617, -34.61, 4.581, 59)
     end
 

--- a/scripts/zones/Crawlers_Nest_[S]/Zone.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(380.617, -34.61, 4.581, 65)
     end
 

--- a/scripts/zones/Dangruf_Wadi/Zone.lua
+++ b/scripts/zones/Dangruf_Wadi/Zone.lua
@@ -24,7 +24,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-4.025, -4.449, 0.016, 112)
     end
 

--- a/scripts/zones/Davoi/Zone.lua
+++ b/scripts/zones/Davoi/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(282.292, 2.498, -17.908, 247)
     end
 

--- a/scripts/zones/Den_of_Rancor/Zone.lua
+++ b/scripts/zones/Den_of_Rancor/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(196.421, 34.595, -60.319, 110)
     end
 

--- a/scripts/zones/Desuetia_Empyreal_Paradox/Zone.lua
+++ b/scripts/zones/Desuetia_Empyreal_Paradox/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         -- player:setPos(x, y, z, rot)
     end
 

--- a/scripts/zones/Dho_Gates/Zone.lua
+++ b/scripts/zones/Dho_Gates/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(62, -10, 83, 84)
     end
 

--- a/scripts/zones/Dragons_Aery/Zone.lua
+++ b/scripts/zones/Dragons_Aery/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-60.006, -2.915, -39.501, 202)
     end
 

--- a/scripts/zones/East_Ronfaure/Zone.lua
+++ b/scripts/zones/East_Ronfaure/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(200.015, -3.187, -536.074, 187)
     end
 

--- a/scripts/zones/East_Ronfaure_[S]/Zone.lua
+++ b/scripts/zones/East_Ronfaure_[S]/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(86.131, -65.817, 273.861, 25)
     end
 

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(305.377, -36.092, 660.435, 71)
     end
 

--- a/scripts/zones/Eastern_Adoulin/Zone.lua
+++ b/scripts/zones/Eastern_Adoulin/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-155, 0, -19, 250)
     end
 

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -35,7 +35,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(260.09, 6.013, 320.454, 76)
     end
 

--- a/scripts/zones/Empyreal_Paradox/Zone.lua
+++ b/scripts/zones/Empyreal_Paradox/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         --player:setPos(502, 0, 500, 222) -- BC Area
         player:setPos(539, -1, -500, 69)
     end

--- a/scripts/zones/Escha_RuAun/Zone.lua
+++ b/scripts/zones/Escha_RuAun/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-0.371, -34.277, -466.98, 187)
     end
 

--- a/scripts/zones/Escha_ZiTah/Zone.lua
+++ b/scripts/zones/Escha_ZiTah/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         -- 0, 0, 0 currently lands the player at a valid location in zone
     end
 

--- a/scripts/zones/FeiYin/Zone.lua
+++ b/scripts/zones/FeiYin/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(99.98, -1.768, 275.993, 70)
     end
 

--- a/scripts/zones/Foret_de_Hennetiel/Zone.lua
+++ b/scripts/zones/Foret_de_Hennetiel/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(360, 6, 455, 93)
     end
 

--- a/scripts/zones/Fort_Ghelsba/Zone.lua
+++ b/scripts/zones/Fort_Ghelsba/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(219.949, -86.032, 19.489, 128)
     end
 

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(820, 25.782, 117.991, 66)
     end
 

--- a/scripts/zones/Full_Moon_Fountain/Zone.lua
+++ b/scripts/zones/Full_Moon_Fountain/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-260.136, 2.09, -325.702, 188)
     end
 

--- a/scripts/zones/Garlaige_Citadel/Zone.lua
+++ b/scripts/zones/Garlaige_Citadel/Zone.lua
@@ -42,7 +42,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-380.035, -13.548, 398.032, 64)
     end
 

--- a/scripts/zones/Garlaige_Citadel_[S]/Zone.lua
+++ b/scripts/zones/Garlaige_Citadel_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-300, -13.548, 157, 64)
     end
 

--- a/scripts/zones/Ghelsba_Outpost/Zone.lua
+++ b/scripts/zones/Ghelsba_Outpost/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(125.852, -22.097, 180.403, 128)
     end
 

--- a/scripts/zones/Giddeus/Zone.lua
+++ b/scripts/zones/Giddeus/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-135.904, -5.788, -300.668, 2)
     end
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
@@ -30,7 +30,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-20, -1.5, -355.482, 192)
     end
 

--- a/scripts/zones/Grauberg_[S]/Zone.lua
+++ b/scripts/zones/Grauberg_[S]/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(495.063, 69.903, 924.102, 23)
     end
 

--- a/scripts/zones/Gusgen_Mines/Zone.lua
+++ b/scripts/zones/Gusgen_Mines/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(100.007, -61.63, -237.441, 187)
     end
 

--- a/scripts/zones/Gustav_Tunnel/Zone.lua
+++ b/scripts/zones/Gustav_Tunnel/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-260.013, -21.802, -276.352, 205)
     end
 

--- a/scripts/zones/Hall_of_Transference/Zone.lua
+++ b/scripts/zones/Hall_of_Transference/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(274, -82, -62 , 180)
     end
 

--- a/scripts/zones/Hall_of_the_Gods/Zone.lua
+++ b/scripts/zones/Hall_of_the_Gods/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-0.011, -1.848, -176.133, 192)
     elseif player:getCurrentMission(xi.mission.log_id.ACP) == xi.mission.id.acp.REMEMBER_ME_IN_YOUR_DREAMS and prevZone == xi.zone.ROMAEVE then
         cs = 5

--- a/scripts/zones/Halvung/Zone.lua
+++ b/scripts/zones/Halvung/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(160.54, -22.001, 139.988, 244)
     end
 

--- a/scripts/zones/Hazhalm_Testing_Grounds/Zone.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/Zone.lua
@@ -9,7 +9,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(652.174, -272.632, -104.92, 148)
     end
 

--- a/scripts/zones/Heavens_Tower/Zone.lua
+++ b/scripts/zones/Heavens_Tower/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(0, 0, 22, 192)
     end
 

--- a/scripts/zones/Horlais_Peak/Zone.lua
+++ b/scripts/zones/Horlais_Peak/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-536.363, 157.713, -210.819, 17)
     end
 

--- a/scripts/zones/Ifrits_Cauldron/Zone.lua
+++ b/scripts/zones/Ifrits_Cauldron/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-60.296, 48.884, 105.967, 69)
     end
 

--- a/scripts/zones/Inner_Horutoto_Ruins/Zone.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-259.996, 6.399, 242.859, 67)
     end
 

--- a/scripts/zones/Jade_Sepulcher/Zone.lua
+++ b/scripts/zones/Jade_Sepulcher/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(340.383, -13.625, -157.447, 189)
     end
 

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -36,7 +36,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(342, -5, 15.117, 169)
     end
 

--- a/scripts/zones/Jugner_Forest_[S]/Zone.lua
+++ b/scripts/zones/Jugner_Forest_[S]/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(621.865, -6.665, 300.264, 149)
     end
 

--- a/scripts/zones/Kamihr_Drifts/Zone.lua
+++ b/scripts/zones/Kamihr_Drifts/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(500, 72, -479, 191)
     end
 

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.KAZHAM_JEUNO_AIRSHIP then
             cs = 10002
         end

--- a/scripts/zones/King_Ranperres_Tomb/Zone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(242.012, 5.305, 340.059, 121)
     end
 

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(521.922, 28.361, 747.85, 45)
     end
 

--- a/scripts/zones/Korroloka_Tunnel/Zone.lua
+++ b/scripts/zones/Korroloka_Tunnel/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-500, -21.824, 0.358, 60)
     end
 

--- a/scripts/zones/Kuftal_Tunnel/Zone.lua
+++ b/scripts/zones/Kuftal_Tunnel/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(20.37, -21.104, 275.782, 46)
     end
 

--- a/scripts/zones/LaLoff_Amphitheater/Zone.lua
+++ b/scripts/zones/LaLoff_Amphitheater/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(189.849, -176.455, 346.531, 244)
     end
 

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -29,7 +29,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-272.118, 21.715, 98.859, 243)
     end
 

--- a/scripts/zones/La_Vaule_[S]/Zone.lua
+++ b/scripts/zones/La_Vaule_[S]/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(236.547, -2.25, 20, 120)
     end
 

--- a/scripts/zones/Labyrinth_of_Onzozo/Zone.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-58.808, -21.364, -286.654, 190)
     end
 

--- a/scripts/zones/Leafallia/Zone.lua
+++ b/scripts/zones/Leafallia/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-1, 0, 0, 151)
     end
 

--- a/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(460.022, -1.77, -103.442, 188)
     end
 

--- a/scripts/zones/Lufaise_Meadows/Zone.lua
+++ b/scripts/zones/Lufaise_Meadows/Zone.lua
@@ -32,7 +32,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-475.825, -20.461, 281.149, 11)
     end
 

--- a/scripts/zones/Mamook/Zone.lua
+++ b/scripts/zones/Mamook/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-117.491, -20.115, -299.997, 6)
     end
 

--- a/scripts/zones/Manaclipper/Zone.lua
+++ b/scripts/zones/Manaclipper/Zone.lua
@@ -16,7 +16,11 @@ zoneObject.onZoneIn = function(player, prevZone)
 
     xi.manaclipper.onZoneIn(player)
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(0, -3, -8, 60)
     end
 

--- a/scripts/zones/Marjami_Ravine/Zone.lua
+++ b/scripts/zones/Marjami_Ravine/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(429, -60, 298, 99)
     end
 

--- a/scripts/zones/Maze_of_Shakhrami/Zone.lua
+++ b/scripts/zones/Maze_of_Shakhrami/Zone.lua
@@ -28,7 +28,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-140.246, -12.738, 160.709, 63)
     end
 

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -29,7 +29,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(752.632, -33.761, -40.035, 129)
     end
 

--- a/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-454.135, 28.409, 657.79, 49)
     end
 

--- a/scripts/zones/Metalworks/Zone.lua
+++ b/scripts/zones/Metalworks/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-9.168, 0, 0.001, 128)
     end
 

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -31,7 +31,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.SHIP_BOUND_FOR_MHAURA or prevZone == xi.zone.OPEN_SEA_ROUTE_TO_MHAURA or prevZone == xi.zone.SHIP_BOUND_FOR_MHAURA_PIRATES then
             cs = 202
             player:setPos(14.960, -3.430, 18.423, 192)

--- a/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
@@ -34,7 +34,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-43.0914, -47.4255, 77.5126, 120)
     end
 

--- a/scripts/zones/Mine_Shaft_2716/Zone.lua
+++ b/scripts/zones/Mine_Shaft_2716/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-116.599, -122.103, -620.01, 253)
     end
 

--- a/scripts/zones/Misareaux_Coast/Zone.lua
+++ b/scripts/zones/Misareaux_Coast/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(567.624, -20, 280.775, 120)
     end
 

--- a/scripts/zones/Mog_Garden/Zone.lua
+++ b/scripts/zones/Mog_Garden/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-2.517, 0.452, -5.068, 190)
     end
 

--- a/scripts/zones/Moh_Gates/Zone.lua
+++ b/scripts/zones/Moh_Gates/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(107, 15, 135, 238)
     end
 

--- a/scripts/zones/Monarch_Linn/Zone.lua
+++ b/scripts/zones/Monarch_Linn/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(12.527, 0.345, -539.602, 127)
     end
 

--- a/scripts/zones/Monastic_Cavern/Zone.lua
+++ b/scripts/zones/Monastic_Cavern/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(261.354, -8.792, 23.124, 175)
     end
 

--- a/scripts/zones/Morimar_Basalt_Fields/Zone.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(579, -7, -484, 199)
     end
 

--- a/scripts/zones/Mount_Kamihr/Zone.lua
+++ b/scripts/zones/Mount_Kamihr/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         -- player:setPos(x, y, z, r)
     end
 

--- a/scripts/zones/Nashmau/Zone.lua
+++ b/scripts/zones/Nashmau/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU then
             cs = 201
             player:setPos(11, 2, -102, 128)

--- a/scripts/zones/Navukgo_Execution_Chamber/Zone.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-660.185, -12.079, -199.532, 192)
     end
 

--- a/scripts/zones/Newton_Movalpolos/Zone.lua
+++ b/scripts/zones/Newton_Movalpolos/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(451.895, 26.214, -19.782, 133)
     end
 

--- a/scripts/zones/Norg/Zone.lua
+++ b/scripts/zones/Norg/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-19.238, -2.163, -63.964, 187)
     end
 

--- a/scripts/zones/North_Gustaberg/Zone.lua
+++ b/scripts/zones/North_Gustaberg/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-518.867, 35.538, 588.64, 50)
     end
 

--- a/scripts/zones/North_Gustaberg_[S]/Zone.lua
+++ b/scripts/zones/North_Gustaberg_[S]/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(380.038, -2.25, 147.627, 192)
     end
 

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -40,7 +40,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(130, -0.2, -3, 160)
     end
 

--- a/scripts/zones/Oldton_Movalpolos/Zone.lua
+++ b/scripts/zones/Oldton_Movalpolos/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(70.956, 5.99, 139.843, 134)
     end
 

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Ordelles_Caves/Zone.lua
+++ b/scripts/zones/Ordelles_Caves/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-76.839, -1.696, 659.969, 122)
     end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/Zone.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(419.991, -9.637, 716.991, 190)
     end
 

--- a/scripts/zones/Outer_RaKaznar/Zone.lua
+++ b/scripts/zones/Outer_RaKaznar/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-40, -180, -20, 128)
     end
 

--- a/scripts/zones/Palborough_Mines/Zone.lua
+++ b/scripts/zones/Palborough_Mines/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(114.483, -42, -140, 96)
     end
 

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -26,7 +26,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(547.841, 23.192, 696.323, 136)
     end
 

--- a/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(547.841, 23.192, 696.323, 134)
     end
 

--- a/scripts/zones/Phanauet_Channel/Zone.lua
+++ b/scripts/zones/Phanauet_Channel/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.15
         player:setPos(position, -2.000, -1.000, 190)
     end

--- a/scripts/zones/Phomiuna_Aqueducts/Zone.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(260.02, -2.12, -290.461, 192)
     end
 

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -31,7 +31,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setHomePoint()
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.BASTOK_JEUNO_AIRSHIP then
             cs = 73
             player:setPos(-36.000, 7.000, -58.000, 194)

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -28,7 +28,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:ChangeMusic(1, 239)
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
             cs = 10018
             player:setPos(-87.000, 12.000, 116.000, 128)

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -27,7 +27,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setHomePoint()
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
             cs = 702
             player:setPos(-1.000, 0.000, 44.000, 0)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -25,7 +25,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setHomePoint()
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.WINDURST_JEUNO_AIRSHIP then
             cs = 10004
             player:setPos(228.000, -3.000, 76.000, 160)

--- a/scripts/zones/Promyvion-Dem/Zone.lua
+++ b/scripts/zones/Promyvion-Dem/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(185.891, 0, -52.331, 128)
     end
 

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(92.033, 0, 80.380, 255) -- To Floor 1 (R)
     end
 

--- a/scripts/zones/Promyvion-Mea/Zone.lua
+++ b/scripts/zones/Promyvion-Mea/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-93.268, 0, 170.749, 162) -- Floor 1 (R)
     end
 

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -15,7 +15,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-14.744, 0.036, -119.736, 1) -- To Floor 1 (R)
     end
 

--- a/scripts/zones/Provenance/Zone.lua
+++ b/scripts/zones/Provenance/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-640, -20, -519.999, 192)
     end
 

--- a/scripts/zones/PsoXja/Zone.lua
+++ b/scripts/zones/PsoXja/Zone.lua
@@ -28,7 +28,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-29.956, -1.903, 212.521, 188)
     end
 

--- a/scripts/zones/QuBia_Arena/Zone.lua
+++ b/scripts/zones/QuBia_Arena/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-241.046, -25.86, 19.991, 0)
     end
 

--- a/scripts/zones/Qufim_Island/Zone.lua
+++ b/scripts/zones/Qufim_Island/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-286.271, -21.619, 320.084, 255)
     end
 

--- a/scripts/zones/Quicksand_Caves/Zone.lua
+++ b/scripts/zones/Quicksand_Caves/Zone.lua
@@ -46,7 +46,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-980.193, 14.913, -282.863, 60)
     end
 

--- a/scripts/zones/Qulun_Dome/Zone.lua
+++ b/scripts/zones/Qulun_Dome/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(337.901, 38.091, 20.087, 129)
     end
 

--- a/scripts/zones/RaKaznar_Inner_Court/Zone.lua
+++ b/scripts/zones/RaKaznar_Inner_Court/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-476, -520.5, 20, 0)
     end
 

--- a/scripts/zones/RaKaznar_Turris/Zone.lua
+++ b/scripts/zones/RaKaznar_Turris/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(58, 30, 20, 0)
     end
 

--- a/scripts/zones/Rabao/Zone.lua
+++ b/scripts/zones/Rabao/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-20.052, 6.074, -122.408, 193)
     end
 

--- a/scripts/zones/Rala_Waterways/Zone.lua
+++ b/scripts/zones/Rala_Waterways/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-267, -5, -380, 133)
     end
 

--- a/scripts/zones/Ranguemont_Pass/Zone.lua
+++ b/scripts/zones/Ranguemont_Pass/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(302.778, -68.131, 257.759, 137)
     end
 

--- a/scripts/zones/Reisenjima/Zone.lua
+++ b/scripts/zones/Reisenjima/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-500.023, -19.074, -487.686, 190)
     end
 

--- a/scripts/zones/Reisenjima_Sanctorium/Zone.lua
+++ b/scripts/zones/Reisenjima_Sanctorium/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(0.002, 3.999, -9.876, 190)
     end
 

--- a/scripts/zones/Riverne-Site_A01/Zone.lua
+++ b/scripts/zones/Riverne-Site_A01/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(732.55, -32.5, -506.544, 90)
     end
 

--- a/scripts/zones/Riverne-Site_B01/Zone.lua
+++ b/scripts/zones/Riverne-Site_B01/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(729.749, -20.319, 407.153, 90)
     end
 

--- a/scripts/zones/RoMaeve/Zone.lua
+++ b/scripts/zones/RoMaeve/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-0.008, -33.595, 123.478, 62)
     end
 

--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -23,7 +23,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-381.747, -31.068, -788.092, 211)
     end
 

--- a/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-376.179, -30.387, -776.159, 220)
     end
 

--- a/scripts/zones/RuLude_Gardens/Zone.lua
+++ b/scripts/zones/RuLude_Gardens/Zone.lua
@@ -18,7 +18,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) + 45
         player:setPos(position, 10, -73, 192)
     end

--- a/scripts/zones/Sacrarium/Zone.lua
+++ b/scripts/zones/Sacrarium/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-219.996, -18.587, 82.795, 64)
     end
 

--- a/scripts/zones/Sacrificial_Chamber/Zone.lua
+++ b/scripts/zones/Sacrificial_Chamber/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(316.848, -2.182, 340.03, 125)
     end
 

--- a/scripts/zones/Sauromugue_Champaign/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign/Zone.lua
@@ -24,7 +24,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-103.991, -25.956, -425.221, 190)
     end
 

--- a/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-104, -25.36, -410, 195)
     end
 

--- a/scripts/zones/Sea_Serpent_Grotto/Zone.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/Zone.lua
@@ -27,7 +27,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-60.566, -2.127, 412, 54)
     end
 

--- a/scripts/zones/Sealions_Den/Zone.lua
+++ b/scripts/zones/Sealions_Den/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(600.101, 130.355, 797.612, 50)
     end
 

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -22,7 +22,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         if prevZone == xi.zone.SHIP_BOUND_FOR_SELBINA or prevZone == xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES then
             cs = 202
             player:setPos(32.500, -2.500, -45.500, 192)

--- a/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura_Pirates/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Ship_bound_for_Selbina/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
+++ b/scripts/zones/Ship_bound_for_Selbina_Pirates/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(-2, 2) + 0.150
         player:setPos(position, -2.100, 3.250, 64)
     end

--- a/scripts/zones/Sih_Gates/Zone.lua
+++ b/scripts/zones/Sih_Gates/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-41, -30, -19, 115)
     end
 

--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-601.433, 35.204, -520.031, 1)
     end
 

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -33,7 +33,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(161, -2, 161, 94)
     end
 

--- a/scripts/zones/Southern_San_dOria_[S]/Zone.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/Zone.lua
@@ -26,7 +26,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(161, -2, 161, 94)
     end
 

--- a/scripts/zones/Spire_of_Dem/Zone.lua
+++ b/scripts/zones/Spire_of_Dem/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-0.539, -2.049, 293.640, 64)
     end
 

--- a/scripts/zones/Spire_of_Holla/Zone.lua
+++ b/scripts/zones/Spire_of_Holla/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(1.460, -2.050, -293.738, 191) -- (R)
     end
 

--- a/scripts/zones/Spire_of_Mea/Zone.lua
+++ b/scripts/zones/Spire_of_Mea/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-1.539, -2.049, 293.640, 64) -- (R)
     end
 

--- a/scripts/zones/Spire_of_Vahzl/Zone.lua
+++ b/scripts/zones/Spire_of_Vahzl/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-0.039, -2.049, 293.640, 64) -- Floor 1 (R)
     end
 

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -27,7 +27,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(442.781, -1.641, -40.144, 160)
     end
 

--- a/scripts/zones/Talacca_Cove/Zone.lua
+++ b/scripts/zones/Talacca_Cove/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(64.007, -9.281, -99.988, 88)
     end
 

--- a/scripts/zones/Tavnazian_Safehold/Zone.lua
+++ b/scripts/zones/Tavnazian_Safehold/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(27.971, -14.068, 43.735, 66)
     end
 

--- a/scripts/zones/Temple_of_Uggalepih/Zone.lua
+++ b/scripts/zones/Temple_of_Uggalepih/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(432.013, 5.353, 216.472, 153)
     end
 

--- a/scripts/zones/The_Boyahda_Tree/Zone.lua
+++ b/scripts/zones/The_Boyahda_Tree/Zone.lua
@@ -18,7 +18,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-140.008, 3.787, 202.715, 64)
     end
 

--- a/scripts/zones/The_Celestial_Nexus/Zone.lua
+++ b/scripts/zones/The_Celestial_Nexus/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-697.114, -6.656, -32.351, 0)
     end
 

--- a/scripts/zones/The_Eldieme_Necropolis/Zone.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/Zone.lua
@@ -19,7 +19,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         cs = 4
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-438.878, -26.091, 540.004, 126)
     end
 

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/Zone.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/Zone.lua
@@ -9,7 +9,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(420.035, -58.114, -119.51, 191)
     end
 

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -113,7 +113,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-351.136, -2.25, -380, 253)
     end
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -28,7 +28,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(539.901, 3.379, -580.218, 126)
     end
 

--- a/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -43,7 +43,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-3.38, 46.326, 60, 122)
     end
 

--- a/scripts/zones/The_Shrouded_Maw/Zone.lua
+++ b/scripts/zones/The_Shrouded_Maw/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-300, -1.5, -220, 62)
     end
 

--- a/scripts/zones/Throne_Room/Zone.lua
+++ b/scripts/zones/Throne_Room/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(114.308, -7.639, 0.022, 126)
     end
 

--- a/scripts/zones/Throne_Room_[S]/Zone.lua
+++ b/scripts/zones/Throne_Room_[S]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(114.308, -7.639, 0.022, 128)
     end
 

--- a/scripts/zones/Throne_Room_[V]/Zone.lua
+++ b/scripts/zones/Throne_Room_[V]/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(114.308, -7.639, 0.022, 128)
     end
 

--- a/scripts/zones/Toraimarai_Canal/Zone.lua
+++ b/scripts/zones/Toraimarai_Canal/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-259.98, 21.794, 81.887, 66)
     end
 

--- a/scripts/zones/Uleguerand_Range/Zone.lua
+++ b/scripts/zones/Uleguerand_Range/Zone.lua
@@ -27,7 +27,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(363.025, 16, -60, 12)
     end
 

--- a/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(12.098, -105.408, 27.683, 239)
     end
 

--- a/scripts/zones/Upper_Jeuno/Zone.lua
+++ b/scripts/zones/Upper_Jeuno/Zone.lua
@@ -27,7 +27,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(46.2, -5, -78, 172)
     end
 

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -39,7 +39,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(60.989, -4.898, -151.001, 198)
     end
 

--- a/scripts/zones/Valley_of_Sorrows/Zone.lua
+++ b/scripts/zones/Valley_of_Sorrows/Zone.lua
@@ -17,7 +17,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(45.25, -2.115, -140.562, 0)
     end
 

--- a/scripts/zones/VeLugannon_Palace/Zone.lua
+++ b/scripts/zones/VeLugannon_Palace/Zone.lua
@@ -19,7 +19,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-100.01, -25.752, -399.468, 59)
     end
 

--- a/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-393.238, -50.034, 741.199, 2)
     end
 

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -21,7 +21,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(610.542, -28.547, 356.247, 122)
     end
 

--- a/scripts/zones/Walk_of_Echoes/Zone.lua
+++ b/scripts/zones/Walk_of_Echoes/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-700.042, 0.4, -441.301, 192)
     end
 

--- a/scripts/zones/Waughroon_Shrine/Zone.lua
+++ b/scripts/zones/Waughroon_Shrine/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-361.434, 101.798, -259.996, 0)
     end
 

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -20,7 +20,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-24.427, -53.107, 140, 127)
     end
 

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -25,7 +25,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-374.008, -23.712, 63.289, 213)
     end
 

--- a/scripts/zones/West_Sarutabaruta_[S]/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/Zone.lua
@@ -14,7 +14,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(320.018, -6.684, -45.166, 189)
     end
 

--- a/scripts/zones/Western_Adoulin/Zone.lua
+++ b/scripts/zones/Western_Adoulin/Zone.lua
@@ -14,7 +14,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
     local heartwingsAndTheKindhearted = player:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.HEARTWINGS_AND_THE_KINDHEARTED
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-142, 4, -18, 4)
     end
 

--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -30,7 +30,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-19.901, 13.607, 440.058, 78)
     end
 

--- a/scripts/zones/Windurst_Walls/Zone.lua
+++ b/scripts/zones/Windurst_Walls/Zone.lua
@@ -16,7 +16,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) - 123
         player:setPos(-257.5, -5.05, position, 0)
     end

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -29,7 +29,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) + 157
         player:setPos(position, -5, -62, 192)
     end

--- a/scripts/zones/Windurst_Waters_[S]/Zone.lua
+++ b/scripts/zones/Windurst_Waters_[S]/Zone.lua
@@ -16,7 +16,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(157 + math.random(1, 5), -5, -62, 192)
     end
 

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -30,7 +30,11 @@ zoneObject.onZoneIn = function(player, prevZone)
     end
 
     -- MOG HOUSE EXIT
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         local position = math.random(1, 5) + 37
         player:setPos(-138, -10, position, 0)
     end

--- a/scripts/zones/Woh_Gates/Zone.lua
+++ b/scripts/zones/Woh_Gates/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(479, 0, 139, 140)
     end
 

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -25,7 +25,11 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:setPos(569.312, -0.098, -270.158, 90)
     end
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-136.287, -23.268, 137.302, 91)
     end
 

--- a/scripts/zones/Xarcabard_[S]/Zone.lua
+++ b/scripts/zones/Xarcabard_[S]/Zone.lua
@@ -12,7 +12,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(-414, -46.5, 20, 253)
     end
 

--- a/scripts/zones/Yahse_Hunting_Grounds/Zone.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/Zone.lua
@@ -13,7 +13,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(361, 4, -211, 136)
     end
 

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -50,7 +50,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(299.997, -5.838, -622.998, 190)
     end
 

--- a/scripts/zones/Yorcia_Weald/Zone.lua
+++ b/scripts/zones/Yorcia_Weald/Zone.lua
@@ -11,7 +11,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(254, 6, 64, 219)
     end
 

--- a/scripts/zones/Yughott_Grotto/Zone.lua
+++ b/scripts/zones/Yughott_Grotto/Zone.lua
@@ -16,7 +16,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(439.814, -42.481, 169.755, 118)
     end
 

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -36,7 +36,11 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
-    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+    if
+        player:getXPos() == 0 and
+        player:getYPos() == 0 and
+        player:getZPos() == 0
+    then
         player:setPos(116.825, 6.613, 100, 140)
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Additional low-hanging fruit in preparation for new CI rule, makes one mass change from single-line 0-position check to multiple.
```
    if
        player:getXPos() == 0 and
        player:getYPos() == 0 and
        player:getZPos() == 0
    then
```
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed.
<!-- Clear and detailed steps to test your changes here -->
