### PR TITLE
[Magic] Implement Nuke Wall to elemental nukes.

### DIFF
--- a/scripts/globals/effects/nuke_wall.lua
+++ b/scripts/globals/effects/nuke_wall.lua
@@ -1,0 +1,15 @@
+-----------------------------------
+-- xi.effect.NUKE_WALL
+-----------------------------------
+local effectObject = {}
+
+effectObject.onEffectGain = function(target, effect)
+end
+
+effectObject.onEffectTick = function(target, effect)
+end
+
+effectObject.onEffectLose = function(target, effect)
+end
+
+return effectObject

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -870,8 +870,9 @@ xi.effect =
     FULL_SPEED_AHEAD         = 803, -- Helper for quest: Full Speed Ahead!
     HYSTERIA                 = 804, -- Used for Hysteroanima to stop after readying a weaponskill with no msg.
     TOMAHAWK                 = 805, -- Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
+    NUKE_WALL                = 806, -- Custom effect for NM type mobs only.
 
-    -- 806-1022
+    -- 807-1022
     -- PLACEHOLDER           = 1023 -- The client dat file seems to have only this many "slots", results of exceeding that are untested.
 }
 

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -750,7 +750,7 @@ enum EFFECT
     // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
 };
 
-#define MAX_EFFECTID 806 // 768 real + 38 custom
+#define MAX_EFFECTID 807 // 768 real + 39 custom
 
 /************************************************************************
  *                                                                       *

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -744,7 +744,9 @@ enum EFFECT
     EFFECT_FULL_SPEED_AHEAD    = 803, // Used to track Full Speed Ahead quest minigame
     EFFECT_HYSTERIA            = 804, // Used for Hysteroanima to stop after readying a weaponskill with no msg.
     EFFECT_TOMAHAWK            = 805, // Silent status effect inflicted by a Warrior using the "Tomahawk" job ability
-    // 806-1022
+    EFFECT_NUKE_WALL           = 806, // Custom effect for NM type mobs only. Applied by elemental magic damage sources
+
+    // 807-1022
     // EFFECT_PLACEHOLDER           = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
 };
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements "Nuke Wall" mechanic, that reduces damage dealt by nukes when done consecutively in a time window.

## Steps to test these changes

You will need to enable/write some prints in damage_spell.lua. Recomended the effect power and remaining duration, aswell as all the diferent function returns.

You will also need a mob. Set it to be immortal for convenience. Get it's level.

Cast repeatedly spells of the same element.

Watch damage be reduced, depending on the damage dealt and the time in between casts, for a maximum of a -40% damage for the next 5 seconds after the first cast. Each consecutive spell will reset the timer and modify the reduction.

Watch Damage needed to cap potency vary depending on mob level.
Watch diferent damage amounts under cap apply different reductions.