### PR TITLE
[core] Refactor getPetID() binding to be called on the pet

### DIFF
--- a/scripts/globals/abilities/elemental_siphon.lua
+++ b/scripts/globals/abilities/elemental_siphon.lua
@@ -14,9 +14,14 @@ require("scripts/globals/utils")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    local pet = player:getPetID()
+    local pet = player:getPet()
+    local petID = 0
 
-    if pet >= 0 and pet <= 7 then -- spirits
+    if pet then
+        petID = pet:getPetID()
+    end
+
+    if petID >= xi.pet.id.FIRE_SPIRIT and petID <= xi.pet.id.DARK_SPIRIT then -- spirits
         return 0, 0
     end
 
@@ -24,8 +29,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    local spiritEle = player:getPetID() + 1 -- get the spirit's ID, it is already aligned in proper element order
+    local spirit    = player:getPet()
+    local spiritEle = 0
+
+    -- get the spirit's ID, it is already aligned in proper element order
     -- element order: fire, ice, wind, earth, thunder, water, light, dark
+    if spirit then
+        spiritEle = spirit:getPetID() + 1
+    end
 
     local pEquipMods = player:getMod(xi.mod.ENHANCES_ELEMENTAL_SIPHON)
     local basePower  = player:getSkillLevel(xi.skill.SUMMONING_MAGIC) + pEquipMods - 50
@@ -57,7 +68,6 @@ abilityObject.onUseAbility = function(player, target, ability)
     end
 
     local power  = math.floor(basePower * weatherDayBonus)
-    local spirit = player:getPet()
     power        = utils.clamp(power, 0, spirit:getMP()) -- cap MP drained at spirit's MP
     power        = utils.clamp(power, 0, player:getMaxMP() - player:getMP()) -- cap MP drained at the max MP - current MP
 

--- a/scripts/globals/abilities/maintenance.lua
+++ b/scripts/globals/abilities/maintenance.lua
@@ -49,12 +49,10 @@ local function removeStatus(target)
 end
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if not player:getPet() then
+    local pet = player:getPet()
+    if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        not player:getPetID() or
-        not (player:getPetID() >= 69 and player:getPetID() <= 72)
-    then
+    elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
         local id = player:getEquipID(xi.slot.AMMO)

--- a/scripts/globals/abilities/overdrive.lua
+++ b/scripts/globals/abilities/overdrive.lua
@@ -12,12 +12,10 @@ require("scripts/globals/status")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if not player:getPet() then
+    local pet = player:getPet()
+    if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        not player:getPetID() or
-        not (player:getPetID() >= 69 and player:getPetID() <= 72)
-    then
+    elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
         ability:setRecast(ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST))

--- a/scripts/globals/abilities/role_reversal.lua
+++ b/scripts/globals/abilities/role_reversal.lua
@@ -12,12 +12,11 @@ require("scripts/globals/status")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if not player:getPet() then
+    local pet = player:getPet()
+
+    if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        not player:getPetID() or
-        not (player:getPetID() >= 69 and player:getPetID() <= 72)
-    then
+    elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
         return 0, 0

--- a/scripts/globals/abilities/ventriloquy.lua
+++ b/scripts/globals/abilities/ventriloquy.lua
@@ -12,12 +12,11 @@ require("scripts/globals/status")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if not player:getPet() then
+    local pet = player:getPet()
+
+    if not pet then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif
-        not player:getPetID() or
-        not (player:getPetID() >= 69 and player:getPetID() <= 72)
-    then
+    elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     end
 

--- a/scripts/globals/avatars_favor.lua
+++ b/scripts/globals/avatars_favor.lua
@@ -111,54 +111,63 @@ local shouldAvatarsFavorBeApplied = function(petId)
 end
 
 local removeAvatarsFavorDebuffsFromPet = function(target)
-    local petId = target:getPetID()
-    if  -- Different pet states for in and out of retail / eras
-        shouldAvatarsFavorBeApplied(petId) and
-        xi.settings.main.ENABLE_SOA == 0
-    then
-        local pet = target:getPet()
-        pet:addMod(xi.mod.MATT, 20)
-        pet:addMod(xi.mod.ATTP, 20)
-        pet:addMod(xi.mod.ACC, 10)
-        pet:addMod(xi.mod.DEFP, 10)
+    local pet = target:getPet()
+    if pet then
+        local petId = pet:getPetID()
+        if  -- Different pet states for in and out of retail / eras
+            shouldAvatarsFavorBeApplied(petId) and
+            xi.settings.main.ENABLE_SOA == 0
+        then
+            pet:addMod(xi.mod.MATT, 20)
+            pet:addMod(xi.mod.ATTP, 20)
+            pet:addMod(xi.mod.ACC, 10)
+            pet:addMod(xi.mod.DEFP, 10)
+        end
     end
 end
 
 xi.avatarsFavor.applyAvatarsFavorAuraToPet = function(target, effect)
