### PR TITLE
[Cleanup] Replace getn() with # and global scripts cleanup 

### DIFF
--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -252,8 +252,8 @@ xi.magian.deliveryCrateOnTrade = function(player, npc, trade)
     local items, itemsTrial = getItemsInTrade(trade)
 
     -- get size of tables
-    local nbitems = table.getn(items)
-    local nbitemsTrial = table.getn(itemsTrial)
+    local nbitems      = #items
+    local nbitemsTrial = #itemsTrial
 
     -- playerTrials = active trials for the player
     local nbTrialsPlayer = 0
@@ -272,8 +272,9 @@ xi.magian.deliveryCrateOnTrade = function(player, npc, trade)
 
     if nbitemsTrial >= 1 then
         for i, item in ipairs(itemsTrial) do
-            local trials = getPlayerTrialByItemId(player, item.id)
-            local nbtrials = table.getn(trials)
+            local trials   = getPlayerTrialByItemId(player, item.id)
+            local nbtrials = #trials
+
             if nbtrials > 0 then
                 currentTrial = trials[1]
                 currentTrialId = trials[1].trial

--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -13,27 +13,31 @@ xi.magian.trialCache = xi.magian.trialCache or {}
 -- creates table to track trial and progress per trial slot
 local function getPlayerTrials(player)
     local activeTrials = xi.magian.trialCache[player:getID()]
+
     if activeTrials then
         return activeTrials
     end
 
     activeTrials = {}
+
     for i = 1, 10 do
-        local trialBits = player:getCharVar("[trial]" .. i)
-        local trialId = bit.rshift(trialBits, 16)
-        local progression = bit.band(trialBits, 0xFFFF)
-        local trialSQL = GetMagianTrial(trialId)
+        local trialBits      = player:getCharVar("[trial]" .. i)
+        local trialId        = bit.rshift(trialBits, 16)
+        local progression    = bit.band(trialBits, 0xFFFF)
+        local trialSQL       = GetMagianTrial(trialId)
         local objectiveTotal = trialSQL.objectiveTotal or 0
-        activeTrials[i] = { trial = trialId, progress = progression, objectiveTotal = objectiveTotal }
+        activeTrials[i]      = { trial = trialId, progress = progression, objectiveTotal = objectiveTotal }
     end
 
     xi.magian.trialCache[player:getID()] = activeTrials
+
     return activeTrials
 end
 
 -- packs current trials into params for onTrigger
 local function parseParams(player)
     local paramTrials = {}
+
     for _, v in pairs(getPlayerTrials(player)) do
         if v.trial > 0 then
             table.insert(paramTrials, v.trial)
@@ -41,6 +45,7 @@ local function parseParams(player)
     end
 
     local params = { 0, 0, 0, 0, 0 }
+
     for i = 1, #paramTrials, 2 do
         params[(i + 1) / 2] = paramTrials[i] + bit.lshift((paramTrials[i + 1] or 0), 16)
     end
@@ -50,21 +55,23 @@ end
 
 -- trial id and progress
 local function getPlayerTrialByIndex(player, i)
-    local activeTrials = getPlayerTrials(player)
-    local progress = activeTrials[i] and activeTrials[i].progress
-    local trial = activeTrials[i] and activeTrials[i].trial
+    local activeTrials   = getPlayerTrials(player)
+    local progress       = activeTrials[i] and activeTrials[i].progress
+    local trial          = activeTrials[i] and activeTrials[i].trial
     local objectiveTotal = activeTrials[i] and activeTrials[i].objectiveTotal
+
     return trial, progress, objectiveTotal
 end
 
 -- Get the active trials who requires the item in parameter
 local function getPlayerTrialByItemId(player, itemId)
-    local trials = xi.magian.trials
+    local trials       = xi.magian.trials
     local trialsPlayer = getPlayerTrials(player)
     local resultTrials = {}
 
     for index, obj in pairs(trialsPlayer) do
         local trialId = obj.trial
+
         if
             trials[trialId] and
             trials[trialId].reqs and
@@ -89,12 +96,15 @@ local function setTrial(player, slot, trialId, progress)
         return
     end
 
-    local trialSQL = GetMagianTrial(trialId)
+    local trialSQL       = GetMagianTrial(trialId)
     local objectiveTotal = trialSQL.objectiveTotal or 0
-    activeTrials[slot].trial = trialId
-    activeTrials[slot].progress = progress or 0
+
+    activeTrials[slot].trial          = trialId
+    activeTrials[slot].progress       = progress or 0
     activeTrials[slot].objectiveTotal = objectiveTotal
+
     local trialBits = bit.lshift(trialId, 16) + progress
+
     player:setCharVar("[trial]" .. slot, trialBits)
 end
 
@@ -123,41 +133,48 @@ end
 
 -- builds augment params for required items
 local function reqAugmentParams(t)
-    local leftAug1 = bit.lshift(t.reqItemAugValue1, 11) + t.reqItemAug1
+    local leftAug1  = bit.lshift(t.reqItemAugValue1, 11) + t.reqItemAug1
     local rightAug1 = bit.lshift(t.reqItemAugValue2, 11) + t.reqItemAug2
-    local augBits1 = bit.lshift(leftAug1, 16) + rightAug1
-    local leftAug2 = bit.lshift(t.reqItemAugValue3, 11) + t.reqItemAug3
+    local augBits1  = bit.lshift(leftAug1, 16) + rightAug1
+    local leftAug2  = bit.lshift(t.reqItemAugValue3, 11) + t.reqItemAug3
     local rightAug2 = bit.lshift(t.reqItemAugValue4, 11) + t.reqItemAug4
-    local augBits2 = bit.lshift(leftAug2, 16) + rightAug2
+    local augBits2  = bit.lshift(leftAug2, 16) + rightAug2
+
     return augBits1, augBits2
 end
 
 -- builds augment params for reward items
 local function rewardAugmentParams(t)
