### PR TITLE
Loot Reformation Part 1

### DIFF
--- a/documentation/AI_Events.txt
+++ b/documentation/AI_Events.txt
@@ -23,6 +23,7 @@ DEATH - Entity, optionalKiller
 DESPAWN - Entity
 DEFEATED_MOB - Mob, Attacker, optParams (Note: optParams is the same table in onMobDeath)
 EXPERIENCE_POINTS - Entity, exp
+ITEM_DROPS - Entity, Loot
 
 TAKE_DAMAGE - Entity, amount, optionalAttacker, attackType, damageType
 CRITICAL_TAKE - Target, Attacker

--- a/scripts/battlefields/Temenos/central_temenos_basement.lua
+++ b/scripts/battlefields/Temenos/central_temenos_basement.lua
@@ -10,6 +10,7 @@ require("scripts/globals/battlefield")
 require("scripts/globals/limbus")
 require("scripts/globals/items")
 require("scripts/globals/keyitems")
+require("scripts/globals/loot")
 -----------------------------------
 
 local content = Limbus:new({
@@ -54,7 +55,10 @@ content.groups =
                     end
                 end)
 
-                -- TODO: Aern should drop ABC = 1 + math.min(3, mob:getLocalVar("AERN_RERAISES")) (before the reraise)
+                mob:addListener("ITEM_DROPS", "ITEM_DROPS_AERN", function(mobArg, loot)
+                    local quantity = math.min(3, mob:getLocalVar("AERN_RERAISES"))
+                    loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARANTEED, quantity)
+                end)
             end
 
             -- Aern are split into groups and 6 of the 10 random groups are assigned a time extension to a random mob

--- a/scripts/globals/loot.lua
+++ b/scripts/globals/loot.lua
@@ -1,0 +1,19 @@
+xi = xi or {}
+xi.loot = xi.loot or {}
+
+------------------------------------
+-- Drop Rarity Rates
+------------------------------------
+
+xi.loot.rate =
+{
+    NEVER       = 0, --   0.00%
+    ULTRA_RARE  = 1, --   0.10%
+    SUPER_RARE  = 2, --   0.50%
+    VERY_RARE   = 3, --   1.00%
+    RARE        = 4, --   5.00%
+    UNCOMMON    = 5, --  10.00%
+    COMMON      = 6, --  15.00%
+    VERY_COMMON = 7, --  24.00%
+    GUARANTEED  = 8, -- 100.00%
+}

--- a/scripts/zones/Apollyon/mobs/Gunpod.lua
+++ b/scripts/zones/Apollyon/mobs/Gunpod.lua
@@ -2,120 +2,72 @@
 -- Area: Apollyon Central
 --  Mob: Gunpod
 -----------------------------------
+require("scripts/globals/loot")
+-----------------------------------
+
 local entity = {}
 
