### PR TITLE
Disallow party invite flag while in a party

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5751,7 +5751,15 @@ void SmallPacket0x0DC(map_session_data_t* const PSession, CCharEntity* const PCh
     {
         case NFLAG_INVITE:
             // /invite [on|off]
-            PChar->nameflags.flags ^= FLAG_INVITE;
+            if (PChar->PParty)
+            {
+                // Can't put flag up while in a party
+                PChar->nameflags.flags &= ~FLAG_INVITE;
+            }
+            else
+            {
+                PChar->nameflags.flags ^= FLAG_INVITE;
+            }
             break;
         case NFLAG_AWAY:
             // /away | /online

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -553,7 +553,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
 
         if (PChar->nameflags.flags & FLAG_INVITE)
         {
-            PChar->nameflags.flags ^= FLAG_INVITE;
+            PChar->nameflags.flags &= ~FLAG_INVITE;
             PChar->updatemask |= UPDATE_HP;
 
             charutils::SaveCharStats(PChar);


### PR DESCRIPTION
Co-authored-by: paladindamarus <paladindamarus@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Imports change from ASB, made by paladindamarus.

It prevents players from flaging up while in a party

## Steps to test these changes

Try to Flag up while in a party
