### PR TITLE
[core] Refactor all uses of ip2str

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -198,7 +198,7 @@ int32 makeConnection(uint32 ip, uint16 port, int32 type)
     remote_address.sin_addr.s_addr = htonl(ip);
     remote_address.sin_port        = htons(port);
 
-    ShowInfo("Connecting to %d.%d.%d.%d:%i", CONVIP(ip), port);
+    ShowInfo(fmt::format("Connecting to {}:{}", ip2str(ip), port));
 
     result = sConnect(fd, (struct sockaddr*)(&remote_address), sizeof(struct sockaddr_in));
     if (result == SOCKET_ERROR)
@@ -294,7 +294,7 @@ std::string ip2str(uint32 ip)
     uint32 reversed_ip = htonl(ip);
     char   address[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &reversed_ip, address, INET_ADDRSTRLEN);
-    return std::string(address);
+    return fmt::format("{}", address);
 }
 
 uint32 str2ip(const char* ip_str)
@@ -378,7 +378,7 @@ static int connect_check(uint32 ip)
     int result = connect_check_(ip);
     if (access_debug)
     {
-        ShowInfo("connect_check: Connection from %d.%d.%d.%d %s", CONVIP(ip), result ? "allowed." : "denied!");
+        ShowInfo(fmt::format("connect_check: Connection from {} {}", ip2str(ip), result ? "allowed." : "denied!"));
     }
     return result;
 }
@@ -402,10 +402,10 @@ static int connect_check_(uint32 ip)
             if (access_debug)
             {
                 ShowInfo(
-                    "connect_check: Found match from allow list:%d.%d.%d.%d IP:%d.%d.%d.%d Mask:%d.%d.%d.%d",
-                    CONVIP(ip),
-                    CONVIP(entry.ip),
-                    CONVIP(entry.mask));
+                    fmt::format("connect_check: Found match from allow list:{} IP:{} Mask:{}",
+                                ip2str(ip),
+                                ip2str(entry.ip),
+                                ip2str(entry.mask)));
             }
             is_allowip = 1;
             break;
@@ -419,10 +419,10 @@ static int connect_check_(uint32 ip)
             if (access_debug)
             {
                 ShowInfo(
-                    "connect_check: Found match from deny list:%d.%d.%d.%d IP:%d.%d.%d.%d Mask:%d.%d.%d.%d",
-                    CONVIP(ip),
-                    CONVIP(entry.ip),
-                    CONVIP(entry.mask));
+                    fmt::format("connect_check: Found match from deny list:{} IP:{} Mask:{}",
+                                ip2str(ip),
+                                ip2str(entry.ip),
+                                ip2str(entry.mask)));
             }
             is_denyip = 1;
             break;
@@ -490,7 +490,7 @@ static int connect_check_(uint32 ip)
                 if (hist->count++ >= connect_count)
                 { // to many attempts detected
                     hist->ddos = 1;
-                    ShowWarning("connect_check: too many connection attempts detected from %d.%d.%d.%d!", CONVIP(ip));
+                    ShowWarning(fmt::format("connect_check: too many connection attempts detected from {}!", ip2str(ip)));
                     return (connect_ok == 2 ? 1 : 0);
                 }
                 return connect_ok;
@@ -605,7 +605,7 @@ int access_ipmask(const char* str, AccessControl* acc)
 
     if (access_debug)
     {
-        ShowInfo("access_ipmask: Loaded IP:%d.%d.%d.%d mask:%d.%d.%d.%d", CONVIP(ip), CONVIP(mask));
+        ShowInfo(fmt::format("access_ipmask: Loaded IP:{} mask:{}", ip2str(ip), ip2str(mask)));
     }
     acc->ip   = ip;
     acc->mask = mask;

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -163,8 +163,6 @@ std::string ip2str(uint32 ip);
 
 uint32 str2ip(const char* ip_str);
 
