### PR TITLE
Fixed DRG Wyvern's Healing Breath not targeting trusts

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -49,7 +49,7 @@ local function doHealingBreath(player, threshold, breath)
     if player:getHPP() < threshold and inBreathRange(player) then
         player:getPet():useJobAbility(breath, player)
     else
-        local party = player:getParty()
+        local party = player:getPartyWithTrusts()
         for _, member in pairs(party) do
             if member:getHPP() < threshold and inBreathRange(member) then
                 player:getPet():useJobAbility(breath, member)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #3170 

## Steps to test these changes

1) !setjob 14 75 
2) !setsjob 3 37
3) !addspell 913 
4) !addspell 71
5) /ja "Call Wyvern" <me>
6) Summon Prishe trust.
7) Target Prishe
8) !hp 2
9) /ma "Barwatera" <me>

Observe wyvern casts Healing Breath on Prishe.
