### PR TITLE
[Fix] Quest Past Perfect

### DIFF
--- a/scripts/quests/bastok/Past_Perfect.lua
+++ b/scripts/quests/bastok/Past_Perfect.lua
@@ -73,7 +73,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.TATTERED_MISSION_ORDERS) then
-                        return quest:keyItem(player, xi.ki.TATTERED_MISSION_ORDERS)
+                        return quest:keyItem(xi.ki.TATTERED_MISSION_ORDERS)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixed quest Past Perfect having too many parameters to quest:keyItem call.  Does not close a known issue.

## Steps to test these changes

Set Bastok rank to 2, Bastok fame to 1000, zone to Port Bastok and start the quest by talking to Evi, to Rafaela, and then Evi again.  Zone to Konschtat and travel southwest from the Crag to the base of the windmill having the ???, and then interact with it.  Instead of an error being reported on the map server about invalid parameters, the key item should be obtained.  Return to Port Bastok and talk to Evi to complete the quest.