### PR TITLE
[core] Add 2500ms delay to pet despawn to better match retail

### DIFF
--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -213,7 +213,7 @@ void CPetEntity::Die()
     }
     else
     {
-        PAI->Internal_Die(0s);
+        PAI->Internal_Die(2500ms);
     }
 
     luautils::OnMobDeath(this, nullptr);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

This allows for longer pet death animations to fully play out, like retail. Delay is approximate.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Call wyvern, !hp 0 wyvern, see it hit the floor and die, fade out on its own (via animation) and then despawn the nameplate.
Summon carbuncle, release or !hp 0 it , watch it play a fairly long animation and disappear naturally along with the blue particles instead of disappear before the blue particles do.