-    local petId = target:getPetID()
-    if shouldAvatarsFavorBeApplied(petId) then
-        local power = avatarsFavorEffect[petId].scaling[effect:getPower()]
-        local avatarEffect = avatarsFavorEffect[petId].effect
+    local pet = target:getPet()
+    if pet then
+        local petId = pet:getPetID()
+        if shouldAvatarsFavorBeApplied(petId) then
+            local power = avatarsFavorEffect[petId].scaling[effect:getPower()]
+            local avatarEffect = avatarsFavorEffect[petId].effect
 
-        --Useful debug message
-        --printf("Power %d, Effect %d", effect:getPower(), power)
+            --Useful debug message
+            --printf("Power %d, Effect %d", effect:getPower(), power)
 
-        target:getPet():addStatusEffectEx(avatarEffect, avatarEffect, 6, 3, 15, avatarEffect, power, xi.auraTarget.ALLIES, bit.bor(xi.effectFlag.NO_LOSS_MESSAGE, xi.effectFlag.AURA))
+            pet:addStatusEffectEx(avatarEffect, avatarEffect, 6, 3, 15, avatarEffect, power, xi.auraTarget.ALLIES, bit.bor(xi.effectFlag.NO_LOSS_MESSAGE, xi.effectFlag.AURA))
+        end
     end
 end
 
 xi.avatarsFavor.removeAvatarsFavorAuraFromPet = function(target)
-    local petId = target:getPetID()
-    if shouldAvatarsFavorBeApplied(petId) then
-        local pet = target:getPet()
-        if pet:hasStatusEffect(avatarsFavorEffect[petId].effect) then
-            pet:delStatusEffect(avatarsFavorEffect[petId].effect)
-        end
+    local pet = target:getPet()
+    if pet then
+        local petId = pet:getPetID()
+        if shouldAvatarsFavorBeApplied(petId) then
+            if pet:hasStatusEffect(avatarsFavorEffect[petId].effect) then
+                pet:delStatusEffect(avatarsFavorEffect[petId].effect)
+            end
 
-        removeAvatarsFavorDebuffsFromPet(target)
+            removeAvatarsFavorDebuffsFromPet(target)
+        end
     end
 end
 
 xi.avatarsFavor.applyAvatarsFavorDebuffsToPet = function(target)
-    local petId = target:getPetID()
-    if  -- Different pet states for in and out of retail / eras
-        shouldAvatarsFavorBeApplied(petId) and
-        xi.settings.main.ENABLE_SOA == 0
-    then
-        local pet = target:getPet()
-        pet:delMod(xi.mod.MATT, 20) -- Other than MATT most of these values are myth and guesses from multiple sources
-        pet:delMod(xi.mod.ATTP, 20)
-        pet:delMod(xi.mod.ACC, 10)
-        pet:delMod(xi.mod.DEFP, 10)
+    local pet = target:getPet()
+    if pet then
+        local petId = pet:getPetID()
+        if  -- Different pet states for in and out of retail / eras
+            shouldAvatarsFavorBeApplied(petId) and
+            xi.settings.main.ENABLE_SOA == 0
+        then
+            pet:delMod(xi.mod.MATT, 20) -- Other than MATT most of these values are myth and guesses from multiple sources
+            pet:delMod(xi.mod.ATTP, 20)
+            pet:delMod(xi.mod.ACC, 10)
+            pet:delMod(xi.mod.DEFP, 10)
+        end
     end
 end

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -64,7 +64,7 @@ end
 local function getWyvern(player)
     local wyvern = player:getPet()
 
-    if wyvern and player:getPetID() == xi.pet.id.WYVERN then
+    if wyvern and wyvern:getPetID() == xi.pet.id.WYVERN then
         return wyvern
     end
 

--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -144,7 +144,7 @@ local potencyData =
 local function getLuopan(player)
     local pet = player:getPet()
 
-    if pet and player:getPetID() == xi.pet.id.LUOPAN then
+    if pet and pet:getPetID() == xi.pet.id.LUOPAN then
         return pet
     end
 
@@ -463,10 +463,10 @@ end
 -----------------------------------
 xi.job_utils.geomancer.bolsterOnEffectLose = function(target, effect)
     local bolsterJP = target:getJobPointLevel(xi.jp.BOLSTER_EFFECT)
+    local pet       = target:getPet()
 
     -- Luopan Geo effect
-    if target:getPet() and target:getPet():getPetID() == xi.pet.id.LUOPAN then
-        local pet            = target:getPet()
+    if pet and pet:getPetID() == xi.pet.id.LUOPAN then
         local geoPotency     = pet:getLocalVar("GEO_POTENCY")
         local currentPotency = pet:getStatusEffect(xi.effect.COLURE_ACTIVE):getSubPower()
         if currentPotency == geoPotency * 2 then -- will always be this value with Bolster or Blaze of Glory active

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -346,14 +346,14 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, damage, element, dmgm
         damage = damage * (((skill:getTP() / 10) * tpvalue) / 100)
     end
 
