### PR TITLE
Add additional dialogue, triggerArea to San d'Oria M6-1

### DIFF
--- a/scripts/missions/sandoria/6_1_Leautes_Last_Wishes.lua
+++ b/scripts/missions/sandoria/6_1_Leautes_Last_Wishes.lua
@@ -3,19 +3,17 @@
 -- San d'Oria M6-1
 -----------------------------------
 -- !addmission 0 16
--- Ambrotien            : !pos 93.419 -0.001 -57.347 230
--- Grilau               : !pos -241.987 6.999 57.887 231
--- Endracion            : !pos -110 1 -34 230
--- Halver               : !pos 2 0.1 0.1 233
--- Door: Great Hall     : !pos 0 -1 13 233
--- Chalvatot            : !pos -105 0.1 72 233
--- Dreamrose            : !pos -262.403 -10.155 49.164 125
+-- Ambrotien        : !pos 93.419 -0.001 -57.347 230
+-- Grilau           : !pos -241.987 6.999 57.887 231
+-- Endracion        : !pos -110 1 -34 230
+-- Halver           : !pos 2 0.1 0.1 233
+-- Door: Great Hall : !pos 0 -1 13 233
+-- Chalvatot        : !pos -105 0.1 72 233
+-- Dreamrose        : !pos -262.403 -10.155 49.164 125
 -----------------------------------
-require('scripts/globals/items')
 require('scripts/globals/keyitems')
 require('scripts/globals/missions')
 require('scripts/globals/npc_util')
-require('scripts/globals/settings')
 require('scripts/globals/interaction/mission')
 require('scripts/globals/zone')
 -----------------------------------
@@ -27,7 +25,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.L
 mission.reward =
 {
     rankPoints = 600,
-    keyItem = xi.ki.PIECE_OF_PAPER,
+    keyItem    = xi.ki.PIECE_OF_PAPER,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)
@@ -71,14 +69,20 @@ mission.sections =
 
         [xi.zone.CHATEAU_DORAGUILLE] =
         {
-            ['Chalvatot'] =
+            ['Arsha'] =
             {
                 onTrigger = function(player, npc)
-                    if
-                        player:getMissionStatus(mission.areaId) == 4 and
-                        player:hasKeyItem(xi.ki.DREAMROSE)
-                    then
-                        return mission:progressEvent(111)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        return mission:progressEvent(85)
+                    end
+                end,
+            },
+
+            ['Chupaile'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        return mission:progressEvent(86)
                     end
                 end,
             },
@@ -105,6 +109,18 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 1 then
                         return mission:progressEvent(87)
+                    end
+                end,
+            },
+
+            onTriggerAreaEnter =
+            {
+                [2] = function(player, triggerArea)
+                    if
+                        player:getMissionStatus(mission.areaId) == 4 and
+                        player:hasKeyItem(xi.ki.DREAMROSE)
+                    then
+                        return mission:progressEvent(111)
                     end
                 end,
             },

--- a/scripts/zones/Chateau_dOraguille/Zone.lua
+++ b/scripts/zones/Chateau_dOraguille/Zone.lua
@@ -7,7 +7,8 @@ require('scripts/globals/zone')
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    zone:registerTriggerArea(1, -95, 0, 75, -85, 5, 85)
+    zone:registerTriggerArea(1, -95, 0, 75, -85, 5, 85)        -- Garden area near Chalvatot
+    zone:registerTriggerArea(2, -87, -1.75, 55.5, -81, -1, 60) -- Stairs approaching Garden
 end
 
 zoneObject.onZoneIn = function(player, prevZone)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds guard NPC dialogue change for when the player is able to talk to Destin, and aligns final event with retail by using triggerArea for Chalvatot cutscene
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
With missionStatus 1, talk to guards outside of Destin
With missionStatus 4, approach garden in Chateau

<!-- Clear and detailed steps to test your changes here -->
