### PR TITLE
[chocobo raising] Add custom debug/test menus

### DIFF
--- a/scripts/commands/chocoboraising.lua
+++ b/scripts/commands/chocoboraising.lua
@@ -1,0 +1,127 @@
+-----------------------------------
+-- func: chocoboraising
+-- desc: Shows a custom debug menu for interacting with and debugging chocobo raising
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+}
+
+local epochDay = 86400
+
+function onTrigger(player)
+    local sex =
+    {
+        [0] = "M",
+        [1] = "F",
+    }
+
+    local chocoState = player:getChocoboRaisingInfo()
+    local menu =
+    {
+        title   = "",
+        options = {},
+    }
+
+    local settingStr = "Enable"
+    if xi.settings.main.ENABLE_CHOCOBO_RAISING then
+        settingStr = "Disable"
+    end
+
+    table.insert(menu.options, {
+        settingStr,
+        function(playerArg)
+            xi.settings.main.ENABLE_CHOCOBO_RAISING = not xi.settings.main.ENABLE_CHOCOBO_RAISING
+            xi.settings.main.DEBUG_CHOCOBO_RAISING  = not xi.settings.main.DEBUG_CHOCOBO_RAISING
+            playerArg:PrintToPlayer(string.format("Chocobo Raising setting: %s", xi.settings.main.ENABLE_CHOCOBO_RAISING),
+                xi.msg.channel.SYSTEM_3, "")
+        end,
+    })
+
+    if chocoState then
+        local stateName = string.format("%s %s [%s]",
+            chocoState.first_name,
+            chocoState.last_name,
+            sex[chocoState.sex])
+
+        menu.title = string.format("Chocobo Raising (%s)", stateName)
+
+        table.insert(menu.options, {
+            "Add age (1d)",
+            function(playerArg)
+                local info = playerArg:getChocoboRaisingInfo()
+                info["created"] = info["created"] - epochDay
+                playerArg:setChocoboRaisingInfo(info)
+                playerArg:PrintToPlayer("Adding 1 day to state.created", xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Add age (10d)",
+            function(playerArg)
+                local info = playerArg:getChocoboRaisingInfo()
+                info["created"] = info["created"] - (epochDay * 10)
+                playerArg:setChocoboRaisingInfo(info)
+                playerArg:PrintToPlayer("Adding 10 days to state.created", xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Change sex",
+            function(playerArg)
+                local info = playerArg:getChocoboRaisingInfo()
+                info["sex"] = (info["sex"] + 1) % 2
+                playerArg:setChocoboRaisingInfo(info)
+                playerArg:PrintToPlayer("Changed sex to " .. sex[info["sex"]], xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Dump chocoState",
+            function(playerArg)
+                local info = playerArg:getChocoboRaisingInfo()
+                playerArg:PrintToPlayer("created " .. os.date("%Y %m %d %H %M %S", info["created"]), xi.msg.channel.SYSTEM_3, "")
+                for k, v in pairs(info) do
+                    playerArg:PrintToPlayer(string.format("%s %s", k, v), xi.msg.channel.SYSTEM_3, "")
+                end
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Delete chocoState",
+            function(playerArg)
+                playerArg:deleteRaisedChocobo()
+                playerArg:PrintToPlayer("Deleted chocoState", xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+    else
+        menu.title = "Chocobo Raising (No chocoState)"
+
+        table.insert(menu.options, {
+            "Create default chocoState",
+            function(playerArg)
+                local egg = {}
+                local newChoco = xi.chocoboRaising.newChocobo(playerArg, egg)
+                player:setChocoboRaisingInfo(newChoco)
+                playerArg:PrintToPlayer("Created default chocoState", xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Give Egg",
+            function(playerArg)
+                npcUtil.giveItem(playerArg, xi.items.CHOCOBO_EGG_SLIGHTLY_WARM)
+            end,
+        })
+    end
+
+    table.insert(menu.options, {
+        "Cancel",
+        function(playerArg)
+        end,
+    })
+
+    player:customMenu(menu)
+end

--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -38,8 +38,8 @@ xi = xi or {}
 xi.chocoboRaising = xi.chocoboRaising or {}
 xi.chocoboRaising.chocoState = xi.chocoboRaising.chocoState or {}
 
--- FOR HEAVILY-IN-DEVELOPMET TESTING, you can force these setting:
--- TODO: When ready for release, publish these to main settings files.
+-- FOR HEAVILY-IN-DEVELOPMET TESTING, you can use the `!chocoboraising`
+-- command to toggle these settings
 xi.settings.main.ENABLE_CHOCOBO_RAISING = false
 xi.settings.main.DEBUG_CHOCOBO_RAISING = false
 
@@ -860,7 +860,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option)
             return
         end
 
-        debug(player, string.format("Update: %i", option))
+        debug(player, string.format("CS Update: %i", option))
 
         -- Setting the name for a chocobo: when the name is
         -- applied from the menu the name offsets (from the menu)
@@ -1038,14 +1038,17 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option)
 
                 -- 8 - 25 are all "-----" (blank)
 
-                -- bit.lshift(0x01, 26): Go forward 1 unit (debug)
+                -- Go forward 1 unit (debug) (Unused, see command: !chocoboraising)
                 local goForward1UnitDebug = -bit.lshift(0x01, 26)
+                utils.unused(goForward1UnitDebug)
 
-                -- bit.lshift(0x01, 27): Abilities print (debug)
+                -- Abilities print (debug) (Unused, see command: !chocoboraising)
                 local abilitiesPrintDebug = -bit.lshift(0x01, 27)
+                utils.unused(abilitiesPrintDebug)
 
-                -- bit.lshift(0x01, 28): User work print (debug)
+                -- User work print (debug) (Unused, see command: !chocoboraising)
                 local userWorkPrintDebug = -bit.lshift(0x01, 28)
+                utils.unused(userWorkPrintDebug)
 
                 local retireOrGiveUp = 0
                 if chocoState.stage < stage.ADULT_1 then
@@ -1075,13 +1078,6 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option)
 
                 if chocoState.stage >= stage.ADULT_1 then
                     -- menuFlags = menuFlags
-                end
-
-                -- GMs can access debug options
-                if player:getGMLevel() > 0 and player:checkNameFlags(0x04000000) then
-                    menuFlags = menuFlags + goForward1UnitDebug
-                    menuFlags = menuFlags + abilitiesPrintDebug
-                    menuFlags = menuFlags + userWorkPrintDebug
                 end
 
                 -- Exit is always available


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a custom menu for debugging and testing chocobo raising, making life _much_ easier and hopefully opening the door for testers in the future (there isn't much testing to do for the moment though)

## Steps to test these changes

- Use `!chocoboraising` as a lv1 GM or higher

<img width="319" alt="image" src="https://user-images.githubusercontent.com/1389729/210187048-acdf4fb2-8a76-4925-aef5-c1c734c306dd.png">
<img width="295" alt="image" src="https://user-images.githubusercontent.com/1389729/210187052-9f409dda-ae2c-4171-b4ae-f0f95b9f4363.png">
<img width="323" alt="image" src="https://user-images.githubusercontent.com/1389729/210187074-7858172a-f06a-4f46-bcc2-d532051b8f9c.png">

