### PR TITLE
[DRK] Implement Scarlet Delirium

### DIFF
--- a/scripts/globals/effects/scarlet_delirium_1.lua
+++ b/scripts/globals/effects/scarlet_delirium_1.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.SCARLET_DELIRIUM_1
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -725,6 +725,19 @@ xi.spells.damage.calculateUndeadDivinePenalty = function(caster, target, spell, 
     return undeadDivinePenalty
 end
 
+xi.spells.damage.calculateScarletDeliriumMultiplier = function(caster)
+    local scarletDeliriumMultiplier = 1
+
+    -- Scarlet delirium are 2 different status effects. SCARLET_DELIRIUM_1 is the one that boosts power.
+    if caster:hasStatusEffect(xi.effect.SCARLET_DELIRIUM_1) then
+        local power = caster:getStatusEffect(xi.effect.SCARLET_DELIRIUM_1):getPower()
+
+        scarletDeliriumMultiplier = 1 + power / 100
+    end
+
+    return scarletDeliriumMultiplier
+end
+
 xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, spellElement)
     local nukeAbsorbOrNullify = 1
 
@@ -776,30 +789,8 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local ninSkillBonus               = xi.spells.damage.calculateNinSkillBonus(caster, target, spell, spellId, skillType)
     local ninFutaeBonus               = xi.spells.damage.calculateNinFutaeBonus(caster, target, spell, skillType)
     local undeadDivinePenalty         = xi.spells.damage.calculateUndeadDivinePenalty(caster, target, spell, skillType)
+    local scarletDeliriumMultiplier   = xi.spells.damage.calculateScarletDeliriumMultiplier(caster)
     local nukeAbsorbOrNullify         = xi.spells.damage.calculateNukeAbsorbOrNullify(caster, target, spell, spellElement)
-
-    -- Debug
-    -- printf("=====================")
-    -- printf("spellDamage = %s", spellDamage)
-    -- printf("======Multipliers====")
-    -- printf("MTDR = %s", multipleTargetReduction)
-    -- printf("eleStaffBonus = %s", eleStaffBonus)
-    -- printf("magianAffinity = %s", magianAffinity)
-    -- printf("SDT = %s", sdt)
-    -- printf("resist = %s", resist)
-    -- printf("magicBurst = %s", magicBurst)
-    -- printf("magicBurstBonus = %s", magicBurstBonus)
-    -- printf("dayAndWeather = %s", dayAndWeather)
-    -- printf("magicBonusDiff = %s", magicBonusDiff)
-    -- printf("TMDA = %s", targetMagicDamageAdjustment)
-    -- printf("divineEmblemMultiplier = %s", divineEmblemMultiplier)
-    -- printf("ebullienceMultiplier = %s", ebullienceMultiplier)
-    -- printf("skillTypeMultiplier = %s", skillTypeMultiplier)
-    -- printf("ninSkillBonus = %s", ninSkillBonus)
-    -- printf("ninFutaeBonus = %s", ninFutaeBonus)
-    -- printf("undeadDivinePenalty = %s", undeadDivinePenalty)
-    -- printf("nukeAbsorbOrNullify = %s", nukeAbsorbOrNullify)
-    -- printf("=====================")
 
     -- Calculate finalDamage. It MUST be floored after EACH multiplication.
     finalDamage = math.floor(spellDamage * multipleTargetReduction)
@@ -818,6 +809,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * ninSkillBonus)
     finalDamage = math.floor(finalDamage * ninFutaeBonus)
     finalDamage = math.floor(finalDamage * undeadDivinePenalty)
+    finalDamage = math.floor(finalDamage * scarletDeliriumMultiplier)
     finalDamage = math.floor(finalDamage * nukeAbsorbOrNullify)
 
     -- Handle Phalanx

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -94,6 +94,18 @@ local function souleaterBonus(attacker, wsParams)
     return bonus
 end
 
+local scarletDeliriumBonus = function(attacker)
+    local bonus = 1
+
+    if attacker:hasStatusEffect(xi.effect.SCARLET_DELIRIUM_1) then
+        local power = attacker:getStatusEffect(xi.effect.SCARLET_DELIRIUM_1):getPower()
+
+        bonus = 1 + power / 100
+    end
+
+    return bonus
+end
+
 local function fencerBonus(attacker)
     local bonus = 0
 
@@ -433,14 +445,18 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
         end
     end
 
+    -- Scarlet Delirium
+    adjustedDamage = adjustedDamage * scarletDeliriumBonus(attacker)
+
+    -- Souleater
+    adjustedDamage = adjustedDamage + souleaterBonus(attacker, wsParams)
+
     if adjustedDamage > 0 then
         adjustedDamage = adjustedDamage - target:getMod(xi.mod.PHALANX)
         adjustedDamage = utils.clamp(adjustedDamage, 0, 99999)
     end
 
     adjustedDamage = utils.stoneskin(target, adjustedDamage)
