### PR TITLE
[Fix] Issue with battlefields when a death callback triggers mob spawns

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -965,6 +965,19 @@ void CBattlefield::handleDeath(CBaseEntity* PEntity)
             {
                 ++group.deathCount;
 
+                break;
+            }
+        }
+    }
+
+    auto groups(m_groups);
+
+    for (auto& group : groups)
+    {
+        for (uint32 mobId : group.mobIds)
+        {
+            if (mobId == PEntity->id)
+            {
                 if (group.deathCallback.valid())
                 {
                     auto result = group.deathCallback(CLuaBattlefield(this), CLuaBaseEntity(PEntity), group.deathCount);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

While iterating through the mob groups in the battlefield one of the callbacks inserted additional mob groups.
This only seemed to crash unix servers likely due to how their std::vector is implemented or something.
The fix here is to first do increment group.deathCount and then create a copy of m_groups and iterate over that for calling the callbacks so that way it is safe to insert mob groups during said callbacks.

## Steps to test these changes

Enter Apollyon NE. Go to second floor and kill all the big birds.
