### PR TITLE
[lua] Intro character cs overhaul

### DIFF
--- a/scripts/globals/cutscenes.lua
+++ b/scripts/globals/cutscenes.lua
@@ -1,7 +1,12 @@
 xi = xi or {}
 xi.cutscenes = {}
 
+-- Flags during events
+-- Note: events have opcodes that can set flags internally, these can be ignored or set for each unique cutscene.
 xi.cutscenes.params =
 {
-    NO_OTHER_ENTITY = 0x93 -- Only Displays Relative Player and NPCs to that Cutscene
+    UNKNOWN_1       = 0x01, -- Commonly set, effect unknown
+    NO_PCS          = 0x02, -- Do not display other Player Characters
+    NO_NPCS         = 0x10, -- Do not display NPCs and Mobs
+    UNKNOWN_2       = 0x80, -- Commonly set, effect unknown
 }

--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -97,6 +97,7 @@ xi.items =
     LANOLIN_CUBE                    = 531,
     MAGICMART_FLYER                 = 532,
     CLUMP_OF_GAUSEBIT_WILDGRASS     = 534,
+    ADVENTURERS_COUPON              = 536,
     DAMSELFLY_WORM                  = 537,
     MAGICKED_SKULL                  = 538,
     CRAB_APRON                      = 539,

--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -139,14 +139,17 @@ xi.player.charCreate = function(player)
         player:setGil(xi.settings.main.START_GIL)
     end
 
-    player:addItem(536) -- adventurer coupon
+    if xi.settings.main.NEW_CHARACTER_CUTSCENE == 0 then -- Add coupon that would normally be added in cutscene.
+        player:addItem(xi.items.ADVENTURERS_COUPON)
+    end
+
     player:addTitle(xi.title.NEW_ADVENTURER)
     player:setCharVar("HQuest[moghouseExpo]notSeen", 1) -- needs Moghouse intro
-    player:setCharVar("spokeKindlix", 1) -- Kindlix introduction
-    player:setCharVar("spokePyropox", 1) -- Pyropox introduction
-    player:setCharVar("TutorialProgress", 1) -- Has not started tutorial
-    player:setCharVar("EinherjarIntro", 1) -- Has not seen Einherjar intro
-    player:setNewPlayer(true) -- apply new player flag
+    player:setCharVar("spokeKindlix", 1)                -- Kindlix introduction
+    player:setCharVar("spokePyropox", 1)                -- Pyropox introduction
+    player:setCharVar("TutorialProgress", 1)            -- Has not started tutorial
+    player:setCharVar("EinherjarIntro", 1)              -- Has not seen Einherjar intro
+    player:setNewPlayer(true)                           -- apply new player flag
 end
 
 -- called by core after a player logs into the server or zones

--- a/scripts/missions/soa/1_1_Rumors_from_the_West.lua
+++ b/scripts/missions/soa/1_1_Rumors_from_the_West.lua
@@ -24,6 +24,16 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
+
+            -- Hack: don't display until first character intro CS is shown.
+            -- This is needed because this mission sorts before hidden quests and gets checked first
+            if
+                xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 and
+                player:getCharVar("HQuest[newCharacterCS]notSeen") == 1
+            then
+                return false
+            end
+
             return currentMission == mission.missionId and xi.settings.main.ENABLE_SOA == 1
         end,
 

