### PR TITLE
Fixed DRG Wyvern not using Super Climb when master uses Super Jump

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -408,7 +408,7 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
         wyvern ~= nil and
         wyvern:getHP() > 0
     then
-        wyvern:useJobAbility(636, wyvern)
+        wyvern:useJobAbility(xi.jobAbility.SUPER_CLIMB, wyvern)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #3198 

## Steps to test these changes

- !setjob 14 75
- /ja "Call Wyvern"
- Target an Enemy
- /ja "Super Jump" <t>

Observe wyvern now uses Super Climb.
