### PR TITLE
Check level sync before procing additional effect

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -131,6 +131,11 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
         DEATH         = 12,
     }
 
+    -- If player is level synced below the level of the item, do no proc
+    if item:getReqLvl() > attacker:getMainLvl() then
+        return 0, 0, 0
+    end
+
     -- If we're not going to proc, lets not execute all those checks!
     if math.random(1, 100) > chance then
         return 0, 0, 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevents an additional effect from triggering when a character is level synced below the level requirement of the equipment. 

## Steps to test these changes

Level sync to 29, Holy Bolt will not proc light damage, sync to 30 and it will. 
