### PR TITLE
[core] Replace operator delete with destroy()

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -51,6 +51,20 @@ using uint16 = std::uint16_t;
 using uint32 = std::uint32_t;
 using uint64 = std::uint64_t;
 
+template <typename T>
+inline void destroy(T*& ptr)
+{
+    delete ptr; // cpp.sh allow
+    ptr = nullptr;
+}
+
+template <typename T>
+inline void destroy_arr(T*& ptr)
+{
+    delete[] ptr; // cpp.sh allow
+    ptr = nullptr;
+}
+
 // string case comparison for *nix portability
 #if !defined(_MSC_VER)
 #define strcmpi strcasecmp

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -60,59 +60,30 @@ void* operator new(std::size_t count)
 {
     void* ptr = malloc(count);
     TracyAlloc(ptr, count);
-    return ptr;
 }
 
 void operator delete(void* ptr) noexcept
 {
     TracyFree(ptr);
     free(ptr);
-    ptr = nullptr;
 }
 
 void operator delete(void* ptr, std::size_t count) noexcept
 {
     TracyFree(ptr);
     free(ptr);
-    ptr = nullptr;
 }
 
 void operator delete[](void* ptr) noexcept
 {
     TracyFree(ptr);
     free(ptr);
-    ptr = nullptr;
 }
 
 void operator delete[](void* ptr, std::size_t count) noexcept
 {
     TracyFree(ptr);
     free(ptr);
-    ptr = nullptr;
-}
-#else  // !TRACY_ENABLE
-void operator delete(void* ptr) noexcept
-{
-    free(ptr);
-    ptr = nullptr;
-}
-
-void operator delete(void* ptr, std::size_t count) noexcept
-{
-    free(ptr);
-    ptr = nullptr;
-}
-
-void operator delete[](void* ptr) noexcept
-{
-    free(ptr);
-    ptr = nullptr;
-}
-
-void operator delete[](void* ptr, std::size_t count) noexcept
-{
-    free(ptr);
-    ptr = nullptr;
 }
 #endif // TRACY_ENABLE
 

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -537,7 +537,7 @@ static int connect_check_clear(time_point tick, CTaskMgr::CTask* PTask)
             if ((!hist->ddos && (tick - hist->tick) > connect_interval * 3) || (hist->ddos && (tick - hist->tick) > connect_lockout))
             { // Remove connection history
                 prev_hist->next = hist->next;
-                delete hist;
+                destroy(hist);
                 hist = prev_hist->next;
                 clear++;
             }
@@ -1068,7 +1068,7 @@ void socket_final_tcp()
         while (hist)
         {
             next_hist = hist->next;
-            delete hist;
+            destroy(hist);
             hist = next_hist;
         }
     }

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -91,7 +91,7 @@ SqlConnection::~SqlConnection()
     {
         mysql_close(&self->handle);
         FreeResult();
-        delete self;
+        destroy(self);
     }
 }
 

--- a/src/common/taskmgr.cpp
+++ b/src/common/taskmgr.cpp
@@ -43,8 +43,7 @@ void CTaskMgr::delInstance()
 {
     if (_instance)
     {
-        delete _instance;
-        _instance = nullptr;
+        destroy(_instance);
     }
 }
 
@@ -131,7 +130,7 @@ duration CTaskMgr::DoTimer(time_point tick)
             case TASK_REMOVE:
             default:
             {
-                delete PTask; // suppose that all tasks were allocated by new
+                destroy(PTask); // suppose that all tasks were allocated by new
             }
             break;
         }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -442,8 +442,9 @@ uint32 packBitsLE(uint8* target, uint64 value, int32 byteOffset, int32 bitOffset
     }
 
     {
-        delete[] modifiedTarget;
+        destroy_arr(modifiedTarget);
     }
+
     return ((byteOffset << 3) + bitOffset + lengthInBit);
 }
 
@@ -500,7 +501,7 @@ uint64 unpackBitsLE(const uint8* target, int32 byteOffset, int32 bitOffset, uint
     }
 
     {
-        delete[] modifiedTarget;
+        destroy(modifiedTarget);
     }
     return retVal;
 }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -501,7 +501,7 @@ uint64 unpackBitsLE(const uint8* target, int32 byteOffset, int32 bitOffset, uint
     }
 
     {
-        destroy(modifiedTarget);
+        destroy_arr(modifiedTarget);
     }
     return retVal;
 }

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -107,7 +107,8 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
 
         this->partyList.clear();
 
