### PR TITLE
Zaldon - Only confirm on trade if item is valid

### DIFF
--- a/scripts/zones/Selbina/npcs/Zaldon.lua
+++ b/scripts/zones/Selbina/npcs/Zaldon.lua
@@ -512,16 +512,17 @@ local function tradeFish(player, fishId)
     local found   = false
     local sum     = 0
 
-    -- NOTE: We confirm the trade now, and not at the end of the cutscene as normal
-    --     : because the cutscene gives away whether or not the trade was successful
-    --     : or not, and it's possible for players to cheese this trade by force-dc-ing.
-    player:confirmTrade()
-
     for i = 1, #rewards do
         sum = sum + rewards[i].chance
         if roll <= sum then
             found = true
             player:setCharVar("insideBellyItemIdx", i)
+
+            -- NOTE: We confirm the trade now, and not at the end of the cutscene as normal
+            --     : because the cutscene gives away whether or not the trade was successful
+            --     : or not, and it's possible for players to cheese this trade by force-dc-ing.
+            player:confirmTrade()
+
             player:startEvent(166, 0, rewards[i].itemId)
             break
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves removing trade to after checking if the trade is valid.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Trade invalid item, do not have trade removed
<!-- Clear and detailed steps to test your changes here -->
