### PR TITLE
[crafting] Add guild rank enum, simplify guild joining logic

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -1,34 +1,62 @@
 -----------------------------------
--- Crafting functions
--- Info from:
--- http://wiki.ffxiclopedia.org/wiki/Crafts_%26_Hobbies
+-- Crafting Guilds
+-- Ref: http://wiki.ffxiclopedia.org/wiki/Crafts_%26_Hobbies
 -----------------------------------
-require("scripts/globals/status")
+require('scripts/globals/items')
+require('scripts/globals/keyitems')
+require('scripts/globals/npc_util')
+require('scripts/globals/status')
+require('scripts/globals/utils')
 -----------------------------------
-
 xi = xi or {}
 xi.crafting = {}
------------------------------------
--- IDs for signupGuild bitmask
------------------------------------
 
 xi.crafting.guild =
 {
-    ["alchemy"]      = 2,
-    ["bonecraft"]    = 4,
-    ["clothcraft"]   = 8,
-    ["cooking"]      = 16,
-    ["fishing"]      = 32,
-    ["goldsmithing"] = 64,
-    ["leathercraft"] = 128,
-    ["smithing"]     = 256,
-    ["woodworking"]  = 512
-    -- Synergy not implemented yet
+    ALCHEMY      = 1,
+    BONECRAFT    = 2,
+    CLOTHCRAFT   = 3,
+    COOKING      = 4,
+    FISHING      = 5,
+    GOLDSMITHING = 6,
+    LEATHERCRAFT = 7,
+    SMITHING     = 8,
+    WOODWORKING  = 9,
 }
 
------------------------------------
+xi.crafting.rank =
+{
+    AMATEUR    = 0,
+    RECRUIT    = 1,
+    INITIATE   = 2,
+    NOVICE     = 3,
+    APPRENTICE = 4,
+    JOURNEYMAN = 5,
+    CRAFTSMAN  = 6,
+    ARTISAN    = 7,
+    ADEPT      = 8,
+    VETERAN    = 9,
+    EXPERT     = 10,
+}
+
+-- Keys are based on the player's current rank in the guild in order to be eligible
+-- for the next rank-up test.  Example: At Amateur, a value of 256 is required to
+-- be eligible for the test to move to Recruit
+local requiredSkillForRank =
+{
+    [xi.crafting.rank.AMATEUR]    = 256,
+    [xi.crafting.rank.RECRUIT]    = 577,
+    [xi.crafting.rank.INITIATE]   = 898,
+    [xi.crafting.rank.NOVICE]     = 1219,
+    [xi.crafting.rank.APPRENTICE] = 1540,
+    [xi.crafting.rank.JOURNEYMAN] = 1861,
+    [xi.crafting.rank.CRAFTSMAN]  = 2182,
+    [xi.crafting.rank.ARTISAN]    = 2503,
+    [xi.crafting.rank.ADEPT]      = 2824,
+    [xi.crafting.rank.VETERAN]    = 3145,
+}
+
 -- Table for Test Items
