### PR TITLE
Clean "Full speed ahead" quest script and IDs

### DIFF
--- a/scripts/quests/full_speed_ahead.lua
+++ b/scripts/quests/full_speed_ahead.lua
@@ -5,6 +5,8 @@ require('scripts/globals/status')
 require('scripts/globals/utils')
 require('scripts/globals/zone')
 -----------------------------------
+local batalliaID = require('scripts/zones/Batallia_Downs/IDs')
+-----------------------------------
 
 --[[
 Debugging:
@@ -27,10 +29,10 @@ FULL_SPEED_AHEAD effect power:
 xi = xi or {}
 xi.full_speed_ahead = xi.full_speed_ahead or {}
 
-xi.full_speed_ahead.duration = 600
-xi.full_speed_ahead.motivation_decay = 2
+xi.full_speed_ahead.duration              = 600
+xi.full_speed_ahead.motivation_decay      = 2
 xi.full_speed_ahead.motivation_food_bonus = 15
-xi.full_speed_ahead.pep_growth = 1
+xi.full_speed_ahead.pep_growth            = 1
 
 xi.full_speed_ahead.onEffectGain = function(player, effect)
     player:setLocalVar("FSA_Time", os.time() + xi.full_speed_ahead.duration)
@@ -63,7 +65,6 @@ xi.full_speed_ahead.tick = function(player, effect)
     player:setLocalVar("FSA_Motivation", player:getLocalVar("FSA_Motivation") - xi.full_speed_ahead.motivation_decay + effect:getPower())
     player:setLocalVar("FSA_Pep", player:getLocalVar("FSA_Pep") + xi.full_speed_ahead.pep_growth + effect:getPower())
 
-    local ID = zones[xi.zone.BATALLIA_DOWNS]
     local timeLeft   = player:getLocalVar("FSA_Time") - os.time()
     local motivation = player:getLocalVar("FSA_Motivation")
     local pep        = player:getLocalVar("FSA_Pep")
@@ -73,8 +74,8 @@ xi.full_speed_ahead.tick = function(player, effect)
     local foodData = {}
     for i = 0, 7 do
         if bit.band(foodByte, bit.lshift(1, i)) > 0 then
-            table.insert(foodData, ID.npc.BLUE_BEAM_BASE + i)
-            table.insert(foodData, ID.npc.RAPTOR_FOOD_BASE + i)
+            table.insert(foodData, batalliaID.npc.BLUE_BEAM_BASE + i)
+            table.insert(foodData, batalliaID.npc.RAPTOR_FOOD_BASE + i)
         end
     end
 
@@ -91,7 +92,6 @@ xi.full_speed_ahead.tick = function(player, effect)
 end
 
 xi.full_speed_ahead.onTriggerAreaEnter = function(player, index)
-    local ID = zones[xi.zone.BATALLIA_DOWNS]
     local foodByte   = player:getLocalVar("FSA_Food")
     local foodCount  = player:getLocalVar("FSA_FoodCount")
     local motivation = player:getLocalVar("FSA_Motivation")
@@ -110,26 +110,25 @@ xi.full_speed_ahead.onTriggerAreaEnter = function(player, index)
         -- Hearts
         player:independentAnimation(player, 251, 4)
 
-        player:messageSpecial(ID.text.RAPTOR_OVERCOME_MUNCHIES, newFoodCount, 5)
+        player:messageSpecial(batalliaID.text.RAPTOR_OVERCOME_MUNCHIES, newFoodCount, 5)
 
         if newFoodCount == 5 then
-            player:messageSpecial(ID.text.MEET_SYRILLIA)
+            player:messageSpecial(batalliaID.text.MEET_SYRILLIA)
         end
     end
 end
 
 xi.full_speed_ahead.onCheer = function(player)
-    local ID = zones[xi.zone.BATALLIA_DOWNS]
-    local timeLeft = player:getLocalVar("FSA_Time") - os.time()
+    local timeLeft   = player:getLocalVar("FSA_Time") - os.time()
     local motivation = player:getLocalVar("FSA_Motivation")
-    local pep = player:getLocalVar("FSA_Pep")
+    local pep        = player:getLocalVar("FSA_Pep")
 
     local newMotivation = utils.clamp(motivation + (pep / 2), 0, 100)
 
     player:setLocalVar("FSA_Motivation", newMotivation)
     player:setLocalVar("FSA_Pep", 0)
 
-    player:messageSpecial(ID.text.RAPTOR_SECOND_WIND)
+    player:messageSpecial(batalliaID.text.RAPTOR_SECOND_WIND)
 
     -- Music Notes
     player:independentAnimation(player, 252, 4)

--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -109,7 +109,9 @@ zones[xi.zone.BATALLIA_DOWNS] =
 
     npc =
     {
-        SYRILLIA = GetFirstID("Syrillia"),
+        SYRILLIA         = GetFirstID("Syrillia"),
+        BLUE_BEAM_BASE   = GetFirstID("NPC[2a4]"),
+        RAPTOR_FOOD_BASE = GetFirstID("Raptors_Food_0"),
     },
 }
 

--- a/scripts/zones/Batallia_Downs/Zone.lua
+++ b/scripts/zones/Batallia_Downs/Zone.lua
@@ -14,10 +14,10 @@ zoneObject.onChocoboDig = function(player, precheck)
 end
 
 local function registerRegionAroundNPC(zone, NPCID, zoneID)
-    local npc = GetNPCByID(NPCID)
-    local x = npc:getXPos()
-    local y = npc:getYPos()
-    local z = npc:getZPos()
+    local npc      = GetNPCByID(NPCID)
+    local x        = npc:getXPos()
+    local y        = npc:getYPos()
+    local z        = npc:getZPos()
     local distance = 7
 
     zone:registerTriggerArea(zoneID,
@@ -29,12 +29,8 @@ zoneObject.onInitialize = function(zone)
     UpdateNMSpawnPoint(ID.mob.AHTU)
     GetMobByID(ID.mob.AHTU):setRespawnTime(math.random(900, 10800))
 
-    -- Prepare everything for Full Speed Ahead!
-    zones[xi.zone.BATALLIA_DOWNS].npc.BLUE_BEAM_BASE   = ID.npc.SYRILLIA + 1
-    zones[xi.zone.BATALLIA_DOWNS].npc.RAPTOR_FOOD_BASE = ID.npc.SYRILLIA + 9
-
     for i = 0, 7 do
-        registerRegionAroundNPC(zone, zones[xi.zone.BATALLIA_DOWNS].npc.RAPTOR_FOOD_BASE + i, i + 1)
+        registerRegionAroundNPC(zone, ID.npc.RAPTOR_FOOD_BASE + i, i + 1)
     end
 
     registerRegionAroundNPC(zone, ID.npc.SYRILLIA, 9)
@@ -87,10 +83,16 @@ end
 zoneObject.onEventFinish = function(player, csid, option)
     if csid == 24 then
         xi.fsa.completeGame(player)
-    elseif csid == 26 and option == 0 then
+    elseif
+        csid == 26 and
+        option == 0
+    then
         player:setCharVar("[QUEST]FullSpeedAhead", 1)
         player:setPos(475, 8.8, -159, 128, 105)
-    elseif csid == 26 and option == 1 then
+    elseif
+        csid == 26 and
+        option == 1
+    then
         player:setCharVar("[QUEST]FullSpeedAhead", 2)
         player:setPos(475, 8.8, -159, 128, 105)
     end


### PR DESCRIPTION
Co-authored-by: kaincenteno <kaincenteno@users.noreply.github.com>
Co-authored-by: WinterSolstice8 <WinterSolstice8@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the 2 Id offsets used in the quest to the Zone IDs file and cleans references.

## Steps to test these changes

Run the quest
