### PR TITLE
[Fix] quest: and mission: used in mission and quest scripts, respectively

### DIFF
--- a/scripts/missions/wotg/43_Pillar_of_Hope.lua
+++ b/scripts/missions/wotg/43_Pillar_of_Hope.lua
@@ -32,7 +32,7 @@ mission.sections =
                     local hasWeapons = (player:getEquipID(xi.slot.MAIN) ~= 0 or player:getEquipID(xi.slot.SUB) ~= 0) and 1 or 0
                     local isRepeated = mission:getVar(player, 'Option')
 
-                    return quest:progressEvent(28, 89, 23, 1743, isRepeated, 0, 0, 0, hasWeapons)
+                    return mission:progressEvent(28, 89, 23, 1743, isRepeated, 0, 0, 0, hasWeapons)
                 end,
             },
 

--- a/scripts/missions/wotg/47_Whispers_of_Dawn.lua
+++ b/scripts/missions/wotg/47_Whispers_of_Dawn.lua
@@ -31,7 +31,7 @@ mission.sections =
                 onTrigger = function(player, npc)
                     local hasWeapons = (player:getEquipID(xi.slot.MAIN) ~= 0 or player:getEquipID(xi.slot.SUB) ~= 0) and 1 or 0
 
-                    return quest:progressEvent(26, 89, 23, 1756, 0, 0, 8323073, 0, hasWeapons)
+                    return mission:progressEvent(26, 89, 23, 1756, 0, 0, 8323073, 0, hasWeapons)
                 end,
             },
 

--- a/scripts/quests/adoulin/The_Starving.lua
+++ b/scripts/quests/adoulin/The_Starving.lua
@@ -73,7 +73,7 @@ quest.sections =
         onEventFinish =
         {
             [3007] = function(player, csid, option, npc)
-                if mission:complete(player) then
+                if quest:complete(player) then
                     xi.quest.setMustZone(player, xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.ALWAYS_MORE_QUOTH_THE_RAVENOUS)
                     xi.quest.setVar(player, xi.quest.log_id.ADOULIN, xi.quest.id.adoulin.ALWAYS_MORE_QUOTH_THE_RAVENOUS, 'Timer', VanadielUniqueDay() + 1)
                 end

--- a/scripts/quests/adoulin/Transporting.lua
+++ b/scripts/quests/adoulin/Transporting.lua
@@ -89,7 +89,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then
-                        return mission:progressEvent(2802)
+                        return quest:progressEvent(2802)
                     end
                 end,
             },

--- a/scripts/quests/bastok/The_Quadavs_Curse.lua
+++ b/scripts/quests/bastok/The_Quadavs_Curse.lua
@@ -50,7 +50,7 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, xi.items.QUADAV_BACKPLATE) then
-                        return mission:progressEvent(81)
+                        return quest:progressEvent(81)
                     end
                 end,
             },

--- a/scripts/quests/otherAreas/The_Rescue.lua
+++ b/scripts/quests/otherAreas/The_Rescue.lua
@@ -61,9 +61,9 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.TRADERS_SACK) then
-                        return mission:progressEvent(81)
+                        return quest:progressEvent(81)
                     else
-                        return mission:event(83)
+                        return quest:event(83)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mass search and replace quest: being used in mission scripts and mission: being used in quest scripts

## Steps to test these changes

Run the quests/missions
