### PR TITLE
[core] [packets] Properly handle incoming equipset packet

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3359,7 +3359,7 @@ void SmallPacket0x052(map_session_data_t* const PSession, CCharEntity* const PCh
     // in this list the slot of whats being updated is old value, replace with new in 116
     // Should Push 0x116 (size 68) in responce
     // 0x04 is start, contains 16 4 byte parts repersently each slot in order
-    PChar->pushPacket(new CAddtoEquipSet(data));
+    PChar->pushPacket(new CAddtoEquipSet(PChar, data));
 }
 
 /************************************************************************
@@ -3391,42 +3391,69 @@ void SmallPacket0x053(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         charutils::SetStyleLock(PChar, true);
 
-        for (int i = 0x08; i < 0x08 + (0x08 * count); i += 0x08)
+        // Build new lockstyle
+        for (int i = 0; i < count; i++)
         {
-            uint8  equipSlotId = data.ref<uint8>(i + 0x01);
-            uint16 itemId      = data.ref<uint16>(i + 0x04);
+            uint8  equipSlotId = data.ref<uint8>(0x09 + 0x08 * i);
+            uint16 itemId      = data.ref<uint16>(0x0C + 0x08 * i);
 
-            if (equipSlotId > SLOT_BACK)
+            // Skip non-visible items
+            if (equipSlotId > SLOT_FEET)
             {
                 continue;
             }
 
-            auto* PItem = itemutils::GetItem(itemId);
+            CItemEquipment* PItem = dynamic_cast<CItemEquipment*>(itemutils::GetItemPointer(itemId));
             if (PItem == nullptr || !(PItem->isType(ITEM_WEAPON) || PItem->isType(ITEM_EQUIPMENT)))
             {
                 itemId = 0;
             }
-            else if (!(((CItemEquipment*)PItem)->getEquipSlotId() & (1 << equipSlotId)))
+            else if ((PItem->getEquipSlotId() & (1 << equipSlotId)) == 0) // item doesnt fit in slot
             {
                 itemId = 0;
             }
 
             PChar->styleItems[equipSlotId] = itemId;
+        }
 
-            switch (equipSlotId)
+        // Check if we need to remove conflicting slots. Essentially, packet injection shenanigan detector.
+        for (int i = 0; i < 10; i++)
+        {
+            CItemEquipment* PItemEquipment = dynamic_cast<CItemEquipment*>(itemutils::GetItemPointer(PChar->styleItems[i]));
+
+            if (PItemEquipment)
+            {
+                auto removeSlotID = PItemEquipment->getRemoveSlotId();
+
+                for (uint8 x = 0; x < sizeof(removeSlotID) * 8; ++x)
+                {
+                    if (removeSlotID & (1 << x))
+                    {
+                        PChar->styleItems[x] = 0;
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < 10; i++)
+        {
+            // variable initialized here due to case/switch optimization throwing warnings inside the case
+            CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)i);
+
+            switch (i)
             {
                 case SLOT_MAIN:
                 case SLOT_SUB:
                 case SLOT_RANGED:
                 case SLOT_AMMO:
-                    charutils::UpdateWeaponStyle(PChar, equipSlotId, (CItemWeapon*)PChar->getEquip((SLOTTYPE)equipSlotId));
+                    charutils::UpdateWeaponStyle(PChar, i, PItem);
                     break;
                 case SLOT_HEAD:
                 case SLOT_BODY:
                 case SLOT_HANDS:
                 case SLOT_LEGS:
                 case SLOT_FEET:
-                    charutils::UpdateArmorStyle(PChar, equipSlotId);
+                    charutils::UpdateArmorStyle(PChar, i);
                     break;
             }
         }

--- a/src/map/packets/macroequipset.cpp
+++ b/src/map/packets/macroequipset.cpp
@@ -19,39 +19,179 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 ===========================================================================
 */
 
+#include "macroequipset.h"
 #include "common/socket.h"
 
-#include "macroequipset.h"
+#include "../item_container.h"
+#include "../items/item_equipment.h"
+#include "../utils/charutils.h"
+#include "../utils/itemutils.h"
 
