### PR TITLE
Allow into mission battlefield if player has completed mission.

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1212,7 +1212,9 @@ function BattlefieldMission:checkRequirements(player, npc, isRegistrant, trade)
     local current = player:getCurrentMission(missionArea)
     local missionStatusArea = self.missionStatusArea or player:getNation()
     local status = player:getMissionStatus(missionStatusArea, self.missionStatus)
-    return current == self.mission and status == self.requiredMissionStatus
+    return (not isRegistrant and (player:hasCompletedMission(missionArea, self.mission) or (current == self.mission and status >= self.requiredMissionStatus))) or
+        (current == self.mission and status == self.requiredMissionStatus)
+
 end
 
 function BattlefieldMission:checkSkipCutscene(player)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently the battlefield framework only allows party members into a mission battlefield if they are on the fight. This allows them to join the battlefield if they have completed the mission and someone on the fight has initialized the battlefield.

## Steps to test these changes

Have party member on 5-2 fight enter shadow lord battlefield and then enter as a character that has completed the fight previously.