------------------------------------
 local testItemsByNPC =
 {
     ["Abd-al-Raziq"]   = {   937,  4157,  4163,   947, 16543,  4116, 16479,  4120, 16609, 10792 },
@@ -45,76 +73,24 @@ local testItemsByNPC =
 
 local hqCrystals =
 {
-    [1] =
-    {
-        id = 4238,
-        cost = 200
-    },
-    [2] =
-    {
-        id = 4239,
-        cost = 200
-    },
-    [3] =
-    {
-        id = 4240,
-        cost = 200
-    },
-    [4] =
-    {
-        id = 4241,
-        cost = 200
-    },
-    [5] =
-    {
-        id = 4242,
-        cost = 200
-    },
-    [6] =
-    {
-        id = 4243,
-        cost = 200
-    },
-    [7] =
-    {
-        id = 4244,
-        cost = 500
-    },
-    [8] =
-    {
-        id = 4245,
-        cost = 500
-    },
+    [1] = { id = xi.items.INFERNO_CRYSTAL,  cost = 200 },
+    [2] = { id = xi.items.GLACIER_CRYSTAL,  cost = 200 },
+    [3] = { id = xi.items.CYCLONE_CRYSTAL,  cost = 200 },
+    [4] = { id = xi.items.TERRA_CRYSTAL,    cost = 200 },
+    [5] = { id = xi.items.PLASMA_CRYSTAL,   cost = 200 },
+    [6] = { id = xi.items.TORRENT_CRYSTAL,  cost = 200 },
+    [7] = { id = xi.items.AURORA_CRYSTAL,   cost = 500 },
+    [8] = { id = xi.items.TWILIGHT_CRYSTAL, cost = 500 },
 }
 
------------------------------------
--- isGuildMember Action
------------------------------------
+xi.crafting.hasJoinedGuild = function(player, guildId)
+    local joinedGuildMask = player:getCharVar("Guild_Member")
 
-xi.crafting.isGuildMember = function(player, guild)
-    local guildOK = player:getCharVar("Guild_Member")
-    local bit = {}
-
-    for i = 12, 1, -1 do
-        local twop = 2^i
-
-        if guildOK >= twop then
-            bit[i]  = 1
-            guildOK = guildOK - twop
-        else
-            bit[i] = 0
-        end
-    end
-
-    return bit[guild]
+    return utils.mask.getBit(joinedGuildMask, guildId)
 end
 
------------------------------------
--- signupGuild Action
------------------------------------
-
-xi.crafting.signupGuild = function(player, nbr)
-    player:incrementCharVar("Guild_Member", nbr)
+xi.crafting.signupGuild = function(player, guildId)
+    player:incrementCharVar("Guild_Member", bit.lshift(1, guildId))
 end
 
 -----------------------------------
@@ -127,30 +103,18 @@ xi.crafting.getTestItem = function(player, npc, craftID)
     return testItemsByNPC[npc:getName()][nextRank]
 end
 
------------------------------------
 -- canGetNewRank Action
------------------------------------
-
-local function canGetNewRank(player, skillLvL, craftID)
-    local rank = player:getSkillRank(craftID) + 1
-    local canGet = 0
+local function canGetNewRank(player, skillLvl, craftId)
+    local requiredSkill = requiredSkillForRank[player:getSkillRank(craftId)]
 
     if
-        (rank == 1 and skillLvL >= 256) or
-        (rank == 2 and skillLvL >= 577) or
-        (rank == 3 and skillLvL >= 898) or
-        (rank == 4 and skillLvL >= 1219) or
-        (rank == 5 and skillLvL >= 1540) or
-        (rank == 6 and skillLvL >= 1861) or
-        (rank == 7 and skillLvL >= 2182) or
-        (rank == 8 and skillLvL >= 2503) or
-        (rank == 9 and skillLvL >= 2824) or
-        (rank == 10 and skillLvL >= 3145)
+        requiredSkill and
+        skillLvl >= requiredSkill
     then
-        canGet = 1
+        return true
     end
 
-    return canGet
+    return false
 end
 
 -----------------------------------
@@ -158,18 +122,17 @@ end
 -----------------------------------
 
 xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
-    local guildID  = craftID - 48
-    local skillLvL = player:getSkillLevel(craftID)
-    local myTI     = xi.crafting.getTestItem(player, npc, craftID)
-    local newRank  = 0
-    -- local signed = trade:getItem():getSignature() == player:getName() and 1 or 0
+    local guildID    = craftID - 48
+    local skillLvL   = player:getSkillLevel(craftID)
+    local testItemId = xi.crafting.getTestItem(player, npc, craftID)
+    local newRank    = 0
 
     if
-        canGetNewRank(player, skillLvL, craftID) == 1 and
-        trade:hasItemQty(myTI, 1) and
-        trade:getItemCount() == 1
+        canGetNewRank(player, skillLvL, craftID) and
+        npcUtil.tradeHasExactly(trade, testItemId)
     then
         newRank = player:getSkillRank(craftID) + 1
+
         if player:getCharVar('[GUILD]currentGuild') == guildID + 1 then
             player:setCharVar('[GUILD]daily_points', 1)
         end
@@ -225,7 +188,7 @@ xi.crafting.unionRepresentativeTrigger = function(player, guildID, csid, currenc
 end
 
 xi.crafting.unionRepresentativeEventUpdateRenounce = function(player, craftID)
-    local ID   = zones[player:getZoneID()]
+    local ID = zones[player:getZoneID()]
 
     player:setSkillRank(craftID, 6)
     player:setSkillLevel(craftID, 700)
@@ -277,8 +240,7 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
         if ki and rank >= ki.rank then
             if player:getCurrency(currency) >= ki.cost then
                 player:delCurrency(currency, ki.cost)
-                player:addKeyItem(ki.id)
-                player:messageSpecial(text.KEYITEM_OBTAINED, ki.id)
+                npcUtil.giveKeyItem(player, ki.id)
             else
                 player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
@@ -311,14 +273,13 @@ xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, 
         local i = hqCrystals[bit.band(bit.rshift(option, 5), 15)]
         local quantity = bit.rshift(option, 9)
         local cost = quantity * i.cost
+
         if i and rank >= 3 then
-            if player:getCurrency(currency) >= cost then
-                if player:addItem(i.id, quantity) then
-                    player:delCurrency(currency, cost)
-                    player:messageSpecial(text.ITEM_OBTAINED, i.id)
-                else
-                    player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id)
-                end
+            if
+                player:getCurrency(currency) >= cost and
+                npcUtil.giveItem(player, { { i.id, quantity } })
+            then
+                player:delCurrency(currency, cost)
             else
                 player:messageText(target, text.NOT_HAVE_ENOUGH_GP, false, 6)
             end
@@ -337,6 +298,7 @@ xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildI
             local totalPoints = 0
             for i = 0, 8 do
                 local items, points = player:addGuildPoints(guildID, i)
+
                 if items ~= 0 and points ~= 0 then
                     totalPoints = totalPoints + points
                     trade:confirmSlot(i, items)

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hadayah.lua
@@ -14,10 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
     local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(638, 4, skillLevel, 1, 511, 187, 0, 7, 2184)
         else

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Kemha_Flasehp.lua
@@ -12,9 +12,7 @@ local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if npcUtil.tradeHas(trade, 2184) then
             if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
                 player:confirmTrade()
@@ -27,17 +25,14 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
-    -- local skillLevel = player:getSkillLevel(xi.skill.FISHING)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(642, 8, 0, 0, 511, 1, 0, 0, 2184)
         else
             player:startEvent(642, 8, 0, 0, 511, 1, 19267, 0, 2184)
         end
     else
-        player:startEvent(642, 0, 0, 0, 0, 0, 0, 0, 0) -- Standard Dialogue
+        player:startEvent(642) -- Standard Dialogue
     end
 end
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Shahau.lua
@@ -14,10 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
     local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(638, 4, skillLevel, 2, 511, 0, 0, 7, 2184)
         else

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sulbahn.lua
@@ -12,9 +12,7 @@ local ID = require("scripts/zones/Aht_Urhgan_Whitegate/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if npcUtil.tradeHas(trade, 2184) then
             if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
                 player:confirmTrade()
@@ -27,10 +25,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
     local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         player:startEvent(636, 2, skillLevel, 0, 511, 0, 0, 7, 2184)
     else
         player:startEvent(636, 0, 0, 0, 0, 0, 0, 7, 0) -- Standard Dialogue

--- a/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Gidappa.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
     local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
             player:startEvent(228, 8, skillLevel, 0, 511, 188, 0, 4, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Macici.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Macici.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(232, 8, skillLevel, 0, 511, 188, 0, 2, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Nudahaal.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
     local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
             player:startEvent(224, 8, skillLevel, 0, 511, 188, 0, 6, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Numaaf.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(222, 8, skillLevel, 0, 511, 188, 0, 8, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Rajaaha.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(230, 8, skillLevel, 0, 511, 188, 0, 3, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Yudi_Yolhbi.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(234, 8, skillLevel, 0, 511, 188, 0, 1, 2184)
         else

--- a/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Zwaluh.lua
@@ -11,9 +11,7 @@ local ID = require("scripts/zones/Al_Zahbi/IDs")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    local guildMember = xi.crafting.isGuildMember(player, 7)
-
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if trade:hasItemQty(2184, 1) and trade:getItemCount() == 1 then
             if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
                 player:tradeComplete()
@@ -26,10 +24,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 7)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(226, 8, skillLevel, 0, 511, 188, 0, 5, 2184)
         else

--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.GOLDSMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(302, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Reinberta.lua
@@ -38,15 +38,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill  = player:getSkillLevel(xi.skill.GOLDSMITHING)
     local testItem    = xi.crafting.getTestItem(player, npc, xi.skill.GOLDSMITHING)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
+    local guildMember = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) and 150995375 or 0
     local rankCap     = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local rank        = player:getSkillRank(xi.skill.GOLDSMITHING)
     local realSkill   = (craftSkill - rank) / 32
     local expertQuestStatus = 0
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 300, realSkill, rankCap, 184549887) then
         return
@@ -74,10 +70,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
-
     if csid == 300 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
             player:setCharVar("GoldsmithingExpertQuest", 1)
         end
     elseif csid == 300 and option == 1 then
@@ -87,7 +81,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.goldsmithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.GOLDSMITHING)
         end
     else
         if player:getLocalVar("GoldsmithingTraded") == 1 then

--- a/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(304, skillCap, skillLevel, 2, 201, player:getGil(), 0, 9, 0)
         else

--- a/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 6)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.GOLDSMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.GOLDSMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.GOLDSMITHING) then
         if not player:hasStatusEffect(xi.effect.GOLDSMITHING_IMAGERY) then
             player:startEvent(303, skillCap, skillLevel, 1, 201, player:getGil(), 0, 3, 0)
         else

--- a/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Abd-al-Raziq.lua
@@ -40,16 +40,12 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.ALCHEMY)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.ALCHEMY)
-    local guildMember       = xi.crafting.isGuildMember(player, 1)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.ALCHEMY)
     local realSkill         = (craftSkill - rank) / 32
     local canRankUp         = rankCap - realSkill -- used to make sure rank up isn't overridden by ASA mission
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 120, realSkill, rankCap, 184549887) then
         return
