### PR TITLE
Implement Moghouse 2F

### DIFF
--- a/scripts/globals/items/patio_design_plan_document.lua
+++ b/scripts/globals/items/patio_design_plan_document.lua
@@ -1,0 +1,20 @@
+-----------------------------------------
+-- ID: 6499
+-- Item: Patio design plan document
+-- Grants keyitem: MOG_PATIO_DESIGN_DOCUMENT
+-----------------------------------------
+require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
+-----------------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    -- TODO: Should there be a failure message here?
+    return target:hasKeyItem(xi.ki.MOG_PATIO_DESIGN_DOCUMENT) and 1 or 0
+end
+
+itemObject.onItemUse = function(target)
+    npcUtil.giveKeyItem(target, xi.ki.MOG_PATIO_DESIGN_DOCUMENT)
+end
+
+return itemObject

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -55,6 +55,20 @@ xi.moghouse.moghouseZones =
     xi.zone.EASTERN_ADOULIN,      -- 257
 }
 
+xi.moghouse.moghouse2FUnlockCSs =
+{
+    [xi.zone.SOUTHERN_SAN_DORIA] = 3535,
+    [xi.zone.NORTHERN_SAN_DORIA] = 904,
+    [xi.zone.PORT_SAN_DORIA]     = 820,
+    [xi.zone.BASTOK_MINES]       = 610,
+    [xi.zone.BASTOK_MARKETS]     = 604,
+    [xi.zone.PORT_BASTOK]        = 456,
+    [xi.zone.WINDURST_WATERS]    = 1086,
+    [xi.zone.WINDURST_WALLS]     = 547,
+    [xi.zone.PORT_WINDURST]      = 903,
+    [xi.zone.WINDURST_WOODS]     = 885,
+}
+
 xi.moghouse.isInMogHouseInHomeNation = function(player)
     if not player:isInMogHouse() then
         return false
@@ -88,6 +102,61 @@ xi.moghouse.isInMogHouseInHomeNation = function(player)
     end
 
     return false
+end
+
+xi.moghouse.set2ndFloorStyle = function(player, style)
+    -- 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+    -- 0x0100: ^ As above
+    local mhflag = player:getMoghouseFlag()
+    utils.mask.setBit(mhflag, 0x0080, utils.mask.getBit(style, 0))
+    utils.mask.setBit(mhflag, 0x0100, utils.mask.getBit(style, 1))
+    player:setMoghouseFlag(mhflag)
+end
+
+xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
+    local cs = -1
+
+    player:eraseAllStatusEffect()
+    player:setPos(0, 0, 0, 192)
+
+    -- Moghouse data (bit-packed)
+    -- 0x0001: SANDORIA exit quest flag
+    -- 0x0002: BASTOK exit quest flag
+    -- 0x0004: WINDURST exit quest flag
+    -- 0x0008: JEUNO exit quest flag
+    -- 0x0010: WEST_AHT_URHGAN exit quest flag
+    -- 0x0020: Unlocked Moghouse2F flag
+    -- 0x0040: Moghouse 2F tracker flag (0: default, 1: using 2F)
+    -- 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+    -- 0x0100: ^ As above
+    local mhflag = player:getMoghouseFlag()
+
+    local growingFlowers   = bit.band(mhflag, 0x0001) > 0
+    local aLadysHeart      = bit.band(mhflag, 0x0002) > 0
+    local flowerChild      = bit.band(mhflag, 0x0004) > 0
+    local unlocked2ndFloor = bit.band(mhflag, 0x0020) > 0
+    local using2ndFloor    = bit.band(mhflag, 0x0040) > 0
+
+    -- NOTE: You can test these quest conditions with:
+    -- Reset: !exec player:setMoghouseFlag(0)
+    -- Complete quests: !exec player:setMoghouseFlag(7)
+    if
+        xi.moghouse.isInMogHouseInHomeNation(player) and
+        growingFlowers and
+        aLadysHeart and
+        flowerChild and
+        not unlocked2ndFloor and
+        not using2ndFloor
+    then
+        cs = xi.moghouse.moghouse2FUnlockCSs[player:getZoneID()]
+
+        player:setMoghouseFlag(bit.band(mhflag, 0x0020)) -- Set unlock flag now, rather than in onEventFinish
+
+        local nation = player:getNation()
+        xi.moghouse.set2ndFloorStyle(player, nation)
+    end
+
+    return cs
 end
 
 xi.moghouse.moogleTrade = function(player, npc, trade)

--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -150,7 +150,7 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
     then
         cs = xi.moghouse.moghouse2FUnlockCSs[player:getZoneID()]
 
-        player:setMoghouseFlag(bit.band(mhflag, 0x0020)) -- Set unlock flag now, rather than in onEventFinish
+        player:setMoghouseFlag(mhflag + 0x0020) -- Set unlock flag now, rather than in onEventFinish
 
         local nation = player:getNation()
         xi.moghouse.set2ndFloorStyle(player, nation)

--- a/scripts/quests/ahtUrhgan/Keeping_Notes.lua
+++ b/scripts/quests/ahtUrhgan/Keeping_Notes.lua
@@ -65,7 +65,7 @@ quest.sections =
                     if quest:complete(player) then
                         player:confirmTrade()
                         local mhflag = player:getMoghouseFlag()
-                        player:setMoghouseFlag(bit.band(mhflag, 0x0010))
+                        player:setMoghouseFlag(mhflag + 0x0010)
                     end
                 end,
             },

--- a/scripts/quests/ahtUrhgan/Keeping_Notes.lua
+++ b/scripts/quests/ahtUrhgan/Keeping_Notes.lua
@@ -64,7 +64,8 @@ quest.sections =
                 [11] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
-                        player:setMoghouseFlag(16)
+                        local mhflag = player:getMoghouseFlag()
+                        player:setMoghouseFlag(bit.band(mhflag, 0x0010))
                     end
                 end,
             },

--- a/scripts/quests/bastok/A_Ladys_Heart.lua
+++ b/scripts/quests/bastok/A_Ladys_Heart.lua
@@ -94,7 +94,7 @@ quest.sections =
                         if quest:complete(player) then
                             player:confirmTrade()
                             local mhflag = player:getMoghouseFlag()
