### PR TITLE
minor correction in scripts/globals/additional_effects.lua

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -100,7 +100,8 @@ end
 -- Disable cyclomatic complexity check for this function:
 -- luacheck: ignore 561
 -- TODO: Reduce complexity in this function:
--- - replace giant if/else chain with switch statement
+-- - replace giant if/else chain with table+key functions
+--   e.g. [procType.DAMAGE] = { code }
 -- - replace each handler (elseif addType == procType.DEBUFF then) with a function
 xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item)
     local addType   = item:getMod(xi.mod.ITEM_ADDEFFECT_TYPE)
@@ -235,7 +236,7 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
             msgParam = dispel
         end
 
-    elseif addType == procType.ABSORB then
+    elseif addType == procType.ABSORB_STATUS then
         -- Ripping off Aura Steal here
         local resist = applyResistanceAddEffect(attacker, defender, element, 0)
         if resist > 0.0625 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects a mistake that was made in a procType check, and amends a comment suggesting future changes to point in the direction I intend to go.

## Steps to test these changes
As the item that would use this is not yet implemented, there are no test steps. But you can see that the enumeration now matches.