@@ -97,10 +93,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
-
     if csid == 120 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
             player:setCharVar("AlchemyExpertQuest", 1)
         end
     elseif csid == 120 and option == 1 then
@@ -111,7 +105,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.alchemy)
+            xi.crafting.signupGuild(player, xi.crafting.guild.ALCHEMY)
         end
     else
         if player:getLocalVar("AlchemyTraded") == 1 then

--- a/scripts/zones/Bastok_Mines/npcs/Azima.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Azima.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
     local skillLevel  = player:getSkillLevel(xi.skill.ALCHEMY)
     local cost        = xi.crafting.getAdvImageSupportCost(player, xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(122, cost, skillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0) -- Event doesn't work
         else

--- a/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Sieglinde.lua
@@ -13,11 +13,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
-    local skillCap    = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
-    local skillLevel  = player:getSkillLevel(xi.skill.SMITHING)
+    local skillCap   = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
+    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(124, skillCap, skillLevel, 2, 201, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Bastok_Mines/npcs/Titus.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Titus.lua
@@ -13,11 +13,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 1)
-    local skillCap    = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
-    local skillLevel  = player:getSkillLevel(xi.skill.ALCHEMY)
+    local skillCap   = xi.crafting.getCraftSkillCap(player, xi.skill.ALCHEMY)
+    local skillLevel = player:getSkillLevel(xi.skill.ALCHEMY)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.ALCHEMY) then
         if not player:hasStatusEffect(xi.effect.ALCHEMY_IMAGERY) then
             player:startEvent(123, skillCap, skillLevel, 1, 137, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Metalworks/npcs/Ghemp.lua
+++ b/scripts/zones/Metalworks/npcs/Ghemp.lua
@@ -38,15 +38,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.SMITHING)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember       = xi.crafting.isGuildMember(player, 8)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.SMITHING)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 101, realSkill, rankCap, 184549887) then
         return
