### PR TITLE
Optimize Daily Tally item selection

### DIFF
--- a/scripts/globals/gobbiemysterybox.lua
+++ b/scripts/globals/gobbiemysterybox.lua
@@ -71,22 +71,14 @@ local anniversaryItems =
 }
 local gobbieJunk =
 {
-    507,   -- Goblin Mail
-    508,   -- Goblin Helm
-    510,   -- Goblin Armor
-    511,   -- Goblin Mask
-    566,   -- Goblin Cup
-    568,   -- Goblin Die
-    1239,  -- Goblin Doll
-    1868,  -- Goblin Coif Cutting
-    2542,  -- Goblin Mess Tin
-    2543,  -- Goblin Weel
-    4539,  -- Goblin Pie
-    4543,  -- Goblin Mushpot
-    9777,  -- Goblin Offering
-    15203, -- Goblin Coif
-    18180, -- Goblin Grenade
-    19220, -- Goblin Cracker
+    2542, -- Goblin Mess Tin
+    2543, -- Goblin Weel
+    4324, -- Hobgoblin Chocolate
+    4325, -- Hobgoblin Pie
+    4328, -- Hobgoblin Bread
+    4458, -- Goblin Bread
+    4495, -- Goblin Chocolate
+    4539, -- Goblin Pie
 }
 xi.mystery.onTrade = function(player, npc, trade, events)
     if trade:getItemCount() == 1 then

--- a/scripts/globals/gobbiemysterybox.lua
+++ b/scripts/globals/gobbiemysterybox.lua
@@ -71,22 +71,22 @@ local anniversaryItems =
 }
 local gobbieJunk =
 {
-    507,
-    508,
-    510,
-    511,
-    566,
-    568,
-    1239,
-    1868,
-    2542,
-    2543,
-    4539,
-    4543,
-    9777,
-    15203,
-    18180,
-    19220,
+    507,   -- Goblin Mail
+    508,   -- Goblin Helm
+    510,   -- Goblin Armor
+    511,   -- Goblin Mask
+    566,   -- Goblin Cup
+    568,   -- Goblin Die
+    1239,  -- Goblin Doll
+    1868,  -- Goblin Coif Cutting
+    2542,  -- Goblin Mess Tin
+    2543,  -- Goblin Weel
+    4539,  -- Goblin Pie
+    4543,  -- Goblin Mushpot
+    9777,  -- Goblin Offering
+    15203, -- Goblin Coif
+    18180, -- Goblin Grenade
+    19220, -- Goblin Cracker
 }
 xi.mystery.onTrade = function(player, npc, trade, events)
     if trade:getItemCount() == 1 then

--- a/src/map/daily_system.cpp
+++ b/src/map/daily_system.cpp
@@ -12,22 +12,14 @@ namespace daily
     std::vector<uint16> sundries2DialItems;
     std::vector<uint16> specialDialItems;
     std::vector<uint16> gobbieJunk = {
-        507,   // Goblin Mail
-        508,   // Goblin Helm
-        510,   // Goblin Armor
-        511,   // Goblin Mask
-        566,   // Goblin Cup
-        568,   // Goblin Die
-        1239,  // Goblin Doll
-        1868,  // Goblin Coif Cutting
-        2542,  // Goblin Mess Tin
-        2543,  // Goblin Weel
-        4539,  // Goblin Pie
-        4543,  // Goblin Mushpot
-        9777,  // Goblin Offering
-        15203, // Goblin Coif
-        18180, // Goblin Grenade
-        19220  // Goblin Cracker
+        2542, // Goblin Mess Tin
+        2543, // Goblin Weel
+        4324, // Hobgoblin Chocolate
+        4325, // Hobgoblin Pie
+        4328, // Hobgoblin Bread
+        4458, // Goblin Bread
+        4495, // Goblin Chocolate
+        4539  // Goblin Pie
     };
 
     uint16 SelectItem(CCharEntity* player, uint8 dial)

--- a/src/map/daily_system.cpp
+++ b/src/map/daily_system.cpp
@@ -11,11 +11,28 @@ namespace daily
     std::vector<uint16> sundries1DialItems;
     std::vector<uint16> sundries2DialItems;
     std::vector<uint16> specialDialItems;
