### PR TITLE
[core] Add message modifier to Spells

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1502,6 +1502,9 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
                 msg = PSpell->getAoEMessage();
             }
 
+            actionTarget.modifier = PSpell->getModifier();
+            PSpell->setModifier(MODIFIER::NONE); // Reset modifier on use
+
             if (damage < 0)
             {
                 msg                = MSGBASIC_MAGIC_RECOVERS_HP;

--- a/src/map/lua/lua_spell.cpp
+++ b/src/map/lua/lua_spell.cpp
@@ -51,6 +51,11 @@ void CLuaSpell::setMsg(uint16 messageID)
     m_PLuaSpell->setMessage(messageID);
 }
 
+void CLuaSpell::setModifier(uint8 modifier)
+{
+    m_PLuaSpell->setModifier(static_cast<MODIFIER>(modifier));
+}
+
 void CLuaSpell::setAoE(uint8 aoe)
 {
     m_PLuaSpell->setAOE(aoe);
@@ -152,6 +157,7 @@ void CLuaSpell::Register()
 {
     SOL_USERTYPE("CSpell", CLuaSpell);
     SOL_REGISTER("setMsg", CLuaSpell::setMsg);
+    SOL_REGISTER("setModifier", CLuaSpell::setModifier);
     SOL_REGISTER("setAoE", CLuaSpell::setAoE);
     SOL_REGISTER("setFlag", CLuaSpell::setFlag);
     SOL_REGISTER("setRadius", CLuaSpell::setRadius);

--- a/src/map/lua/lua_spell.h
+++ b/src/map/lua/lua_spell.h
@@ -41,6 +41,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CLuaSpell& spell);
 
     void   setMsg(uint16 messageID);
+    void   setModifier(uint8 modifier);
     void   setAoE(uint8 aoe);
     void   setFlag(uint8 flags);
     void   setRadius(float radius);

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -326,6 +326,16 @@ void CSpell::setMagicBurstMessage(uint16 message)
     m_MagicBurstMessage = message;
 }
 
+MODIFIER CSpell::getModifier()
+{
+    return m_MessageModifier;
+}
+
+void CSpell::setModifier(MODIFIER modifier)
+{
+    m_MessageModifier = modifier;
+}
+
 uint16 CSpell::getElement() const
 {
     return m_element;

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -1110,6 +1110,9 @@ public:
     void setMultiplier(float multiplier);
     void setMessage(uint16 message);
     void setMagicBurstMessage(uint16 message);
+    auto getModifier() -> MODIFIER;
+    void setModifier(MODIFIER modifier); // set Spell modifier message, MUST reset the modifier on use otherwise it will be stale
+
     void setCE(uint16 ce);
     void setVE(uint16 ve);
     void setRequirements(uint8 requirements);
@@ -1148,6 +1151,7 @@ private:
     uint16      m_element{};                       // element of spell
     uint16      m_message{};                       // message id
     uint16      m_MagicBurstMessage{};             // Message used for magic bursts.
+    MODIFIER    m_MessageModifier{};               // Message modifier, "Cover!", "Resist!" or "Immunobreak!"
     uint16      m_CE{};                            // cumulative enmity of spell
     uint16      m_VE{};                            // volatile enmity of spell
     std::string m_name;                            // spell name


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the ability to set the message modifier on spells from lua

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
An example of how to use it, though only for demonstration purposes:
```
spellObject.onSpellCast = function(caster, target, spell)
    spell:setModifier(xi.actionModifier.RESIST)
    return xi.spells.damage.useDamageSpell(caster, target, spell)
end
```

after that your modified spell should land with "Resist! {normal message here}"