### PR TITLE
Replace switch with table in checkquest gm command

### DIFF
--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -17,6 +17,13 @@ function error(player, msg)
     player:PrintToPlayer("!checkquest <logID> <questID> (player)")
 end
 
+local questStatusString =
+{
+    [0] = 'AVAILABLE',
+    [1] = 'ACCEPTED',
+    [2] = 'COMPLETED',
+}
+
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
@@ -58,21 +65,7 @@ function onTrigger(player, logId, questId, target)
 
     -- get quest status
     local status = targ:getQuestStatus(logId, questId)
-    switch (status): caseof
-    {
-        [0] = function()
-            status = "AVAILABLE"
-        end,
-
-        [1] = function()
-            status = "ACCEPTED"
-        end,
-
-        [2] = function()
-            status = "COMPLETED"
-        end,
-    }
 
     -- show quest status
-    player:PrintToPlayer(string.format("%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status))
+    player:PrintToPlayer(string.format("%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, questStatusString[status]))
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
There's a lot of switches in our codebase that exist that could easily be replaced by direct lookups.  This performs that change for the gm command !checkquest
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use !checkquest for any quest input, see expected string printed
<!-- Clear and detailed steps to test your changes here -->
