### PR TITLE
[login] Fix Linux socket crashes above >1024, handle EPOLLPRI

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -227,7 +227,9 @@ int32 makeConnection(uint32 ip, uint16 port, int32 type)
 void do_close(int32 fd)
 {
     TracyZoneScoped;
-    sFD_CLR(fd, &readfds);    // this needs to be done before closing the socket
+#ifdef __APPLE__
+    sFD_CLR(fd, &readfds); // this needs to be done before closing the socket
+#endif
     sShutdown(fd, SHUT_RDWR); // Disallow further reads/writes
     sClose(fd);               // We don't really care if these closing functions return an error, we are just shutting down and not reusing this socket.
 }
@@ -774,8 +776,9 @@ int connect_client(int listen_fd, sockaddr_in& client_address)
     {
         fd_max = fd + 1;
     }
+#ifdef __APPLE__
     sFD_SET(fd, &readfds);
-
+#endif
     return fd;
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Remove some FD related calls via IFDEF, as they are undefined behavior above 1024 in Linux.
Handle EPOLLPRI which is apparently another method for the socket to tell us there's data.
The IFDEFs added only affect login, as only login uses those functions.


## Steps to test these changes

Spam connections at the server with headless xi > 1024 and still accept connections on linux