### PR TITLE
[Refactor] Move Magic Accuracy calculations to it's own file. Cleanup TP and damage_spell files

### DIFF
--- a/scripts/globals/damage/magic_accuracy.lua
+++ b/scripts/globals/damage/magic_accuracy.lua
@@ -1,0 +1,179 @@
+-----------------------------------
+xi = xi or {}
+xi.damage = xi.damage or {}
+xi.damage.magicAccuracy = xi.damage.magicAccuracy or {}
+-----------------------------------
+-- Modifier Tables per element.
+local spellAcc          = { xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,              xi.mod.LIGHTACC,           xi.mod.DARKACC           }
+local strongAffinityAcc = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,    xi.mod.LIGHT_AFFINITY_ACC, xi.mod.DARK_AFFINITY_ACC }
+local rdmMerit          = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY }
+
+xi.damage.magicAccuracy.calculateCasterMagicAccuracy = function(caster, target, spell, skillType, spellElement, statDiff)
+    local casterJob     = caster:getMainJob()
+    local casterWeather = caster:getWeather()
+    local spellGroup    = spell and spell:getSpellGroup() or xi.magic.spellGroup.NONE
+    local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
+
+    -- Get the base magicAcc (just skill + skill mod (79 + skillID = ModID))
+    if skillType ~= 0 then
+        magicAcc = magicAcc + caster:getSkillLevel(skillType)
+    else
+        -- For mob skills / additional effects which don't have a skill.
+        magicAcc = magicAcc + utils.getSkillLvl(1, caster:getMainLvl())
+    end
+
+    if spellElement ~= xi.magic.ele.NONE then
+        -- Add acc for elemental affinity accuracy and element specific accuracy
+        local affinityBonus = caster:getMod(strongAffinityAcc[spellElement]) * 10
+        local elementBonus  = caster:getMod(spellAcc[spellElement])
+        magicAcc            = magicAcc + affinityBonus + elementBonus
+    end
+
+    -- Get dStat Magic Accuracy. NOTE: Ninjutsu does not get this bonus/penalty.
+    if skillType ~= xi.skill.NINJUTSU then
+        if statDiff > 10 then
+            magicAcc = magicAcc + 10 + (statDiff - 10) / 2
+        else
+            magicAcc = magicAcc + statDiff
+        end
+    end
+
+    -----------------------------------
+    -- magicAcc from status effects.
+    -----------------------------------
+    -- Altruism
+    if
+        caster:hasStatusEffect(xi.effect.ALTRUISM) and
+        spellGroup == xi.magic.spellGroup.WHITE
+    then
+        magicAcc = magicAcc + caster:getStatusEffect(xi.effect.ALTRUISM):getPower()
+    end
+
+    -- Focalization
+    if
+        caster:hasStatusEffect(xi.effect.FOCALIZATION) and
+        spellGroup == xi.magic.spellGroup.BLACK
+    then
+        magicAcc = magicAcc + caster:getStatusEffect(xi.effect.FOCALIZATION):getPower()
+    end
+
+    --Add acc for klimaform
+    if
+        spellElement > 0 and
+        caster:hasStatusEffect(xi.effect.KLIMAFORM) and
+        (casterWeather == xi.magic.singleWeatherStrong[spellElement] or casterWeather == xi.magic.doubleWeatherStrong[spellElement])
+    then
+        magicAcc = magicAcc + 15
+    end
+
+    -- Apply Divine Emblem to Banish and Holy families
+    if
+        casterJob == xi.job.PLD and
+        skillType == xi.skill.DIVINE_MAGIC and
+        caster:hasStatusEffect(xi.effect.DIVINE_EMBLEM)
+    then
+        magicAcc = magicAcc + 100 -- TODO: Confirm this value in retail
+    end
+
+    -- Dark Seal
+    if
+        casterJob == xi.job.DRK and
+        skillType == xi.skill.DARK_MAGIC and
+        caster:hasStatusEffect(xi.effect.DARK_SEAL)
+    then
+        magicAcc = magicAcc + 256 -- Need citation. 256 seems OP
+    end
+
+    -----------------------------------
+    -- magicAcc from Job Points.
+    -----------------------------------
+    switch (casterJob) : caseof
+    {
+        [xi.job.WHM] = function()
+            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.WHM_MAGIC_ACC_BONUS)
+        end,
+
+        [xi.job.BLM] = function()
+            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.BLM_MAGIC_ACC_BONUS)
+        end,
+
+        [xi.job.RDM] = function()
+            -- RDM Job Point: During saboteur, Enfeebling MACC +2
+            if
+                skillType == xi.skill.ENFEEBLING_MAGIC and
+                caster:hasStatusEffect(xi.effect.SABOTEUR)
+            then
+                magicAcc = magicAcc + (caster:getJobPointLevel(xi.jp.SABOTEUR_EFFECT)) * 2
+            end
+
+            -- RDM Job Point: Magic Accuracy Bonus, All MACC + 1
+            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.RDM_MAGIC_ACC_BONUS)
+        end,
+
+        [xi.job.NIN] = function()
+            if skillType == xi.skill.NINJUTSU then
+                magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.NINJITSU_ACC_BONUS)
+            end
+        end,
+
+        [xi.job.SCH] = function()
+            if
+                (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
+                (spellGroup == xi.magic.spellGroup.BLACK and caster:hasStatusEffect(xi.effect.PENURY))
+            then
+                magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.STRATEGEM_EFFECT_I)
+            end
+        end,
+    }
+
+    -----------------------------------
+    -- magicAcc from Merits.
+    -----------------------------------
+    switch (casterJob) : caseof
+    {
+        [xi.job.BLM] = function()
+            if skillType == xi.skill.ELEMENTAL_MAGIC then
+                magicAcc = magicAcc + caster:getMerit(xi.merit.ELEMENTAL_MAGIC_ACCURACY)
+            end
+        end,
+
+        [xi.job.RDM] = function()
+            -- Category 1
+            if
+                spellElement >= xi.magic.element.FIRE and
+                spellElement <= xi.magic.element.WATER
+            then
+                magicAcc = magicAcc + caster:getMerit(rdmMerit[spellElement])
+            end
+
+            -- Category 2
+            magicAcc = magicAcc + caster:getMerit(xi.merit.MAGIC_ACCURACY)
+        end,
+
+        [xi.job.NIN] = function()
+            if skillType == xi.skill.NINJUTSU then
+                magicAcc = magicAcc + caster:getMerit(xi.merit.NIN_MAGIC_ACCURACY)
+            end
+        end,
+
+        [xi.job.BLU] = function()
+            if skillType == xi.skill.BLUE_MAGIC then
+                magicAcc = magicAcc + caster:getMerit(xi.merit.MAGICAL_ACCURACY)
+            end
+        end,
+    }
+
+    -----------------------------------
+    -- magicAcc from Food.
+    -----------------------------------
+    local maccFood = magicAcc * (caster:getMod(xi.mod.FOOD_MACCP) / 100)
+    magicAcc = magicAcc + utils.clamp(maccFood, 0, caster:getMod(xi.mod.FOOD_MACC_CAP))
+
+    -----------------------------------
+    -- Apply level correction and return final magic accuracy.
+    -----------------------------------
+    local levelDiff = utils.clamp(caster:getMainLvl() - target:getMainLvl(), -5, 5)
+    magicAcc        = magicAcc + levelDiff * 3
+
+    return magicAcc
+end

