### PR TITLE
Support mob skills ignoring battle ids

### DIFF
--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1364,7 +1364,7 @@ INSERT INTO `mob_skills` VALUES (1527,1086,'laser_shower',4,10.0,2000,1500,4,0,0
 INSERT INTO `mob_skills` VALUES (1528,1087,'floodlight',2,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1529,1089,'hyper_pulse',1,10.0,2000,1500,4,0,0,0,0,0,0); -- Proto-Omega
 INSERT INTO `mob_skills` VALUES (1530,1088,'stun_cannon',4,20.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,0,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1531,772,'wz_recover_all',1,20.0,0,0,1028,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1532,1124,'pod_ejection',0,7.0,4500,1,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1533,1117,'pile_pitch',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1534,1118,'guided_missile',2,5.0,2000,1500,4,0,0,0,0,0,0);

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -430,7 +430,7 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
 
     if (m_PBattleEntity->StatusEffectContainer->GetConfrontationEffect() != PTarget->StatusEffectContainer->GetConfrontationEffect() ||
         m_PBattleEntity->PBattlefield != PTarget->PBattlefield || m_PBattleEntity->PInstance != PTarget->PInstance ||
-        m_PBattleEntity->getBattleID() != PTarget->getBattleID())
+        ((m_findFlags & FINDFLAGS_IGNORE_BATTLEID) == FINDFLAGS_NONE && m_PBattleEntity->getBattleID() != PTarget->getBattleID()))
     {
         return false;
     }
@@ -586,7 +586,9 @@ CBattleEntity* CTargetFind::getValidTarget(uint16 actionTargetID, uint16 validTa
         return m_PBattleEntity->PPet;
     }
 
-    if (m_PBattleEntity->getBattleID() == PTarget->getBattleID() && PTarget->ValidTarget(m_PBattleEntity, validTargetFlags))
+    bool ignoreBattleId  = (validTargetFlags & TARGET_IGNORE_BATTLEID) == TARGET_IGNORE_BATTLEID;
+    bool hasSameBattleId = m_PBattleEntity->getBattleID() == PTarget->getBattleID();
+    if ((ignoreBattleId || hasSameBattleId) && PTarget->ValidTarget(m_PBattleEntity, validTargetFlags))
     {
         return PTarget;
     }

--- a/src/map/ai/helpers/targetfind.h
+++ b/src/map/ai/helpers/targetfind.h
@@ -53,12 +53,13 @@ enum class AURA_TARGET : uint8
 
 enum FINDFLAGS
 {
-    FINDFLAGS_NONE      = 0,
-    FINDFLAGS_DEAD      = 1, // target dead
-    FINDFLAGS_ALLIANCE  = 2, // force target alliance
-    FINDFLAGS_PET       = 4, // force target pet
-    FINDFLAGS_UNLIMITED = 8, // unlimited distance
-    FINDFLAGS_HIT_ALL   = 16 // hit all targets, regardless of party
+    FINDFLAGS_NONE            = 0,
+    FINDFLAGS_DEAD            = 1,  // target dead
+    FINDFLAGS_ALLIANCE        = 2,  // force target alliance
+    FINDFLAGS_PET             = 4,  // force target pet
+    FINDFLAGS_UNLIMITED       = 8,  // unlimited distance
+    FINDFLAGS_HIT_ALL         = 16, // hit all targets, regardless of party
+    FINDFLAGS_IGNORE_BATTLEID = 32, // ignore battle id check
 };
 
 /*

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -419,6 +419,7 @@ enum TARGETTYPE
     TARGET_PLAYER_PARTY_PIANISSIMO = 0x80,
     TARGET_PET                     = 0x100,
     TARGET_PLAYER_PARTY_ENTRUST    = 0x200,
+    TARGET_IGNORE_BATTLEID         = 0x400, // Can hit targets that do not have the same battle ID
 };
 
 enum SKILLCHAIN_ELEMENT

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -641,6 +641,11 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     if (PSkill->getValidTargets() == TARGET_SELF)
     {
         findFlags |= FINDFLAGS_PET;
+    }
+
+    if ((PSkill->getValidTargets() & TARGET_IGNORE_BATTLEID) == TARGET_IGNORE_BATTLEID)
+    {
+        findFlags |= FINDFLAGS_IGNORE_BATTLEID;
     }
 
     action.id = id;

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -301,6 +301,11 @@ void CPetEntity::OnPetSkillFinished(CPetSkillState& state, action_t& action)
         findFlags |= FINDFLAGS_PET;
     }
 
+    if ((PSkill->getValidTargets() & TARGET_IGNORE_BATTLEID) == TARGET_IGNORE_BATTLEID)
+    {
+        findFlags |= FINDFLAGS_IGNORE_BATTLEID;
+    }
+
     action.id         = id;
     action.actiontype = (ACTIONTYPE)PSkill->getSkillFinishCategory();
     action.actionid   = PSkill->getID();


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add support for mob skills to ignore battle id. Usually we don't want mobs to interact with other players outside of the battle id but sometimes we do such as with the recover Armoury Crates in Limbus. We don't want the player interacting with them (including AoE) but we do need the crate to interact with the player - recovery is done through a mob skill.

This actually fixes an issue with Limbus recover Armoury Crates since [Battle IDs](https://github.com/LandSandBoat/server/pull/3036) were merged in. 

## Steps to test these changes

Go into a Limbus area and open a recovery crate. It should fully recover your HP and MP.