-    local leftAug1 = bit.lshift(t.rewardItemAugValue1, 11) + t.rewardItemAug1
+    local leftAug1  = bit.lshift(t.rewardItemAugValue1, 11) + t.rewardItemAug1
     local rightAug1 = bit.lshift(t.rewardItemAugValue2, 11) + t.rewardItemAug2
-    local augBits1 = bit.lshift(leftAug1, 16) + rightAug1
-    local leftAug2 = bit.lshift(t.rewardItemAugValue3, 11) + t.rewardItemAug3
+    local augBits1  = bit.lshift(leftAug1, 16) + rightAug1
+    local leftAug2  = bit.lshift(t.rewardItemAugValue3, 11) + t.rewardItemAug3
     local rightAug2 = bit.lshift(t.rewardItemAugValue4, 11) + t.rewardItemAug4
-    local augBits2 = bit.lshift(leftAug2, 16) + rightAug2
+    local augBits2  = bit.lshift(leftAug2, 16) + rightAug2
+
     return augBits1, augBits2
 end
 
 local function checkAndSetProgression(player, trialId, conditions, multiplier)
-    local trials = xi.magian.trials
+    local trials                   = xi.magian.trials
     local cachePosition, cacheData = hasTrial(player, trialId)
+
     if trialId and cachePosition then
         local increment = trials[trialId]:check(player, conditions)
+
         if increment > 0 then
             if cacheData.progress < cacheData.objectiveTotal then
-                local newProgress = math.min(cacheData.progress + (increment * multiplier), cacheData.objectiveTotal)
+                local newProgress         = math.min(cacheData.progress + (increment * multiplier), cacheData.objectiveTotal)
                 local remainingObjectives = cacheData.objectiveTotal - newProgress
+
                 setTrial(player, cachePosition, trialId, newProgress)
+
                 if remainingObjectives == 0 then
                     player:messageBasic(xi.msg.basic.MAGIAN_TRIAL_COMPLETE, trialId) -- trial complete
                 else
                     player:messageBasic(xi.msg.basic.MAGIAN_TRIAL_COMPLETE - 1, trialId, remainingObjectives) -- trial <trialid>: x objectives remain
                 end
+
             elseif cacheData.progress > cacheData.objectiveTotal then
                 setTrial(player, cachePosition, trialId, cacheData.objectiveTotal)
             end
@@ -167,6 +184,7 @@ end
 
 local function checkItemIdExistsInTable(table, itemId)
     local exists = false
+
     for index, v in ipairs(table) do
         if not exists and v.id == itemId then
             exists = true
@@ -178,12 +196,13 @@ end
 
 local function getItemsInTrade(trade)
     local itemsTrials = { }
-    local otherItems = { }
+    local otherItems  = { }
 
     for i = 0, 7 do
         local item = trade:getItem(i)
+
         if item then
-            local itemId = item:getID()
+            local itemId      = item:getID()
             local trialNumber = item:getTrialNumber()
 
             if trialNumber ~= 0 then
@@ -242,7 +261,8 @@ end
 
 xi.magian.deliveryCrateOnTrigger = function(player, npc)
     local zoneid = player:getZoneID()
-    local msg = zones[zoneid].text
+    local msg    = zones[zoneid].text
+
     player:messageSpecial(msg.DELIVERY_CRATE_TEXT)
 end
 
@@ -263,7 +283,7 @@ xi.magian.deliveryCrateOnTrade = function(player, npc, trade)
     local currentItemTrial = nil
 
     -- currentTrial = trial use for event
-    local currentTrial = nil
+    local currentTrial   = nil
     local currentTrialId = 0
 
     if nbitemsTrial == 0 then
@@ -292,7 +312,8 @@ xi.magian.deliveryCrateOnTrade = function(player, npc, trade)
         currentItem = items[1]
     end
 
-    local nbOverItems = (currentTrial.objectiveTotal - (currentTrial.progress + currentItemTrial.quantity)) * -1
+    local nbOverItems = (currentTrial.objectiveTotal - currentTrial.progress + currentItemTrial.quantity) * -1
+
     if nbOverItems > 0 then
         player:addItem(currentItemTrial.id, nbOverItems)
         currentItemTrial.quantity = currentItemTrial.quantity - nbOverItems
@@ -312,53 +333,58 @@ xi.magian.deliveryCrateOnTrade = function(player, npc, trade)
 end
 
 xi.magian.deliveryCrateOnEventUpdate = function(player, csid, option)
-    local optionMod = bit.band(option, 0xFF)
-    local itemTrialId = player:getLocalVar("storeItemTrialId")
+    local optionMod      = bit.band(option, 0xFF)
+    local itemTrialId    = player:getLocalVar("storeItemTrialId")
     local nbTrialsPlayer = player:getLocalVar("storeNbTrialsPlayer")
-    local maxNumber = 31
+    local maxNumber      = 31
 
-    if csid == 10134 and optionMod == 101 then
-        player:updateEvent(itemTrialId, 0, 0, 0, 0, 0, maxNumber, 0)
-    end
+    if csid == 10134 then
+        if optionMod == 101 then
+            player:updateEvent(itemTrialId, 0, 0, 0, 0, 0, maxNumber, 0)
 
-    if csid == 10134 and optionMod == 103 then
-        local places = bit.rshift(maxNumber, nbTrialsPlayer)
-        local trials = getPlayerTrialByItemId(player, itemTrialId)
+        elseif optionMod == 103 then
+            local places = bit.rshift(maxNumber, nbTrialsPlayer)
+            local trials = getPlayerTrialByItemId(player, itemTrialId)
+            local trialBits = getTrialsBits(player, trials)
 
-        local trialBits = getTrialsBits(player, trials)
-        player:updateEvent(trialBits[1], trialBits[2], trialBits[3], trialBits[4], trialBits[5], nbTrialsPlayer, places, 0)
+            player:updateEvent(trialBits[1], trialBits[2], trialBits[3], trialBits[4], trialBits[5], nbTrialsPlayer, places, 0)
+        end
     end
 end
 
 xi.magian.deliveryCrateOnEventFinish = function(player, csid, option)
