### PR TITLE
[lua] Make sure Lua calls for onMobDeath return valid values

### DIFF
--- a/scripts/globals/interaction/interaction_lookup.lua
+++ b/scripts/globals/interaction/interaction_lookup.lua
@@ -379,7 +379,11 @@ local function onHandler(data, secondLevelKey, thirdLevelKey, args, fallbackHand
     local playerArg = args.playerArg or 1
     local player = args[playerArg]
     if not player then -- if no player object is present, we can't do anything in the handler system
-        return fallbackHandler(unpack(args))
+        if fallbackHandler then
+            return fallbackHandler(unpack(args))
+        end
+
+        return defaultReturn -- likely nil in most cases
     end
 
     local actions, priority = getHighestPriorityActions(data, player, secondLevelKey, thirdLevelKey, args)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3463,6 +3463,8 @@ namespace luautils
 
                     // onMobDeath(mob, player, optParams)
                     auto result = onMobDeathFramework(LuaMobEntity, optLuaAllyEntity, optParams, onMobDeath);
+
+                    // NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
                     if (!result.valid())
                     {
                         sol::error err = result;
@@ -3481,6 +3483,8 @@ namespace luautils
 
             // onMobDeath(mob, player, optParams)
             auto result = onMobDeathFramework(CLuaBaseEntity(PMob), sol::lua_nil, optParams, onMobDeath);
+
+            // NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
             if (!result.valid())
             {
                 sol::error err = result;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the issue when any entity is killed if they dont have an onMobDeath function defined:
```
[01/02/23 22:50:44:896][map][error] luautils::onMobDeath: .\scripts/globals/interaction/interaction_lookup.lua:382: attempt to call local 'fallbackHandler' (a nil value)
stack traceback:
        .\scripts/globals/interaction/interaction_lookup.lua:382: in function <.\scripts/globals/interaction/interaction_lookup.lua:378> (luautils::OnMobDeath:3487)
```

Interesting notes:

This fix doesn't seem like it's enough right? I didn't think so either until I tested sol out a bit: https://godbolt.org/z/dE1aPxqxo

As I mention in the comments:
```
// NOTE: result is only NOT valid if the function call fails. If it returns nil its still valid (this is expected)
```

`nil` is a valid function call result. It's only not valid if there has been an error.

Closes https://github.com/LandSandBoat/server/issues/3464
Closes https://github.com/LandSandBoat/server/issues/411

## Steps to test these changes

- Goto Qufim
- `!hp 0` some normal mobs, `!hp 0` some Gigas Leeches -> no errors
- `!changejob SMN 99`, `!addallspells`, summon something, kill it or release it -> no errors
