### PR TITLE
Add triggerArea requirements to Transformations quest

### DIFF
--- a/scripts/quests/ahtUrhgan/Transformations.lua
+++ b/scripts/quests/ahtUrhgan/Transformations.lua
@@ -142,11 +142,11 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if
-                        questProgress == 1 and
+                        questProgress == 3 and
                         not GetMobByID(alzadaalID.mob.NEPIONIC_SOULFLAYER):isSpawned()
                     then
                         return quest:progressEvent(4)
-                    elseif questProgress == 2 then
+                    elseif questProgress == 4 then
                         return quest:progressEvent(5)
                     end
                 end,
@@ -155,14 +155,37 @@ quest.sections =
             ['Nepionic_Soulflayer'] =
             {
                 onMobDeath = function(mob, player, optParams)
+                    if quest:getVar(player, 'Prog') == 3 then
+                        quest:setVar(player, 'Prog', 4)
+                    end
+                end,
+            },
+
+            onTriggerAreaEnter =
+            {
+                [24] = function(player, triggerArea)
                     if quest:getVar(player, 'Prog') == 1 then
-                        quest:setVar(player, 'Prog', 2)
+                        return quest:progressEvent(2)
+                    end
+                end,
+
+                [25] = function(player, triggerArea)
+                    if quest:getVar(player, 'Prog') == 2 then
+                        return quest:progressEvent(3)
                     end
                 end,
             },
 
             onEventFinish =
             {
+                [2] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+
+                [3] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
                 [4] = function(player, csid, option, npc)
                     npcUtil.popFromQM(player, npc, alzadaalID.mob.NEPIONIC_SOULFLAYER, { hide = 0 })
                 end,

--- a/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/Zone.lua
@@ -149,18 +149,6 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         [22] = function(x)
             player:startEvent(210)
         end,
-
-        [24] = function(x)
-            if player:getCharVar("TransformationsProgress") == 2 then
-                player:startEvent(2)
-            end
-        end,
-
-        [25] = function(x)
-            if player:getCharVar("TransformationsProgress") == 3 then
-                player:startEvent(3)
-            end
-        end,
     }
 end
 
@@ -183,11 +171,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
-    if csid == 2 then
-        player:setCharVar("TransformationsProgress", 3)
-    elseif csid == 3 then
-        player:setCharVar("TransformationsProgress", 4)
-    elseif csid == 116 and player:getLocalVar("SalvageArrapago") == 1 then -- enter Salvage Silver Sea zone
+    if csid == 116 and player:getLocalVar("SalvageArrapago") == 1 then -- enter Salvage Silver Sea zone
         player:setPos(0, 0, 0, 0, 74)
     elseif csid == 116 and player:getLocalVar("SalvageSilverSea") == 1 then -- enter Salvage Arrapago zone
         player:setPos(0, 0, 0, 0, 76)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Nepionic_Soulflayer.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Nepionic_Soulflayer.lua
@@ -13,9 +13,6 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    if player:getCharVar("TransformationsProgress") == 4 then
-        player:setCharVar("TransformationsProgress", 5)
-    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds mission triggerArea conditions to BLU AF quest "Transformations"
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Follow guides for quest, see that region requirement is enforced
<!-- Clear and detailed steps to test your changes here -->