-#define CONVIP(ip) ((ip) >> 24) & 0xFF, ((ip) >> 16) & 0xFF, ((ip) >> 8) & 0xFF, ((ip) >> 0) & 0xFF
-
 uint16 ntows(uint16 netshort);
 
 /************************************************/

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -93,9 +93,9 @@ int32 lobbydata_parse(int32 fd)
         char* buff = &sessions[fd]->rdata[0];
         if (ref<uint8>(buff, 0) == 0x0d)
         {
-            ShowWarning("Possible Crash Attempt from IP: <%s>", ip2str(sessions[fd]->client_addr));
+            ShowWarning(fmt::format("Possible Crash Attempt from IP: <{}>", ip2str(sessions[fd]->client_addr)));
         }
-        ShowDebug("lobbydata_parse:Incoming Packet: <%x> from ip:<%s>", ref<uint8>(buff, 0), ip2str(sd->client_addr));
+        ShowDebug(fmt::format("lobbydata_parse:Incoming Packet: <{}> from ip:<{}>", ref<uint8>(buff, 0), ip2str(sd->client_addr)));
 
         auto maintMode  = settings::get<uint8>("login.MAINT_MODE");
         auto searchPort = settings::get<uint16>("network.SEARCH_PORT");
@@ -107,7 +107,7 @@ int32 lobbydata_parse(int32 fd)
             {
                 if (RFIFOREST(fd) < 9)
                 {
-                    ShowError("lobbydata_parse: <%s> sent less then 9 bytes", ip2str(sessions[fd]->client_addr));
+                    ShowError(fmt::format("lobbydata_parse: <{}> sent less then 9 bytes", ip2str(sessions[fd]->client_addr)));
                     do_close_lobbydata(sd, fd);
                     return -1;
                 }
@@ -257,7 +257,7 @@ int32 lobbydata_parse(int32 fd)
 
                     RFIFOSKIP(sd->login_lobbyview_fd, sessions[sd->login_lobbyview_fd]->rdata.size());
                     RFIFOFLUSH(sd->login_lobbyview_fd);
-                    ShowWarning("lobbydata_parse: char:(%i) login during maintenance mode (0xA2). Sending error to client.", sd->accid);
+                    ShowWarning(fmt::format("lobbydata_parse: char:({}) login during maintenance mode (0xA2). Sending error to client.", sd->accid));
                     // TODO: consider logging failed attempts during maintenance
                     return -1;
                 }
@@ -282,7 +282,7 @@ int32 lobbydata_parse(int32 fd)
                 }
                 else // Cleanup
                 {
-                    ShowWarning("lobbydata_parse: char:(%i) login data corrupt (0xA1). Disconnecting client.", sd->accid);
+                    ShowWarning(fmt::format("lobbydata_parse: char:({}) login data corrupt (0xA1). Disconnecting client.", sd->accid));
                     do_close_lobbydata(sd, fd);
                     return -1;
                 }
@@ -304,7 +304,7 @@ int32 lobbydata_parse(int32 fd)
 
                 if (sessions[sd->login_lobbyview_fd] == nullptr)
                 {
-                    ShowWarning("lobbydata_parse: char:(%i) login data corrupt (0xA2). Disconnecting client.", sd->accid);
+                    ShowWarning(fmt::format("lobbydata_parse: char:({}) login data corrupt (0xA2). Disconnecting client.", sd->accid));
                     do_close_lobbydata(sd, fd);
                     return -1;
                 }
@@ -351,7 +351,8 @@ int32 lobbydata_parse(int32 fd)
                     ref<uint32>(ReservePacket, 32) = charid;
                     std::memcpy(ReservePacket + 36, &strCharName, 16);
 
-                    ShowInfo("lobbydata_parse: zoneid:(%u),zoneip:(%s),zoneport:(%u) for char:(%u)", ZoneID, ip2str(ntohl(ZoneIP)), ZonePort, charid);
+                    ShowInfo(fmt::format("lobbydata_parse: zoneid:({}), zoneip:({}), zoneport:({}) for char:({})",
+                                         ZoneID, ip2str(ntohl(ZoneIP)), ZonePort, charid));
 
                     // Check the number of sessions
                     uint16 sessionCount = 0;
