### PR TITLE
[Magic] Simplify base damage calculations for (converted) magic spells

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -729,15 +729,15 @@ xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, 
     local nukeAbsorbOrNullify = 1
 
     -- Calculate chance for spell absorption.
-    if math.random(1, 100) < (target:getMod(xi.magic.absorbMod[spellElement]) + 1) then
+    if math.random(1, 100) <= (target:getMod(xi.magic.absorbMod[spellElement]) + 1) then
         nukeAbsorbOrNullify = -1
     end
 
     -- Calculate chance for spell nullification.
     local nullifyChance = math.random(1, 100)
     if
-        nullifyChance < (target:getMod(nullMod[spellElement]) + 1) or
-        nullifyChance < target:getMod(xi.mod.MAGIC_NULL)
+        nullifyChance <= (target:getMod(nullMod[spellElement]) + 1) or
+        nullifyChance <= target:getMod(xi.mod.MAGIC_NULL)
     then
         nukeAbsorbOrNullify = 0
     end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -207,7 +207,10 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
     -----------------------------------
     -- STEP 1: baseSpellDamage (V)
     -----------------------------------
-    if caster:isPC() and not xi.settings.main.USE_OLD_MAGIC_DAMAGE then
+    if
+        caster:isPC() and
+        not xi.settings.main.USE_OLD_MAGIC_DAMAGE
+    then
         baseSpellDamage = pTable[spellId][vPC] -- vPC
     else
         baseSpellDamage = pTable[spellId][vNPC] -- vNPC
@@ -216,10 +219,11 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
     -----------------------------------
     -- STEP 2: statDiffBonus (statDiff * M)
     -----------------------------------
-    -- Player Elemental magic.
+    -- New System: Player Elemental magic. Setting for old system must be false.
     if
         skillType == xi.skill.ELEMENTAL_MAGIC and
-        caster:isPC()
+        caster:isPC() and
+        not xi.settings.main.USE_OLD_MAGIC_DAMAGE
     then
         local mTable =
         {
@@ -236,11 +240,13 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
             statDiffBonus = statDiffBonus + math.floor(utils.clamp(statDiff - mTable[i][1], 0, mTable[i][2]) * pTable[spellId][5 + i])
         end
 
-    -- Divine magic and Non-Player Elemental magic.
     -- TODO: Investigate "inflection point" (I) and its relation with the terms "soft cap" and "hard cap"
+
+    -- Old System: Divine magic, Non-Player Elemental magic and Player elemental magic IF setting for old system is used.
     elseif
         skillType == xi.skill.DIVINE_MAGIC or
-        (skillType == xi.skill.ELEMENTAL_MAGIC and not caster:isPC())
+        (skillType == xi.skill.ELEMENTAL_MAGIC and not caster:isPC()) or                                    -- Mobs always use old system
+        (skillType == xi.skill.ELEMENTAL_MAGIC and caster:isPC() and xi.settings.main.USE_OLD_MAGIC_DAMAGE) -- Players use old system only when setting is enabled.
     then
         local spellMultiplier = pTable[spellId][mNPC]            -- M
         local inflexionPoint  = pTable[spellId][inflectionPoint] -- I
@@ -253,7 +259,7 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
             statDiffBonus = math.floor(inflexionPoint * spellMultiplier) + math.floor((statDiff - inflexionPoint) * spellMultiplier / 2)
         end
 
-    -- Ninjutsu.
+    -- Old System: Ninjutsu. "I" (Infection point) isn't used due to lack of information. Values in table are currently made up and unused.
     elseif skillType == xi.skill.NINJUTSU then
         statDiffBonus = math.floor(statDiff * pTable[spellId][mNPC])
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Simplifies the logic to calculate spell base damage based on stat diff.
- Make "old school setting" affect player spell base damage (stat diff step) when turned on.

## Steps to test these changes

With default settings, no changes should be observed, but reading whats happening should be simpler.
With setting enabled, player spell damage should be equal to mob.
