### PR TITLE
Remove duplicate assault globals, CI style fixes

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -198,13 +198,6 @@ end
 -----------------------------------
 -- Variable for addTeleport and getRegionPoint
 -----------------------------------
-LEUJAOAM_ASSAULT_POINT   = 0
-MAMOOL_ASSAULT_POINT     = 1
-LEBROS_ASSAULT_POINT     = 2
-PERIQIA_ASSAULT_POINT    = 3
-ILRUSI_ASSAULT_POINT     = 4
-NYZUL_ISLE_ASSAULT_POINT = 5
-
 xi.besieged.addRunicPortal = function(player, portal)
     player:addTeleport(xi.teleport.type.RUNIC_PORTAL, portal)
 end

--- a/scripts/globals/events/handler.lua
+++ b/scripts/globals/events/handler.lua
@@ -19,7 +19,10 @@ function SeasonalEvent:new(id)
     setmetatable(obj, self)
     obj.id = id
     obj.isEnabled = false
-    obj.enableCheck = function() return false end
+    obj.enableCheck = function()
+        return false
+    end
+
     obj.startFunc = {}
     obj.endFunc = {}
     return obj
@@ -46,6 +49,7 @@ function SeasonalEvent:checkStarting()
         print("Starting Seasonal Event: " .. self.id)
         self:startFunc()
     end
+
     return self
 end
 
@@ -55,6 +59,7 @@ function SeasonalEvent:checkEnding()
         print("Ending Seasonal Event: " .. self.id)
         self:endFunc()
     end
+
     return self
 end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Bhoy_Yhupplo.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Bhoy_Yhupplo.lua
@@ -60,7 +60,7 @@ entity.onEventUpdate = function(player, csid, option)
     if csid == 277 and selectiontype == 2 then
         local item = bit.rshift(option, 14)
         local choice = items[item]
-        local assaultPoints = player:getAssaultPoint(ILRUSI_ASSAULT_POINT)
+        local assaultPoints = player:getAssaultPoint(xi.assault.assaultArea.ILRUSI_ATOLL)
         local canEquip = player:canEquipItem(choice.itemid) and 2 or 0
 
         player:updateEvent(0, 0, assaultPoints, 0, canEquip)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Zasshal.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Zasshal.lua
@@ -4,6 +4,7 @@
 -- Type: Salvage Key Item giver
 -- !pos 101.468 -1 -20.088 50
 -----------------------------------
+require("scripts/globals/assault")
 require("scripts/globals/missions")
 require("scripts/globals/keyitems")
 -----------------------------------
@@ -39,31 +40,31 @@ entity.onEventUpdate = function(player, csid, option)
     if
         (csid == 818 or csid == 820) and
         option == 10 and
-        player:getAssaultPoint(LEUJAOAM_ASSAULT_POINT) >= 500
+        player:getAssaultPoint(xi.assault.assaultArea.LEUJAOAM_SANCTUM) >= 500
     then
         player:setLocalVar("SalvageValid", 1)
     elseif
         (csid == 818 or csid == 820) and
         option == 11 and
-        player:getAssaultPoint(MAMOOL_ASSAULT_POINT) >= 500
+        player:getAssaultPoint(xi.assault.assaultArea.MAMOOL_JA_TRAINING_GROUNDS) >= 500
     then
         player:setLocalVar("SalvageValid", 2)
     elseif
         (csid == 818 or csid == 820) and
         option == 12 and
-        player:getAssaultPoint(LEBROS_ASSAULT_POINT) >= 500
+        player:getAssaultPoint(xi.assault.assaultArea.LEBROS_CAVERN) >= 500
     then
         player:setLocalVar("SalvageValid", 3)
     elseif
         (csid == 818 or csid == 820) and
         option == 13 and
-        player:getAssaultPoint(PERIQIA_ASSAULT_POINT) >= 500
+        player:getAssaultPoint(xi.assault.assaultArea.PERIQIA) >= 500
     then
         player:setLocalVar("SalvageValid", 4)
     elseif
         (csid == 818 or csid == 820) and
         option == 14 and
-        player:getAssaultPoint(ILRUSI_ASSAULT_POINT) >= 500
+        player:getAssaultPoint(xi.assault.assaultArea.ILRUSI_ATOLL) >= 500
     then
         player:setLocalVar("SalvageValid", 5)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Arva.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Arva.lua
@@ -11,7 +11,7 @@ local entity = {}
 entity.onTrade = function(player, npc, trade)
     if
         trade:getItemCount() == 1 and
-        trade:hasItemQty(536, 1) == true
+        trade:hasItemQty(536, 1)
     then
         player:startEvent(4)
         player:addGil(xi.settings.main.GIL_RATE * 50)

--- a/scripts/zones/RuLude_Gardens/npcs/Neraf-Najiruf.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Neraf-Najiruf.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
 
     elseif
         saveMySister == QUEST_COMPLETED and
-        player:hasKeyItem(xi.ki.DUCAL_GUARDS_LANTERN) == true
+        player:hasKeyItem(xi.ki.DUCAL_GUARDS_LANTERN)
     then
         player:startEvent(97) -- last CS (after talk with baudin)
 

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -206,13 +206,6 @@ global_objects=(
     BlueFinalAdjustments
     getBlueEffectDuration
 
-    LEUJAOAM_ASSAULT_POINT
-    MAMOOL_ASSAULT_POINT
-    LEBROS_ASSAULT_POINT
-    PERIQIA_ASSAULT_POINT
-    ILRUSI_ASSAULT_POINT
-    NYZUL_ISLE_ASSAULT_POINT
-
     ForceCrash
     BuildString
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes global variables that were deprecated by xi.assault global and fixes various CI warnings for style from recent changes.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed
<!-- Clear and detailed steps to test your changes here -->
