### PR TITLE
Initial Framework for Cutscene Opt Params

### DIFF
--- a/scripts/globals/cutscenes.lua
+++ b/scripts/globals/cutscenes.lua
@@ -1,0 +1,7 @@
+xi = xi or {}
+xi.cutscenes = {}
+
+xi.cutscenes.params =
+{
+    NO_OTHER_ENTITY = 0x93 -- Only Displays Relative Player and NPCs to that Cutscene
+}

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -2,6 +2,7 @@
 -- Zone: Bastok_Markets (235)
 -----------------------------------
 require('scripts/globals/events/harvest_festivals')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/zone')
 local ID = require('scripts/zones/Bastok_Markets/IDs')
@@ -13,12 +14,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 0
+            cs = { 0, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
         player:setPos(-280, -12, -91, 15)
         player:setHomePoint()

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -4,6 +4,7 @@
 local ID = require('scripts/zones/Bastok_Mines/IDs')
 require('scripts/globals/events/harvest_festivals')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/chocobo')
 require('scripts/globals/zone')
@@ -18,12 +19,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 1
+            cs = { 1, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
         player:setPos(-45, -0, 26, 213)
         player:setHomePoint()

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -5,6 +5,7 @@ local ID = require('scripts/zones/Northern_San_dOria/IDs')
 require('scripts/globals/events/harvest_festivals')
 require('scripts/quests/flyers_for_regine')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/missions')
 require('scripts/globals/npc_util')
 require('scripts/globals/settings')
@@ -24,12 +25,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 535
+            cs = { 535, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
 
         player:setPos(0, 0, -11, 191)
@@ -39,7 +40,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getCharVar("peaceForTheSpiritCS") == 5 and
         player:getFreeSlotsCount() >= 1
     then
-        cs = 49
+        cs = { 49 }
     end
 
     -- MOG HOUSE EXIT

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 local ID = require('scripts/zones/Port_Bastok/IDs')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/zone')
 -----------------------------------
@@ -19,12 +20,12 @@ zoneObject.onConquestUpdate = function(zone, updatetype)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 1
+            cs = { 1, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
 
         player:setPos(132, -8.5, -13, 179)
@@ -37,7 +38,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.BASTOK_JEUNO_AIRSHIP then
-            cs = 73
+            cs = { 73 }
             player:setPos(-36.000, 7.000, -58.000, 194)
         else
             local position = math.random(1, 5) + 57

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -4,6 +4,7 @@
 local ID = require('scripts/zones/Port_San_dOria/IDs')
 require('scripts/quests/flyers_for_regine')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/missions')
 require('scripts/globals/settings')
 require('scripts/globals/zone')
@@ -15,12 +16,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 500
+            cs = { 500, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
 
         player:setPos(-104, -8, -128, 227)
@@ -33,7 +34,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
-            cs = 702
+            cs = { 702 }
             player:setPos(-1.000, 0.000, 44.000, 0)
         else
             player:setPos(80, -16, -135, 165)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 local ID = require('scripts/zones/Port_Windurst/IDs')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/zone')
 -----------------------------------
@@ -13,12 +14,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 305
+            cs = { 305, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
 
         player:setPos(-120, -5.5, 175, 48)
@@ -31,7 +32,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.WINDURST_JEUNO_AIRSHIP then
-            cs = 10004
+            cs = { 10004 }
             player:setPos(228.000, -3.000, 76.000, 160)
         else
             local position = math.random(1, 5) + 195

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -5,6 +5,7 @@ local ID = require('scripts/zones/Southern_San_dOria/IDs')
 require('scripts/globals/events/harvest_festivals')
 require('scripts/quests/flyers_for_regine')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/chocobo')
 require('scripts/globals/zone')
@@ -20,12 +21,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 503
+            cs = { 503, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
         end
 
         player:setPos(-96, 1, -40, 224)

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -4,6 +4,7 @@
 local ID = require('scripts/zones/Windurst_Waters/IDs')
 require('scripts/globals/events/harvest_festivals')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/zone')
 -----------------------------------
@@ -17,12 +18,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 531
+            cs = { 531, -1, xi.cutscenes.params.NO_OTHER_ENTITY }
         end
         player:setPos(-40, -5, 80, 64)
         player:setHomePoint()

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -4,6 +4,7 @@
 local ID = require('scripts/zones/Windurst_Woods/IDs')
 require('scripts/globals/events/harvest_festivals')
 require('scripts/globals/conquest')
+require('scripts/globals/cutscenes')
 require('scripts/globals/settings')
 require('scripts/globals/chocobo')
 require('scripts/globals/zone')
@@ -17,12 +18,12 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { -1 }
 
     -- FIRST LOGIN (START CS)
     if player:getPlaytime(false) == 0 then
         if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = 367
+            cs = { 367, -1, xi.cutscenes.params.NO_OTHER_ENTITY }
         end
 
         player:setPos(0, 0, -50, 0)

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -62,6 +62,7 @@ struct EventInfo : EventPrep
     EVENT_TYPE         type = NORMAL;
     std::vector<int32> cutsceneOptions;
     uint16             interruptText = 0;
+    uint32             eventFlags    = 0;
 
     bool hasCutsceneOption(int32 _option)
     {
@@ -76,7 +77,8 @@ struct EventInfo : EventPrep
         cutsceneOptions.clear();
         params.clear();
         strings.clear();
-        textTable = -1;
+        textTable  = -1;
+        eventFlags = 0;
     }
 };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -853,6 +853,7 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         // Parse out other misc. possible arguments for events.
         eventToStart->textTable     = table.get_or<int16>("text_table", -1);
         eventToStart->interruptText = table.get_or<int16>("interrupt_text", 0);
+        eventToStart->eventFlags    = table.get_or<uint32>("flags", 0);
 
         sol::object csOption = table["cs_option"];
         if (csOption.is<int32>())

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1823,8 +1823,9 @@ namespace luautils
         {
             auto resultTable = result.get<sol::table>();
 
-            PChar->currentEvent->eventId   = resultTable.get_or(1, -1);
-            PChar->currentEvent->textTable = resultTable.get_or(2, -1);
+            PChar->currentEvent->eventId    = resultTable.get_or(1, -1);
+            PChar->currentEvent->textTable  = resultTable.get_or(2, -1);
+            PChar->currentEvent->eventFlags = resultTable.get_or(3, 0);
         }
         else if (result.get_type() == sol::type::number)
         {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -391,7 +391,7 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         }
 
         PChar->pushPacket(new CDownloadingDataPacket());
-        PChar->pushPacket(new CZoneInPacket(PChar, PChar->currentEvent->eventId));
+        PChar->pushPacket(new CZoneInPacket(PChar, PChar->currentEvent));
         PChar->pushPacket(new CZoneVisitedPacket(PChar));
     }
 }

--- a/src/map/packets/event.cpp
+++ b/src/map/packets/event.cpp
@@ -77,7 +77,17 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
         }
 
         ref<uint16>(0x2C) = eventInfo->eventId;
-        ref<uint8>(0x2E)  = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+
+        if (eventInfo->eventFlags != 0)
+        {
+            ref<uint16>(0x2E) = eventInfo->eventFlags & 0xFFFF;
+            ref<uint16>(0x32) = eventInfo->eventFlags >> 16;
+        }
+        else
+        {
+            // Backwards compatibility
+            ref<uint8>(0x2E) = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+        }
     }
     else
     {
@@ -86,5 +96,8 @@ CEventPacket::CEventPacket(CCharEntity* PChar, EventInfo* eventInfo)
 
         ref<uint16>(0x0A) = PChar->getZone();
         ref<uint16>(0x10) = PChar->getZone();
+
+        ref<uint16>(0x0E) = eventInfo->eventFlags & 0xFFFF;
+        ref<uint16>(0x12) = eventInfo->eventFlags >> 16;
     }
 }

--- a/src/map/packets/event_string.cpp
+++ b/src/map/packets/event_string.cpp
@@ -52,7 +52,17 @@ CEventStringPacket::CEventStringPacket(CCharEntity* PChar, EventInfo* eventInfo)
     ref<uint16>(0x08) = npcLocalID;
     ref<uint16>(0x0A) = PChar->getZone();
     ref<uint16>(0x0C) = eventInfo->eventId;
-    ref<uint8>(0x0E)  = 8; // camera "jumps" behind the character if < 8 params
+
+    if (eventInfo->eventFlags != 0)
+    {
+        // Note that only the first 16 bits are supported by this packet type.
+        ref<uint16>(0x0E) = eventInfo->eventFlags & 0xFFFF;
+    }
+    else
+    {
+        // Backwards compatibility
+        ref<uint16>(0x0E) = 8; // if the parameter is less than 8, then after the event is over the camera will "jump" behind the character
+    }
 
     for (auto stringPair : eventInfo->strings)
     {

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -28,6 +28,7 @@
 #include "../status_effect_container.h"
 #include "../utils/zoneutils.h"
 #include "../vana_time.h"
+#include "map/zone.h"
 
 /************************************************************************
  *                                                                       *
@@ -114,7 +115,7 @@ uint8 GetMogHouseFlag(CCharEntity* PChar)
  *                                                                       *
  ************************************************************************/
 
-CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
+CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
 {
     this->setType(0x0A);
     this->setSize(0x104);
@@ -180,6 +181,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
     // ref<uint32>(0x6C) = PChar->loc.zone->GetWeather();
     // ref<uint32>(0x70) = PChar->loc.zone->GetWeatherChangeTime();
 
+    auto csid = currentEvent->eventId;
     if (csid != -1)
     {
         // ref<uint8>(data,(0x1F)) = 4;                             // предположительно animation
@@ -187,7 +189,10 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, int16 csid)
 
         ref<uint16>(0x40) = PChar->currentEvent->textTable == -1 ? PChar->getZone() : PChar->currentEvent->textTable;
         ref<uint16>(0x62) = PChar->getZone();
-        ref<uint16>(0x64) = csid;
+        ref<uint16>(0x64) = currentEvent->eventId;
+
+        // Note that only the first 16 bits are supported by this packet type.
+        ref<uint16>(0x66) = currentEvent->eventFlags & 0xFFFF;
     }
 
     ref<uint16>(0x30) = PChar->getZone();

--- a/src/map/packets/zone_in.h
+++ b/src/map/packets/zone_in.h
@@ -27,11 +27,12 @@
 #include "basic.h"
 
 class CCharEntity;
+struct EventInfo;
 
 class CZoneInPacket : public CBasicPacket
 {
 public:
-    CZoneInPacket(CCharEntity* PChar, int16);
+    CZoneInPacket(CCharEntity* PChar, const EventInfo*);
 };
 
 #endif


### PR DESCRIPTION
Co-Authored-By: Velyn <46884288+mehvvy@users.noreply.github.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Commits initial framework for Cutscene optional parameters:
Framework

New Player Cutscene examples:
Flags for not displaying NPCs not involved in CS + Other Players not involved in CS

## Steps to test these changes
Open Server start new character in Windurst. See the intro cutscene without tons of random NPCs or other players in it.

Starts to address: https://github.com/LandSandBoat/server/issues/3214
