### PR TITLE
[codeql] Use _ variable for unused db query result

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -410,7 +410,7 @@ def import_file(file):
         return
     print("Importing " + file)
     query = f"SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0; SOURCE {file}; SET unique_checks=1; SET foreign_key_checks=1; COMMIT;"
-    result = db_query(query)
+    _ = db_query(query)
 
 
 def connect():
@@ -741,7 +741,7 @@ def set_external_ip(ip_str):
     """
     print("Executing query:")
     print(query)
-    result = db_query(query)
+    _ = db_query(query)
 
 
 def set_external_ip_dialog():


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
db query result in import_file and set_external_ip were unused, changed variable to unused type (`_`)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should occur, codeql warning should be removed
<!-- Clear and detailed steps to test your changes here -->
