### PR TITLE
Fixed Zdei Abilities

### DIFF
--- a/scripts/globals/mobskills/reactor_cool.lua
+++ b/scripts/globals/mobskills/reactor_cool.lua
@@ -12,6 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if mob:getAnimationSub() > 1 then
         return 1
     end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)


### PR DESCRIPTION
Now Zdei can use Reactor Cool.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As it stands, Zdei cannot use Reactor Cool, this fixes that and allows Reactor Cool to be used while in "Pot Form" along with the Optic Induration (and it's charge).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
