### PR TITLE
[core] Fix Tracy build mode for Linux

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -86,6 +86,12 @@ void operator delete(void* ptr) noexcept
     TracyFree(ptr);
     free(ptr);
 }
+
+void operator delete(void* ptr, std::size_t count)
+{
+    TracyFree(ptr);
+    free(ptr);
+}
 #endif // TRACY_ENABLE
 
 const char* MAP_CONF_FILENAME = nullptr;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes build for Tracy in linux

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

cmake with `-DTRACY_ENABLE=ON`, build normally

cd into `ext/tracy/tracy-0.8.2/capture/build/unix` or `ext/tracy/tracy-0.8.2/profiler/build/unix`, build that with `make`  -- may need some dependencies, GUI needs

```
libdbus1-dev
libglfw-dev
libcapstone-dev
libfreetype-dev
```

run ./xi_map, run Tracy with CLI or GUI to localhost,
example of CLI:
`./capture-release -o ~/test.tracy -a ::1`
see output in log/GUI