### PR TITLE
[Settings] Adds setting checks for JST midnight

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -44,6 +44,12 @@ xi.settings.main =
     FOV_REWARD_ALLIANCE   = 0, -- Allow Fields of Valor rewards while being a member of an alliance. (default retail behavior: 0)
     GOV_REWARD_ALLIANCE   = 1, -- Allow Grounds of Valor rewards while being a member of an alliance. (default retail behavior: 1)
 
+    -- Daily points / Gobbie mystery box.
+    ENABLE_DAILY_TALLY = 1,  -- Allows acquisition of daily points for gobbie mystery box.
+    DAILY_TALLY_AMOUNT = 10,
+    DAILY_TALLY_LIMIT  = 50000,
+    GOBBIE_BOX_MIN_AGE = 45, -- Minimum character age in days before a character can sign up for Gobbie Mystery Box
+
     -- Records of Eminence
     ENABLE_ROE            = 1, -- Enable Records of Eminence
     ENABLE_ROE_TIMED      = 1, -- Enable 4-hour timed records
@@ -234,6 +240,5 @@ xi.settings.main =
     DIG_GRANT_BORE               = 0,     -- Set to 1 to grant bore ability
     ENM_COOLDOWN                 = 120,   -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
     FORCE_SPAWN_QM_RESET_TIME    = 300,   -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
-    GOBBIE_BOX_MIN_AGE           = 45,    -- Minimum character age in days before a character can sign up for Gobbie Mystery Box
     EQUIP_FROM_OTHER_CONTAINERS  = false, -- true/false. Allows equipping items from Mog Satchel, Sack, and Case. Only possible with the use of client addons.
 }

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -246,10 +246,6 @@ xi.settings.map =
     -- Set to 1 to completely disable auto-jailing offenders
     ANTICHEAT_JAIL_DISABLE = false,
 
-    -- Gobbie Mystery Box settings
-    DAILY_TALLY_AMOUNT = 10,
-    DAILY_TALLY_LIMIT  = 50000,
-
     -- Enable/disable keeping jug pets through zoning
     KEEP_JUGPET_THROUGH_ZONING = false,
 }

--- a/src/map/daily_system.cpp
+++ b/src/map/daily_system.cpp
@@ -154,8 +154,8 @@ namespace daily
 
     void UpdateDailyTallyPoints()
     {
-        uint16 dailyTallyLimit  = settings::get<uint16>("map.DAILY_TALLY_LIMIT");
-        uint16 dailyTallyAmount = settings::get<uint16>("map.DAILY_TALLY_AMOUNT");
+        uint16 dailyTallyLimit  = settings::get<uint16>("main.DAILY_TALLY_LIMIT");
+        uint16 dailyTallyAmount = settings::get<uint16>("main.DAILY_TALLY_AMOUNT");
 
         const char* fmtQuery = "UPDATE char_points \
                 SET char_points.daily_tally = LEAST(%u, char_points.daily_tally + %u) \

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -94,8 +94,16 @@ int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
     {
         if (tick > (lastTickedJstMidnight + 1h))
         {
-            daily::UpdateDailyTallyPoints();
-            roeutils::CycleDailyRecords();
+            if (settings::get<bool>("main.ENABLE_DAILY_TALLY"))
+            {
+                daily::UpdateDailyTallyPoints();
+            }
+
+            if (settings::get<bool>("main.ENABLE_ROE"))
+            {
+                roeutils::CycleDailyRecords();
+            }
+
             guildutils::UpdateGuildPointsPattern();
             luautils::OnJSTMidnight();
             lastTickedJstMidnight = tick;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a new setting for gobbie mistery box/daily tally.
- Unifies all daily tally settings into the same file (main) and changes references so they point to the correct file.
- Adds checks to JST midnight, so we only perform those operations IF we have the related systems enabled.

## Steps to test these changes

- Disable RoE and Dailly tally.
- Wait for JST midnight (4 PM GMT, iirc).
- Confirm those operations are not performed.