-    local optionMod = bit.band(option, 0xFF)
-    local zoneid = player:getZoneID()
-    local msg = zones[zoneid].text
-    local trialId = bit.rshift(option, 8)
-    local itemTrialId = player:getLocalVar("storeItemTrialId")
+    local optionMod         = bit.band(option, 0xFF)
+    local zoneid            = player:getZoneID()
+    local msg               = zones[zoneid].text
+    local trialId           = bit.rshift(option, 8)
+    local itemTrialId       = player:getLocalVar("storeItemTrialId")
     local itemTrialQuantity = player:getLocalVar("storeItemTrialQty")
-    local nbTrialsPlayer = player:getLocalVar("storeNbTrialsPlayer")
-    local itemId = player:getLocalVar("storeItemId")
+    local nbTrialsPlayer    = player:getLocalVar("storeNbTrialsPlayer")
+    local itemId            = player:getLocalVar("storeItemId")
 
-    if csid == 10134 and optionMod == 0 then
-        player:addItem(itemTrialId, itemTrialQuantity)
-        player:messageSpecial(msg.RETURN_ITEM, itemTrialId)
-
-    elseif csid == 10134 and optionMod == 102 then
-        checkAndSetProgression(player, trialId, { itemId = itemTrialId, quantity = itemTrialQuantity }, xi.settings.main.MAGIAN_TRIALS_TRADE_MULTIPLIER)
-    end
-
-    if  csid == 10134 and (optionMod == 0 or optionMod == 102) then
-        if itemId ~= 0 and nbTrialsPlayer > 0 then
-            local t = GetMagianTrial(trialId)
-            player:addItem(t.reqItem, 1, t.reqItemAug1, t.reqItemAugValue1, t.reqItemAug2, t.reqItemAugValue2, t.reqItemAug3, t.reqItemAugValue3, t.reqItemAug4, t.reqItemAugValue4, trialId)
+    if csid == 10134 then
+        if optionMod == 0 then
+            player:addItem(itemTrialId, itemTrialQuantity)
+            player:messageSpecial(msg.RETURN_ITEM, itemTrialId)
+        elseif optionMod == 102 then
+            checkAndSetProgression(player, trialId, { itemId = itemTrialId, quantity = itemTrialQuantity }, xi.settings.main.MAGIAN_TRIALS_TRADE_MULTIPLIER)
         end
 
-        player:setLocalVar("storeTrialId", 0)
-        player:setLocalVar("storeItemId", 0)
-        player:setLocalVar("storeItemTrialId", 0)
-        player:setLocalVar("storeItemTrialQty", 0)
-        player:setLocalVar("storeNbTrialsPlayer", 0)
+        if
+            optionMod == 0 or
+            optionMod == 102
+        then
+            if itemId ~= 0 and nbTrialsPlayer > 0 then
+                local t = GetMagianTrial(trialId)
+                player:addItem(t.reqItem, 1, t.reqItemAug1, t.reqItemAugValue1, t.reqItemAug2, t.reqItemAugValue2, t.reqItemAug3, t.reqItemAugValue3, t.reqItemAug4, t.reqItemAugValue4, trialId)
+            end
+
+            player:setLocalVar("storeTrialId", 0)
+            player:setLocalVar("storeItemId", 0)
+            player:setLocalVar("storeItemTrialId", 0)
+            player:setLocalVar("storeItemTrialQty", 0)
+            player:setLocalVar("storeNbTrialsPlayer", 0)
+        end
     end
 end
 
@@ -366,6 +392,7 @@ end
 xi.magian.checkMagianTrial = function(player, conditions)
     for _, slot in pairs({ xi.slot.MAIN, xi.slot.SUB, xi.slot.RANGED }) do
         local trialIdOnItem = player:getEquippedItem(slot) and player:getEquippedItem(slot):getTrialNumber()
+
         if trialIdOnItem ~= 0 then
             checkAndSetProgression(player, trialIdOnItem, conditions, xi.settings.main.MAGIAN_TRIALS_MOBKILL_MULTIPLIER)
         end
@@ -375,7 +402,6 @@ end
 -----------------------------------
 -- Magian Orange / Blue
 -----------------------------------
-
 xi.magian.magianOnTrigger = function(player, npc, EVENT_IDS)
     local p, t = parseParams(player)
 
@@ -391,14 +417,14 @@ xi.magian.magianOnTrigger = function(player, npc, EVENT_IDS)
 end
 
 xi.magian.magianOnTrade = function(player, npc, trade, TYPE, EVENT_IDS)
-    local itemId = trade:getItemId()
-    local item = trade:getItem()
+    local itemId  = trade:getItemId()
+    local item    = trade:getItem()
     local matchId = item:getMatchingTrials()
     local trialId = item:getTrialNumber()
-    local t = GetMagianTrial(trialId)
-    local zoneid = player:getZoneID()
-    local msg = zones[zoneid].text
-    local _, pt = parseParams(player)
+    local t       = GetMagianTrial(trialId)
+    local zoneid  = player:getZoneID()
+    local msg     = zones[zoneid].text
+    local _, pt   = parseParams(player)
 
     player:setLocalVar("storeItemId", itemId)
 
@@ -406,11 +432,13 @@ xi.magian.magianOnTrade = function(player, npc, trade, TYPE, EVENT_IDS)
         if not next(matchId) and item:isType(TYPE) then
             player:setLocalVar("invalidItem", 1)
             player:startEvent(EVENT_IDS[4], 0, 0, 0, 0, 0, 0, 0, utils.MAX_UINT32) -- invalid weapon
+
             return
 
         -- player can only keep 10 trials at once
         elseif pt >= 10 and trialId == 0 then
             player:startEvent(EVENT_IDS[4], 0, 0, 0, 0, 0, 0, 0, utils.MAX_UINT32 - 254)
+
             return
 
         elseif trialId ~= 0 then
