### PR TITLE
[TCP] Enable SO_REUSEADDR for tcp bound sockets

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -817,6 +817,19 @@ int32 makeListenBind_tcp(const char* ip, uint16 port, RecvFunc connect_client)
     inet_pton(AF_INET, ip, &server_address.sin_addr.s_addr);
     server_address.sin_port = htons(port);
 
+    // https://stackoverflow.com/questions/3229860/what-is-the-meaning-of-so-reuseaddr-setsockopt-option-linux
+    // Avoid hangs in TIME_WAIT state of TCP
+#ifdef WIN32
+    // Windows doesn't seem to have this problem, but apparently this would be the right way to explicitly mimic SO_REUSEADDR unix's behavior.
+    setsockopt(sock_arr[fd], SOL_SOCKET, SO_DONTLINGER, "\x00\x00\x00\x00", 4);
+#else
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0)
+    {
+        ShowError("setsockopt SO_REUSEADDR failed!");
+    }
+#endif
+
     result = sBind(fd, (struct sockaddr*)&server_address, sizeof(server_address));
     if (result == SOCKET_ERROR)
     {


### PR DESCRIPTION
This will prevent immediate re-launch of login from failing to bind if sessions were active.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enable SO_REUSEADDR for tcp bound sockets
See https://stackoverflow.com/questions/3229860/what-is-the-meaning-of-so-reuseaddr-setsockopt-option-linux for an explanation, but the long story short is

When Login closes improperly, the bound sockets listening for connections go into a state where it waits for al the other TCP connections that used to be on that socket to close. FFXI does not seem to to this timely, so we need to set SO_REUSEADDR which will only rebind the socket if it's in that particular state. It will not rebind if another instance is actually using that port.

## Steps to test these changes

On Linux:
./xi_connect
connect on a client
sudo killall -9 xi_connect ; ./xi_connect
see it immediately re-bind without issues

On windows, something similar but more manual. 
open xi_connect
connect on a client
kill it and reopen immediately and bind without issue