### PR TITLE
Add missing event parameter in Windurst star onion brigade quest 1

### DIFF
--- a/scripts/quests/windurst/SOB1_Truth_Justice_and_the_Onion_Way.lua
+++ b/scripts/quests/windurst/SOB1_Truth_Justice_and_the_Onion_Way.lua
@@ -60,7 +60,7 @@ quest.sections =
 
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, xi.items.RARAB_TAIL) then
-                        return quest:progressEvent(378, 0, xi.items.RARAB_TAIL)
+                        return quest:progressEvent(378, 0, xi.items.RARAB_TAIL, xi.items.JUSTICE_BADGE)
                     end
                 end,
             },


### PR DESCRIPTION
Co-authored-by: LoxleyXI <LoxleyXI@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Imports change from ASB, made by LoxleyXI.

Adds missing event parameter that displays item name in CS

## Steps to test these changes

Run affected quest or !exec player:startEvent(378, 0, x, y) chaning x and y values to make item names display
