### PR TITLE
[ci] Enforce Const East

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,7 +22,7 @@ KeepEmptyLinesAtTheStartOfBlocks: 'false'
 Language: Cpp
 NamespaceIndentation: All
 PointerAlignment: Left
-QualifierAlignment: Left # East Const
+QualifierAlignment: Right # East Const
 ReflowComments: true
 SortIncludes: 'true'
 SortUsingDeclarations: 'true'


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the new rule for clang-format. I got caught in my own copy/paste hubris.