-CAddtoEquipSet::CAddtoEquipSet(uint8* orig)
+// This packet is sent to the map server whenever a client is assembling an equip set.
+// On retail, it seems to do the following:
+// Prevent you from equipping items that shouldn't pair together, such as:
+// 2h weapon & shield
+// 2h weapon & 1h weapon
+// h2h and any sub
+// head item while wearing a cloak
+// etc
+// Later, these sets may be used for /lockstyleset.
+// /lockstyleset commands also have their own checking for slots that should never be used together
+CAddtoEquipSet::CAddtoEquipSet(CCharEntity* PChar, uint8* orig)
 {
-    // Im guessing this is here to check if you can use A Item, as it seems useless to have this sent to server
-    // as It will check requirements when it goes to equip the items anyway
-    // 0x04 is slot of updated item
-    // 0x08 is info for updated item
-    // 0x0C is first slot every 4 bytes is another set, in (01-equip 0-2 remve),(container),(ID),(ID)
-    // in this list the slot of whats being updated is old value, replace with new in 116
-    // Should Push 0x116 (size 68) in responce
-    // 0x04 is start, contains 16 4 byte parts repersently each slot in order
     this->setType(0x116);
     this->setSize(0x46);
 
-    uint8 slotID = ::ref<uint8>(orig, 0x04);
+    CItemEquipment* equipSet[16]         = {};
+    uint8           equipSetBag[16]      = {};
+    uint8           equipSetBagIndex[16] = {};
+    bool            equipSetDisabled[16] = {};
+
+    uint8                 equippedIndex       = ::ref<uint8>(orig, 0x4);                       // Where packet claims the new item is going
+    [[maybe_unused]] bool newItemEnabled      = (::ref<uint8>(orig, 0x08) & 0x01) == 1;        // single bit indicating item is in the equipset
+    bool                  newItemSlotDisabled = ((::ref<uint8>(orig, 0x08) & 0x02) >> 1) == 1; // single bit, indicates this slot is intentionally disabled
+    uint8                 newItemBag          = ::ref<uint8>(orig, 0x08) >> 2;                 // 6 bits for bag
+    uint8                 newItemBagIndex     = ::ref<uint8>(orig, 0x09);                      // one byte for bag index
+    uint16                newItemID           = ::ref<uint16>(orig, 0x0A);                     // 2 bytes for item ID
+
+    // Previous set
     for (int i = 0; i < 0x10; i++)
     {
-        if (i == slotID)
+        [[maybe_unused]] bool enabled      = (::ref<uint8>(orig, 0x0C + (0x04 * i)) & 0x01) == 1;        // single bit indicating item is in equipset
+        bool                  slotDisabled = ((::ref<uint8>(orig, 0x0C + (0x04 * i)) & 0x02) >> 1) == 1; // single bit, indicates slot intentionally disabled
+        uint8                 bag          = ::ref<uint8>(orig, 0x0C + (0x04 * i)) >> 2;                 // 6 bits for bag
+        uint8                 bagIndex     = ::ref<uint8>(orig, 0x0D + (0x04 * i));                      // one byte for bag index
+        uint16                itemID       = ::ref<uint16>(orig, 0x0E + (0x04 * i));                     // 2 bytes for item ID
+
+        // Retail doesn't do strict checking on items already in the set
+        // This is probably due to the fact you can move items later
+        // The actual equip command should handle erroneous input and/or missing items
+        CItemEquipment* PItem = dynamic_cast<CItemEquipment*>(itemutils::GetItemPointer(itemID));
+
+        equipSet[i]         = PItem;
+        equipSetBag[i]      = bag;
+        equipSetBagIndex[i] = bagIndex;
+        equipSetDisabled[i] = slotDisabled;
+    }
+
+    CItemEquipment* newItem = dynamic_cast<CItemEquipment*>(PChar->getStorage(newItemBag)->GetItem(newItemBagIndex));
+    // check for bad packet
+    if (newItem && ((newItem->getEquipSlotId() & (1 << equippedIndex)) == 0 || newItemID != newItem->getID()))
+    {
+        return;
+    }
+
+    if (newItem && !newItemSlotDisabled)
+    {
+        // Check if we need to remove stuff
+        auto removeSlotID = newItem->getRemoveSlotId();
+
+        for (uint8 i = 0; i < sizeof(removeSlotID) * 8; ++i)
         {
-            ref<uint8>(0x04 + 0x04 * i) = ::ref<uint8>(orig, 0x08);
-            ref<uint8>(0x05 + 0x04 * i) = ::ref<uint8>(orig, 0x09);
-            ref<uint8>(0x06 + 0x04 * i) = ::ref<uint8>(orig, 0x0A);
-            ref<uint8>(0x07 + 0x04 * i) = ::ref<uint8>(orig, 0x0B);
+            // Remove things this item should remove
+            if (removeSlotID & (1 << i))
+            {
+                equipSet[i] = nullptr;
+            }
+
+            // Check if the existing item conflicts
+            if (equipSet[i])
+            {
+                if (equipSet[i]->getRemoveSlotId() & newItem->getEquipSlotId())
+                {
+                    equipSet[i] = nullptr;
+                }
+            }
         }
-        else
+
+        CItemWeapon* PWeapon       = dynamic_cast<CItemWeapon*>(equipSet[SLOT_MAIN]);
+        CItemWeapon* PSub          = dynamic_cast<CItemWeapon*>(equipSet[SLOT_SUB]);
+        CItemWeapon* PRanged       = dynamic_cast<CItemWeapon*>(equipSet[SLOT_RANGED]);
+        CItemWeapon* PAmmo         = dynamic_cast<CItemWeapon*>(equipSet[SLOT_AMMO]);
+        CItemWeapon* newItemWeapon = dynamic_cast<CItemWeapon*>(newItem);
+
+        if (newItemWeapon)
         {
-            ref<uint8>(0x04 + 0x04 * i) = ::ref<uint8>(orig, 0x0C + (0x04 * i));
-            ref<uint8>(0x05 + 0x04 * i) = ::ref<uint8>(orig, 0x0D + (0x04 * i));
-            ref<uint8>(0x06 + 0x04 * i) = ::ref<uint8>(orig, 0x0E + (0x04 * i));
-            ref<uint8>(0x07 + 0x04 * i) = ::ref<uint8>(orig, 0x0F + (0x04 * i));
+            // Remove sub for H2H
+            if (newItemWeapon->isHandToHand())
+            {
+                equipSet[SLOT_SUB] = nullptr;
+            }
+
+            // Remove one handed weapons or shield from sub if new item is two handed
+            if (newItemWeapon->isTwoHanded())
+            {
+                if ((PSub && PSub->getSkillType() != SKILL_NONE) || (equipSet[SLOT_SUB] && equipSet[SLOT_SUB]->IsShield()))
+                {
+                    equipSet[SLOT_SUB] = nullptr;
+                }
+            }
+
+            // Remove non-matching ammo/ranged weapon
+            if (newItemWeapon->isRanged())
+            {
+                if (PAmmo && PAmmo->getSkillType() != newItemWeapon->getSkillType())
+                {
+                    equipSet[SLOT_AMMO] = nullptr;
+                }
+                if (PRanged && PRanged->getSkillType() != newItemWeapon->getSkillType())
+                {
+                    equipSet[SLOT_RANGED] = nullptr;
+                }
+            }
+
+            // Equipping grip, remove non-2h weapon
+            if (newItemWeapon->getSkillType() == SKILL_NONE && newItemWeapon->getEquipSlotId() & 0x02)
+            {
+                if (PWeapon && !PWeapon->isTwoHanded())
+                {
+                    equipSet[SLOT_MAIN] = nullptr;
+                }
+            }
+
+            // Equipping 1h item in main slot with grip in sub
+            if (equippedIndex == SLOT_MAIN && !newItemWeapon->isHandToHand() && !newItemWeapon->isTwoHanded())
+            {
+                if (PSub && PSub->getSkillType() == SKILL_NONE)
+                {
+                    equipSet[SLOT_SUB] = nullptr;
+                }
+            }
+        }
+
+        // remove two handed weapons in main slot if new item is a shield
+        if (newItem->IsShield() && PWeapon && PWeapon->isTwoHanded())
+        {
+            equipSet[SLOT_MAIN] = nullptr;
+        }
+
+        equipSet[equippedIndex]         = newItem;
+        equipSetBag[equippedIndex]      = newItemBag;
+        equipSetBagIndex[equippedIndex] = newItemBagIndex;
+        equipSetDisabled[equippedIndex] = newItemSlotDisabled;
+    }
+    else
+    {
+        equipSet[equippedIndex]         = nullptr;
+        equipSetDisabled[equippedIndex] = true;
+    }
+
+    for (int i = 0; i < 0x10; i++)
+    {
+        // If the item exists and it can be equipped in that slot
+        if (equipSet[i] && equipSet[i]->getEquipSlotId() & (1 << i))
+        {
+            // set Active, pack in bag index
+            ref<uint8>(0x04 + 0x04 * i)  = (1 | (equipSetBag[i] << 2));
+            ref<uint8>(0x05 + 0x04 * i)  = equipSetBagIndex[i];
+            ref<uint16>(0x06 + 0x04 * i) = equipSet[i]->getID();
+        }
+        else if (equipSetDisabled[i])
+        {
+            // set the disabled bit
+            ref<uint8>(0x04 + 0x04 * i)  = 0x02;
+            ref<uint8>(0x05 + 0x04 * i)  = 0;
+            ref<uint16>(0x06 + 0x04 * i) = 0;
         }
     }
 }