-local loot =
-{
-    [1] = -- AF
-    {
-        {
-            { itemid = 1933, droprate =  9 }, -- MNK
-            { itemid = 1931, droprate = 53 }, -- WAR
-            { itemid = 1959, droprate =  6 }, -- SMN
-            { itemid = 1935, droprate = 12 }, -- WHM
-            { itemid = 1945, droprate = 29 }, -- DRK
-            { itemid = 1957, droprate = 12 }, -- DRG
-            { itemid = 1949, droprate = 35 }, -- BRD
-            { itemid = 2659, droprate = 35 }, -- COR
-            { itemid = 1939, droprate = 12 }, -- RDM
-            { itemid = 1951, droprate = 12 }, -- RNG
-            { itemid = 2661, droprate = 12 }, -- PUP
-            { itemid = 1937, droprate = 18 }, -- BLM
-            { itemid = 1955, droprate = 29 }, -- NIN
-            { itemid = 2717, droprate = 12 }, -- SCH
-            { itemid = 1947, droprate = 12 }, -- BST
-            { itemid = 2657, droprate = 18 }, -- BLU
-            { itemid = 2715, droprate =  5 }, -- DNC
-            { itemid = 1953, droprate = 35 }, -- SAM
-            { itemid = 1941, droprate = 41 }, -- THF
-            { itemid = 1943, droprate = 18 }, -- PLD
-        },
-    },
-
-    [2] = -- Chip
-    {
-        {
-            { itemid = 1987, droprate = 53 }, -- Charcoal Chip
-            { itemid = 1988, droprate = 76 }, -- Magenta Chip
-            { itemid = 1909, droprate = 64 }, -- Smalt Chip
-            { itemid = 1910, droprate = 41 }, -- Smoky Chip
-        },
-    },
-
-    [3] = -- Crafting
-    {
-        {
-            { itemid =  646, droprate = 50 }, -- Adaman Ore
-            { itemid = 1633, droprate = 50 }, -- Clot Plasma
-            { itemid =  664, droprate = 50 }, -- Darksteel Sheet
-            { itemid =  645, droprate = 50 }, -- Darksteel Ore
-            { itemid = 1311, droprate = 50 }, -- Oxblood
-            { itemid = 1681, droprate = 50 }, -- Light Steel
-            { itemid =  821, droprate = 50 }, -- Rainbow Thread
-            { itemid = 1883, droprate = 50 }, -- Shell Powder
-        },
-    },
-
-    [4] = -- ABCs
-    {
-        {
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-
-        {
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-
-        {
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-
-        {
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-
-        {
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-
-        {
-            { itemid =    0, droprate = 1000 }, -- Ancient Beastcoin
-            { itemid = 1875, droprate = 1000 }, -- Ancient Beastcoin
-        },
-    },
-}
-
-entity.onMobDeath = function(mob, player, optParams)
-    if optParams.isKiller or optParams.noKiller then
-        local players = mob:getBattlefield():getPlayers()
-        local random  = math.random(1, 4)
-
-        for i = 1, #loot[random] do
-            local lootGroup = loot[random][i]
-
-            if lootGroup then
-                local max = 0
-
-                for _, entry in pairs(lootGroup) do
-                    max = max + entry.droprate
-                end
-
-                local roll = math.random(max)
-
-                for _, entry in pairs(lootGroup) do
-                    max = max - entry.droprate
-
-                    if roll > max then
-                        if entry.itemid ~= 0 then
-                            players[1]:addTreasure(entry.itemid, mob)
-                        end
-
-                        break
-                    end
-                end
-            end
+entity.onMobInitialize = function(mob)
+    mob:addListener("ITEM_DROPS", "GUNPOD_ITEM_DROPS", function(mobArg, loot)
+        local result = math.random(1, 100)
+        local group = nil
+        if result <= 25 then
+            -- Apollyon Chips
+            group =
+            {
+                { item = xi.items.SMALT_CHIP },
+                { item = xi.items.SMOKY_CHIP },
+                { item = xi.items.CHARCOAL_CHIP },
+                { item = xi.items.MAGENTA_CHIP },
+            }
+        elseif result <= 50 then
+            -- Craft Materials
+            group =
+            {
+                { item = xi.items.CHUNK_OF_DARKSTEEL_ORE },
+                { item = xi.items.CHUNK_OF_ADAMAN_ORE },
+                { item = xi.items.DARKSTEEL_INGOT },
+                { item = xi.items.DARKSTEEL_SHEET },
+                { item = xi.items.SPOOL_OF_RAINBOW_THREAD },
+                { item = xi.items.PIECE_OF_OXBLOOD },
+                { item = xi.items.HANDFUL_OF_CLOT_PLASMA },
+                { item = xi.items.LIGHT_STEEL_INGOT },
+                { item = xi.items.PONZE_OF_SHELL_POWDER },
+            }
+        elseif result <= 86 then
+            -- AF+1 Materials
+            group =
+            {
+                { item = xi.items.ARGYRO_RIVET },
+                { item = xi.items.ANCIENT_BRASS_INGOT },
+                { item = xi.items.SPOOL_OF_BENEDICT_YARN },
+                { item = xi.items.SPOOL_OF_DIABOLIC_YARN },
+                { item = xi.items.SQUARE_OF_CARDINAL_CLOTH },
+                { item = xi.items.SPOOL_OF_LIGHT_FILAMENT },
+                { item = xi.items.WHITE_RIVET },
+                { item = xi.items.BLACK_RIVET },
+                { item = xi.items.FETID_LANOLIN_CUBE },
+                { item = xi.items.SQUARE_OF_BROWN_DOESKIN },
+                { item = xi.items.SQUARE_OF_CHARCOAL_COTTON },
+                { item = xi.items.SHEET_OF_KUROGANE },
+                { item = xi.items.POT_OF_EBONY_LACQUER },
+                { item = xi.items.BLUE_RIVET },
+                { item = xi.items.SQUARE_OF_ASTRAL_LEATHER },
+                { item = xi.items.SQUARE_OF_FLAMESHUN_CLOTH },
+                { item = xi.items.SQUARE_OF_CANVAS_TOILE },
+                { item = xi.items.SQUARE_OF_CORDUROY_CLOTH },
+                { item = xi.items.GOLD_STUD },
+                { item = xi.items.ELECTRUM_STUD },
+            }
+        else
+            -- Acient Beastcoins
+            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARANTEED, 5)
+            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.COMMON)
+            return
         end
-    end
+
+        loot:addGroup(xi.loot.rate.GUARANTEED, group)
+    end)
 end
 
 return entity

--- a/src/map/ai/helpers/event_handler.cpp
+++ b/src/map/ai/helpers/event_handler.cpp
@@ -53,3 +53,8 @@ void CAIEventHandler::removeListener(std::string const& identifier)
         eventListener.second.erase(it, eventListener.second.end());
     }
 }
+
+bool CAIEventHandler::hasListener(std::string const& eventName)
+{
+    return eventListeners.count(eventName) > 0;
+}

--- a/src/map/ai/helpers/event_handler.h
+++ b/src/map/ai/helpers/event_handler.h
@@ -46,6 +46,7 @@ class CAIEventHandler
 public:
     void addListener(std::string const& eventname, sol::function lua_func, std::string const& identifier);
     void removeListener(std::string const& identifier);
+    bool hasListener(std::string const& eventName);
 
     // calls event from core
     template <class... Args>

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -32,6 +32,7 @@
 #include "../conquest_system.h"
 #include "../enmity_container.h"
 #include "../entities/charentity.h"
+#include "../lua/lua_loot.h"
 #include "../mob_modifier.h"
 #include "../mob_spell_container.h"
 #include "../mob_spell_list.h"
@@ -918,21 +919,20 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     // Limit number of items that can drop to the treasure pool size
     uint8 dropCount = 0;
 
-    // Make a temporary copy of the global droplist entry for this drop id
-    // so we can modify it without modifying the global lists
-    DropList_t DropList;
-    if (auto droplistPtr = itemutils::GetDropList(m_DropID))
-    {
-        DropList = *droplistPtr;
-    }
+    DropList_t* dropList = itemutils::GetDropList(m_DropID);
 
-    if (!getMobMod(MOBMOD_NO_DROPS) && (!DropList.Items.empty() || !DropList.Groups.empty()))
+    if (!getMobMod(MOBMOD_NO_DROPS) && dropList != nullptr && (!dropList->Items.empty() || !dropList->Groups.empty() || PAI->EventHandler.hasListener("ITEM_DROPS")))
     {
         // THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
         int16 maxRolls = 1 + (m_THLvl > 2 ? 2 : m_THLvl);
         int16 bonus    = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
 
-        for (const DropGroup_t& group : DropList.Groups)
+        LootContainer loot(dropList);
+
+        PAI->EventHandler.triggerListener("ITEM_DROPS", CLuaBaseEntity(this), CLuaLootContainer(&loot));
+
+        // clang-format off
+        loot.ForEachGroup([&](const DropGroup_t& group)
         {
             uint16 total = 0;
             for (const DropItem_t& item : group.Items)
@@ -964,9 +964,9 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                     break;
                 }
             }
-        }
+        });
 
