### PR TITLE
[abyssea] Correct trigger area function references

### DIFF
--- a/scripts/zones/Abyssea-Altepa/Zone.lua
+++ b/scripts/zones/Abyssea-Altepa/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Attohwa/Zone.lua
+++ b/scripts/zones/Abyssea-Attohwa/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Grauberg/Zone.lua
+++ b/scripts/zones/Abyssea-Grauberg/Zone.lua
@@ -36,7 +36,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -45,7 +45,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Konschtat/Zone.lua
+++ b/scripts/zones/Abyssea-Konschtat/Zone.lua
@@ -40,7 +40,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -49,7 +49,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-La_Theine/Zone.lua
+++ b/scripts/zones/Abyssea-La_Theine/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Misareaux/Zone.lua
+++ b/scripts/zones/Abyssea-Misareaux/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Tahrongi/Zone.lua
+++ b/scripts/zones/Abyssea-Tahrongi/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Uleguerand/Zone.lua
+++ b/scripts/zones/Abyssea-Uleguerand/Zone.lua
@@ -34,7 +34,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -43,7 +43,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end

--- a/scripts/zones/Abyssea-Vunkerl/Zone.lua
+++ b/scripts/zones/Abyssea-Vunkerl/Zone.lua
@@ -36,7 +36,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionEnter(player)
+            xi.abyssea.onWardTriggerAreaEnter(player)
         end,
     }
 end
@@ -45,7 +45,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
     switch (triggerArea:GetTriggerAreaID()): caseof
     {
         [1] = function()
-            xi.abyssea.onWardRegionLeave(player)
+            xi.abyssea.onWardTriggerAreaLeave(player)
         end,
     }
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Region functions were renamed as a result of changing 'Region' to 'TriggerArea'.  Updates Zone.lua references to the new function name.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enter Abyssea, don't see errors in logs regarding region
<!-- Clear and detailed steps to test your changes here -->
