### PR TITLE
[Fix] Add missing player argument to npcUtil.giveKeyItem()

### DIFF
--- a/scripts/missions/wotg/23_Dungeons_and_Dancers.lua
+++ b/scripts/missions/wotg/23_Dungeons_and_Dancers.lua
@@ -72,7 +72,7 @@ mission.sections =
                 end,
 
                 [25] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(xi.ki.AROMA_BUG)
+                    npcUtil.giveKeyItem(player, xi.ki.AROMA_BUG)
                 end,
             },
         },

--- a/scripts/quests/bastok/Cids_Secret.lua
+++ b/scripts/quests/bastok/Cids_Secret.lua
@@ -100,7 +100,7 @@ quest.sections =
                 [133] = function(player, csid, option, npc)
                     player:confirmTrade()
 
-                    npcUtil.giveKeyItem(xi.ki.UNFINISHED_LETTER)
+                    npcUtil.giveKeyItem(player, xi.ki.UNFINISHED_LETTER)
                 end,
             },
         },

--- a/scripts/quests/bastok/The_Usual.lua
+++ b/scripts/quests/bastok/The_Usual.lua
@@ -78,7 +78,7 @@ quest.sections =
                 [135] = function(player, csid, option, npc)
                     player:confirmTrade()
 
-                    npcUtil.giveKeyItem(xi.ki.STEAMING_SHEEP_INVITATION)
+                    npcUtil.giveKeyItem(player, xi.ki.STEAMING_SHEEP_INVITATION)
                 end,
 
                 [136] = function(player, csid, option, npc)

--- a/scripts/quests/windurst/Curses_Foiled_A_Golem.lua
+++ b/scripts/quests/windurst/Curses_Foiled_A_Golem.lua
@@ -32,7 +32,7 @@ local feiyinMob =
     onMobDeath = function(mob, player, optParams)
         if player:hasKeyItem(xi.ki.SHANTOTTOS_NEW_SPELL) then
             player:delKeyItem(xi.ki.SHANTOTTOS_NEW_SPELL)
-            npcUtil.giveKeyItem(xi.ki.SHANTOTTOS_EX_SPELL)
+            npcUtil.giveKeyItem(player, xi.ki.SHANTOTTOS_EX_SPELL)
         end
     end,
 }

--- a/scripts/zones/Western_Adoulin/npcs/Flapano.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Flapano.lua
@@ -93,7 +93,7 @@ entity.onEventFinish = function(player, csid, option)
         player:confirmTrade()
         player:setCharVar("ATWTTB_Payments", utils.mask.setBit(player:getCharVar("ATWTTB_Payments"), 2, true))
         if utils.mask.isFull(player:getCharVar("ATWTTB_Payments"), 5) then
-            npcUtil.giveKeyItem(xi.ki.TARUTARU_SAUCE_RECEIPT)
+            npcUtil.giveKeyItem(player, xi.ki.TARUTARU_SAUCE_RECEIPT)
         end
 
     -- EXOTIC DELICACIES


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mass replace all cases where npcUtil.giveKeyItem(player, KI) didnt have the first argument (player)

## Steps to test these changes

Test the quests and npc
