### PR TITLE
[Interaction] Convert "Beauty and the Galka" quest

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -167,7 +167,7 @@ xi.quest.id =
     [xi.quest.area[xi.quest.log_id.BASTOK]] =
     {
         THE_SIRENS_TEAR                 = 0,  -- ± Converted
-        BEAUTY_AND_THE_GALKA            = 1,  -- ±
+        BEAUTY_AND_THE_GALKA            = 1,  -- ± Converted
         WELCOME_TO_BASTOK               = 2,  -- + Converted
         GUEST_OF_HAUTEUR                = 3,  -- + Converted
         THE_QUADAVS_CURSE               = 4,  -- ± Converted

--- a/scripts/quests/bastok/Beauty_and_the_Galka.lua
+++ b/scripts/quests/bastok/Beauty_and_the_Galka.lua
@@ -1,0 +1,147 @@
+-----------------------------------
+-- Beauty and the Galka
+-----------------------------------
+-- Log ID: 1, Quest ID: 1
+-- Talib : !pos -101.133 4.649 28.803 236
+-----------------------------------
+require('scripts/globals/items')
+require('scripts/globals/quests')
+require('scripts/globals/zone')
+require('scripts/globals/interaction/quest')
+-----------------------------------
+
+local quest = Quest:new(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
+
+quest.reward =
+{
+    fame     = 75,
+    fameArea = xi.quest.fame_area.BASTOK,
+    item     = xi.items.BRONZE_KNIFE,
+}
+
+quest.sections =
+{
+    {
+        check = function(player, status, vars)
+            return status == QUEST_AVAILABLE
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Talib'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:event(4) -- Denied Cornelia's request.
+                    else
+                        return quest:progressEvent(2) -- First time.
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [2] = function(player, csid, option, npc)
+                    if option == 1 then -- Decline quest
+                        quest:setVar(player, 'Prog', 1)
+                    else
+                        quest:begin(player)
+                    end
+                end,
+            },
+        },
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Parraggoh'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(6) -- Denied Cornelia's request.
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [6] = function(player, csid, option, npc)
+                    if option == 0 then
+                        quest:begin(player)
+                    end
+                end,
+            },
+        }
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_ACCEPTED
+        end,
+
+        [xi.zone.PORT_BASTOK] =
+        {
+            ['Talib'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(4)
+                end,
+
+                onTrade = function(player, npc, trade)
+                    if
+                        npcUtil.tradeHasExactly(trade, xi.items.CHUNK_OF_ZINC_ORE) and
+                        not player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
+                    then
+                        return quest:progressEvent(3)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [3] = function(player, csid, option, npc)
+                    player:confirmTrade()
+                    npcUtil.giveKeyItem(player, xi.ki.PALBOROUGH_MINES_LOGS)
+                end,
+            },
+        },
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            ['Parraggoh'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
+                        return quest:progressEvent(10)
+                    elseif math.random(1, 2) == 1 then
+                        return quest:event(8)
+                    else
+                        return quest:event(9)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
+                    end
+                end,
+            },
+        }
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == QUEST_COMPLETED
+        end,
+
+        [xi.zone.BASTOK_MINES] =
+        {
+            -- New default texts.
+            ['Parraggoh'] = quest:event(12):replaceDefault(),
+        },
+    },
+}
+
+return quest

--- a/scripts/quests/bastok/Shady_Business.lua
+++ b/scripts/quests/bastok/Shady_Business.lua
@@ -5,7 +5,6 @@
 -- Talib : !pos -101.133 4.649 28.803 236
 -----------------------------------
 require('scripts/globals/items')
-require('scripts/globals/titles')
 require('scripts/globals/quests')
 require('scripts/globals/zone')
 require('scripts/globals/interaction/quest')
@@ -24,48 +23,41 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == QUEST_AVAILABLE and
+            return status >= QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-        end,
-
-        [xi.zone.PORT_BASTOK] =
-        {
-            ['Talib'] = quest:progressEvent(90),
-
-            onEventFinish =
-            {
-                [90] = function(player, csid, option, npc)
-                    quest:begin(player)
-                end,
-            },
-        },
-    },
-
-    {
-        check = function(player, status, vars)
-            return status >= QUEST_ACCEPTED
         end,
 
         [xi.zone.PORT_BASTOK] =
         {
             ['Talib'] =
             {
+                onTrigger = function(player, npc)
+                    return quest:event(90)
+                end,
+
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.items.CHUNK_OF_ZINC_ORE, 4 } }) then
                         return quest:progressEvent(91)
                     end
                 end,
 