@@ -418,6 +446,7 @@ xi.magian.magianOnTrade = function(player, npc, trade, TYPE, EVENT_IDS)
                 if v.trial == trialId then
                     player:setLocalVar("storeTrialId", trialId)
                     player:tradeComplete()
+
                     if v.progress >= t.objectiveTotal then
                         player:startEvent(EVENT_IDS[6], 0, 0, 0, t.rewardItem, 0, 0, 0, itemId) -- completes trial
                     else
@@ -432,12 +461,14 @@ xi.magian.magianOnTrade = function(player, npc, trade, TYPE, EVENT_IDS)
             player:setLocalVar("storeTrialId", trialId)
             player:startEvent(EVENT_IDS[5], trialId, t.reqItem, 0, 0, 0, 0, 0, utils.MAX_UINT32 - 2)
             player:tradeComplete()
+
             return
 
         elseif next(matchId) then
             player:setLocalVar("storeTrialId", matchId[1])
             player:tradeComplete()
             player:startEvent(EVENT_IDS[4], matchId[1], matchId[2], matchId[3], matchId[4], 0, itemId) -- starts trial
+
             return
         else
             player:messageSpecial(msg.ITEM_NOT_WEAPON_MAGIAN) -- item traded isn't a weapon
@@ -455,42 +486,58 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
     switch (optionMod): caseof
     {
         [1] = function()
-            if csid == EVENT_IDS[3] or csid == EVENT_IDS[4] or csid == EVENT_IDS[5] then
+            if
+                csid == EVENT_IDS[3] or
+                csid == EVENT_IDS[4] or
+                csid == EVENT_IDS[5]
+            then
                 local trialId = bit.rshift(option, 16)
-                local t = GetMagianTrial(trialId)
-                local a1, a2 = reqAugmentParams(t)
-                local itemId = getItemIdByTrials(trialId)
+                local t       = GetMagianTrial(trialId)
+                local a1, a2  = reqAugmentParams(t)
+                local itemId  = getItemIdByTrials(trialId)
 
                 player:updateEvent(2, a1, a2, t.reqItem, 0, itemId, t.trialTarget)
             end
         end,
 
         [2] = function()
-            if csid == EVENT_IDS[3] or csid == EVENT_IDS[4] or csid == EVENT_IDS[5] then
-                local trialId = bit.rshift(option, 16)
-                local t = GetMagianTrial(trialId)
+            if
+                csid == EVENT_IDS[3] or
+                csid == EVENT_IDS[4] or
+                csid == EVENT_IDS[5]
+            then
+                local trialId      = bit.rshift(option, 16)
+                local t            = GetMagianTrial(trialId)
                 local _, cacheData = hasTrial(player, trialId)
-                local progress = cacheData and cacheData.progress or 0
-                local itemId = getItemIdByTrials(trialId)
+                local progress     = cacheData and cacheData.progress or 0
+                local itemId       = getItemIdByTrials(trialId)
 
                 player:updateEvent(t.objectiveTotal, 0, progress, 0, 0, itemId, t.element)
             end
         end,
 
         [3] = function()
-            if csid == EVENT_IDS[3] or csid == EVENT_IDS[4] or csid == EVENT_IDS[5] then
+            if
+                csid == EVENT_IDS[3] or
+                csid == EVENT_IDS[4] or
+                csid == EVENT_IDS[5]
+            then
                 local trialId = bit.rshift(option, 16)
-                local t = GetMagianTrial(trialId)
-                local a1, a2 = rewardAugmentParams(t)
+                local t       = GetMagianTrial(trialId)
+                local a1, a2  = rewardAugmentParams(t)
 
                 player:updateEvent(2, a1, a2, t.rewardItem, 0, t.objectiveItem)
             end
         end,
 
         [4] = function()
-            if csid == EVENT_IDS[3] or csid == EVENT_IDS[4] or csid == EVENT_IDS[5] then
+            if
+                csid == EVENT_IDS[3] or
+                csid == EVENT_IDS[4] or
+                csid == EVENT_IDS[5]
+            then
                 local trialId = bit.rshift(option, 16)
-                local t = GetMagianTrial(trialId)
+                local t       = GetMagianTrial(trialId)
                 local results = GetMagianTrialsWithParent(trialId)
 
                 if results then
@@ -512,7 +559,7 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         [6] = function()
             if csid == EVENT_IDS[3] then
                 local trialId = bit.rshift(option, 8)
-                local slot = hasTrial(player, trialId)
+                local slot    = hasTrial(player, trialId)
 
                 if slot then
                     player:updateEvent(0, 0, 0, 0, 0, slot)
@@ -525,9 +572,9 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         [7] = function()
             if csid == EVENT_IDS[4] then
                 local trialId = bit.rshift(option, 8)
-                local t = GetMagianTrial(trialId)
-                local a1, a2 = reqAugmentParams(t)
-                local slot = hasTrial(player, trialId)
+                local t       = GetMagianTrial(trialId)
+                local a1, a2  = reqAugmentParams(t)
+                local slot    = hasTrial(player, trialId)
 
                 if slot then
                     player:updateEvent(0, 0, 0, 0, 0, 0, 0, utils.MAX_UINT32)
@@ -542,7 +589,7 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         [8] = function()
             if csid == EVENT_IDS[5] then
                 local trialId = bit.rshift(option, 8)
-                local t = GetMagianTrial(trialId)
+                local t       = GetMagianTrial(trialId)
 
                 player:updateEvent(0, 0, 0, t.reqItem)
             end
@@ -551,7 +598,7 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         [11] = function()
             if csid == EVENT_IDS[5] then
                 local trialId = bit.rshift(option, 8)
-                local t = GetMagianTrial(trialId)
+                local t       = GetMagianTrial(trialId)
 
                 player:updateEvent(0, 0, 0, t.reqItem)
             end
@@ -560,9 +607,9 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         -- Checks if item's level will increase
         [13] = function()
             if csid == EVENT_IDS[4] then
-                local trialId = bit.rshift(option, 8)
-                local t = GetMagianTrial(trialId)
-                local reqItem = GetReadOnlyItem(t.reqItem)
+                local trialId    = bit.rshift(option, 8)
+                local t          = GetMagianTrial(trialId)
+                local reqItem    = GetReadOnlyItem(t.reqItem)
                 local rewardItem = GetReadOnlyItem(t.rewardItem)
 
                 if reqItem:getReqLvl() < rewardItem:getReqLvl() then
@@ -577,7 +624,7 @@ xi.magian.magianEventUpdate = function(player, csid, option, EVENT_IDS)
         [14] = function()
             if csid == EVENT_IDS[4] then
                 local trialId = bit.rshift(option, 8)
-                local t = GetMagianTrial(trialId)
+                local t       = GetMagianTrial(trialId)
 
                 if player:hasItem(t.rewardItem) and rareItems[t.rewardItem] then
                     player:updateEvent(1)
@@ -591,18 +638,25 @@ end
 
 xi.magian.magianOnEventFinish = function(player, csid, option, EVENT_IDS)
     local optionMod = bit.band(option, 0xFF)
-    local zoneid = player:getZoneID()
-    local msg = zones[zoneid].text
-    local ID = require("scripts/zones/RuLude_Gardens/IDs")
+    local zoneid    = player:getZoneID()
+    local msg       = zones[zoneid].text
+    local ID        = require("scripts/zones/RuLude_Gardens/IDs")
 
-    if csid == EVENT_IDS[2] and option == 1 then
+    if
+        csid == EVENT_IDS[2] and
+        option == 1
+    then
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.MAGIAN_TRIAL_LOG)
         player:addKeyItem(xi.ki.MAGIAN_TRIAL_LOG)
 
     -- starts a trial