@@ -75,10 +71,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
-
     if csid == 101 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
             player:setCharVar("SmithingExpertQuest", 1)
         end
     elseif csid == 101 and option == 1 then
@@ -87,7 +81,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4096)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4096) -- Fire Crystal
-            xi.crafting.signupGuild(player, xi.crafting.guild.smithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.SMITHING)
         end
     else
         if player:getLocalVar("SmithingTraded") == 1 then

--- a/scripts/zones/Metalworks/npcs/Hugues.lua
+++ b/scripts/zones/Metalworks/npcs/Hugues.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(104, skillCap, skillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Metalworks/npcs/Romero.lua
+++ b/scripts/zones/Metalworks/npcs/Romero.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(105, skillCap, skillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Metalworks/npcs/Wise_Owl.lua
+++ b/scripts/zones/Metalworks/npcs/Wise_Owl.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(103, cost, skillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Amarefice.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(624, skillCap, skillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beadurinc.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(630, skillCap, skillLevel, 2, 205, player:getGil(), 0, 90, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Cheupirudaux.lua
@@ -39,15 +39,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.WOODWORKING)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.WOODWORKING)
-    local guildMember       = xi.crafting.isGuildMember(player, 9)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.WOODWORKING)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 621, realSkill, rankCap, 184549887) then
         return
@@ -76,10 +72,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
-
     if csid == 621 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
             player:setCharVar("WoodworkingExpertQuest", 1)
         end
     elseif csid == 621 and option == 1 then
@@ -88,7 +82,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4098)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4098) -- Wind Crystal
-            xi.crafting.signupGuild(player, xi.crafting.guild.woodworking)
+            xi.crafting.signupGuild(player, xi.crafting.guild.WOODWORKING)
         end
     else
         if player:getLocalVar("WoodworkingTraded") == 1 then

