### PR TITLE
Keep (gm) speed when zoning / relogging

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5167,6 +5167,7 @@ void CLuaBaseEntity::setSpeed(uint8 speedVal)
         if (m_PBaseEntity->objtype == TYPE_PC)
         {
             auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+            PChar->setCharVar("speed", speed);
             PChar->pushPacket(new CCharUpdatePacket(PChar));
         }
         else

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -329,6 +329,12 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
             PChar->m_charHistory.mhEntrances++;
             gardenutils::UpdateGardening(PChar, false);
         }
+
+        // Restore speed saved by !speed command (if set and gm char)
+        auto savedSpeed = PChar->getCharVar("speed");
+        if (savedSpeed > 0 && PChar->m_GMlevel > 0) {
+            PChar->speed = std::clamp<uint8>(savedSpeed, 0, 255);
+        }
     }
 
     // Only release client from "Downloading Data" if the packet sequence came in without a drop on 0x00D


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Preserves the value of the last saved speed via !speed command, so that it persists after zoning or relogging

## Steps to test these changes

!speed 255. Zone or warp.
