### PR TITLE
[Chocobo] Send digging animation to players in range and add fatige bypass modifier

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1787,6 +1787,8 @@ xi.mod =
     BLUE_MAGIC_EFFECT       = 1059, -- TODO: Bonus to Attribute Value of spell (percent)
     QUICK_DRAW_RECAST       = 1060, -- TODO: Quick Draw Charge Reduction (seconds)
 
+    DIG_BYPASS_FATIGUE      = 1074, -- Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent.
+
     -- IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN src/map/modifier.h ASWELL!
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -6296,7 +6296,8 @@ INSERT INTO `item_mods` VALUES (11323,1,2); -- DEF: 2
 INSERT INTO `item_mods` VALUES (11324,1,2); -- DEF: 2
 
 -- Blue Racing Silks
-INSERT INTO `item_mods` VALUES (11325,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (11325,1,2);     -- DEF: 2
+INSERT INTO `item_mods` VALUES (11325,1074,50); -- DIG_BYPASS_FATIGUE: 50
 
 -- Red Racing Silks
 INSERT INTO `item_mods` VALUES (11326,1,2); -- DEF: 2

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -925,6 +925,8 @@ enum class Mod
     AUGMENT_BLU_MAGIC      = 1036, // Percent chance for BLU magic to receive 3x WSC value for spell (BLU AF3 Sets)
     GEOMANCY_MP_NO_DEPLETE = 1037, // Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
+    DIG_BYPASS_FATIGUE = 1074, // Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent.
+
     // IF YOU ADD ANY NEW MODIFIER HERE, ADD IT IN scripts/globals/status.lua ASWELL!
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
@@ -938,7 +940,7 @@ enum class Mod
     // 192 to 223
     // 261 to 280
     //
-    // SPARE = 1074, and onward
+    // SPARE = 1075, and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1026,7 +1026,7 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
                     charutils::UpdateItem(PChar, LOC_INVENTORY, slotID, -1);
 
                     PChar->pushPacket(new CInventoryFinishPacket());
-                    PChar->pushPacket(new CChocoboDiggingPacket(PChar));
+                    PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChocoboDiggingPacket(PChar));
 
                     // dig is possible
                     luautils::OnChocoboDig(PChar, false);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1 - Sends digging animation to players in range when someone digs.
2 - Adds modifier for Blue Race Silks, which allows digs not to count toward individual fatigue, based on a %.
3 - Adds modifier to Blue Race Silks. Set power to 50 (so a 50% chance) as per https://www.bg-wiki.com/ffxi/Blue_Race_Silks

NOTE: This doesn't actually implement the bypass, but allows for a simple player modifier check in chocobo digging, once that get's a rewrite.

## Steps to test these changes

Dualbox. Dig with character A, see character A dig with character B.