-        for (const DropItem_t& item : DropList.Items)
+        loot.ForEachItem([&](const DropItem_t& item)
         {
             for (int16 roll = 0; roll < maxRolls; ++roll)
             {
@@ -979,7 +979,8 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                     break;
                 }
             }
-        }
+        });
+        // clang-format on
     }
 
     ZONE_TYPE zoneType  = zoneutils::GetZone(PChar->getZone())->GetType();

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -915,26 +915,6 @@ void CMobEntity::DropItems(CCharEntity* PChar)
         return dropCount >= TREASUREPOOL_SIZE;
     };
 
-    auto UpdateDroprateOrAddToList = [&](std::vector<DropItem_t>& list, uint8 dropType, uint16 itemID, uint16 dropRate)
-    {
-        // Try and update droprate for an item in place
-        bool updated = false;
-        for (auto& entry : list)
-        {
-            if (!updated && entry.ItemID == itemID)
-            {
-                entry.DropRate = dropRate;
-                updated        = true;
-            }
-        }
-
-        // If that item wasn't found and updated, add the item and droprate to the list
-        if (!updated)
-        {
-            list.emplace_back(DropItem_t(dropType, itemID, dropRate));
-        }
-    };
-
     // Limit number of items that can drop to the treasure pool size
     uint8 dropCount = 0;
 
