### PR TITLE
Interaction - HQuest: Trust: Shantotto

### DIFF
--- a/scripts/quests/hiddenQuests/Trust_Shantotto.lua
+++ b/scripts/quests/hiddenQuests/Trust_Shantotto.lua
@@ -1,0 +1,122 @@
+-----------------------------------
+-- Trust: Shantotto
+-----------------------------------
+-- Shantotto : !pos 122 -2 112 239
+-----------------------------------
+require('scripts/globals/magic')
+require('scripts/globals/trust')
+require('scripts/globals/quests')
+require('scripts/globals/keyitems')
+require('scripts/globals/missions')
+require('scripts/globals/interaction/hidden_quest')
+-----------------------------------
+local wallsID = require('scripts/zones/Windurst_Walls/IDs')
+-----------------------------------
+
+local quest = HiddenQuest:new("TrustShantotto")
+
+local requiredTrusts =
+{
+    xi.magic.spell.KUPIPI,
+    xi.magic.spell.NANAA_MIHGO,
+    xi.magic.spell.AJIDO_MARUJIDO,
+    xi.magic.spell.EXCENMILLE,
+    xi.magic.spell.CURILLA,
+    xi.magic.spell.TRION,
+    xi.magic.spell.AYAME,
+    xi.magic.spell.NAJI,
+    xi.magic.spell.VOLKER,
+}
+
+local function hasRequiredTrusts(player)
+    for _, trustSpellId in ipairs(requiredTrusts) do
+        if not player:hasSpell(trustSpellId) then
+            return false
+        end
+    end
+
+    return true
+end
+
+local trustMemory = function(player)
+    local memories = 0
+    --[[ TODO
+    -- 2 - The Three Kingdoms
+    if player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_TO_BASTOK2) or player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) then
+        memories = memories + 2
+    end
+    -- 4 - Where Two Paths Converge
+    if player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE) then
+        memories = memories + 4
+    end
+    -- 8 - The Pirate's Cove
+    if player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_PIRATES_COVE) then
+        memories = memories + 8
+    end
+    -- 16 - Ayame and Kaede
+    if player:hasCompletedQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.AYAME_AND_KAEDE) then
+        memories = memories + 16
+    end
+    -- 32 - Light of Judgement
+    if player:hasCompletedMission(xi.mission.log_id.TOAU, xi.mission.id.toau.LIGHT_OF_JUDGMENT) then
+        memories = memories + 32
+    end
+    -- 64 - True Strength
+    if player:hasCompletedQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TRUE_STRENGTH) then
+        memories = memories + 64
+    end
+    ]]--
+
+    -- Kill a Taru under the gun
+    -- Defeated Shadowlord
+    -- Saving Star Sibyl
+    -- Grade, came up in spades
+    -- Bring back Prishe
+    -- Yoran Oran: No Heir
+    -- Incident with Ragnarok
+    -- Chocobo Races
+    -- Markovich
+    -- Puppet Twin battle
+    -- Yoran-Oran and Koru-Moru
+    -- Grimy Hat
+    return memories
+end
+
+quest.sections =
+{
+    {
+        check = function(player, questVars, vars)
+            return not player:hasSpell(xi.magic.spell.SHANTOTTO) and
+                player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT)
+        end,
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Shantotto'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        player:hasCompletedQuest(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CURSES_FOILED_A_GOLEM) and
+                        hasRequiredTrusts(player)
+                    then
+                        return quest:progressEvent(529, { [3] = trustMemory(player), [7] = 1 })
+                    else
+                        return quest:event(529):importantEvent()
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [529] = function(player, csid, option, npc)
+                    if option == 2 then
+                        player:addSpell(xi.magic.spell.SHANTOTTO, true, true)
+                        player:messageSpecial(wallsID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.SHANTOTTO)
+                    end
+                end,
+            },
+        },
+    },
+}
+
+return quest

--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -2,66 +2,16 @@
 -- Area: Windurst Walls (239)
 --  NPC: Shantotto
 -- !pos 122 -2 112 239
