### PR TITLE
[Conquest] Fix zone checked , so city zones are also included

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -51,10 +51,13 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Update);
-                PZone->ForEachChar([](CCharEntity* PChar) { PChar->PLatentEffectContainer->CheckLatentsZone(); });
+                PZone->ForEachChar([](CCharEntity* PChar)
+                {
+                    PChar->PLatentEffectContainer->CheckLatentsZone();
+                });
             }
         });
         // clang-format on
@@ -365,7 +368,7 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_Start);
             }
@@ -392,7 +395,7 @@ namespace conquest
         zoneutils::ForEachZone([](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
+            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
             {
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_End);
                 PZone->ForEachChar([](CCharEntity* PChar)


### PR DESCRIPTION
Co-authored-by: zach2good <zach2good@users.noreply.github.com>

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue with conquest zone checks. City zones were not being included. Thiswould affect conquest-dependant npcs, like the traveling merchant troupe not spawning.

## Steps to test these changes

Add a print in city zones dependant on conquest and check if cities are called now.
