### PR TITLE
[core] Remove over-the-top Trace messaging

### DIFF
--- a/src/common/tracy.h
+++ b/src/common/tracy.h
@@ -7,7 +7,7 @@
 #include "cbasetypes.h"
 
 #define TracyFrameMark          FrameMark
-#define TracyZoneScoped         ZoneScoped; ShowTrace(__func__)
+#define TracyZoneScoped         ZoneScoped;
 #define TracyZoneScopedN(n)     ZoneScopedN(n)
 #define TracyZoneNamed(var)     ZoneNamedN(var, #var, true)
 #define TracyZoneText(n, l)     ZoneText(n, l)
@@ -52,7 +52,7 @@ inline std::string Hex16ToString(uint16 hex)
 
 #else // Empty stubs for regular builds
 #define TracyFrameMark                     ;
-#define TracyZoneScoped                    ShowTrace(__func__);
+#define TracyZoneScoped                    ;
 #define TracyZoneScopedN(n)                std::ignore = n;
 #define TracyZoneNamed(var)                std::ignore = #var;
 #define TracyZoneText(n, l)                std::ignore = n; std::ignore = l;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I slipped in some extra logging to populate the usually-invisible backtrace buffer, in both regular and tracy builds, but it turns out to be quite expensive (even though thats 1-5us per call, its called ALL THE TIME):

![image](https://user-images.githubusercontent.com/1389729/214978433-218d824c-33e6-4e33-9331-83d51fb9d837.png)

This removes it.