### PR TITLE
Fix regression with dynamic entities not being cleaned up correctly

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -586,12 +586,20 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
             // allies targid >= 0x700
             if (PEntity->targid >= 0x700)
             {
+                // Disappear pets that do not belong to players
+                auto* PPetEntity = dynamic_cast<CPetEntity*>(PEntity);
+                if (PPetEntity && (!PPetEntity->PMaster || PPetEntity->PMaster->objtype != TYPE_PC))
+                {
+                    PEntity->status = STATUS_TYPE::DISAPPEAR;
+                }
+
                 if (auto* PMobEntity = dynamic_cast<CMobEntity*>(PEntity))
                 {
                     if (std::find(m_AllyList.begin(), m_AllyList.end(), PMobEntity) != m_AllyList.end())
                     {
                         m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                     }
+                    PEntity->status = STATUS_TYPE::DISAPPEAR;
                 }
             }
             else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This regression was caused in #3156.
This is fixed by adding back in the disappear which causes the dynamic entity to be cleaned up later. The only scenario we truly don't want this happening is for player's pets. Trusts do not hit this code due to the enclosing conditional `else if (PEntity->objtype == TYPE_MOB || PEntity->objtype == TYPE_PET)`.

## Steps to test these changes

Go into a battlefield with an ally such as Volker in "Where Two Paths Converge" and then go into another battlefield and Volker wont be there as he was before this change.