--- a/scripts/globals/damage/tp.lua
+++ b/scripts/globals/damage/tp.lua
@@ -7,7 +7,7 @@ xi.damage.tp = {}
 -----------------------------------
 
 -- returns a single melee hit's TP return
-function xi.damage.tp.getSingleMeleeHitTPReturn(attacker, defender, isZanshin)
+xi.damage.tp.getSingleMeleeHitTPReturn = function(attacker, defender, isZanshin)
     isZanshin = isZanshin or false -- optional input, defaults to false.
 
     local delay        = attacker:getBaseDelay()
@@ -23,7 +23,7 @@ function xi.damage.tp.getSingleMeleeHitTPReturn(attacker, defender, isZanshin)
     return math.floor(tpReturn * storeTPModifier)
 end
 
-function xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
+xi.damage.tp.getModifiedDelayAndCanZanshin = function(attacker, delay)
     local modifiedDelay = delay
     local canZanshin    = false
 
@@ -56,7 +56,7 @@ function xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
 end
 
 -- returns a single melee hit's TP return
-function xi.damage.tp.getSingleRangedHitTPReturn(attacker, defender)
+xi.damage.tp.getSingleRangedHitTPReturn = function(attacker, defender)
     local delay = attacker:getBaseRangedDelay() -- there do not appear to be any delay modifiers for ranged attacks, snapshot does not seem to effect this
 
     if delay > 0 then
