### PR TITLE
[core] Improve core dumps for Linux

### DIFF
--- a/src/common/debug_linux.cpp
+++ b/src/common/debug_linux.cpp
@@ -1,4 +1,5 @@
 #include <csignal>
+#include <sys/resource.h>
 
 #include "debug.h"
 #include "kernel.h"
@@ -6,9 +7,17 @@
 #define BACKWARD_HAS_BFD 1
 #include "../../ext/backward/backward.hpp"
 
+// https://man7.org/linux/man-pages/man7/signal-safety.7.html
+void safe_print(const char* str)
+{
+    // https://man7.org/linux/man-pages/man2/write.2.html
+    // https://man7.org/linux/man-pages/man3/strlen.3.html
+    write(1, str, strlen(str));
+}
+
 void dumpBacktrace(int signal)
 {
-    ShowCritical("Crash detected, generating traceback (this may take a while)");
+    safe_print("Crash detected, generating traceback (this may take a while)\n");
 
     backward::StackTrace trace;
     backward::Printer    printer;
@@ -23,15 +32,16 @@ void dumpBacktrace(int signal)
 
     std::ostringstream traceStream;
     printer.print(trace, traceStream);
-    spdlog::get("critical")->critical(traceStream.str());
-
-    std::signal(signal, SIG_DFL); // Prevent recursive exceptions
-
-    do_final(EXIT_FAILURE);
+    safe_print(traceStream.str().c_str()); // This probably isn't safe?
+    raise(SIGQUIT);                        // Let OS dump the core file
 }
 
 void debug::init()
 {
+    struct rlimit core_limits;
+    core_limits.rlim_cur = core_limits.rlim_max = RLIM_INFINITY;
+    setrlimit(RLIMIT_CORE, &core_limits);
+
     // things we want to handle
     std::signal(SIGABRT, dumpBacktrace);
     std::signal(SIGSEGV, dumpBacktrace);


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes core dumps appearing to never dump
This also increases the max size of core dumps to unlimited, as core dumps may have been too large for the OS.


## Steps to test these changes

build, launch xi_map, run crash command
on ubuntu (this is OS specific, check your `sysctl kernel.core_pattern` to see what handles dumps):

`cat /var/log/apport.log`, see the last core dump file in that file:

```
ERROR: apport (pid 98410) Wed Nov 16 11:03:01 2022: writing core dump to core._home_username_dev_server_xi_map.1002.fa774e45-8b2d-4969-87d7-416c57603ce2.98322.71637175 (limit: -1)
```

`gdb -q -nh /path/to/xi_map /var/lib/apport/coredump/core._home_username_dev_server_xi_map.1002.fa774e45-8b2d-4969-87d7-416c57603ce2.97437.71483278`

`bt` in gdb debugger, see this in output
![image](https://user-images.githubusercontent.com/60417494/202270958-075cb8db-c96c-4918-9e5c-803c232da0a3.png)


Note: the core dumps use the full size of memory used, 1.7gb for me. This will be improved with either a setting or guide in the future.