### PR TITLE
[QUEST] fixes on error ticks on server console for Full Speed Ahead!

### DIFF
--- a/scripts/quests/full_speed_ahead.lua
+++ b/scripts/quests/full_speed_ahead.lua
@@ -5,8 +5,6 @@ require('scripts/globals/status')
 require('scripts/globals/utils')
 require('scripts/globals/zone')
 -----------------------------------
-local ID = require('scripts/zones/Batallia_Downs/IDs')
------------------------------------
 
 --[[
 Debugging:
@@ -65,6 +63,7 @@ xi.full_speed_ahead.tick = function(player, effect)
     player:setLocalVar("FSA_Motivation", player:getLocalVar("FSA_Motivation") - xi.full_speed_ahead.motivation_decay + effect:getPower())
     player:setLocalVar("FSA_Pep", player:getLocalVar("FSA_Pep") + xi.full_speed_ahead.pep_growth + effect:getPower())
 
+    local ID = zones[xi.zone.BATALLIA_DOWNS]
     local timeLeft = player:getLocalVar("FSA_Time") - os.time()
     local motivation = player:getLocalVar("FSA_Motivation")
     local pep = player:getLocalVar("FSA_Pep")
@@ -92,6 +91,7 @@ xi.full_speed_ahead.tick = function(player, effect)
 end
 
 xi.full_speed_ahead.onTriggerAreaEnter = function(player, index)
+    local ID = zones[xi.zone.BATALLIA_DOWNS]
     local food_byte = player:getLocalVar("FSA_Food")
     local food_count = player:getLocalVar("FSA_FoodCount")
     local motivation = player:getLocalVar("FSA_Motivation")
@@ -119,6 +119,7 @@ xi.full_speed_ahead.onTriggerAreaEnter = function(player, index)
 end
 
 xi.full_speed_ahead.onCheer = function(player)
+    local ID = zones[xi.zone.BATALLIA_DOWNS]
     local timeLeft = player:getLocalVar("FSA_Time") - os.time()
     local motivation = player:getLocalVar("FSA_Motivation")
     local pep = player:getLocalVar("FSA_Pep")

--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -109,6 +109,7 @@ zones[xi.zone.BATALLIA_DOWNS] =
 
     npc =
     {
+        SYRILLIA = DYNAMIC_LOOKUP
     },
 }
 

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -30,15 +30,11 @@ zoneObject.onInitialize = function(zone)
     GetMobByID(ID.mob.AHTU):setRespawnTime(math.random(900, 10800))
 
     -- Prepare everything for Full Speed Ahead!
-    local syrillia   = zone:queryEntitiesByName("Syrillia")[1]
-    local syrilliaID = syrillia:getID()
-
-    ID.npc.SYRILLIA         = syrilliaID
-    ID.npc.BLUE_BEAM_BASE   = syrilliaID + 1
-    ID.npc.RAPTOR_FOOD_BASE = syrilliaID + 9
+    zones[xi.zone.BATALLIA_DOWNS].npc.BLUE_BEAM_BASE   = ID.npc.SYRILLIA + 1
+    zones[xi.zone.BATALLIA_DOWNS].npc.RAPTOR_FOOD_BASE = ID.npc.SYRILLIA + 9
 
     for i = 0, 7 do
-        registerRegionAroundNPC(zone, ID.npc.RAPTOR_FOOD_BASE + i, i + 1)
+        registerRegionAroundNPC(zone, zones[xi.zone.BATALLIA_DOWNS].npc.RAPTOR_FOOD_BASE + i, i + 1)
     end
 
     registerRegionAroundNPC(zone, ID.npc.SYRILLIA, 9)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

fixes https://github.com/LandSandBoat/server/issues/3277

## Steps to test these changes

!setplayervar <name> [QUEST]FullSpeedAhead 1
!zone { Batallia Downs }
