### PR TITLE
[ci] Add lua check for deprecated functions

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -22,6 +22,11 @@ import re
 import regex
 import sys
 
+# [["deprecated func", "suggested replacement"], ...]
+deprecated_functions = [
+    ["table.getn", "#t"],
+]
+
 def contains_word(word):
     return re.compile(r'\b({0})\b'.format(word)).search
 
@@ -228,6 +233,13 @@ class LuaStyleCheck:
             if not 'if' in condition_end and condition_end != '':
                 self.error("Invalid multiline conditional format")
 
+    def check_deprecated_functions(self, line):
+        for entry in deprecated_functions:
+            deprecated_func = entry[0]
+            replacement     = entry[1]
+            if contains_word(deprecated_func)(line):
+                self.error(f"Use of deprecated function: {deprecated_func}. Suggested replacement: {replacement}")
+
     def run_style_check(self):
         if self.filename is None:
             print("ERROR: No filename provided to LuaStyleCheck class.")
@@ -272,6 +284,8 @@ class LuaStyleCheck:
 
                 # Multiline conditionals should not have data in if, elseif, or then
                 self.check_multiline_condition_format(code_line)
+
+                self.check_deprecated_functions(code_line)
 
                 # Condition blocks/lines should not have outer parentheses
                 # Find all strings contained in parentheses: \((([^\)\(]+)|(?R))*+\)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cloases https://github.com/LandSandBoat/server/issues/3475

## Steps to test these changes

Add a bogus change, then run:
```
zach2good@ZACH-LAPTOP:/mnt/c/ffxi/server$ ./tools/ci/lua.sh scripts/globals/chocobo_raising.lua
Use of deprecated function: table.getn: scripts/globals/chocobo_raising.lua:864
table.getn(player)                              <-- HERE

Lua styling errors: 1
```
