### PR TITLE
[core] Make sure cache entries aren't overwritten on multiple file reads

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -75,7 +75,7 @@ for _, entry in pairs(nmsToShield) do
 
             mobArg:setClaimable(true)
             mobArg:setUnkillable(false)
-            mob:setCallForHelpBlocked(false)
+            mobArg:setCallForHelpBlocked(false)
 
             mobArg:resetAI()
             mobArg:setHP(mobArg:getMaxHP())

--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -5,26 +5,6 @@ require("scripts/globals/settings")
 require("scripts/globals/utils")
 -----------------------------------
 
--- Global, for use in C++
-function applyOverride(base_table, name, func, fullname, filename)
-    local old = base_table[name]
-
-    if old == nil then
-        if xi.settings.logging.DEBUG_MODULES then
-            print(string.format("Inserting empty function to override for: %s (%s)", fullname, filename))
-        end
-        old = function() end -- Insert empty function
-    end
-
-    local thisenv = getfenv(old)
-
-    local env = { super = old }
-    setmetatable(env, { __index = thisenv })
-
-    setfenv(func, env)
-    base_table[name] = func
-end
-
 -- Override Object
 Override = {}
 Override.__index = Override

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -343,6 +343,7 @@ namespace luautils
 
         for (auto const& filename : filenames)
         {
+            ShowInfo("[FileWatcher] %s", filename);
             CacheLuaObjectFromFile(filename, true);
         }
     }
@@ -504,7 +505,7 @@ namespace luautils
     // Assumes filename in the form "./scripts/folder0/folder1/folder2/mob_name.lua
     // Object returned form that script will be cached to:
     // xi.folder0.folder1.folder2.mob_name
-    void CacheLuaObjectFromFile(std::string filename, bool printOutput /*= false*/)
+    void CacheLuaObjectFromFile(std::string filename, bool overwriteCurrentEntry /* = false*/)
     {
         TracyZoneScoped;
         TracyZoneString(filename);
@@ -680,18 +681,20 @@ namespace luautils
         {
             if (part == parts.back())
             {
-                table[sol::override_value][part] = file_result;
+                if (overwriteCurrentEntry)
+                {
+                    table[sol::override_value][part] = file_result;
+                }
+                else
+                {
+                    table[sol::update_if_empty][part] = file_result;
+                }
             }
             else
             {
                 table = table[part].get_or_create<sol::table>(lua.create_table());
             }
             out_str += "." + part;
-        }
-
-        if (printOutput)
-        {
-            ShowInfo("[FileWatcher] %s -> %s", filename, out_str);
         }
 
         moduleutils::TryApplyLuaModules();

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -126,7 +126,7 @@ namespace luautils
 
     // Cache helpers
     auto getEntityCachedFunction(CBaseEntity* PEntity, std::string funcName) -> sol::function;
-    void CacheLuaObjectFromFile(std::string filename, bool printOutput = false);
+    void CacheLuaObjectFromFile(std::string filename, bool overwriteCurrentEntry = false);
     auto GetCacheEntryFromFilename(std::string filename) -> sol::table;
     void OnEntityLoad(CBaseEntity* PEntity);
 

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -128,6 +128,21 @@ namespace moduleutils
         // Load the helper file
         lua.safe_script_file("./modules/module_utils.lua");
 
+        lua.safe_script(R""(
+            function applyOverride(base_table, name, func, fullname, filename)
+                local old = base_table[name]
+
+                local thisenv = getfenv(old)
+
+                local env = { super = old }
+                setmetatable(env, { __index = thisenv })
+
+                setfenv(func, env)
+
+                base_table[name] = func
+            end
+        )"");
+
         // Read lines from init.txt
         std::vector<std::string> list;
         std::ifstream            file("./modules/init.txt", std::ios_base::in);
@@ -254,6 +269,13 @@ namespace moduleutils
                     {
                         DebugModules(fmt::format("Applying override: {}", override.overrideName));
 
+                        if (table[lastElem] == sol::lua_nil)
+                        {
+                            DebugModules("Inserting empty function to override for: %s (%s)", override.overrideName, override.filename);
+                            table[lastElem] = []() {};
+                        }
+
+                        // Function defined in LoadLuaModules()
                         lua["applyOverride"](table, lastElem, override.func, override.overrideName, override.filename);
 
                         override.applied = true;

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -29,7 +29,6 @@ global_objects=(
     Module
     Override
     super
-    applyOverride
 
     common
     zones


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I kept a bunch of notes of my findings in https://github.com/LandSandBoat/server/issues/3412, this moves some things around and makes sure that cache entries aren't overwritten unless you pass `true` into the caching function.

Closes: https://github.com/LandSandBoat/server/issues/3412

**THIS WILL REQUIRE A LOT OF TESTING TO MAKE SURE EVERYTHING STILL WORKS AS EXPECTED: Hot-reloading, modules, etc.**

## Steps to test these changes

See my notes in https://github.com/LandSandBoat/server/issues/3412
