### PR TITLE
[core] Add Packet Mods

### DIFF
--- a/scripts/commands/packetmod.lua
+++ b/scripts/commands/packetmod.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- func: packetmod
+-- desc: Adds a modifier for S->C packets
+-----------------------------------
+
+cmdprops =
+{
+    permission = 5,
+    parameters = "ssss"
+}
+
+function onTrigger(player, operation, packetId, offset, value)
+    if operation == "add" then
+        player:addPacketMod(tonumber(packetId), tonumber(offset), tonumber(value))
+    elseif operation == "del" then
+        -- TODO
+    elseif operation == "clear" then
+        player:clearPacketMods()
+    else
+        -- TODO: Print list of mods
+    end
+end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -164,6 +164,8 @@
 #include "utils/trustutils.h"
 #include "utils/zoneutils.h"
 
+extern std::unordered_map<uint32, std::unordered_map<uint16, std::vector<std::pair<uint16, uint8>>>> PacketMods;
+
 //======================================================//
 
 CLuaBaseEntity::CLuaBaseEntity(CBaseEntity* PEntity)
@@ -14950,6 +14952,29 @@ uint8 CLuaBaseEntity::getMannequinPose(uint16 itemID)
 
     return 0;
 }
+
+void CLuaBaseEntity::addPacketMod(uint16 packetId, uint16 offset, uint8 value)
+{
+    TracyZoneScoped;
+
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        ShowInfo(fmt::format("Adding Packet Mod ({}): 0x{:04X}: 0x{:04X}: 0x{:02X}",
+                             PChar->name, packetId, offset, value));
+        PacketMods[PChar->id][packetId].emplace_back(std::make_pair(offset, value));
+    }
+}
+
+void CLuaBaseEntity::clearPacketMods()
+{
+    TracyZoneScoped;
+
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        PacketMods[PChar->id].clear();
+    }
+}
+
 //==========================================================//
 
 void CLuaBaseEntity::Register()
@@ -15739,6 +15764,9 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("setMannequinPose", CLuaBaseEntity::setMannequinPose);
     SOL_REGISTER("getMannequinPose", CLuaBaseEntity::getMannequinPose);
+
+    SOL_REGISTER("addPacketMod", CLuaBaseEntity::addPacketMod);
+    SOL_REGISTER("clearPacketMods", CLuaBaseEntity::clearPacketMods);
 }
 
 std::ostream& operator<<(std::ostream& os, const CLuaBaseEntity& entity)

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -849,6 +849,9 @@ public:
     void  setMannequinPose(uint16 itemID, uint8 race, uint8 pose);
     uint8 getMannequinPose(uint16 itemID);
 
+    void addPacketMod(uint16 packetId, uint16 offset, uint8 value);
+    void clearPacketMods();
+
     static void Register();
 };
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -115,6 +115,8 @@ extern std::map<uint16, CZone*> g_PZoneList; // Global array of pointers for zon
 
 bool gLoadAllLua = false;
 
+std::unordered_map<uint32, std::unordered_map<uint16, std::vector<std::pair<uint16, uint8>>>> PacketMods;
+
 namespace
 {
     uint32 MAX_BUFFER_SIZE             = 2500U;
@@ -859,6 +861,24 @@ int32 send_parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_da
                 packetList.pop_front();
 
                 PSmallPacket->setSequence(map_session_data->server_packet_id);
+
+                // Apply packet mods if available
+                if (!PacketMods[PChar->id].empty())
+                {
+                    auto type = PSmallPacket->getType();
+                    if (PacketMods[PChar->id].find(type) != PacketMods[PChar->id].end())
+                    {
+                        for (auto& entry : PacketMods[PChar->id][type])
+                        {
+                            auto offset = entry.first;
+                            auto value  = entry.second;
+                            ShowInfo(fmt::format("Packet Mod ({}): {:04X}: {:04X}: {:02X}",
+                                                 PChar->name, type, offset, value));
+                            PSmallPacket->ref<uint8>(offset) = value;
+                        }
+                    }
+                }
+
                 memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->getSize());
 
                 *buffsize += PSmallPacket->getSize();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

While fiddling with Moghouse 2F, I got tired of having to keep closing out and recompiling to test what different bits in outgoing packets would do to the client. So I wrote up a little container that will keep track of your requested mods and apply them **JUST BEFORE** the packets are sent out.

## Example

`!packetmod add 0x00A 0xAA 0x68`
- Add packet mod to Zone In packet (0x00A)
- At offset 0xAA (the lower byte of Zone Model (remember these numbers are in LSB not MSB!))
- Mod the value to be 0x68

That uint8 will now be forced to whatever value you set, JUST BEFORE IT IS SENT OUT!

All of the inputs are read as strings and then converted to numbers, so you can use 0x00A, 0X00a, A, 10, or whatever you want.

To clear:

`!packetmod clear`