### PR TITLE
[codeql] Add null checks for several warnings

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -494,6 +494,12 @@ namespace gambits
                     {
                         CStatusEffect* PSCEffect = target->StatusEffectContainer->GetStatusEffect(EFFECT_SKILLCHAIN, 0);
 
+                        if (PSCEffect == nullptr)
+                        {
+                            ShowError("G_SELECT::MB_ELEMENT: PSCEffect was null.");
+                            return;
+                        }
+
                         std::list<SKILLCHAIN_ELEMENT> resonanceProperties;
                         if (uint16 power = PSCEffect->GetPower())
                         {
@@ -1010,6 +1016,13 @@ namespace gambits
             if (chosen_skill->skill_type == G_REACTION::WS)
             {
                 CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(chosen_skill->skill_id);
+
+                if (PWeaponSkill == nullptr)
+                {
+                    ShowError("G_REACTION::WS: PWeaponSkill was null.");
+                    return false;
+                }
+
                 if (chosen_skill->valid_targets & TARGET_SELF)
                 {
                     target = POwner;

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -581,6 +581,12 @@ void CAttack::ProcessDamage()
     {
         CStatusEffect* effect = m_attacker->StatusEffectContainer->GetStatusEffect(EFFECT_RESTRAINT);
 
+        if (effect == nullptr)
+        {
+            ShowError("Restraint effect was null.");
+            return;
+        }
+
         if (effect->GetPower() < 30)
         {
             uint8 jpBonus = 0;

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -982,7 +982,7 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
                     for (auto& deathMobId : group.mobIds)
                     {
                         CMobEntity* PMob = (CMobEntity*)zoneutils::GetEntity(deathMobId, TYPE_MOB | TYPE_PET);
-                        if (PMob->isDead())
+                        if (PMob != nullptr && PMob->isDead())
                         {
                             ++deathCount;
                         }
@@ -1017,6 +1017,13 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
 void CBattlefield::setPlayerEntered(CCharEntity* PChar, bool entered)
 {
     CStatusEffect* effect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD);
+
+    if (effect == nullptr)
+    {
+        ShowError("Effect was null.");
+        return;
+    }
+
     effect->SetTier(entered ? 1 : 0);
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3966,6 +3966,13 @@ auto CLuaBaseEntity::addSoulPlate(std::string const& name, uint16 mobFamily, uin
 
         // Used Soul Plate
         CItem* PItem = itemutils::GetItem(2477);
+
+        if (PItem == nullptr)
+        {
+            ShowError("PItem was null for soulplate");
+            return std::nullopt;
+        }
+
         PItem->setQuantity(1);
         PItem->setSoulPlateData(name, mobFamily, zeni, skillIndex, fp);
         auto SlotID = charutils::AddItem(PChar, LOC_INVENTORY, PItem, true);
@@ -4122,6 +4129,12 @@ bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
 
     auto* PItem = static_cast<CItemEquipment*>(itemutils::GetItem(itemID));
     auto* PChar = static_cast<CBattleEntity*>(m_PBaseEntity);
+
+    if (PItem == nullptr)
+    {
+        ShowError("PItem was null, itemID = %d.", itemID);
+        return false;
+    }
 
     if (!(PItem->getJobs() & (1 << (PChar->GetMJob() - 1))))
     {
@@ -4362,6 +4375,12 @@ uint8 CLuaBaseEntity::storeWithPorterMoogle(uint16 slipId, sol::table const& ext
 
     auto* slip = PChar->getStorage(LOC_INVENTORY)->GetItem(slipSlotId);
 
+    if (slip == nullptr)
+    {
+        ShowError("Slip Item was null.");
+        return 0;
+    }
+
     auto extraVec  = extraTable.as<std::vector<uint8>>();
     auto extraSize = extraVec.size();
     for (size_t i = 0; i < extraSize; i++)
@@ -4442,6 +4461,12 @@ sol::table CLuaBaseEntity::getRetrievableItemsForSlip(uint16 slipId)
 
     auto* slip = PChar->getStorage(LOC_INVENTORY)->GetItem(slipSlotId);
 
+    if (slip == nullptr)
+    {
+        ShowError("Slip item was null.");
+        return {};
+    }
+
     sol::table table = lua.create_table();
     // TODO Is extra sized defined anywhere?
     for (int i = 0; i < 24; i++)
@@ -4472,6 +4497,12 @@ void CLuaBaseEntity::retrieveItemFromSlip(uint16 slipId, uint16 itemId, uint16 e
     }
 
     auto* slip = PChar->getStorage(LOC_INVENTORY)->GetItem(slipSlotId);
+
+    if (slip == nullptr)
+    {
+        ShowError("Slip item was null.");
+        return;
+    }
 
     slip->m_extra[extraId] &= extraData;
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2414,6 +2414,12 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
 
                     CItem* PUBoxItem = itemutils::GetItem(PItem->getID());
 
+                    if (PUBoxItem == nullptr)
+                    {
+                        ShowError("PUBoxItem was null.");
+                        return;
+                    }
+
                     char receiver[PacketNameLength] = {};
                     memcpy(&receiver, data[0x10], PacketNameLength - 1);
                     PUBoxItem->setReceiver(receiver);
@@ -6872,7 +6878,7 @@ void SmallPacket0x0FF(map_session_data_t* const PSession, CCharEntity* const PCh
     CItemContainer* PItemContainer = PChar->getStorage(containerID);
     CItemFlowerpot* PItem          = (CItemFlowerpot*)PItemContainer->GetItem(slotID);
 
-    if (PItem->isPlanted() && PItem->getStage() > FLOWERPOT_STAGE_INITIAL && PItem->getStage() < FLOWERPOT_STAGE_WILTED && !PItem->isDried())
+    if (PItem != nullptr && PItem->isPlanted() && PItem->getStage() > FLOWERPOT_STAGE_INITIAL && PItem->getStage() < FLOWERPOT_STAGE_WILTED && !PItem->isDried())
     {
         PChar->pushPacket(new CMessageStandardPacket(itemID, 133)); // Your moogle dries the plant in the <item>.
         PChar->pushPacket(new CFurnitureInteractPacket(PItem, containerID, slotID));

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -582,7 +582,7 @@ void CZone::updateCharLevelRestriction(CCharEntity* PChar)
     {
         // If the level restriction is already the same then no need to change it
         CStatusEffect* statusEffect = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_RESTRICTION);
-        if (statusEffect->GetPower() == m_levelRestriction)
+        if (statusEffect == nullptr || statusEffect->GetPower() == m_levelRestriction)
         {
             return;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds null checks for several codeql warnings and logs output
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed (unless null, then get logs)
<!-- Clear and detailed steps to test your changes here -->
