### PR TITLE
[porter moogle] Fix missing entry for Reforged BLM+1 head

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -5656,6 +5656,7 @@ xi.items =
     PUMMELERS_MASK_P1               = 27684,
     ANCHORITES_CROWN_P1             = 27685,
     THEOPHANY_CAP_P1                = 27686,
+    SPAEKONAS_PETASOS_P1            = 27687,
     ATROPHY_CHAPEAU_P1              = 27688,
     PILLAGERS_BONNET_P1             = 27689,
     REVERENCE_CORONET_P1            = 27690,

--- a/scripts/globals/porter_slip_items.lua
+++ b/scripts/globals/porter_slip_items.lua
@@ -1969,7 +1969,7 @@ local slipItems =
         xi.items.THEOPHANY_MITTS_P1,
         xi.items.THEOPHANY_PANTALOONS_P1,
         xi.items.THEOPHANY_DUCKBILLS_P1,
-        xi.items.THEOPHANY_DUCKBILLS_P1,
+        xi.items.SPAEKONAS_PETASOS_P1,
         xi.items.SPAEKONAS_COAT_P1,
         xi.items.SPAEKONAS_GLOVES_P1,
         xi.items.SPAEKONAS_TONBAN_P1,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
WHM Feet+1 were listed twice in Porter Moogle (one of which was for BLM+1 Head).  This corrects that table entry, and adds Reforged BLM+1 Head to items.lua enum
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Store a BLM head, get back the same item.
<!-- Clear and detailed steps to test your changes here -->
