### PR TITLE
Correct the exit event for 'Against all odds' COR quest.

### DIFF
--- a/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
@@ -59,7 +59,7 @@ instanceObject.onInstanceComplete = function(instance)
             v:setCharVar("AgainstAllOdds", 3)
             v:setCharVar("AgainstAllOddsTimer", 0)
         end
-        v:startEvent(101)
+        v:startEvent(102)
     end
 end
 


### PR DESCRIPTION
Co-authored-by: N3ckB3ard <djdeffkid@gmail.com>

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects an issue where after the fight, player will enter a black screen.
Wrong exit event is referenced.

## Steps to test these changes

Enter fight and you will exit normally and be able to receive your AF