@@ -945,29 +925,6 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     {
         DropList = *droplistPtr;
     }
-
-    // Apply m_DropListModifications changes to DropList
-    for (auto& entry : m_DropListModifications)
-    {
-        uint16    itemID   = entry.first;
-        uint16    dropRate = entry.second.first;
-        DROP_TYPE dropType = static_cast<DROP_TYPE>(entry.second.second);
-
-        if (dropType == DROP_NORMAL)
-        {
-            UpdateDroprateOrAddToList(DropList.Items, DROP_NORMAL, itemID, dropRate);
-        }
-        else if (dropType == DROP_GROUPED)
-        {
-            for (auto& group : DropList.Groups)
-            {
-                UpdateDroprateOrAddToList(group.Items, DROP_NORMAL, itemID, dropRate);
-            }
-        }
-    }
-
-    // Make sure m_DropListModifications doesn't persist by clearing it out now
-    m_DropListModifications.clear();
 
     if (!getMobMod(MOBMOD_NO_DROPS) && (!DropList.Items.empty() || !DropList.Groups.empty()))
     {
@@ -1407,7 +1364,7 @@ void CMobEntity::OnDespawn(CDespawnState& /*unused*/)
     FadeOut();
     PAI->Internal_Respawn(std::chrono::milliseconds(m_RespawnTime));
     luautils::OnMobDespawn(this);
-    //#event despawn
+    // #event despawn
     PAI->EventHandler.triggerListener("DESPAWN", CLuaBaseEntity(this));
 }
 

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -185,9 +185,6 @@ public:
 
     uint32 m_DropID; // dropid of items to be dropped. dropid in Database (mob_droplist)
 
-    // ItemID, <Droprate, DropType>
-    std::map<uint16, std::pair<uint16, uint8>> m_DropListModifications;
-
     uint8  m_minLevel; // lowest possible level of the mob
     uint8  m_maxLevel; // highest possible level of the mob
     uint32 HPmodifier; // HP in Database (mob_groups)

