### PR TITLE
BattlefieldMission support for missions without a status

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1209,10 +1209,15 @@ function BattlefieldMission:checkRequirements(player, npc, isRegistrant, trade)
 
     local missionArea = self.missionArea or player:getNation()
     local current = player:getCurrentMission(missionArea)
-    local missionStatusArea = self.missionStatusArea or player:getNation()
-    local status = player:getMissionStatus(missionStatusArea, self.missionStatus)
-    return (not isRegistrant and (player:hasCompletedMission(missionArea, self.mission) or (current == self.mission and status >= self.requiredMissionStatus))) or
-        (current == self.mission and status == self.requiredMissionStatus)
+
+    if self.requiredMissionStatus ~= nil then
+        local missionStatusArea = self.missionStatusArea or player:getNation()
+        local status = player:getMissionStatus(missionStatusArea, self.missionStatus)
+        return (not isRegistrant and (player:hasCompletedMission(missionArea, self.mission) or (current == self.mission and status >= self.requiredMissionStatus))) or
+            (current == self.mission and status == self.requiredMissionStatus)
+    else
+        return (not isRegistrant and player:hasCompletedMission(missionArea, self.mission)) or current == self.mission
+    end
 end
 
 function BattlefieldMission:checkSkipCutscene(player)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Some missions do not have a status and consequently do not need the mission status related elements when checking eligibility for battlefield entry. This change handles that scenario properly.

## Steps to test these changes

Currently untestable on LSB as no mission battlefields have been migrated to the new system that do not require a status. This came about from work being done on ASB.
