### PR TITLE
[ci] Increase exe run time to 5 mins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,7 +413,7 @@ jobs:
     - name: Startup and character login checks
       uses: nick-invision/retry@v2
       with:
-        timeout_minutes: 5
+        timeout_minutes: 15
         max_attempts: 3
         retry_on: timeout
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -428,8 +428,8 @@ jobs:
           screen -d -m -S xi_search ./xi_search --log search-server.log
           screen -d -m -S xi_map ./xi_map --log map-server.log
 
-          printf "\nWaiting 90s for servers to fully start up\n"
-          sleep 90s
+          printf "\nWaiting 5m for servers to fully start up\n"
+          sleep 300s
 
           printf "\nPopulating database\n"
           mysql xidb -h 127.0.0.1 -uroot -proot << EOF
@@ -549,7 +549,7 @@ jobs:
         screen -d -m -S xi_search ./xi_search --log search-server.log
         screen -d -m -S xi_map ./xi_map --log map-server-0.log --ip 127.0.0.1 --port 54230
         screen -d -m -S xi_map ./xi_map --log map-server-1.log --ip 127.0.0.1 --port 54231
-        sleep 2m
+        sleep 300s
         killall screen
     - name: Check for errors and warnings
       if: ${{ success() || failure() }}

--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -49,10 +49,6 @@ local nmsToShield =
     { "Valkurm_Dunes", "Valkurm_Emperor" },
     { "Wajaom_Woodlands", "Hydra" },
     { "Western_Altepa_Desert", "King_Vinegarroon" },
-    { "South_Gustaberg", "Leaping_Lizzy" },
-    { "Valkurm_Dunes", "Valkurm_Emperor" },
-    { "Maze_of_Shakhrami", "Argus" },
-    { "Sea_Serpent_Grotto", "Charybdis" },
 }
 
 -- Find the position of a target entity in a table,

--- a/tools/ci/startup_checks.py
+++ b/tools/ci/startup_checks.py
@@ -19,7 +19,7 @@ def main():
         ["xi_map", "--log", "game-server.log", "--load_all"], stdout=subprocess.PIPE
     )
 
-    print("Sleeping for 2 minutes...")
+    print("Sleeping for 5 minutes...")
 
     time.sleep(300)
 

--- a/tools/ci/startup_checks.py
+++ b/tools/ci/startup_checks.py
@@ -21,7 +21,7 @@ def main():
 
     print("Sleeping for 2 minutes...")
 
-    time.sleep(120)
+    time.sleep(300)
 
     p0.kill()
     p1.kill()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

CI was doing runs of 2 mins and then killing the run. In some cases, this wasn't long enough to actually do the full init of all zones and catch any errors, so mistakes with claim_shield module got through. This increases the run time, and fixes the errors