--- a/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
+++ b/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
@@ -1,0 +1,330 @@
+-----------------------------------
+-- New Character Cutscenes
+-----------------------------------
+require('scripts/globals/cutscenes')
+require('scripts/globals/interaction/hidden_quest')
+require('scripts/globals/items')
+require('scripts/globals/npc_util')
+require('scripts/globals/zone')
+-----------------------------------
+local quest = HiddenQuest:new("newCharacterCS")
+
+quest.reward = {}
+
+-- Note:
+-- Some areas swap order of when you get the Adventurer's coupon and the marker help text.
+-- On retail, even if your inventory is full and change nations, the starting cutscene will attempt to give you the Adventurer's coupon and report your inventory is full.
+quest.sections =
+{
+    {
+        check = function(player, questVars, vars)
+            return quest:getVar(player, 'notSeen') == 1 and xi.settings.main.NEW_CHARACTER_CUTSCENE == 1
+        end,
+
+        [xi.zone.BASTOK_MARKETS] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 0, -1, cutsceneFlags } -- CS 0 is not a typo.
+                end
+            },
+
+            onEventFinish =
+            {
+                [0] = function(player, csid, option, npc)
+                    -- Retail normally zones you for this -- but testing proved there was no difference other than NOT zoning by just calling the next event.
+                    -- event 0x00 fades your screen to black and seems to wait for another event, otherwise it will never fade back in.
+                    -- TODO: research if there was some purpose to the zoning.
+
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    player:startEvent(7, { flags = cutsceneFlags } )
+                end,
+
+                [7] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+
+                    player:setPos(-280, -12, -90, 0)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+                    return { 1, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [1] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+
+                    player:setPos(-45, -0, 25, 192)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+                    return { 1, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [1] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    player:setPos(134, 8.5, -11, 96)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 535, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [535] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    player:setPos(0, 0, -12, 192)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.SOUTHERN_SAN_DORIA] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 503, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [503] = function(player, csid, option, npc)
+
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    player:setPos(-100, 1, -40, 224) --cs exit
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.PORT_SAN_DORIA] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 500, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [500] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+
+                    player:setPos(-100, -8, -125, 224)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.NO_NPCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 531, -1, cutsceneFlags }
+                end
+            },
+
+            onEventUpdate =
+            {
+                [531] = function(player, csid, option, npc)
+                    -- param 7 is checked in the event according to decomp, but it was never set on Hume F starting a new character.
+                    -- param 7 was 0x20012 on a galka changing nations.
+                    player:updateEvent({ [7] = 0 })
+                end,
+            },
+
+            onEventFinish =
+            {
+                [531] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    -- The HP position is slightly different than the CS exit.
+                    player:setPos(-40.0, -5, 100, 64)
+                    player:setHomePoint()
+                    player:setPos(-40.611, -5, 102.5, 57) -- Move back to CS exit position
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.NO_NPCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+                    return { 367, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [367] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    player:setPos(30, 2, -40, 128)
+                    player:setHomePoint()
+
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+
+        [xi.zone.PORT_WINDURST] =
+        {
+            onZoneIn =
+            {
+                function(player, prevZone)
+                    local cutsceneFlags = bit.bor(
+                        xi.cutscenes.params.UNKNOWN_1,
+                        xi.cutscenes.params.NO_PCS,
+                        xi.cutscenes.params.UNKNOWN_2
+                    )
+
+                    return { 305, -1, cutsceneFlags }
+                end
+            },
+
+            onEventFinish =
+            {
+                [305] = function(player, csid, option, npc)
+                    local ID = zones[player:getZoneID()]
+                    player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
+                    -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
+                    npcUtil.giveItem(player, xi.items.ADVENTURERS_COUPON)
+
+                    player:setPos(-120, -5.5, 175, 48)
+                    player:setHomePoint()
+
+                    player:setPos(-140, -7, 172, 32)
+                    quest:setVar(player, 'notSeen', 0)
+                end,
+            },
+        },
+    },
+}
+return quest

--- a/scripts/zones/Bastok_Markets/IDs.lua
+++ b/scripts/zones/Bastok_Markets/IDs.lua
@@ -29,6 +29,7 @@ zones[xi.zone.BASTOK_MARKETS] =
         ORIGINAL_MISSION_OFFSET       = 6524,  -- You can consult the Mission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed.
         CONQUEST_BASE                 = 6592,  -- Tallying conquest results...
         MOG_LOCKER_OFFSET             = 6886,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
+        MAP_MARKER_TUTORIAL           = 7084,  -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
         GOLDSMITHING_SUPPORT          = 7091,  -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].
         GUILD_TERMINATE_CONTRACT      = 7105,  -- You have terminated your trading contract with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         GUILD_NEW_CONTRACT            = 7113,  -- You have formed a new trading contract with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -14,18 +14,6 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = { -1 }
-
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 0, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(-280, -12, -91, 15)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if
         player:getXPos() == 0 and
@@ -35,8 +23,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         local position = math.random(1, 5) - 33
         player:setPos(-177, -8, position, 127)
     end
-
-    return cs
 end
 
 zoneObject.onConquestUpdate = function(zone,  updatetype)
