### PR TITLE
[login] Increase max file descriptors open for Linux to MAX_FD

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -47,6 +47,7 @@
 #include <sys/ioctl.h>
 #else
 #include <sys/epoll.h>
+#include <sys/resource.h>
 #endif
 
 typedef int HANDLE;
@@ -101,6 +102,19 @@ int32 do_init(int32 argc, char** argv)
     epoll_ctl(epollHandle, EPOLL_CTL_ADD, login_fd, &loginEpollEvent);
     epoll_ctl(epollHandle, EPOLL_CTL_ADD, login_lobbydata_fd, &login_lobbydataEpollEvent);
     epoll_ctl(epollHandle, EPOLL_CTL_ADD, login_lobbyview_fd, &login_lobbyviewEpollEvent);
+
+    struct rlimit limits;
+
+    // Get old limits
+    if (getrlimit(RLIMIT_NOFILE, &limits) == 0)
+    {
+        // Increase open file limit, which includes sockets, to MAX_FD. This only effects the current process and child processes
+        limits.rlim_cur = MAX_FD;
+        if (setrlimit(RLIMIT_NOFILE, &limits) == -1)
+        {
+            ShowError("Failed to increase rlim_cur to %d", MAX_FD);
+        }
+    }
 #endif
 #endif
 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set file descriptor limits on the login process to allow MAX_FD number of files open to increase the max socket count
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

build and run, still be able to login on linux