### PR TITLE
Fixing some battlefield interactions

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -796,6 +796,7 @@ function Battlefield.redirectEventCall(eventName, player, csid, option)
 end
 
 function Battlefield:onEventFinishEnter(player, csid, option)
+    player:setEnteredBattlefield(true)
     player:setLocalVar("[battlefield]area", 0)
     self:setLocalVar(player, "CS", 1)
 end
@@ -892,13 +893,14 @@ end
 function Battlefield:onBattlefieldRegister(player, battlefield)
 end
 
-function Battlefield:onBattlefieldStatusChange(battlefield, players, status)
+function Battlefield:onBattlefieldStatusChange(battlefield, status)
     -- Remove battlefield effect for players in alliance not inside battlefield once the battlefield gets locked. Do this only once.
     if
         status == xi.battlefield.status.LOCKED and
         battlefield:getLocalVar("statusRemoval") == 0
     then
         battlefield:setLocalVar("statusRemoval", 1)
+        local players = battlefield:getPlayers()
 
         for _, player in pairs(players) do
             local alliance = player:getAlliance()
@@ -981,11 +983,6 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
     end
 
     player:messageSpecial(ID.text.TIME_LIMIT_FOR_THIS_BATTLE_IS, 0, 0, 0, math.floor(self.timeLimit / 60))
-
-    if player:hasStatusEffect(xi.effect.BATTLEFIELD) then
-        local status = player:getStatusEffect(xi.effect.BATTLEFIELD)
-        status:setSubPower(1)
-    end
 end
 
 function Battlefield:onBattlefieldDestroy(battlefield)
@@ -996,9 +993,6 @@ function Battlefield:onBattlefieldLeave(player, battlefield, leavecode)
         self:onBattlefieldWin(player, battlefield)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         self:onBattlefieldLoss(player, battlefield)
-    elseif player:hasStatusEffect(xi.effect.BATTLEFIELD) then
-        local status = player:getStatusEffect(xi.effect.BATTLEFIELD)
-        status:setSubPower(0)
     end
 end
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -529,7 +529,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
 
         if (leavecode == BATTLEFIELD_LEAVE_CODE_EXIT && PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
-            PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->SetSubPower(0);
+            setPlayerEntered(PChar, false);
         }
 
         if (PChar->isDead())
@@ -1005,4 +1005,25 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
             }
         }
     }
+}
+
+void CBattlefield::setPlayerEntered(CCharEntity* PChar, bool entered)
+{
+    CStatusEffect* effect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD);
+    effect->SetTier(entered ? 1 : 0);
+}
+
+bool CBattlefield::hasPlayerEntered(CCharEntity* PChar)
+{
+    if (!PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+    {
+        return false;
+    }
+
+    return PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetTier() == 1;
+}
+
+uint16 CBattlefield::getBattlefieldArea(CCharEntity* PChar)
+{
+    return PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetSubPower();
 }

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -529,7 +529,14 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
 
         if (leavecode == BATTLEFIELD_LEAVE_CODE_EXIT && PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
-            setPlayerEntered(PChar, false);
+            if (GetStatus() == BATTLEFIELD_STATUS_LOCKED)
+            {
+                PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_CONFRONTATION, true);
+            }
+            else
+            {
+                setPlayerEntered(PChar, false);
+            }
         }
 
         if (PChar->isDead())

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -203,6 +203,11 @@ public:
     void addGroup(BattlefieldGroup group);
     void handleDeath(CBaseEntity* PEntity);
 