-
-    adjustedDamage = adjustedDamage + souleaterBonus(attacker, wsParams)
 
     return adjustedDamage
 end
@@ -865,6 +881,10 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
         local ftp = fTP(tp, wsParams.ftp100, wsParams.ftp200, wsParams.ftp300) + bonusfTP
 
         dmg = dmg * ftp
+
+        -- Apply Consume Mana and Scarlet Delirium
+        -- TODO: dmg = (dmg + consumeManaBonus(attacker)) * scarletDeliriumBonus(attacker)
+        dmg = dmg * scarletDeliriumBonus(attacker)
 
         -- Factor in "all hits" bonus damage mods
         local bonusdmg = attacker:getMod(xi.mod.ALL_WSDMG_ALL_HITS) -- For any WS

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -507,6 +507,15 @@ void CAttack::ProcessDamage()
         m_damage = (uint32)((m_attacker->GetRangedWeaponDmg() + battleutils::GetFSTR(m_attacker, m_victim, slot)) * m_damageRatio);
     }
 
+    // Apply Scarlet Delirium damage bonus
+    // EFFECT_SCARLET_DELIRIUM_1 is only active after damage has been dealt to the DRK and EFFECT_SCARLET_DELIRIUM has been removed.
+    if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SCARLET_DELIRIUM_1))
+    {
+        float effectPower = 1.0f + (m_attacker->StatusEffectContainer->GetStatusEffect(EFFECT_SCARLET_DELIRIUM_1)->GetPower() / 100.0f);
+
+        m_damage = (uint32)(m_damage * effectPower);
+    }
+
     // Apply "Double Attack" damage and "Triple Attack" damage mods
     if (m_attackType == PHYSICAL_ATTACK_TYPE::DOUBLE && m_attacker->objtype == TYPE_PC)
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2180,6 +2180,9 @@ namespace battleutils
         }
         damage = std::clamp(damage, -99999, 99999);
 
+        // Scarlet Delirium: Updates status effect power with damage bonus
+        battleutils::HandleScarletDelirium(PDefender, damage);
+
         int32 corrected = PDefender->takeDamage(damage, PAttacker, attackType, damageType);
         if (damage < 0)
         {
@@ -2484,6 +2487,9 @@ namespace battleutils
 
     int32 TakeSpellDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, CSpell* PSpell, int32 damage, ATTACK_TYPE attackType, DAMAGE_TYPE damageType)
     {
+        // Scarlet Delirium: Updates status effect power with damage bonus
+        battleutils::HandleScarletDelirium(PDefender, damage);
+
         PDefender->takeDamage(damage, PAttacker, attackType, damageType);
 
         // Remove effects from damage
@@ -5592,6 +5598,25 @@ namespace battleutils
             }
         }
         return damage;
+    }
+
+    void HandleScarletDelirium(CBattleEntity* PDefender, int32 damage)
+    {
+        // Check for Scarlet Delirium and update Effect Power with bonus from damage
+        CStatusEffect* effectScarDel = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_SCARLET_DELIRIUM);
+
+        // Damage bonus calculation, update Effect Power
+        if (effectScarDel && effectScarDel->GetPower() == 0)
+        {
+            // Damage to Max HP Ratio
+            int8   bonus    = std::floor(((damage * 100) / PDefender->GetMaxHP()) / 2);
+            int8   jpValue  = effectScarDel->GetSubPower();
+            uint32 duration = 90 + jpValue;
+
+            // Convert status effect from "Absorb damage" mode to "Provide damage bonus" mode
+            PDefender->StatusEffectContainer->DelStatusEffectSilent(EFFECT_SCARLET_DELIRIUM);
+            PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_SCARLET_DELIRIUM_1, EFFECT_SCARLET_DELIRIUM_1, bonus, 0, duration), true);
+        }
     }
 
     int32 HandleSevereDamageEffect(CBattleEntity* PDefender, EFFECT effect, int32 damage, bool removeEffect)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -229,6 +229,7 @@ namespace battleutils
     int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage);
     int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage);
     int32 HandleFanDance(CBattleEntity* PDefender, int32 damage);
+    void  HandleScarletDelirium(CBattleEntity* PDefender, int32 damage);
 
     // stores damage for afflatus misery if active
     void HandleAfflatusMiseryDamage(CBattleEntity* PDefender, int32 damage);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds functionality for scarlet Delirium damage multiplier
Taken from PR #2877

## Steps to test these changes

Log damage. Observe an enhancement in damage when Scarlet Delirium is active.
