### PR TITLE
[core] Replace DYNAMIC_LOOKUP with GetFirstID

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -449,7 +449,7 @@
         "ForceCrash",
         "BuildString",
         "SendLuaFuncStringToZone",
-        "DYNAMIC_LOOKUP",
+        "GetFirstID",
     ],
     "Lua.diagnostics.disable": [
         "lowercase-global"

--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -7,8 +7,6 @@
 
 xi = xi or {}
 
-DYNAMIC_LOOKUP = -1
-
 xi.zoneType =
 {
     NONE           = 0,

--- a/scripts/zones/Arrapago_Reef/IDs.lua
+++ b/scripts/zones/Arrapago_Reef/IDs.lua
@@ -56,11 +56,11 @@ zones[xi.zone.ARRAPAGO_REEF] =
         {
             [16998653] = 16998655, -- 136.234 -6.831 468.779
         },
-        MEDUSA                = DYNAMIC_LOOKUP,
-        LIL_APKALLU           = DYNAMIC_LOOKUP,
-        VELIONIS              = DYNAMIC_LOOKUP,
-        ZAREEHKL_THE_JUBILANT = DYNAMIC_LOOKUP,
-        NUHN                  = DYNAMIC_LOOKUP,
+        MEDUSA                = GetFirstID("Medusa"),
+        LIL_APKALLU           = GetFirstID("Lil_Apkallu"),
+        VELIONIS              = GetFirstID("Velionis"),
+        ZAREEHKL_THE_JUBILANT = GetFirstID("Zareehkl_the_Jubilant"),
+        NUHN                  = GetFirstID("Nuhn"),
     },
     npc =
     {

--- a/scripts/zones/Bastok_Markets/IDs.lua
+++ b/scripts/zones/Bastok_Markets/IDs.lua
@@ -83,7 +83,7 @@ zones[xi.zone.BASTOK_MARKETS] =
     },
     npc =
     {
-        AQUILLINA = DYNAMIC_LOOKUP,
+        AQUILLINA = GetFirstID("Aquillina"),
 
         HALLOWEEN_SKINS =
         {

--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -109,7 +109,7 @@ zones[xi.zone.BATALLIA_DOWNS] =
 
     npc =
     {
-        SYRILLIA = DYNAMIC_LOOKUP
+        SYRILLIA = GetFirstID("Syrillia"),
     },
 }
 

--- a/scripts/zones/Batallia_Downs_[S]/IDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/IDs.lua
@@ -54,7 +54,7 @@ zones[xi.zone.BATALLIA_DOWNS_S] =
             [17121602] = 17121603,
         },
 
-        MENECHME = DYNAMIC_LOOKUP,
+        MENECHME = GetFirstID("Menechme"),
 
         VOIDWALKER =
         {

--- a/scripts/zones/Beaucedine_Glacier_[S]/IDs.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/IDs.lua
@@ -42,7 +42,7 @@ zones[xi.zone.BEAUCEDINE_GLACIER_S] =
 
     mob =
     {
-        ORCISH_BLOODLETTER = DYNAMIC_LOOKUP,
+        ORCISH_BLOODLETTER = GetFirstID("Orcish_Bloodletter"),
 
         GRANDGOULE_PH =
         {

--- a/scripts/zones/Halvung/IDs.lua
+++ b/scripts/zones/Halvung/IDs.lua
@@ -35,7 +35,7 @@ zones[xi.zone.HALVUNG] =
     },
     mob =
     {
-        BIG_BOMB               = 17031401,
+        BIG_BOMB               = GetFirstID("Big_Bomb"),
         GURFURLUR_THE_MENACING = 17031592,
         DEXTROSE               = 17031598,
         REACTON                = 17031599,

--- a/scripts/zones/The_Eldieme_Necropolis/IDs.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/IDs.lua
@@ -84,7 +84,7 @@ zones[xi.zone.THE_ELDIEME_NECROPOLIS] =
     npc =
     {
         GATE_OFFSET        = 17576306,
-        BRAZIER            = DYNAMIC_LOOKUP,
+        BRAZIER            = GetFirstID("Brazier"),
         TREASURE_CHEST     = 17576356,
         TREASURE_COFFER    = 17576357,
         SARCOPHAGUS_OFFSET = 17576394,

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -872,6 +872,11 @@ bool matches(std::string const& target, std::string const& pattern, std::string 
     return matchesRecur(target.c_str(), pattern.c_str(), wildcard.c_str(), matchesRecur);
 }
 
+bool starts_with(std::string const& target, std::string const& pattern)
+{
+    return target.rfind(pattern, 0) != std::string::npos;
+}
+
 look_t stringToLook(std::string str)
 {
     look_t out{};

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -92,6 +92,7 @@ auto to_lower(std::string const& s) -> std::string;
 auto to_upper(std::string const& s) -> std::string;
 auto trim(const std::string& str, const std::string& whitespace = " \t") -> std::string;
 bool matches(std::string const& target, std::string const& pattern, std::string const& wildcard = "%");
+bool starts_with(std::string const& target, std::string const& pattern);
 
 look_t stringToLook(std::string str);
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -200,6 +200,11 @@ namespace luautils
                 version::GetGitCommitSubject(),
                 version::GetGitDate());
         });
+
+        lua.set_function("GetFirstID", [](std::string const& name)
+        {
+            return "LOOKUP_" + name;
+        });
         // clang-format on
 
         // Register Sol Bindings
@@ -768,8 +773,14 @@ namespace luautils
 
         // Make sure this has been run at least once!
         auto result = lua.safe_script_file("scripts/globals/zone.lua");
+        if (!result.valid())
+        {
+            sol::error err = result;
+            ShowError(fmt::format("Failed to load globals/zone.lua: {}", err.what()));
+        }
 
         // clang-format off
+        std::string lookupPrefix = "LOOKUP_";
         auto handleZone = [&](CZone* PZone)
         {
             auto zoneName = PZone->GetName();
@@ -784,54 +795,58 @@ namespace luautils
                     {
                         for (auto [innerKey, innerValue] : outerValue.as<sol::table>())
                         {
-                            if (innerKey.get_type() == sol::type::string && innerValue.get_type() == sol::type::number)
+                            if (innerKey.get_type() == sol::type::string && innerValue.get_type() == sol::type::string)
                             {
-                                auto name = to_upper(innerKey.as<std::string>());
-                                auto num  = innerValue.as<int32>();
+                                auto innerName  = to_upper(innerKey.as<std::string>());
+                                auto lookupName = innerValue.as<std::string>();
 
-                                // -1 == DYNAMIC_LOOKUP
-                                if (num == -1)
+                                if (!starts_with(lookupName, lookupPrefix))
                                 {
-                                    bool found = false;
-                                    if (outerName == "mob")
-                                    {
-                                        // TODO: Execute this as a single query per-zone and pull out the desired results.
-                                        auto query = fmt::sprintf("SELECT mobid FROM mob_spawn_points "
-                                                            "WHERE ((mobid >> 12) & 0xFFF) = %i AND "
-                                                            "UPPER(REPLACE(mobname, '-', '_')) = '%s' "
-                                                            "LIMIT 1;", PZone->GetID(), name.c_str());
-                                        DebugIDLookup(query.c_str());
-                                        auto ret = sql->Query(query.c_str());
-                                        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
-                                        {
-                                            lua["zones"][PZone->GetID()][outerName][name] = sql->GetUIntData(0);
-                                            found = true;
-                                            DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
-                                                zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][name].get<uint32>()));
-                                        }
-                                    }
-                                    else if (outerName == "npc")
-                                    {
-                                        // TODO: Execute this as a single query per-zone and pull out the desired results.
-                                        auto query = fmt::sprintf("SELECT npcid FROM npc_list "
-                                                            "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
-                                                            "UPPER(REPLACE(CAST(`name` as CHAR(64)), '-', '_')) = '%s' "
-                                                            "LIMIT 1;", PZone->GetID(), name.c_str());
-                                        DebugIDLookup(query.c_str());
-                                        auto ret = sql->Query(query.c_str());
-                                        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
-                                        {
-                                            lua["zones"][PZone->GetID()][outerName][name] = sql->GetUIntData(0);
-                                            found = true;
-                                            DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
-                                                zoneName, outerName, name, lua["zones"][PZone->GetID()][outerName][name].get<uint32>()));
-                                        }
-                                    }
+                                    continue;
+                                }
 
-                                    if (!found)
+                                // We have a lookup string, remove the prefix
+                                lookupName = lookupName.substr(lookupPrefix.length());
+
+                                bool found = false;
+                                if (outerName == "mob")
+                                {
+                                    // TODO: Execute this as a single query per-zone and pull out the desired results.
+                                    auto query = fmt::sprintf("SELECT mobid FROM mob_spawn_points "
+                                                        "WHERE ((mobid >> 12) & 0xFFF) = %i AND "
+                                                        "UPPER(REPLACE(mobname, '-', '_')) = '%s' "
+                                                        "LIMIT 1;", PZone->GetID(), lookupName.c_str());
+                                    DebugIDLookup(query.c_str());
+                                    auto ret = sql->Query(query.c_str());
+                                    if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
                                     {
-                                        ShowError(fmt::format("Could not complete id lookup for {}.ID.{}.{}", zoneName, outerName, name))
+                                        lua["zones"][PZone->GetID()][outerName][innerName] = sql->GetUIntData(0);
+                                        found = true;
+                                        DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
+                                            zoneName, outerName, innerName, lua["zones"][PZone->GetID()][outerName][innerName].get<uint32>()));
                                     }
+                                }
+                                else if (outerName == "npc")
+                                {
+                                    // TODO: Execute this as a single query per-zone and pull out the desired results.
+                                    auto query = fmt::sprintf("SELECT npcid FROM npc_list "
+                                                        "WHERE ((npcid >> 12) & 0xFFF) = %i AND "
+                                                        "UPPER(REPLACE(CAST(`name` as CHAR(64)), '-', '_')) = '%s' "
+                                                        "LIMIT 1;", PZone->GetID(), lookupName.c_str());
+                                    DebugIDLookup(query.c_str());
+                                    auto ret = sql->Query(query.c_str());
+                                    if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+                                    {
+                                        lua["zones"][PZone->GetID()][outerName][innerName] = sql->GetUIntData(0);
+                                        found = true;
+                                        DebugIDLookup(fmt::format("New value for {}.ID.{}.{} = {}",
+                                            zoneName, outerName, innerName, lua["zones"][PZone->GetID()][outerName][innerName].get<uint32>()));
+                                    }
+                                }
+
+                                if (!found)
+                                {
+                                    ShowError(fmt::format("Could not complete id lookup for {}.ID.{}.{}", zoneName, outerName, innerName))
                                 }
                             }
                         }

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -191,7 +191,7 @@ global_objects=(
     ForceCrash
     BuildString
 
-    DYNAMIC_LOOKUP
+    GetFirstID
 )
 
 ignores=(


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`DYNAMIC_LOOKUP` had very limited use, and wasn't super clear about how it worked under the hood. I've replaced with with `GetFirstID`, which uses the same logic, in the same order, but allows you to look up anything regardless of the key you're applying it to. 

Will be good for building offsets, etc.

## Steps to test these changes

Server starts up fine, without any errors, zone into `Arrapago_Reef`, still no errors
