### PR TITLE
[core] Add broader filters for logging

### DIFF
--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -37,12 +37,20 @@ xi.settings.logging =
     --]]
     PATTERN = "[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)",
 
-    DEBUG_SOCKETS        = false,
-    DEBUG_NAVMESH        = false,
-    DEBUG_PACKETS        = false,
-    DEBUG_ACTIONS        = false,
-    DEBUG_SQL            = false,
-    DEBUG_ID_LOOKUP      = false,
-    DEBUG_MODULES        = false,
-    DEBUG_PACKET_BACKLOG = false,
+    -- Enable/Disable these logging types globally
+    LOG_DEBUG   = true,
+    LOG_INFO    = true,
+    LOG_WARNING = true,
+    LOG_LUA     = true, -- Prints from Lua using `print()`
+
+    -- Specific Debug loggers
+    -- NOTE: None of these will print unless you also have the above LOG_DEBUG setting set to true!
+    DEBUG_SOCKETS        = false, -- Calls in C++: DebugSockets(...)
+    DEBUG_NAVMESH        = false, -- Calls in C++: DebugNavmesh(...)
+    DEBUG_PACKETS        = false, -- Calls in C++: DebugPackets(...)
+    DEBUG_ACTIONS        = false, -- Calls in C++: DebugActions(...)
+    DEBUG_SQL            = false, -- Calls in C++: DebugSQL(...)
+    DEBUG_ID_LOOKUP      = false, -- Calls in C++: DebugIDLookup(...)
+    DEBUG_MODULES        = false, -- Calls in C++: DebugModules(...)
+    DEBUG_PACKET_BACKLOG = false, -- Special logic in map.cpp::send_parse
 }

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -110,16 +110,13 @@ public:
 namespace logging
 {
     const std::vector<std::string> logNames = {
-        // Regular loggers
         "critical",
         "error",
+        "lua",
         "warn",
         "info",
         "debug",
         "trace",
-
-        // Special loggers
-        "lua",
     };
 
     void InitializeLog(std::string const& serverName, std::string const& logFile, bool appendDate)

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -27,6 +27,8 @@
 #include <string>
 
 // Set this higher to strip out lower messages at compile time
+// NOTE: We don't strip anything by default, as we use all the logger
+//     : levels for different things.
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 
 #include "spdlog/spdlog.h"
@@ -80,25 +82,31 @@ namespace logging
         }                                                                                                             \
     }
 
-// Regular Loggers
-#define ShowTrace(...)    BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_TRACE(spdlog::get("trace"), _msgStr); } END_CATCH_HANDLER
-#define ShowDebug(...)    BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_DEBUG(spdlog::get("debug"), _msgStr); } END_CATCH_HANDLER
-#define ShowInfo(...)     BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_INFO(spdlog::get("info"), _msgStr); } END_CATCH_HANDLER
-#define ShowWarning(...)  BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_WARN(spdlog::get("warn"), _msgStr); } END_CATCH_HANDLER
-#define ShowError(...)    BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_ERROR(spdlog::get("error"), _msgStr); } END_CATCH_HANDLER
-#define ShowCritical(...) BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_CRITICAL(spdlog::get("critical"), _msgStr); } END_CATCH_HANDLER
+#define LOGGER_BODY(LOG_TYPE_MACRO, LogStringName, ...) \
+    BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER
 
-// Special Loggers
-#define ShowLua(...) BEGIN_CATCH_HANDLER { auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyMessageStr(_msgStr); SPDLOG_LOGGER_INFO(spdlog::get("lua"), _msgStr); } END_CATCH_HANDLER
+#define LOGGER_ENABLE(SettingsString, ...) \
+    if (settings::get<bool>(SettingsString)) { __VA_ARGS__ }
+
+// Regular Loggers
+// NOTE 1: Trace is not for logging to screen or file; it's for filling the crash backtrace buffer and reporting to Tracy.
+// NOTE 2: It isn't possible (or a good idea) to allow the user to disable TRACE, ERROR, or CRITICAL logging.
+#define ShowTrace(...)    LOGGER_BODY(SPDLOG_LOGGER_TRACE, "trace", __VA_ARGS__)
+#define ShowDebug(...)    LOGGER_ENABLE("logging.LOG_DEBUG", LOGGER_BODY(SPDLOG_LOGGER_DEBUG, "debug", __VA_ARGS__))
+#define ShowInfo(...)     LOGGER_ENABLE("logging.LOG_INFO", LOGGER_BODY(SPDLOG_LOGGER_INFO, "info", __VA_ARGS__))
+#define ShowWarning(...)  LOGGER_ENABLE("logging.LOG_WARNING", LOGGER_BODY(SPDLOG_LOGGER_WARN, "warn", __VA_ARGS__))
+#define ShowLua(...)      LOGGER_ENABLE("logging.LOG_LUA", LOGGER_BODY(SPDLOG_LOGGER_INFO, "lua", __VA_ARGS__))
+#define ShowError(...)    LOGGER_BODY(SPDLOG_LOGGER_ERROR, "error", __VA_ARGS__)
+#define ShowCritical(...) LOGGER_BODY(SPDLOG_LOGGER_CRITICAL, "critical", __VA_ARGS__)
 
 // Debug Loggers