@@ -58,9 +44,6 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 0 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    end
 end
 
 return zoneObject

--- a/scripts/zones/Bastok_Mines/IDs.lua
+++ b/scripts/zones/Bastok_Mines/IDs.lua
@@ -28,6 +28,7 @@ zones[xi.zone.BASTOK_MINES] =
         CONQUEST_BASE                  = 6592,  -- Tallying conquest results...
         MARIADOK_DIALOG                = 6751,  -- Your fate rides on the changing winds of Vana'diel. I can give you insight on the local weather.
         MOG_LOCKER_OFFSET              = 6864,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
+        MAP_MARKER_TUTORIAL            = 7062,  -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
         ALCHEMY_SUPPORT                = 7069,  -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].
         HEMEWMEW_DIALOG                = 7076,  -- Hello, [sir/ma'am]. I have been appointed by the Guildworkers' Union to manage the trading of manufactured crafts and the exchange of guild points.
         GUILD_TERMINATE_CONTRACT       = 7083,  -- You have terminated your trading contract with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -19,18 +19,6 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = { -1 }
-
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 1, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(-45, -0, 26, 213)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if
         player:getXPos() == 0 and
@@ -40,8 +28,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         local position = math.random(1, 5) - 75
         player:setPos(116, 0.99, position, 127)
     end
-
-    return cs
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
@@ -55,9 +41,6 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 1 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536) -- adventurer coupon
-    end
 end
 
 return zoneObject

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -123,6 +123,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         FRAGMENTS_MELD                = 18100, -- The tiny fragments of Lilisette's memory meld together to form <keyitem>!
         RETRIEVE_DIALOG_ID            = 18135, -- You retrieve <item> from the porter moogle's care.
         COMMON_SENSE_SURVIVAL         = 18481, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
+        MAP_MARKER_TUTORIAL           = 18603, -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
     },
     mob =
     {

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -27,16 +27,7 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = { -1 }
 
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 535, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(0, 0, -11, 191)
-        player:setHomePoint()
-    -- RDM AF3 CS
-    elseif
+    if
         player:getCharVar("peaceForTheSpiritCS") == 5 and
         player:getFreeSlotsCount() >= 1
     then
@@ -89,9 +80,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 535 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536) -- adventurer coupon
-    elseif csid == 569 then
+    if csid == 569 then
         player:setPos(0, 0, -13, 192, 233)
     elseif
         csid == 49 and

--- a/scripts/zones/Port_Bastok/IDs.lua
+++ b/scripts/zones/Port_Bastok/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.PORT_BASTOK] =
         CONQUEST_BASE                 = 6537,  -- Tallying conquest results...
         TENSHODO_SHOP_OPEN_DIALOG     = 6738,  -- Ah, one of our members. Welcome to the Tenshodo shop.
         MOG_LOCKER_OFFSET             = 6836,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
+        MAP_MARKER_TUTORIAL           = 7095,   -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
         FISHING_MESSAGE_OFFSET        = 7098,  -- You can't fish here.
         POWHATAN_DIALOG_1             = 7286,  -- I'm sick and tired of entertaining guests.
         YOU_ACCEPT_THE_MISSION        = 7357,  -- You have accepted the mission.

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -22,16 +22,6 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = { -1 }
 
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 1, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(132, -8.5, -13, 179)
-        player:setHomePoint()
-    end
-
     if
         player:getXPos() == 0 and
         player:getYPos() == 0 and
@@ -63,9 +53,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 1 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 71 then
+    if csid == 71 then
         player:setPos(0, 0, 0, 0, 224)
     end
 end

--- a/scripts/zones/Port_San_dOria/IDs.lua
+++ b/scripts/zones/Port_San_dOria/IDs.lua
@@ -80,6 +80,7 @@ zones[xi.zone.PORT_SAN_DORIA] =
         FRAGMENTS_MELD                 = 11515, -- The tiny fragments of Lilisette's memory meld together to form <keyitem>!
         OBTAINED_NUM_KEYITEMS          = 11540, -- Obtained key item: <number> <keyitem>!
         NOT_ACQUAINTED                 = 11542, -- I'm sorry, but I don't believe we're acquainted. Please leave me be.
