### PR TITLE
[core] Logging improvements

### DIFF
--- a/documentation/model_ids.txt
+++ b/documentation/model_ids.txt
@@ -2460,6 +2460,24 @@ ID Number    Costume Name
 2909    FF14 Spriggan
 2910    FF14 Spriggan
 2928    Porxie
+2933    Mumor II
+2934    Gargoyle
+2935    Purple Imp
+2936    White Ooze
+2937    Pet Behemoth
+2938    Iroha
+2939    Dark Promathia
+2940    Purple Dragon
+2941    Swirling Orb of Darkness
+2942    Cloud of Darkness
+2944    Pet Dragon
+2945    Pet Mantis
+2948    Pet Sheep
+2954    Big Mandragora
+2955    Big Rabbit
+2956    Big Worm
+2957    Tiny Morbol
+2965    Golden Crab
 3000    Trust: Shantotto
 3001    Trust: Naji
 3002    Trust: Kupipi

--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -11,6 +11,32 @@ xi.settings = xi.settings or {}
 
 xi.settings.logging =
 {
+    --[[
+        # General pattern to be used by spdlog
+
+        ## Additional custom flags:
+        %& : the exe type name (login, map, search, world)
+        %_ : the first letter of the exe type name (L, M, S, W)
+        %* : a fixed-length (32) and right-truncated function name + file line number
+        %q : a fixed-length (32) and right-truncated file name + file line number
+
+        "Classic" pattern : "[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)"
+        [12/03/22 19:25:12:812][map][info] do_init: connecting to database (do_init:221)
+        [12/03/22 19:25:12:815][map][info] database client version: 3.2.8 (do_init:224)
+        [12/03/22 19:25:12:815][map][info] database server version: 10.6.10-MariaDB (do_init:225)
+        [12/03/22 19:25:12:815][map][info] luautils: Lua initializing (luautils::init:113)
+
+        "New" pattern : "%Y/%m/%d %T:%e | %_ | %^%-4!l%$ | %* | %v"
+        2022/12/03 19:24:08:984 | M | info |                      do_init:221 | do_init: connecting to database
+        2022/12/03 19:24:08:987 | M | info |                      do_init:224 | database client version: 3.2.8
+        2022/12/03 19:24:08:987 | M | info |                      do_init:225 | database server version: 10.6.10-MariaDB
+        2022/12/03 19:24:08:987 | M | info |               luautils::init:113 | luautils: Lua initializing
+
+        ## Docs:
+        https://spdlog.docsforge.com/v1.x/3.custom-formatting/
+    --]]
+    PATTERN = "[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)",
+
     DEBUG_SOCKETS        = false,
     DEBUG_NAVMESH        = false,
     DEBUG_PACKETS        = false,

--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -28,7 +28,7 @@
 #include <windows.h>
 #endif
 
-Application::Application(std::string const& serverName, std::unique_ptr<argparse::ArgumentParser>&& pArgParser)
+Application::Application(std::string serverName, std::unique_ptr<argparse::ArgumentParser>&& pArgParser)
 : m_ServerName(serverName)
 , m_IsRunning(true)
 , gArgParser(std::move(pArgParser))

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -31,7 +31,7 @@
 class Application
 {
 public:
-    Application(std::string const& serverName, std::unique_ptr<argparse::ArgumentParser>&& pArgParser);
+    Application(std::string serverName, std::unique_ptr<argparse::ArgumentParser>&& pArgParser);
     virtual ~Application() = default;
 
     Application(const Application&)            = delete;

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -57,12 +57,6 @@
 
 std::atomic<bool> gRunFlag = true;
 
-int    arg_c = 0;
-char** arg_v = nullptr;
-
-char* SERVER_NAME = nullptr;
-char  SERVER_TYPE = XI_SERVER_NONE;
-
 std::array<std::unique_ptr<socket_data>, FD_SETSIZE> sessions;
 
 // This must be manually created
@@ -202,20 +196,8 @@ int main(int argc, char** argv)
     SetConsoleMode(hInput, ENABLE_EXTENDED_FLAGS | (prev_mode & ~ENABLE_QUICK_EDIT_MODE));
 #endif // _WIN32
 
-    { // initialize program arguments
-        char* p1 = SERVER_NAME = argv[0];
-        char* p2               = p1;
-        while ((p1 = strchr(p2, '/')) != nullptr || (p1 = strchr(p2, '\\')) != nullptr)
-        {
-            SERVER_NAME = ++p1;
-            p2          = p1;
-        }
-        arg_c = argc;
-        arg_v = argv;
-    }
-
     log_init(argc, argv);
-    set_server_type();
+    set_socket_type();
     usercheck();
     signals_init();
     timer_init();

--- a/src/common/kernel.h
+++ b/src/common/kernel.h
@@ -26,17 +26,11 @@
 #include "console_service.h"
 #include "settings.h"
 
-extern int    arg_c;
-extern char** arg_v;
-
 extern std::atomic<bool> gRunFlag;
-
-extern char* SERVER_NAME;
-extern char  SERVER_TYPE;
 
 extern void  log_init(int, char**);
 extern int32 do_init(int32, char**);
-extern void  set_server_type(void);
+extern void  set_socket_type(void);
 extern void  do_abort(void);
 extern void  do_final(int);
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -32,6 +32,81 @@
 #include "spdlog/sinks/daily_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
+std::string ServerName;
+
+class star_formatter_flag : public spdlog::custom_flag_formatter
+{
+public:
+    void format(const spdlog::details::log_msg& msg, const std::tm&, spdlog::memory_buf_t& dest) override
+    {
+        // spdlog and libfmt don't appear to have functionality to truncate text leaving the contents
+        // on the right, so we have to do it by hand.
+        // If longer than length, we pad, if less, then we build a new string of size length.
+        // https://fmt.dev/latest/syntax.html
+        std::size_t length      = 32;
+        std::string locationStr = fmt::format("{}:{}", msg.source.funcname, msg.source.line);
+        std::string outStr      = locationStr.size() > length ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
+        dest.append(outStr.data(), outStr.data() + outStr.size());
+    }
+
+    std::unique_ptr<custom_flag_formatter> clone() const override
+    {
+        return spdlog::details::make_unique<star_formatter_flag>();
+    }
+};
+
+class ampersand_formatter_flag : public spdlog::custom_flag_formatter
+{
+public:
+    void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
+    {
+        std::string outStr = ServerName;
+        dest.append(outStr.data(), outStr.data() + outStr.size());
+    }
+
+    std::unique_ptr<custom_flag_formatter> clone() const override
+    {
+        return spdlog::details::make_unique<ampersand_formatter_flag>();
+    }
+};
+
+class underscore_formatter_flag : public spdlog::custom_flag_formatter
+{
+public:
+    void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
+    {
+        std::string firstChar = std::string(1, ServerName[0]);
+        std::string outStr    = to_upper(firstChar);
+        dest.append(outStr.data(), outStr.data() + outStr.size());
+    }
+
+    std::unique_ptr<custom_flag_formatter> clone() const override
+    {
+        return spdlog::details::make_unique<underscore_formatter_flag>();
+    }
+};
+
+class q_formatter_flag : public spdlog::custom_flag_formatter
+{
+public:
+    void format(const spdlog::details::log_msg& msg, const std::tm&, spdlog::memory_buf_t& dest) override
+    {
+        // spdlog and libfmt don't appear to have functionality to truncate text leaving the contents
+        // on the right, so we have to do it by hand.
+        // If longer than length, we pad, if less, then we build a new string of size length.
+        // https://fmt.dev/latest/syntax.html
+        std::size_t length      = 32;
+        std::string locationStr = fmt::format("{}:{}", msg.source.filename, msg.source.line);
+        std::string outStr      = locationStr.size() > 12 ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
+        dest.append(outStr.data(), outStr.data() + outStr.size());
+    }
+
+    std::unique_ptr<custom_flag_formatter> clone() const override
+    {
+        return spdlog::details::make_unique<q_formatter_flag>();
+    }
+};
+
 namespace logging
 {
     const std::vector<std::string> logNames = {
@@ -47,9 +122,11 @@ namespace logging
         "lua",
     };
 
-    void InitializeLog(std::string serverName, std::string logFile, bool appendDate)
+    void InitializeLog(std::string const& serverName, std::string const& logFile, bool appendDate)
     {
         TracyZoneScoped;
+
+        ServerName = serverName;
 
         // If you create more than one worker thread, messages may be delivered out of order
         spdlog::init_thread_pool(8192, 1);
@@ -77,11 +154,6 @@ namespace logging
             spdlog::register_logger(logger);
         }
 
-        // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
-        // [date time:ms][server name][log name] message (func_name:func_line)
-        //                            ^level col^
-        spdlog::set_pattern(fmt::format("[%D %T:%e][{}]%^[%n]%$ %v (%!:%#)", serverName));
-
         spdlog::set_level(spdlog::level::debug);
 
         spdlog::enable_backtrace(16);
@@ -93,5 +165,17 @@ namespace logging
 
         spdlog::drop_all();
         spdlog::shutdown();
+    }
+
+    void SetPattern(std::string const& str)
+    {
+        // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
+        auto formatter = std::make_unique<spdlog::pattern_formatter>();
+        formatter->add_flag<star_formatter_flag>('*');
+        formatter->add_flag<ampersand_formatter_flag>('&');
+        formatter->add_flag<underscore_formatter_flag>('_');
+        formatter->add_flag<q_formatter_flag>('q');
+        formatter->set_pattern(str);
+        spdlog::set_formatter(std::move(formatter));
     }
 } // namespace logging

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -36,8 +36,6 @@ void lua_init()
 {
     TracyZoneScoped;
 
-    ShowInfo("lua initialising");
-
     lua.open_libraries();
 
     // Globally require bit library

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -57,8 +57,6 @@ namespace settings
      */
     void init()
     {
-        ShowInfo("Loading settings files");
-
         // Load defaults
         for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./settings/default/"))
         {
@@ -219,6 +217,8 @@ namespace settings
             auto inner                          = to_upper(parts[1]);
             lua["xi"]["settings"][outer][inner] = value;
         }
+
+        logging::SetPattern(get<std::string>("logging.PATTERN"));
 
         // Test to ensure requires aren't trampling changes, and that the user's settings aren't reverting
         // to the defaults:

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -154,7 +154,7 @@ namespace settings
             // clang-format on
         }
 
-        ShowError(fmt::format("Settings: Failed to look up key: {}, using default value: \"{}\"", name, out).c_str());
+        ShowError(fmt::format("Settings: Failed to look up key: {}, using default value: \"{}\"", name, out));
         return T();
     }
 } // namespace settings