-#define DebugSockets(...)  { if (settings::get<bool>("logging.DEBUG_SOCKETS"))   { ShowDebug(__VA_ARGS__); } }
-#define DebugNavmesh(...)  { if (settings::get<bool>("logging.DEBUG_NAVMESH"))   { ShowDebug(__VA_ARGS__); } }
-#define DebugPackets(...)  { if (settings::get<bool>("logging.DEBUG_PACKETS"))   { ShowDebug(__VA_ARGS__); } }
-#define DebugActions(...)  { if (settings::get<bool>("logging.DEBUG_ACTIONS"))   { ShowDebug(__VA_ARGS__); } }
-#define DebugSQL(...)      { if (settings::get<bool>("logging.DEBUG_SQL"))       { ShowDebug(__VA_ARGS__); } }
-#define DebugIDLookup(...) { if (settings::get<bool>("logging.DEBUG_ID_LOOKUP")) { ShowDebug(__VA_ARGS__); } }
-#define DebugModules(...)  { if (settings::get<bool>("logging.DEBUG_MODULES"))   { ShowDebug(__VA_ARGS__); } }
+#define DebugSockets(...)  LOGGER_ENABLE("logging.DEBUG_SOCKETS", ShowDebug(__VA_ARGS__))
+#define DebugNavmesh(...)  LOGGER_ENABLE("logging.DEBUG_NAVMESH", ShowDebug(__VA_ARGS__))
+#define DebugPackets(...)  LOGGER_ENABLE("logging.DEBUG_PACKETS", ShowDebug(__VA_ARGS__))
+#define DebugActions(...)  LOGGER_ENABLE("logging.DEBUG_ACTIONS", ShowDebug(__VA_ARGS__))
+#define DebugSQL(...)      LOGGER_ENABLE("logging.DEBUG_SQL", ShowDebug(__VA_ARGS__))
+#define DebugIDLookup(...) LOGGER_ENABLE("logging.DEBUG_ID_LOOKUP", ShowDebug(__VA_ARGS__))
+#define DebugModules(...)  LOGGER_ENABLE("logging.DEBUG_MODULES", ShowDebug(__VA_ARGS__))
 
 // Crash dump utils
 #define DumpBacktrace() spdlog::get("trace")->dump_backtrace()

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -342,7 +342,13 @@ int32 do_init(int32 argc, char** argv)
         fmt::print("Promoting {} to GM level {}\n", PChar->name, level);
         PChar->pushPacket(new CChatMessagePacket(PChar, MESSAGE_SYSTEM_3,
             fmt::format("You have been set to GM level {}.", level), ""));
+    });
 
+    gConsoleService->RegisterCommand("reload_settings", "Reload settings files.",
+    [&](std::vector<std::string> inputs)
+    {
+        fmt::print("Reloading settings files\n");
+        settings::init();
     });
 
     gConsoleService->RegisterCommand("exit", "Terminate the program.",


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds settings to filter out whole categories of logging levels, not just specific debug ones.
- Adds a bunch of comments
- Adds new console command: `reload_settings`
- EVEN MORE MACROS IN `logging.h`!!!!

## Steps to test these changes

- Copy the new settings across from `settings/default/logging.lua` to `settings/logging.lua`
- Change the settings however you like
- Either restart your server or use the new console command `reload_settings` to see changes in logging

Example:
- Don't alter the default settings
- Log in with a character
- See debug logging for ZoneCounterIncrease etc.
- Disable `LOG_DEBUG` and use `reload_settings`
- Zone your character, that debug logging is gone
