### PR TITLE
Fix pets lost when warping

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -437,11 +437,11 @@ void CCharEntity::setPetZoningInfo()
         case PET_TYPE::AVATAR:
         case PET_TYPE::AUTOMATON:
         case PET_TYPE::WYVERN:
-            petZoningInfo.petLevel     = PPetEntity->getSpawnLevel();
-            petZoningInfo.petHP        = PPet->health.hp;
-            petZoningInfo.petTP        = PPet->health.tp;
-            petZoningInfo.petMP        = PPet->health.mp;
-            petZoningInfo.petType      = PPetEntity->getPetType();
+            petZoningInfo.petLevel = PPetEntity->getSpawnLevel();
+            petZoningInfo.petHP    = PPet->health.hp;
+            petZoningInfo.petTP    = PPet->health.tp;
+            petZoningInfo.petMP    = PPet->health.mp;
+            petZoningInfo.petType  = PPetEntity->getPetType();
             break;
         default:
             break;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -431,6 +431,8 @@ void CCharEntity::setPetZoningInfo()
             {
                 break;
             }
+            petZoningInfo.jugSpawnTime = PPetEntity->getJugSpawnTime();
+            petZoningInfo.jugDuration  = PPetEntity->getJugDuration();
             [[fallthrough]];
         case PET_TYPE::AVATAR:
         case PET_TYPE::AUTOMATON:
@@ -440,8 +442,6 @@ void CCharEntity::setPetZoningInfo()
             petZoningInfo.petTP        = PPet->health.tp;
             petZoningInfo.petMP        = PPet->health.mp;
             petZoningInfo.petType      = PPetEntity->getPetType();
-            petZoningInfo.jugSpawnTime = ((CPetEntity*)PPet)->getJugSpawnTime();
-            petZoningInfo.jugDuration  = ((CPetEntity*)PPet)->getJugDuration();
             break;
         default:
             break;
@@ -462,6 +462,32 @@ void CCharEntity::resetPetZoningInfo()
     petZoningInfo.jugSpawnTime = 0;
     petZoningInfo.jugDuration  = 0;
 }
