### PR TITLE
[map] Fix long names returning NULL PChar for certain zmq message types

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -109,8 +109,8 @@ namespace message
             }
             case MSG_CHAT_TELL:
             {
-                char characterName[15] = {};
-                memcpy(&characterName, reinterpret_cast<char*>(extra.data()) + 4, sizeof(characterName));
+                char characterName[PacketNameLength] = {};
+                memcpy(&characterName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
 
                 CCharEntity* PChar = zoneutils::GetCharByName(characterName);
                 if (PChar && PChar->status != STATUS_TYPE::DISAPPEAR && !jailutils::InPrison(PChar))
@@ -394,16 +394,16 @@ namespace message
 
                 if (PLinkshell)
                 {
-                    char memberName[15] = {};
-                    memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, sizeof(memberName));
+                    char memberName[PacketNameLength] = {};
+                    memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
                     PLinkshell->ChangeMemberRank(memberName, ref<uint8>((uint8*)extra.data(), 28));
                 }
                 break;
             }
             case MSG_LINKSHELL_REMOVE:
             {
-                char memberName[15] = {};
-                memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, sizeof(memberName));
+                char memberName[PacketNameLength] = {};
+                memcpy(&memberName, reinterpret_cast<char*>(extra.data()) + 4, PacketNameLength - 1);
                 CCharEntity* PChar = zoneutils::GetCharByName(memberName);
 
                 if (PChar && PChar->PLinkshell1 && PChar->PLinkshell1->getID() == ref<uint32>((uint8*)extra.data(), 24))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes long named characters to have the following work on a different process:
* tell
* linkshell promote to sack
* linkshell kick

The effective change expands out to

`char characterName[15] = {};`
->
`char characterName[16] = {};`
but only memcpy 15 characters to guarantee the null terminator

## Steps to test these changes

have longest name character, attempt to /tell, kick from ls, or promote to sack from a different process and have it work
