### PR TITLE
Switch to checking mainly for charset at database level

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -192,30 +192,31 @@ void SqlConnection::SetupKeepalive()
     m_PingInterval = timeout + reserve;
 }
 
-void SqlConnection::CheckCollation()
+void SqlConnection::CheckCharset()
 {
-    // Check collation is what we require
-    auto ret = QueryStr("SHOW VARIABLES LIKE 'collation%';");
+    // Check that the SQL charset is what we require
+    auto ret = QueryStr("SELECT @@character_set_database, @@collation_database;");
     if (ret != SQL_ERROR && NumRows())
     {
         bool foundError = false;
         while (NextRow() == SQL_SUCCESS)
         {
-            auto collationType     = GetStringData(0);
-            auto collectionSetting = GetStringData(1);
-            if (!starts_with(collectionSetting, "utf8"))
+            auto charsetSetting   = GetStringData(0);
+            auto collationSetting = GetStringData(1);
+            if (!starts_with(charsetSetting, "utf8") || !starts_with(collationSetting, "utf8"))
             {
                 foundError = true;
                 // clang-format off
-                ShowWarning(fmt::format("Unexpected collation setting in database: {}: {}. Expected utf8*.",
-                    collationType, collectionSetting).c_str());
+                ShowWarning(fmt::format("Unexpected character_set or collation setting in database: {}: {}. Expected utf8*.",
+                    charsetSetting, collationSetting).c_str());
                 // clang-format on
             }
         }
 
         if (foundError)
         {
-            ShowWarning("This can result in data reads and writes being corrupted!");
+            ShowWarning("Non utf8 charset can result in data reads and writes being corrupted!");
+            ShowWarning("Non utf8 collation can be indicative that the database was not set up per required specifications.");
         }
     }
 }

--- a/src/common/sql.h
+++ b/src/common/sql.h
@@ -103,7 +103,7 @@ public:
 
     void SetupKeepalive();
 
-    void CheckCollation();
+    void CheckCharset();
 
     /// Pings the connection.
     ///

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -225,7 +225,7 @@ int32 do_init(int32 argc, char** argv)
 
     ShowInfo(sql->GetClientVersion().c_str());
     ShowInfo(sql->GetServerVersion().c_str());
-    sql->CheckCollation();
+    sql->CheckCharset();
 
     luautils::init(); // Also calls moduleutils::LoadLuaModules();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Techniclaly its not the collation we need, its the charset. But collation does tip us off that someone probably has a bad charset. I've modified the function to check the database rather than mariadb's global variables, because thats really what we need to know: the step in setup (use utf8) will prevent the problem for newbies tho.

This way also prevents unneeded warnings on databases other than ours.

## Steps to test these changes
Deliberately set bad charset and or collation, start map server

![image](https://user-images.githubusercontent.com/6871475/217629953-251eefc3-8052-416c-8620-df513b748208.png)