--- a/src/map/lua/CMakeLists.txt
+++ b/src/map/lua/CMakeLists.txt
@@ -11,6 +11,8 @@ set(LUA_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_instance.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_item.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lua_loot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/lua_loot.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_mobskill.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_mobskill.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lua_petskill.cpp

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14237,7 +14237,6 @@ void CLuaBaseEntity::setDropID(uint32 dropID)
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
     PMob->m_DropID = dropID;
-    PMob->m_DropListModifications.clear();
 }
 
 /************************************************************************
@@ -14389,25 +14388,6 @@ int16 CLuaBaseEntity::getTHlevel()
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
     return PMob->isDead() ? PMob->m_THLvl : PMob->PEnmityContainer->GetHighestTH();
-}
-
-/************************************************************************
- *  Function: addDropListModification()
- *  Purpose : Adds a modification to the drop list of this mob, to be applied just before loot is rolled.
- *  Example : mob:addDropListModification(4112, 1000) -- Set drop rate of Potion to 100%
- *  Notes   : Erased on death, once the modifications are applied.
- *          : Modifications are cleared if the drop list is changed.
- ************************************************************************/
-
-void CLuaBaseEntity::addDropListModification(uint16 id, uint16 newRate, sol::variadic_args va)
-{
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
-
-    auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
-
-    uint8 dropType = va[0].get_type() == sol::type::number ? va[0].as<uint8>() : 0;
-
-    PMob->m_DropListModifications[id] = std::pair<uint16, uint8>(newRate, dropType);
 }
 
 /************************************************************************
@@ -15590,7 +15570,6 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getDespoilDebuff", CLuaBaseEntity::getDespoilDebuff);
     SOL_REGISTER("itemStolen", CLuaBaseEntity::itemStolen);
     SOL_REGISTER("getTHlevel", CLuaBaseEntity::getTHlevel);
-    SOL_REGISTER("addDropListModification", CLuaBaseEntity::addDropListModification);
 
     SOL_REGISTER("getPlayerTriggerAreaInZone", CLuaBaseEntity::getPlayerTriggerAreaInZone);
     SOL_REGISTER("updateToEntireZone", CLuaBaseEntity::updateToEntireZone);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -828,7 +828,6 @@ public:
     uint16 getDespoilDebuff(uint16 itemID);                                              // gets the status effect id to apply to the mob on successful despoil
     bool   itemStolen();                                                                 // sets mob's ItemStolen var = true
     int16  getTHlevel();                                                                 // Returns the Monster's current Treasure Hunter Tier
-    void   addDropListModification(uint16 id, uint16 newRate, sol::variadic_args va);    // Adds a modification to the drop list of this mob, erased on death
 
     uint32 getAvailableTraverserStones();
     time_t getTraverserEpoch();

--- a/src/map/lua/lua_loot.cpp
+++ b/src/map/lua/lua_loot.cpp
@@ -1,0 +1,107 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022-2022 LandSandBoat
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "lua_loot.h"
+
+CLuaLootContainer::CLuaLootContainer(LootContainer* loot)
+: m_PLootContainer(loot)
+{
+    if (m_PLootContainer == nullptr)
+    {
+        ShowError("CLuaLootContainer created with nullptr instead of valid LootContainer*!");
+    }
+}
+
+/************************************************************************
+ *  Function: addItem()
+ *  Purpose : Adds an item to the loot container
+ *  Example : loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARENTEED, 2);
+ *  Notes   : Last parameter, quantity, is optional and defaults to 1
+ ************************************************************************/
+
+void CLuaLootContainer::addItem(uint16 item, uint16 rate, sol::variadic_args va)
+{
+    const auto quantity = va.get_type(0) == sol::type::number ? va.get<uint16>(0) : 1;
+    for (uint16 i = 0; i < quantity; ++i)
+    {
+        m_PLootContainer->drops.Items.emplace_back(DROP_TYPE::DROP_NORMAL, item, rate);
+    }
+}
+
+/************************************************************************
+ *  Function: addGroup()
+ *  Purpose : Adds a group of items to the loot container
+ *  Example : loot:addGroup(xi.loot.rate.COMMON, { { item = xi.items.ANCIENT_BEASTCOIN, weight = 100 } });
+ *  Notes   : Item table is a list of tables with "item" key and an optional "weight" which defaults to 1
+ ************************************************************************/
+
+void CLuaLootContainer::addGroup(uint16 groupRate, sol::table items)
+{
+    DropGroup_t group(groupRate);
+
+    for (const auto& entryTable : items)
+    {
+        sol::table entry = entryTable.second;
+        auto       item  = entry["item"];
+        if (!item.valid() || !item.is<uint16>())
+        {
+            ShowError("CLuaLootContainer::addGroup() - entry in group is missing valid 'item'");
+            continue;
+        }
+
+        uint16 weight = entry.get_or<uint16>("weight", 1);
+        group.Items.emplace_back(DROP_TYPE::DROP_GROUPED, item.get<uint16>(), weight);
+    }
+
+    m_PLootContainer->drops.Groups.push_back(std::move(group));
+}
+
+void CLuaLootContainer::Register()
+{
+    SOL_USERTYPE("CLootContainer", CLuaLootContainer);
+    SOL_REGISTER("addItem", CLuaLootContainer::addItem);
+    SOL_REGISTER("addGroup", CLuaLootContainer::addGroup);
+};
+
+std::ostream& operator<<(std::ostream& os, const CLuaLootContainer& loot)
+{
+    os << "CLuaLootContainer(\n";
+
+    // clang-format off
+    loot.m_PLootContainer->ForEachGroup([&](const DropGroup_t& group)
+    {
+        os << "    Group(rate = " << group.GroupRate << ", items = {\n";
+        for (const auto& item : group.Items)
+        {
+            os << "        item(id = " << item.ItemID << ", rate = " << item.DropRate << "),\n";
+        }
+        os << "    ),\n";
+    });
+
+    loot.m_PLootContainer->ForEachItem([&](const DropItem_t& item)
+    {
+        os << "    item(id = " << item.ItemID << ", rate = " << item.DropRate << "),\n";
+    });
+    os << ")";
+    // clang-format on
+
+    return os;
+}