@@ -387,7 +388,7 @@ int32 lobbydata_parse(int32 fd)
 
                     if (!loginLimitOK)
                     {
-                        ShowWarning("%s already has %u active session(s), limit is %u", sd->login, sessionCount, loginLimit);
+                        ShowWarning(fmt::format("{} already has {} active session(s), limit is {}", sd->login, sessionCount, loginLimit));
                     }
 
                     if ((isNotMaint && loginLimitOK) || isGM)
@@ -483,7 +484,7 @@ int32 lobbydata_parse(int32 fd)
 
                 do_close_tcp(sd->login_lobbyview_fd);
 
-                ShowInfo("lobbydata_parse: client %s finished work with lobbyview", ip2str(sd->client_addr));
+                ShowInfo(fmt::format("lobbydata_parse: client {} finished work with lobbyview", ip2str(sd->client_addr)));
                 break;
             }
             default:
@@ -498,18 +499,18 @@ int32 do_close_lobbydata(login_session_data_t* loginsd, int32 fd)
 {
     if (loginsd != nullptr)
     {
-        ShowInfo("lobbydata_parse: %s shutdown the socket", loginsd->login);
+        ShowInfo(fmt::format("lobbydata_parse: {} shutdown the socket", loginsd->login));
         if (session_isActive(loginsd->login_lobbyview_fd))
         {
             do_close_tcp(loginsd->login_lobbyview_fd);
         }
         erase_loginsd_byaccid(loginsd->accid);
-        ShowInfo("lobbydata_parse: %s's login_session_data is deleted", loginsd->login);
+        ShowInfo(fmt::format("lobbydata_parse: {}'s login_session_data is deleted", loginsd->login));
         do_close_tcp(fd);
         return 0;
     }
 
-    ShowInfo("lobbydata_parse: %s shutdown the socket", ip2str(sessions[fd]->client_addr));
+    ShowInfo(fmt::format("lobbydata_parse: {} shutdown the socket", ip2str(sessions[fd]->client_addr)));
     do_close_tcp(fd);
     return 0;
 }
@@ -554,7 +555,7 @@ int32 lobbyview_parse(int32 fd)
         auto maintMode = settings::get<uint8>("login.MAINT_MODE");
 
         char* buff = &sessions[fd]->rdata[0];
