### PR TITLE
Fixed Ayame SC, order was reversed.

### DIFF
--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -977,14 +977,14 @@ namespace gambits
                         for (auto& skill : tp_skills)
                         {
                             std::list<SKILLCHAIN_ELEMENT> resonanceProperties;
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getPrimarySkillchain());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getSecondarySkillchain());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getTertiarySkillchain());
+                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)skill.primary);
+                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)skill.secondary);
+                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)skill.tertiary);
 
                             std::list<SKILLCHAIN_ELEMENT> skillProperties;
-                            skillProperties.push_back((SKILLCHAIN_ELEMENT)skill.primary);
-                            skillProperties.push_back((SKILLCHAIN_ELEMENT)skill.secondary);
-                            skillProperties.push_back((SKILLCHAIN_ELEMENT)skill.tertiary);
+                            skillProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getPrimarySkillchain());
+                            skillProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getSecondarySkillchain());
+                            skillProperties.push_back((SKILLCHAIN_ELEMENT)PMasterLastWeaponSkill->getTertiarySkillchain());
                             if (SKILLCHAIN_ELEMENT possible_skillchain = battleutils::FormSkillchain(resonanceProperties, skillProperties);
                                 possible_skillchain != SC_NONE)
                             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixed Ayame's SC calculation issue. Ayame is an OPENER, so the skillchain order should be reversed so that when it calculates the battleutil 'FormSkillchain', it uses her weaponskill as the 'resonanceProperties', and the player's weaponskill as the 'skillProperties'. 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Tested on local server and now it properly opens with the right SC.