### PR TITLE
[core] Update AoE cure messages to behave like retail

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -488,7 +488,12 @@ xi.spells.blue.useCuringSpell = function(caster, target, spell, params)
     target:addHP(final)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
-    spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     return final
 end

--- a/scripts/globals/mobskills/white_wind.lua
+++ b/scripts/globals/mobskills/white_wind.lua
@@ -21,6 +21,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    --  TODO: get capture of messages, message may be the following:
+    --[[
+    if target:getID() == target:getID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
+    --]]
     skill:setMsg(xi.msg.basic.SKILL_RECOVERS_HP)
     -- Todo: verify/correct maths
     return xi.mobskills.mobHealMove(mob, math.floor(mob:getHP() / 7) * 2)

--- a/scripts/globals/spells/white/cura.lua
+++ b/scripts/globals/spells/white/cura.lua
@@ -115,7 +115,11 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     --Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/cura_ii.lua
+++ b/scripts/globals/spells/white/cura_ii.lua
@@ -116,7 +116,11 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     --Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/cura_iii.lua
+++ b/scripts/globals/spells/white/cura_iii.lua
@@ -117,7 +117,11 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     --Enmity for Cura III is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/curaga.lua
+++ b/scripts/globals/spells/white/curaga.lua
@@ -44,7 +44,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/curaga_ii.lua
+++ b/scripts/globals/spells/white/curaga_ii.lua
@@ -44,7 +44,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/curaga_iii.lua
+++ b/scripts/globals/spells/white/curaga_iii.lua
@@ -44,7 +44,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/curaga_iv.lua
+++ b/scripts/globals/spells/white/curaga_iv.lua
@@ -44,7 +44,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/scripts/globals/spells/white/curaga_v.lua
+++ b/scripts/globals/spells/white/curaga_v.lua
@@ -41,7 +41,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     target:wakeUp()
     caster:updateEnmityFromCure(target, final)
 
-    spell:setMsg(xi.msg.basic.AOE_HP_RECOVERY)
+    if target:getID() == spell:getPrimaryTargetID() then
+        spell:setMsg(xi.msg.basic.MAGIC_RECOVERS_HP)
+    else
+        spell:setMsg(xi.msg.basic.SELF_HEAL_SECONDARY)
+    end
 
     local mpBonusPercent = (final * caster:getMod(xi.mod.CURE2MP_PERCENT)) / 100
     if mpBonusPercent > 0 then

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1440,6 +1440,7 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
     auto totalTargets = (uint16)PAI->TargetFind->m_targets.size();
 
     PSpell->setTotalTargets(totalTargets);
+    PSpell->setPrimaryTargetID(PActionTarget->id);
 
     action.id         = id;
     action.actiontype = ACTION_MAGIC_FINISH;
@@ -1505,15 +1506,7 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
             actionTarget.modifier = PSpell->getModifier();
             PSpell->setModifier(MODIFIER::NONE); // Reset modifier on use
 
-            if (damage < 0)
-            {
-                msg                = MSGBASIC_MAGIC_RECOVERS_HP;
-                actionTarget.param = static_cast<uint16>(std::clamp(damage * -1, 0, PTarget->GetMaxHP() - PTarget->health.hp));
-            }
-            else
-            {
-                actionTarget.param = damage;
-            }
+            actionTarget.param = damage;
         }
 
         if (actionTarget.animation == 122)

--- a/src/map/lua/lua_spell.cpp
+++ b/src/map/lua/lua_spell.cpp
@@ -91,6 +91,11 @@ void CLuaSpell::setCastTime(uint32 casttime)
     m_PLuaSpell->setCastTime(casttime);
 }
 
+uint32 CLuaSpell::getPrimaryTargetID()
+{
+    return m_PLuaSpell->getPrimaryTargetID();
+}
+
 bool CLuaSpell::canTargetEnemy()
 {
     return m_PLuaSpell->canTargetEnemy();
@@ -176,6 +181,7 @@ void CLuaSpell::Register()
     SOL_REGISTER("getSpellFamily", CLuaSpell::getSpellFamily);
     SOL_REGISTER("getFlag", CLuaSpell::getFlag);
     SOL_REGISTER("getCastTime", CLuaSpell::getCastTime);
+    SOL_REGISTER("getPrimaryTargetID", CLuaSpell::getPrimaryTargetID);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaSpell& spell)

--- a/src/map/lua/lua_spell.h
+++ b/src/map/lua/lua_spell.h
@@ -61,6 +61,7 @@ public:
     uint8  getSpellFamily();
     uint8  getFlag();
     uint32 getCastTime();
+    uint32 getPrimaryTargetID();
 
     static void Register();
 };

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -336,6 +336,11 @@ void CSpell::setModifier(MODIFIER modifier)
     m_MessageModifier = modifier;
 }
 
