### PR TITLE
[Core] Delay removal of dynamic targids

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -481,7 +481,7 @@ void CZoneEntities::AssignDynamicTargIDandLongID(CBaseEntity* PEntity)
         id += 0x100;
     }
 
-    m_zone->GetZoneEntities()->dynamicTargIds.insert(targid);
+    dynamicTargIds.insert(targid);
 
     PEntity->targid   = targid;
     PEntity->id       = id;
@@ -1362,7 +1362,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
 
             it->second = nullptr;
             m_mobList.erase(it++);
-            dynamicTargIds.erase(PMob->targid);
+            dynamicTargIdsToDelete.push_back(std::make_pair(PMob->targid, server_clock::now()));
             delete PMob;
             continue;
         }
@@ -1426,7 +1426,8 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
                     delete it->second;
                     it->second = nullptr;
                 }
-                dynamicTargIds.erase(it->first);
+                dynamicTargIdsToDelete.push_back(std::make_pair(it->first, server_clock::now()));
+
                 m_petList.erase(it++);
                 continue;
             }
@@ -1471,7 +1472,8 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
 
                 delete it->second;
                 it->second = nullptr;
-                dynamicTargIds.erase(it->first);
+                dynamicTargIdsToDelete.push_back(std::make_pair(it->first, server_clock::now()));
+
                 m_trustList.erase(it++);
                 continue;
             }

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -89,6 +89,8 @@ public:
     std::set<uint16> charTargIds;    // Sorted set of targids for characters
     std::set<uint16> dynamicTargIds; // Sorted set of targids for dynamic entities
 
+    std::vector<std::pair<uint16, time_point>> dynamicTargIdsToDelete; // List of targids pending deletion at a later date
+
     CZoneEntities(CZone*);
     ~CZoneEntities();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds delay to removal of dynamic targIDs

This helps with client jank where immediate re-use of the same ID while a pet is dying causes strange display issues such as nameplates of dead pets moving, and pets being invisible until they change animation to attack again

Also cleanup an access in AssignDynamicTargIDandLongID to dynamicTargID where the class needlessly called back out and into itself with a seperate accessor.

Timer of 60s subject to scrutiny, retail clients do appear to eventually cleanup targID<-> name associations if they haven't gotten an 0x00E update in some amount of time.

## Steps to test these changes

Call wyvern, check targid, dismiss, call wyvern immediately, note targid + 1 of old, !reset, dismiss, wait >1~ 5 min, note original targid is back.