### PR TITLE
[core] Allow charm to change state to CAttackState

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -203,14 +203,14 @@ bool CAIContainer::Internal_Engage(uint16 targetid)
         //#TODO: remove m_battleTarget if possible (need to check disengage)
         // Check if an entity can change to the attack state
         // Allow entity with prevent action effect to very briefly switch to the attack state to be properly engaged
-        if (CanChangeState() || (GetCurrentState() && GetCurrentState()->IsCompleted()) || entity->StatusEffectContainer->HasPreventActionEffect())
+        if (CanChangeState() || (GetCurrentState() && GetCurrentState()->IsCompleted()) || entity->StatusEffectContainer->HasPreventActionEffect(true))
         {
             if (ForceChangeState<CAttackState>(entity, targetid))
             {
                 entity->OnEngage(*static_cast<CAttackState*>(m_stateStack.top().get()));
 
                 // Resume being inactive if entity has a status effect preventing them from doing actions
-                if (entity->StatusEffectContainer->HasPreventActionEffect())
+                if (entity->StatusEffectContainer->HasPreventActionEffect(true))
                 {
                     entity->PAI->Inactive(0ms, false);
                 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -918,7 +918,10 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
         break;
         case 0x04: // disengage
         {
-            PChar->PAI->Disengage();
+            if (!PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_CHARM, EFFECT_CHARM_II }))
+            {
+                PChar->PAI->Disengage();
+            }
         }
         break;
         case 0x05: // call for help

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1963,8 +1963,13 @@ void CStatusEffectContainer::TickRegen(time_point tick)
     }
 }
 
-bool CStatusEffectContainer::HasPreventActionEffect()
+bool CStatusEffectContainer::HasPreventActionEffect(bool ignoreCharm)
 {
+    if (ignoreCharm)
+    {
+        return HasStatusEffect(
+            { EFFECT_SLEEP, EFFECT_SLEEP_II, EFFECT_PETRIFICATION, EFFECT_LULLABY, EFFECT_PENALTY, EFFECT_STUN, EFFECT_TERROR });
+    }
     return HasStatusEffect(
         { EFFECT_SLEEP, EFFECT_SLEEP_II, EFFECT_PETRIFICATION, EFFECT_LULLABY, EFFECT_CHARM, EFFECT_CHARM_II, EFFECT_PENALTY, EFFECT_STUN, EFFECT_TERROR });
 }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -110,7 +110,7 @@ public:
 
     void WakeUp(); // remove sleep effects
     bool IsAsleep();
-    bool HasPreventActionEffect(); // checks if owner has an effect that prevents actions, like stun, petrify, sleep etc
+    bool HasPreventActionEffect(bool ignoreCharm = false); // checks if owner has an effect that prevents actions, like stun, petrify, sleep etc
 
     uint16 GetConfrontationEffect();                        // gets confrontation number (bcnm, confrontation, campaign, reive mark)
     void   CopyConfrontationEffect(CBattleEntity* PEntity); // copies confrontation status (pet summoning, etc)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4930,6 +4930,11 @@ namespace battleutils
             battleutils::RelinquishClaim(static_cast<CCharEntity*>(PVictim));
             PVictim->PMaster = PCharmer;
             PVictim->updatemask |= UPDATE_ALL_CHAR;
+
+            // Prevent auto attacks for a little bit to simulate retail
+            // On retail, you don't engage for a little bit, which we have no mechanism for yet
+            // TODO: implement the delays on engage (also applies to mobs) and verify exact timings for those things.
+            PVictim->PAI->Inactive(5000ms, false);
         }
         PVictim->allegiance = PCharmer->allegiance;
         PVictim->updatemask |= UPDATE_HP;


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes a disengage bug if you were not already engaged before getting charmed, and allows you to change state to engaged state while charmed. You would also not auto-attack if you were disengaged before being charmed.
Also adds in a short inactive delay to prevent immediate auto attacks which is not what retail does.

## Steps to test these changes

Spawn Xolotl (16806215), force him to use a charm move (`!exec target:useMobAbility(1329)`) while disengaged with a "friend" around and see the charmed player engage, auto attack and eventually disengage when uncharmed

repeat, except sleep the player through charm and they will eventually disengage upon waking if charm has worn off
