### PR TITLE
Changing Ultima in One to be Feared to use stages and skill lists

### DIFF
--- a/scripts/globals/mobskills/antimatter.lua
+++ b/scripts/globals/mobskills/antimatter.lua
@@ -10,24 +10,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    local mobhp     = mob:getHPP()
-    local phase     = mob:getLocalVar("battlePhase")
-
-    if
-        (skillList == 729 and phase < 4) or
-        (skillList == 728 and mobhp < 20)
-    then
-        if mob:getLocalVar("nuclearWaste") == 0 then
-            return 0
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/chemical_bomb.lua
+++ b/scripts/globals/mobskills/chemical_bomb.lua
@@ -10,24 +10,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    local mobhp = mob:getHPP()
-    local phase = mob:getLocalVar("battlePhase")
-
-    if
-        (skillList == 729 and phase < 2) or
-        (skillList == 728 and (mobhp >= 70 or mobhp < 40))
-    then
-        if mob:getLocalVar("nuclearWaste") == 0 then
-            return 0
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/cryo_jet.lua
+++ b/scripts/globals/mobskills/cryo_jet.lua
@@ -12,19 +12,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/equalizer.lua
+++ b/scripts/globals/mobskills/equalizer.lua
@@ -10,24 +10,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    local mobhp = mob:getHPP()
-    local phase = mob:getLocalVar("battlePhase")
-
-    if
-        (skillList == 729 and phase >= 2 and phase <= 3) or
-        (mobhp < 40 and mobhp > 20 and skillList == 728)
-    then
-        if mob:getLocalVar("nuclearWaste") == 0 then
-            return 0
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/flame_thrower.lua
+++ b/scripts/globals/mobskills/flame_thrower.lua
@@ -10,19 +10,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/high-tension_discharger.lua
+++ b/scripts/globals/mobskills/high-tension_discharger.lua
@@ -11,19 +11,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/hydro_canon.lua
+++ b/scripts/globals/mobskills/hydro_canon.lua
@@ -12,19 +12,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/nuclear_waste.lua
+++ b/scripts/globals/mobskills/nuclear_waste.lua
@@ -9,24 +9,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    local mobhp = mob:getHPP()
-    local phase = mob:getLocalVar("battlePhase")
-
-    if
-        (skillList == 729 and phase >= 1 and phase <= 2) or
-        (skillList == 728 and mobhp < 70 and mobhp >= 40)
-    then
-        if mob:getLocalVar("nuclearWaste") == 0 then
-            return 0
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/particle_shield.lua
+++ b/scripts/globals/mobskills/particle_shield.lua
@@ -13,13 +13,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local mobhp = mob:getHPP()
-
-    if mobhp >= 70 or mobhp < 40 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/smoke_discharger.lua
+++ b/scripts/globals/mobskills/smoke_discharger.lua
@@ -12,19 +12,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/turbofan.lua
+++ b/scripts/globals/mobskills/turbofan.lua
@@ -11,19 +11,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    -- local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    -- local mobhp = mob:getHPP()
-    -- local phase = mob:getLocalVar("battlePhase")
-
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/wire_cutter.lua
+++ b/scripts/globals/mobskills/wire_cutter.lua
@@ -10,21 +10,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(xi.mobMod.SKILL_LIST)
-    local mobhp = mob:getHPP()
-    local phase = mob:getLocalVar("battlePhase")
-
-    if (skillList == 729 and phase < 2) or (skillList == 728 and mobhp > 70) then
-        if mob:getLocalVar("nuclearWaste") == 0 then
-            return 0
-        end
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -15,8 +15,13 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.GIL_MAX, -1)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 728)
+end
+
 entity.onMobWeaponSkillPrepare = function(mob, target)
-    if mob:getHPP() > 75 then
+    local stage = mob:getLocalVar("stage")
+    if stage == 0 then
         local checker = math.random()
         if checker < 0.50 then
             return abilities[1]
@@ -25,9 +30,7 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
         else
             return abilities[4]
         end
-    end
-
-    if mob:getHPP() < 20 then
+    elseif stage == 3 then
         -- does a specific order of moves in final phase
         local order = mob:getLocalVar("order")
 
@@ -44,21 +47,29 @@ entity.onMobWeaponSkillPrepare = function(mob, target)
     end
 end
 
-entity.onMobFight = function(mob, target)
-    -- Gains regain at under 25% HP
-    if
-        mob:getHPP() < 25 and not
-        mob:hasStatusEffect(xi.effect.REGAIN)
-    then
-        mob:addStatusEffect(xi.effect.REGAIN, 5, 3, 0)
-        mob:getStatusEffect(xi.effect.REGAIN):setFlag(xi.effectFlag.DEATH)
+entity.onMobWeaponSkill = function(target, mob, skill)
+    -- After using Nuclear Waste use a random elemental conal attack
+    if skill:getID() == 1268 then
+        mob:timer(4000, function(mobArg)
+            local ability = math.random(1262, 1267)
+            mob:useMobAbility(ability)
+        end)
     end
+end
 
-    if mob:getLocalVar("nuclearWaste") == 1 then
-        -- after nuclear waste immediately uses a random element ability
-        local ability = math.random(1262, 1267)
-        mob:useMobAbility(ability)
-        mob:setLocalVar("nuclearWaste", 0)
+entity.onMobFight = function(mob, target)
+    local stage = mob:getLocalVar("stage")
+    local hpp = mob:getHPP()
+    if stage == 0 and hpp < 70 then
+        mob:setLocalVar("stage", 1)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 1190)
+    elseif stage == 1 and hpp < 40 then
+        mob:setLocalVar("stage", 2)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 1191)
+    elseif stage == 2 and hpp < 20 then
+        mob:setLocalVar("stage", 3)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 1192)
+        mob:setMod(xi.mod.REGAIN, 100)
     end
 end
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -2448,18 +2448,9 @@ INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1535); -- hyper_pulse
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1536); -- target_analysis
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1538); -- ion_efflux
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega',727,1539); -- rear_lasers
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1259);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1260);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1261);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1262);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1263);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1264);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1265);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1266);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1267);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1268);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1269);
-INSERT INTO `mob_skill_lists` VALUES ('Ultima',728,1270);
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase1',728,1259); -- wire_cutter
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase1',728,1269); -- chemical_bomb
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase1',728,1270); -- particle_shield
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Ultima',729,1259);
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Ultima',729,1260);
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Ultima',729,1261);
@@ -3845,6 +3836,13 @@ INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega_Standing',1188,1529); -- hype
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega_Standing',1188,1530); -- stun_cannon
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega_Final',1189,1526); -- colossal_blow
 INSERT INTO `mob_skill_lists` VALUES ('Proto-Omega_Final',1189,1527); -- laser_shower
+
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase2',1190,1268); -- nuclear_waste
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase3',1191,1261); -- equalizer
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase3',1191,1269); -- chemical_bomb
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase3',1191,1270); -- particle_shield
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase4',1192,1260); -- antimatter
+INSERT INTO `mob_skill_lists` VALUES ('Ultima_Phase4',1192,1270); -- particle_shield
 
 -- Next available ID: 1190
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reworking Ultima from One to be Feared to use combat stages and skill lists instead of sticking the logic inside the mob skill scripts. This is being done primarily in preparation for Proto-Ultima.

## Steps to test these changes

```
!zone 32
!addmission 6 638
!setplayervar <me> 'Mission[6][638]Status' 3
```

Go through the battle and get to Ultima and then keep doing `!tp 3000` to make it use TP moves at the different stages (69%, 39%, 19%).
