### PR TITLE
Remove IDLE_DESPAWN mod for Capricious Cassie

### DIFF
--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -1418,9 +1418,6 @@ INSERT INTO `mob_spawn_mods` VALUES (17596729,55,300,1); -- IDLE_DESPAWN: 300
 -- Altedour I Tavnazia
 INSERT INTO `mob_spawn_mods` VALUES (17612836,55,180,1); -- IDLE_DESPAWN: 180
 
--- Capricious Cassie
-INSERT INTO `mob_spawn_mods` VALUES (17613129,55,300,1); -- IDLE_DESPAWN: 300
-
 -- Mimic
 INSERT INTO `mob_spawn_mods` VALUES (17617157,55,120,1); -- IDLE_DESPAWN: 120
 


### PR DESCRIPTION
http://wiki.ffo.jp/html/980.html
https://www.bg-wiki.com/ffxi/Capricious_Cassie
https://ffxiclopedia.fandom.com/wiki/Capricious_Cassie

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently there's an Idle despawn of 5 mins on this NM. This is not accurate.  I have provided info sheets from various sites (in my commit message) to support this.

## Steps to test these changes
Engage CC, die, HP come back and notice CC is still up and has not despawned.