### PR TITLE
Move salvageUtil global to xi.salvage, remove deprecated CI exceptions

### DIFF
--- a/scripts/globals/items/castellanus_cell.lua
+++ b/scripts/globals/items/castellanus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0210)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0210)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0210, 1)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0210, 1)
 end
 
 return itemObject

--- a/scripts/globals/items/congestus_cell.lua
+++ b/scripts/globals/items/congestus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x004)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x004)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x004, 13)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x004, 13)
 end
 
 return itemObject

--- a/scripts/globals/items/cumulus_cell.lua
+++ b/scripts/globals/items/cumulus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0020)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0020)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0020, 2)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0020, 2)
 end
 
 return itemObject

--- a/scripts/globals/items/fractus_cell.lua
+++ b/scripts/globals/items/fractus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x002)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x002)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x002, 12)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x002, 12)
 end
 
 return itemObject

--- a/scripts/globals/items/humilus_cell.lua
+++ b/scripts/globals/items/humilus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x080)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x080)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x080, 18)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x080, 18)
 end
 
 return itemObject

--- a/scripts/globals/items/incus_cell.lua
+++ b/scripts/globals/items/incus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0003)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0003)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0003, 0)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0003, 0)
 end
 
 return itemObject

--- a/scripts/globals/items/mediocris_cell.lua
+++ b/scripts/globals/items/mediocris_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x040)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x040)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x040, 17)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x040, 17)
 end
 
 return itemObject

--- a/scripts/globals/items/nimbus_cell.lua
+++ b/scripts/globals/items/nimbus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x008)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x008)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x008, 14)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x008, 14)
 end
 
 return itemObject

--- a/scripts/globals/items/pannus_cell.lua
+++ b/scripts/globals/items/pannus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x001)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x001)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x001, 11)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x001, 11)
 end
 
 return itemObject

--- a/scripts/globals/items/pileus_cell.lua
+++ b/scripts/globals/items/pileus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x020)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x020)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x020, 16)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x020, 16)
 end
 
 return itemObject

--- a/scripts/globals/items/radiatus_cell.lua
+++ b/scripts/globals/items/radiatus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0040)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0040)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0040, 3)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0040, 3)
 end
 
 return itemObject

--- a/scripts/globals/items/spissatus_cell.lua
+++ b/scripts/globals/items/spissatus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x100)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x100)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x100, 19)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x100, 19)
 end
 
 return itemObject

--- a/scripts/globals/items/stratus_cell.lua
+++ b/scripts/globals/items/stratus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0180)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x0180)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0180, 4)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x0180, 4)
 end
 
 return itemObject

--- a/scripts/globals/items/undulatus_cell.lua
+++ b/scripts/globals/items/undulatus_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x000C)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x000C)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x000C, 6)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x000C, 6)
 end
 
 return itemObject

--- a/scripts/globals/items/velum_cell.lua
+++ b/scripts/globals/items/velum_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.DEBILITATION, 0x010)
+    return xi.salvage.onCellItemCheck(target, xi.effect.DEBILITATION, 0x010)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.DEBILITATION, 0x010, 15)
+    return xi.salvage.onCellItemUse(target, xi.effect.DEBILITATION, 0x010, 15)
 end
 
 return itemObject

--- a/scripts/globals/items/virga_cell.lua
+++ b/scripts/globals/items/virga_cell.lua
@@ -9,11 +9,11 @@ require("scripts/globals/salvage")
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return salvageUtil.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x7800)
+    return xi.salvage.onCellItemCheck(target, xi.effect.ENCUMBRANCE_I, 0x7800)
 end
 
 itemObject.onItemUse = function(target)
-    return salvageUtil.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x7800, 7)
+    return xi.salvage.onCellItemUse(target, xi.effect.ENCUMBRANCE_I, 0x7800, 7)
 end
 
 return itemObject

--- a/scripts/globals/salvage.lua
+++ b/scripts/globals/salvage.lua
@@ -4,10 +4,11 @@
 require("scripts/globals/status")
 require("scripts/globals/zone")
 -----------------------------------
-salvageUtil = {}
+xi = xi or {}
+xi.salvage = xi.salvage or {}
 -----------------------------------
 
-function salvageUtil.onCellItemCheck(target, effect, value)
+xi.salvage.onCellItemCheck = function(target, effect, value)
     local statusEffect = target:getStatusEffect(effect)
     if statusEffect then
         local power = statusEffect:getPower()
@@ -19,7 +20,7 @@ function salvageUtil.onCellItemCheck(target, effect, value)
     return 55
 end
 
-function salvageUtil.onCellItemUse(target, effect, value, offset)
+xi.salvage.onCellItemUse = function(target, effect, value, offset)
     local statusEffect = target:getStatusEffect(effect)
     local power = statusEffect:getPower()
     local newpower = bit.band(power, bit.bnot(value))

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -101,10 +101,6 @@ global_objects=(
     getMeleeDmg
     handleWSGorgetBelt
 
-    getRecommendedAssaultLevel
-
-    PATHFLAG_WALLHACK
-
     RoeParseTimed
     getRoeRecords
     RoeParseRecords
@@ -118,8 +114,6 @@ global_objects=(
     applyHalloweenNpcCostumes
     isHalloweenEnabled
     onHalloweenTrade
-
-    salvageUtil
 
     addBonuses
     addBonusesAbility


### PR DESCRIPTION
Remove deprecated CI exceptions

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves Lua salvageUtil.* to xi.salvage.* and updates relevant scripts
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed
<!-- Clear and detailed steps to test your changes here -->
