### PR TITLE
[ci] Remove bad options from setup-git-user

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: fregante/setup-git-user@v1
-      with:
-        fetch-depth: 1
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`fetch-depth: 1` doesn't belong to `setup-git-user`. If I typo'd long ago and it was meant to belong to `checkout`, the default value is 1 anyway so it's redundant.