-    elseif csid == EVENT_IDS[4] and optionMod == 7 then
+    elseif
+        csid == EVENT_IDS[4] and
+        optionMod == 7
+    then
         local trialId = bit.rshift(option, 8)
-        local t = GetMagianTrial(trialId)
+        local t       = GetMagianTrial(trialId)
+
         player:addItem(t.reqItem, 1, t.reqItemAug1, t.reqItemAugValue1, t.reqItemAug2, t.reqItemAugValue2, t.reqItemAug3, t.reqItemAugValue3, t.reqItemAug4, t.reqItemAugValue4, trialId)
         player:messageSpecial(msg.RETURN_MAGIAN_ITEM, t.reqItem)
         setTrial(player, firstEmptySlot(player), trialId, 0)
@@ -610,17 +664,25 @@ xi.magian.magianOnEventFinish = function(player, csid, option, EVENT_IDS)
         player:setLocalVar("storeItemId", 0)
 
     -- returns item to player
-    elseif csid == EVENT_IDS[5] and (optionMod == 0 or optionMod == 4) then
+    elseif
+        csid == EVENT_IDS[5] and
+        (optionMod == 0 or optionMod == 4)
+    then
         local trialId = player:getLocalVar("storeTrialId")
-        local t = GetMagianTrial(trialId)
+        local t       = GetMagianTrial(trialId)
+
         player:addItem(t.reqItem, 1, t.reqItemAug1, t.reqItemAugValue1, t.reqItemAug2, t.reqItemAugValue2, t.reqItemAug3, t.reqItemAugValue3, t.reqItemAug4, t.reqItemAugValue4, trialId)
         player:messageSpecial(msg.RETURN_MAGIAN_ITEM, t.reqItem)
         player:setLocalVar("storeTrialId", 0)
 
-    elseif csid == EVENT_IDS[4] and (optionMod == 0 or option == utils.MAX_UINT32) then
+    elseif
+        csid == EVENT_IDS[4] and
+        (optionMod == 0 or option == utils.MAX_UINT32)
+    then
         local trialId = player:getLocalVar("storeTrialId")
-        local itemId = player:getLocalVar("storeItemId")
-        local t = GetMagianTrial(trialId)
+        local itemId  = player:getLocalVar("storeItemId")
+        local t       = GetMagianTrial(trialId)
+
         if player:getLocalVar("invalidItem") ~= 1 then
             player:addItem(t.reqItem, 1, t.reqItemAug1, t.reqItemAugValue1, t.reqItemAug2, t.reqItemAugValue2, t.reqItemAug3, t.reqItemAugValue3, t.reqItemAug4, t.reqItemAugValue4, trialId)
         end
@@ -631,9 +693,13 @@ xi.magian.magianOnEventFinish = function(player, csid, option, EVENT_IDS)
         player:setLocalVar("storeItemId", 0)
 
     -- gives back item after removing trial id
-    elseif csid == EVENT_IDS[5] and (optionMod == 8 or optionMod == 11) then
+    elseif
+        csid == EVENT_IDS[5] and
+        (optionMod == 8 or optionMod == 11)
+    then
         local trialId = bit.rshift(option, 8)
-        local t = GetMagianTrial(trialId)
+        local t       = GetMagianTrial(trialId)
+
         for i = 1, 10 do
             local tr, _, _ = getPlayerTrialByIndex(player, i)
             if tr == trialId then
@@ -646,9 +712,13 @@ xi.magian.magianOnEventFinish = function(player, csid, option, EVENT_IDS)
         player:messageSpecial(msg.RETURN_MAGIAN_ITEM, t.reqItem)
 
     -- finishes a trial
-    elseif csid == EVENT_IDS[6] and optionMod == 0 then
+    elseif
+        csid == EVENT_IDS[6] and
+        optionMod == 0
+    then
         local trialId = player:getLocalVar("storeTrialId")
-        local slot = hasTrial(player, trialId)
+        local slot    = hasTrial(player, trialId)
+
         if slot then
             setTrial(player, slot, 0, 0)
         end

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1088,9 +1088,9 @@ xi.regime.bookOnTrigger = function(player, regimeType)
         -- arg2 is a bitmask that controls which pages appear for examination
         -- here, we only show pages that have regime info
         -- arg4 reduces prices of field suppord
