### PR TITLE
[lua] [core] [DRG] Fix Wyvern Super Climb, reduce delay on use

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -470,13 +470,14 @@ xi.job_utils.dragoon.useSuperJump = function(player, target, ability)
         playerArg:untargetableAndUnactionable(5000)
     end)
 
-    -- If the Dragoon's wyvern is out and alive, tell it to use Super Climb
+    -- If the Dragoon's wyvern is out, alive, and engaged, tell it to use Super Climb
     local wyvern = getWyvern(player)
     if
         wyvern ~= nil and
-        wyvern:getHP() > 0
+        wyvern:getHP() > 0 and
+        wyvern:isEngaged()
     then
-        wyvern:useJobAbility(636, wyvern)
+        wyvern:useJobAbility(xi.jobAbility.SUPER_CLIMB, wyvern)
     end
 end
 

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -529,6 +529,11 @@ bool CAIContainer::QueueEmpty()
     return ActionQueue.isEmpty();
 }
 
+void CAIContainer::checkQueueImmediately()
+{
+    ActionQueue.checkAction(server_clock::now());
+}
+
 bool CAIContainer::Internal_Despawn(bool instantDespawn)
 {
     if (!IsCurrentState<CDespawnState>() && !IsCurrentState<CRespawnState>())

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -122,6 +122,7 @@ public:
 
     void QueueAction(queueAction_t&&);
     bool QueueEmpty();
+    void checkQueueImmediately();
 
     // stores all events and their associated lua callbacks
     CAIEventHandler              EventHandler;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13818,8 +13818,9 @@ void CLuaBaseEntity::castSpell(sol::object const& spell, sol::object entity)
 /************************************************************************
  *  Function: useJobAbility()
  *  Purpose : Instruct a Mob to use a specified Job Ability
- *  Example : wyvern:useJobAbility(636, wyvern) -- Specifying pet to use
- *  Notes   : Inserts directly into queue stack with 0ms delay
+ *  Example : wyvern:useJobAbility(xi.jobAbility.SUPER_CLIMB, wyvern) -- Specifying pet to use
+ *  Notes   : Inserts directly into queue stack with 0ms delay,
+ *  and checks queue for immediate use.
  ************************************************************************/
 
 void CLuaBaseEntity::useJobAbility(uint16 skillID, sol::object const& pet)
@@ -13847,6 +13848,9 @@ void CLuaBaseEntity::useJobAbility(uint16 skillID, sol::object const& pet)
         }
     }));
     // clang-format on
+
+    // Check queue immediately in case of 0 ms delay abilities
+    m_PBaseEntity->PAI->checkQueueImmediately();
 }
 
 /************************************************************************


### PR DESCRIPTION
* This adds a function to immediately check an action queue for 0ms delay queue items

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes use of Super Climb on the wyvern, adds the engaged check like retail and adds functionality to check the action queue for 0ms delay abilities (such as super climb)
The timing isn't perfect with retail, the wyvern still uses it a little bit too late but this is way better than it was without the change.

## Steps to test these changes

Engage mob on drg with wyvern, use super jump and see your wyvern use super climb

Closes #3198 
