### PR TITLE
Fix Animated Hammer dialogue reference

### DIFF
--- a/scripts/zones/Dynamis-Xarcabard/mobs/Animated_Hammer.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Animated_Hammer.lua
@@ -14,7 +14,7 @@ entity.onMobEngaged = function(mob, target)
         SetDropRate(106, 1581, 0)
     end
 
-    target:showText(mob, ID.text.ANIMATED_HORN_DIALOG)
+    target:showText(mob, ID.text.ANIMATED_HAMMER_DIALOG)
 end
 
 entity.onMobFight = function(mob, target)
@@ -22,11 +22,11 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onMobDisengage = function(mob)
-    mob:showText(mob, ID.text.ANIMATED_HORN_DIALOG + 2)
+    mob:showText(mob, ID.text.ANIMATED_HAMMER_DIALOG + 2)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.ANIMATED_HORN_DIALOG + 1)
+    player:showText(mob, ID.text.ANIMATED_HAMMER_DIALOG + 1)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3017 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Attack Animated Hammer in Dynamis-Xarcabard, see appropriate message (and not Horn)
<!-- Clear and detailed steps to test your changes here -->
