### PR TITLE
Implement correct message for nexus cape

### DIFF
--- a/scripts/globals/items/nexus_cape.lua
+++ b/scripts/globals/items/nexus_cape.lua
@@ -10,7 +10,7 @@ require('scripts/globals/zone')
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    local result = xi.msg.basic.ITEM_UNABLE_TO_USE -- Default is fail.
+    local result = xi.msg.basic.ITEM_UNABLE_TO_USE
     local leader = target:getPartyLeader()
     -- In a party and we were able to find the leader
     -- (currently fails in cross map server situations)
@@ -121,10 +121,14 @@ itemObject.onItemCheck = function(target)
                 -- xi.zone.KAMIHR_DRIFTS,
                 -- xi.zone.LEAFALLIA,
             }
+
             -- Make sure we can actually tele to that zone..
+            result = xi.msg.basic.ITEM_UNABLE_TO_USE_PARTY_LEADER
+
             for _, validZone in ipairs(validZoneList) do
                 if validZone == leaderZone and target:hasVisitedZone(validZone) then
                     result = 0
+                    break
                 end
             end
         end

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -217,21 +217,22 @@ xi.msg.basic =
     EATS_FINDS_NOTHING      = 604,  -- <actor> eats a <item>, but finds nothing inside...
 
     -- Items
-    ITEM_USES               = 28,   -- <actor> uses a <item>.
-    ITEM_UNABLE_TO_USE      = 55,   -- Unable to use item.
-    ITEM_UNABLE_TO_USE_2    = 56,   -- Unable to use item.
-    ITEM_FAILS_TO_ACTIVATE  = 62,   -- The <item> fails to activate.
-    ITEM_NO_PETRAS          = 65,   -- You are not carrying any Petras.<br>You cannot use the <item>.
-    ITEM_DOES_NOT_HAVE      = 91,   -- <actor> does not have any <item>.
-    ITEM_CANNOT_USE_ON      = 92,   -- Cannot use the <item> on <target>.
-    ITEM_YOU_OBTAIN_FROM    = 98,   -- You obtain a <item> from <target>.
-    ITEM_NO_USE_LEVEL       = 104,  -- Unable to use item.<br>You do not meet the level requirement.
-    ITEM_NO_USE_MEDICATED   = 111,  -- You cannot use <item> while medicated.
-    ITEM_NO_USE_INVENTORY   = 308,  -- Unable to use the <item>.<br><target>'s inventory is full.
-    ITEM_RECEIVES_EFFECT    = 375,  -- <actor> uses a <item>.<br><target> receives the effect of <status>.
-    ITEM_OBTAINS_A          = 376,  -- <actor> uses a <item>.<br><target> obtains a <item2>.
-    ITEM_OBTAINS            = 377,  -- <actor> uses a <item>.<br><target> obtains <item2>.
-    ITEM_EFFECT_DISAPPEARS  = 378,  -- <actor> uses a <item>.<br><target>'s <status> effect disappears!
+    ITEM_USES                       = 28,  -- <actor> uses a <item>.
+    ITEM_UNABLE_TO_USE              = 55,  -- Unable to use item.
+    ITEM_UNABLE_TO_USE_2            = 56,  -- Unable to use item.
+    ITEM_FAILS_TO_ACTIVATE          = 62,  -- The <item> fails to activate.
+    ITEM_NO_PETRAS                  = 65,  -- You are not carrying any Petras.<br>You cannot use the <item>.
+    ITEM_DOES_NOT_HAVE              = 91,  -- <actor> does not have any <item>.
+    ITEM_CANNOT_USE_ON              = 92,  -- Cannot use the <item> on <target>.
+    ITEM_YOU_OBTAIN_FROM            = 98,  -- You obtain a <item> from <target>.
+    ITEM_NO_USE_LEVEL               = 104, -- Unable to use item.<br>You do not meet the level requirement.
+    ITEM_NO_USE_MEDICATED           = 111, -- You cannot use <item> while medicated.
+    ITEM_NO_USE_INVENTORY           = 308, -- Unable to use the <item>.<br><target>'s inventory is full.
+    ITEM_RECEIVES_EFFECT            = 375, -- <actor> uses a <item>.<br><target> receives the effect of <status>.
+    ITEM_OBTAINS_A                  = 376, -- <actor> uses a <item>.<br><target> obtains a <item2>.
+    ITEM_OBTAINS                    = 377, -- <actor> uses a <item>.<br><target> obtains <item2>.
+    ITEM_EFFECT_DISAPPEARS          = 378, -- <actor> uses a <item>.<br><target>'s <status> effect disappears!
+    ITEM_UNABLE_TO_USE_PARTY_LEADER = 580, -- Unable to use <item>. The party leader is in either an area beyond warping range or a place you have yet to visit.
 
     -- Ranged
     NO_RANGED_WEAPON       = 216, -- You do not have an appropriate ranged weapon equipped.
@@ -239,7 +240,7 @@ xi.msg.basic =
     MOVE_AND_INTERRUPT     = 218, -- You move and interrupt your aim.
 
     -- Additional effects and spike effects
-    SPIKES_EFFECT_DMG      = 44 , -- <Defender>'s spikes deal <number> points of damage to the <Attacker>.
+    SPIKES_EFFECT_DMG      = 44,  -- <Defender>'s spikes deal <number> points of damage to the <Attacker>.
     SPIKES_EFFECT_HP_DRAIN = 132, -- <Defender>'s spikes drain <number> HP from the <Attacker>.
     ADD_EFFECT_MP_HEAL     = 152, -- Additional effect: The <player> recovers <number> MP.
     ADD_EFFECT_STATUS      = 160, -- Additional effect: <Status Effect>.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Returns correct message for nexus cape item use failure when party leader exists and isn't yourself.

## Steps to test these changes

Use the item when party leader is in an invalid zone.
