### PR TITLE
[Interaction] Add missing KI in event  in Windurst 8-2 Mission

### DIFF
--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -291,7 +291,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        return mission:progressEvent(588)
+                        return mission:progressEvent(588, 0, xi.ki.MANUSTERY_RING)
                     elseif missionStatus == 2 then
                         return mission:progressEvent(601, 0, xi.ki.ORASTERY_RING)
                     elseif missionStatus == 6 then


### PR DESCRIPTION
Co-authored-by: LoxleyXI <LoxleyXI@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a missing parameter in event 588 so KI name appears in text

## Steps to test these changes

Run mission
