### PR TITLE
[modules] Make ah_announcement.cpp more stable

### DIFF
--- a/modules/custom/cpp/ah_announcement.cpp
+++ b/modules/custom/cpp/ah_announcement.cpp
@@ -1,9 +1,9 @@
 ﻿/************************************************************************
-* Auction House Announcements
-*
-* This will send a message to the seller of an item when it is bought,
-* informing them that their item sold, to who, and for how much.
-* It will only send this message if the seller is online.
+ * Auction House Announcements
+ *
+ * This will send a message to the seller of an item when it is bought,
+ * informing them that their item sold, to who, and for how much.
+ * It will only send this message if the seller is online.
  ************************************************************************/
 
 #include "map/utils/moduleutils.h"
@@ -21,6 +21,7 @@
 #include <numeric>
 
 extern uint8 PacketSize[512];
+
 extern std::function<void(map_session_data_t* const, CCharEntity* const, CBasicPacket)> PacketParser[512];
 
 class AHAnnouncementModule : public CPPModule
@@ -69,26 +70,28 @@ class AHAnnouncementModule : public CPPModule
                                 }
                             }
                         }
+
                         CItem* gil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
 
                         if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= price)
                         {
-                            auto sellerId = 0;
-
-                            auto ret = sql->Query(
-                                "SELECT seller FROM auction_house WHERE itemid = %u AND buyer_name IS NULL "
-                                "AND stack = %u AND price <= %u ORDER BY price LIMIT 1",
-                                itemid, quantity == 0, price);
-
-                            if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
-                            {
-                                sellerId = sql->GetUIntData(0);
-                            }
-
-                            ret = sql->Query(
-                                "UPDATE auction_house SET buyer_name = '%s', sale = %u, sell_date = %u WHERE itemid = %u AND buyer_name IS NULL "
-                                "AND stack = %u AND price <= %u ORDER BY price LIMIT 1",
-                                PChar->GetName(), price, (uint32)time(nullptr), itemid, quantity == 0, price);
+                            // clang-format off
+                            auto ret = sql->Query(fmt::format(R"(
+                                UPDATE auction_house
+                                SET buyer_name = '{}', sale = {}, sell_date = {}
+                                WHERE itemid = {}
+                                AND buyer_name IS NULL
+                                AND stack = {}
+                                AND price <= {}
+                                # LAST_INSERT_ID:
+                                # The ID that was generated is maintained in the server on a per-connection basis.
+                                # Always evaluates to a positive integer, therefore true
+                                AND LAST_INSERT_ID(seller)
+                                ORDER BY price
+                                LIMIT 1;
+                                )",
+                                PChar->GetName(), price, (uint32)time(nullptr), itemid, quantity == 0, price).c_str());
+                            // clang-format on
 
                             if (ret != SQL_ERROR && sql->AffectedRows() != 0)
                             {
@@ -101,12 +104,26 @@ class AHAnnouncementModule : public CPPModule
                                     PChar->pushPacket(new CAuctionHousePacket(action, 0x01, itemid, price));
                                     PChar->pushPacket(new CInventoryFinishPacket());
 
+                                    ret = sql->Query(R"(
+                                        SELECT seller
+                                        FROM auction_house
+                                        WHERE id = LAST_INSERT_ID();
+                                    )");
+
+                                    uint32 sellerId = 0;
+
+                                    if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
+                                    {
+                                        sellerId = sql->GetUIntData(0);
+                                    }
+
                                     if (sellerId > 0)
                                     {
+                                        // clang-format off
                                         // Sanitize name
-                                        std::string name = PItem->getName();
-                                        auto parts = split(name, "_");
-                                        name = "";
+                                        std::string name  = PItem->getName();
+                                        auto        parts = split(name, "_");
+                                        name              = "";
                                         name += std::accumulate(std::begin(parts), std::end(parts), std::string(),
                                         [](std::string& ss, std::string& s)
                                         {
@@ -117,6 +134,7 @@ class AHAnnouncementModule : public CPPModule
                                         // Send message to seller!
                                         message::send(sellerId, new CChatMessagePacket(PChar, MESSAGE_SYSTEM_3,
                                             fmt::format("Your '{}' has sold to {} for {} gil!", name, PChar->name, price).c_str(), ""));
+                                        // clang-format on
                                     }
                                 }
                                 return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The two queries that comprise the logic in here weren't guaranteed to be handling the same rows, so in a highly contested (multi-process) environment messages may have been harmlessly sent to the wrong recipients.

Now, we store the seller id in LAST_INSERT_ID, which is guaranteed to be correct per-connection.

Each thread has its own connection, so no worries across threads.

## Steps to test these changes

- Enable the module
- Log in with 2 chars
- Sell something on char 1
- Buy it with char 2
- char 1 gets the notification
