### PR TITLE
[Settings] Disable Unity Checks when settings for RoE are turned off

### DIFF
--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -1,7 +1,4 @@
 ﻿/*
- * roe.cpp
- *      Author: Kreidos | github.com/kreidos
- *
 ===========================================================================
 
   Copyright (c) 2020 Topaz Dev Teams
@@ -687,6 +684,12 @@ namespace roeutils
     void CycleUnityRankings()
     {
         TracyZoneScoped;
+
+        if (!settings::get<bool>("main.ENABLE_ROE"))
+        {
+            return;
+        }
+
         const char* rankingQuery = "UPDATE unity_system SET members_prev = members_current, points_prev = points_current, members_current = 0, points_current = 0;";
         sql->Query(rankingQuery);
 
@@ -696,6 +699,12 @@ namespace roeutils
     void UpdateUnityRankings()
     {
         TracyZoneScoped;
+
+        if (!settings::get<bool>("main.ENABLE_ROE"))
+        {
+            return;
+        }
+
         const char* memberQuery = "UPDATE unity_system JOIN (SELECT unity_leader, COUNT(*) AS members FROM char_profile GROUP BY unity_leader) TMP ON unity_system.leader = unity_leader SET unity_system.members_current = members;";
         sql->Query(memberQuery);
 


### PR DESCRIPTION
Co-authored-by: panicstevenson <panicstevenson@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Imports change from ASB, made by panicstevenson.

Disables unity checks when settings for RoE are not "on"... As title sais.

## Steps to test these changes

Start the server. When setting is on, no change should be observed. When off, unity checks should be disabled.