+void CSpell::setPrimaryTargetID(uint32 targid)
+{
+    m_primaryTargetID = targid;
+}
+
 uint16 CSpell::getElement() const
 {
     return m_element;
@@ -419,6 +424,11 @@ const std::string& CSpell::getContentTag()
 float CSpell::getRange() const
 {
     return m_range;
+}
+
+uint32 CSpell::getPrimaryTargetID() const
+{
+    return m_primaryTargetID;
 }
 
 void CSpell::setContentTag(const std::string& contentTag)

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -1081,6 +1081,7 @@ public:
     uint8              getFlag() const;
     const std::string& getContentTag();
     float              getRange() const;
+    uint32             getPrimaryTargetID() const;
     bool               tookEffect() const; // returns true if the spell landed, not resisted or missed
     bool               hasMPCost();        // checks if spell costs mp to use
     bool               isHeal();           // is a heal spell
@@ -1112,6 +1113,7 @@ public:
     void setMagicBurstMessage(uint16 message);
     auto getModifier() -> MODIFIER;
     void setModifier(MODIFIER modifier); // set Spell modifier message, MUST reset the modifier on use otherwise it will be stale
+    void setPrimaryTargetID(uint32);
 
     void setCE(uint16 ce);
     void setVE(uint16 ve);
@@ -1130,10 +1132,11 @@ protected:
     CSpell& operator=(const CSpell&) = default;
 
 private:
-    SpellID     m_ID;           // spell id
-    uint32      m_castTime{};   // time to cast spell
-    uint32      m_recastTime{}; // recast time
-    uint16      m_animation{};  // animation for spell
+    SpellID     m_ID;                // spell id
+    uint32      m_primaryTargetID{}; // primary target ID
+    uint32      m_castTime{};        // time to cast spell
+    uint32      m_recastTime{};      // recast time
+    uint16      m_animation{};       // animation for spell
     uint16      m_animationTime{};
     uint8       m_skillType{};
     float       m_range{};


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes AoE cure messages to look like retail (the following are retail caps):
![image](https://user-images.githubusercontent.com/60417494/209705882-2d57a1c8-1a82-4eab-8286-5dc41c5df8b6.png)
all messages are primary target = 7, secondary = 263
```
[09:08:44] {
[09:08:44]   actor_id = 165091,
[09:08:44]   category = 4,
[09:08:44]   param = 7,
[09:08:44]   recast = 6,
[09:08:44]   target_count = 2,
[09:08:44]   targets = { {
[09:08:44]       action_count = 1,
[09:08:44]       actions = { {
[09:08:44]           add_effect_animation = 0,
[09:08:44]           add_effect_effect = 0,
[09:08:44]           add_effect_message = 0,
[09:08:44]           add_effect_param = 0,
[09:08:44]           animation = 7,
[09:08:44]           effect = 0,
[09:08:44]           has_add_effect = false,
[09:08:44]           has_spike_effect = false,
[09:08:44]           knockback = 0,
[09:08:44]           message = 7,
[09:08:44]           param = 0,
[09:08:44]           reaction = 0,
[09:08:44]           spike_effect_animation = 0,
[09:08:44]           spike_effect_effect = 0,
[09:08:44]           spike_effect_message = 0,
[09:08:44]           spike_effect_param = 0,
[09:08:44]           stagger = 0,
[09:08:44]           unknown = 0
[09:08:44]         } },
[09:08:44]       id = 43455
[09:08:44]     }, {
[09:08:44]       action_count = 1,
[09:08:44]       actions = { {
[09:08:44]           add_effect_animation = 0,
[09:08:44]           add_effect_effect = 0,
[09:08:44]           add_effect_message = 0,
[09:08:44]           add_effect_param = 0,
[09:08:44]           animation = 7,
[09:08:44]           effect = 0,
[09:08:44]           has_add_effect = false,
[09:08:44]           has_spike_effect = false,
[09:08:44]           
[09:08:44] knockback = 0,
[09:08:44]           message = 263,
[09:08:44]           param = 0,
[09:08:44]           reaction = 0,
[09:08:44]           spike_effect_animation = 0,
[09:08:44]           spike_effect_effect = 0,
[09:08:44]           spike_effect_message = 0,
[09:08:44]           spike_effect_param = 0,
[09:08:44]           stagger = 0,
[09:08:44]           unknown = 0
[09:08:44]         } },
[09:08:44]       id = 165091
[09:08:44]     } },
[09:08:44]   unknown = 0
[09:08:44] }
```
TODO: implement for white wind when its implemented, check what mobs do with white wind/healing breeze


## Steps to test these changes

Use cures, and see correct log output
Note: I intentionally removed the clamp on message output so that we could discover broken messages. After lua processing, we should _never_ have negative numbers and we want to stamp it out.