### PR TITLE
Add suport for bonus MEVA from STATUS_MEVA mods

### DIFF
--- a/scripts/globals/damage/magic_hit_rate.lua
+++ b/scripts/globals/damage/magic_hit_rate.lua
@@ -195,11 +195,20 @@ xi.damage.magicHitRate.calculateCasterMagicAccuracy = function(caster, target, s
     local maccFood = magicAcc * (caster:getMod(xi.mod.FOOD_MACCP) / 100)
     magicAcc = magicAcc + utils.clamp(maccFood, 0, caster:getMod(xi.mod.FOOD_MACC_CAP))
 
+    -----------------------------------
+    -- magicAcc from Magic Burst
+    -----------------------------------
+    local _, skillchainCount = FormMagicBurst(spellElement, target)
+
+    if skillchainCount > 0 then
+        magicAcc = magicAcc + 100
+    end
+
     return magicAcc
 end
 
 -- Target Magic Evasion
-xi.damage.magicHitRate.calculateTargetMagicEvasion = function(caster, target, spellElement)
+xi.damage.magicHitRate.calculateTargetMagicEvasion = function(caster, target, spellElement, isEnfeeble, mEvaMod)
     local magicEva   = target:getMod(xi.mod.MEVA) -- Base MACC.
     local resistRank = 0 -- Elemental specific Resistance rank. Acts as multiplier to base MACC.
     local resMod     = 0 -- Elemental specific magic evasion. Acts as a additive bonus to base MACC after affected by resistance rank.
@@ -213,6 +222,11 @@ xi.damage.magicHitRate.calculateTargetMagicEvasion = function(caster, target, sp
 
         magicEva = magicEva * (1 + (resistRank * 0.075))
         magicEva = magicEva + resMod
+    end
+
+    -- Magic evasion against specific status effects.
+    if isEnfeeble then
+        magicEva = magicEva + target:getMod(mEvaMod) + target:getMod(xi.mod.STATUS_MEVA)
     end
 
     -- Level correction. Target gets a bonus when higher level. Never a penalty.

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -381,10 +381,7 @@ end
 -- This function is used to calculate Resist tiers. The resist tiers work differently for enfeebles (which usually affect duration, not potency) than for nukes.
 -- This is for nukes damage only. If an spell happens to do both damage and apply an status effect, they are calculated separately.
 xi.spells.damage.calculateResist = function(caster, target, spell, skillType, spellElement, statUsed)
-    local resist        = 1 -- The variable we want to calculate
-
-    -- Magic Bursts of the correct element do not get resisted. SDT isn't involved here.
-    local _, skillchainCount = FormMagicBurst(spellElement, target)
+    local resist = 0 -- The variable we want to calculate
 
     -- Function flow:
     -- Step 0: We check for exceptions that would make the next steps obsolete.
@@ -396,11 +393,8 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- STEP 0: Exceptions.
     -----------------------------------
-    -- Magic Shield and magic burst exceptions.
+    -- Magic Shield exceptions.
     if target:hasStatusEffect(xi.effect.MAGIC_SHIELD, 0) then
-        resist = 0
-        return resist
-    elseif skillchainCount > 0 then
         return resist
     end
 
@@ -412,7 +406,7 @@ xi.spells.damage.calculateResist = function(caster, target, spell, skillType, sp
     -----------------------------------
     -- STEP 2: Get target magic evasion
     -----------------------------------
-    local magicEva = xi.damage.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement)
+    local magicEva = xi.damage.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, false, 0) -- false = not an enfeeble. 0 = No meva modifier.
 
     -----------------------------------
     -- STEP 3: Get Magic Hit Rate


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds support to MEVA calculations for STATUS_MEVA family of modifiers. May need PR  #3350
- Removes unresisted magic bursts. Adds 100 MACC to Magic bursts in exchange. Changes according to BG wiki.

## Steps to test these changes

None for now
