### PR TITLE
[Mission: Headstone Pilgrimage] missing returns

### DIFF
--- a/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
+++ b/scripts/missions/rotz/05_Headstone_Pilgrimage.lua
@@ -320,6 +320,8 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.FIRE_FRAGMENT) then
                         player:messageName(yuhtungaJungleID.text.ALREADY_OBTAINED_FRAG, nil, xi.ki.FIRE_FRAGMENT)
+
+                        return mission:noAction()
                     elseif os.time() >= npc:getLocalVar('cooldown') then
                         if
                             not GetMobByID(yuhtungaJungleID.mob.TIPHA):isSpawned() and
@@ -327,7 +329,7 @@ mission.sections =
                         then
                             return mission:progressEvent(200, xi.ki.FIRE_FRAGMENT)
                         else
-                            player:messageSpecial(yuhtungaJungleID.text.SOMETHING_BETTER)
+                            return mission:messageSpecial(yuhtungaJungleID.text.SOMETHING_BETTER)
                         end
                     else
                         return mission:progressEvent(201, xi.ki.FIRE_FRAGMENT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

missing some returns to framework so you were getting default dialog and framework dialog on niche circumstances

