### PR TITLE
Correct Zoredonite NM Respawn

### DIFF
--- a/scripts/zones/Manaclipper/mobs/Zoredonite.lua
+++ b/scripts/zones/Manaclipper/mobs/Zoredonite.lua
@@ -18,7 +18,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    mob:getLocalVar("respawn", os.time() + 43200) -- 12 hour respawn
+    mob:setLocalVar("respawn", os.time() + 43200) -- 12 hour respawn
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes a typo I made when creating the NM Zoredonite to properly set the NM's spawn time on despawn. It is currently spawning on every Manaclipper boat ride.

## Steps to test these changes

- Load into Manaclipper boat, kill Zoredonite
- !zone Manaclipper multiple times to see that it does not respawn every time.