+        MAP_MARKER_TUTORIAL            = 11890, -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
     },
     mob =
     {

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -18,16 +18,6 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = { -1 }
 
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 500, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(-104, -8, -128, 227)
-        player:setHomePoint()
-    end
-
     if
         player:getXPos() == 0 and
         player:getYPos() == 0 and
@@ -63,9 +53,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 500 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 700 then
+    if csid == 700 then
         player:setPos(0, 0, 0, 0, 223)
     end
 end

--- a/scripts/zones/Port_Windurst/IDs.lua
+++ b/scripts/zones/Port_Windurst/IDs.lua
@@ -50,6 +50,7 @@ zones[xi.zone.PORT_WINDURST] =
         HOMEPOINT_SET                   = 11073, -- Home point set!
         YOU_ACCEPT_THE_MISSION          = 11166, -- You have accepted the mission.
         KHEL_PAHLHAMA_SHOP_DIALOG       = 11212, -- These magic shells are full of mysteries...
+        MAP_MARKER_TUTORIAL             = 11405, -- The map will open when you select Map from the main menu. Choose Markers and scroll to the right to check the location.
         MOG_LOCKER_OFFSET               = 11490, -- Your Mog Locker lease is valid until <timestamp>, kupo.
         FISHING_MESSAGE_OFFSET          = 11588, -- You can't fish here.
         FISHING_SUPPORT                 = 11692, -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -16,16 +16,6 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = { -1 }
 
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 305, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(-120, -5.5, 175, 48)
-        player:setHomePoint()
-    end
-
     if
         player:getXPos() == 0 and
         player:getYPos() == 0 and
@@ -55,9 +45,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 305 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 10002 then
+    if csid == 10002 then
         player:setPos(0, 0, 0, 0, 225)
     end
 end

--- a/scripts/zones/Southern_San_dOria/IDs.lua
+++ b/scripts/zones/Southern_San_dOria/IDs.lua
@@ -107,6 +107,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA] =
         NOT_ENOUGH_SPARKS              = 15417, -- You do not possess enough sparks of eminence to complete the transaction.
         MAX_SPARKS_LIMIT_REACHED       = 15418, -- You have reached the maximum number of sparks that you can exchange this week (<number>). Your ability to purchase skill books and equipment will be restricted until next week.
         YOU_NOW_HAVE_AMT_CURRENCY      = 15428, -- You now have <number> [sparks of eminence/conquest points/points of imperial standing/Allied Notes/bayld/Fields of Valor points/assault points (Leujaoam)/assault points (Mamool Ja Training Grounds)/assault points (Lebros Cavern)/assault points (Periqia)/assault points (Ilrusi Atoll)/cruor/kinetic units/obsidian fragments/mweya plasm corpuscles/ballista points/Unity accolades/pinches of Escha silt/resistance credits].
+        MAP_MARKER_TUTORIAL            = 15660, -- Selecting Map from the main menu opens the map of the area in which you currently reside. Select Markers and press the right arrow key to see all the markers placed on your map.
         YOU_HAVE_JOINED_UNITY          = 15968, -- ou have joined [Pieuje's/Ayame's/Invincible Shield's/Apururu's/Maat's/Aldo's/Jakoh Wahcondalo's/Naja Salaheem's/Flaviria's/Yoran-Oran's/Sylvie's] Unity!
         HAVE_ALREADY_CHANGED_UNITY     = 16044, -- ou have already changed Unities. Please wait until the next tabulation period.
         TEAR_IN_FABRIC_OF_SPACE        = 16505, -- There appears to be a tear in the fabric of space...

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -21,18 +21,6 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = { -1 }
-
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 503, -1, xi.cutscenes.params.NO_OTHER_ENTITY } -- (cs, textTable, Flags)
-        end
-
-        player:setPos(-96, 1, -40, 224)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if
         player:getXPos() == 0 and
@@ -41,8 +29,6 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         player:setPos(161, -2, 161, 94)
     end
-
-    return cs
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
@@ -70,9 +56,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 503 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    elseif csid == 758 then
+    if csid == 758 then
         player:setCharVar("COP_louverance_story", 3)
     end
 end

