### PR TITLE
[core] update CCharJobsPacket to send Max HP/MP instead of current

### DIFF
--- a/src/map/packets/char_jobs.cpp
+++ b/src/map/packets/char_jobs.cpp
@@ -41,8 +41,8 @@ CCharJobsPacket::CCharJobsPacket(CCharEntity* PChar)
     memcpy(data + (0x20), &PChar->stats, 14);
     memcpy(data + (0x44), &PChar->jobs, 27);
 
-    ref<uint32>(0x3C) = PChar->health.hp;
-    ref<uint32>(0x40) = PChar->health.mp;
+    ref<uint32>(0x3C) = PChar->health.maxhp;
+    ref<uint32>(0x40) = PChar->health.maxmp;
 
     ref<uint32>(0x44) = PChar->jobs.unlocked & 1; // первый бит в unlocked отвечает за дополнительную профессию
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin, updates a wrong portion of a packet to match retail

## Steps to test these changes

Dump packet and check its max hp/mp and not current hp/mp at the specified offsets.