--- a/src/map/lua/lua_loot.cpp
+++ b/src/map/lua/lua_loot.cpp
@@ -21,6 +21,20 @@
 
 #include "lua_loot.h"
 
+// Converts known TH rarity rates to their respective percentages
+// Once the new TH logic has been applied to mobentity.cpp then this can be removed
+static const std::array<uint16, 10> RATE_PERCENTAGES = {
+    0,    // NEVER         0.00%
+    1,    // ULTRA_RARE    0.10%
+    5,    // SUPER_RARE    0.50%
+    10,   // VERY_RARE     1.00%
+    50,   // RARE          5.00%
+    100,  // UNCOMMON     10.00%
+    150,  // COMMON       15.00%
+    240,  // VERY_COMMON  24.00%
+    1000, // GUARANTEED  100.00%
+};
+
 CLuaLootContainer::CLuaLootContainer(LootContainer* loot)
 : m_PLootContainer(loot)
 {
@@ -42,7 +56,7 @@ void CLuaLootContainer::addItem(uint16 item, uint16 rate, sol::variadic_args va)
     const auto quantity = va.get_type(0) == sol::type::number ? va.get<uint16>(0) : 1;
     for (uint16 i = 0; i < quantity; ++i)
     {
-        m_PLootContainer->drops.Items.emplace_back(DROP_TYPE::DROP_NORMAL, item, rate);
+        m_PLootContainer->drops.Items.emplace_back(DROP_TYPE::DROP_NORMAL, item, RATE_PERCENTAGES[rate]);
     }
 }
 
