### PR TITLE
Update Bhaflau IDs to use GetFirstID

### DIFF
--- a/scripts/zones/Bhaflau_Thickets/IDs.lua
+++ b/scripts/zones/Bhaflau_Thickets/IDs.lua
@@ -62,8 +62,8 @@ zones[xi.zone.BHAFLAU_THICKETS] =
             [16990398] = 16990403, -- -119 -15 -651
         },
         HARVESTMAN         = 16990252,
-        LIVIDROOT_AMOOSHAH = DYNAMIC_LOOKUP,
-        DEA                = DYNAMIC_LOOKUP,
+        LIVIDROOT_AMOOSHAH = GetFirstID("Lividroot_Amooshah"),
+        DEA                = GetFirstID("Dea"),
     },
     npc =
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes deprecated `DYNAMIC_LOOKUP` from Bhaflau Thickets, and replaces with GetFirstID()
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Mob ID should be looked up and cached successfully.
<!-- Clear and detailed steps to test your changes here -->
