### PR TITLE
[login] Better detection logic for first time characters intro CS

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -331,7 +331,7 @@ int32 lobbydata_parse(int32 fd)
                     gmlevel  = (uint16)sql->GetUIntData(4);
 
                     // new char only (first login from char create)
-                    if (PrevZone == 0)
+                    if (sd->justCreatedNewChar)
                     {
                         key3[16] += 6;
                     }
@@ -749,6 +749,7 @@ int32 lobbyview_parse(int32 fd)
                     return -1;
                 }
 
+                sd->justCreatedNewChar = true;
                 ShowInfo(fmt::format("lobbyview_parse: char <{}> was successfully created", sd->charname));
                 /////////////////////////
                 LOBBY_ACTION_DONE(ReservePacket);

--- a/src/login/login_session.h
+++ b/src/login/login_session.h
@@ -40,6 +40,8 @@ struct login_session_data_t
     int32 login_lobbydata_fd;
     int32 login_lobbyview_fd;
     int32 login_lobbyconf_fd;
+
+    bool justCreatedNewChar = false;
 };
 
 typedef std::list<login_session_data_t*> login_sd_list_t;


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes first time CS if you disconnected/crashed before actually logging in, which could prevent extraneous waiting for your character to logout. The original logic checked if your previous zone wasn't set -- apparently the client does not agree with this logic.


## Steps to test these changes

Create character, but dont click OK to login immediately, crash your client, relog and see the intro cs