### PR TITLE
[Fix] AoE Waltzs consuming TP per target

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -386,7 +386,11 @@ xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
     local statMultiplier = waltzInfo[2]
     local amtCured       = 0
 
-    if not player:hasStatusEffect(xi.effect.TRANCE) then
+    -- Handle TP cost.
+    if
+        not player:hasStatusEffect(xi.effect.TRANCE) and
+        target:getID() == ability:getPrimaryTargetID() -- Ensure TP is only used once, and not once per target.
+    then
         player:delTP(waltzInfo[1])
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Divine Waltz I and II from consuming TP one time per target affected

## Steps to test these changes

Use divine waltz on more than 1 target and on yourself alone. See if TP is the same
