### PR TITLE
Tweak `!goto` and `!bring`

### DIFF
--- a/scripts/commands/goto.lua
+++ b/scripts/commands/goto.lua
@@ -37,6 +37,6 @@ function onTrigger(player, target, forceZone)
     if targ and not targ:isInMogHouse() then
         player:setPos(targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos(), forceZone == 1 and targ:getZoneID() or nil)
     elseif not player:gotoPlayer(target) then
-        error(player, string.format("Player named: %s not found!"), target)
+        error(player, string.format("Player named: %s not found!", target))
     end
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3209,11 +3209,13 @@ void CLuaBaseEntity::goToEntity(uint32 targetID, sol::object const& option)
 
 bool CLuaBaseEntity::gotoPlayer(std::string const& playerName)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    bool found = false;
 
-    bool        found    = false;
+    char escapedCharName[16 * 2 + 1];
+    sql->EscapeString(escapedCharName, playerName.c_str());
+
     const char* fmtQuery = "SELECT charid FROM chars WHERE charname = '%s';";
-    int32       ret      = sql->Query(fmtQuery, playerName.c_str());
+    int32       ret      = sql->Query(fmtQuery, escapedCharName);
 
     if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
     {
@@ -3241,8 +3243,11 @@ bool CLuaBaseEntity::bringPlayer(std::string const& playerName)
 {
     bool found = false;
 
+    char escapedCharName[16 * 2 + 1];
+    sql->EscapeString(escapedCharName, playerName.c_str());
+
     const char* fmtQuery = "SELECT charid FROM chars WHERE charname = '%s';";
-    int32       ret      = sql->Query(fmtQuery, playerName.c_str());
+    int32       ret      = sql->Query(fmtQuery, escapedCharName);
 
     if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
1. Fix misplaced `)` in `!goto`
2. Escape the input name like we do elsewhere.
3. Remove unneeded `XI_DEBUG_BREAK_IF`
## Steps to test these changes
1. Build it
2. use `!gfoto` and `!bring`  in the following scenarios:
- The target player is online and in the same map server instance (should work)
- The target player is on but in a different instance (should work)
- The target player is offline (this should print an error message in game)
- The target player **does not exist** (this should print an error message in game)
- The target has a completely invalid name with symbols or jank in it (this should print an error message in game)