-        delete this;
+        CAlliance* alliance = this;
+        destroy(alliance);
     }
 }
 

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -107,8 +107,10 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
 
         this->partyList.clear();
 
-        CAlliance* alliance = this;
-        destroy(alliance);
+        // TODO: This entire system needs rewriting to both:
+        //     : - Make it stable
+        //     : - Get rid of `delete this` and manage memory nicely
+        delete this; // cpp.sh allow
     }
 }
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -712,7 +712,6 @@ bool CBattlefield::Cleanup(time_point time, bool force)
         }
     }
 
-    // todo: delete all the things?
     for (const auto& mob : m_RequiredEnemyList)
     {
         if (mob.PMob->isAlive() && mob.PMob->PAI->IsSpawned())

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -77,7 +77,7 @@ void CBattlefieldHandler::HandleBattlefields(time_point tick)
             {
                 it = m_Battlefields.erase(it);
                 ShowDebug("[CBattlefieldHandler]HandleBattlefields cleaned up Battlefield %s", PBattlefield->GetName().c_str());
-                delete PBattlefield;
+                destroy(PBattlefield);
                 continue;
             }
         }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -264,21 +264,23 @@ CCharEntity::~CCharEntity()
         PTreasurePool->DelMember(this);
     }
 
-    delete TradeContainer;
-    delete Container;
-    delete UContainer;
-    delete CraftContainer;
-    delete PMeritPoints;
-    delete PJobPoints;
+    destroy(TradeContainer);
+    destroy(Container);
+    destroy(UContainer);
+    destroy(CraftContainer);
+    destroy(PMeritPoints);
+    destroy(PJobPoints);
+
     PGuildShop = nullptr;
-    delete eventPreparation;
-    delete currentEvent;
+
+    destroy(eventPreparation);
+    destroy(currentEvent);
 
     while (!eventQueue.empty())
     {
         auto head = eventQueue.front();
         eventQueue.pop_front();
-        delete head;
+        destroy(head);
     }
 }
 
@@ -296,7 +298,8 @@ void CCharEntity::clearPacketList()
 {
     while (!PacketList.empty())
     {
-        delete popPacket();
+        auto* packet = popPacket();
+        destroy(packet);
     }
 }
 