--- a/src/map/packets/macroequipset.h
+++ b/src/map/packets/macroequipset.h
@@ -22,14 +22,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CAddtoEquipSet_H
 #define _CAddtoEquipSet_H
 
+#include "basic.h"
 #include "common/cbasetypes.h"
 
-#include "basic.h"
+class CCharEntity;
 
 class CAddtoEquipSet : public CBasicPacket
 {
 public:
-    CAddtoEquipSet(uint8* data);
+    CAddtoEquipSet(CCharEntity* PChar, uint8* data);
 };
 
 #endif

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1356,6 +1356,10 @@ namespace charutils
 
     bool HasItem(CCharEntity* PChar, uint16 ItemID)
     {
+        if (ItemID == 0)
+        {
+            return false;
+        }
         for (uint8 LocID = 0; LocID < CONTAINER_ID::MAX_CONTAINER_ID; ++LocID)
         {
             if (PChar->getStorage(LocID)->SearchItem(ItemID) != ERROR_SLOTID)
@@ -1548,7 +1552,7 @@ namespace charutils
     {
         if (charutils::UpdateItem(PChar, container, slotID, -quantity) != 0)
         {
-            ShowInfo("Player %s DROPPING itemID: %s (%u) quantity: %u", PChar->GetName(), itemutils::GetItem(ItemID)->getName(), ItemID, quantity);
+            ShowInfo("Player %s DROPPING itemID: %s (%u) quantity: %u", PChar->GetName(), itemutils::GetItemPointer(ItemID)->getName(), ItemID, quantity);
             PChar->pushPacket(new CMessageStandardPacket(nullptr, ItemID, quantity, MsgStd::ThrowAway));
             PChar->pushPacket(new CInventoryFinishPacket());
         }
@@ -2112,8 +2116,23 @@ namespace charutils
 
     bool hasValidStyle(CCharEntity* PChar, CItemEquipment* PItem, CItemEquipment* AItem)
     {
-        return (PItem != nullptr && AItem != nullptr && (((CItemWeapon*)AItem)->getSkillType() == ((CItemWeapon*)PItem)->getSkillType()) &&
-                HasItem(PChar, AItem->getID()) && canEquipItemOnAnyJob(PChar, AItem));
+        if (AItem && PItem)
+        {
+            // Shield special case
+            if (AItem->IsShield() && PItem->IsShield())
+            {
+                return HasItem(PChar, AItem->getID()) && canEquipItemOnAnyJob(PChar, AItem);
+            }
+
+            CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PItem);
+            CItemWeapon* AWeapon = dynamic_cast<CItemWeapon*>(AItem);
+
+            if (PWeapon && AWeapon && PWeapon->getSkillType() == AWeapon->getSkillType())
+            {
+                return HasItem(PChar, AItem->getID()) && canEquipItemOnAnyJob(PChar, AItem);
+            }
+        }
+        return false;
     }
 
     void SetStyleLock(CCharEntity* PChar, bool isStyleLocked)
@@ -2142,15 +2161,19 @@ namespace charutils
         PChar->setStyleLocked(isStyleLocked);
     }
 
-    void UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemWeapon* PItem)
+    void UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemEquipment* PItem)
     {
         if (!PChar->getStyleLocked())
         {
             return;
         }
 
-        auto* appearance      = (CItemEquipment*)itemutils::GetItem(PChar->styleItems[equipSlotID]);
-        auto  appearanceModel = (appearance == nullptr) ? 0 : appearance->getModelId();
+        CItemEquipment* appearance      = dynamic_cast<CItemEquipment*>(itemutils::GetItemPointer(PChar->styleItems[equipSlotID]));
+        uint16          appearanceModel = 0;
+        if (appearance)
+        {
+            appearanceModel = appearance->getModelId();
+        }
 
         switch (equipSlotID)
         {
@@ -2170,19 +2193,23 @@ namespace charutils
                 }
                 else
                 {
-                    switch (PItem->getSkillType())
+                    CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PItem);
+                    if (PWeapon)
                     {
-                        case SKILL_HAND_TO_HAND:
-                            PChar->mainlook.sub = appearanceModel + 0x1000;
-                            break;
-                        case SKILL_GREAT_SWORD:
-                        case SKILL_GREAT_AXE:
-                        case SKILL_SCYTHE:
-                        case SKILL_POLEARM:
-                        case SKILL_GREAT_KATANA:
-                        case SKILL_STAFF:
-                            PChar->mainlook.sub = PChar->look.sub;
-                            break;
+                        switch (PWeapon->getSkillType())
+                        {
+                            case SKILL_HAND_TO_HAND:
+                                PChar->mainlook.sub = appearanceModel + 0x1000;
+                                break;
+                            case SKILL_GREAT_SWORD:
+                            case SKILL_GREAT_AXE:
+                            case SKILL_SCYTHE:
+                            case SKILL_POLEARM:
+                            case SKILL_GREAT_KATANA:
+                            case SKILL_STAFF:
+                                PChar->mainlook.sub = PChar->look.sub;
+                                break;
+                        }
                     }
                 }
                 break;
