### PR TITLE
[dbtool][cpp] Ensure iterated dirs are sorted

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -60,9 +60,9 @@ namespace settings
         ShowInfo("Loading settings files");
 
         // Load defaults
-        for (auto const& entry : std::filesystem::directory_iterator("./settings/default/"))
+        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./settings/default/"))
         {
-            auto path     = std::filesystem::path(entry).relative_path();
+            auto path     = entry.relative_path();
             auto isLua    = path.extension() == ".lua";
             auto filename = path.string();
             auto key      = path.lexically_normal().replace_extension("").generic_string();
@@ -123,9 +123,9 @@ namespace settings
         }
 
         // Load user settings
-        for (auto const& entry : std::filesystem::directory_iterator("./settings/"))
+        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./settings/"))
         {
-            auto path     = std::filesystem::path(entry).relative_path();
+            auto path     = entry.relative_path();
             auto isLua    = path.extension() == ".lua";
             auto filename = path.string();
             auto key      = path.lexically_normal().replace_extension("").generic_string();

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -23,9 +23,12 @@
 #define _UTILS_H_
 #define _USE_MATH_DEFINES
 
-#include "../common/cbasetypes.h"
-#include "../common/mmo.h"
+#include "common/cbasetypes.h"
+#include "common/mmo.h"
+
+#include <filesystem>
 #include <math.h>
+#include <set>
 
 constexpr size_t PacketNameLength = 16; // 15 + null terminator
 
@@ -100,6 +103,17 @@ bool definitelyGreaterThan(float a, float b);
 bool definitelyLessThan(float a, float b);
 
 void crash();
+
+template <typename T>
+std::set<std::filesystem::path> sorted_directory_iterator(std::string path_name)
+{
+    std::set<std::filesystem::path> sorted_by_name;
+    for (auto& entry : T(path_name))
+    {
+        sorted_by_name.insert(entry.path());
+    }
+    return sorted_by_name;
+}
 
 class ScopeGuard
 {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -222,11 +222,11 @@ namespace luautils
         roeutils::init(); // TODO: Get rid of the need to do this
 
         // Then the rest...
-        for (auto entry : std::filesystem::directory_iterator("./scripts/globals"))
+        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/globals"))
         {
-            if (entry.path().extension() == ".lua")
+            if (entry.extension() == ".lua")
             {
-                auto relative_path_string = entry.path().relative_path().generic_string();
+                auto relative_path_string = entry.relative_path().generic_string();
 
                 ShowTrace("Loading global script %s", relative_path_string);
 
@@ -246,11 +246,11 @@ namespace luautils
 
         if (gLoadAllLua) // Load all lua files (for sanity testing, no need for during regular use)
         {
-            for (auto entry : std::filesystem::recursive_directory_iterator("./scripts"))
+            for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts"))
             {
-                if (entry.path().extension() == ".lua")
+                if (entry.extension() == ".lua")
                 {
-                    auto result = lua.safe_script_file(entry.path().relative_path().generic_string());
+                    auto result = lua.safe_script_file(entry.relative_path().generic_string());
                     if (!result.valid())
                     {
                         sol::error err = result;
@@ -351,9 +351,9 @@ namespace luautils
         // "scripts/battlefields/(zone)/(filename).lua"
         auto scrapeSubdir = [&](std::string subFolder) -> void
         {
-            for (auto const& entry : std::filesystem::recursive_directory_iterator(subFolder))
+            for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>(subFolder))
             {
-                auto path = entry.path().relative_path();
+                auto path = entry.relative_path();
 
                 // TODO(compiler updates):
                 // entry.depth() is not yet available in all of our compilers
@@ -361,7 +361,7 @@ namespace luautils
 
                 bool isHelpersFile = path.filename() == "helpers.lua";
 
-                if (!entry.is_directory() &&
+                if (!std::filesystem::is_directory(path) &&
                     path.extension() == ".lua" &&
                     depth == 4 &&
                     !isHelpersFile)

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -145,9 +145,9 @@ namespace moduleutils
         {
             if (std::filesystem::is_directory(entry))
             {
-                for (auto const& innerEntry : std::filesystem::recursive_directory_iterator(entry))
+                for (auto const& innerEntry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>(entry))
                 {
-                    auto path = innerEntry.path().relative_path();
+                    auto path = innerEntry.relative_path();
                     expandedList.emplace_back(path.generic_string());
                 }
             }

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -293,7 +293,7 @@ def fetch_module_files():
             if not line.startswith("#") and line.strip() and not line in ["\n", "\r\n"]:
                 line = from_server_path("modules/" + line.strip())
                 if pathlib.Path(line).is_dir():
-                    for filename in pathlib.Path(line).glob("**/*.sql"):
+                    for filename in sorted(pathlib.Path(line).glob("**/*.sql")):
                         import_files.append(str(filename).replace("\\", "/"))
                 else:
                     if line.endswith(".sql"):
@@ -352,13 +352,13 @@ def fetch_files(express=False):
             print_red("Error checking diffs.\nCheck that hash is valid in config.yaml.")
     else:
         for (_, _, filenames) in os.walk(from_server_path("sql/")):
-            for filename in filenames:
+            for filename in sorted(filenames):
                 import_files.append(from_server_path("sql/" + filename))
             break
     check_protected()
     backups.clear()
     for (_, _, filenames) in os.walk(from_server_path("sql/backups/")):
-        for file in filenames:
+        for file in sorted(filenames):
             if not ".gitignore" in file:
                 backups.append(from_server_path("sql/backups/" + file))
         break


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

While iterating directories, it isn't guaranteed on Linux that they're going to be in any specific order. On Windows it is. This forces all our current iterators to be in order.

## Steps to test these changes

Use modules, use dbtool on Linux