-                onTrigger = quest:event(90),
             },
 
             onEventFinish =
             {
+                [90] = function(player, csid, option, npc)
+                    -- We can complete the quest without accepting it, but quest will NOT get re-accepted after completed.
+                    if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.SHADY_BUSINESS) == QUEST_AVAILABLE then
+                        quest:begin(player)
+                    end
+                end,
+
                 [91] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
                     end
                 end,
+
             },
         },
     },

--- a/scripts/zones/Bastok_Mines/npcs/Parraggoh.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Parraggoh.lua
@@ -3,55 +3,18 @@
 --  NPC: Parraggoh
 -- Finishes Quest: Beauty and the Galka
 -----------------------------------
-local ID = require("scripts/zones/Bastok_Mines/IDs")
-require("scripts/globals/quests")
-require("scripts/globals/keyitems")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local beautyAndTheGalka = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-
-    -- Beauty and the Galka
-    if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
-        player:startEvent(10)
-
-    elseif beautyAndTheGalka == QUEST_ACCEPTED then
-        if math.random(1, 2) == 1 then
-            player:startEvent(8)
-        else
-            player:startEvent(9)
-        end
-
-    elseif player:getCharVar("BeautyAndTheGalkaDenied") == 1 then
-        player:startEvent(7)
-
-    elseif beautyAndTheGalka == QUEST_COMPLETED then
-        player:startEvent(12)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 7 and option == 0 then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-    elseif csid == 10 then
-        if player:getFreeSlotsCount() >= 1 then
-            player:completeQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-            player:setCharVar("BeautyAndTheGalkaDenied", 0)
-            player:delKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
-            player:addFame(xi.quest.fame_area.BASTOK, 75)
-            player:addItem(16465)
-            player:messageSpecial(ID.text.ITEM_OBTAINED, 16465)
-        else
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, 16465)
-        end
-    end
 end
 
 return entity

--- a/scripts/zones/Port_Bastok/npcs/Talib.lua
+++ b/scripts/zones/Port_Bastok/npcs/Talib.lua
@@ -3,46 +3,18 @@
 --  NPC: Talib
 -- Starts Quest: Beauty and the Galka
 -----------------------------------
-require("scripts/globals/keyitems")
-require("scripts/globals/quests")
-local ID = require("scripts/zones/Port_Bastok/IDs")
------------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA) == QUEST_ACCEPTED then
-        if trade:hasItemQty(642, 1) and trade:getItemCount() == 1 then
-            player:startEvent(3)
-        end
-    end
 end
 
 entity.onTrigger = function(player, npc)
-    local beautyAndTheGalka = player:getQuestStatus(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-
-    if
-        beautyAndTheGalka == QUEST_ACCEPTED or
-        player:getCharVar("BeautyAndTheGalkaDenied") >= 1
-    then
-        player:startEvent(4)
-    else
-        player:startEvent(2)
-    end
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    if csid == 2 and option == 0 then
-        player:addQuest(xi.quest.log_id.BASTOK, xi.quest.id.bastok.BEAUTY_AND_THE_GALKA)
-    elseif csid == 2 and option == 1 then
-        player:setCharVar("BeautyAndTheGalkaDenied", 1)
-    elseif csid == 3 then
-        player:tradeComplete()
-        player:addKeyItem(xi.ki.PALBOROUGH_MINES_LOGS)
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.PALBOROUGH_MINES_LOGS)
-    end
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Converts "Beauty and the Galka" quest to interaction system. This may or may not fix a supposed possible skip.
- Corrects "Shady bussiness" logic to match retail. You can, indeed, just trade 4 ores to Talib immediately after completing "Beauty and the Galka", without speaking to him again, to complete the quest directly, without accepting it.

## Steps to test these changes

Run both quests.