-        local pages = table.getn(info.page)
-        local arg2 = 0
-        local arg4 = 0
+        local pages = #info.page
+        local arg2  = 0
+        local arg4  = 0
 
         for i = 1, 10 do
             if i > pages then

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -17,16 +17,16 @@ xi.treasure = xi.treasure or {}
 
 xi.treasure.type =
 {
-    CHEST   = 1,
-    COFFER  = 2,
+    CHEST  = 1,
+    COFFER = 2,
 }
 
 local keyType =
 {
-    ZONE_KEY      = 1,
-    THIEF_TOOLS   = 2,
-    SKELETON_KEY  = 3,
-    LIVING_KEY    = 4,
+    ZONE_KEY     = 1,
+    THIEF_TOOLS  = 2,
+    SKELETON_KEY = 3,
+    LIVING_KEY   = 4,
 }
 
 local thiefKeyInfo =

--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1655,12 +1655,12 @@ xi.treasure.onTrade = function(player, npc, trade, chestType)
 
     -- gem
     elseif roll <= (info.gil[1] + info.gem[1]) then
-        local gemIndex = math.random(table.getn(info.gem) - 1) + 1
+        local gemIndex = math.random(#info.gem - 1) + 1
         player:addTreasure(info.gem[gemIndex], npc)
 
     -- item
     elseif info.item then
-        local itemIndex = math.random(table.getn(info.item) - 1) + 1
+        local itemIndex = math.random(#info.item - 1) + 1
         player:addTreasure(info.item[itemIndex], npc)
     end
 

--- a/scripts/globals/voidwalker.lua
+++ b/scripts/globals/voidwalker.lua
@@ -90,7 +90,7 @@ local function removeMobIdFromPos(zoneId, mobId)
 end
 
 local function searchEmptyPos(zoneId)
-    local maxPos = table.getn(xi.voidwalker.pos[zoneId])
+    local maxPos = #xi.voidwalker.pos[zoneId]
     local pos = math.random(1, maxPos)
     local currentPos = xi.voidwalker.pos[zoneId][pos]
     if currentPos.mobId == nil then
@@ -126,7 +126,7 @@ local getNearestMob = function(player, mobs)
         return a.distance < b.distance
     end)
 
-    if table.getn(results) > 0 then
+    if #results > 0 then
         return results[1]
     else
         return nil
@@ -481,7 +481,7 @@ xi.voidwalker.onHealing = function(player)
     local abyssites = getCurrentKIsFromPlayer(player)
 
     if
-        table.getn(abyssites) == 0 or
+        #abyssites == 0 or
         not zones[zoneId].mob or
         not zones[zoneId].mob.VOIDWALKER
     then

--- a/scripts/globals/voidwalker.lua
+++ b/scripts/globals/voidwalker.lua
@@ -7,6 +7,7 @@ require("scripts/globals/settings")
 require("scripts/globals/status")
 require("scripts/globals/voidwalkerpos")
 require("scripts/globals/zone")
+-----------------------------------
 
 xi = xi or {}
 xi.voidwalker = xi.voidwalker or {}
@@ -38,6 +39,7 @@ local abyssiteMessage =
 
 local function getCurrentKIsBitsFromPlayer(player)
     local results = 0
+
     for i, keyitem in ipairs(abyssiteKeyitems) do
         local currentBit = 0
         if player:hasKeyItem(keyitem) then
@@ -52,6 +54,7 @@ end
 
 local function getCurrentKIsFromPlayer(player)
     local results = {}
+
     for i, keyitem in ipairs(abyssiteKeyitems) do
         if player:hasKeyItem(keyitem) then
             table.insert(results, keyitem)
@@ -63,6 +66,7 @@ end
 
 local function getMobsFromAbyssites(zoneId, abyssites)
     local results = {}
+
     for i, keyitem in ipairs(abyssites) do
         if
             zones[zoneId] and
@@ -71,6 +75,7 @@ local function getMobsFromAbyssites(zoneId, abyssites)
         then
             for _, mobId in ipairs(zones[zoneId].mob.VOIDWALKER[keyitem]) do
                 local mob = GetMobByID(mobId)
+
                 if mob:isAlive() and mob:getLocalVar("[VoidWalker]PopedBy") == 0 then
                     table.insert(results, { mobId = mobId, keyItem = keyitem })
                 end
@@ -90,9 +95,10 @@ local function removeMobIdFromPos(zoneId, mobId)
 end
 
 local function searchEmptyPos(zoneId)
-    local maxPos = #xi.voidwalker.pos[zoneId]
-    local pos = math.random(1, maxPos)
+    local maxPos     = #xi.voidwalker.pos[zoneId]
+    local pos        = math.random(1, maxPos)
     local currentPos = xi.voidwalker.pos[zoneId][pos]
+
     if currentPos.mobId == nil then
         return pos
     else
@@ -102,23 +108,30 @@ end
 
 local function setRandomPos(zoneId, mobId)
     local mob = GetMobByID(mobId)
-    if not mob or not xi.voidwalker.pos[zoneId] then
+
+    if
+        not mob or
+        not xi.voidwalker.pos[zoneId]
+    then
         return
     end
 
     local pos = searchEmptyPos(zoneId)
 
     xi.voidwalker.pos[zoneId][pos].mobId = mobId
-    local vPos = xi.voidwalker.pos[zoneId][pos].pos
+    local vPos                           = xi.voidwalker.pos[zoneId][pos].pos
+
     mob:setSpawn(vPos[1], vPos[2], vPos[3])
     mob:setPos(vPos[1], vPos[2], vPos[3])
 end
 
 local getNearestMob = function(player, mobs)
     local results = {}
+
     for _, v in ipairs(mobs) do
-        local mob = GetMobByID(v.mobId)
+        local mob      = GetMobByID(v.mobId)
         local distance = player:checkDistance(mob)
+
         table.insert(results, { mobId = v.mobId, keyItem = v.keyItem, distance = distance })
     end
 
@@ -135,34 +148,50 @@ end
 
 local getDirection = function(player, mob, distance)
     local posPlayer = player:getPos()
-    local posMob = mob:getPos()
-    local diffx = posMob.x - posPlayer.x
-    local diffz = posMob.z - posPlayer.z
+    local posMob    = mob:getPos()
+    local diffx     = posMob.x - posPlayer.x
+    local diffz     = posMob.z - posPlayer.z
+    local tan       = math.atan(diffz / diffx)
+    local degree    = math.deg(tan)
 
-    local tan = math.atan(diffz / diffx)
-    local degree = math.deg(tan)
     if degree < 0 then
         degree = degree * -1
     end
 
     local minDegree = 20
     local maxDegree = 70
-    if diffz >= 0 and degree >= maxDegree then
-        return 6
-    elseif diffz <= 0 and degree >= maxDegree then
-        return 2
-    elseif diffx <= 0 and degree <= minDegree then
-        return 4
-    elseif diffx >= 0 and degree <= minDegree then
-        return 0
-    elseif diffz >= 0 and diffx <= 0 and degree <= maxDegree and degree >= minDegree then
-        return 5
-    elseif diffz >= 0 and diffx >= 0 and degree <= maxDegree and degree >= minDegree then
-        return 7
-    elseif diffz <= 0 and diffx <= 0 and degree <= maxDegree and degree >= minDegree then
-        return 3
-    elseif diffz <= 0 and diffx >= 0 and degree <= maxDegree and degree >= minDegree then
-        return 1
+
+    -- Degree >= 70
+    if degree >= maxDegree then
+        if diffz >= 0 then
+            return 6
+        else
+            return 2
+        end
+
+    -- Degree <= 20
+    elseif degree <= minDegree then
+        if diffx >= 0 then
+            return 0
+        else
+            return 4
+        end
+
+    -- Degree between 20 and 70
+    else
+        if diffz >= 0 then
+            if diffx >= 0 then
+                return 7
+            else
+                return 5
+            end
+        else
+            if diffx >= 0 then
+                return 1
+            else
+                return 3
+            end
+        end
     end
 end
 
@@ -170,10 +199,13 @@ end
 -- check keyitem upgrade
 -----------------------------------
 local function checkUpgrade(player, mob, nextKeyItem)
-    if player and mob:getZoneID() == player:getZoneID() then
-        local zoneTextTable = zones[mob:getZoneID()].text
+    if
+        player and
+        mob:getZoneID() == player:getZoneID()
+    then
+        local zoneTextTable  = zones[mob:getZoneID()].text
         local currentKeyItem = mob:getLocalVar("[VoidWalker]PopedWith")
-        local rand = math.random(1, 10)
+        local rand           = math.random(1, 10)
 
         if rand == 5 then
             if player:hasKeyItem(currentKeyItem) then
@@ -182,6 +214,7 @@ local function checkUpgrade(player, mob, nextKeyItem)
 
             if nextKeyItem then
                 player:addKeyItem(nextKeyItem)
+
                 if currentKeyItem == xi.keyItem.CLEAR_ABYSSITE then
                     player:messageSpecial(zoneTextTable.VOIDWALKER_UPGRADE_KI_1, currentKeyItem, nextKeyItem)
                 elseif currentKeyItem == xi.keyItem.COLORFUL_ABYSSITE then
@@ -208,9 +241,14 @@ end
 
 xi.voidwalker.npcOnEventUpdate = function(player, csid, option)
     local opt = bit.band(option, 0xF)
-    if csid == 10120 and opt == 3 then
+
+    if
+        csid == 10120 and
+        opt == 3
+    then
         local hasGil = player:getGil() >= 1000
-        local hasKi = player:hasKeyItem(xi.keyItem.CLEAR_ABYSSITE)
+        local hasKi  = player:hasKeyItem(xi.keyItem.CLEAR_ABYSSITE)
+
         if not hasGil then
             player:updateEvent(3)
         elseif hasKi then
@@ -223,15 +261,18 @@ end
 
 xi.voidwalker.npcOnEventFinish = function(player, csid, option)
     local opt = bit.band(option, 0xF)
-    if csid == 10120 and opt == 1 then
-        local msg = require("scripts/zones/RuLude_Gardens/IDs")
-        local ki = abyssiteKeyitems[1]
-        player:delGil(1000)
-        player:addKeyItem(ki)
-        player:messageSpecial(msg.text.KEYITEM_OBTAINED, ki)
-    elseif csid == 10120 and opt == 2 then
-        local numAbyssite = bit.rshift(option, 4)
-        player:delKeyItem(abyssiteKeyitems[numAbyssite])
+
+    if csid == 10120 then
+        if opt == 1 then
+            local msg = require("scripts/zones/RuLude_Gardens/IDs")
+            local ki  = abyssiteKeyitems[1]
+            player:delGil(1000)
+            player:addKeyItem(ki)
+            player:messageSpecial(msg.text.KEYITEM_OBTAINED, ki)
+        elseif opt == 2 then
+            local numAbyssite = bit.rshift(option, 4)
+            player:delKeyItem(abyssiteKeyitems[numAbyssite])
+        end
     end
 end
 
@@ -239,7 +280,7 @@ end
 -- Zone On Init
 -----------------------------------
 xi.voidwalker.zoneOnInit = function(zone)
-    local zoneId = zone:getID()
+    local zoneId         = zone:getID()
     local voidwalkerMobs = zones[zoneId].mob.VOIDWALKER
 
     for ki, mobs in pairs(voidwalkerMobs) do
@@ -251,6 +292,7 @@ end
 
 local mobIsBusy = function(mob)
     local act = mob:getCurrentAction()
+
     return  act == xi.act.MOBABILITY_START or
             act == xi.act.MOBABILITY_USING or
             act == xi.act.MOBABILITY_FINISH or
@@ -261,11 +303,19 @@ end
 
 local function doMobSkillEveryHPP(mob, every, start, mobskill, condition)
     local mobhpp = mob:getHPP()
-    if mobhpp <= start and condition then
-        local mobHppModulo = mobhpp % every
+
+    if
+        mobhpp <= start and
+        condition
+    then
+        local mobHppModulo   = mobhpp % every
         local startHppModulo = start % every
-        local isSame = startHppModulo == mobHppModulo
-        if isSame and mob:getLocalVar('MOB_SKILL_' .. mobhpp) == 0 then
+        local isSame         = startHppModulo == mobHppModulo
+
+        if
+            isSame and
+            mob:getLocalVar('MOB_SKILL_' .. mobhpp) == 0
+        then
             mob:useMobAbility(mobskill)
             mob:setLocalVar('MOB_SKILL_' .. mobhpp, 1)
         end
@@ -286,9 +336,11 @@ end
 
 local function DespawnPet(mob)
     local zoneId = mob:getZoneID()
-    local mobId = mob:getID()
+    local mobId  = mob:getID()
+
     if zones[zoneId].pet and zones[zoneId].pet[mobId] then
         local petIds = zones[zoneId].pet[mobId]
+
         for i, petId in ipairs(petIds) do
             local pet = GetMobByID(petId)
             DespawnMob(petId)
@@ -385,6 +437,7 @@ xi.voidwalker.onMobSpawn = function(mob)
     mob:hideName(true)
     mob:setUntargetable(true)
     local mods = modByMobName[mobName]
+
     if mods then
         mods(mob)
     end
@@ -392,14 +445,14 @@ end
 
 xi.voidwalker.onMobFight = function(mob, target)
     local mobName = mob:getName()
-    local mixin = mixinByMobName[mobName]
+    local mixin   = mixinByMobName[mobName]
 
     if mixin then
         mixin(mob)
     end
 
     local poptime = mob:getLocalVar("[VoidWalker]PopedAt")
-    local now = os.time()
+    local now     = os.time()
 
     if
         mob:isSpawned() and
@@ -431,7 +484,8 @@ end
 
 xi.voidwalker.onMobDespawn = function(mob)
     local zoneId = mob:getZoneID()
-    local mobId = mob:getID()
+    local mobId  = mob:getID()
+
     removeMobIdFromPos(zoneId, mobId)
     setRandomPos(zoneId, mobId)
     mob:setLocalVar("[VoidWalker]PopedBy", 0)
@@ -446,10 +500,12 @@ end
 xi.voidwalker.onMobDeath = function(mob, player, optParams, keyItem)
     if player then
         local popkeyitem = mob:getLocalVar("[VoidWalker]PopedWith")
+
         if optParams.isKiller then
             local playerpoped = GetPlayerByID(mob:getLocalVar("[VoidWalker]PopedBy"))
-            local alliance = player:getAlliance()
-            local outOfParty = true
+            local alliance    = player:getAlliance()
+            local outOfParty  = true
+
             for _, member in pairs(alliance) do
                 if member:getID() == playerpoped:getID() then
                     outOfParty = false
@@ -457,12 +513,18 @@ xi.voidwalker.onMobDeath = function(mob, player, optParams, keyItem)
                 end
             end
 
-            if outOfParty and not playerpoped:hasKeyItem(keyItem) then
+            if
+                outOfParty and
+                not playerpoped:hasKeyItem(keyItem)
+            then
                 checkUpgrade(playerpoped, mob, keyItem)
             end
         end
 
-        if player:hasKeyItem(popkeyitem) and not player:hasKeyItem(keyItem) then
+        if
+            player:hasKeyItem(popkeyitem) and
+            not player:hasKeyItem(keyItem)
+        then
             checkUpgrade(player, mob, keyItem)
         end
     end
@@ -476,9 +538,9 @@ xi.voidwalker.onHealing = function(player)
         return
     end
 
-    local zoneId = player:getZoneID()
+    local zoneId        = player:getZoneID()
     local zoneTextTable = zones[zoneId].text
-    local abyssites = getCurrentKIsFromPlayer(player)
+    local abyssites     = getCurrentKIsFromPlayer(player)
 
     if
         #abyssites == 0 or
@@ -488,7 +550,7 @@ xi.voidwalker.onHealing = function(player)
         return
     end
 
-    local mobs = getMobsFromAbyssites(zoneId, abyssites)
+    local mobs       = getMobsFromAbyssites(zoneId, abyssites)
     local mobNearest = getNearestMob(player, mobs)
 
     if not mobNearest then
@@ -498,6 +560,7 @@ xi.voidwalker.onHealing = function(player)
         mob:setLocalVar("[VoidWalker]PopedBy", player:getID())
         mob:setLocalVar("[VoidWalker]PopedWith", mobNearest.keyItem)
         mob:setLocalVar("[VoidWalker]PopedAt", os.time())
+
         if
             mobNearest.keyItem ~= xi.keyItem.CLEAR_ABYSSITE and
             mobNearest.keyItem ~= xi.keyItem.COLORFUL_ABYSSITE
@@ -513,10 +576,12 @@ xi.voidwalker.onHealing = function(player)
         mob:setUntargetable(false)
         mob:setStatus(xi.status.MOB)
         mob:updateClaim(player)
+
     elseif mobNearest.distance >= 300 then
         player:messageSpecial(zoneTextTable.VOIDWALKER_MOB_TOO_FAR, mobNearest.keyItem)
+
     else
-        local mob = GetMobByID(mobNearest.mobId)
+        local mob       = GetMobByID(mobNearest.mobId)
         local direction = getDirection(player, mob, mobNearest.distance)
         player:messageSpecial(zoneTextTable.VOIDWALKER_MOB_HINT, abyssiteMessage[mobNearest.keyItem], direction, mobNearest.distance, mobNearest.keyItem)
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Replaces all uses of `getn(x)` deprecated function with `#x`
- Cleans affected scripts
- Corrects a few bad uses of ">=" or "<=" in voidwalker file.

## Steps to test these changes

No changes should be noticed.
The important stuff is in commit 1 and the cleanup is commit 2