### PR TITLE
[Magic] Implement Resist! and add magic burst messages to msg file.

### DIFF
--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -685,15 +685,6 @@ xi.reaction =
     ABILITY  = 0x10,
 }
 
-xi.actionModifier =
-{
-    NONE        = 0x00,
-    COVER       = 0x01,
-    RESIST      = 0x02,
-    MAGIC_BURST = 0x04, -- Currently known to be used for Swipe/Lunge only
-    IMMUNOBREAK = 0x08,
-}
-
 xi.specEffect =
 {
     NONE           = 0x00,

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -705,7 +705,7 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
         -- The bit does not actually change the message.
         action:messageID(target:getID(), xi.msg.basic.JA_RECOVERS_HP)
         if magicBurst > 1  then
-            action:modifier(target:getID(), xi.actionModifier.MAGIC_BURST)
+            action:modifier(target:getID(), xi.msg.actionModifier.MAGIC_BURST)
         end
 
         return target:addHP(math.abs(damage))

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -650,7 +650,7 @@ xi.job_utils.rune_fencer.useSwipeLunge = function(player, target, ability, actio
     end
 
     if magicBursted then -- Note: the vanilla client does not report a healed magic burst, but this bit is set.
-        action:modifier(target:getID(), xi.actionModifier.MAGIC_BURST)
+        action:modifier(target:getID(), xi.msg.actionModifier.MAGIC_BURST)
     end
 
     return math.abs(cumulativeDamage)

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -81,6 +81,9 @@ xi.msg.basic =
     MAGIC_GAIN_EFFECT      = 230, -- <caster> casts <spell>. <target> gains the effect of <status>.
     MAGIC_ENFEEB_IS        = 236, -- <caster> casts <spell>. <target> is <status>.
     MAGIC_ENFEEB           = 237, -- <caster> casts <spell>. <target> receives the effect of <status>.
+    MAGIC_BURST_DAMAGE     = 252, -- <caster> casts <spell> Magic burst! <target> takes <amount> points of damage.
+    MAGIC_BURST_ENFEEB     = 268, -- <caster> casts <spell> Magic burst! <target> receives the effect of <status>.
+    MAGIC_BURST_ENFEEB_IS  = 271, -- <caster> casts <spell> Magic burst! <target> is <status>.
     MAGIC_RESIST_2         = 284, -- <target> resists the effects of the spell!
     MAGIC_CASTS_ON         = 309, -- <caster> casts <spell> on <target>.
     MAGIC_ABSORB_STR       = 329, -- <caster> casts <spell>. <target>'s STR is drained.
@@ -371,6 +374,16 @@ xi.msg.basic =
     -- TRUST & ALTER EGO
     TRUST_NO_CAST_TRUST     = 700,  -- You are unable to use Trust magic at this time.
     TRUST_NO_CALL_AE        = 717,  -- You cannot call forth alter egos here.
+}
+
+-- Used to modify certain basic messages.
+xi.msg.actionModifier =
+{
+    NONE        = 0x00,
+    COVER       = 0x01,
+    RESIST      = 0x02, -- Resist! <Regular message> -- Used for resist traits triggers.
+    MAGIC_BURST = 0x04, -- Currently known to be used for Swipe/Lunge only
+    IMMUNOBREAK = 0x08,
 }
 
 -----------------------------------

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -864,7 +864,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
 
         -- Add "Magic Burst!" message
         if magicBurst > 1 then
-            spell:setMsg(spell:getMagicBurstMessage())
+            spell:setMsg(xi.msg.basic.MAGIC_BURST_DAMAGE)
             caster:triggerRoeEvent(xi.roe.triggers.magicBurst)
         end
     end

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -328,7 +328,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local traitTrigger = xi.spells.enfeebling.checkTraitTrigger(caster, target, spellId)
 
     if traitTrigger then
-        -- TODO: Change action modifier so Resist! appears.
+        spell:setModifier(xi.msg.actionModifier.RESIST)
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
 
         return spellEffect
@@ -378,7 +378,6 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     end
 
     if resistDuration <= 1 / (2 ^ resistStages) then
-        -- spell:setModifier(xi.actionModifier.RESIST)
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
 
         return spellEffect
@@ -455,7 +454,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
         local _, skillchainCount = FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
 
         if skillchainCount > 0 then
-            spell:setMsg(spell:getMagicBurstMessage())
+            spell:setMsg(xi.msg.basic.MAGIC_BURST_ENFEEB_IS - message * 3)
             caster:triggerRoeEvent(xi.roe.triggers.magicBurst)
         else
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS + message)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

 - Moves action modifiers definitions to msg.lua file. (As discussed in discord with WinterSolstice)
 - Adds magic burst messages that do not depend on the data in the database.
 - Makes enfeebles return Resist! and Magic burst! messages when aplicable. NOTE: Enfeebles have 2 different kind of Magic Burst! messages, since they also have 2 different regular messages. They do not align ID wise, hence, the math.
 - Makes Ninjutsus return Magic Burst! messages.
 
 Closes Issue #777

## Steps to test these changes

Perform magic bursts and see the magic burst message pop up.

