### PR TITLE
[lua] Remove duplicate counter handling of Seigan

### DIFF
--- a/scripts/globals/effects/seigan.lua
+++ b/scripts/globals/effects/seigan.lua
@@ -9,7 +9,6 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.SEIGAN_EFFECT)
 
-    target:addMod(xi.mod.COUNTER, (target:getMod(xi.mod.ZANSHIN) / 4))
     target:addMod(xi.mod.DEF, jpValue * 3)
 end
 
@@ -19,7 +18,6 @@ end
 effectObject.onEffectLose = function(target, effect)
     local jpValue = target:getJobPointLevel(xi.jp.SEIGAN_EFFECT)
 
-    target:delMod(xi.mod.COUNTER, (target:getMod(xi.mod.ZANSHIN) / 4))
     target:delMod(xi.mod.DEF, jpValue * 3)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Seigan's Counter effect is already handled in attack.cpp, so removing it from the effect lua.

## Steps to test these changes

Check if you can still counter with just Seigan up