### PR TITLE
[Appraisal] move tradeConfirm to onTrade

### DIFF
--- a/scripts/globals/appraisal.lua
+++ b/scripts/globals/appraisal.lua
@@ -1514,6 +1514,7 @@ xi.appraisal.appraiseItem = function(player, npc, trade, gil, appraisalCsid)
                 if appraisedItem ~= 0 then
                     player:startEvent(appraisalCsid, 1, appraisedItem)
                     player:setLocalVar("Appraisal", appraisedItem) -- anticheat
+                    player:confirmTrade()
                 end
                 break
             end
@@ -1550,7 +1551,6 @@ end
 xi.appraisal.appraisalOnEventFinish = function(player, csid, option, gil, appraisalCsid, npc)
     if csid == appraisalCsid then
         local appraisedItem = player:getLocalVar("Appraisal")
-        player:confirmTrade()
         player:addTreasure(appraisedItem, npc)
         player:delGil(gil)
         player:setLocalVar("Appraisal", 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

moves the consume of item on the trade itself so people cant d/c on an item and keep it when they see its not the item they want