@@ -313,7 +316,7 @@ void CCharEntity::pushPacket(CBasicPacket* packet)
         if (PendingPositionPacket)
         {
             PendingPositionPacket->copy(packet);
-            delete packet;
+            destroy(packet);
         }
         else
         {
@@ -404,7 +407,8 @@ void CCharEntity::erasePackets(uint8 num)
 {
     for (auto i = 0; i < num; i++)
     {
-        delete popPacket();
+        auto* packet = popPacket();
+        destroy(packet);
     }
 }
 
@@ -2654,7 +2658,7 @@ void CCharEntity::tryStartNextEvent()
     EventInfo* oldEvent = currentEvent;
     currentEvent        = eventQueue.front();
     eventQueue.pop_front();
-    delete oldEvent;
+    destroy(oldEvent);
 
     eventPreparation->reset();
 

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -154,8 +154,8 @@ void CMobEntity::setEntityFlags(uint32 EntityFlags)
 
 CMobEntity::~CMobEntity()
 {
-    delete PEnmityContainer;
-    delete SpellContainer;
+    destroy(PEnmityContainer);
+    destroy(SpellContainer);
 }
 
 /************************************************************************

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -45,19 +45,19 @@ CInstance::~CInstance()
 {
     for (auto entity : m_mobList)
     {
-        delete entity.second;
+        destroy(entity.second);
     }
     for (auto entity : m_npcList)
     {
-        delete entity.second;
+        destroy(entity.second);
     }
     for (auto entity : m_petList)
     {
-        delete entity.second;
+        destroy(entity.second);
     }
     for (auto entity : m_trustList)
     {
-        delete entity.second;
+        destroy(entity.second);
     }
 }
 

--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -44,7 +44,7 @@ CItemContainer::~CItemContainer()
 {
     for (uint8 SlotID = 0; SlotID <= m_size; ++SlotID)
     {
-        delete m_ItemList[SlotID];
+        destroy(m_ItemList[SlotID]);
     }
 }
 
@@ -151,7 +151,7 @@ uint8 CItemContainer::InsertItem(CItem* PItem)
     }
     ShowDebug("ItemContainer: Container is full");
 
-    // delete PItem;//todo: what if the item is a valid item??
+    // destroy(PItem); //TODO: what if the item is a valid item??
     return ERROR_SLOTID;
 }
 
@@ -185,7 +185,7 @@ uint8 CItemContainer::InsertItem(CItem* PItem, uint8 SlotID)
     }
     ShowDebug("ItemContainer: SlotID %i is out of range", SlotID);
 
-    delete PItem;
+    destroy(PItem);
     return ERROR_SLOTID;
 }
 
@@ -251,7 +251,7 @@ void CItemContainer::Clear()
 {
     for (uint8 SlotID = 0; SlotID <= m_size; ++SlotID)
     {
-        delete m_ItemList[SlotID];
+        destroy(m_ItemList[SlotID]);
         m_ItemList[SlotID] = nullptr;
     }
 }

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -189,7 +189,8 @@ void CLinkshell::ChangeMemberRank(const std::string& MemberName, uint8 toSack)
                     newShellItem->setSubType(ITEM_LOCKED);
                     uint8 LocationID = PItemLinkshell->getLocationID();
                     uint8 SlotID     = PItemLinkshell->getSlotID();
-                    delete PItemLinkshell;
+                    destroy(PItemLinkshell);
+
                     PItemLinkshell = newShellItem;
                     char extra[sizeof(PItemLinkshell->m_extra) * 2 + 1];
                     sql->EscapeStringLen(extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
@@ -342,7 +343,7 @@ void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
             member->pushPacket(newPacket);
         }
     }
-    delete packet;
+    destroy(packet);
 }
 
 void CLinkshell::PushLinkshellMessage(CCharEntity* PChar, bool ls1)

--- a/src/map/los/los_tree.cpp
+++ b/src/map/los/los_tree.cpp
@@ -41,15 +41,15 @@ LosTree::LosTree(Triangle* elements, int elementCount)
 
     root = new LosTreeNode(this->elements, boundingBoxes, this->elementNexts, indices, 0, elementCount - 1, 100, 1, 5, true);
 
-    delete[] boundingBoxes;
-    delete[] indices;
+    destroy_arr(boundingBoxes);
+    destroy_arr(indices);
 }
 
 LosTree::~LosTree()
 {
-    delete root;
-    delete[] elements;
-    delete[] elementNexts;
+    destroy(root);
+    destroy_arr(elements);
+    destroy_arr(elementNexts);
 }
 
 LosTreeNodeStats LosTree::GetStats()

--- a/src/map/los/los_tree_node.cpp
+++ b/src/map/los/los_tree_node.cpp
@@ -172,8 +172,8 @@ LosTreeNode::LosTreeNode(
 
 LosTreeNode::~LosTreeNode()
 {
-    delete left;
-    delete right;
+    destroy(left);
+    destroy(right);
 }
 
 void LosTreeNode::SetElements(Triangle* elements, int* elementNexts, int* elementIndices, int indexStart, int indexEnd)

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -364,10 +364,8 @@ void do_final(int code)
 {
     TracyZoneScoped;
 
-    delete[] g_PBuff;
-    g_PBuff = nullptr;
-    delete[] PTempBuff;
-    PTempBuff = nullptr;
+    destroy_arr(g_PBuff);
+    destroy_arr(PTempBuff);
 
     itemutils::FreeItemList();
     battleutils::FreeWeaponSkillsList();
@@ -377,6 +375,7 @@ void do_final(int code)
     petutils::FreePetList();
     trustutils::FreeTrustList();
     zoneutils::FreeZoneList();
+
     message::close();
     if (messageThread.joinable())
     {
@@ -993,10 +992,9 @@ int32 map_close_session(time_point tick, map_session_data_t* map_session_data)
 
         map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(map_session_data->shuttingDown == 1);
 
-        delete[] map_session_data->server_packet_data;
-        delete map_session_data->PChar;
-        delete map_session_data;
-        map_session_data = nullptr;
+        destroy_arr(map_session_data->server_packet_data);
+        destroy(map_session_data->PChar);
+        destroy(map_session_data);
 
         map_session_list.erase(ipp);
         return 0;
@@ -1077,10 +1075,9 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                         map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
                         sql->Query("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
 
-                        delete[] map_session_data->server_packet_data;
-                        delete map_session_data->PChar;
-                        delete map_session_data;
-                        map_session_data = nullptr;
+                        destroy_arr(map_session_data->server_packet_data);
+                        destroy(map_session_data->PChar);
+                        destroy(map_session_data);
 
                         map_session_list.erase(it++);
                         continue;
@@ -1093,9 +1090,9 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
                     const char* Query = "DELETE FROM accounts_sessions WHERE client_addr = %u AND client_port = %u";
                     sql->Query(Query, map_session_data->client_addr, map_session_data->client_port);
 
-                    delete[] map_session_data->server_packet_data;
+                    destroy_arr(map_session_data->server_packet_data);
                     map_session_list.erase(it++);
-                    delete map_session_data;
+                    destroy(map_session_data);
                     continue;
                 }
             }

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -811,8 +811,14 @@ namespace message
 
         if (packet)
         {
-            msg.packet = zmq::message_t(*packet, packet->getSize(), [](void* data, void* hint)
-                                        { delete[](uint8*) data; });
+            // clang-format off
+            msg.packet = zmq::message_t(*packet, packet->getSize(),
+            [](void* data, void* hint)
+            {
+                auto* intdata = (uint8*)data;
+                destroy_arr(intdata);
+            });
+            // clang-format on
         }
         else
         {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2461,7 +2461,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                     else
                     {
-                        delete PUBoxItem;
+                        destroy(PUBoxItem);
                     }
                 }
             }
@@ -2726,7 +2726,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     }
                     if (!commit || !sql->TransactionCommit())
                     {
-                        delete PItem;
+                        destroy(PItem);
 
                         sql->TransactionRollback();
                         ShowError("Could not find new item to add to delivery box. PlayerID: %d Box :%d Slot: %d", PChar->id, boxtype, slotID);
@@ -2767,7 +2767,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                 PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, 0, 0x02));
                                 PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, deliverySlotID, received_items, 0x01));
                                 PChar->UContainer->SetItem(deliverySlotID, nullptr);
-                                delete PItem;
+                                destroy(PItem);
                             }
                         }
                     }
@@ -2839,7 +2839,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                                 {
                                     PChar->UContainer->SetItem(slotID, nullptr);
                                     PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
-                                    delete PItem;
+                                    destroy(PItem);
                                     commit = true;
                                 }
                             }
@@ -2923,7 +2923,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                         PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
                         PChar->pushPacket(new CInventoryFinishPacket());
                         PChar->UContainer->SetItem(slotID, nullptr);
-                        delete PItem;
+                        destroy(PItem);
                     }
                 }
 
@@ -2949,7 +2949,7 @@ void SmallPacket0x04D(map_session_data_t* const PSession, CCharEntity* const PCh
                     PChar->UContainer->SetItem(slotID, nullptr);
 
                     PChar->pushPacket(new CDeliveryBoxPacket(action, boxtype, PItem, slotID, PChar->UContainer->GetItemsCount(), 1));
-                    delete PItem;
+                    destroy(PItem);
                 }
             }
             return;
@@ -5534,7 +5534,7 @@ void SmallPacket0x0C4(map_session_data_t* const PSession, CCharEntity* const PCh
             LinkshellID = linkshell::RegisterNewLinkshell(DecodedName, LinkshellColor);
             if (LinkshellID != 0)
             {
-                delete PItemLinkshell;
+                destroy(PItemLinkshell);
                 PItemLinkshell = (CItemLinkshell*)itemutils::GetItem(513);
                 if (PItemLinkshell == nullptr)
                 {

--- a/src/map/packets/basic.h
+++ b/src/map/packets/basic.h
@@ -104,7 +104,7 @@ public:
     {
         if (owner && data)
         {
-            delete[] data;
+            destroy_arr(data);
         }
     }
 

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -163,7 +163,8 @@ void CParty::DisbandParty(bool playerInitiated)
             member->PParty = nullptr;
         }
     }
-    delete this;
+    CParty* PParty = this;
+    destroy(PParty);
 }
 
 // Assign roles to group members (players only)
@@ -442,7 +443,8 @@ void CParty::PopMember(CBattleEntity* PEntity)
                 }
             }
         }
-        delete this;
+        CParty* PParty = this;
+        destroy(PParty);
     }
     PEntity->PParty = nullptr;
 }
@@ -1091,7 +1093,7 @@ void CParty::PushPacket(uint32 senderID, uint16 ZoneID, CBasicPacket* packet)
             }
         }
     }
-    delete packet;
+    destroy(packet);
 }
 
 void CParty::PushEffectsPacket()

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -163,8 +163,11 @@ void CParty::DisbandParty(bool playerInitiated)
             member->PParty = nullptr;
         }
     }
-    CParty* PParty = this;
-    destroy(PParty);
+
+    // TODO: This entire system needs rewriting to both:
+    //     : - Make it stable
+    //     : - Get rid of `delete this` and manage memory nicely
+    delete this; // cpp.sh allow
 }
 
 // Assign roles to group members (players only)
@@ -443,8 +446,7 @@ void CParty::PopMember(CBattleEntity* PEntity)
                 }
             }
         }
-        CParty* PParty = this;
-        destroy(PParty);
+        delete this; // cpp.sh allow
     }
     PEntity->PParty = nullptr;
 }

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -226,7 +226,7 @@ CStatusEffectContainer::~CStatusEffectContainer()
 {
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
     {
-        delete PStatusEffect;
+        destroy(PStatusEffect);
     }
 }
 
@@ -558,7 +558,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
     }
     else
     {
-        delete PStatusEffect;
+        destroy(PStatusEffect);
     }
 
     return false;
@@ -586,7 +586,7 @@ void CStatusEffectContainer::DeleteStatusEffects()
                 update_icons = true;
             }
             effect_iter = m_StatusEffectSet.erase(effect_iter);
-            delete PStatusEffect;
+            destroy(PStatusEffect);
             effects_removed = true;
         }
         else
@@ -727,7 +727,7 @@ void CStatusEffectContainer::KillAllStatusEffect()
 
             effect_iter = m_StatusEffectSet.erase(effect_iter);
 
-            delete PStatusEffect;
+            destroy(PStatusEffect);
         }
         else
         {

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -141,8 +141,10 @@ void CTreasurePool::DelMember(CCharEntity* PChar)
 
     if (m_TreasurePoolType != TREASUREPOOL_ZONE && members.empty())
     {
-        CTreasurePool* PTreasurePool = this;
-        destroy(PTreasurePool);
+        // TODO: This entire system needs rewriting to both:
+        //     : - Make it stable
+        //     : - Get rid of `delete this` and manage memory nicely
+        delete this; // cpp.sh allow
         return;
     }
 }

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -141,7 +141,8 @@ void CTreasurePool::DelMember(CCharEntity* PChar)
 
     if (m_TreasurePoolType != TREASUREPOOL_ZONE && members.empty())
     {
-        delete this;
+        CTreasurePool* PTreasurePool = this;
+        destroy(PTreasurePool);
         return;
     }
 }

--- a/src/map/unitychat.cpp
+++ b/src/map/unitychat.cpp
@@ -66,7 +66,7 @@ void CUnityChat::PushPacket(uint32 senderID, CBasicPacket* packet)
             member->pushPacket(newPacket);
         }
     }
-    delete packet;
+    destroy(packet);
 }
 
 namespace unitychat

--- a/src/map/universal_container.cpp
+++ b/src/map/universal_container.cpp
@@ -49,9 +49,10 @@ void CUContainer::Clean()
     {
         for (uint8 i = 0; i < UCONTAINER_SIZE; ++i)
         {
-            delete m_PItem[i];
+            destroy(m_PItem[i]);
         }
     }
+
     if (m_ContainerType == UCONTAINER_TRADE)
     {
         for (auto&& PItem : m_PItem)
@@ -62,6 +63,7 @@ void CUContainer::Clean()
             }
         }
     }
+
     m_ContainerType = UCONTAINER_EMPTY;
 
     m_lock   = false;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -319,8 +319,7 @@ namespace battleutils
     {
         for (int32 SkillId = 0; SkillId < MAX_WEAPONSKILL_ID; ++SkillId)
         {
-            delete g_PWeaponSkillList[SkillId];
-            g_PWeaponSkillList[SkillId] = nullptr;
+            destroy(g_PWeaponSkillList[SkillId]);
         }
     }
 
@@ -331,8 +330,7 @@ namespace battleutils
     {
         for (auto& mobskill : g_PMobSkillList)
         {
-            delete mobskill;
-            mobskill = nullptr;
+            destroy(mobskill);
         }
     }
 
@@ -343,7 +341,7 @@ namespace battleutils
     {
         for (auto& petskill : g_PPetSkillList)
         {
-            delete petskill.second;
+            destroy(petskill.second);
         }
         g_PPetSkillList.clear();
     }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1292,9 +1292,10 @@ namespace charutils
         if (PItem->isType(ITEM_CURRENCY))
         {
             UpdateItem(PChar, LocationID, 0, PItem->getQuantity());
-            delete PItem;
+            destroy(PItem);
             return 0;
         }
+
         if (PItem->getFlag() & ITEM_FLAG_RARE)
         {
             if (HasItem(PChar, PItem->getID()))
@@ -1303,7 +1304,7 @@ namespace charutils
                 {
                     PChar->pushPacket(new CMessageStandardPacket(PChar, PItem->getID(), 0, MsgStd::ItemEx));
                 }
-                delete PItem;
+                destroy(PItem);
                 return ERROR_SLOTID;
             }
         }
@@ -1339,7 +1340,7 @@ namespace charutils
             {
                 ShowError("charplugin::AddItem: Cannot insert item to database");
                 PChar->getStorage(LocationID)->InsertItem(nullptr, SlotID);
-                delete PItem;
+                destroy(PItem);
                 return ERROR_SLOTID;
             }
             PChar->pushPacket(new CInventoryItemPacket(PItem, LocationID, SlotID));
@@ -1348,7 +1349,7 @@ namespace charutils
         else
         {
             ShowDebug("charplugin::AddItem: Location %i is full", LocationID);
-            delete PItem;
+            destroy(PItem);
         }
         return SlotID;
     }
@@ -1546,7 +1547,7 @@ namespace charutils
                     }
                 }
                 luautils::OnItemDrop(PChar, PItem);
-                delete PItem;
+                destroy(PItem);
             }
         }
         return ItemID;
@@ -6001,6 +6002,7 @@ namespace charutils
             if (PChar->PParty->GetMemberCountAcrossAllProcesses() == 1)
             {
                 PChar->PParty->DisbandParty();
+                destroy(PChar->PParty);
             }
         }
     }

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1895,7 +1895,7 @@ namespace fishingutils
 
         if (PChar->hookedFish != nullptr)
         {
-            delete PChar->hookedFish;
+            destroy(PChar->hookedFish);
             PChar->hookedFish = nullptr;
         }
 
@@ -1943,7 +1943,8 @@ namespace fishingutils
         if (FishingAreaID > 0)
         {
             PChar->fishingToken = 1 + xirand::GetRandomNumber(9999);
-            delete PChar->hookedFish;
+            destroy(PChar->hookedFish);
+
             PChar->hookedFish              = new fishresponse_t();
             PChar->hookedFish->hooked      = false;
             PChar->hookedFish->successtype = FISHINGSUCCESSTYPE_NONE;
@@ -2648,7 +2649,7 @@ namespace fishingutils
 
                 if (PChar->hookedFish != nullptr)
                 {
-                    delete PChar->hookedFish;
+                    destroy(PChar->hookedFish);
                     PChar->hookedFish = nullptr;
                 }
 
@@ -2755,7 +2756,7 @@ namespace fishingutils
 
                         if (response != nullptr)
                         {
-                            delete response;
+                            destroy(response);
                             response = nullptr;
                         }
                     }
@@ -2848,7 +2849,7 @@ namespace fishingutils
                         }
                     }
 
-                    delete PChar->hookedFish;
+                    destroy(PChar->hookedFish);
                     PChar->hookedFish = nullptr;
                 }
 

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -678,13 +678,13 @@ namespace itemutils
     {
         for (int32 ItemID = 0; ItemID < MAX_ITEMID; ++ItemID)
         {
-            delete g_pItemList[ItemID];
+            destroy(g_pItemList[ItemID]);
             g_pItemList[ItemID] = nullptr;
         }
 
         for (int32 DropID = 0; DropID < MAX_DROPID; ++DropID)
         {
-            delete g_pDropList[DropID];
+            destroy(g_pDropList[DropID]);
             g_pDropList[DropID] = nullptr;
         }
     }

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -325,7 +325,7 @@ namespace petutils
     {
         while (!g_PPetList.empty())
         {
-            delete *g_PPetList.begin();
+            destroy(*g_PPetList.begin());
             g_PPetList.erase(g_PPetList.begin());
         }
     }

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -55,7 +55,7 @@ namespace puppetutils
                 auto* PZone = zoneutils::GetZone(PChar->PAutomaton->getZone());
                 if (PZone == nullptr || PZone->GetEntity(PChar->PAutomaton->targid, TYPE_PET) == nullptr)
                 {
-                    delete PChar->PAutomaton;
+                    destroy(PChar->PAutomaton);
                 }
                 else
                 {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1155,11 +1155,10 @@ namespace zoneutils
     {
         for (auto PZone : g_PZoneList)
         {
-            delete PZone.second;
+            destroy(PZone.second);
         }
         g_PZoneList.clear();
-        delete g_PTrigger;
-        g_PTrigger = nullptr;
+        destroy(g_PTrigger);
     }
 
     void ForEachZone(const std::function<void(CZone*)>& func)

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -46,8 +46,7 @@ void CVanaTime::delInstance()
 {
     if (_instance)
     {
-        delete _instance;
-        _instance = nullptr;
+        destroy(_instance);
     }
 }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -146,9 +146,9 @@ CZone::CZone(ZONEID ZoneID, REGION_TYPE RegionID, CONTINENT_TYPE ContinentID, ui
 
 CZone::~CZone()
 {
-    delete m_TreasurePool;
-    delete m_CampaignHandler;
-    delete m_zoneEntities;
+    destroy(m_TreasurePool);
+    destroy(m_CampaignHandler);
+    destroy(m_zoneEntities);
 }
 
 /************************************************************************
@@ -481,8 +481,7 @@ void CZone::LoadNavMesh()
     if (!m_navMesh->load(file))
     {
         DebugNavmesh("CZone::LoadNavMesh: Cannot load navmesh file (%s)", file);
-        delete m_navMesh;
-        m_navMesh = nullptr;
+        destroy(m_navMesh);
     }
 }
 
@@ -497,7 +496,7 @@ void CZone::LoadZoneLos()
     if (lineOfSight)
     {
         // Clean up previous object if one exists.
-        delete lineOfSight;
+        destroy(lineOfSight);
     }
 
     lineOfSight = ZoneLos::Load((uint16)GetID(), fmt::sprintf("losmeshes/%s.obj", GetName()));

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1161,7 +1161,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         // Ensure this packet is not despawning us..
         if (packet->ref<uint8>(0x0A) != 0x20)
         {
-            delete packet;
+            destroy(packet);
             return;
         }
     }
@@ -1286,7 +1286,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         }
         // clang-format on
     }
-    delete packet;
+    destroy(packet);
 }
 
 void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
@@ -1371,7 +1371,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
             it->second = nullptr;
             m_mobList.erase(it++);
             dynamicTargIdsToDelete.push_back(std::make_pair(PMob->targid, server_clock::now()));
-            delete PMob;
+            destroy(PMob);
             continue;
         }
 
@@ -1418,8 +1418,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
                 }
             }
 
-            delete it->second;
-            it->second = nullptr;
+            destroy(it->second);
             dynamicTargIdsToDelete.push_back({ it->first, server_clock::now() });
 
             m_npcList.erase(it++);
@@ -1454,8 +1453,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
 
                 if (PPet->getPetType() != PET_TYPE::AUTOMATON || !PPet->PMaster)
                 {
-                    delete it->second;
-                    it->second = nullptr;
+                    destroy(it->second);
                 }
 
                 dynamicTargIdsToDelete.push_back(std::make_pair(it->first, server_clock::now()));
@@ -1502,8 +1500,7 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
                     }
                 }
 
-                delete it->second;
-                it->second = nullptr;
+                destroy(it->second);
                 dynamicTargIdsToDelete.push_back(std::make_pair(it->first, server_clock::now()));
 
                 m_trustList.erase(it++);

--- a/src/search/packets/auction_history.cpp
+++ b/src/search/packets/auction_history.cpp
@@ -49,7 +49,8 @@ void CAHHistoryPacket::AddItem(ahHistory* item)
 
         ref<uint16>(m_PData, (0x08)) = 0x20 + 40 * ++m_count;
     }
-    delete item;
+
+    destroy(item);
 }
 
 /************************************************************************

--- a/src/search/packets/auction_list.cpp
+++ b/src/search/packets/auction_list.cpp
@@ -58,7 +58,8 @@ void CAHItemsListPacket::AddItem(ahItem* item)
     ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 6) = item->StackAmount;
 
     m_count++;
-    delete item;
+
+    destroy(item);
 }
 
 /************************************************************************

--- a/src/search/packets/linkshell_list.cpp
+++ b/src/search/packets/linkshell_list.cpp
@@ -128,7 +128,7 @@ bool CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer)
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
 
-    delete PPlayer;
+    destroy(PPlayer);
 
     return true;
 }

--- a/src/search/packets/party_list.cpp
+++ b/src/search/packets/party_list.cpp
@@ -117,7 +117,8 @@ void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
 
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
-    delete PPlayer;
+
+    destroy(PPlayer);
 }
 
 /************************************************************************

--- a/src/search/packets/search_list.cpp
+++ b/src/search/packets/search_list.cpp
@@ -115,7 +115,7 @@ bool CSearchListPacket::AddPlayer(SearchEntity* PPlayer)
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
 
-    delete PPlayer;
+    destroy(PPlayer);
 
     return true;
 }

--- a/src/search/tcp_request.cpp
+++ b/src/search/tcp_request.cpp
@@ -62,7 +62,8 @@ CTCPRequestPacket::CTCPRequestPacket(SOCKET* socket)
 
 CTCPRequestPacket::~CTCPRequestPacket()
 {
-    delete[] m_data;
+    destroy_arr(m_data);
+    m_data = nullptr;
 
 #ifdef WIN32
     shutdown(*m_socket, SD_SEND);
@@ -106,7 +107,9 @@ int32 CTCPRequestPacket::ReceiveFromSocket()
         ShowError("Search packetsize wrong. Size %d should be %d.", m_size, ref<uint16>(recvbuf, (0x00)));
         return 0;
     }
-    delete[] m_data;
+
+    destroy_arr(m_data);
+
     m_data = new uint8[m_size];
 
     memcpy(&m_data[0], &recvbuf[0], m_size);

--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -37,6 +37,9 @@ def contains_delete(line):
     if "// cpp.sh allow" in line:
         return False
 
+    if "void operator delete" in line:
+        return False
+
     if "//" in line:
         line = line.split("//")[0]
 

--- a/tools/ci/cpp.sh
+++ b/tools/ci/cpp.sh
@@ -26,3 +26,44 @@ cppcheck -v -j 4 --force --quiet --inconclusive --std=c++17 \
 --suppress=passedByValue:src/map/packet_system.cpp \
 -DSA_INTERRUPT -DZMQ_DEPRECATED -DZMQ_EVENT_MONITOR_STOPPED -DTRACY_ENABLE \
 ${target}
+
+python3 << EOF
+import glob
+import os
+
+target = '${target}'
+
+def contains_delete(line):
+    if "// cpp.sh allow" in line:
+        return False
+
+    if "//" in line:
+        line = line.split("//")[0]
+
+    if "*" in line:
+        line = line.split("*")[0]
+
+    line = line.strip()
+    if line.startswith("Show"):
+        return False
+
+    return "delete " in line or "delete[]" in line or "delete []" in line
+
+def check(name):
+    if os.path.isfile(name):
+        with open(name) as f:
+            counter = 0
+            for line in f.readlines():
+                counter = counter + 1
+                if contains_delete(line):
+                    print(f"{name}:{counter}: Found naked delete. Please use destroy(ptr) or destroy_arr(ptr).")
+                    print(line)
+
+if target == 'src':
+    for filename in glob.iglob('src/**/*.cpp', recursive=True):
+        check(filename)
+    for filename in glob.iglob('src/**/*.h', recursive=True):
+        check(filename)
+else:
+    check(target)
+EOF


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a CI check to block usage of delete and delete[]
- Replaced delete and delete[] with destroy() and destroy_arr
- Comments about `delete this;`, since we can't drop-in replace those

## Steps to test these changes

Everything should work as it did before, but now when we delete things, they are nulled out as we want.