@@ -55,7 +69,7 @@ void CLuaLootContainer::addItem(uint16 item, uint16 rate, sol::variadic_args va)
 
 void CLuaLootContainer::addGroup(uint16 groupRate, sol::table items)
 {
-    DropGroup_t group(groupRate);
+    DropGroup_t group(RATE_PERCENTAGES[groupRate]);
 
     for (const auto& entryTable : items)
     {

--- a/src/map/lua/lua_loot.h
+++ b/src/map/lua/lua_loot.h
@@ -1,0 +1,45 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2022-2022 LandSandBoat
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#ifndef _LUALOOT_H
+#define _LUALOOT_H
+
+#include "../utils/itemutils.h"
+#include "luautils.h"
+
+struct action_t;
+struct actionList_t;
+class CLuaLootContainer
+{
+    LootContainer* m_PLootContainer;
+
+public:
+    CLuaLootContainer(LootContainer* loot);
+
+    friend std::ostream& operator<<(std::ostream& out, const CLuaLootContainer& action);
+
+    void addItem(uint16 item, uint16 rate, sol::variadic_args va);
+    void addGroup(uint16 groupRate, sol::table items);
+
+    static void Register();
+};
+
+#endif

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -35,6 +35,7 @@
 #include "lua_battlefield.h"
 #include "lua_instance.h"
 #include "lua_item.h"
+#include "lua_loot.h"
 #include "lua_mobskill.h"
 #include "lua_petskill.h"
 #include "lua_spell.h"
@@ -207,6 +208,7 @@ namespace luautils
         CLuaBaseEntity::Register();
         CLuaBattlefield::Register();
         CLuaInstance::Register();
+        CLuaLootContainer::Register();
         CLuaMobSkill::Register();
         CLuaPetSkill::Register();
         CLuaTriggerArea::Register();

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -46,6 +46,37 @@ DropGroup_t::DropGroup_t(uint16 GroupRate)
 {
 }
 
+LootContainer::LootContainer(DropList_t* dropList)
+: dropList(dropList)
+{
+}
+
+void LootContainer::ForEachGroup(const std::function<void(const DropGroup_t&)>& func)
+{
+    for (const auto& group : dropList->Groups)
+    {
+        func(group);
+    }
+
+    for (const auto& group : drops.Groups)
+    {
+        func(group);
+    }
+}
+
+void LootContainer::ForEachItem(const std::function<void(const DropItem_t&)>& func)
+{
+    for (const auto& item : dropList->Items)
+    {
+        func(item);
+    }
+
+    for (const auto& item : drops.Items)
+    {
+        func(item);
+    }
+}
+
 /************************************************************************
  *                                                                       *
  *  Actually methods of working with a global collection of items        *
@@ -579,6 +610,9 @@ namespace itemutils
                 }
             }
         }
+
+        // Populate 0 drop list with an empty list to support mobs that only drop loot through script logic
+        g_pDropList[0] = new DropList_t;
     }
 
     /************************************************************************

--- a/src/map/utils/itemutils.h
+++ b/src/map/utils/itemutils.h
@@ -78,6 +78,18 @@ struct LootItem_t
 
 typedef std::vector<LootItem_t> LootList_t;
 
+struct LootContainer
+{
+    LootContainer(DropList_t* dropList);
+    DropList_t drops;
+
+    void ForEachGroup(const std::function<void(const DropGroup_t&)>& func);
+    void ForEachItem(const std::function<void(const DropItem_t&)>& func);
+
+private:
+    DropList_t* dropList;
+};
+
 /************************************************************************
  *                                                                       *
  *  The namespace for working with a global lists of items               *


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This replaces `addDropListModification` with ITEM_DROPS event that provides scripts with a `CLuaLootContainer` object that can have items and item groups added to it. I have provided two example use cases for it but there are countless more. Both `SetDropID` and `SetDropRate` could primarily be replaced with these; however, they are used in modules so we may want to leave the functions around for overriding data.

## Steps to test these changes

Go into Central Temenos Basement or Central Apollyon and kill Aern or Gunpod respectively and they should drop different loot based off of the logic in the scripts.