-    std::vector<uint16> gobbieJunk = { 507, 508, 510, 511, 566, 568, 1239, 1868, 2542, 2543, 4539, 4543, 9777, 15203, 18180, 19220 };
+    std::vector<uint16> gobbieJunk = {
+        507,   // Goblin Mail
+        508,   // Goblin Helm
+        510,   // Goblin Armor
+        511,   // Goblin Mask
+        566,   // Goblin Cup
+        568,   // Goblin Die
+        1239,  // Goblin Doll
+        1868,  // Goblin Coif Cutting
+        2542,  // Goblin Mess Tin
+        2543,  // Goblin Weel
+        4539,  // Goblin Pie
+        4543,  // Goblin Mushpot
+        9777,  // Goblin Offering
+        15203, // Goblin Coif
+        18180, // Goblin Grenade
+        19220  // Goblin Cracker
+    };
 
     uint16 SelectItem(CCharEntity* player, uint8 dial)
     {
-        int                  selection;
+        uint16               selection;
         std::vector<uint16>* dialItems = &gobbieJunk;
         switch (dial)
         {
@@ -50,16 +67,16 @@ namespace daily
                 break;
             }
         }
-        selection = std::rand() % dialItems->size();
+        selection = xirand::GetRandomElement(dialItems);
 
         // Check if Rare item is already owned and substitute with Goblin trash item.
-        if ((itemutils::GetItem((*dialItems)[selection])->getFlag() & ITEM_FLAG_RARE) > 0 && charutils::HasItem(player, (*dialItems)[selection]))
+        if ((itemutils::GetItem(selection)->getFlag() & ITEM_FLAG_RARE) > 0 && charutils::HasItem(player, selection))
         {
             dialItems = &gobbieJunk;
-            selection = std::rand() % dialItems->size();
+            selection = xirand::GetRandomElement(dialItems);
         }
 
-        return (*dialItems)[selection];
+        return selection;
     }
 
     void LoadDailyItems()

--- a/src/map/daily_system.cpp
+++ b/src/map/daily_system.cpp
@@ -11,49 +11,55 @@ namespace daily
     std::vector<uint16> sundries1DialItems;
     std::vector<uint16> sundries2DialItems;
     std::vector<uint16> specialDialItems;
+    std::vector<uint16> gobbieJunk = { 507, 508, 510, 511, 566, 568, 1239, 1868, 2542, 2543, 4539, 4543, 9777, 15203, 18180, 19220 };
 
     uint16 SelectItem(CCharEntity* player, uint8 dial)
     {
-        int                 selection;
-        std::vector<uint16> dialItems;
+        int                  selection;
+        std::vector<uint16>* dialItems = &gobbieJunk;
         switch (dial)
         {
             case 1:
             {
-                dialItems = materialsDialItems;
+                dialItems = &materialsDialItems;
                 break;
             }
             case 2:
             {
-                dialItems = foodDialItems;
+                dialItems = &foodDialItems;
                 break;
             }
             case 3:
             {
-                dialItems = medicineDialItems;
+                dialItems = &medicineDialItems;
                 break;
             }
             case 4:
             {
-                dialItems = sundries1DialItems;
+                dialItems = &sundries1DialItems;
                 break;
             }
             case 5:
             {
-                dialItems = sundries2DialItems;
+                dialItems = &sundries2DialItems;
                 break;
             }
             case 6:
             {
-                dialItems = specialDialItems;
+                dialItems = &specialDialItems;
                 break;
             }
         }
-        do
+        selection = std::rand() % dialItems->size();
+
+        // Check if Rare item is already owned and substitute with Goblin trash item.
+        if ((itemutils::GetItem((*dialItems)[selection])->getFlag() & ITEM_FLAG_RARE) > 0 && charutils::HasItem(player, (*dialItems)[selection]))
         {
-            selection = std::rand() % dialItems.size();
-        } while ((itemutils::GetItem(dialItems[selection])->getFlag() & ITEM_FLAG_RARE) > 0 && charutils::HasItem(player, dialItems[selection]));
-        return dialItems[selection];
+            dialItems = &gobbieJunk;
+            selection = std::rand() % dialItems->size();
+        }
+
+        return (*dialItems)[selection];
     }
 
     void LoadDailyItems()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reference item vectors instead of copying them every time we select an item.
- Select some goblin junk to distribute if an owned Rare item is selected instead of rerolling.

## Steps to test these changes

Use the box, should work as expected.
