### PR TITLE
Adds lua binding for checking difficulty of a mob

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -531,10 +531,10 @@ xi.mob.difficulty =
     INCREDIBLY_EASY_PREY = 1,
     EASY_PREY            = 2,
     DECENT_CHALLENGE     = 3,
-    EVENMATCH            = 4,
+    EVEN_MATCH           = 4,
     TOUGH                = 5,
-    VERYTOUGH            = 6,
-    INCREDIBLYTOUGH      = 7,
+    VERY_TOUGH           = 6,
+    INCREDIBLY_TOUGH     = 7,
     MAX                  = 8,
 }
 xi.mob.diff = xi.mob.difficulty

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -520,3 +520,21 @@ xi.mob.onAddEffect = function(mob, target, damage, effect, params)
 
     return 0, 0, 0
 end
+
+-----------------------------------
+-- mob difficulty enums for checkDifficulty()
+-----------------------------------
+
+xi.mob.difficulty =
+{
+    TOO_WEAK             = 0,
+    INCREDIBLY_EASY_PREY = 1,
+    EASY_PREY            = 2,
+    DECENT_CHALLENGE     = 3,
+    EVENMATCH            = 4,
+    TOUGH                = 5,
+    VERYTOUGH            = 6,
+    INCREDIBLYTOUGH      = 7,
+    MAX                  = 8,
+}
+xi.mob.diff = xi.mob.difficulty

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9150,15 +9150,15 @@ bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object
  ************************************************************************/
 uint8 CLuaBaseEntity::checkDifficulty(CLuaBaseEntity* PLuaBaseEntity)
 {
-    CMobEntity*  PMob  = static_cast<CMobEntity*>(PLuaBaseEntity->GetBaseEntity());
-    CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    CMobEntity*  PMob  = dynamic_cast<CMobEntity*>(PLuaBaseEntity->GetBaseEntity());
+    CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
     if (PChar && PMob)
     {
         return (uint8)charutils::CheckMob((PChar->GetMLevel()), (PMob->GetMLevel()));
     }
 
-    ShowError("lua::checkDifficulty value is not valid");
+    ShowError("CLuaBaseEntity::checkDifficulty value is not valid");
     return 0;
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9158,7 +9158,7 @@ uint8 CLuaBaseEntity::checkDifficulty(CLuaBaseEntity* PLuaBaseEntity)
         return (uint8)charutils::CheckMob((PChar->GetMLevel()), (PMob->GetMLevel()));
     }
 
-    ShowError("CLuaBaseEntity::checkDifficulty value is not valid");
+    ShowError("Value is not valid");
     return 0;
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9143,6 +9143,26 @@ bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object
 }
 
 /************************************************************************
+ *  Function: checkDifficulty()
+ *  Purpose : Checks the mobs difficulty
+ *  Example : local difficulty = player:checkDifficulty(mob)
+ *  Notes   : Returns a value based on the enum EMobDifficulty
+ ************************************************************************/
+uint8 CLuaBaseEntity::checkDifficulty(CLuaBaseEntity* PLuaBaseEntity)
+{
+    CMobEntity*  PMob  = static_cast<CMobEntity*>(PLuaBaseEntity->GetBaseEntity());
+    CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+    if (PChar && PMob)
+    {
+        return (uint8)charutils::CheckMob((PChar->GetMLevel()), (PMob->GetMLevel()));
+    }
+
+    ShowError("lua::checkDifficulty value is not valid");
+    return 0;
+}
+
+/************************************************************************
  *  Function: getInstance()
  *  Purpose : Get the instance object that the Entity is part of
  *  Example : local instance = door:getInstance()
@@ -15124,6 +15144,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("checkSoloPartyAlliance", CLuaBaseEntity::checkSoloPartyAlliance);
 
     SOL_REGISTER("checkKillCredit", CLuaBaseEntity::checkKillCredit);
+
+    SOL_REGISTER("checkDifficulty", CLuaBaseEntity::checkDifficulty);
 
     // Instances
     SOL_REGISTER("getInstance", CLuaBaseEntity::getInstance);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -511,6 +511,8 @@ public:
 
     bool checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1, sol::object const& arg2);
 
+    uint8 checkDifficulty(CLuaBaseEntity* PLuaBaseEntity); // Checks difficulty of the mob
+
     // Instances
     auto getInstance() -> std::optional<CLuaInstance>;
     void setInstance(CLuaInstance* PLuaInstance);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds a lua entity so you can check the difficulty of a mob
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This will return the value of the following enum:
![image](https://user-images.githubusercontent.com/105882754/204098226-c9dc3c03-beba-4e65-9afb-8009f1b43c9f.png)

This can be used in several cases where you need to check the difficulty of the mob in order to do something specific.

## Steps to test these changes
As an example add the line:
`local difficulty = player:checkDifficulty(target)`
`if difficulty > 0 then`
`    *do something special if mob is not too weak*`
`end`

If the mob is IEP is will return 1, EP 2, etc.
<!-- Clear and detailed steps to test your changes here -->