+
+bool CCharEntity::shouldPetPersistThroughZoning()
+{
+    PET_TYPE petType;
+    auto     PPetEntity = dynamic_cast<CPetEntity*>(PPet);
+
+    if (PPetEntity == nullptr && !petZoningInfo.respawnPet)
+    {
+        return false;
+    }
+
+    if (PPetEntity != nullptr)
+    {
+        petType = PPetEntity->getPetType();
+    }
+    else // petZoningInfo.respawnPet == true
+    {
+        petType = petZoningInfo.petType;
+    }
+
+    return petType == PET_TYPE::WYVERN ||
+           petType == PET_TYPE::AVATAR ||
+           petType == PET_TYPE::AUTOMATON ||
+           (petType == PET_TYPE::JUG_PET && settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"));
+}
+
 /************************************************************************
  *
  * Return the container with the specified ID.If the ID goes beyond, then *

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -319,17 +319,18 @@ public:
     uint8             m_TraitList[18];        // List of active job traits in the form of a bit mask
     uint8             m_PetCommands[64];      // List of available pet commands
     uint8             m_WeaponSkills[32];
-    questlog_t        m_questLog[MAX_QUESTAREA];     // список всех квестов
-    missionlog_t      m_missionLog[MAX_MISSIONAREA]; // список миссий
-    eminencelog_t     m_eminenceLog;                 // Record of Eminence log
-    eminencecache_t   m_eminenceCache;               // Caching data for Eminence lookups
-    assaultlog_t      m_assaultLog;                  // список assault миссий
-    campaignlog_t     m_campaignLog;                 // список campaign миссий
-    uint32            m_lastBcnmTimePrompt;          // the last message prompt in seconds
-    PetInfo_t         petZoningInfo;                 // used to repawn dragoons pets ect on zone
-    void              setPetZoningInfo();            // set pet zoning info (when zoning and logging out)
-    void              resetPetZoningInfo();          // reset pet zoning info (when changing job ect)
-    uint8             m_SetBlueSpells[20];           // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
+    questlog_t        m_questLog[MAX_QUESTAREA];       // список всех квестов
+    missionlog_t      m_missionLog[MAX_MISSIONAREA];   // список миссий
+    eminencelog_t     m_eminenceLog;                   // Record of Eminence log
+    eminencecache_t   m_eminenceCache;                 // Caching data for Eminence lookups
+    assaultlog_t      m_assaultLog;                    // список assault миссий
+    campaignlog_t     m_campaignLog;                   // список campaign миссий
+    uint32            m_lastBcnmTimePrompt;            // the last message prompt in seconds
+    PetInfo_t         petZoningInfo;                   // used to repawn dragoons pets ect on zone
+    void              setPetZoningInfo();              // set pet zoning info (when zoning and logging out)
+    void              resetPetZoningInfo();            // reset pet zoning info (when changing job ect)
+    bool              shouldPetPersistThroughZoning(); // if true, zoning should not cause a currently active pet to despawn
+    uint8             m_SetBlueSpells[20];             // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
     uint32            m_FieldChocobo;
 
     UnlockedAttachments_t m_unlockedAttachments; // Unlocked Automaton Attachments (1 bit per attachment)

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -248,14 +248,6 @@ void CPetEntity::Spawn()
     luautils::OnMobSpawn(this);
 }
 
-bool CPetEntity::shouldPersistThroughZone()
-{
-    return getPetType() == PET_TYPE::WYVERN ||
-           getPetType() == PET_TYPE::AVATAR ||
-           getPetType() == PET_TYPE::AUTOMATON ||
-           (getPetType() == PET_TYPE::JUG_PET && settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"));
-}
-
 bool CPetEntity::shouldDespawn(time_point tick)
 {
     // This check was moved from the original call site when this method was added.
@@ -286,8 +278,12 @@ void CPetEntity::loadPetZoningInfo()
         health.tp = static_cast<uint16>(master->petZoningInfo.petTP);
         health.hp = master->petZoningInfo.petHP;
         health.mp = master->petZoningInfo.petMP;
-        setJugDuration(master->petZoningInfo.jugDuration);
-        setJugSpawnTime(master->petZoningInfo.jugSpawnTime);
+
+        if (m_PetType == PET_TYPE::JUG_PET)
+        {
+            setJugDuration(master->petZoningInfo.jugDuration);
+            setJugSpawnTime(master->petZoningInfo.jugSpawnTime);
+        }
     }
 }
 

--- a/src/map/entities/petentity.h
+++ b/src/map/entities/petentity.h
@@ -66,7 +66,6 @@ public:
     virtual void FadeOut() override;
     virtual void Die() override;
     virtual void Spawn() override;
-    bool         shouldPersistThroughZone();     // if true, zoning should not cause a currently active pet to despawn
     bool         shouldDespawn(time_point tick); // if true, the pet should despawn at this point in time
     void         loadPetZoningInfo();            // loads info from previous zone (hp / mp / tp / spawn time). This MUST be called after Spawn()
     virtual void OnAbility(CAbilityState&, action_t&) override;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2627,11 +2627,6 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
-            if (PChar->PPet != nullptr)
-            {
-                PChar->setPetZoningInfo();
-            }
-
             PChar->loc.destination = zoneid;
             PChar->status          = STATUS_TYPE::DISAPPEAR;
             PChar->loc.boundary    = 0;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6061,15 +6061,15 @@ namespace charutils
     {
         switch (PChar->profile.nation)
         {
-        case 0:
-            return "sandoria_cp";
-        case 1:
-            return "bastok_cp";
-        case 2:
-            return "windurst_cp";
-        default:
-            XI_DEBUG_BREAK_IF(true);
-            return nullptr;
+            case 0:
+                return "sandoria_cp";
+            case 1:
+                return "bastok_cp";
+            case 2:
+                return "windurst_cp";
+            default:
+                XI_DEBUG_BREAK_IF(true);
+                return nullptr;
         }
     }
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -704,11 +704,11 @@ namespace charutils
                 PChar->petZoningInfo.petType      = static_cast<PET_TYPE>(sql->GetUIntData(10));
                 PChar->petZoningInfo.petLevel     = sql->GetUIntData(13);
                 PChar->petZoningInfo.respawnPet   = true;
-                PChar->petZoningInfo.jugSpawnTime = PChar->getCharVar("jug-pet-spawn-time");
-                PChar->petZoningInfo.jugDuration  = PChar->getCharVar("jug-duration-seconds");
+                PChar->petZoningInfo.jugSpawnTime = PChar->getCharVar("jugpet-spawn-time");
+                PChar->petZoningInfo.jugDuration  = PChar->getCharVar("jugpet-duration-seconds");
 
                 // clear the charvars used for jug state
-                PChar->clearCharVarsWithPrefix("jug-");
+                PChar->clearCharVarsWithPrefix("jugpet-");
             }
         }
 
@@ -5069,8 +5069,8 @@ namespace charutils
 
         // These two are jug only variables. We should probably move pet char stats into its own table, but in the meantime
         // we use charvars for jug specific things
-        PChar->setCharVar("jug-pet-spawn-time", PChar->petZoningInfo.jugSpawnTime);
-        PChar->setCharVar("jug-duration-seconds", PChar->petZoningInfo.jugDuration);
+        PChar->setCharVar("jugpet-spawn-time", PChar->petZoningInfo.jugSpawnTime);
+        PChar->setCharVar("jugpet-duration-seconds", PChar->petZoningInfo.jugDuration);
     }
 
     /************************************************************************
@@ -6061,15 +6061,15 @@ namespace charutils
     {
         switch (PChar->profile.nation)
         {
-            case 0:
-                return "sandoria_cp";
-            case 1:
-                return "bastok_cp";
-            case 2:
-                return "windurst_cp";
-            default:
-                XI_DEBUG_BREAK_IF(true);
-                return nullptr;
+        case 0:
+            return "sandoria_cp";
+        case 1:
+            return "bastok_cp";
+        case 2:
+            return "windurst_cp";
+        default:
+            XI_DEBUG_BREAK_IF(true);
+            return nullptr;
         }
     }
 
@@ -6101,6 +6101,15 @@ namespace charutils
         else
         {
             SaveCharPosition(PChar);
+        }
+
+        if (PChar->shouldPetPersistThroughZoning())
+        {
+            PChar->setPetZoningInfo();
+        }
+        else
+        {
+            PChar->resetPetZoningInfo();
         }
 
         PChar->pushPacket(new CServerIPPacket(PChar, type, ipp));


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Make pets persist through warping in addition to other types of zoning.

Also fix console [critical] messages in debug mode related to jug pet code.

Note: I moved the `shouldPersistThroughZone()` pet helper function to `CCharEntity` rather than `CPetEntity`.

Fixes #3220

## Steps to test these changes

See #3220

Note: I am noticing an issue where the pet's stats are not preserved across zoning. I imagine this happens when `SaveCharStats()` is called *before* `setPetZoningInfo()`.

EDIT: Actually, I'm not able to reproduce the "pet's stats are not preserved across zoning". Maybe the stat update was delayed in one of my tests and that's why I thought it wasn't updating.