+    static void setPlayerEntered(CCharEntity* PChar, bool entered);
+    static bool hasPlayerEntered(CCharEntity* PChar);
+
+    static uint16 getBattlefieldArea(CCharEntity* PChar);
+
     uint8 m_isMission;
     bool  m_showTimer = true;
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9445,6 +9445,39 @@ bool CLuaBaseEntity::isInDynamis()
 }
 
 /************************************************************************
+ *  Function: setEnteredBattlefield()
+ *  Purpose : Sets if the player has entered the battlefield or not
+ *  Example : player:setEnteredBattlefield(true)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setEnteredBattlefield(bool entered)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+    {
+        CBattlefield::setPlayerEntered(PChar, entered);
+    }
+}
+
+/************************************************************************
+ *  Function: hasEnteredBattlefield()
+ *  Purpose : Checks if the player has entered the battlefield or not
+ *  Example : if player:hasEnteredBattlefield() then
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::hasEnteredBattlefield()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+    return CBattlefield::hasPlayerEntered(PChar);
+}
+
+/************************************************************************
  *  Function: isAlive()
  *  Purpose : Returns true if an Entity is alive
  *  Example : if mob:isAlive() then
@@ -15213,6 +15246,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("enterBattlefield", CLuaBaseEntity::enterBattlefield);
     SOL_REGISTER("leaveBattlefield", CLuaBaseEntity::leaveBattlefield);
     SOL_REGISTER("isInDynamis", CLuaBaseEntity::isInDynamis);
+    SOL_REGISTER("setEnteredBattlefield", CLuaBaseEntity::setEnteredBattlefield);
+    SOL_REGISTER("hasEnteredBattlefield", CLuaBaseEntity::hasEnteredBattlefield);
 
     // Battle Utilities
     SOL_REGISTER("isAlive", CLuaBaseEntity::isAlive);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -531,6 +531,8 @@ public:
     bool  enterBattlefield(sol::object const& area);                                                                               // enter a battlefield entity is registered with
     bool  leaveBattlefield(uint8 leavecode);                                                                                       // leave battlefield if inside one
     bool  isInDynamis();                                                                                                           // If player is in Dynamis return true else false
+    void  setEnteredBattlefield(bool entered);                                                                                     // Sets if the player has entered into a battlefield or not
+    bool  hasEnteredBattlefield();                                                                                                 // If the player has entered into a battlefield return true else false
 
     // Battle Utilities
     bool isAlive();

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1052,13 +1052,12 @@ void CZone::CharZoneIn(CCharEntity* PChar)
         auto* PBattlefield = m_BattlefieldHandler->GetBattlefield(PChar, true);
         if (PBattlefield != nullptr && PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
-            bool isEntered = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetSubPower() == 1;
-            PBattlefield->InsertEntity(PChar, isEntered);
+            PBattlefield->InsertEntity(PChar, CBattlefield::hasPlayerEntered(PChar));
         }
         else if (PChar->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_CONFRONTATION))
         {
             // Player is in a zone with a battlefield but they are not part of one.
-            if (PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetSubPower() == 1)
+            if (CBattlefield::hasPlayerEntered(PChar))
             {
                 // If inside of the battlefield arena then kick them out
                 // Battlefield and level restriction effects will be removed once fully kicked.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes a few issues:

**If the player's party enters a battlefield with area 1 but never goes inside but logs out with the effect then when they log in they'll be incorrectly kicked out of the battlefield.**

Fix #3332 
The fix is to better track the player's battlefield entered status with effect's subpower. The first bit of the subpower is the entered status and everything after that is used for which battlefield area the player is in. This is done in order to know if the player needs to be ejected when logging in with a battlefield status effect.

I was partially doing this before but I failed to realize that the subpower was being set to the battlefield area when the status effect is created. This stored area value it not used from what I can see but I figured I'd preserve it just in case we do ever need it. 

**Character is able to reenter a locked battlefield if they leave after it has been locked**

This is easily fixed by removing the battlefield status effect when they leave a locked battlefield. This is how the character is prevented from entering a locked battlefield normally or at least should have...

**Character's battlefield status effect is not removed when a battlefield is locked**

This was simply an issue with `Battlefield:onBattlefieldStatusChange` trying to take an extra parameter. I had forgotten I had even fixed this otherwise I would have put it into its own commit. Whoops!

## Steps to test these changes

Go to a battlefield with two characters and try the scenarios described above.