@@ -72,7 +72,7 @@ end
 -- Gainee is the target who is going to gain the TP.
 -- For instance, if a player attacks a mob, the mob uses the mob formula when gaining TP from the returned hit.
 -- This appears to be a measure to not buff mobs when players were buffed with the new TP gain formula.
-function xi.damage.tp.calculateTPReturn(gainee, delay)
+xi.damage.tp.calculateTPReturn = function(gainee, delay)
     if gainee and gainee:getObjType() ~= xi.objType.MOB then -- Pets and PCs have been observed to use this formula
         if delay <= 180 then
             return math.floor(61 + ((delay - 180) * 63 / 360))
@@ -103,7 +103,7 @@ function xi.damage.tp.calculateTPReturn(gainee, delay)
 end
 
 -- TODO: does Ikishoten factor into this as a bonus to baseTPGain if it procs on the hit? Needs verification.
-function xi.damage.tp.calculateTPGainOnPhysicalDamage(totalDamage, delay, attacker, defender)
+xi.damage.tp.calculateTPGainOnPhysicalDamage = function(totalDamage, delay, attacker, defender)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and defender and attacker then
         local attackOutput       = xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
@@ -136,7 +136,7 @@ function xi.damage.tp.calculateTPGainOnPhysicalDamage(totalDamage, delay, attack
     return 0
 end
 
-function xi.damage.tp.calculateTPGainOnMagicalDamage(totalDamage, attacker, defender)
+xi.damage.tp.calculateTPGainOnMagicalDamage = function(totalDamage, attacker, defender)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and defender and attacker then
         local dAGI               = attacker:getMod(xi.mod.AGI) - defender:getMod(xi.mod.AGI)

--- a/scripts/globals/damage/tp.lua
+++ b/scripts/globals/damage/tp.lua
@@ -1,12 +1,13 @@
 require("scripts/globals/status")
 require("scripts/globals/utils")
-
+-----------------------------------
 xi = xi or {}
 xi.damage = xi.damage or {}
 xi.damage.tp = {}
+-----------------------------------
 
 -- returns a single melee hit's TP return
-xi.damage.tp.getSingleMeleeHitTPReturn = function (attacker, defender, isZanshin)
+function xi.damage.tp.getSingleMeleeHitTPReturn(attacker, defender, isZanshin)
     isZanshin = isZanshin or false -- optional input, defaults to false.
 
     local delay        = attacker:getBaseDelay()
@@ -23,24 +24,22 @@ xi.damage.tp.getSingleMeleeHitTPReturn = function (attacker, defender, isZanshin
 end
 
 function xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
-
     local modifiedDelay = delay
-    local canZanshin = false
+    local canZanshin    = false
+
     -- DW/H2H delay is halved for the purposes of a single hit's TP return when applicable, see https://www.bg-wiki.com/ffxi/Tactical_Points
     if attacker:isDualWielding() then -- NOTE: this "isDualWielding" may trip on non-PCs even if they are "using h2h". If this is rectified in core in the future this should fall through correctly.
         modifiedDelay = (delay * (100 - attacker:getMod(xi.mod.DUAL_WIELD)) / 100) / 2
     elseif attacker:isUsingH2H() then
-
         if attacker:getObjType() == xi.objType.PC then            -- handle h2h with > 1 swing only on PC
             if
                 attacker:getEquippedItem(xi.slot.SUB) ~= nil or   -- equipped shield = one swing
                 attacker:getSkillRank(xi.skill.HAND_TO_HAND) == 0 -- zero h2h rank skill = one swing
             then
-                modifiedDelay = math.max((delay - attacker:getMod(xi.mod.MARTIAL_ARTS)), 96) -- min delay of 96 total, -- https://www.bg-wiki.com/ffxi/Attack_Speed
-                canZanshin = true -- Zanshin can proc on an "unarmed" swing                  -- https://www.bg-wiki.com/ffxi/Zanshin
+                modifiedDelay = math.max((delay - attacker:getMod(xi.mod.MARTIAL_ARTS)), 96) -- min delay of 96 total, https://www.bg-wiki.com/ffxi/Attack_Speed
+                canZanshin    = true -- Zanshin can proc on an "unarmed" swing               -- https://www.bg-wiki.com/ffxi/Zanshin
             else
-                modifiedDelay = math.max((delay - attacker:getMod(xi.mod.MARTIAL_ARTS)) / 2, 48) -- min delay of 96 total so 96/2 per fist, -- https://www.bg-wiki.com/ffxi/Attack_Speed
-
+                modifiedDelay = math.max((delay - attacker:getMod(xi.mod.MARTIAL_ARTS)) / 2, 48) -- min delay of 96 total so 96/2 per fist, https://www.bg-wiki.com/ffxi/Attack_Speed
             end
         else
             -- TODO: handle the corner case where a PC-like entity is using h2h but is only hitting with one "fist". Perhaps they have a shield with no main weapon.
@@ -57,8 +56,7 @@ function xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
 end
 
 -- returns a single melee hit's TP return
-xi.damage.tp.getSingleRangedHitTPReturn = function (attacker, defender)
-
+function xi.damage.tp.getSingleRangedHitTPReturn(attacker, defender)
     local delay = attacker:getBaseRangedDelay() -- there do not appear to be any delay modifiers for ranged attacks, snapshot does not seem to effect this
 
     if delay > 0 then
@@ -74,8 +72,7 @@ end
 -- Gainee is the target who is going to gain the TP.
 -- For instance, if a player attacks a mob, the mob uses the mob formula when gaining TP from the returned hit.
 -- This appears to be a measure to not buff mobs when players were buffed with the new TP gain formula.
-xi.damage.tp.calculateTPReturn = function(gainee, delay)
-
+function xi.damage.tp.calculateTPReturn(gainee, delay)
     if gainee and gainee:getObjType() ~= xi.objType.MOB then -- Pets and PCs have been observed to use this formula
         if delay <= 180 then
             return math.floor(61 + ((delay - 180) * 63 / 360))
@@ -106,8 +103,7 @@ xi.damage.tp.calculateTPReturn = function(gainee, delay)
 end
 
 -- TODO: does Ikishoten factor into this as a bonus to baseTPGain if it procs on the hit? Needs verification.
-xi.damage.tp.calculateTPGainOnPhysicalDamage = function (totalDamage, delay, attacker, defender)
-
+function xi.damage.tp.calculateTPGainOnPhysicalDamage(totalDamage, delay, attacker, defender)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and defender and attacker then
         local attackOutput       = xi.damage.tp.getModifiedDelayAndCanZanshin(attacker, delay)
@@ -140,8 +136,7 @@ xi.damage.tp.calculateTPGainOnPhysicalDamage = function (totalDamage, delay, att
     return 0
 end
 
-xi.damage.tp.calculateTPGainOnMagicalDamage = function (totalDamage, attacker, defender)
-
+function xi.damage.tp.calculateTPGainOnMagicalDamage(totalDamage, attacker, defender)
     -- TODO: does dAGI penalty work against/for Trusts/Pets? Nothing is documented for this. Currently assuming mob only.
     if totalDamage > 0 and defender and attacker then
         local dAGI               = attacker:getMod(xi.mod.AGI) - defender:getMod(xi.mod.AGI)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -2,13 +2,14 @@
 -- Damage Spell Utilities
 -- Used for spells that deal direct damage. (Black, White, Dark and Ninjutsu)
 -----------------------------------
-require("scripts/globals/spell_data")
+require("scripts/globals/damage/magic_accuracy")
 require("scripts/globals/jobpoints")
 require("scripts/globals/magicburst")
-require("scripts/globals/status")
-require("scripts/globals/utils")
 require("scripts/globals/msg")
 require("scripts/globals/settings")
+require("scripts/globals/spell_data")
+require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 xi = xi or {}
 xi.spells = xi.spells or {}
@@ -33,13 +34,10 @@ xi.magic.specificDmgTakenMod = { xi.mod.FIRE_SDT,      xi.mod.ICE_SDT,        xi
 xi.magic.absorbMod           = { xi.mod.FIRE_ABSORB,   xi.mod.ICE_ABSORB,     xi.mod.WIND_ABSORB,   xi.mod.EARTH_ABSORB,   xi.mod.LTNG_ABSORB,       xi.mod.WATER_ABSORB,      xi.mod.LIGHT_ABSORB,      xi.mod.DARK_ABSORB       }
 xi.magic.barSpell            = { xi.effect.BARFIRE,    xi.effect.BARBLIZZARD, xi.effect.BARAERO,    xi.effect.BARSTONE,    xi.effect.BARTHUNDER,     xi.effect.BARWATER        }
 
-local elementalObi           = { xi.mod.FORCE_FIRE_DWBONUS,    xi.mod.FORCE_ICE_DWBONUS,    xi.mod.FORCE_WIND_DWBONUS,     xi.mod.FORCE_EARTH_DWBONUS,    xi.mod.FORCE_LIGHTNING_DWBONUS,    xi.mod.FORCE_WATER_DWBONUS,     xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
-local spellAcc               = { xi.mod.FIREACC,               xi.mod.ICEACC,               xi.mod.WINDACC,                xi.mod.EARTHACC,               xi.mod.THUNDERACC,                 xi.mod.WATERACC,                xi.mod.LIGHTACC,            xi.mod.DARKACC            }
-local strongAffinityDmg      = { xi.mod.FIRE_AFFINITY_DMG,     xi.mod.ICE_AFFINITY_DMG,     xi.mod.WIND_AFFINITY_DMG,      xi.mod.EARTH_AFFINITY_DMG,     xi.mod.THUNDER_AFFINITY_DMG,       xi.mod.WATER_AFFINITY_DMG,      xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG  }
-local strongAffinityAcc      = { xi.mod.FIRE_AFFINITY_ACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.WIND_AFFINITY_ACC,      xi.mod.EARTH_AFFINITY_ACC,     xi.mod.THUNDER_AFFINITY_ACC,       xi.mod.WATER_AFFINITY_ACC,      xi.mod.LIGHT_AFFINITY_ACC,  xi.mod.DARK_AFFINITY_ACC  }
-local nullMod                = { xi.mod.FIRE_NULL,             xi.mod.ICE_NULL,             xi.mod.WIND_NULL,              xi.mod.EARTH_NULL,             xi.mod.LTNG_NULL,                  xi.mod.WATER_NULL,              xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL          }
-local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY,  xi.merit.ICE_MAGIC_POTENCY,  xi.merit.WIND_MAGIC_POTENCY,   xi.merit.EARTH_MAGIC_POTENCY,  xi.merit.LIGHTNING_MAGIC_POTENCY,  xi.merit.WATER_MAGIC_POTENCY    }
-local rdmMerit               = { xi.merit.FIRE_MAGIC_ACCURACY, xi.merit.ICE_MAGIC_ACCURACY, xi.merit.WIND_MAGIC_ACCURACY,  xi.merit.EARTH_MAGIC_ACCURACY, xi.merit.LIGHTNING_MAGIC_ACCURACY, xi.merit.WATER_MAGIC_ACCURACY   }
+local elementalObi           = { xi.mod.FORCE_FIRE_DWBONUS,   xi.mod.FORCE_ICE_DWBONUS,   xi.mod.FORCE_WIND_DWBONUS,   xi.mod.FORCE_EARTH_DWBONUS,   xi.mod.FORCE_LIGHTNING_DWBONUS,   xi.mod.FORCE_WATER_DWBONUS,  xi.mod.FORCE_LIGHT_DWBONUS, xi.mod.FORCE_DARK_DWBONUS }
+local strongAffinityDmg      = { xi.mod.FIRE_AFFINITY_DMG,    xi.mod.ICE_AFFINITY_DMG,    xi.mod.WIND_AFFINITY_DMG,    xi.mod.EARTH_AFFINITY_DMG,    xi.mod.THUNDER_AFFINITY_DMG,      xi.mod.WATER_AFFINITY_DMG,   xi.mod.LIGHT_AFFINITY_DMG,  xi.mod.DARK_AFFINITY_DMG  }
+local nullMod                = { xi.mod.FIRE_NULL,            xi.mod.ICE_NULL,            xi.mod.WIND_NULL,            xi.mod.EARTH_NULL,            xi.mod.LTNG_NULL,                 xi.mod.WATER_NULL,           xi.mod.LIGHT_NULL,          xi.mod.DARK_NULL          }
+local blmMerit               = { xi.merit.FIRE_MAGIC_POTENCY, xi.merit.ICE_MAGIC_POTENCY, xi.merit.WIND_MAGIC_POTENCY, xi.merit.EARTH_MAGIC_POTENCY, xi.merit.LIGHTNING_MAGIC_POTENCY, xi.merit.WATER_MAGIC_POTENCY }
 
 -- Table variables.
 local stat            = 1
@@ -384,11 +382,8 @@ end
 -- This is for nukes damage only. If an spell happens to do both damage and apply an status effect, they are calculated separately.
 xi.spells.damage.calculateResist = function(caster, target, spell, skillType, spellElement, statDiff)
     local resist        = 1 -- The variable we want to calculate
-    local casterJob     = caster:getMainJob()
-    local casterWeather = caster:getWeather()
-    local spellGroup    = spell and spell:getSpellGroup() or xi.magic.spellGroup.NONE
 
-    local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
+    local magicAcc      = 0
     local magicEva      = 0
     local magicHitRate  = 0
     local resMod        = 0 -- Some spells may possibly be non elemental.
@@ -417,171 +412,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- STEP 1: Get Caster Magic Accuracy.
     -----------------------------------
-    -- Get the base magicAcc (just skill + skill mod (79 + skillID = ModID))
-    if skillType ~= 0 then
-        magicAcc = magicAcc + caster:getSkillLevel(skillType)
-    else
-        -- For mob skills / additional effects which don't have a skill.
-        magicAcc = magicAcc + utils.getSkillLvl(1, caster:getMainLvl())
-    end
-
-    if spellElement ~= xi.magic.ele.NONE then
-        -- Add acc for elemental affinity accuracy and element specific accuracy
-        local affinityBonus = caster:getMod(strongAffinityAcc[spellElement]) * 10
-        local elementBonus  = caster:getMod(spellAcc[spellElement])
-        magicAcc = magicAcc + affinityBonus + elementBonus
-    end
-
-    -- Get dStat Magic Accuracy. NOTE: Ninjutsu does not get this bonus/penalty.
-    if skillType ~= xi.skill.NINJUTSU then
-        if statDiff > 10 then
-            magicAcc = magicAcc + 10 + (statDiff - 10) / 2
-        else
-            magicAcc = magicAcc + statDiff
-        end
-    end
-
-    -----------------------------------
-    -- magicAcc from status effects.
-    -----------------------------------
-    -- Altruism
-    if
-        caster:hasStatusEffect(xi.effect.ALTRUISM) and
-        spellGroup == xi.magic.spellGroup.WHITE
-    then
-        magicAcc = magicAcc + caster:getStatusEffect(xi.effect.ALTRUISM):getPower()
-    end
-
-    -- Focalization
-    if
-        caster:hasStatusEffect(xi.effect.FOCALIZATION) and
-        spellGroup == xi.magic.spellGroup.BLACK
-    then
-        magicAcc = magicAcc + caster:getStatusEffect(xi.effect.FOCALIZATION):getPower()
-    end
-
-    --Add acc for klimaform
-    if
-        spellElement > 0 and
-        caster:hasStatusEffect(xi.effect.KLIMAFORM) and
-        (casterWeather == xi.magic.singleWeatherStrong[spellElement] or casterWeather == xi.magic.doubleWeatherStrong[spellElement])
-    then
-        magicAcc = magicAcc + 15
-    end
-
-    -- Apply Divine Emblem to Banish and Holy families
-    if
-        casterJob == xi.job.PLD and
-        skillType == xi.skill.DIVINE_MAGIC and
-        caster:hasStatusEffect(xi.effect.DIVINE_EMBLEM)
-    then
-        magicAcc = magicAcc + 100 -- TODO: Confirm this value in retail
-    end
-
-    -- Dark Seal
-    if
-        casterJob == xi.job.DRK and
-        skillType == xi.skill.DARK_MAGIC and
-        caster:hasStatusEffect(xi.effect.DARK_SEAL)
-    then
-        magicAcc = magicAcc + 256 -- Need citation. 256 seems OP
-    end
-
-    -- Add acc for skillchains
-    if skillchainCount > 0 then -- This makes no sense.
-        magicAcc = magicAcc + 25
-    end
-
-    -----------------------------------
-    -- magicAcc from Job Points.
-    -----------------------------------
-    switch (casterJob) : caseof
-    {
-        [xi.job.WHM] = function()
-            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.WHM_MAGIC_ACC_BONUS)
-        end,
-
-        [xi.job.BLM] = function()
-            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.BLM_MAGIC_ACC_BONUS)
-        end,
-
-        [xi.job.RDM] = function()
-            -- RDM Job Point: During saboteur, Enfeebling MACC +2
-            if
-                skillType == xi.skill.ENFEEBLING_MAGIC and
-                caster:hasStatusEffect(xi.effect.SABOTEUR)
-            then
-                magicAcc = magicAcc + (caster:getJobPointLevel(xi.jp.SABOTEUR_EFFECT)) * 2
-            end
-
-            -- RDM Job Point: Magic Accuracy Bonus, All MACC + 1
-            magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.RDM_MAGIC_ACC_BONUS)
-        end,
-
-        [xi.job.NIN] = function()
-            if skillType == xi.skill.NINJUTSU then
-                magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.NINJITSU_ACC_BONUS)
-            end
-        end,
-
-        [xi.job.SCH] = function()
-            if
-                (spellGroup == xi.magic.spellGroup.WHITE and caster:hasStatusEffect(xi.effect.PARSIMONY)) or
-                (spellGroup == xi.magic.spellGroup.BLACK and caster:hasStatusEffect(xi.effect.PENURY))
-            then
-                magicAcc = magicAcc + caster:getJobPointLevel(xi.jp.STRATEGEM_EFFECT_I)
-            end
-        end,
-    }
-
-    -----------------------------------
-    -- magicAcc from Merits.
-    -----------------------------------
-    switch (casterJob) : caseof
-    {
-        [xi.job.BLM] = function()
-            if skillType == xi.skill.ELEMENTAL_MAGIC then
-                magicAcc = magicAcc + caster:getMerit(xi.merit.ELEMENTAL_MAGIC_ACCURACY)
-            end
-        end,
-
-        [xi.job.RDM] = function()
-            -- Category 1
-            if
-                spellElement >= xi.magic.element.FIRE and
-                spellElement <= xi.magic.element.WATER
-            then
-                magicAcc = magicAcc + caster:getMerit(rdmMerit[spellElement])
-            end
-
-            -- Category 2
-            magicAcc = magicAcc + caster:getMerit(xi.merit.MAGIC_ACCURACY)
-        end,
-
-        [xi.job.NIN] = function()
-            if skillType == xi.skill.NINJUTSU then
-                magicAcc = magicAcc + caster:getMerit(xi.merit.NIN_MAGIC_ACCURACY)
-            end
-        end,
-
-        [xi.job.BLU] = function()
-            if skillType == xi.skill.BLUE_MAGIC then
-                magicAcc = magicAcc + caster:getMerit(xi.merit.MAGICAL_ACCURACY)
-            end
-        end,
-    }
-
-    -----------------------------------
-    -- magicAcc from Food.
-    -----------------------------------
-    local maccFood = magicAcc * (caster:getMod(xi.mod.FOOD_MACCP) / 100)
-    magicAcc = magicAcc + utils.clamp(maccFood, 0, caster:getMod(xi.mod.FOOD_MACC_CAP))
-
-    -----------------------------------
-    -- Apply level correction.
-    -----------------------------------
-    local levelDiff = utils.clamp(caster:getMainLvl() - target:getMainLvl(), -5, 5)
-    magicAcc        = magicAcc + levelDiff * 3
+    magicAcc = xi.damage.magicAccuracy.calculateCasterMagicAccuracy(caster, target, spell, skillType, spellElement, statDiff)
 
     -----------------------------------
     -- STEP 2: Get target magic evasion

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -382,13 +382,13 @@ end
 
 -- This function is used to calculate Resist tiers. The resist tiers work differently for enfeebles (which usually affect duration, not potency) than for nukes.
 -- This is for nukes damage only. If an spell happens to do both damage and apply an status effect, they are calculated separately.
