### PR TITLE
[ci] Colorize cpp diff output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,6 +22,7 @@ KeepEmptyLinesAtTheStartOfBlocks: 'false'
 Language: Cpp
 NamespaceIndentation: All
 PointerAlignment: Left
+QualifierAlignment: Left # East Const
 ReflowComments: true
 SortIncludes: 'true'
 SortUsingDeclarations: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,8 @@ jobs:
             fi
           fi
         done
-        git diff >> cpp_formatting_checks.txt
+        npm install -g diff-so-fancy
+        git diff --color | diff-so-fancy >> cpp_formatting_checks.txt
         cat cpp_formatting_checks.txt
         git reset --hard
         if [ -s cpp_formatting_checks.txt ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         sudo apt-get install -y software-properties-common cppcheck luajit-5.1-dev luarocks mariadb-server mariadb-client libmariadb-dev-compat binutils-dev
         pip install -r tools/requirements.txt
         luarocks install luacheck --local
+        npm install -g diff-so-fancy
     - id: changed-files
       name: Get Changed Files
       uses: Ana06/get-changed-files@v2.2.0
@@ -106,8 +107,8 @@ jobs:
             fi
           fi
         done
-        npm install -g diff-so-fancy
-        git diff --color | diff-so-fancy >> cpp_formatting_checks.txt
+        git diff --color | diff-so-fancy || true
+        git diff >> cpp_formatting_checks.txt
         cat cpp_formatting_checks.txt
         git reset --hard
         if [ -s cpp_formatting_checks.txt ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,10 +111,12 @@ jobs:
         git reset --hard
         if [ -s cpp_formatting_checks.txt ]
         then
+          echo ""
           echo "You have errors in your C++ code formatting."
           echo "Please see below in red for the incorrect formatting, and in green for the correct formatting."
           echo "You can either fix the formatting by hand or use clang-format."
           echo "(You can safely ignore warnings about \$TERM and tput)"
+          echo ""
           cat cpp_formatting_checks.txt | diff-so-fancy || true
           exit 1
         fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,12 +107,14 @@ jobs:
             fi
           fi
         done
-        git diff --color | diff-so-fancy || true
-        git diff >> cpp_formatting_checks.txt
-        cat cpp_formatting_checks.txt
+        git diff --color >> cpp_formatting_checks.txt
         git reset --hard
         if [ -s cpp_formatting_checks.txt ]
         then
+          echo "You have errors in your C++ code formatting."
+          echo "Please see below in red for the incorrect formatted, and in green for the correct formatting."
+          echo "(You can ignore warnings about tput and \$TERM)"
+          cat cpp_formatting_checks.txt | diff-so-fancy || true
           exit 1
         fi
         exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,9 @@ jobs:
         if [ -s cpp_formatting_checks.txt ]
         then
           echo "You have errors in your C++ code formatting."
-          echo "Please see below in red for the incorrect formatted, and in green for the correct formatting."
-          echo "(You can ignore warnings about tput and \$TERM)"
+          echo "Please see below in red for the incorrect formatting, and in green for the correct formatting."
+          echo "You can either fix the formatting by hand or use clang-format."
+          echo "(You can safely ignore warnings about \$TERM and tput)"
           cat cpp_formatting_checks.txt | diff-so-fancy || true
           exit 1
         fi

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -40,7 +40,8 @@
 #include "packets/party_define.h"
 #include "packets/party_member_update.h"
 
-CAlliance::CAlliance(CBattleEntity* PEntity) {
+CAlliance::CAlliance(CBattleEntity* PEntity)
+{
     XI_DEBUG_BREAK_IF(PEntity->PParty == nullptr);
 
     m_AllianceID = PEntity->PParty->GetPartyID();

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -40,8 +40,7 @@
 #include "packets/party_define.h"
 #include "packets/party_member_update.h"
 
-CAlliance::CAlliance(CBattleEntity* PEntity)
-{
+CAlliance::CAlliance(CBattleEntity* PEntity) {
     XI_DEBUG_BREAK_IF(PEntity->PParty == nullptr);
 
     m_AllianceID = PEntity->PParty->GetPartyID();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

![image](https://user-images.githubusercontent.com/1389729/207872211-70b77d5e-b15c-4ffe-bf0f-9ad30f0337cc.png)

I have seen that it should be possible to colorize the diff output inside the github action output. This would make it much clearer to people trying to format their code, if they aren't comfortable reading plaintext diffs

## Steps to test these changes

CI DANCE!