### PR TITLE
[lua] Miscellaneous Dragoon fixes

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -780,6 +780,7 @@ xi.job_utils.dragoon.useRestoringBreath = function(player, ability, action)
         local maxHPDiff = member:getMaxHP() - member:getHP()
         if
             inBreathRange(member) and
+            not member:isDead() and
             (maxHPDiff > highestHPDiff and maxHPDiff > 0) -- Dont pick target if they have full HP
         then
             target = member

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -567,7 +567,7 @@ xi.job_utils.dragoon.useSteadyWing = function(player, target, ability, action)
 
     -- https://www.bg-wiki.com/ffxi/Steady_Wing
     if wyvern then
-        local power = 1.3 * wyvern:getMaxHP() + wyvern:getHP()
+        local power = wyvern:getMaxHP() * 1.3 + wyvern:getMaxHP() - wyvern:getHP()
 
         action:reaction(wyvern:getID(), 0x10) -- Observed on retail
         if wyvern:addStatusEffect(xi.effect.STONESKIN, power, 0, 300) then

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -68,7 +68,11 @@ local function doHealingBreath(player, threshold)
     else
         local party = player:getPartyWithTrusts()
         for _, member in pairs(party) do
-            if member:getHPP() <= threshold and inBreathRange(member) then
+            if
+                member:getHPP() <= threshold and
+                inBreathRange(member) and
+                not member:isDead()
+            then
                 player:getPet():useJobAbility(healingbreath, member)
                 break
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Healing Breath and Restoring Breath from not targeting dead players
Adjusts Steady Wing stoneskin formula to match retail (confirmed formula with JP wiki)

## Steps to test these changes
Use 3 accounts, one is a drg, the other 2 are any other jobs with the same max hp
!hp 1 on the non-drgs
Use healing breath via restoring breath or regular healing breath
!hp 0 on the target the wyvern picked, reuse healing breath/restoring breath and the wyvern should use healing breath on the still alive player

For steady wing, you can contrive a test with 1k/10k needles and check stoneskin value to match the expected formula