-    -- resistence is added last
+    -- resistance is added last
     local finaldmg = damage * mab * dmgmod
 
-    -- get resistence
+    -- get resistance
     local avatarAccBonus = 0
     if mob:isPet() and mob:getMaster() ~= nil then
         local master = mob:getMaster()
-        if master:getPetID() >= 0 and master:getPetID() <= 20 then -- check to ensure pet is avatar
+        if mob:isAvatar() then
             avatarAccBonus = utils.clamp(master:getSkillLevel(xi.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC), 0, 200)
         end
     end

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
@@ -19,11 +19,13 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    local pet = player:getPet()
     if
         player:getCharVar("KnightStalker_Progress") == 4 and
         player:getCharVar("KnightStalker_Kill") == 0 and
         player:getMainJob() == xi.job.DRG and
-        player:getPetID() == xi.pet.id.WYVERN and
+        pet and
+        pet:getPetID() == xi.pet.id.WYVERN and
         npcUtil.popFromQM(player, npc, { ID.mob.CLEUVARION_M_RESOAIX, ID.mob.ROMPAULION_S_CITALLE }, { hide = 0, claim = false })
     then
         player:messageSpecial(ID.text.SOME_SORT_OF_CEREMONY + 1) -- Your wyvern reacts violently to this spot!

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12315,14 +12315,54 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::getPet()
 
 uint32 CLuaBaseEntity::getPetID()
 {
-    auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
-
-    if (PBattle->PPet)
+    if (m_PBaseEntity->objtype == TYPE_PET)
     {
-        return static_cast<CPetEntity*>(PBattle->PPet)->m_PetID;
+        return static_cast<CPetEntity*>(m_PBaseEntity)->m_PetID;
     }
 
     return 0;
+}
+
+/************************************************************************
+ *  Function: isAutomaton()
+ *  Purpose : Returns true if entity is an automaton
+ *  Example : local isAutomaton = pet:isAutomaton()
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::isAutomaton()
+{
+    if (m_PBaseEntity->objtype == TYPE_PET)
+    {
+        uint32 petID = static_cast<CPetEntity*>(m_PBaseEntity)->m_PetID;
+        if (petID >= PETID_HARLEQUINFRAME and petID <= PETID_STORMWAKERFRAME)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/************************************************************************
+ *  Function: isAvatar()
+ *  Purpose : Returns true if entity is an avatar
+ *  Example : local isAvatar = pet:isAvatar()
+ *  Notes   :
+ ************************************************************************/
+
+bool CLuaBaseEntity::isAvatar()
+{
+    if (m_PBaseEntity->objtype == TYPE_PET)
+    {
+        uint32 petID = static_cast<CPetEntity*>(m_PBaseEntity)->m_PetID;
+        if ((petID >= PETID_CARBUNCLE && petID <= PETID_CAIT_SITH) || petID == PETID_SIREN)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /************************************************************************
@@ -15408,6 +15448,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("hasPet", CLuaBaseEntity::hasPet);
     SOL_REGISTER("getPet", CLuaBaseEntity::getPet);
     SOL_REGISTER("getPetID", CLuaBaseEntity::getPetID);
+    SOL_REGISTER("isAutomaton", CLuaBaseEntity::isAutomaton);
+    SOL_REGISTER("isAvatar", CLuaBaseEntity::isAvatar);
     SOL_REGISTER("getPetElement", CLuaBaseEntity::getPetElement);
     SOL_REGISTER("setPet", CLuaBaseEntity::setPet);
     SOL_REGISTER("getMaster", CLuaBaseEntity::getMaster);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -702,7 +702,9 @@ public:
 
     bool   hasPet();                                  // returns true if the player has a pet
     auto   getPet() -> std::optional<CLuaBaseEntity>; // Creates an LUA reference to a pet entity
-    uint32 getPetID();                                // If the entity has a pet, returns the PetID to identify pet type.
+    uint32 getPetID();                                // returns the PetID of an entity if it is a pet, otherwise 0.
+    bool   isAutomaton();                             // returns true if entity is an automaton.
+    bool   isAvatar();                                // returns true if entity is an avatar
     auto   getMaster() -> std::optional<CLuaBaseEntity>;
     uint8  getPetElement();
     void   setPet(sol::object const& petObj);


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Previously, getPetID() was called on the entity that owned the pet
Add isAvatar() and isAutomaton() bindings
Update Repair to match retail, fix 0 HP direct heal


## Steps to test these changes

Use effected abilities, start effected quest and see no change (other than Repair restoring HP correctly)
