### PR TITLE
healing.lua fix for Dances with Luopans Geo quest

### DIFF
--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -38,7 +38,7 @@ effectObject.onEffectGain = function(target, effect)
         target:messageSpecial(ID.text.ENERGIES_COURSE)
 
         local maxWaitTime = 480  -- Max wait of 8 minutes
-        local secondsPerTick = xi.settings.main.map.HEALING_TICK_DELAY
+        local secondsPerTick = xi.settings.map.HEALING_TICK_DELAY
         local minWaitTime = math.min(3 * secondsPerTick, maxWaitTime)
         local waitTimeInSeconds = math.random(minWaitTime, maxWaitTime)
         target:setLocalVar("GEO_DWL_Resting", os.time() + waitTimeInSeconds)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fix is for completing the "Dances with Luopans" GEO job unlock quest.

## Steps to test these changes

During the quest, you /heal at the Ergon Locust. The one I chose is near the frontier station in Ceizak Battlegrounds.
While healing, I immediately received the message: "The arcane energies begin to course within your veins."
According to the quest's script, the maximum wait time while healing is 8 minutes. I ended up waiting for over 30 for the next message to display, which never did. At the same time received this error msg in the map server:

[12/21/22 16:28:06:540][map][error] luautils::onEffectGain: ./scripts/globals/effects/healing.lua:41: attempt to index field 'map' (a nil value)
stack traceback:
	./scripts/globals/effects/healing.lua:41: in function <./scripts/globals/effects/healing.lua:16> (luautils::OnEffectGain:2375)

Now I'm by no means an expert, it just seemed odd to me the "main" in xi.settings.main.map.HEALING_TICK_DELAY was there. So I deleted it. Rebooted the server. Retested /heal near the locust and sure enough, 4 and a half minutes later I received the second message: "You feel a mystical warmth welling up inside you!" Also there were no errors in the map server after this change.