### PR TITLE
correct 2 unused params that were renamed

### DIFF
--- a/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
+++ b/scripts/zones/Mamook/mobs/Hundredfaced_Hapool_Ja.lua
@@ -51,7 +51,7 @@ entity.onMobEngaged = function(mob, target)
     mob:castSpell(xi.magic.spell.UTSUSEMI_SAN, mob)
 end
 
-entity.onMobDeath = function(mob, player, isKiller)
+entity.onMobDeath = function(mob, player, optParams)
     local hundredfacedHapoolJa = mob:getID()
     for i = 1, 4 do DespawnMob(hundredfacedHapoolJa + i) end
 end

--- a/scripts/zones/Misareaux_Coast/mobs/Alsha.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Alsha.lua
@@ -46,7 +46,7 @@ entity.onMobFight = function(mob, target)
     end
 end
 
-entity.onMobDeath = function(mob, player, isKiller)
+entity.onMobDeath = function(mob, player, optParams)
     -- TODO: Requires logic to ensure Alsha is killed by a player and not by herself.
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
`isKiller` -> `optPrams`

They were unused in these 2 scripts, but the param is still invalid (it would be `optPrams.isKiller` now to check killer)

## Steps to test these changes
N/A