--- a/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Greubaque.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(628, cost, skillLevel, 0, 205, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mevreauche.lua
@@ -38,15 +38,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.SMITHING)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.SMITHING)
-    local guildMember       = xi.crafting.isGuildMember(player, 8)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.SMITHING)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 626, realSkill, rankCap, 184549887) then
         return
@@ -75,10 +71,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
-
     if csid == 626 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
             player:setCharVar("SmithingExpertQuest", 1)
         end
     elseif csid == 626 and option == 1 then
@@ -87,7 +81,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4096)
             player:messageSpecial(ID.text.ITEM_OBTAINED, 4096) -- Fire Crystal
-            xi.crafting.signupGuild(player, xi.crafting.guild.smithing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.SMITHING)
         end
     else
         if player:getLocalVar("SmithingTraded") == 1 then

--- a/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pinok-Morok.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.SMITHING)
     local skillLevel = player:getSkillLevel(xi.skill.SMITHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.SMITHING) then
         if not player:hasStatusEffect(xi.effect.SMITHING_IMAGERY) then
             player:startEvent(629, skillCap, skillLevel, 1, 205, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ramua.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.WOODWORKING)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(625, skillCap, skillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ulycille.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 9)
     local skillLevel = player:getSkillLevel(xi.skill.WOODWORKING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.WOODWORKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.WOODWORKING) then
         if not player:hasStatusEffect(xi.effect.WOODWORKING_IMAGERY) then
             player:startEvent(623, cost, skillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else

--- a/scripts/zones/Port_Windurst/npcs/Degong.lua
+++ b/scripts/zones/Port_Windurst/npcs/Degong.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local skillLevel = player:getSkillLevel(xi.skill.FISHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10013, skillCap, skillLevel, 2, 239, player:getGil(), 0, 30, 0) -- p1 = skill level
         else

--- a/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
+++ b/scripts/zones/Port_Windurst/npcs/Erabu-Fumulubu.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local skillLevel = player:getSkillLevel(xi.skill.FISHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10012, skillCap, skillLevel, 1, 239, player:getGil(), 0, 0, 0) -- p1 = skill level
         else

--- a/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
+++ b/scripts/zones/Port_Windurst/npcs/Panja-Nanja.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 8)
     local skillLevel = player:getSkillLevel(xi.skill.FISHING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.FISHING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
         if not player:hasStatusEffect(xi.effect.FISHING_IMAGERY) then
             player:startEvent(10011, cost, skillLevel, 0, 239, player:getGil(), 0, 0, 0) -- p1 = skill level
         else

--- a/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
+++ b/scripts/zones/Port_Windurst/npcs/Thubu_Parohren.lua
@@ -32,15 +32,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill = player:getSkillLevel(xi.skill.FISHING)
     local testItem = xi.crafting.getTestItem(player, npc, xi.skill.FISHING)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
+    local guildMember = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) and 150995375 or 0
     local rankCap = xi.crafting.getCraftSkillCap(player, xi.skill.FISHING)
     local expertQuestStatus = 0
     local rank = player:getSkillRank(xi.skill.FISHING)
     local realSkill = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if player:getCharVar("FishingExpertQuest") == 1 then
         if player:hasKeyItem(xi.keyItem.ANGLERS_ALMANAC) then
