### PR TITLE
[BLU] Spell corrections

### DIFF
--- a/scripts/globals/spells/blue/exuviation.lua
+++ b/scripts/globals/spells/blue/exuviation.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.divisor1 = 2
     params.constant1 = 65
     params.powerThreshold2 = 459
-    params.divisor2 = 1.5
+    params.divisor2 = 6.5
     params.constant2 = 144.6666
 
     target:eraseStatusEffect()

--- a/scripts/globals/spells/blue/flying_hip_press.lua
+++ b/scripts/globals/spells/blue/flying_hip_press.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.hpMod = 3
     params.lvlMod = 0
 
-    local results = xi.spells.blue.useBreathSpell(caster, target, spell, params, true)
+    local results = xi.spells.blue.useBreathSpell(caster, target, spell, params, false)
     local damage = results[1]
 
     return damage

--- a/scripts/globals/spells/blue/light_of_penance.lua
+++ b/scripts/globals/spells/blue/light_of_penance.lua
@@ -40,7 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         spell:setMsg(xi.msg.basic.MAGIC_TP_REDUCE) -- this doesn't seem to do much
         target:delTP(100)
-        local actionOne = target:addStatusEffect(typeEffectOne, 100, 0, duration * resist)
+        local actionOne = target:addStatusEffect(typeEffectOne, 10, 0, duration * resist)
         local actionTwo = target:addStatusEffect(typeEffectTwo, 1, 0, duration * resist)
 
         -- Gaze move


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes 3 spells with wrong values. These were submitted with the [BLU cleanup](https://github.com/LandSandBoat/server/pull/3381) PR. Fixes:
- **Exuviation**: divisor was set too low, bringing about a jump in cure value above a certain treshold.
- **Flying Hip Press**: is AoE spell, but was set to conal.
- **Light of Penance**: Blind effect was wrongly set to 100 instead of 10.
