### PR TITLE
[Fix] Instances where Nuke Wall effect displayed a message when it shouldnt

### DIFF
--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -798,8 +798,8 @@ xi.spells.damage.calculateNukeWallFactor = function(caster, target, spell, spell
     local finalPotency = utils.clamp(math.floor(4000 * finalDamage / damageCap) + potency, 0, 4000)
 
     -- Renew status effect.
-    target:delStatusEffect(xi.effect.NUKE_WALL)
-    target:addStatusEffect(xi.effect.NUKE_WALL, finalPotency, 0, 5, 0, spellElement)
+    target:delStatusEffectSilent(xi.effect.NUKE_WALL)
+    target:addStatusEffectEx(xi.effect.NUKE_WALL, 0, finalPotency, 0, 5, 0, spellElement)
 
     return nukeWallFactor
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents Nuke Wall from returning a message when wearing off, ever.
Also change use of `addStatusEffect` to `addStatusEffectEx` to force icon to be 0 and never display an empty slot, just in case.

## Steps to test these changes

Cast elemental nukes in quick succession. kill mob. make sure the "Wear off" message isnt displayed on mob pop or in any other circustance.