-        ShowDebug("lobbyview_parse:Incoming Packet: <%x> from ip:<%s>", ref<uint8>(buff, 8), ip2str(sd->client_addr));
+        ShowDebug(fmt::format("lobbyview_parse:Incoming Packet: <{}> from ip:<{}>", ref<uint8>(buff, 8), ip2str(sd->client_addr)));
         uint8 code = ref<uint8>(buff, 8);
         switch (code)
         {
@@ -573,7 +574,7 @@ int32 lobbyview_parse(int32 fd)
 
                 if (ver_mismatch)
                 {
-                    ShowError("lobbyview_parse: Incorrect client version: got %s, expected %s", client_ver_data.c_str(), expected_version.c_str());
+                    ShowError(fmt::format("lobbyview_parse: Incorrect client version: got {}, expected {}", client_ver_data.c_str(), expected_version.c_str()));
 
                     switch (settings::get<uint8>("login.VER_LOCK"))
                     {
@@ -661,8 +662,8 @@ int32 lobbyview_parse(int32 fd)
                 // delete char
                 uint32 CharID = ref<uint32>(sessions[fd]->rdata.data(), 0x20);
 
-                ShowInfo("lobbyview_parse: attempt to delete char:<%d> from ip:<%s>", CharID,
-                         ip2str(sd->client_addr));
+                ShowInfo(fmt::format("lobbyview_parse: attempt to delete char:<{}> from ip:<{}>",
+                                     CharID, ip2str(sd->client_addr)));
 
                 uint8 sendsize = 0x20;
 
@@ -688,13 +689,13 @@ int32 lobbyview_parse(int32 fd)
             {
                 if (sessions[sd->login_lobbydata_fd] == nullptr)
                 {
-                    ShowInfo("0x1F nullptr: fd %i lobbydata fd %i lobbyview fd %i . Closing session.", fd, sd->login_lobbydata_fd, sd->login_lobbyview_fd);
+                    ShowInfo(fmt::format("0x1F nullptr: fd {} lobbydata fd {} lobbyview fd {}. Closing session.", fd, sd->login_lobbydata_fd, sd->login_lobbyview_fd));
                     uint32 val = 1337;
                     if (sd->login_lobbydata_fd - 1 >= 0 && sessions[sd->login_lobbydata_fd - 1] != nullptr)
                     {
                         val = sessions[sd->login_lobbydata_fd - 1]->client_addr;
                     }
-                    ShowInfo("Details: %s ip %i and lobbydata-1 fd ip is %i", sd->login, sd->client_addr, val);
+                    ShowInfo(fmt::format("Details: {} ip {} and lobbydata-1 fd ip is {}", sd->login, sd->client_addr, val));
                     do_close_tcp(fd);
                     return -1;
                 }
@@ -724,13 +725,13 @@ int32 lobbyview_parse(int32 fd)
             {
                 if (sessions[sd->login_lobbydata_fd] == nullptr)
                 {
-                    ShowInfo("0x07 nullptr: fd %i lobbydata fd %i lobbyview fd %i . Closing session.", fd, sd->login_lobbydata_fd, sd->login_lobbyview_fd);
+                    ShowInfo(fmt::format("0x07 nullptr: fd {} lobbydata fd {} lobbyview fd {}. Closing session.", fd, sd->login_lobbydata_fd, sd->login_lobbyview_fd));
                     uint32 val = 1337;
                     if (sd->login_lobbydata_fd - 1 >= 0 && sessions[sd->login_lobbydata_fd - 1] != nullptr)
                     {
                         val = sessions[sd->login_lobbydata_fd - 1]->client_addr;
                     }
-                    ShowInfo("Details: %s ip %i and lobbydata-1 fd ip is %i", sd->login, sd->client_addr, val);
+                    ShowInfo(fmt::format("Details: {} ip {} and lobbydata-1 fd ip is {}", sd->login, sd->client_addr, val));
                     do_close_tcp(fd);
                     return -1;
                 }
@@ -748,7 +749,7 @@ int32 lobbyview_parse(int32 fd)
                     return -1;
                 }
 
-                ShowInfo("lobbyview_parse: char <%s> was successfully created", sd->charname);
+                ShowInfo(fmt::format("lobbyview_parse: char <{}> was successfully created", sd->charname));
                 /////////////////////////
                 LOBBY_ACTION_DONE(ReservePacket);
                 unsigned char hash[16];
@@ -855,7 +856,7 @@ int32 lobbyview_parse(int32 fd)
 
                     if (invalidNameReason.has_value())
                     {
-                        ShowWarning("lobbyview_parse: new character name error <%s>: %s", CharName, (*invalidNameReason).c_str());
+                        ShowWarning(fmt::format("lobbyview_parse: new character name error <{}>: {}", CharName, (*invalidNameReason).c_str()));
 
                         // Send error code:
                         // The character name you entered is unavailable. Please choose another name.
@@ -892,7 +893,7 @@ int32 lobbyview_parse(int32 fd)
 
 int32 do_close_lobbyview(login_session_data_t* sd, int32 fd)
 {
-    ShowInfo("lobbyview_parse: %s shutdown the socket", sd->login);
+    ShowInfo(fmt::format("lobbyview_parse: {} shutdown the socket", sd->login));
     do_close_tcp(fd);
     return 0;
 }
@@ -916,8 +917,8 @@ int32 lobby_createchar(login_session_data_t* loginsd, int8* buf)
     // Log that the character attempting to create a non-starting job.
     if (mjob != createchar.m_mjob)
     {
-        ShowInfo("lobby_createchar: %s attempted to create invalid starting job %d substituting %d",
-                 loginsd->charname, mjob, createchar.m_mjob);
+        ShowInfo(fmt::format("lobby_createchar: {} attempted to create invalid starting job {} substituting {}",
+                             loginsd->charname, mjob, createchar.m_mjob));
     }
 
     createchar.m_nation = ref<uint8>(buf, 54);
@@ -960,7 +961,7 @@ int32 lobby_createchar(login_session_data_t* loginsd, int8* buf)
         return -1;
     }
 
-    ShowDebug("lobby_createchar: char<%s> successfully saved", createchar.m_name);
+    ShowDebug(fmt::format("lobby_createchar: char<{}> successfully saved", createchar.m_name));
     return 0;
 };
 
@@ -970,7 +971,7 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
 
     if (sql->Query(Query, charid, accid, createchar->m_name, createchar->m_zone, createchar->m_nation) == SQL_ERROR)
     {
-        ShowDebug("lobby_ccsave: char<%s>, accid: %u, charid: %u", createchar->m_name, accid, charid);
+        ShowDebug(fmt::format("lobby_ccsave: char<{}>, accid: {}, charid: {}", createchar->m_name, accid, charid));
         return -1;
     }
 
@@ -978,7 +979,7 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
 
     if (sql->Query(Query, charid, createchar->m_look.face, createchar->m_look.race, createchar->m_look.size) == SQL_ERROR)
     {
-        ShowDebug("lobby_cLook: char<%s>, charid: %u", createchar->m_name, charid);
+        ShowDebug(fmt::format("lobby_cLook: char<{}>, charid: {}", createchar->m_name, charid));
         return -1;
     }
 
@@ -986,7 +987,7 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
 
     if (sql->Query(Query, charid, createchar->m_mjob) == SQL_ERROR)
     {
-        ShowDebug("lobby_cStats: charid: %u", charid);
+        ShowDebug(fmt::format("lobby_cStats: charid: {}", charid));
         return -1;
     }
 

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -60,13 +60,13 @@ bool requestExit = false;
 int32 do_init(int32 argc, char** argv)
 {
     login_fd = makeListenBind_tcp(settings::get<std::string>("network.LOGIN_AUTH_IP").c_str(), settings::get<uint16>("network.LOGIN_AUTH_PORT"), connect_client_login);
-    ShowInfo("The login-server-auth is ready (Server is listening on the port %u).", settings::get<uint16>("network.LOGIN_AUTH_PORT"));
+    ShowInfo(fmt::format("The login-server-auth is ready (Server is listening on the port {}).", settings::get<uint16>("network.LOGIN_AUTH_PORT")));
 
     login_lobbydata_fd = makeListenBind_tcp(settings::get<std::string>("network.LOGIN_DATA_IP").c_str(), settings::get<uint16>("network.LOGIN_DATA_PORT"), connect_client_lobbydata);
-    ShowInfo("The login-server-lobbydata is ready (Server is listening on the port %u).", settings::get<uint16>("network.LOGIN_DATA_PORT"));
+    ShowInfo(fmt::format("The login-server-lobbydata is ready (Server is listening on the port {}).", settings::get<uint16>("network.LOGIN_DATA_PORT")));
 
     login_lobbyview_fd = makeListenBind_tcp(settings::get<std::string>("network.LOGIN_VIEW_IP").c_str(), settings::get<uint16>("network.LOGIN_VIEW_PORT"), connect_client_lobbyview);
-    ShowInfo("The login-server-lobbyview is ready (Server is listening on the port %u).", settings::get<uint16>("network.LOGIN_VIEW_PORT"));
+    ShowInfo(fmt::format("The login-server-lobbyview is ready (Server is listening on the port {}).", settings::get<uint16>("network.LOGIN_VIEW_PORT")));
 
     // NOTE: See login_conf.h for more information about what happens on this port
     // login_lobbyconf_fd = makeListenBind_tcp(settings::get<std::string>("network.LOGIN_CONF_IP").c_str(), settings::get<uint16>("network.LOGIN_CONF_PORT"), connect_client_lobbyconf);
@@ -193,7 +193,7 @@ int do_sockets(fd_set* rfd, duration next)
     {
         if (sErrno != S_EINTR)
         {
-            ShowCritical("do_sockets: select() failed, error code %d!", sErrno);
+            ShowCritical(fmt::format("do_sockets: select() failed, error code {}!", sErrno));
             exit(EXIT_FAILURE);
         }
         return 0; // interrupted by a signal, just loop and try again

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -49,9 +49,7 @@ enum ACCOUNT_PRIVILIGE_CODE : uint8
 };
 
 /*
- *
  *       LOGIN SECTION
- *
  */
 int32 connect_client_login(int32 listenfd)
 {
@@ -105,7 +103,7 @@ int32 login_parse(int32 fd)
         // data check
         if (check_string(name, 16) && check_string(password, 16))
         {
-            ShowWarning("login_parse: %s send unreadable data", ip2str(sd->client_addr));
+            ShowWarning(fmt::format("login_parse: {} send unreadable data", ip2str(sd->client_addr)));
             sessions[fd]->wdata.resize(1);
             ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR;
             do_close_login(sd, fd);
@@ -186,14 +184,14 @@ int32 login_parse(int32 fd)
 
                     if (numCons > 1)
                     {
-                        ShowInfo("login_parse: <%s> has logged in %i times! Removing older logins.", escaped_name, numCons);
+                        ShowInfo(fmt::format("login_parse: <{}> has logged in {} times! Removing older logins.", escaped_name, numCons));
                         for (int j = 0; j < (numCons - 1); j++)
                         {
                             for (login_sd_list_t::iterator i = login_sd_list.begin(); i != login_sd_list.end(); ++i)
                             {
                                 if ((*i)->accid == sd->accid)
                                 {
-                                    ShowTrace("Current login fd=%i Removing fd=%i", sd->login_fd, (*i)->login_fd);
+                                    ShowTrace(fmt::format("Current login fd={} Removing fd={}", sd->login_fd, (*i)->login_fd));
                                     login_sd_list.erase(i);
                                     break;
                                 }
@@ -202,13 +200,13 @@ int32 login_parse(int32 fd)
                     }
                     //////
 
-                    ShowInfo("login_parse: <%s> was connected", escaped_name, status);
+                    ShowInfo(fmt::format("login_parse: <{}> was connected", escaped_name, status));
                     return 0;
                 }
 
                 sessions[fd]->wdata.resize(1);
                 ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR;
-                ShowWarning("login_parse: unexisting user <%s> tried to connect", escaped_name);
+                ShowWarning(fmt::format("login_parse: unexisting user <{}> tried to connect", escaped_name));
                 do_close_login(sd, fd);
             }
             break;
@@ -217,8 +215,8 @@ int32 login_parse(int32 fd)
                 // check if account creation is disabled
                 if (!settings::get<bool>("login.ACCOUNT_CREATION"))
                 {
-                    ShowWarning("login_parse: New account attempt <%s> but is disabled in settings.",
-                                escaped_name);
+                    ShowWarning(fmt::format("login_parse: New account attempt <{}> but is disabled in settings.",
+                                            escaped_name));
                     sessions[fd]->wdata.resize(1);
                     ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE_DISABLED;
                     do_close_login(sd, fd);
@@ -277,14 +275,14 @@ int32 login_parse(int32 fd)
                         return -1;
                     }
 
-                    ShowInfo("login_parse: account<%s> was created", escaped_name);
+                    ShowInfo(fmt::format("login_parse: account<{}> was created", escaped_name));
                     sessions[fd]->wdata.resize(1);
                     ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_SUCCESS_CREATE;
                     do_close_login(sd, fd);
                 }
                 else
                 {
-                    ShowWarning("login_parse: account<%s> already exists", escaped_name);
+                    ShowWarning(fmt::format("login_parse: account<{}> already exists", escaped_name));
                     sessions[fd]->wdata.resize(1);
                     ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE_TAKEN;
                     do_close_login(sd, fd);
@@ -300,7 +298,7 @@ int32 login_parse(int32 fd)
                 {
                     sessions[fd]->wdata.resize(1);
                     ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR;
-                    ShowWarning("login_parse: user <%s> could not be found using the provided information. Aborting.", escaped_name);
+                    ShowWarning(fmt::format("login_parse: user <{}> could not be found using the provided information. Aborting.", escaped_name));
                     do_close_login(sd, fd);
                     return 0;
                 }
@@ -314,7 +312,7 @@ int32 login_parse(int32 fd)
                 {
                     sessions[fd]->wdata.resize(1);
                     ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR_CHANGE_PASSWORD;
-                    ShowInfo("login_parse: banned user <%s> detected. Aborting.", escaped_name);
+                    ShowInfo(fmt::format("login_parse: banned user <{}> detected. Aborting.", escaped_name));
                     do_close_login(sd, fd);
                     return 0;
                 }
@@ -335,8 +333,8 @@ int32 login_parse(int32 fd)
                     {
                         sessions[fd]->wdata.resize(1);
                         ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR_CHANGE_PASSWORD;
-                        ShowWarning("login_parse: Invalid packet size (%d). Could not update password for user <%s>.", size,
-                                    escaped_name);
+                        ShowWarning(fmt::format("login_parse: Invalid packet size ({}). Could not update password for user <{}>.",
+                                                size, escaped_name));
                         do_close_login(sd, fd);
                         return 0;
                     }
@@ -355,7 +353,7 @@ int32 login_parse(int32 fd)
                     {
                         sessions[fd]->wdata.resize(1);
                         ref<uint8>(sessions[fd]->wdata.data(), 0) = LOGIN_ERROR_CHANGE_PASSWORD;
-                        ShowWarning("login_parse: Error trying to update password in database for user <%s>.", escaped_name);
+                        ShowWarning(fmt::format("login_parse: Error trying to update password in database for user <{}>.", escaped_name));
                         do_close_login(sd, fd);
                         return 0;
                     }
@@ -373,7 +371,7 @@ int32 login_parse(int32 fd)
             }
             break;
             default:
-                ShowWarning("login_parse: undefined code:[%d], ip sender:<%s>", code, ip2str(sessions[fd]->client_addr));
+                ShowWarning(fmt::format("login_parse: undefined code:[{}], ip sender:<{}>", code, ip2str(sessions[fd]->client_addr)));
                 do_close_login(sd, fd);
                 break;
         };
@@ -387,7 +385,7 @@ int32 login_parse(int32 fd)
 
 int32 do_close_login(login_session_data_t* loginsd, int32 fd)
 {
-    ShowInfo("login_parse: %s shutdown socket", ip2str(loginsd->client_addr));
+    ShowInfo(fmt::format("login_parse: {} shutdown socket", ip2str(loginsd->client_addr)));
     erase_loginsd(fd);
     do_close_tcp(fd);
     return 0;

--- a/src/login/login_conf.cpp
+++ b/src/login/login_conf.cpp
@@ -165,18 +165,18 @@ int32 do_close_lobbyconf(login_session_data_t* loginsd, int32 fd)
 {
     if (loginsd != nullptr)
     {
-        ShowInfo("do_close_lobbyconf: %s shutdown the socket", loginsd->login);
+        ShowInfo(fmt::format("do_close_lobbyconf: {} shutdown the socket", loginsd->login));
         if (session_isActive(loginsd->login_lobbyconf_fd))
         {
             do_close_tcp(loginsd->login_lobbyconf_fd);
         }
         erase_loginsd_byaccid(loginsd->accid);
-        ShowInfo("lobbyconf_parse: %s's login_session_data is deleted", loginsd->login);
+        ShowInfo(fmt::format("lobbyconf_parse: {}'s login_session_data is deleted", loginsd->login));
         do_close_tcp(fd);
         return 0;
     }
 
-    ShowInfo("lobbyconf_parse: %s shutdown the socket", ip2str(sessions[fd]->client_addr));
+    ShowInfo(fmt::format("lobbyconf_parse: {} shutdown the socket", ip2str(sessions[fd]->client_addr)));
     do_close_tcp(fd);
     return 0;
 }

--- a/src/login/login_session.cpp
+++ b/src/login/login_session.cpp
@@ -57,7 +57,7 @@ login_session_data_t* find_loginsd_byip(uint32 ip)
 
     if (multiple_ip_count > 1)
     {
-        ShowInfo("Detected %i instances from %s. Returning best account match.", multiple_ip_count, ip2str(ip));
+        ShowInfo(fmt::format("Detected {} instances from {}. Returning best account match.", multiple_ip_count, ip2str(ip)));
     }
 
     for (auto& i : login_sd_list)

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -57,7 +57,7 @@ void message_server_send(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zm
     }
     catch (zmq::error_t& e)
     {
-        ShowError("Message: %s", e.what());
+        ShowError(fmt::format("Message: {}", e.what()));
     }
 }
 
@@ -158,15 +158,15 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
         default:
         {
-            ShowDebug("Message: unknown type received: %d from %s:%hu", static_cast<uint8>(type), from_address, from_port);
+            ShowDebug(fmt::format("Message: unknown type received: {} from {}:{}", static_cast<uint8>(type), from_address, from_port));
             break;
         }
     }
 
     if (ret != SQL_ERROR)
     {
-        ShowDebug("Message: Received message %s (%d) from %s:%hu",
-                  msgTypeToStr(type), static_cast<uint8>(type), from_address, from_port);
+        ShowDebug(fmt::format("Message: Received message {} ({}) from {}:{}",
+                              msgTypeToStr(type), static_cast<uint8>(type), from_address, from_port));
 
         while (zmqSql->NextRow() == SQL_SUCCESS)
         {
@@ -187,7 +187,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
 
             char target_address[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &target, target_address, INET_ADDRSTRLEN);
-            ShowDebug("Message: -> rerouting to %s:%lu", target_address, port);
+            ShowDebug(fmt::format("Message: -> rerouting to {}:{}", target_address, port));
             ip |= (port << 32);
 
             if (type == MSG_CHAT_PARTY || type == MSG_PT_RELOAD || type == MSG_PT_DISBAND)
@@ -227,7 +227,7 @@ void message_server_listen(const bool& requestExit)
                 return;
             }
 
-            ShowError("Message: %s", e.what());
+            ShowError(fmt::format("Message: {}", e.what()));
             continue;
         }
 
@@ -262,7 +262,7 @@ void message_server_init(const bool& requestExit)
     }
     catch (zmq::error_t& err)
     {
-        ShowCritical("Unable to bind chat socket: %s", err.what());
+        ShowCritical(fmt::format("Unable to bind chat socket: {}", err.what()));
     }
 
     message_server_listen(requestExit);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -164,13 +164,14 @@ map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
     ipp |= port64 << 32;
     map_session_list[ipp] = map_session_data;
 
-    const char* fmtQuery = "SELECT charid FROM accounts_sessions WHERE inet_ntoa(client_addr) = '%s' LIMIT 1;";
+    auto ipstr    = ip2str(map_session_data->client_addr);
+    auto fmtQuery = fmt::format("SELECT charid FROM accounts_sessions WHERE inet_ntoa(client_addr) = '{}' LIMIT 1;", ipstr);
 
-    int32 ret = sql->Query(fmtQuery, ip2str(map_session_data->client_addr));
+    int32 ret = sql->Query(fmtQuery.c_str());
 
     if (ret == SQL_ERROR || sql->NumRows() == 0)
     {
-        ShowError("recv_parse: Invalid login attempt from %s", ip2str(map_session_data->client_addr));
+        ShowError(fmt::format("recv_parse: Invalid login attempt from {}", ipstr));
         return nullptr;
     }
     return map_session_data;
@@ -579,7 +580,7 @@ int32 map_decipher_packet(int8* buff, size_t size, sockaddr_in* from, map_sessio
         return 0;
     }
 
-    ShowError("map_encipher_packet: bad packet from <%s>", ip2str(ip));
+    ShowError(fmt::format("map_encipher_packet: bad packet from <{}>", ip2str(ip)));
     return -1;
 }
 
@@ -606,7 +607,7 @@ int32 recv_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
     }
     catch (...)
     {
-        ShowError("Possible crash attempt from: %s", ip2str(map_session_data->client_addr));
+        ShowError(fmt::format("Possible crash attempt from: {}", ip2str(map_session_data->client_addr)));
         return -1;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Through heavy load testing, fmt's internals exploded when encountering a C++ string created directly from a bogus output of inet_ntop.

To get around this, the C++ string isn't created directly from the output anymore, it's passed into the very resilient `fmt::format("{}", input)`, which should handle it much more gracefully.

Refactored all uses of ip2str to use `fmt::format`'s `{}` syntax, which is less fragile than `fmt::sprintf`.

Removed the macro: CONVIP, and replaced it with equivalent calls to ip2str.

## Steps to test these changes

Login as expected, possibly with ipv6 or some other strange network voodoo, and see the login server not die.
