### PR TITLE
Bail out and log if not a valid entity type for the function

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13459,6 +13459,12 @@ void CLuaBaseEntity::setSpellList(uint16 spellList)
 
 void CLuaBaseEntity::setAutoAttackEnabled(bool state)
 {
+    if (m_PBaseEntity->objtype & TYPE_NPC || m_PBaseEntity->objtype & TYPE_PC)
+    {
+        ShowError("CLuaBaseEntity::setAutoAttackEnabled invalid entity (name: %s type: %d)", m_PBaseEntity->name, m_PBaseEntity->objtype);
+        return;
+    }
+
     m_PBaseEntity->PAI->GetController()->SetAutoAttackEnabled(state);
 }
 
@@ -13471,6 +13477,12 @@ void CLuaBaseEntity::setAutoAttackEnabled(bool state)
 
 void CLuaBaseEntity::setMagicCastingEnabled(bool state)
 {
+    if (m_PBaseEntity->objtype & TYPE_NPC || m_PBaseEntity->objtype & TYPE_PC)
+    {
+        ShowError("CLuaBaseEntity::setMagicCastingEnabled invalid entity (name: %s type: %d)", m_PBaseEntity->name, m_PBaseEntity->objtype);
+        return;
+    }
+
     m_PBaseEntity->PAI->GetController()->SetMagicCastingEnabled(state);
 }
 
@@ -13483,6 +13495,12 @@ void CLuaBaseEntity::setMagicCastingEnabled(bool state)
 
 void CLuaBaseEntity::setMobAbilityEnabled(bool state)
 {
+    if (m_PBaseEntity->objtype & TYPE_NPC || m_PBaseEntity->objtype & TYPE_PC)
+    {
+        ShowError("CLuaBaseEntity::setMobAbilityEnabled invalid entity (name: %s type: %d)", m_PBaseEntity->name, m_PBaseEntity->objtype);
+        return;
+    }
+
     m_PBaseEntity->PAI->GetController()->SetWeaponSkillEnabled(state);
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Bail out and log if not a valid entity type for the function
on the following functions:
 - setAutoAttackEnabled
 - setMagicCastingEnabled
 - setMobAbilityEnabled

## Steps to test these changes
Try and stop mobskills on an entity type that doesn't HAVE mobskills because it's not a mob. Observe log message.
