### PR TITLE
Use MOBMOD_DETECTION for all detection logic

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -101,7 +101,7 @@ bool CMobController::TryDeaggro()
 bool CMobController::CanPursueTarget(CBattleEntity* PTarget)
 {
     TracyZoneScoped;
-    if (PMob->m_Detects & DETECT_SCENT)
+    if (PMob->getMobMod(MOBMOD_DETECTION) & DETECT_SCENT)
     {
         // if mob is in water it will instant deaggro if target cannot be detected
         if (!PMob->PAI->PathFind->InWater() && !PTarget->StatusEffectContainer->HasStatusEffect(EFFECT_DEODORIZE))
@@ -238,9 +238,8 @@ bool CMobController::CanDetectTarget(CBattleEntity* PTarget, bool forceSight)
         return false;
     }
 
-    int16 detection       = PMob->getMobMod(MOBMOD_DETECTION);
-    auto  detects         = detection != 0 ? detection : PMob->m_Detects;
-    auto  currentDistance = distance(PTarget->loc.p, PMob->loc.p) + PTarget->getMod(Mod::STEALTH);
+    auto detects         = PMob->getMobMod(MOBMOD_DETECTION);
+    auto currentDistance = distance(PTarget->loc.p, PMob->loc.p) + PTarget->getMod(Mod::STEALTH);
 
     bool detectSight  = (detects & DETECT_SIGHT) || forceSight;
     bool hasInvisible = false;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -117,7 +117,6 @@ CMobEntity::CMobEntity()
     m_neutral       = false;
     m_Aggro         = false;
     m_TrueDetection = false;
-    m_Detects       = DETECT_NONE;
     m_Link          = 0;
     m_isAggroable   = false;
     m_battlefieldID = 0;
@@ -326,13 +325,10 @@ bool CMobEntity::CanLink(position_t* pos, int16 superLink)
         return false;
     }
 
-    // link only if I see him
-    if (m_Detects & DETECT_SIGHT)
+    // Link if can see mob
+    if (getMobMod(MOBMOD_DETECTION) & DETECT_SIGHT && !facing(loc.p, *pos, 64))
     {
-        if (!facing(loc.p, *pos, 64))
-        {
-            return false;
-        }
+        return false;
     }
 
     if (distance(loc.p, *pos) > getMobMod(MOBMOD_LINK_RADIUS))

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -222,7 +222,6 @@ public:
     uint8     m_Type; // mob type
     bool      m_Aggro;
     bool      m_TrueDetection; // Has true sight or sound
-    uint16    m_Detects;       // mobs detection methods, sight, sound, etc
     uint8     m_Link;          // link with mobs of it's family
     bool      m_isAggroable;   // Can be aggroed by other monsters when in the player allegiance
     uint16    m_Behaviour;     // mob behaviour

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -215,7 +215,7 @@ CInstance* CInstanceLoader::LoadInstance()
 
             PMob->m_MobSkillList  = sql->GetUIntData(70);
             PMob->m_TrueDetection = sql->GetUIntData(71);
-            PMob->m_Detects       = sql->GetUIntData(72);
+            PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(72));
 
             PMob->setMobMod(MOBMOD_CHARMABLE, sql->GetUIntData(73));
 

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1605,7 +1605,7 @@ namespace fishingutils
 
         // PMob->SetLocalVar("QuestBattleID", PChar->GetLocalVar("QuestBattleID"));
         // PChar->StatusEffectContainer->CopyConfrontationEffect(PMob);
-        if ((mob->log < 255 && mob->quest < 255) || mob->questOnly || (PMob->m_TrueDetection && PMob->m_Detects & DETECT_SCENT) || !PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK))
+        if ((mob->log < 255 && mob->quest < 255) || mob->questOnly || (PMob->m_TrueDetection && PMob->getMobMod(MOBMOD_DETECTION) & DETECT_SCENT) || !PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK))
         {
             PMob->PEnmityContainer->AddBaseEnmity(PChar);
             battleutils::ClaimMob(PMob, (CBattleEntity*)PChar);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -584,7 +584,7 @@ namespace mobutils
             ShowError("Mobutils::CalculateMobStats Mob (%s, %d) with magic but no cool down set!", PMob->GetName(), PMob->id);
         }
 
-        if (PMob->m_Detects == 0)
+        if (PMob->getMobMod(MOBMOD_DETECTION) == 0)
         {
             ShowError("Mobutils::CalculateMobStats Mob (%s, %d, %d) has no detection methods!", PMob->GetName(), PMob->id, PMob->m_Family);
         }
@@ -1377,7 +1377,7 @@ Usage:
                 PMob->m_Aggro         = sql->GetUIntData(66);
                 PMob->m_MobSkillList  = sql->GetUIntData(67);
                 PMob->m_TrueDetection = sql->GetUIntData(68);
-                PMob->m_Detects       = sql->GetUIntData(69);
+                PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(69));
 
                 CZone* newZone = zoneutils::GetZone(zoneID);
 
@@ -1537,7 +1537,7 @@ Usage:
                 PMob->m_Aggro         = sql->GetUIntData(66);
                 PMob->m_MobSkillList  = sql->GetUIntData(67);
                 PMob->m_TrueDetection = sql->GetUIntData(68);
-                PMob->m_Detects       = sql->GetUIntData(69);
+                PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(69));
 
                 // must be here first to define mobmods
                 mobutils::InitializeMob(PMob, zoneutils::GetZone(targetZoneId));

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -504,7 +504,7 @@ namespace zoneutils
                     PMob->m_MobSkillList = sql->GetUIntData(73);
 
                     PMob->m_TrueDetection = sql->GetUIntData(74);
-                    PMob->m_Detects       = sql->GetUIntData(75);
+                    PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(75));
 
                     PMob->setMobMod(MOBMOD_CHARMABLE, sql->GetUIntData(76));
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -291,7 +291,7 @@ void CZoneEntities::WeatherChange(WEATHER weather)
 
         PCurrentMob->PAI->EventHandler.triggerListener("WEATHER_CHANGE", CLuaBaseEntity(PCurrentMob), static_cast<int>(weather), element);
         // can't detect by scent in this weather
-        if (PCurrentMob->m_Detects & DETECT_SCENT)
+        if (PCurrentMob->getMobMod(MOBMOD_DETECTION) & DETECT_SCENT)
         {
             PCurrentMob->m_disableScent = (weather == WEATHER_RAIN || weather == WEATHER_SQUALL || weather == WEATHER_BLIZZARDS);
         }


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I previously added in `MOBMOD_DETECTION` to support changing the detection programatically. After encountering an issue with linking due to not using this mobmod I decided it would likely be best to have a single source for detection. Now detection is read into the mobmod from db and is only used that way.

## Steps to test these changes

Go get aggro