--- a/src/common/tracy.h
+++ b/src/common/tracy.h
@@ -51,23 +51,23 @@ inline std::string Hex16ToString(uint16 hex)
     TracyReportGraphBytes("Lua Memory Usage", static_cast<double>(lua_gc(L, LUA_GCCOUNT, 0)) * 1024.0); \
 
 #else // Empty stubs for regular builds
-#define TracyFrameMark
-#define TracyZoneScoped
-#define TracyZoneScopedN(n)                std::ignore = n
-#define TracyZoneNamed(var)                std::ignore = #var
-#define TracyZoneText(n, l)                std::ignore = n; std::ignore = l
-#define TracyZoneScopedC(c)                std::ignore = c
-#define TracyZoneString(str)               std::ignore = str
-#define TracyZoneCString(cstr)             std::ignore = cstr
-#define TracyZoneIString(istr)             std::ignore = istr
-#define TracyZoneHex8(num)                 std::ignore = num
-#define TracyZoneHex16(num)                std::ignore = num
-#define TracyReportGraphNumber(name, num)  std::ignore = name; std::ignore = num
-#define TracyReportGraphBytes(name, num)   std::ignore = name; std::ignore = num
-#define TracyReportGraphPercent(name, num) std::ignore = name; std::ignore = num
-#define TracyReportLuaMemory(L)            std::ignore = L
-#define TracyMessageStr(str)               std::ignore = str
-#define TracySetThreadName(str)            std::ignore = str
+#define TracyFrameMark                     ;
+#define TracyZoneScoped                    ;
+#define TracyZoneScopedN(n)                std::ignore = n;
+#define TracyZoneNamed(var)                std::ignore = #var;
+#define TracyZoneText(n, l)                std::ignore = n; std::ignore = l;
+#define TracyZoneScopedC(c)                std::ignore = c;
+#define TracyZoneString(str)               std::ignore = str;
+#define TracyZoneCString(cstr)             std::ignore = cstr;
+#define TracyZoneIString(istr)             std::ignore = istr;
+#define TracyZoneHex8(num)                 std::ignore = num;
+#define TracyZoneHex16(num)                std::ignore = num;
+#define TracyReportGraphNumber(name, num)  std::ignore = name; std::ignore = num;
+#define TracyReportGraphBytes(name, num)   std::ignore = name; std::ignore = num;
+#define TracyReportGraphPercent(name, num) std::ignore = name; std::ignore = num;
+#define TracyReportLuaMemory(L)            std::ignore = L;
+#define TracyMessageStr(str)               std::ignore = str;
+#define TracySetThreadName(str)            std::ignore = str;
 #endif
 // clang-format on
 

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -172,9 +172,8 @@ void do_abort()
     do_final(EXIT_FAILURE);
 }
 
-void set_server_type()
+void set_socket_type()
 {
-    SERVER_TYPE = XI_SERVER_LOGIN;
     SOCKET_TYPE = socket_type::TCP;
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -417,13 +417,12 @@ void do_abort()
 
 /************************************************************************
  *                                                                       *
- *  set_server_type                                                      *
+ *  set_socket_type                                                      *
  *                                                                       *
  ************************************************************************/
 
-void set_server_type()
+void set_socket_type()
 {
-    SERVER_TYPE = XI_SERVER_MAP;
     SOCKET_TYPE = socket_type::UDP;
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Introduce new setting: logging.PATTERN; allowing the user to set whatever logging pattern they'd like. Adds examples for "classic" and "new".
- Adds custom options for logging patterns.
- Make core logging macros exception safe. Example:
```
[12/03/22 20:50:18:666][login][error] Encountered logging exception!: invalid type specifier (do_init:63)
[12/03/22 20:50:18:666][login][error] C:\ffxi\server\src\login\login.cpp:63 (do_init:63)
```
- Remove logging that may happen before the logging pattern is loaded
- Removes another little chunk of kernel