### PR TITLE
[Proposal] Set account ID to 0 instead of deleting character. (For Login Rewrite branch)

### DIFF
--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS `chars`;
 CREATE TABLE `chars` (
   `charid` int(10) unsigned NOT NULL,
   `accid` int(10) unsigned NOT NULL,
+  `original_accid` int(10) unsigned NOT NULL DEFAULT '0',
   `charname` varchar(15) NOT NULL,
   `nation` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `pos_zone` smallint(3) unsigned NOT NULL,

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -44,32 +44,32 @@ CREATE TRIGGER char_delete
     BEFORE DELETE ON chars
     FOR EACH ROW
 BEGIN
-    DELETE FROM `char_blacklist`  WHERE `charid_owner` = OLD.charid;
-    DELETE FROM `char_effects`    WHERE `charid` = OLD.charid;
-    DELETE FROM `char_equip`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_blacklist`   WHERE `charid_owner` = OLD.charid;
+    DELETE FROM `char_effects`     WHERE `charid` = OLD.charid;
+    DELETE FROM `char_equip`       WHERE `charid` = OLD.charid;
     DELETE FROM `char_equip_saved` WHERE `charid` = OLD.charid;
-    DELETE FROM `char_exp`        WHERE `charid` = OLD.charid;
-    DELETE FROM `char_history`    WHERE `charid` = OLD.charid;
-    DELETE FROM `char_inventory`  WHERE `charid` = OLD.charid;
-    DELETE FROM `char_jobs`       WHERE `charid` = OLD.charid;
-    DELETE FROM `char_job_points` WHERE `charid` = OLD.charid;
-    DELETE FROM `char_look`       WHERE `charid` = OLD.charid;
-    DELETE FROM `char_merit`      WHERE `charid` = OLD.charid;
-    DELETE FROM `char_pet`        WHERE `charid` = OLD.charid;
-    DELETE FROM `char_points`     WHERE `charid` = OLD.charid;
-    DELETE FROM `char_profile`    WHERE `charid` = OLD.charid;
-    DELETE FROM `char_recast`     WHERE `charid` = OLD.charid;
-    DELETE FROM `char_skills`     WHERE `charid` = OLD.charid;
-    DELETE FROM `char_spells`     WHERE `charid` = OLD.charid;
-    DELETE FROM `char_stats`      WHERE `charid` = OLD.charid;
-    DELETE FROM `char_storage`    WHERE `charid` = OLD.charid;
-    DELETE FROM `char_style`      WHERE `charid` = OLD.charid;
-    DELETE FROM `char_unlocks`    WHERE `charid` = OLD.charid;
-    DELETE FROM `char_vars`       WHERE `charid` = OLD.charid;
-    DELETE FROM `auction_house`   WHERE `seller` = OLD.charid;
-    DELETE FROM `delivery_box`    WHERE `charid` = OLD.charid;
-    UPDATE `account_ip_record` SET `charid`  = 0 where `charid` = OLD.charid;
-    UPDATE `delivery_box` SET sent = 0 WHERE box = 2 AND received = 0 AND sent = 1 AND senderid = OLD.charid;
+    DELETE FROM `char_exp`         WHERE `charid` = OLD.charid;
+    DELETE FROM `char_history`     WHERE `charid` = OLD.charid;
+    DELETE FROM `char_inventory`   WHERE `charid` = OLD.charid;
+    DELETE FROM `char_jobs`        WHERE `charid` = OLD.charid;
+    DELETE FROM `char_job_points`  WHERE `charid` = OLD.charid;
+    DELETE FROM `char_look`        WHERE `charid` = OLD.charid;
+    DELETE FROM `char_merit`       WHERE `charid` = OLD.charid;
+    DELETE FROM `char_pet`         WHERE `charid` = OLD.charid;
+    DELETE FROM `char_points`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_profile`     WHERE `charid` = OLD.charid;
+    DELETE FROM `char_recast`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_skills`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_spells`      WHERE `charid` = OLD.charid;
+    DELETE FROM `char_stats`       WHERE `charid` = OLD.charid;
+    DELETE FROM `char_storage`     WHERE `charid` = OLD.charid;
+    DELETE FROM `char_style`       WHERE `charid` = OLD.charid;
+    DELETE FROM `char_unlocks`     WHERE `charid` = OLD.charid;
+    DELETE FROM `char_vars`        WHERE `charid` = OLD.charid;
+    DELETE FROM `auction_house`    WHERE `seller` = OLD.charid;
+    DELETE FROM `delivery_box`     WHERE `charid` = OLD.charid;
+    UPDATE `account_ip_record` SET `charid` = 0 WHERE `charid` = OLD.charid;
+    UPDATE `delivery_box`      SET `sent` = 0   WHERE `box` = 2 AND `received` = 0 AND `sent` = 1 AND `senderid` = OLD.charid;
 END $$
 
 DROP TRIGGER IF EXISTS char_insert $$

--- a/src/login/connect_server.h
+++ b/src/login/connect_server.h
@@ -1054,11 +1054,12 @@ protected:
                 ShowInfo(fmt::format("attempt to delete char:<{}> from ip:<{}>",
                                      CharID, ipAddress));
 
-                // Perform character deletion from the database. It is sufficient to remove the
-                // value from the `chars` table. The mysql server will handle the rest.
+                // Perform character deletion.
+                // Instead of performing an actual character deletion, we simply set accid to 0, and original_accid to old accid.
+                // This allows character recovery.
 
-                const char* pfmtQuery = "DELETE FROM chars WHERE charid = %i AND accid = %i";
-                sql->Query(pfmtQuery, CharID, session.accountID);
+                const char* pfmtQuery = "UPDATE chars SET accid = 0, original_accid = %i WHERE charid = %i AND accid = %i";
+                sql->Query(pfmtQuery, session.accountID, CharID, session.accountID);
             }
             break;
             case 0x21: // 33: Registering character name onto the lobby server

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -677,11 +677,12 @@ int32 lobbyview_parse(int32 fd)
                 RFIFOSKIP(fd, sessions[fd]->rdata.size());
                 RFIFOFLUSH(fd);
 