@@ -2197,8 +2224,17 @@ namespace charutils
                 }
                 break;
             case SLOT_RANGED:
-            case SLOT_AMMO:
-                // Appears as though these aren't implemented by SE.
+                if (hasValidStyle(PChar, PItem, appearance))
+                {
+                    PChar->mainlook.ranged = appearanceModel;
+                }
+                else
+                {
+                    PChar->mainlook.ranged = PChar->look.ranged;
+                }
+
+                break;
+            default:
                 break;
         }
     }
@@ -2210,9 +2246,14 @@ namespace charutils
             return;
         }
 
-        auto  itemID          = PChar->styleItems[equipSlotID];
-        auto* appearance      = (CItemEquipment*)itemutils::GetItem(itemID);
-        auto  appearanceModel = (appearance == nullptr || !HasItem(PChar, itemID)) ? 0 : appearance->getModelId();
+        uint16          itemID          = PChar->styleItems[equipSlotID];
+        CItemEquipment* appearance      = dynamic_cast<CItemEquipment*>(itemutils::GetItemPointer(itemID));
+        uint16          appearanceModel = 0;
+
+        if (appearance && HasItem(PChar, itemID))
+        {
+            appearanceModel = appearance->getModelId();
+        }
 
         if (!canEquipItemOnAnyJob(PChar, appearance))
         {

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -124,7 +124,7 @@ namespace charutils
     bool   EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
     void   CheckUnarmedWeapon(CCharEntity* PChar);
     void   SetStyleLock(CCharEntity* PChar, bool isStyleLocked);
-    void   UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemWeapon* PItem);
+    void   UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemEquipment* PItem);
     void   UpdateArmorStyle(CCharEntity* PChar, uint8 equipSlotID);
     void   AddItemToRecycleBin(CCharEntity* PChar, uint32 container, uint8 slotID, uint8 quantity);
     void   EmptyRecycleBin(CCharEntity* PChar);


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* This adds functionality to tell the client how to assemble equipsets, such as no shield with 2h weapons or h2h
* This also fixes a bug where you could lockstyle a cloak and helm at the same time
* Add ranged weapon lockstyle
* Fix a memory leak on a few calls to GetItem internally calling new when GetItemPointer was all that was needed
## Steps to test these changes

Create equipsets in game, see them work normally. Such as equipping a shield unequips a 2h weapon, equipping a h2h weapon unequips the sub, helms unequip cloaks, cloaks unequip helms, etc.