-                            player:setMoghouseFlag(bit.band(mhflag, 0x0002))
+                            player:setMoghouseFlag(mhflag + 0x0002)
                             player:messageSpecial(portBastokID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/quests/bastok/A_Ladys_Heart.lua
+++ b/scripts/quests/bastok/A_Ladys_Heart.lua
@@ -93,7 +93,8 @@ quest.sections =
                     if option == 2002 then
                         if quest:complete(player) then
                             player:confirmTrade()
-                            player:setMoghouseFlag(2)
+                            local mhflag = player:getMoghouseFlag()
+                            player:setMoghouseFlag(bit.band(mhflag, 0x0002))
                             player:messageSpecial(portBastokID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/quests/jeuno/Pretty_Little_Things.lua
+++ b/scripts/quests/jeuno/Pretty_Little_Things.lua
@@ -106,7 +106,9 @@ quest.sections =
 
                     if option == 4002 then
                         if quest:complete(player) then
-                            player:setMoghouseFlag(8)
+                            player:confirmTrade()
+                            local mhflag = player:getMoghouseFlag()
+                            player:setMoghouseFlag(bit.band(mhflag, 0x0008))
                             player:messageSpecial(portJeunoID.text.MOGHOUSE_EXIT)
                         end
                     elseif player:getQuestStatus(quest.areaId, quest.questId) == QUEST_AVAILABLE then

--- a/scripts/quests/jeuno/Pretty_Little_Things.lua
+++ b/scripts/quests/jeuno/Pretty_Little_Things.lua
@@ -108,7 +108,7 @@ quest.sections =
                         if quest:complete(player) then
                             player:confirmTrade()
                             local mhflag = player:getMoghouseFlag()
-                            player:setMoghouseFlag(bit.band(mhflag, 0x0008))
+                            player:setMoghouseFlag(mhflag + 0x0008)
                             player:messageSpecial(portJeunoID.text.MOGHOUSE_EXIT)
                         end
                     elseif player:getQuestStatus(quest.areaId, quest.questId) == QUEST_AVAILABLE then

--- a/scripts/quests/sandoria/Growing_Flowers.lua
+++ b/scripts/quests/sandoria/Growing_Flowers.lua
@@ -94,7 +94,7 @@ quest.sections =
                         if quest:complete(player) then
                             player:confirmTrade()
                             local mhflag = player:getMoghouseFlag()
-                            player:setMoghouseFlag(bit.band(mhflag, 0x0001))
+                            player:setMoghouseFlag(mhflag + 0x0001)
                             player:messageSpecial(northenSandoriaID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/quests/sandoria/Growing_Flowers.lua
+++ b/scripts/quests/sandoria/Growing_Flowers.lua
@@ -93,7 +93,8 @@ quest.sections =
                     if option == 1002 then
                         if quest:complete(player) then
                             player:confirmTrade()
-                            player:setMoghouseFlag(1)
+                            local mhflag = player:getMoghouseFlag()
+                            player:setMoghouseFlag(bit.band(mhflag, 0x0001))
                             player:messageSpecial(northenSandoriaID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/quests/windurst/Flower_Child.lua
+++ b/scripts/quests/windurst/Flower_Child.lua
@@ -93,7 +93,8 @@ quest.sections =
                     if option == 3002 then
                         if quest:complete(player) then
                             player:confirmTrade()
-                            player:setMoghouseFlag(4)
+                            local mhflag = player:getMoghouseFlag()
+                            player:setMoghouseFlag(bit.band(mhflag, 0x0004))
                             player:messageSpecial(windurstWallsID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/quests/windurst/Flower_Child.lua
+++ b/scripts/quests/windurst/Flower_Child.lua
@@ -94,7 +94,7 @@ quest.sections =
                         if quest:complete(player) then
                             player:confirmTrade()
                             local mhflag = player:getMoghouseFlag()
-                            player:setMoghouseFlag(bit.band(mhflag, 0x0004))
+                            player:setMoghouseFlag(mhflag + 0x0004)
                             player:messageSpecial(windurstWallsID.text.MOGHOUSE_EXIT)
                         end
 

--- a/scripts/zones/Residential_Area/Zone.lua
+++ b/scripts/zones/Residential_Area/Zone.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Zone: Residential_Area
 -----------------------------------
-local ID = require('scripts/zones/Residential_Area/IDs')
+require('scripts/globals/moghouse')
 -----------------------------------
 local zoneObject = {}
 
@@ -9,12 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
-
-    player:eraseAllStatusEffect()
-    player:setPos(0, 0, 0, 192)
-
-    return cs
+    return xi.moghouse.onMoghouseZoneIn(player, prevZone)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/sql/char_stats.sql
+++ b/sql/char_stats.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `char_stats` (
   `hp` smallint(4) unsigned NOT NULL DEFAULT '50',
   `mp` smallint(4) unsigned NOT NULL DEFAULT '50',
   `nameflags` int(10) unsigned NOT NULL DEFAULT '0',
-  `mhflag` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mhflag` smallint(4) unsigned NOT NULL DEFAULT '0',
   `mjob` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `sjob` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `death` int(10) unsigned NOT NULL DEFAULT '0',

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -1941,6 +1941,7 @@ INSERT INTO `item_usable` VALUES (6468,'plate_of_sublime_sushi',1,1,28,0,0,0,0,0
 INSERT INTO `item_usable` VALUES (6469,'plate_of_sublime_sushi_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6475,'pair_of_lucid_wings_ii',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6498,'bunch_of_fortune_fruits',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6499,'patio_design_plan_document',1,1,117,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6538,'altanas_repast',1,1,28,0,0,0,0,1);
 INSERT INTO `item_usable` VALUES (6539,'altanas_repast_+1',1,1,28,0,0,0,0,1);
 INSERT INTO `item_usable` VALUES (6540,'altanas_repast_+2',1,1,28,0,0,0,0,1);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2244,6 +2244,7 @@ bool CCharEntity::hasMoghancement(uint16 moghancementID) const
 void CCharEntity::UpdateMoghancement()
 {
     TracyZoneScoped;
+
     // Add up all of the installed furniture auras
     std::array<uint16, 8> elements = { 0 };
     for (auto containerID : { LOC_MOGSAFE, LOC_MOGSAFE2 })
@@ -2255,7 +2256,7 @@ void CCharEntity::UpdateMoghancement()
             if (PItem != nullptr && PItem->isType(ITEM_FURNISHING))
             {
                 CItemFurnishing* PFurniture = static_cast<CItemFurnishing*>(PItem);
-                if (PFurniture->isInstalled())
+                if (PFurniture->isInstalled() && !PFurniture->getOn2ndFloor())
                 {
                     elements[PFurniture->getElement() - 1] += PFurniture->getAura();
                 }
@@ -2298,7 +2299,7 @@ void CCharEntity::UpdateMoghancement()
                 {
                     CItemFurnishing* PFurniture = static_cast<CItemFurnishing*>(PItem);
                     // If aura is tied then use whichever furniture was placed most recently
-                    if (PFurniture->isInstalled() && PFurniture->getElement() == dominantElement &&
+                    if (PFurniture->isInstalled() && !PFurniture->getOn2ndFloor() && PFurniture->getElement() == dominantElement &&
                         (PFurniture->getAura() > bestAura || (PFurniture->getAura() == bestAura && PFurniture->getOrder() < bestOrder)))
                     {
                         bestAura          = PFurniture->getAura();

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -69,9 +69,20 @@ struct jobs_t
 
 struct profile_t
 {
-    uint8      nation;     // Your Nation Allegiance.
-    // TODO: Migrate from uint8 to uint16
-    uint16     mhflag;     // Moghouse data. 0x01-0x10: Flag of exit from Moghouse, 0x20-0x80: Flags for Moghouse 2F
+    uint8 nation; // Your Nation Allegiance.
+
+    // Moghouse data (bit-packed)
+    // 0x0001: SANDORIA exit quest flag
+    // 0x0002: BASTOK exit quest flag
+    // 0x0004: WINDURST exit quest flag
+    // 0x0008: JEUNO exit quest flag
+    // 0x0010: WEST_AHT_URHGAN exit quest flag
+    // 0x0020: Unlocked Moghouse2F flag
+    // 0x0040: Moghouse 2F tracker flag (0: default, 1: using 2F)
+    // 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+    // 0x0100: ^ As above
+    uint16 mhflag;
+
     uint16     title;      // rank
     uint16     fame[15];   // Fame
     uint8      rank[3];    // RAGN in three states

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -70,7 +70,8 @@ struct jobs_t
 struct profile_t
 {
     uint8      nation;     // Your Nation Allegiance.
-    uint8      mhflag;     // Flag of exit from MOGHOUSE
+    // TODO: Migrate from uint8 to uint16
+    uint16     mhflag;     // Moghouse data. 0x01-0x10: Flag of exit from Moghouse, 0x20-0x80: Flags for Moghouse 2F
     uint16     title;      // rank
     uint16     fame[15];   // Fame
     uint8      rank[3];    // RAGN in three states

--- a/src/map/items/item_furnishing.cpp
+++ b/src/map/items/item_furnishing.cpp
@@ -160,3 +160,20 @@ uint8 CItemFurnishing::getMannequinPose()
 {
     return ref<uint8>(m_extra, 0x13);
 }
+
+void CItemFurnishing::setOn2ndFloor(bool on2ndFloor)
+{
+    if (on2ndFloor)
+    {
+        ref<uint8>(m_extra, 0x01) |= 0x01;
+    }
+    else
+    {
+        ref<uint8>(m_extra, 0x01) &= ~0x01;
+    }
+}
+
+bool CItemFurnishing::getOn2ndFloor()
+{
+    return ref<uint8>(m_extra, 0x01) & 01;
+}

--- a/src/map/items/item_furnishing.cpp
+++ b/src/map/items/item_furnishing.cpp
@@ -177,3 +177,18 @@ bool CItemFurnishing::getOn2ndFloor()
 {
     return ref<uint8>(m_extra, 0x01) & 01;
 }
+
+bool CItemFurnishing::isGardeningPot()
+{
+    auto id = CItem::getID();
+    return id == 216 ||  // porcelain_flowerpot
+           id == 217 ||  // brass_flowerpot
+           id == 218 ||  // earthen_flowerpot
+           id == 219 ||  // ceramic_flowerpot
+           id == 220 ||  // wooden_flowerpot
+           id == 221 ||  // arcane_flowerpot
+           id == 3744 || // mandragora_pot
+           id == 3745 || // korrigan_pot
+           id == 3746 || // adenium_pot
+           id == 3747;   // citrullus_pot
+}

--- a/src/map/items/item_furnishing.h
+++ b/src/map/items/item_furnishing.h
@@ -136,6 +136,8 @@ public:
     void setOn2ndFloor(bool on2ndFloor);
     bool getOn2ndFloor();
 
+    bool isGardeningPot();
+
 private:
     uint8  m_storage;
     uint16 m_moghancement;

--- a/src/map/items/item_furnishing.h
+++ b/src/map/items/item_furnishing.h
@@ -133,6 +133,9 @@ public:
     void  setMannequinPose(uint8 pose);
     uint8 getMannequinPose();
 
+    void setOn2ndFloor(bool on2ndFloor);
+    bool getOn2ndFloor();
+
 private:
     uint8  m_storage;
     uint16 m_moghancement;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1179,7 +1179,7 @@ void CLuaBaseEntity::setFlag(uint32 flags)
  *  Notes   :  Used in Mog House exit quests (ex. A Lady's Heart)
  ************************************************************************/
 
-void CLuaBaseEntity::setMoghouseFlag(uint8 flag)
+void CLuaBaseEntity::setMoghouseFlag(uint16 flag)
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
@@ -1196,7 +1196,7 @@ void CLuaBaseEntity::setMoghouseFlag(uint8 flag)
  *  Notes   :  Used in Mog House exit quests (ex. A Lady's Heart)
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getMoghouseFlag()
+uint16 CLuaBaseEntity::getMoghouseFlag()
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1173,23 +1173,6 @@ void CLuaBaseEntity::setFlag(uint32 flags)
 }
 
 /************************************************************************
- *  Function: setMoghouseFlag()
- *  Purpose : Creates or returns exit flag for Mog House
- *  Example : player:moghouseFlag(2)
- *  Notes   :  Used in Mog House exit quests (ex. A Lady's Heart)
- ************************************************************************/
-
-void CLuaBaseEntity::setMoghouseFlag(uint16 flag)
-{
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-
-    PChar->profile.mhflag |= flag;
-    charutils::SaveCharStats(PChar);
-}
-
-/************************************************************************
  *  Function: getMoghouseFlag()
  *  Purpose : Returns exit flag for Mog House
  *  Example :
@@ -1202,6 +1185,24 @@ uint16 CLuaBaseEntity::getMoghouseFlag()
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->profile.mhflag;
+}
+
+/************************************************************************
+ *  Function: setMoghouseFlag()
+ *  Purpose : Creates or returns exit flag for Mog House
+ *  Example : player:moghouseFlag(bit.band(mhflag, 0x02))
+ *  Notes   : Used in Mog House exit quests (ex. A Lady's Heart)
+ ************************************************************************/
+
+void CLuaBaseEntity::setMoghouseFlag(uint16 flag)
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        PChar->profile.mhflag = flag;
+        charutils::SaveCharStats(PChar);
+    }
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1183,8 +1183,12 @@ uint16 CLuaBaseEntity::getMoghouseFlag()
 {
     XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-    return PChar->profile.mhflag;
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        return PChar->profile.mhflag;
+    }
+
+    return 0;
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -99,10 +99,10 @@ public:
     bool didGetMessage();   // Used by interaction framework to determine if player triggered something else
     void resetGotMessage(); // Used by interaction framework to reset if player triggered something else
 
-    void  setFlag(uint32 flags);
-    uint8 getMoghouseFlag();
-    void  setMoghouseFlag(uint8 flag);
-    bool  needToZone(sol::object const& arg0); // Check if player has zoned since the flag has been raised
+    void   setFlag(uint32 flags);
+    uint16 getMoghouseFlag();
+    void   setMoghouseFlag(uint16 flag);
+    bool   needToZone(sol::object const& arg0); // Check if player has zoned since the flag has been raised
 
     // Object Identification
     uint32 getID();

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3743,6 +3743,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
         if (zoneLineID == 1903324538)
         {
             uint16 destinationZone = PChar->getZone();
+
             // Note: zone zero actually exists but is unused in retail, we should stop using zero someday.
             // If zero, return to previous zone otherwise, determine the zone
             if (requestedZone != 0)
@@ -3777,16 +3778,21 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
             }
 
-            bool moghouseExitRegular = requestedZone == 0 && PChar->m_moghouseID > 0;
-
-            auto startingRegion            = zoneutils::GetCurrentRegion(startingZone);
-            auto destinationRegion         = zoneutils::GetCurrentRegion(destinationZone);
-            auto moghouseExitRegions       = { REGION_TYPE::SANDORIA, REGION_TYPE::BASTOK, REGION_TYPE::WINDURST, REGION_TYPE::JEUNO, REGION_TYPE::WEST_AHT_URHGAN };
-            auto moghouseQuestComplete     = PChar->profile.mhflag & (town ? 0x01 << (town - 1) : 0);
-            bool moghouseExitQuestZoneline = moghouseQuestComplete && startingRegion == destinationRegion && PChar->m_moghouseID > 0 &&
-                                             std::any_of(moghouseExitRegions.begin(), moghouseExitRegions.end(),
+            bool moghouseExitRegular          = requestedZone == 0 && PChar->m_moghouseID > 0;
+            bool requestedMoghouseFloorChange = startingZone == destinationZone;
+            bool moghouse2FUnlocked           = PChar->profile.mhflag & 0x20;
+            auto startingRegion               = zoneutils::GetCurrentRegion(startingZone);
+            auto destinationRegion            = zoneutils::GetCurrentRegion(destinationZone);
+            auto moghouseExitRegions          = { REGION_TYPE::SANDORIA, REGION_TYPE::BASTOK, REGION_TYPE::WINDURST, REGION_TYPE::JEUNO, REGION_TYPE::WEST_AHT_URHGAN };
+            auto moghouseSameRegion           = std::any_of(moghouseExitRegions.begin(), moghouseExitRegions.end(),
                                                          [&destinationRegion](REGION_TYPE acceptedReg)
                                                          { return destinationRegion == acceptedReg; });
+            auto moghouseQuestComplete        = PChar->profile.mhflag & (town ? 0x01 << (town - 1) : 0);
+            bool moghouseExitQuestZoneline    = moghouseQuestComplete &&
+                                             startingRegion == destinationRegion &&
+                                             PChar->m_moghouseID > 0 &&
+                                             moghouseSameRegion &&
+                                             !requestedMoghouseFloorChange;
 
             bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->m_moghouseID > 0;
 
@@ -3794,6 +3800,17 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
             if (moghouseExitRegular || moghouseExitQuestZoneline || moghouseExitMogGardenZoneline)
             {
                 PChar->m_moghouseID    = 0;
+                PChar->loc.destination = destinationZone;
+                PChar->loc.p           = {};
+
+                // Clear "onMogHouse2F" bit
+                PChar->profile.mhflag &= ~(0x40);
+            }
+            else if (moghouse2FUnlocked && requestedMoghouseFloorChange)
+            {
+                // Toggle "onMogHouse2F" bit
+                PChar->profile.mhflag ^= 0x40;
+
                 PChar->loc.destination = destinationZone;
                 PChar->loc.p           = {};
             }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -717,7 +717,23 @@ void SmallPacket0x016(map_session_data_t* const PSession, CCharEntity* const PCh
                 ShowWarning(fmt::format("Server missing npc_list.sql entry <{}> in zone <{} ({})>",
                                         PEntity->id, zoneutils::GetZone(PChar->getZone())->GetName(), PChar->getZone()));
             }
-            PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+
+            // Special case for onZoneIn cutscenes in Mog House
+            if (PChar->m_moghouseID &&
+                PEntity->status == STATUS_TYPE::DISAPPEAR &&
+                PEntity->loc.p.z == 1.5 &&
+                PEntity->look.face == 0x52)
+            {
+                // Using the same logic as in ZoneEntities::SpawnMoogle:
+                // Change the status of the entity, send the packet, change it back to disappear
+                PEntity->status = STATUS_TYPE::NORMAL;
+                PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+                PEntity->status = STATUS_TYPE::DISAPPEAR;
+            }
+            else
+            {
+                PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+            }
         }
     }
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3828,7 +3828,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                     //     : happen through packet abuse.
                     PChar->loc.destination = startingZone;
                     PChar->loc.p           = startingPos;
-                    PChar->status = STATUS_TYPE::NORMAL;
+                    PChar->status          = STATUS_TYPE::NORMAL;
                     ShowWarning("SmallPacket0x05E: Moghouse 2F requested without it being unlocked: %s", PChar->GetName());
                 }
             }
@@ -6558,7 +6558,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         // Update installed furniture placement orders
         // First we place the furniture into placed items using the order number as the index
-        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE * 2> placedItems = { nullptr };
+        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE* 2> placedItems = { nullptr };
         for (auto safeContainerId : { LOC_MOGSAFE, LOC_MOGSAFE2 })
         {
             CItemContainer* PContainer = PChar->getStorage(safeContainerId);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3803,12 +3803,12 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                 PChar->loc.destination = destinationZone;
                 PChar->loc.p           = {};
 
-                // Clear "onMogHouse2F" bit
+                // Clear Moghouse 2F tracker flag
                 PChar->profile.mhflag &= ~(0x40);
             }
             else if (moghouse2FUnlocked && requestedMoghouseFloorChange)
             {
-                // Toggle "onMogHouse2F" bit
+                // Toggle Moghouse 2F tracker flag
                 PChar->profile.mhflag ^= 0x40;
 
                 PChar->loc.destination = destinationZone;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5693,7 +5693,7 @@ void SmallPacket0x0CB(map_session_data_t* const PSession, CCharEntity* const PCh
     else if (operation == 5)
     {
         // remodel mog house
-        auto type = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105
+        auto type   = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105
         std::ignore = type;
     }
     else
@@ -6474,6 +6474,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
     uint8 slotID      = data.ref<uint8>(0x06);
     uint8 containerID = data.ref<uint8>(0x07);
+    uint8 on2ndFloor  = data.ref<uint8>(0x08);
     uint8 col         = data.ref<uint8>(0x09);
     uint8 level       = data.ref<uint8>(0x0A);
     uint8 row         = data.ref<uint8>(0x0B);
@@ -6495,6 +6496,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         bool wasInstalled = PItem->isInstalled();
         PItem->setInstalled(true);
+        PItem->setOn2ndFloor(on2ndFloor);
         PItem->setCol(col);
         PItem->setRow(row);
         PItem->setLevel(level);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -6549,6 +6549,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
             }
             placedItems[i]->setOrder(placedItems[i]->getOrder() + 1);
         }
+
         // Set this item to being the most recently placed item
         PItem->setOrder(0);
 
@@ -6566,7 +6567,11 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         if (sql->Query(Query, extra, containerID, slotID, PChar->id) != SQL_ERROR && sql->AffectedRows() != 0 && !wasInstalled)
         {
-            PChar->getStorage(LOC_STORAGE)->AddBuff(PItem->getStorage());
+            // Storage mods only apply on the 1st floor
+            if (!PItem->getOn2ndFloor())
+            {
+                PChar->getStorage(LOC_STORAGE)->AddBuff(PItem->getStorage());
+            }
 
             PChar->pushPacket(new CInventorySizePacket(PChar));
 
@@ -6657,7 +6662,12 @@ void SmallPacket0x0FB(map_session_data_t* const PSession, CCharEntity* const PCh
                         charutils::MoveItem(PChar, LOC_STORAGE, SlotID, ERROR_SLOTID);
                     }
                 }
-                PChar->getStorage(LOC_STORAGE)->AddBuff(-(int8)PItem->getStorage());
+
+                // Storage mods only apply on the 1st floor
+                if (!PItem->getOn2ndFloor())
+                {
+                    PChar->getStorage(LOC_STORAGE)->AddBuff(-(int8)PItem->getStorage());
+                }
 
                 PChar->pushPacket(new CInventorySizePacket(PChar));
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -5693,8 +5693,20 @@ void SmallPacket0x0CB(map_session_data_t* const PSession, CCharEntity* const PCh
     else if (operation == 5)
     {
         // remodel mog house
-        auto type   = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105
-        std::ignore = type;
+        auto type = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105, Patio: 106
+
+        // 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+        // 0x0100: ^ As above
+
+        // Clear bits first
+        PChar->profile.mhflag &= ~(0x0080);
+        PChar->profile.mhflag &= ~(0x0100);
+
+        // Write new model bits
+        PChar->profile.mhflag |= ((type - 103) << 7);
+        charutils::SaveCharStats(PChar);
+
+        // TODO: It's possible to do this from 2F, so if you're on 2F (check the  flag), force a re-zone to get the new look
     }
     else
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5707,8 +5707,17 @@ void SmallPacket0x0CB(map_session_data_t* const PSession, CCharEntity* const PCh
         // remodel mog house
         auto type = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105, Patio: 106
 
+        if (type == 106 && !charutils::hasKeyItem(PChar, 3051))
+        {
+            ShowWarning(fmt::format("Player {} is trying to remodel to MH2F to Patio without owning the KI to unlock it.", PChar->GetName()));
+            return;
+        }
+
         // 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
         // 0x0100: ^ As above
+
+        // Extract original model and add 103 so it's in line with what comes in with the packet.
+        uint16 oldType = (uint8)(((PChar->profile.mhflag & 0x0100) + (PChar->profile.mhflag & 0x0080)) >> 7) + 103;
 
         // Clear bits first
         PChar->profile.mhflag &= ~(0x0080);
@@ -5718,7 +5727,20 @@ void SmallPacket0x0CB(map_session_data_t* const PSession, CCharEntity* const PCh
         PChar->profile.mhflag |= ((type - 103) << 7);
         charutils::SaveCharStats(PChar);
 
-        // TODO: It's possible to do this from 2F, so if you're on 2F (check the  flag), force a re-zone to get the new look
+        // TODO: Send message on successful remodel
+
+        // If the model changes AND you're on MH2F; force a rezone so the model change can take effect.
+        if (type != oldType && PChar->profile.mhflag & 0x0040)
+        {
+            auto zoneid = PChar->getZone();
+            auto ipp    = zoneutils::GetZoneIPP(zoneid);
+
+            PChar->loc.destination = zoneid;
+            PChar->status          = STATUS_TYPE::DISAPPEAR;
+
+            PChar->clearPacketList();
+            charutils::SendToZone(PChar, 2, ipp);
+        }
     }
     else
     {
@@ -6511,6 +6533,14 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
     CItemFurnishing* PItem = (CItemFurnishing*)PChar->getStorage(containerID)->GetItem(slotID);
 
+    // Try to catch packet abuse, leading to gardening pots being placed on 2nd floor.
+    if (PItem->getOn2ndFloor() && PItem->isGardeningPot())
+    {
+        ShowWarning(fmt::format("{} has tried to gardening pot {} ({}) on 2nd floor",
+                                PChar->GetName(), PItem->getID(), PItem->getName()));
+        return;
+    }
+
     if (PItem != nullptr && PItem->getID() == ItemID && PItem->isType(ITEM_FURNISHING))
     {
         if (PItem->getFlag() & ITEM_FLAG_WALLHANGING)
@@ -6528,7 +6558,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         // Update installed furniture placement orders
         // First we place the furniture into placed items using the order number as the index
-        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE* 2> placedItems = { nullptr };
+        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE * 2> placedItems = { nullptr };
         for (auto safeContainerId : { LOC_MOGSAFE, LOC_MOGSAFE2 })
         {
             CItemContainer* PContainer = PChar->getStorage(safeContainerId);
@@ -6729,6 +6759,13 @@ void SmallPacket0x0FC(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
+    if (!PPotItem->isGardeningPot())
+    {
+        ShowWarning(fmt::format("{} has tried to invalid gardening pot {} ({})",
+                                PChar->GetName(), PPotItem->getID(), PPotItem->getName()));
+        return;
+    }
+
     CItemContainer* PItemContainer = PChar->getStorage(containerID);
     CItem*          PItem          = PItemContainer->GetItem(slotID);
     if (PItem == nullptr || PItem->getQuantity() < 1)
@@ -6874,6 +6911,14 @@ void SmallPacket0x0FE(map_session_data_t* const PSession, CCharEntity* const PCh
     CItemFlowerpot* PItem          = (CItemFlowerpot*)PItemContainer->GetItem(slotID);
     if (PItem == nullptr)
     {
+        return;
+    }
+
+    // Try to catch packet abuse, leading to gardening pots being placed on 2nd floor.
+    if (PItem->getOn2ndFloor() && PItem->isGardeningPot())
+    {
+        ShowWarning(fmt::format("{} has tried to uproot gardening pot {} ({}) on 2nd floor",
+                                PChar->GetName(), PItem->getID(), PItem->getName()));
         return;
     }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3767,12 +3767,16 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                         break;
                 }
 
-                // Handle case for mog garden (Above addition does not work for this zone.)
+                // Handle case for mog garden (Above addition does not work for this zone)
                 if (requestedZone == 127)
                 {
                     destinationZone = ZONE_MOG_GARDEN;
                 }
-                else if (requestedZone == 125) // Go to second floor
+                else if (requestedZone == 126) // Go to first floor from second
+                {
+                    destinationZone = PChar->getZone();
+                }
+                else if (requestedZone == 125) // Go to second floor from first
                 {
                     destinationZone = PChar->getZone();
                 }
@@ -3785,8 +3789,8 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
             auto destinationRegion            = zoneutils::GetCurrentRegion(destinationZone);
             auto moghouseExitRegions          = { REGION_TYPE::SANDORIA, REGION_TYPE::BASTOK, REGION_TYPE::WINDURST, REGION_TYPE::JEUNO, REGION_TYPE::WEST_AHT_URHGAN };
             auto moghouseSameRegion           = std::any_of(moghouseExitRegions.begin(), moghouseExitRegions.end(),
-                                                         [&destinationRegion](REGION_TYPE acceptedReg)
-                                                         { return destinationRegion == acceptedReg; });
+                                                            [&destinationRegion](REGION_TYPE acceptedReg)
+                                                            { return destinationRegion == acceptedReg; });
             auto moghouseQuestComplete        = PChar->profile.mhflag & (town ? 0x01 << (town - 1) : 0);
             bool moghouseExitQuestZoneline    = moghouseQuestComplete &&
                                              startingRegion == destinationRegion &&
@@ -3795,6 +3799,9 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                                              !requestedMoghouseFloorChange;
 
             bool moghouseExitMogGardenZoneline = destinationZone == ZONE_MOG_GARDEN && PChar->m_moghouseID > 0;
+
+            // TODO: Handle 2F unlock
+            std::ignore = moghouse2FUnlocked;
 
             // Validate travel
             if (moghouseExitRegular || moghouseExitQuestZoneline || moghouseExitMogGardenZoneline)
@@ -3806,7 +3813,7 @@ void SmallPacket0x05E(map_session_data_t* const PSession, CCharEntity* const PCh
                 // Clear Moghouse 2F tracker flag
                 PChar->profile.mhflag &= ~(0x40);
             }
-            else if (moghouse2FUnlocked && requestedMoghouseFloorChange)
+            else if (requestedMoghouseFloorChange)
             {
                 // Toggle Moghouse 2F tracker flag
                 PChar->profile.mhflag ^= 0x40;
@@ -5666,20 +5673,28 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
 
 /************************************************************************
  *                                                                       *
- *  Open/Close Mog House                                                 *
+ *  Mog House actions                                                    *
  *                                                                       *
  ************************************************************************/
 
 void SmallPacket0x0CB(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    if (data.ref<uint8>(0x04) == 1)
+
+    auto operation = data.ref<uint8>(0x04);
+    if (operation == 1)
     {
-        // open
+        // open mog house
     }
-    else if (data.ref<uint8>(0x04) == 2)
+    else if (operation == 2)
     {
-        // close
+        // close mog house
+    }
+    else if (operation == 5)
+    {
+        // remodel mog house
+        auto type = data.ref<uint8>(0x06); // Sandy: 103, Bastok: 104, Windy: 105
+        std::ignore = type;
     }
     else
     {

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -175,7 +175,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     auto csid = currentEvent->eventId;
     if (csid != -1)
     {
-        // ref<uint8>(data,(0x1F)) = 4;                             // Presumably Animation
+        // ref<uint8>(data,(0x1F)) = 4; // Presumably Animation
         // ref<uint8>(data,(0x20)) = 2;
 
         ref<uint16>(0x40) = PChar->currentEvent->textTable == -1 ? PChar->getZone() : PChar->currentEvent->textTable;
@@ -193,17 +193,23 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     {
         ref<uint8>(0x80)  = 1;
         ref<uint16>(0xAA) = GetMogHouseModelID(PChar);
-        ref<uint8>(0xAE)  = GetMogHouseLeavingFlag(PChar);
     }
     else
     {
         ref<uint8>(0x80)  = 2;
         ref<uint16>(0xAA) = 0x01FF;
+
+        // TODO: This has also been seen as 0x04
         ref<uint8>(0xAC)  = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
         ref<uint8>(0xAF)  = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // flag allows you to use Mog Menu outside Mog House
     }
 
     ref<uint32>(0xA0) = PChar->GetPlayTime(); // time spent by the character in the game from the moment of creation
+
+    // Using Moghouse2F
+    ref<uint8>(0xA8) = PChar->profile.mhflag & 0x40 ? 0x3A : 0x38;
+
+    ref<uint8>(0xAE)  = GetMogHouseLeavingFlag(PChar);
 
     uint32 pktTime = CVanaTime::getInstance()->getVanaTime();
 
@@ -211,6 +217,10 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     ref<uint32>(0x3C) = pktTime;
 
     ref<uint32>(0xA4) = PChar->GetTimeRemainingUntilDeathHomepoint();
+
+    // TODO: What are these for?
+    ref<uint8>(0xB0) = 0x01;
+    ref<uint8>(0xB2) = 0x02;
 
     ref<uint8>(0xB4) = PChar->GetMJob();
     ref<uint8>(0xB7) = PChar->GetSJob();

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -19,57 +19,52 @@
 ===========================================================================
 */
 
-#include "common/socket.h"
-
 #include "zone_in.h"
 
-#include "../entities/charentity.h"
-#include "../instance.h"
-#include "../status_effect_container.h"
-#include "../utils/zoneutils.h"
-#include "../vana_time.h"
-#include "map/zone.h"
+#include "entities/charentity.h"
+#include "utils/zoneutils.h"
 
-/************************************************************************
- *                                                                       *
- *  Returns the ID of the mog house map to be used                       *
- *                                                                       *
- ************************************************************************/
+#include "instance.h"
+#include "status_effect_container.h"
+#include "vana_time.h"
+#include "zone.h"
 
-uint16 GetMogHouseID(CCharEntity* PChar)
+// Returns the Model ID of the mog house to be used
+// This is not the same as the actual Zone ID!
+// (These used to be entries in the ZONEID enum, but that was wrong, knowing what we know now)
+uint16 GetMogHouseModelID(CCharEntity* PChar)
 {
-    // TODO: verify wtf is going on with this function. either these aren't supposed to be zone IDs or somehow Jeuno's mog is western adoulin!
+    // TODO: Hook these up using information stored in PChar
+    bool   requestingMoghouse2F = PChar->profile.mhflag & 0x40;
+    uint16 moghouse2FModel      = 0x026A; // TODO: Lookup which model the play has saved
+
+    // clang-format off
     switch (zoneutils::GetCurrentRegion(PChar->getZone()))
     {
         case REGION_TYPE::WEST_AHT_URHGAN:
-            return ZONE_214;
+            return 214;
         case REGION_TYPE::RONFAURE_FRONT:
-            return ZONE_189;
+            return 189;
         case REGION_TYPE::GUSTABERG_FRONT:
-            return ZONE_199;
+            return 199;
         case REGION_TYPE::SARUTA_FRONT:
-            return ZONE_219;
+            return 219;
         case REGION_TYPE::SANDORIA:
-            return (PChar->profile.nation == 0 ? 0x0121 : 0x0101);
+            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 0 ? 0x0121 : 0x0101;
         case REGION_TYPE::BASTOK:
-            return (PChar->profile.nation == 1 ? 0x0122 : 0x0102);
+            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 1 ? 0x0122 : 0x0102;
         case REGION_TYPE::WINDURST:
-            return (PChar->profile.nation == 2 ? 0x0123 : 0x0120);
+            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 2 ? 0x0123 : 0x0120;
         case REGION_TYPE::JEUNO:
             return 0x0100;
         default:
             ShowWarning("Default case reached for GetMogHouseID by %s (%u)", PChar->GetName(), PChar->getZone());
             return 0x0100;
     }
+    // clang-format on
 }
 
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/
-
-uint8 GetMogHouseFlag(CCharEntity* PChar)
+uint8 GetMogHouseLeavingFlag(CCharEntity* PChar)
 {
     switch (zoneutils::GetCurrentRegion(PChar->getZone()))
     {
@@ -109,25 +104,19 @@ uint8 GetMogHouseFlag(CCharEntity* PChar)
     return 0;
 }
 
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/
-
 CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
 {
     this->setType(0x0A);
     this->setSize(0x104);
 
-    // необходимо для работы manaklipper
-    // последние 8 байт похожи на время
+    // It is necessary to work Manaklipper
+    // The last 8 bytes are similar for a while
     // unsigned char packet [] = {
     // 0x0D, 0x3A, 0x0C, 0x00, 0x11, 0x00, 0x19, 0x00, 0x02, 0xE4, 0x93, 0x10, 0x91, 0xE5, 0x93, 0x10}; // 0x2a = 0x10
     // 0x89, 0x39, 0x0C, 0x00, 0x19, 0x00, 0x07, 0x00, 0x5C, 0xE1, 0x93, 0x10, 0x81, 0xE3, 0x93, 0x10}; // 0x2a = 0x08
     // memcpy(data + 0x70, &packet, 16);
 
-    // data[0x2A] = 0x08;//data[0x2A] = 0x80;  // в зоне 3 управляет путями следования транспорта 0x10 и 0x08
+    // data[0x2A] = 0x08;//data[0x2A] = 0x80;  // in zone 3 controls the routes of transport 0x10 and 0x08
 
     ref<uint32>(0x04) = PChar->id;
     ref<uint16>(0x08) = PChar->targid;
@@ -178,13 +167,15 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     ref<uint16>(0x60) = PChar->loc.boundary;
     ref<uint16>(0x68) = PChar->loc.zone->GetWeather();
     ref<uint32>(0x6A) = PChar->loc.zone->GetWeatherChangeTime();
+
+    // TODO: Could this be previous weather, for weather transitions?
     // ref<uint32>(0x6C) = PChar->loc.zone->GetWeather();
     // ref<uint32>(0x70) = PChar->loc.zone->GetWeatherChangeTime();
 
     auto csid = currentEvent->eventId;
     if (csid != -1)
     {
-        // ref<uint8>(data,(0x1F)) = 4;                             // предположительно animation
+        // ref<uint8>(data,(0x1F)) = 4;                             // Presumably Animation
         // ref<uint8>(data,(0x20)) = 2;
 
         ref<uint16>(0x40) = PChar->currentEvent->textTable == -1 ? PChar->getZone() : PChar->currentEvent->textTable;
@@ -201,18 +192,18 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     if (PChar->m_moghouseID != 0)
     {
         ref<uint8>(0x80)  = 1;
-        ref<uint16>(0xAA) = GetMogHouseID(PChar);   // Mog House id
-        ref<uint8>(0xAE)  = GetMogHouseFlag(PChar); // Mog House leaving flag
+        ref<uint16>(0xAA) = GetMogHouseModelID(PChar);
+        ref<uint8>(0xAE)  = GetMogHouseLeavingFlag(PChar);
     }
     else
     {
         ref<uint8>(0x80)  = 2;
         ref<uint16>(0xAA) = 0x01FF;
         ref<uint8>(0xAC)  = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
-        ref<uint8>(0xAF)  = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // флаг, позволяет использовать mog menu за пределами mog house
+        ref<uint8>(0xAF)  = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // flag allows you to use Mog Menu outside Mog House
     }
 
-    ref<uint32>(0xA0) = PChar->GetPlayTime(); // время, проведенное персонажем в игре с момента создания
+    ref<uint32>(0xA0) = PChar->GetPlayTime(); // time spent by the character in the game from the moment of creation
 
     uint32 pktTime = CVanaTime::getInstance()->getVanaTime();
 

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -205,15 +205,12 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
         ref<uint8>(0x80)  = 2;
         ref<uint16>(0xAA) = 0x01FF;
 
-        // TODO: This has also been seen as 0x04
+        // TODO: This has also been seen as 0x04 and 0x07
         ref<uint8>(0xAC) = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
         ref<uint8>(0xAF) = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // flag allows you to use Mog Menu outside Mog House
     }
 
     ref<uint32>(0xA0) = PChar->GetPlayTime(); // time spent by the character in the game from the moment of creation
-
-    // Using Moghouse2F
-    ref<uint8>(0xA8) = PChar->profile.mhflag & 0x40 ? 0x3A : 0x38;
 
     ref<uint8>(0xAE) = GetMogHouseLeavingFlag(PChar);
 
@@ -223,10 +220,6 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     ref<uint32>(0x3C) = pktTime;
 
     ref<uint32>(0xA4) = PChar->GetTimeRemainingUntilDeathHomepoint();
-
-    // TODO: What are these for?
-    ref<uint8>(0xB0) = 0x01;
-    ref<uint8>(0xB2) = 0x02;
 
     ref<uint8>(0xB4) = PChar->GetMJob();
     ref<uint8>(0xB7) = PChar->GetSJob();

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -34,9 +34,15 @@
 // (These used to be entries in the ZONEID enum, but that was wrong, knowing what we know now)
 uint16 GetMogHouseModelID(CCharEntity* PChar)
 {
-    // TODO: Hook these up using information stored in PChar
+    // Shift right 7 places, mask the bottom two bits.
+    // 0x0080: This bit and the next track which 2F decoration style is being used (0: SANDORIA, 1: BASTOK, 2: WINDURST, 3: PATIO)
+    // 0x0100: ^ As above
+    uint16 moghouse2FModel      = 0x0267 + ((PChar->profile.mhflag >> 7) & 0x03);
     bool   requestingMoghouse2F = PChar->profile.mhflag & 0x40;
-    uint16 moghouse2FModel      = 0x026A; // TODO: Lookup which model the play has saved
+    if (requestingMoghouse2F)
+    {
+        return moghouse2FModel;
+    }
 
     // clang-format off
     switch (zoneutils::GetCurrentRegion(PChar->getZone()))
@@ -50,11 +56,11 @@ uint16 GetMogHouseModelID(CCharEntity* PChar)
         case REGION_TYPE::SARUTA_FRONT:
             return 219;
         case REGION_TYPE::SANDORIA:
-            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 0 ? 0x0121 : 0x0101;
+            return PChar->profile.nation == 0 ? 0x0121 : 0x0101;
         case REGION_TYPE::BASTOK:
-            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 1 ? 0x0122 : 0x0102;
+            return PChar->profile.nation == 1 ? 0x0122 : 0x0102;
         case REGION_TYPE::WINDURST:
-            return requestingMoghouse2F ? moghouse2FModel : PChar->profile.nation == 2 ? 0x0123 : 0x0120;
+            return PChar->profile.nation == 2 ? 0x0123 : 0x0120;
         case REGION_TYPE::JEUNO:
             return 0x0100;
         default:

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -200,8 +200,8 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
         ref<uint16>(0xAA) = 0x01FF;
 
         // TODO: This has also been seen as 0x04
-        ref<uint8>(0xAC)  = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
-        ref<uint8>(0xAF)  = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // flag allows you to use Mog Menu outside Mog House
+        ref<uint8>(0xAC) = csid > 0 ? 0x01 : 0x00;                    // if 0x01 then pause between zone
+        ref<uint8>(0xAF) = PChar->loc.zone->CanUseMisc(MISC_MOGMENU); // flag allows you to use Mog Menu outside Mog House
     }
 
     ref<uint32>(0xA0) = PChar->GetPlayTime(); // time spent by the character in the game from the moment of creation
@@ -209,7 +209,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity* PChar, const EventInfo* currentEvent)
     // Using Moghouse2F
     ref<uint8>(0xA8) = PChar->profile.mhflag & 0x40 ? 0x3A : 0x38;
 
-    ref<uint8>(0xAE)  = GetMogHouseLeavingFlag(PChar);
+    ref<uint8>(0xAE) = GetMogHouseLeavingFlag(PChar);
 
     uint32 pktTime = CVanaTime::getInstance()->getVanaTime();
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -679,7 +679,7 @@ namespace charutils
             HP = sql->GetIntData(3);
             MP = sql->GetIntData(4);
 
-            PChar->profile.mhflag = (uint8)sql->GetIntData(5);
+            PChar->profile.mhflag = (uint16)sql->GetIntData(5);
             PChar->profile.title  = (uint16)sql->GetIntData(6);
 
             int8* bazaarMessage = sql->GetData(7);

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -232,7 +232,7 @@ enum ZONEID : uint16
     ZONE_DYNAMIS_BASTOK                 = 186,
     ZONE_DYNAMIS_WINDURST               = 187,
     ZONE_DYNAMIS_JEUNO                  = 188,
-    ZONE_189                            = 189, // Southern San d'Oria [S] Residential Area
+    ZONE_189                            = 189,
     ZONE_KING_RANPERRES_TOMB            = 190,
     ZONE_DANGRUF_WADI                   = 191,
     ZONE_INNER_HORUTOTO_RUINS           = 192,
@@ -242,7 +242,7 @@ enum ZONEID : uint16
     ZONE_GUSGEN_MINES                   = 196,
     ZONE_CRAWLERS_NEST                  = 197,
     ZONE_MAZE_OF_SHAKHRAMI              = 198,
-    ZONE_199                            = 199, // Bastok Markets [S] Residential Area
+    ZONE_199                            = 199,
     ZONE_GARLAIGE_CITADEL               = 200,
     ZONE_CLOISTER_OF_GALES              = 201,
     ZONE_CLOISTER_OF_STORMS             = 202,
@@ -257,12 +257,12 @@ enum ZONEID : uint16
     ZONE_CLOISTER_OF_TIDES              = 211,
     ZONE_GUSTAV_TUNNEL                  = 212,
     ZONE_LABYRINTH_OF_ONZOZO            = 213,
-    ZONE_214                            = 214, // Aht Urhgan Residential Area
+    ZONE_214                            = 214,
     ZONE_ABYSSEA_ATTOHWA                = 215,
     ZONE_ABYSSEA_MISAREAUX              = 216,
     ZONE_ABYSSEA_VUNKERL                = 217,
     ZONE_ABYSSEA_ALTEPA                 = 218,
-    ZONE_219                            = 219, // Windurst Waters [S] Residential Area
+    ZONE_219                            = 219,
     ZONE_SHIP_BOUND_FOR_SELBINA         = 220,
     ZONE_SHIP_BOUND_FOR_MHAURA          = 221,
     ZONE_PROVENANCE                     = 222,

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -853,6 +853,13 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
 void CZoneEntities::SpawnMoogle(CCharEntity* PChar)
 {
     TracyZoneScoped;
+
+    // If on Moghouse2F; don't spawn the Moogle
+    if (PChar->profile.mhflag & 0x40)
+    {
+        return;
+    }
+
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
     {
         CNpcEntity* PCurrentNpc = (CNpcEntity*)it->second;

--- a/tools/migrations/034_expand_mhflag_column.py
+++ b/tools/migrations/034_expand_mhflag_column.py
@@ -1,0 +1,26 @@
+import mariadb
+
+
+def migration_name():
+    return "Expanding mhflag column in char_stats table"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    cur.execute("DESCRIBE char_stats mhflag;")
+    return cur.fetchone()[1] != "smallint(4) unsigned"
+
+
+def migrate(cur, db):
+    try:
+        # `mhflag` smallint(4) unsigned NOT NULL DEFAULT '0',
+        cur.execute(
+            "ALTER TABLE char_stats \
+                MODIFY mhflag smallint(4) unsigned NOT NULL DEFAULT '0';"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- [ ] Make sure "Change Floors" option isn't available if you've not completed enough exit quests
- [x] Make sure all exit quests still work
  - [x] Sandy
  - [x] Bastok
  - [x] Windy
  - [x] Jeuno
  - [x] AhtUrghan
- [x] Make sure you can't get to 2F through packet abuse
- [x] Log and reject any packet abuse around Moghouse zoneline and 2F
- [x] Changing floors (1F)
- [x] Changing floors (2F)
- [x] Exit from 2F, re-enter into 1F
- [x] Exit from 1F, re-enter into 1F
- [x] Log out in 1F, log in to 1F
- [x] Log out in 2F, log in to 2F
- [x] DC in 1F, log in to 1F
- [x] DC in 2F, log in to 2F
- [x] Furniture placement (2F)
- [x] Hide Moogle in 2F
- [x] Cutscene telling you you've unlocked 2F
  - [x] Cutscene works, but Moogle is stuck in DISAPPEAR state... 
- [x] Mog patio item + usage
- [x] Mog patio KI and checking when remodelling
- Remodelling
  - [x] Sandoria
  - [x] Bastok
  - [x] Windurst
  - [x] Patio (+ enable with KI)
  - [x] Remodelling (changing) while you're on 2F zones you so the change can take effect
- [x] Ensure 2F furniture doesn't increase storage (is that right?)
- [x] Ensure 2F furniture doesn't affect Moghancement or Moglification (is that right?)
- [x] Ensure it isn't possible to do Gardening on 2F
  - It looks like its possible to do gardening on your existing pots in your STORAGE_1, like when you're in a rent-a-room
  - If you have pots available to place in your storage, they're filtered out when you open the menu
  - Should still be checking, because, packet abuse

NOTE: Change Floors option is greyed out when you're in a rent-a-room, that could be a good place to look for how to grey out this option when you're at home.

### Out of scope

- Invite to Moghouse
- Exit to Mog Garden

## Steps to test these changes

Go through the checklist above