-                // Perform character deletion from the database. It is sufficient to remove the
-                // value from the `chars` table. The mysql server will handle the rest.
+                // Perform character deletion.
+                // Instead of performing an actual character deletion, we simply set accid to 0, and original_accid to old accid.
+                // This allows character recovery.
 
-                const char* pfmtQuery = "DELETE FROM chars WHERE charid = %i AND accid = %i";
-                sql->Query(pfmtQuery, CharID, sd->accid);
+                const char* pfmtQuery = "UPDATE chars SET accid = 0, original_accid = %i WHERE charid = %i AND accid = %i";
+                sql->Query(pfmtQuery, sd->accid, CharID, sd->accid);
 
                 break;
             }

--- a/tools/migrations/034_original_account_tracking.py
+++ b/tools/migrations/034_original_account_tracking.py
@@ -1,0 +1,32 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding original_accid column to chars table"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure column doesn't already exist.
+    cur.execute("SHOW COLUMNS FROM chars LIKE 'original_accid';")
+
+    row = cur.fetchone()
+    if row:
+        return False
+
+    return True
+
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE `chars` \
+            ADD COLUMN `original_accid` int(10) unsigned NOT NULL DEFAULT '0' AFTER `accid`;"
+        )
+        db.commit()
+
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As discussed a few weeks ago, retail doesn't immediately delete characters.
Setting a character account ID to 0 will make that character Inaccessible but will keep the character data, allowing for a fast recovery.

What this does:
- Sets account to 0 instead of deleting char ID
- Adds `original_accid` to chars table, to keep track of who the character belonged to/if some1 is abusing the system

## Steps to test these changes

Create a character
Delete a character
- Check in sql that data is still there
- Check that character cannot be accessed.
