### PR TITLE
[Trust] Add Missing Parameter from PR #2931

### DIFF
--- a/scripts/globals/spells/trust/mumor.lua
+++ b/scripts/globals/spells/trust/mumor.lua
@@ -62,7 +62,7 @@ spellObject.onMobSpawn = function(mob)
     for i = 1, #healingJobs do
         local master  = mob:getMaster()
         if master:getMainJob() == healingJobs[i] then
-            mob:addSimpleGambit(ai.t.SELF, ai.c.NO_SAMBA, ai.r.JA, ai.s.SPECIFIC, xi.ja.HASTE_SAMBA)
+            mob:addSimpleGambit(ai.t.SELF, ai.c.NO_SAMBA, ai.r.JA, 0, ai.s.SPECIFIC, xi.ja.HASTE_SAMBA)
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects error being generated when casting Mumor.
![image](https://user-images.githubusercontent.com/99501957/202951062-9c752a42-cb26-4d38-9b93-68356aa32095.png)

Line 65, gambit was missing a parameter causing a break, I missed this on PR #2931 when initially adding these enhancements.

Before and after:
![image](https://user-images.githubusercontent.com/99501957/202951489-d2d5bcce-4641-4729-b7ce-4a4e56328f42.png)
![image](https://user-images.githubusercontent.com/99501957/202951569-7ea26260-5525-4d7c-a33e-b6a95cb22fb7.png)


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1.  Load in changes,
2.  Cast Mumor with a main healer job. 

<!-- Clear and detailed steps to test your changes here -->
