### PR TITLE
Correct Cursed Orb cutscene to prevent player pretzles

### DIFF
--- a/scripts/quests/hiddenQuests/Crimson_Orb.lua
+++ b/scripts/quests/hiddenQuests/Crimson_Orb.lua
@@ -54,7 +54,7 @@ local pondOnTrigger = function(player, npc)
     then
         quest:setLocalVar(player, 'npcOffset', npcOffset)
         player:messageSpecial(davoiID.text.ORB_QUEST_OFFSET)
-        return quest:progressEvent(50 + npcOffset, 0, numPonds, 7)
+        return quest:progressEvent(50 + npcOffset, 0, numPonds, player:getRace())
     else
         return quest:messageSpecial(davoiID.text.COLOR_OF_BLOOD)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Bug fix to adjust the param passed for cursed orb cutscene to animate the player depending on their race. Can see AirSkyBoat/AirSkyBoat#1020 for what currently happens as the param is hard set for mithra animation currently.

## Steps to test these changes

Run `!cs` within Davoi using the differing params passed in the code to see your character either pretzle or animate correctly. Can also use different addons in Ashita or Windower to change your displayed race to test.