### PR TITLE
[core] Better handling of dropped 0x00A packets on zoning in

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -783,6 +783,15 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
 
     if (ref<uint16>(buff, 2) != map_session_data->server_packet_id)
     {
+        /*
+         * If the client and server have become out of sync, then caching takes place. However, caching
+         * zone packets will result in the client never properly connecting. Ignore those specifically.
+         */
+        if (SmallPD_Type == 0x0A)
+        {
+            return 0;
+        }
+
         ref<uint16>(map_session_data->server_packet_data, 2) = SmallPD_Code;
         ref<uint16>(map_session_data->server_packet_data, 8) = (uint32)time(nullptr);
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -248,6 +248,22 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         return;
     }
 
+    /*
+     * Handle out of sync zone correction..
+     */
+    if (data.ref<uint16_t>(0x02) > 1)
+    {
+        PSession->server_packet_id = data.ref<uint16_t>(0x02);
+
+        // Clear all pending packets for this character.
+        // This incoming 0x00A from the client wants us to set the the starting sync count for all new packets to the sync count from 0x02.
+        // If we do not do this, all further packets may be ignored by the client and will result in disconnection from the server.
+        if (PChar)
+        {
+            PChar->clearPacketList();
+        }
+    }
+
     if (PSession->blowfish.status == BLOWFISH_WAITING) // Generate new blowfish session, call zone in, etc, only once.
     {
         PChar->clearPacketList();


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This changes 0x00A handling to copy the syncCount to CZoneInPacket,

The client expects CZoneInPacket to match its sent sync count and otherwise will not accept the data. This means that CZoneInPacket (0x00A) *cannot* be cached.

## Steps to test these changes

On ashitav4, install this addon and load:
[test.zip](https://github.com/LandSandBoat/server/files/10434571/test.zip)
Block server to client 0x00A, try to zone. wait for counters to go up, unblock, and be able to zone in.
