### PR TITLE
Fixed Dancer Finishing Moves Count

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -5,6 +5,7 @@ require('scripts/globals/jobpoints')
 require('scripts/globals/magic')
 require('scripts/globals/msg')
 require('scripts/globals/status')
+require("scripts/globals/utils")
 require('scripts/globals/weaponskills')
 -----------------------------------
 xi = xi or {}
@@ -28,6 +29,9 @@ local function getStepFinishingMovesBase(player)
     elseif player:getMainJob() == xi.job.DNC then
         numAwardedMoves = 2
     end
+
+    numAwardedMoves = numAwardedMoves + player:getMod(xi.mod.STEP_FINISH)
+    utils.clamp(numAwardedMoves, 0, 5)
 
     return numAwardedMoves
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This fixes the calculation for Finishing Moves to include the MOD 'xi.mod.STEP_FINISH'. This will now allow the Dancer mythic weapon 'Terpsichore' to perform accurately.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

This can be verified simply by doing a '!setmod 494 1 Player' and seeing that step count rewards an extra step now.