-xi.spells.damage.calculateResist = function(caster, target, spell, skillType, spellElement, statDiff, bonusMagicAccuracy)
+xi.spells.damage.calculateResist = function(caster, target, spell, skillType, spellElement, statDiff)
     local resist        = 1 -- The variable we want to calculate
     local casterJob     = caster:getMainJob()
     local casterWeather = caster:getWeather()
     local spellGroup    = spell and spell:getSpellGroup() or xi.magic.spellGroup.NONE
 
-    local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc() + bonusMagicAccuracy
+    local magicAcc      = caster:getMod(xi.mod.MACC) + caster:getILvlMacc()
     local magicEva      = 0
     local magicHitRate  = 0
     local resMod        = 0 -- Some spells may possibly be non elemental.
@@ -426,9 +426,6 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     end
 
     if spellElement ~= xi.magic.ele.NONE then
-        -- Mod set in database. Base 0 means not resistant nor weak.
-        resMod = target:getMod(xi.magic.resistMod[spellElement])
-
         -- Add acc for elemental affinity accuracy and element specific accuracy
         local affinityBonus = caster:getMod(strongAffinityAcc[spellElement]) * 10
         local elementBonus  = caster:getMod(spellAcc[spellElement])
@@ -590,6 +587,11 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -- STEP 2: Get target magic evasion
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
     -----------------------------------
