### PR TITLE
Add support for quest related battlefields in new framework

### DIFF
--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -70,6 +70,7 @@ global_objects=(
     Event
     Battlefield
     BattlefieldMission
+    BattlefieldQuest
     Limbus
 
     removeSleepEffects


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds `BattlefieldQuest` which is for quest battlefields. This was made for "The Holy Crest" which is currently being put into ASB but I hope to eventually get that over to LSB along with the other battlefields.

It is fairly straightforward as it just overrides a few Battlefield functions very similar to how `BattlefieldMission` works.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