@@ -51,7 +47,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if expertQuestStatus == 550 then
-        --[[
+        --[[ TODO: This is resolved.  Replace with actual logic.
         Feeding the proper parameter currently hangs the client in cutscene. This may
         possibly be due to an unimplemented packet or function (display recipe?) Work
         around to present dialog to player to let them know the trade is ready to be
@@ -70,10 +66,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 5)
-
     if csid == 10009 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.FISHING) then
             player:setCharVar("FishingExpertQuest", 1)
         end
     elseif csid == 10009 and option == 1 then
@@ -84,7 +78,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.fishing)
+            xi.crafting.signupGuild(player, xi.crafting.guild.FISHING)
         end
     else
         if player:getLocalVar("FishingTraded") == 1 then

--- a/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Faulpie.lua
@@ -39,16 +39,12 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.LEATHERCRAFT)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.LEATHERCRAFT)
-    local guildMember       = xi.crafting.isGuildMember(player, 7)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.LEATHERCRAFT)
     local realSkill         = (craftSkill - rank) / 32
     local canRankUp         = rankCap - realSkill -- used to make sure rank up isn't overridden by ASA mission
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 648, realSkill, rankCap, 184549887) then
         return
@@ -96,10 +92,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 7)
-
     if csid == 648 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
             player:setCharVar("LeathercraftExpertQuest", 1)
         end
     elseif csid == 648 and option == 1 then
@@ -109,7 +103,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.leathercraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.LEATHERCRAFT)
         end
     else
         if player:getLocalVar("LeathercraftTraded") == 1 then

--- a/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Kipopo.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
         sayItWithAHandbagCS == 1
     then
         player:startEvent(908)
-    elseif xi.crafting.isGuildMember(player, 7) == 1 then
+    elseif xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(651, skillCap, skillLevel, 1, 239, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Orechiniel.lua
@@ -13,11 +13,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 7)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.LEATHERCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(650, cost, skillLevel, 0, 239, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Tek_Lengyon.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 7)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.LEATHERCRAFT)
     local skillLevel = player:getSkillLevel(xi.skill.LEATHERCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.LEATHERCRAFT) then
         if not player:hasStatusEffect(xi.effect.LEATHERCRAFT_IMAGERY) then
             player:startEvent(652, skillCap, skillLevel, 2, 239, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hakeem.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10017, skillCap, skillLevel, 2, 495, player:getGil(), 0, 4095, 0) -- p1 = skill level
         else

--- a/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jacodaut.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10016, skillCap, skillLevel, 1, 495, player:getGil(), 0, 4095, 0) -- p1 = skill level
         else

--- a/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kipo-Opo.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
     local skillLevel = player:getSkillLevel(xi.skill.COOKING)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.COOKING)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
         if not player:hasStatusEffect(xi.effect.COOKING_IMAGERY) then
             player:startEvent(10015, cost, skillLevel, 0, 495, player:getGil(), 0, 0, 0) -- p1 = skill level
         else

--- a/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Piketo-Puketo.lua
@@ -38,15 +38,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.COOKING)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.COOKING)
-    local guildMember       = xi.crafting.isGuildMember(player, 4)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) and 150995375 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.COOKING)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.COOKING)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 150995375
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10013, realSkill, rankCap, 184549887) then
         return
@@ -75,10 +71,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 4)
-
     if csid == 10013 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.COOKING) then
             player:setCharVar("CookingExpertQuest", 1)
         end
     elseif csid == 10013 and option == 1 then
@@ -88,7 +82,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.cooking)
+            xi.crafting.signupGuild(player, xi.crafting.guild.COOKING)
         end
     else
         if player:getLocalVar("CookingTraded") == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Anillah.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Anillah.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
     local skillCap    = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local skillLevel  = xi.crafting.getRealSkill(player, xi.skill.CLOTHCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
             player:startEvent(10015, skillCap, skillLevel, 2, 511, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kyaa_Taali.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
             player:startEvent(10020, skillCap, skillLevel, 2, 509, player:getGil(), 0, 0, 0)
         else

--- a/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Lih_Pituu.lua
@@ -28,11 +28,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
     local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.BONECRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
             player:startEvent(10018, cost, skillLevel, 0, 511, player:getGil(), 0, 7028, 0)
         else

--- a/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nikkoko.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
             player:startEvent(10014, skillCap, skillLevel, 1, 511, player:getGil(), 0, 4095, 0) -- p1 = skill level
         else

--- a/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Peshi_Yohnts.lua
@@ -38,15 +38,11 @@ end
 entity.onTrigger = function(player, npc)
     local craftSkill        = player:getSkillLevel(xi.skill.BONECRAFT)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.BONECRAFT)
-    local guildMember       = xi.crafting.isGuildMember(player, 2)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) and 64 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.BONECRAFT)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 64
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10016, realSkill, rankCap, 184549887) then
         return
