### PR TITLE
Added Gargouille family functionality.

### DIFF
--- a/scripts/globals/mobskills/bloody_claw.lua
+++ b/scripts/globals/mobskills/bloody_claw.lua
@@ -14,7 +14,11 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    return 0
+    if mob:getAnimationSub() ~= 4 then
+        return 1
+    else
+        return 0
+    end
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)

--- a/scripts/globals/mobskills/dark_mist.lua
+++ b/scripts/globals/mobskills/dark_mist.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() ~= 1 then
+    if mob:getAnimationSub() ~= 5 then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/dark_orb.lua
+++ b/scripts/globals/mobskills/dark_orb.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() ~= 1 then
+    if mob:getAnimationSub() ~= 5 then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/terror_eye.lua
+++ b/scripts/globals/mobskills/terror_eye.lua
@@ -14,7 +14,7 @@ require("scripts/globals/mobskills")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() ~= 0 then
+    if mob:getAnimationSub() ~= 4 then
         return 1
     else
         return 0

--- a/scripts/globals/mobskills/triumphant_roar.lua
+++ b/scripts/globals/mobskills/triumphant_roar.lua
@@ -14,7 +14,7 @@ require("scripts/globals/status")
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getAnimationSub() ~= 0 then
+    if mob:getAnimationSub() ~= 4 then
         return 1
     else
         return 0

--- a/scripts/mixins/families/gargouille.lua
+++ b/scripts/mixins/families/gargouille.lua
@@ -1,0 +1,58 @@
+-----------------------------------
+-- Gargouille family mixin
+-----------------------------------
+require("scripts/globals/mixins")
+require("scripts/globals/status")
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+-- This mobs switches between standing and flying at regular intervals (every 3-4 mins)
+-- While standing, they use Terror Eye, Triumphant Roar and Bloody Claw
+-- While flying, they use Dark Mist and Dark Orb, and they receive Evasion +60 and Magic Dmg Taken -12.5%.
+-- Some Gargouille NMs can also use Shadow Burst
+
+local function changeStance(mob)
+    -- If mob is standing
+    if mob:getAnimationSub() == 4 then
+        mob:setAnimationSub(5) -- Fly
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 117) -- Set Fly Skill List. ("Dark Mist" and "Dark Orb")
+        mob:addMod(xi.mod.EVA, 60)
+        mob:addMod(xi.mod.DMGMAGIC, -1250)
+
+    -- If mob is flying
+    else
+        mob:setAnimationSub(4) -- Stand
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 118) -- Set Standing Skill List. ("Terror Eye", "Triumphant Roar" and "Bloody Claw")
+        mob:delMod(xi.mod.EVA, 60)
+        mob:delMod(xi.mod.DMGMAGIC, -1250)
+    end
+
+    -- Reset timer
+    mob:setLocalVar("formTimer", os.time() + math.random(180, 240))
+end
+
+g_mixins.families.gargouille = function(gargouilleMob)
+    -- Set default state.
+    gargouilleMob:addListener("SPAWN", "GARGOUILLE_SPAWN", function(mob)
+        mob:setAnimationSub(4)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 118) -- Set Standing Skill List. ("Terror Eye", "Triumphant Roar" and "Bloody Claw")
+        mob:setLocalVar("formTimer", os.time() + math.random(180, 240))
+    end)
+
+    -- Handle regular changes on roam.
+    gargouilleMob:addListener("ROAM_TICK", "GARGOUILLE_ROAM", function(mob)
+        if os.time() - mob:getLocalVar("formTimer") >= 0 then
+            changeStance(mob)
+        end
+    end)
+
+    -- Handle swapping stances in combat
+    gargouilleMob:addListener("COMBAT_TICK", "GARGOUILLE_COMBAT", function(mob)
+        if os.time() - mob:getLocalVar("formTimer") >= 0 then
+            changeStance(mob)
+        end
+    end)
+end
+
+return g_mixins.families.gargouille

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 local ID = require("scripts/zones/Beaucedine_Glacier_[S]/IDs")
 require("scripts/globals/mobs")
+mixins = { require("scripts/mixins/families/gargouille") }
 -----------------------------------
 local entity = {}
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -469,8 +469,8 @@ INSERT INTO `mob_skill_lists` VALUES ('Funguar',116,312);
 INSERT INTO `mob_skill_lists` VALUES ('Funguar',116,314);
 INSERT INTO `mob_skill_lists` VALUES ('Funguar',116,315);
 -- 117: Gruesome Gargouille
-INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',118,2421);
-INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',118,2422);
+INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',117,2421);
+INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',117,2422);
 INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',118,2423);
 INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',118,2424);
 INSERT INTO `mob_skill_lists` VALUES ('Gargoyle',118,2425);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This adds the Gargouille family functionality for swapping between standing/flying stances and also properly allows them to use the correct abilities while in the correct stance. This will also allow Blue Mages to be able to learn the Triumphant Roar spell.

Gargouilles swap between flying and standing stances at a random interval between 3 and 4 minutes.
Gargouilles use the abilities Bloody Claw, Terror Eye and Triumphant Roar while standing.
Gargouilles use the abilities Dark Orb and Dark Mist while flying.
While flying, Gargouille gain Evasion +60 and Magic Dmg Taken -12.5%.

[BG-Wiki]: https://www.bg-wiki.com/ffxi/Category:Gargouille
[JP-Wiki]: http://wiki.ffo.jp/html/17592.html

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

This includes changes to the .sql itself, so all changes will need to be implemented before these changes will work properly.