### PR TITLE
[Fix] rare ocurrence of spells being wrongly absorbed/nullified

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -729,14 +729,14 @@ xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, 
     local nukeAbsorbOrNullify = 1
 
     -- Calculate chance for spell absorption.
-    if math.random(1, 100) <= (target:getMod(xi.magic.absorbMod[spellElement]) + 1) then
+    if math.random(1, 100) <= target:getMod(xi.magic.absorbMod[spellElement]) then
         nukeAbsorbOrNullify = -1
     end
 
     -- Calculate chance for spell nullification.
     local nullifyChance = math.random(1, 100)
     if
-        nullifyChance <= (target:getMod(nullMod[spellElement]) + 1) or
+        nullifyChance <= target:getMod(nullMod[spellElement]) or
         nullifyChance <= target:getMod(xi.mod.MAGIC_NULL)
     then
         nukeAbsorbOrNullify = 0


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a 1% chance of spells being absorbed or nullified when they shouldn't. This happened because we were adding a +1 by default to the modifier checks when we should have not.

## Steps to test these changes

Cast non stop and not have your spell absorbed/nullified when the target doesnt have those modifiers.
