### PR TITLE
Fix SQL query for updating unity accolades

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6028,7 +6028,7 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        const char* Query = "UPDATE char_points SET %s = GREATEST(LEAST(%s+%d, %d), 0) WHERE charid = %u;";
+        const char* Query = "UPDATE char_points SET %s = GREATEST(LEAST(%s+(%d), %d), 0) WHERE charid = %u;";
 
         sql->Query(Query, type, type, amount, max, PChar->id);
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6035,7 +6035,7 @@ namespace charutils
         if (strcmp(type, "unity_accolades") == 0 && amount > 0)
         {
             float       evalPoints   = static_cast<float>(amount) / 1000;
-            const char* rankingQuery = "UPDATE unity_system SET points_current = points_current+%f WHERE leader=%d;";
+            const char* rankingQuery = "UPDATE unity_system SET points_current = points_current+(%f) WHERE leader=%d;";
 
             AddPoints(PChar, "current_accolades", amount, std::numeric_limits<int32>::max()); // Do not cap current_accolades
             sql->Query(rankingQuery, evalPoints, PChar->profile.unity_leader);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects an error issue where accolades are failing to update due to a malformed query.
![image](https://user-images.githubusercontent.com/65316697/205507724-4b7ca6bd-a350-4b76-bbde-327a51ae448b.png)


## Steps to test these changes
Watch map server log while gaining accolades and you shouldn't encounter errors.