### PR TITLE
[core] Disable LOS meshes on 32-bit build

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -9,6 +9,25 @@
 
 #include "logging.h"
 
+// https://stackoverflow.com/questions/1505582/determining-32-vs-64-bit-in-c
+// Check Windows
+#if _WIN32 || _WIN64
+#if _WIN64
+#define ENV64BIT
+#else
+#define ENV32BIT
+#endif
+#endif
+
+// Check GCC
+#if __GNUC__
+#if __x86_64__ || __ppc64__
+#define ENV64BIT
+#else
+#define ENV32BIT
+#endif
+#endif
+
 // debug mode
 #if defined(_DEBUG) && !defined(DEBUG)
 #define DEBUG

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -763,6 +763,10 @@ namespace zoneutils
             g_PZoneList[0] = CreateZone(0);
         }
 
+#ifdef ENV32BIT
+        ShowInfo("NOTE: LOS meshes wont be loaded on the 32-bit build. They take up enough memory to crash to process.");
+#endif // ENV32BIT
+
         // clang-format off
         {
             ts::task_system ts;
@@ -773,12 +777,16 @@ namespace zoneutils
                     // NOTE: It is not safe to use SQL in this parallel loop!
                     g_PZoneList[zone]->LoadNavMesh();
                 });
-
+#ifndef ENV32BIT
+                // The LOS meshes take up A LOT of memory, so they're hard-disabled on 32-bit builds.
+                // (If you re-enable them, you'll meed the memory limit for a 32-bit application and crash!)
+                // TODO: Find a sane way around this
                 ts.schedule([zone]()
                 {
                     // NOTE: It is not safe to use SQL in this parallel loop!
                     g_PZoneList[zone]->LoadZoneLos();
                 });
+#endif // !ENV32BIT
             }
         }
         // clang-format on


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes https://github.com/LandSandBoat/server/issues/3554

Disables LOS loading completely on 32-bit builds, warns whats going on.

## Steps to test these changes

Build and launch 32-bit build, see it doesn't explode