+    if spellElement ~= xi.magic.ele.NONE then
+        -- Mod set in database. Base 0 means not resistant nor weak.
+        resMod = target:getMod(xi.magic.resistMod[spellElement])
+    end
+
     magicEva = target:getMod(xi.mod.MEVA) + resMod
 
     -----------------------------------
@@ -824,7 +826,10 @@ xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spell, spell
     end
 
     -- Ancient Magic I and II MAB
-    if spellId > 203 and spellId < 216 then -- If spell is Ancient Magic
+    if
+        spellId >= xi.magic.spell.FLARE and
+        spellId <= xi.magic.spell.FLOOD_II
+    then
         mab = mab + caster:getMerit(xi.merit.ANCIENT_MAGIC_ATK_BONUS)
     end
 
@@ -987,7 +992,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local eleStaffBonus               = xi.spells.damage.calculateEleStaffBonus(caster, spell, spellElement)
     local magianAffinity              = xi.spells.damage.calculateMagianAffinity(caster, spell)
     local sdt                         = xi.spells.damage.calculateSDT(caster, target, spell, spellElement)
-    local resist                      = xi.spells.damage.calculateResist(caster, target,  spell, skillType, spellElement, statDiff, 0)
+    local resist                      = xi.spells.damage.calculateResist(caster, target,  spell, skillType, spellElement, statDiff)
     local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(caster, target,  spell, spellElement)
     local magicBurstBonus             = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spell, spellId, spellElement)
     local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, target, spell, spellId, spellElement)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

To avoid repeated code and ciclomatic complexity issues in future spell rewrites, this moves magic accuracy calculations to a different file inside damage folder.

## Steps to test these changes

Cast spells and bash mobs with weapons. Make sure tp gains and nuke damage is the same as before.
