### PR TITLE
[core] Switch from SUNSHINE weather to NONE/CLEAR at night

### DIFF
--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -637,9 +637,12 @@ void CZone::UpdateWeather()
 {
     TracyZoneScoped;
 
-    uint32 CurrentVanaDate   = CVanaTime::getInstance()->getDate();                                  // Current Vanadiel timestamp in minutes
-    uint32 StartFogVanaDate  = (CurrentVanaDate - (CurrentVanaDate % VTIME_DAY)) + (VTIME_HOUR * 2); // Vanadiel timestamp of 2 AM in minutes
-    uint32 EndFogVanaDate    = StartFogVanaDate + (VTIME_HOUR * 5);                                  // Vanadiel timestamp of 7 AM in minutes
+    uint32 CurrentVanaDate   = CVanaTime::getInstance()->getDate();             // Current Vanadiel timestamp in minutes
+    uint32 Midnight          = CurrentVanaDate - (CurrentVanaDate % VTIME_DAY); // Vanadiel timestamp of midnight in minutes
+    uint32 StartFogVanaDate  = Midnight + (VTIME_HOUR * 2);                     // Vanadiel timestamp of 2 AM in minutes
+    uint32 EndFogVanaDate    = Midnight + (VTIME_HOUR * 7);                     // Vanadiel timestamp of 7 AM in minutes
+    uint32 NightTimeVanaDate = Midnight + (VTIME_HOUR * 18);                    // Vanadiel timestamp of 6 PM in minutes
+
     uint32 WeatherNextUpdate = 0;
     uint32 WeatherDay        = 0;
     uint8  WeatherChance     = 0;
@@ -686,6 +689,15 @@ void CZone::UpdateWeather()
     else
     {
         Weather = weatherType.normal;
+    }
+
+    // If the weather is SUNSHINE, but its after 6pm (or before 7am)
+    // change the weather to NONE/CLEAR
+    if (((CurrentVanaDate >= NightTimeVanaDate) ||
+        (CurrentVanaDate < EndFogVanaDate)) &&
+        Weather == WEATHER_SUNSHINE)
+    {
+        Weather = WEATHER_NONE;
     }
 
     // Fog in the morning between the hours of 2 and 7 if there is not a specific elemental weather to override it


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

TODO: Check this is actually what retail does

## Steps to test these changes

Put `print(zone:getWeather())` in the onInit script for Bastok Markets and boot up at Vana nighttime, it'll now print 0. It printed 1 before.