### PR TITLE
[core] Improve random number generator seeding

### DIFF
--- a/src/common/xirand.h
+++ b/src/common/xirand.h
@@ -39,8 +39,28 @@ public:
     {
         std::array<uint32_t, std::mt19937::state_size> seed_data;
         std::random_device                             rd;
-        std::generate(seed_data.begin(), seed_data.end(), std::ref(rd));
-        std::seed_seq seq(seed_data.begin(), seed_data.end());
+
+        // Certain systems were noted to have bad seeding via only std::random_device,
+        // the following indicated how we could mix in std::random_device with other seed sources
+        // https://stackoverflow.com/a/68382489
+        for (auto it = seed_data.begin(); it != seed_data.end(); ++it)
+        {
+            // read from std::random_device
+            *it = rd();
+
+            // mix with a C++ equivalent of time(NULL) - UNIX time in seconds
+            *it ^= std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+
+            // mix with a high precision time in microseconds
+            *it ^= std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::high_resolution_clock::now().time_since_epoch())
+                       .count();
+
+            //*it ^= more_external_random_stuff;
+        }
+        std::seed_seq seq(seed_data.cbegin(), seed_data.cend());
         mt().seed(seq);
     }
 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

An issue was identified on a Linux machine where std::random_device was not producing randomness
This solves that issue and further improves randomness by mixing in extra entropy sources

The code to check the RNG:
```
    double   data;
    int      count    = 100000000;
    uint64_t mincount = 0;
    uint64_t maxcount = 0;
    srand((uint32)time(nullptr));
    xirand::seed();

    for (int i = 0; i < count; i++)
    {
        data = xirand::GetRandomNumber(1.);
        if (data < 0.1)
        {
            mincount += 1;
        }
        else if (data > 0.9)
        {
            maxcount += 1;
        }
    }
    ShowWarning(fmt::format("mincount: {}, maxcount: {}", mincount, maxcount));
```

On my aarch64 VPS I got this output:

`[12/23/22 22:49:24:206][map][warn] mincount: 1032, maxcount: 998 (do_init:226)`
`[12/23/22 22:49:23:078][map][warn] mincount: 1032, maxcount: 998 (do_init:226)`
`[12/23/22 22:49:53:314][map][warn] mincount: 1032, maxcount: 998 (do_init:226)`
after reboot it was still the same. RNG seeding from random_device seemed to be flawed.

On x86_64 windows (bare metal):
`[12/23/22 22:56:06:851][map][warn] mincount: 9999605, maxcount: 10000596 (do_init:213)`
`[12/23/22 22:56:52:332][map][warn] mincount: 9999110, maxcount: 9997137 (do_init:213)`

On aarch64 linux (bare metal raspi cm4 (clock is wrong)):
`[12/24/22 08:01:36:844][map][warn] mincount: 9999434, maxcount: 10002177 (do_init:213)`
`[12/24/22 08:01:44:470][map][warn] mincount: 9998454, maxcount: 10000237 (do_init:213)`
`[12/24/22 08:01:54:959][map][warn] mincount: 9999175, maxcount: 10002578 (do_init:213)`

On x86_64 linux (bare metal):
`[12/23/22 23:08:45:985][map][warn] mincount: 10000853, maxcount: 9995567 (do_init:213)`
`[12/23/22 23:09:02:234][map][warn] mincount: 9997815, maxcount: 10000108 (do_init:213)`

On x86_64 through oracle vbox hypervisor:
`[12/24/22 00:41:34:376][map][warn] mincount: 10002661, maxcount: 9995869 (do_init:213)`
`[12/24/22 00:41:38:140][map][warn] mincount: 9994863, maxcount: 9997509 (do_init:213)`

Failing aarch64 VPS after this PR:
`[12/23/22 23:51:59:253][map][warn] mincount: 9999480, maxcount: 9998603 (do_init:228)`
`[12/23/22 23:52:34:999][map][warn] mincount: 10002596, maxcount: 10007311 (do_init:228)`
## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Test RNG, as above, see fluctuations in the upper and lower 10th percentile 