### PR TITLE
Fixed Dancer Job Utils

### DIFF
--- a/scripts/globals/abilities/building_flourish.lua
+++ b/scripts/globals/abilities/building_flourish.lua
@@ -10,44 +10,16 @@
 -- Using two Finishing Moves boosts both the Accuracy and Attack of your next weapon skill.
 -- Using three Finishing Moves boosts the Accuracy, Attack and Critical Hit Rate of your next weapon skill.
 -----------------------------------
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require('scripts/globals/job_utils/dancer')
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_5)
-    then
-        return 0, 0
-    end
-
-    return xi.msg.basic.NO_FINISHINGMOVES, 0
+    return xi.job_utils.dancer.checkBuildingFlourishAbility(player, target, ability)
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 1, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 2, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_3)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_4)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_5)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    end
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.dancer.useBuildingFlourishAbility(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/abilities/contradance.lua
+++ b/scripts/globals/abilities/contradance.lua
@@ -5,16 +5,16 @@
 -- Recast Time: 00:05:00
 -- Duration: 00:01:00
 -----------------------------------
-require("scripts/globals/status")
+require('scripts/globals/job_utils/dancer')
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return 0, 0
+    return xi.job_utils.dancer.checkContradanceAbility(player, target, ability)
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    -- player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60) -- TODO: implement xi.effect.CONTRADANCE
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.dancer.useContradanceAbility(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/abilities/wild_flourish.lua
+++ b/scripts/globals/abilities/wild_flourish.lua
@@ -6,53 +6,16 @@
 -- Recast Time: 0:30
 -- Duration: 0:05
 -----------------------------------
-require("scripts/globals/msg")
-require("scripts/globals/status")
-require("scripts/globals/weaponskills")
+require('scripts/globals/job_utils/dancer')
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if player:getAnimation() ~= 1 then
-        return xi.msg.basic.REQUIRES_COMBAT, 0
-    else
-        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-            player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_3)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_4)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_5)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_3, 1, 0, 7200)
-            return 0, 0
-        else
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        end
-    end
+    return xi.job_utils.dancer.checkWildFlourishAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    if
-        not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
-        not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
-    then
-        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 1, 0, 5, 0, 1)
-    else
-        ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
-    end
-
-    action:setAnimation(target:getID(), getFlourishAnimation(player:getWeaponSkillType(xi.slot.MAIN)))
-    action:speceffect(target:getID(), 1)
-
-    return 0
+    return xi.job_utils.dancer.useWildFlourishAbility(player, target, ability, action)
 end
 
 return abilityObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Adjusted the calculation of finishing moves to account for the mythic dagger 'Terpsichore'

Fixed the abilities:
- Wild Flourish
- Building Flourish

Brought the ability Contradance into the Dancer job_utils so everything is all together (this still requires some core work to convert into an AoE Waltz effect)

References:
https://www.bg-wiki.com/ffxi/Finishing_Move
https://www.bg-wiki.com/ffxi/Terpsichore
https://www.bg-wiki.com/ffxi/Wild_Flourish
https://www.bg-wiki.com/ffxi/Building_Flourish

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Bring these changes into server and observe how the step counts are accurate and account for dancer mythic dagger now, and the Wild Flourish/Building Flourish JAs work now.