### PR TITLE
Save essential pet modifiers in case it's affected by level restriction

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -110,14 +110,6 @@ end
 entity.onMobSpawn = function(mob)
     local master = mob:getMaster()
 
-    -- https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#Combat_Stats
-    -- innate -40% DT, which does not contribute to the -50% cap (this is a unique attribute to pets having a "higher" DT cap)
-    -- TODO: need "UDMG" modifier or equivalent
-    mob:addMod(xi.mod.DMG, -4000)
-
-    -- innate +40 subtle blow
-    mob:addMod(xi.mod.SUBTLE_BLOW, 40)
-
     if master:getMod(xi.mod.WYVERN_SUBJOB_TRAITS) > 0 then
         mob:addJobTraits(master:getSubJob(), master:getSubLvl())
     end
@@ -181,7 +173,7 @@ entity.onMobSpawn = function(mob)
     end)
 end
 
-entity.onMobDeath = function(mob, player)
+local function removeWyvernLevels(mob)
     local master  = mob:getMaster()
     local numLvls = mob:getLocalVar("level_Ups")
 
@@ -197,12 +189,23 @@ entity.onMobDeath = function(mob, player)
         master:delMod(xi.mod.DOUBLE_ATTACK, wyvernBonusDA * numLvls)
         master:delMod(xi.mod.ALL_WSDMG_ALL_HITS, 2 * numLvls)
     end
+end
 
+entity.onMobDeath = function(mob, player)
+    removeWyvernLevels(mob)
+
+    local master  = mob:getMaster()
     master:removeListener("PET_WYVERN_WS")
     master:removeListener("PET_WYVERN_MAGIC")
     master:removeListener("PET_WYVERN_ENGAGE")
     master:removeListener("PET_WYVERN_DISENGAGE")
     master:removeListener("PET_WYVERN_EXP")
+end
+
+entity.onPetLevelRestriction = function(pet)
+    removeWyvernLevels(pet)
+    pet:setLocalVar("wyvern_exp", 0)
+    pet:setLocalVar("level_Ups", 0)
 end
 
 return entity

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5687,6 +5687,9 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
                         return PChar->m_LevelRestriction;
                 }
 
+                // Allow global pet script to handle the level restriction
+                luautils::OnPetLevelRestriction(PPet);
+
                 // Setup pet with master since traits, abilities and some status effects need to be reapplied
                 petutils::SetupPetWithMaster(PChar, PPet);
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3575,6 +3575,38 @@ namespace luautils
     }
 
     /************************************************************************
+     *                                                                       *
+     *  Сalled when a pet's level restriction status changes                 *
+     *                                                                       *
+     ************************************************************************/
+
+    int32 OnPetLevelRestriction(CBaseEntity* PMob)
+    {
+        TracyZoneScoped;
+
+        if (PMob == nullptr || PMob->objtype != TYPE_PET)
+        {
+            return -1;
+        }
+
+        sol::function onPetLevelRestriction = getEntityCachedFunction(PMob, "onPetLevelRestriction");
+        if (!onPetLevelRestriction.valid())
+        {
+            return -1;
+        }
+
+        auto result = onPetLevelRestriction(CLuaBaseEntity(PMob));
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError("luautils::onPetLevelRestriction: %s", err.what());
+            return -1;
+        }
+
+        return 0;
+    }
+
+    /************************************************************************
      *   OnGameDayAutomatisation()                                           *
      *   used for creating action of npc every game day                      *
      *                                                                       *

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -260,6 +260,8 @@ namespace luautils
     int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller); // triggers on mob death
     int32 OnMobDespawn(CBaseEntity* PMob);                     // triggers on mob despawn (death not assured)
 
+    int32 OnPetLevelRestriction(CBaseEntity* PMob); // Triggers onPetLevelRestriction in global pet script
+
     int32 OnPath(CBaseEntity* PEntity);         // triggers when an entity is on a pathfind point
     int32 OnPathPoint(CBaseEntity* PEntity);    // triggers when an entity stops on a path point and has finished waiting at it
     int32 OnPathComplete(CBaseEntity* PEntity); // triggers when an entity finishes its pathing

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1030,6 +1030,14 @@ namespace petutils
         PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
         PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, mLvl > 99 ? 99 : mLvl));
 
+        // https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#Combat_Stats
+        // innate -40 % DT, which does not contribute to the -50 % cap (this is a unique attribute to pets having a "higher" DT cap)
+        // TODO: need "UDMG" modifier or equivalent
+        PPet->setModifier(Mod::DMG, -4000);
+
+        // innate + 40 subtle blow
+        PPet->setModifier(Mod::SUBTLE_BLOW, 40);
+
         // Job Point: Wyvern Max HP
         if (PMaster->objtype == TYPE_PC)
         {

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1799,6 +1799,7 @@ namespace petutils
         else
         {
             PPet = new CPetEntity(petType);
+            PPet->saveModifiers();
         }
 
         PPet->loc = PMaster->loc;

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -68,6 +68,8 @@ namespace puppetutils
             if (PChar->GetMJob() == JOB_PUP || PChar->GetSJob() == JOB_PUP)
             {
                 PChar->PAutomaton = new CAutomatonEntity();
+                PChar->PAutomaton->saveModifiers();
+
                 PChar->PAutomaton->name.insert(0, (const char*)sql->GetData(1));
                 automaton_equip_t tempEquip;
                 attachments = nullptr;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes pets taking 0 melee damage after being affected by level restriction.
When a pet undergoes level restriction its modifiers are cleared and then rebuilt; however, the melee SDT mods are set in CBattleEntity ctor and are not reset elsewhere. Consequently they end up being 0 after level restriction. The easiest fix here is to save the modifiers immediately after the pet object is created.

## Steps to test these changes

Change to a pet job, get a pet out and then do `!addeffect level_restriction 40` and then check your pet's `!getmod SLASH_SDT`. It should be 1000.
