### PR TITLE
[Fix] Incorrect item ID and item short name

### DIFF
--- a/scripts/battlefields/Apollyon/ne_apollyon.lua
+++ b/scripts/battlefields/Apollyon/ne_apollyon.lua
@@ -393,7 +393,7 @@ content.loot =
             { item = xi.items.PIECE_OF_OXBLOOD, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.LIGHT_STEEL_INGOT, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.SPOOL_OF_RAINBOW_THREAD, weight = xi.loot.weight.VERY_LOW },
-            { item = xi.items.SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
+            { item = xi.items.PONZE_OF_SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
         },
     },
 

--- a/scripts/battlefields/Apollyon/nw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/nw_apollyon.lua
@@ -487,7 +487,7 @@ content.loot =
             { item = xi.items.PIECE_OF_OXBLOOD, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.LIGHT_STEEL_INGOT, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.SPOOL_OF_RAINBOW_THREAD, weight = xi.loot.weight.VERY_LOW },
-            { item = xi.items.SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
+            { item = xi.items.PONZE_OF_SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
         },
 
         {

--- a/scripts/battlefields/Apollyon/se_apollyon.lua
+++ b/scripts/battlefields/Apollyon/se_apollyon.lua
@@ -428,7 +428,7 @@ content.loot =
             { item = xi.items.PIECE_OF_OXBLOOD, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.LIGHT_STEEL_INGOT, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.SPOOL_OF_RAINBOW_THREAD, weight = xi.loot.weight.VERY_LOW },
-            { item = xi.items.SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
+            { item = xi.items.PONZE_OF_SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
         },
     },
 

--- a/scripts/battlefields/Apollyon/sw_apollyon.lua
+++ b/scripts/battlefields/Apollyon/sw_apollyon.lua
@@ -559,7 +559,7 @@ content.loot =
             { item = xi.items.PIECE_OF_OXBLOOD, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.LIGHT_STEEL_INGOT, weight = xi.loot.weight.VERY_LOW },
             { item = xi.items.SPOOL_OF_RAINBOW_THREAD, weight = xi.loot.weight.VERY_LOW },
-            { item = xi.items.SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
+            { item = xi.items.PONZE_OF_SHELL_POWDER, weight = xi.loot.weight.VERY_LOW },
         },
     },
 

--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -4,6 +4,8 @@
 -----------------------------------
 xi = xi or {}
 
+-- NOTE: When adding items to this list, be sure to add the long name variant, not the short name.
+-- Example: PONZE_OF_SHELL_POWDER instead of SHELL_POWDER
 xi.items =
 {
     NONE                            = 0,
@@ -353,7 +355,7 @@ xi.items =
     WATER_BEAD                      = 1304,
     LIGHT_BEAD                      = 1305,
     DARK_BEAD                       = 1306,
-    PIECE_OF_OXBLOOD                = 1312,
+    PIECE_OF_OXBLOOD                = 1311,
     PIECE_OF_ANGEL_SKIN             = 1312,
     DRYADIC_ABJURATION_HEAD         = 1314,
     DRYADIC_ABJURATION_BODY         = 1315,
@@ -587,7 +589,7 @@ xi.items =
     BRIGANDS_CHART                  = 1873,
     PIRATES_CHART                   = 1874,
     ANCIENT_BEASTCOIN               = 1875,
-    SHELL_POWDER                    = 1887,
+    PONZE_OF_SHELL_POWDER           = 1883,
     GLASS_SHEET                     = 1887,
     VICE_OF_ANTIPATHY               = 1901,
     IVORY_CHIP                      = 1904,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes SHELL_POWDER and PIECE_OF_OXBLOOD incorrect item Id in items.lua
Fixes SHELL_POWDER using short name. We already had a reference of that item using it's long name version, but it got changed, without changing the references in other scripts.

## Steps to test these changes

None