### PR TITLE
[core] Add functions for SQL profiling

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -634,6 +634,56 @@ bool SqlConnection::TransactionRollback()
     return false;
 }
 
+// Prepares to profile a single query.
+// If you try to query multiple queries inside a start/end block,
+// only the most recent will print results.
+void SqlConnection::StartProfiling()
+{
+    TracyZoneScoped;
+    if (self && QueryStr("SET profiling = 1;") != SQL_ERROR)
+    {
+        return;
+    }
+
+    ShowCritical("Query: %s", self->buf);
+    ShowCritical("StartProfiling: SQL_ERROR: %s (%u)", mysql_error(&self->handle), mysql_errno(&self->handle));
+}
+
+// Finished profiling a single query.
+// Will print out a table corresponding to the results shown by `SHOW PROFILE;`
+// If you try to query multiple queries inside a start/end block,
+// only the most recent will print results.
+void SqlConnection::FinishProfiling()
+{
+    TracyZoneScoped;
+    if (!self)
+    {
+        return;
+    }
+
+    auto lastQuery = self->buf;
+    if (QueryStr("SHOW PROFILE;") != SQL_ERROR && NumRows() > 0)
+    {
+        std::string outStr = "SQL SHOW PROFILE:\n";
+        outStr += fmt::format("Query: {}\n", lastQuery);
+        outStr += fmt::format("| {:<31}| {:<8} |\n", "Status", "Duration");
+        outStr += fmt::format("|{:=<32}|{:=<10}|\n", "", "");
+
+        while (NextRow() == SQL_SUCCESS)
+        {
+            auto category    = GetStringData(0);
+            auto measurement = GetStringData(1);
+            outStr += fmt::format("| {:<31}| {:<8} |\n", category, measurement);
+        }
+        QueryStr("SET profiling = 0;");
+        ShowInfo(outStr);
+        return;
+    }
+
+    ShowCritical("Query: %s", self->buf);
+    ShowCritical("FinishProfiling: SQL_ERROR: %s (%u)", mysql_error(&self->handle), mysql_errno(&self->handle));
+}
+
 void SqlConnection::InitPreparedStatements()
 {
     TracyZoneScoped;

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -186,6 +186,9 @@ public:
     bool TransactionCommit();
     bool TransactionRollback();
 
+    void StartProfiling();
+    void FinishProfiling();
+
     std::shared_ptr<SqlPreparedStatement> GetPreparedStatement(std::string const& name);
 
     // NOTE: You need to be very careful of the lifetime you pass into these std::functions.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds some calls that will allow profiling of SQL. 

## Steps to test these changes

With 10'000 accounts:
```cpp
    auto sql = SqlConnection();
    sql.StartProfiling();
    if (sql.Query("SELECT * FROM accounts;") != SQL_ERROR && sql.NumRows() && sql.NextRow())
    {
        std::ignore = sql.GetUIntData(0);
    }
    sql.FinishProfiling();
```

```
[12/30/22 15:46:43:355][world][info] SQL SHOW PROFILE:
Query: SELECT * FROM accounts;
| Status                  | Duration |
|=========================|==========|
| Starting                | 0.000017 |
| checking permissions    | 0.000007 |
| Opening tables          | 0.000011 |
| After opening tables    | 0.000003 |
| System lock             | 0.000003 |
| table lock              | 0.000004 |
| init                    | 0.000012 |
| Optimizing              | 0.000004 |
| Statistics              | 0.000006 |
| Preparing               | 0.000005 |
| Executing               | 0.000002 |
| Sending data            | 0.005573 |
| End of update loop      | 0.000011 |
| Query end               | 0.000003 |
| Commit                  | 0.000004 |
| closing tables          | 0.000003 |
| Unlocking tables        | 0.000002 |
| closing tables          | 0.000007 |
| Starting cleanup        | 0.000004 |
| Freeing items           | 0.000005 |
| Updating status         | 0.000017 |
| Reset for next command  | 0.000003 |
 (SqlConnection::FinishProfiling:669)
```