--- CSID's missing in autoEventID please check the old forums under resources for all of shantotto's csid's. I found them all manually.
 -----------------------------------
-local ID = require("scripts/zones/Windurst_Walls/IDs")
-require("scripts/globals/keyitems")
-require("scripts/globals/settings")
 require("scripts/globals/quests")
-require("scripts/globals/titles")
 require("scripts/globals/utils")
 -----------------------------------
 local entity = {}
-
-local trustMemory = function(player)
-    local memories = 0
-    --[[ TODO
-    -- 2 - The Three Kingdoms
-    if player:hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_TO_BASTOK2) or player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2) then
-        memories = memories + 2
-    end
-    -- 4 - Where Two Paths Converge
-    if player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE) then
-        memories = memories + 4
-    end
-    -- 8 - The Pirate's Cove
-    if player:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_PIRATES_COVE) then
-        memories = memories + 8
-    end
-    -- 16 - Ayame and Kaede
-    if player:hasCompletedQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.AYAME_AND_KAEDE) then
-        memories = memories + 16
-    end
-    -- 32 - Light of Judgement
-    if player:hasCompletedMission(xi.mission.log_id.TOAU, xi.mission.id.toau.LIGHT_OF_JUDGMENT) then
-        memories = memories + 32
-    end
-    -- 64 - True Strength
-    if player:hasCompletedQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.TRUE_STRENGTH) then
-        memories = memories + 64
-    end
-    ]]--
-
-    -- Kill a Taru under the gun
-    -- Defeated Shadowlord
-    -- Saving Star Sibyl
-    -- Grade, came up in spades
-    -- Bring back Prishe
-    -- Yoran Oran: No Heir
-    -- Incident with Ragnarok
-    -- Chocobo Races
-    -- Markovich
-    -- Puppet Twin battle
-    -- Yoran-Oran and Koru-Moru
-    -- Grimy Hat
-    return memories
-end
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local foiledAGolem = player:getQuestStatus(xi.quest.log_id.WINDURST, xi.quest.id.windurst.CURSES_FOILED_A_GOLEM)
     local wildcatWindurst = player:getCharVar("WildcatWindurst")
 
     if
@@ -74,18 +24,6 @@ entity.onTrigger = function(player, npc)
         player:getCharVar("ClassReunionProgress") == 3
     then
         player:startEvent(409) -- she mentions that Sunny-Pabonny left for San d'Oria
-
-    -- Trust
-    -- TODO: Wiki's aren't clear on the exact conditions for this event, assuming it's the final nation "extreme" trust
-    elseif
-        player:hasSpell(898) and -- Kupipi
-        player:hasSpell(901) and -- Nanaa Mihgo
-        player:hasSpell(903) and -- Volker
-        player:hasSpell(904) and -- Ajido-Marujido
-        player:hasSpell(905) and -- Trion
-        not player:hasSpell(896) -- NOT Shantotto
-    then
-        player:startEvent(529, 0, 0, 0, trustMemory(player), 0, 0, 0, foiledAGolem == QUEST_COMPLETED and 1 or 0)
     end
 end
 
@@ -94,11 +32,6 @@ entity.onEventFinish = function(player, csid, option)
         player:setCharVar("ClassReunionProgress", 4)
     elseif csid == 498 then
         player:setCharVar("WildcatWindurst", utils.mask.setBit(player:getCharVar("WildcatWindurst"), 6, true))
-
-        -- TRUST
-    elseif csid == 529 and option == 2 then
-        player:addSpell(896, true, true)
-        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 896)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Converts Trust: Shantotto logic to Hidden Quest
* Adds optional dialogue that occurs after obtaining Windurst trust permit, but prior to meeting both trust and quest conditions
* Adds all required trusts to condition for obtaining Shantotto, and uses xi.magic.spell enum

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Talk to Shantotto prior to obtaining Windurst Trust Permit (No action)
2. Talk to Shantotto after obtaining Permit, but not meeting conditions (Get 529, last param=0)
3. Talk to Shantotto after meeting all conditions (get long cs, obtain trust)
<!-- Clear and detailed steps to test your changes here -->