@@ -75,10 +71,8 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
-
     if csid == 10016 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
             player:setCharVar("BonecraftExpertQuest", 1)
         end
     elseif csid == 10016 and option == 1 then
@@ -88,7 +82,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(crystal)
             player:messageSpecial(ID.text.ITEM_OBTAINED, crystal)
-            xi.crafting.signupGuild(player, xi.crafting.guild.bonecraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.BONECRAFT)
         end
     else
         if player:getLocalVar("BonecraftTraded") == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Ponono.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ponono.lua
@@ -52,15 +52,11 @@ entity.onTrigger = function(player, npc)
 
     local craftSkill        = player:getSkillLevel(xi.skill.CLOTHCRAFT)
     local testItem          = xi.crafting.getTestItem(player, npc, xi.skill.CLOTHCRAFT)
-    local guildMember       = xi.crafting.isGuildMember(player, 3)
+    local guildMember       = xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) and 10000 or 0
     local rankCap           = xi.crafting.getCraftSkillCap(player, xi.skill.CLOTHCRAFT)
     local expertQuestStatus = 0
     local rank              = player:getSkillRank(xi.skill.CLOTHCRAFT)
     local realSkill         = (craftSkill - rank) / 32
-
-    if guildMember == 1 then
-        guildMember = 10000
-    end
 
     if xi.crafting.unionRepresentativeTriggerRenounceCheck(player, 10011, realSkill, rankCap, 184549887) then
         return
@@ -105,8 +101,6 @@ entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
-
     if csid == 700 then
         player:setCharVar("moral", 2)
     elseif csid == 705 then
@@ -114,7 +108,7 @@ entity.onEventFinish = function(player, csid, option)
             player:setCharVar("moral", 4)
         end
     elseif csid == 10011 and option == 2 then
-        if guildMember == 1 then
+        if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
             player:setCharVar("ClothcraftExpertQuest", 1)
         end
     elseif csid == 10011 and option == 1 then
@@ -123,7 +117,7 @@ entity.onEventFinish = function(player, csid, option)
         else
             player:addItem(4099) -- earth crystal
             player:messageSpecial(ID.text.ITEM_OBTAINED, xi.items.EARTH_CRYSTAL)
-            xi.crafting.signupGuild(player, xi.crafting.guild.clothcraft)
+            xi.crafting.signupGuild(player, xi.crafting.guild.CLOTHCRAFT)
         end
     else
         if player:getLocalVar("ClothcraftTraded") == 1 then

--- a/scripts/zones/Windurst_Woods/npcs/Ronana.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ronana.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 2)
     local skillCap = xi.crafting.getCraftSkillCap(player, xi.skill.BONECRAFT)
     local skillLevel = player:getSkillLevel(xi.skill.BONECRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.BONECRAFT) then
         if not player:hasStatusEffect(xi.effect.BONECRAFT_IMAGERY) then
             player:startEvent(10019, skillCap, skillLevel, 1, 511, player:getGil(), 0, 36408, 0)
         else

--- a/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Terude-Harude.lua
@@ -14,11 +14,10 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local guildMember = xi.crafting.isGuildMember(player, 3)
     local skillLevel = player:getSkillLevel(xi.skill.CLOTHCRAFT)
     local cost = xi.crafting.getAdvImageSupportCost(player, xi.skill.CLOTHCRAFT)
 
-    if guildMember == 1 then
+    if xi.crafting.hasJoinedGuild(player, xi.crafting.guild.CLOTHCRAFT) then
         if not player:hasStatusEffect(xi.effect.CLOTHCRAFT_IMAGERY) then
             player:startEvent(10013, cost, skillLevel, 0, 511, player:getGil(), 0, 4095, 0)
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Simplifies crafting guild joining logic and adds enum for crafting ranks in order to support future changes
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed
<!-- Clear and detailed steps to test your changes here -->
