### PR TITLE
[core] Adjust trade logic to be more retail-like

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -199,6 +199,8 @@ CCharEntity::CCharEntity()
     m_isBlockingAid = false;
 
     BazaarID.clean();
+
+    lastTradeInvite = {};
     TradePending.clean();
     InvitePending.clean();
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -419,10 +419,11 @@ public:
     SpawnIDList_t SpawnTRUSTList; // list of visible trust
     SpawnIDList_t SpawnNPCList;   // list of visible npc's
 
-    void SetName(int8* name); // устанавливаем имя персонажа (имя ограничивается 15-ю символами)
+    void SetName(int8* name); // set the name of character, limtied to 15 characters
 
-    EntityID_t   TradePending;    // ID персонажа, предлагающего обмен
-    EntityID_t   InvitePending;   // ID персонажа, отправившего приглашение в группу
+    time_point   lastTradeInvite;
+    EntityID_t   TradePending;    // character ID offering trade
+    EntityID_t   InvitePending;   // character ID sending party invite
     EntityID_t   BazaarID;        // Pointer to the bazaar we are browsing.
     BazaarList_t BazaarCustomers; // Array holding the IDs of the current customers
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1481,20 +1481,10 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
             return;
         }
 
-        // If PChar is invisible don't allow the trade, but you are able to initiate a trade TO an invisible player
-        if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
-        {
-            // 155 = "You cannot perform that action on the specified target."
-            // TODO: Correct message is "You cannot use that command while invisible."
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
-            return;
-        }
-
         // If either player is in prison don't allow the trade.
         if (jailutils::InPrison(PChar) || jailutils::InPrison(PTarget))
         {
-            // 316 = "That action cannot be used in this area."
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 316));
+            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
             return;
         }
 
@@ -1502,7 +1492,7 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
         if (PChar->animation == ANIMATION_SYNTH || PTarget->animation == ANIMATION_SYNTH)
         {
             ShowDebug("%s trade request with %s was blocked.", PChar->GetName(), PTarget->GetName());
-            PChar->pushPacket(new CMessageStandardPacket(MsgStd::CannotBeProcessed));
+            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
             return;
         }
 
@@ -1514,23 +1504,54 @@ void SmallPacket0x032(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->pushPacket(new CMessageSystemPacket(0, 0, 225));
             // Interaction was blocked
             PTarget->pushPacket(new CMessageSystemPacket(0, 0, 226));
-            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x01));
+            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
             return;
         }
 
         if (PTarget->TradePending.id == PChar->id)
         {
-            ShowDebug("%s already sent a trade request to %s", PChar->GetName(), PTarget->GetName());
+            ShowDebug("%s has already sent a trade request to %s", PChar->GetName(), PTarget->GetName());
             return;
         }
+
         if (!PTarget->UContainer->IsContainerEmpty())
         {
-            ShowDebug("%s UContainer is not empty. %s cannot trade with them at this time", PTarget->GetName(), PChar->GetName());
+            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            ShowDebug("%s's UContainer is not empty. %s cannot trade with them at this time", PTarget->GetName(), PChar->GetName());
             return;
         }
+
+        auto lastTargetTradeTimeSeconds = std::chrono::duration_cast<std::chrono::seconds>(server_clock::now() - PTarget->lastTradeInvite).count();
+        if ((PTarget->TradePending.targid != 0 && lastTargetTradeTimeSeconds < 60) || PTarget->UContainer->GetType() == UCONTAINER_TRADE)
+        {
+            // Can't trade with someone who's already got a pending trade before timeout
+            PChar->pushPacket(new CTradeActionPacket(PTarget, 0x07));
+            return;
+        }
+
+        // This block usually doesn't trigger,
+        // The client is generally forced to send a trade cancel packet via a cancel yes/no menu,
+        // resulting in an outgoing 0x033 with 0x04 set to 0x01 for their old trade target, but sometimes the menu does not happen and a cancel is sent instead.
+        if (PChar->TradePending.id != 0)
+        {
+            // Tell previous trader we don't want their business
+            CCharEntity* POldTradeTarget = (CCharEntity*)PChar->GetEntity(PChar->TradePending.id, TYPE_PC);
+            if (POldTradeTarget && POldTradeTarget->id == PChar->TradePending.id)
+            {
+                POldTradeTarget->TradePending.clean();
+                PChar->TradePending.clean();
+
+                POldTradeTarget->pushPacket(new CTradeActionPacket(PChar, 0x07));
+                PChar->pushPacket(new CTradeActionPacket(POldTradeTarget, 0x07));
+                return;
+            }
+        }
+
+        PChar->lastTradeInvite     = server_clock::now();
         PChar->TradePending.id     = charid;
         PChar->TradePending.targid = targid;
 
+        PTarget->lastTradeInvite     = server_clock::now();
         PTarget->TradePending.id     = PChar->id;
         PTarget->TradePending.targid = PChar->targid;
         PTarget->pushPacket(new CTradeRequestPacket(PChar));
@@ -1744,12 +1765,11 @@ void SmallPacket0x036(map_session_data_t* const PSession, CCharEntity* const PCh
 {
     TracyZoneScoped;
 
-    // If PChar is invisible don't allow the trade, but you are able to initiate a trade TO an invisible player
+    // If PChar is invisible don't allow the trade
     if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_INVISIBLE))
     {
-        // 155 = "You cannot perform that action on the specified target."
-        // TODO: Correct message is "You cannot use that command while invisible."
-        PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 155));
+        // "You cannot use that command while invisible."
+        PChar->pushPacket(new CMessageSystemPacket(0, 0, 172));
         return;
     }
 


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add a 60 second timeout between trades between different characters than the original trade request with a rejection
Add the apparent failsafe in case the client menu acts up
Remove character trade invisible check
Fix NPC trade invisible message
Fix various error values not matching retail

## Steps to test these changes

Make 3 characters, trade between two of them but don't initiate -- use the third and try to trade with either, you should get an error message on the third, repeat but initiate, get an error message
Trade to an NPC while invisible, get  "You cannot perform that action while invisible" error
Trade to a player while you or both are invisible, be able to trade