--- a/scripts/zones/Windurst_Waters/IDs.lua
+++ b/scripts/zones/Windurst_Waters/IDs.lua
@@ -26,6 +26,7 @@ zones[xi.zone.WINDURST_WATERS] =
         YOU_ACCEPT_THE_MISSION        = 6742,  -- You have accepted the mission.
         MOG_LOCKER_OFFSET             = 6823,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
         FISHING_MESSAGE_OFFSET        = 7062,  -- You can't fish here.
+        MAP_MARKER_TUTORIAL           = 7057,  -- The map will open when you select Map from the main menu. Choose Markers and scroll to the right to check the location.
         COOKING_SUPPORT               = 7166,  -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].
         GUILD_TERMINATE_CONTRACT      = 7180,  -- You have terminated your trading contract with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.
         GUILD_NEW_CONTRACT            = 7188,  -- You have formed a new trading contract with the [Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild.

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -18,17 +18,6 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = { -1 }
-
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 531, -1, xi.cutscenes.params.NO_OTHER_ENTITY }
-        end
-        player:setPos(-40, -5, 80, 64)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if
         player:getXPos() == 0 and
@@ -38,8 +27,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         local position = math.random(1, 5) + 157
         player:setPos(position, -5, -62, 192)
     end
-
-    return cs
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
@@ -53,9 +40,6 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 531 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    end
 end
 
 return zoneObject

--- a/scripts/zones/Windurst_Woods/IDs.lua
+++ b/scripts/zones/Windurst_Woods/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.WINDURST_WOODS] =
         HOMEPOINT_SET                 = 6649,  -- Home point set!
         YOU_ACCEPT_THE_MISSION        = 6742,  -- You have accepted the mission.
         ITEM_DELIVERY_DIALOG          = 6838,  -- We can deliver goods to your residence or to the residences of your friends.
+        MAP_MARKER_TUTORIAL           = 6929,  -- The map will open when you select Map from the main menu. Choose Markers and scroll to the right to check the location.
         MOG_LOCKER_OFFSET             = 7014,  -- Your Mog Locker lease is valid until <timestamp>, kupo.
         FISHING_MESSAGE_OFFSET        = 7112,  -- You can't fish here.
         IMAGE_SUPPORT                 = 7216,  -- Your [fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up [a little/ever so slightly/ever so slightly].

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -18,18 +18,6 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = { -1 }
-
-    -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if xi.settings.main.NEW_CHARACTER_CUTSCENE == 1 then
-            cs = { 367, -1, xi.cutscenes.params.NO_OTHER_ENTITY }
-        end
-
-        player:setPos(0, 0, -50, 0)
-        player:setHomePoint()
-    end
-
     -- MOG HOUSE EXIT
     if
         player:getXPos() == 0 and
@@ -39,8 +27,6 @@ zoneObject.onZoneIn = function(player, prevZone)
         local position = math.random(1, 5) + 37
         player:setPos(-138, -10, position, 0)
     end
-
-    return cs
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype)
@@ -54,9 +40,6 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 367 then
-        player:messageSpecial(ID.text.ITEM_OBTAINED, 536)
-    end
 end
 
 return zoneObject

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -1049,5 +1049,13 @@ int32 lobby_createchar_save(uint32 accid, uint32 charid, char_mini* createchar)
         return -1;
     }
 
+    if (settings::get<bool>("main.NEW_CHARACTER_CUTSCENE"))
+    {
+        Query = "INSERT INTO char_vars(charid, varname, value) VALUES(%u, '%s', %u);";
+        if (sql->Query(Query, charid, "HQuest[newCharacterCS]notSeen", 1) == SQL_ERROR)
+        {
+            return -1;
+        }
+    }
     return 0;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Overhauls intro character cutscene handling
Fixes Bastok Markets intro CS to use the second CS that's followed up on
Fixes SoA cutscene firing instead of intro CS in bastok markets by depending on intro CS flag (though if you disable starting CS you will see SoA CS on login)
Fixes some minor positions for home points and intro CS exits
Updates cutscene flags with some more data and comments
Adds some missing NPCs

## Steps to test these changes

`!exec player:setCharVar("HQuest[newCharacterCS]notSeen", 1)`
zone to an intro CS area, set the flag back, repeat until you see all CS
zone into bastok markets, you'll see SoA CS when HQuest[newCharacterCS]notSeen is missing (or if intro CS is disabled)
