### PR TITLE
Better handling of clearing battlefield enmity when removing entities

### DIFF
--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -189,7 +189,6 @@ public:
     void setArmouryCrate(uint32 entityId);
 
     void         ApplyLevelRestrictions(CCharEntity* PChar) const;
-    void         ClearEnmityForEntity(CBattleEntity* PEntity);
     bool         InsertEntity(CBaseEntity* PEntity, bool inBattlefield = false, BATTLEFIELDMOBCONDITION conditions = CONDITION_NONE, bool ally = false);
     CBaseEntity* GetEntity(CBaseEntity* PEntity);
     bool         IsRegistered(CCharEntity* PChar);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes #3276
Depending on order of removal some mobs would NOT have their enmity container cleared which would result in a subsequent entry thinking the battlefield is locked when it shouldn't be. The fix is to completely clear the enmity container when a mob is being removed from the battlefield.

## Steps to test these changes

Follow steps in #3276.
