### PR TITLE
[DNC] Move logic from 3 abilities to job utils and update their functions to match new effect method

### DIFF
--- a/scripts/globals/abilities/animated_flourish.lua
+++ b/scripts/globals/abilities/animated_flourish.lua
@@ -10,7 +10,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkAnimatedFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, false, 1)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/box_step.lua
+++ b/scripts/globals/abilities/box_step.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.stepAbilityCheck(player, target, ability)
+    return xi.job_utils.dancer.checkStepAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/building_flourish.lua
+++ b/scripts/globals/abilities/building_flourish.lua
@@ -15,7 +15,7 @@ require("scripts/globals/job_utils/dancer")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkBuildingFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, false, 1)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/building_flourish.lua
+++ b/scripts/globals/abilities/building_flourish.lua
@@ -10,44 +10,16 @@
 -- Using two Finishing Moves boosts both the Accuracy and Attack of your next weapon skill.
 -- Using three Finishing Moves boosts the Accuracy, Attack and Critical Hit Rate of your next weapon skill.
 -----------------------------------
-require("scripts/globals/msg")
-require("scripts/globals/status")
+require("scripts/globals/job_utils/dancer")
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_5)
-    then
-        return 0, 0
-    end
-
-    return xi.msg.basic.NO_FINISHINGMOVES, 0
+    return xi.job_utils.dancer.checkBuildingFlourishAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 1, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 2, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_3)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_4)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_5)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    end
+    return xi.job_utils.dancer.useBuildingFlourishAbility(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/globals/abilities/contradance.lua
+++ b/scripts/globals/abilities/contradance.lua
@@ -5,7 +5,7 @@
 -- Recast Time: 00:05:00
 -- Duration: 00:01:00
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/job_utils/dancer")
 -----------------------------------
 local abilityObject = {}
 
@@ -14,7 +14,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
-    -- player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60) -- TODO: implement xi.effect.CONTRADANCE
+    return xi.job_utils.dancer.useContradanceAbility(player, target, ability)
 end
 
 return abilityObject

--- a/scripts/globals/abilities/desperate_flourish.lua
+++ b/scripts/globals/abilities/desperate_flourish.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkDesperateFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, true, 1)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/feather_step.lua
+++ b/scripts/globals/abilities/feather_step.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.stepAbilityCheck(player, target, ability)
+    return xi.job_utils.dancer.checkStepAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/quickstep.lua
+++ b/scripts/globals/abilities/quickstep.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.stepAbilityCheck(player, target, ability)
+    return xi.job_utils.dancer.checkStepAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/reverse_flourish.lua
+++ b/scripts/globals/abilities/reverse_flourish.lua
@@ -10,7 +10,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkReverseFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, false, 1)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)

--- a/scripts/globals/abilities/stutter_step.lua
+++ b/scripts/globals/abilities/stutter_step.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.stepAbilityCheck(player, target, ability)
+    return xi.job_utils.dancer.checkStepAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/violent_flourish.lua
+++ b/scripts/globals/abilities/violent_flourish.lua
@@ -11,7 +11,7 @@ require('scripts/globals/job_utils/dancer')
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkViolentFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, true, 1)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/wild_flourish.lua
+++ b/scripts/globals/abilities/wild_flourish.lua
@@ -11,7 +11,7 @@ require("scripts/globals/job_utils/dancer")
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    return xi.job_utils.dancer.checkWildFlourishAbility(player, target, ability)
+    return xi.job_utils.dancer.checkFlourishAbility(player, target, ability, true, 2)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/globals/abilities/wild_flourish.lua
+++ b/scripts/globals/abilities/wild_flourish.lua
@@ -6,53 +6,16 @@
 -- Recast Time: 0:30
 -- Duration: 0:05
 -----------------------------------
-require("scripts/globals/msg")
-require("scripts/globals/status")
-require("scripts/globals/weaponskills")
+require("scripts/globals/job_utils/dancer")
 -----------------------------------
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    if player:getAnimation() ~= 1 then
-        return xi.msg.basic.REQUIRES_COMBAT, 0
-    else
-        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-            player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_3)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_4)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_5)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_3, 1, 0, 7200)
-            return 0, 0
-        else
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        end
-    end
+    return xi.job_utils.dancer.checkWildFlourishAbility(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    if
-        not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
-        not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
-    then
-        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 1, 0, 5, 0, 1)
-    else
-        ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
-    end
-
-    action:setAnimation(target:getID(), getFlourishAnimation(player:getWeaponSkillType(xi.slot.MAIN)))
-    action:speceffect(target:getID(), 1)
-
-    return 0
+    return xi.job_utils.dancer.useWildFlourishAbility(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -152,39 +152,20 @@ xi.job_utils.dancer.checkViolentFlourishAbility = function(player, target, abili
 end
 
 xi.job_utils.dancer.checkBuildingFlourishAbility = function(player, target, ability)
-    if
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) or
-        player:hasStatusEffect(xi.effect.FINISHING_MOVE_5)
-    then
+    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
         return 0, 0
+    else
+        return xi.msg.basic.NO_FINISHINGMOVES, 0
     end
-
-    return xi.msg.basic.NO_FINISHINGMOVES, 0
 end
 
 xi.job_utils.dancer.checkWildFlourishAbility = function(player, target, ability)
     if player:getAnimation() ~= 1 then
         return xi.msg.basic.REQUIRES_COMBAT, 0
     else
-        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-            player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_3)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_4)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-            return 0, 0
-        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_5)
-            player:addStatusEffect(xi.effect.FINISHING_MOVE_3, 1, 0, 7200)
+        local finishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+
+        if finishingMoves >= 2 then
             return 0, 0
         else
             return xi.msg.basic.NO_FINISHINGMOVES, 0

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -27,6 +27,24 @@ local waltzAbilities =
     [xi.jobAbility.DIVINE_WALTZ_II ] = { 800, 0.75, 270 },
 }
 
+local animationTable =
+{
+-- [weapon type] = { step, flourish }
+    [ 0] = { 15, 25 },
+    [ 1] = { 15, 25 },
+    [ 2] = { 14, 24 },
+    [ 3] = { 14, 24 },
+    [ 4] = { 19, 29 },
+    [ 5] = { 16, 26 },
+    [ 6] = { 18, 28 },
+    [ 7] = { 18, 28 },
+    [ 8] = { 20, 30 },
+    [ 9] = { 21, 31 },
+    [10] = { 22, 32 },
+    [11] = { 17, 27 },
+    [12] = { 23, 33 },
+}
+
 -----------------------------------
 -- Local functions.
 -----------------------------------
@@ -72,7 +90,7 @@ local function setFinishingMoves(player, numMoves)
     numMoves              = math.min(numMoves, getMaxFinishingMoves(player))
 
     if finishingEffect then
-        if numMoves <= 0 then
+        if numMoves == 0 then
             player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
         else
             finishingEffect:setPower(numMoves)
@@ -85,52 +103,16 @@ local function setFinishingMoves(player, numMoves)
 end
 
 local function getStepAnimation(weaponSkillType)
-    if weaponSkillType <= 1 then
-        return 15
-    elseif weaponSkillType <= 3 then
-        return 14
-    elseif weaponSkillType == 4 then
-        return 19
-    elseif weaponSkillType == 5 then
-        return 16
-    elseif weaponSkillType <= 7 then
-        return 18
-    elseif weaponSkillType == 8 then
-        return 20
-    elseif weaponSkillType == 9 then
-        return 21
-    elseif weaponSkillType == 10 then
-        return 22
-    elseif weaponSkillType == 11 then
-        return 17
-    elseif weaponSkillType == 12 then
-        return 23
+    if weaponSkillType <= 12 then
+        return animationTable[weaponSkillType][1]
     else
         return 0
     end
 end
 
 local function getFlourishAnimation(weaponSkillType)
-    if weaponSkillType <= 1 then
-        return 25
-    elseif weaponSkillType <= 3 then
-        return 24
-    elseif weaponSkillType == 4 then
-        return 29
-    elseif weaponSkillType == 5 then
-        return 26
-    elseif weaponSkillType <= 7 then
-        return 28
-    elseif weaponSkillType == 8 then
-        return 30
-    elseif weaponSkillType == 9 then
-        return 31
-    elseif weaponSkillType == 10 then
-        return 32
-    elseif weaponSkillType == 11 then
-        return 27
-    elseif weaponSkillType == 12 then
-        return 33
+    if weaponSkillType <= 12 then
+        return animationTable[weaponSkillType][2]
     else
         return 0
     end
@@ -176,9 +158,9 @@ xi.job_utils.dancer.checkFlourishAbility = function(player, target, ability, com
     end
 
     -- Finishing Move check.
-    local finishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+    local numFinishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
 
-    if finishingMoves >= minimumCost then
+    if numFinishingMoves >= minimumCost then
         return 0, 0
     else
         return xi.msg.basic.NO_FINISHINGMOVES, 0
@@ -430,7 +412,7 @@ xi.job_utils.dancer.useBuildingFlourishAbility = function(player, target, abilit
     local power = utils.clamp(availableMoves, 0, 3)
 
     player:addStatusEffect(xi.effect.BUILDING_FLOURISH, power, 0, 60, 0, flourishMerits)
-    setFinishingMoves(player, availableMoves - 3)
+    setFinishingMoves(player, availableMoves - power)
 end
 
 xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, action)

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -151,6 +151,47 @@ xi.job_utils.dancer.checkViolentFlourishAbility = function(player, target, abili
     end
 end
 
+xi.job_utils.dancer.checkBuildingFlourishAbility = function(player, target, ability)
+    if
+        player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) or
+        player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) or
+        player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) or
+        player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) or
+        player:hasStatusEffect(xi.effect.FINISHING_MOVE_5)
+    then
+        return 0, 0
+    end
+
+    return xi.msg.basic.NO_FINISHINGMOVES, 0
+end
+
+xi.job_utils.dancer.checkWildFlourishAbility = function(player, target, ability)
+    if player:getAnimation() ~= 1 then
+        return xi.msg.basic.REQUIRES_COMBAT, 0
+    else
+        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
+            return xi.msg.basic.NO_FINISHINGMOVES, 0
+        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
+            player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
+            return 0, 0
+        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
+            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_3)
+            player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
+            return 0, 0
+        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
+            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_4)
+            player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
+            return 0, 0
+        elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
+            player:delStatusEffectSilent(xi.effect.FINISHING_MOVE_5)
+            player:addStatusEffect(xi.effect.FINISHING_MOVE_3, 1, 0, 7200)
+            return 0, 0
+        else
+            return xi.msg.basic.NO_FINISHINGMOVES, 0
+        end
+    end
+end
+
 xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
     local waltzInfo = waltzAbilities[ability:getID()]
 
@@ -387,6 +428,48 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
         ability:setMsg(xi.msg.basic.JA_MISS)
         return 0
     end
+end
+
+xi.job_utils.dancer.useBuildingFlourishAbility = function(player, target, ability)
+    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
+        player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
+        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 1, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
+    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
+        player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
+        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 2, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
+    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
+        player:delStatusEffect(xi.effect.FINISHING_MOVE_3)
+        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
+    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
+        player:delStatusEffect(xi.effect.FINISHING_MOVE_4)
+        player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
+        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
+    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
+        player:delStatusEffect(xi.effect.FINISHING_MOVE_5)
+        player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
+        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
+    end
+end
+
+xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, action)
+    if
+        not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
+        not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
+    then
+        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 1, 0, 5, 0, 1)
+    else
+        ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
+    end
+
+    action:setAnimation(target:getID(), getFlourishAnimation(player:getWeaponSkillType(xi.slot.MAIN)))
+    action:speceffect(target:getID(), 1)
+
+    return 0
+end
+
+-- TODO: Implement Contradance status effect.
+xi.job_utils.dancer.useContradanceAbility = function(player, target, ability)
+    -- player:addStatusEffect(xi.effect.CONTRADANCE, 19, 1, 60)
 end
 
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -111,65 +111,22 @@ xi.job_utils.dancer.checkNoFootRiseAbility = function(player, target, ability)
     end
 end
 
-xi.job_utils.dancer.checkReverseFlourishAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
+xi.job_utils.dancer.checkFlourishAbility = function(player, target, ability, combatOnly, minimumCost)
+    -- Combat Check.
+    if
+        combatOnly and
+        player:getAnimation() ~= 1
+    then
+        return xi.msg.basic.REQUIRES_COMBAT, 0
+    end
+
+    -- Finishing Move check.
+    local finishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+
+    if finishingMoves >= minimumCost then
         return 0, 0
     else
         return xi.msg.basic.NO_FINISHINGMOVES, 0
-    end
-end
-
-xi.job_utils.dancer.checkAnimatedFlourishAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-        return 0, 0
-    else
-        return xi.msg.basic.NO_FINISHINGMOVES, 0
-    end
-end
-
-xi.job_utils.dancer.checkDesperateFlourishAbility = function(player, target, ability)
-    if player:getAnimation() ~= 1 then
-        return xi.msg.basic.REQUIRES_COMBAT, 0
-    else
-        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-            return 0, 0
-        else
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        end
-    end
-end
-
-xi.job_utils.dancer.checkViolentFlourishAbility = function(player, target, ability)
-    if player:getAnimation() ~= 1 then
-        return xi.msg.basic.REQUIRES_COMBAT, 0
-    else
-        if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-            return 0, 0
-        else
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        end
-    end
-end
-
-xi.job_utils.dancer.checkBuildingFlourishAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-        return 0, 0
-    else
-        return xi.msg.basic.NO_FINISHINGMOVES, 0
-    end
-end
-
-xi.job_utils.dancer.checkWildFlourishAbility = function(player, target, ability)
-    if player:getAnimation() ~= 1 then
-        return xi.msg.basic.REQUIRES_COMBAT, 0
-    else
-        local finishingMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
-
-        if finishingMoves >= 2 then
-            return 0, 0
-        else
-            return xi.msg.basic.NO_FINISHINGMOVES, 0
-        end
     end
 end
 

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -57,7 +57,7 @@ local function setFinishingMoves(player, numMoves)
     numMoves              = math.min(numMoves, getMaxFinishingMoves(player))
 
     if finishingEffect then
-        if numMoves == 0 then
+        if numMoves <= 0 then
             player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
         else
             finishingEffect:setPower(numMoves)
@@ -369,27 +369,18 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
 end
 
 xi.job_utils.dancer.useBuildingFlourishAbility = function(player, target, ability)
-    if player:hasStatusEffect(xi.effect.FINISHING_MOVE_1) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_1)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 1, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_2) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_2)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 2, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_3) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_3)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_4) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_4)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_1, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    elseif player:hasStatusEffect(xi.effect.FINISHING_MOVE_5) then
-        player:delStatusEffect(xi.effect.FINISHING_MOVE_5)
-        player:addStatusEffect(xi.effect.FINISHING_MOVE_2, 1, 0, 7200)
-        player:addStatusEffect(xi.effect.BUILDING_FLOURISH, 3, 0, 60, 0, player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT))
-    end
+    local flourishMerits = player:getMerit(xi.merit.BUILDING_FLOURISH_EFFECT)
+    local availableMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+
+    local power = utils.clamp(availableMoves, 0, 3)
+
+    player:addStatusEffect(xi.effect.BUILDING_FLOURISH, power, 0, 60, 0, flourishMerits)
+    setFinishingMoves(player, availableMoves - 3)
 end
 
 xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, action)
+    local numMoves = player:getStatusEffect(xi.effect.FINISHING_MOVE_1):getPower()
+
     if
         not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
         not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
@@ -401,6 +392,7 @@ xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, a
 
     action:setAnimation(target:getID(), getFlourishAnimation(player:getWeaponSkillType(xi.slot.MAIN)))
     action:speceffect(target:getID(), 1)
+    setFinishingMoves(player, numMoves - 2)
 
     return 0
 end

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -403,16 +403,23 @@ xi.job_utils.dancer.useContradanceAbility = function(player, target, ability)
 end
 
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
-    local waltzInfo      = waltzAbilities[ability:getID()]
+    local abilityId      = ability:getID()
+    local waltzInfo      = waltzAbilities[abilityId]
     local statMultiplier = waltzInfo[2]
     local amtCured       = 0
 
     -- Handle TP cost.
-    if
-        not player:hasStatusEffect(xi.effect.TRANCE) and
-        target:getID() == ability:getPrimaryTargetID() -- Ensure TP is only used once, and not once per target.
-    then
-        player:delTP(waltzInfo[1])
+    if not player:hasStatusEffect(xi.effect.TRANCE) then
+        if
+            abilityId == xi.jobAbility.DIVINE_WALTZ or
+            abilityId == xi.jobAbility.DIVINE_WALTZ_II
+        then
+            if player:getID() == target:getID() then
+                player:delTP(waltzInfo[1])
+            end
+        else
+            player:delTP(waltzInfo[1])
+        end
     end
 
     if player:getMainJob() ~= xi.job.DNC then

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -13,7 +13,22 @@ xi.job_utils.dancer = xi.job_utils.dancer or {}
 -----------------------------------
 
 -----------------------------------
--- Local functions and tables.
+-- Local tables.
+-----------------------------------
+local waltzAbilities =
+{
+--  [Ability ID] =     { tpCost, statMultiplier, baseHp }
+    [xi.jobAbility.CURING_WALTZ    ] = { 200, 0.25,  60 },
+    [xi.jobAbility.CURING_WALTZ_II ] = { 350, 0.50, 130 },
+    [xi.jobAbility.CURING_WALTZ_III] = { 500, 0.75, 270 },
+    [xi.jobAbility.CURING_WALTZ_IV ] = { 650, 1.00, 450 },
+    [xi.jobAbility.CURING_WALTZ_V  ] = { 800, 1.25, 600 },
+    [xi.jobAbility.DIVINE_WALTZ    ] = { 400, 0.25,  60 },
+    [xi.jobAbility.DIVINE_WALTZ_II ] = { 800, 0.75, 270 },
+}
+
+-----------------------------------
+-- Local functions.
 -----------------------------------
 local function getMaxFinishingMoves(player)
     return 5 + player:getMod(xi.mod.MAX_FINISHING_MOVE_BONUS)
@@ -69,17 +84,57 @@ local function setFinishingMoves(player, numMoves)
     end
 end
 
-local waltzAbilities =
-{
---  [Ability ID] =     { tpCost, statMultiplier, baseHp }
-    [xi.jobAbility.CURING_WALTZ    ] = { 200, 0.25,  60 },
-    [xi.jobAbility.CURING_WALTZ_II ] = { 350, 0.50, 130 },
-    [xi.jobAbility.CURING_WALTZ_III] = { 500, 0.75, 270 },
-    [xi.jobAbility.CURING_WALTZ_IV ] = { 650, 1.00, 450 },
-    [xi.jobAbility.CURING_WALTZ_V  ] = { 800, 1.25, 600 },
-    [xi.jobAbility.DIVINE_WALTZ    ] = { 400, 0.25,  60 },
-    [xi.jobAbility.DIVINE_WALTZ_II ] = { 800, 0.75, 270 },
-}
+local function getStepAnimation(weaponSkillType)
+    if weaponSkillType <= 1 then
+        return 15
+    elseif weaponSkillType <= 3 then
+        return 14
+    elseif weaponSkillType == 4 then
+        return 19
+    elseif weaponSkillType == 5 then
+        return 16
+    elseif weaponSkillType <= 7 then
+        return 18
+    elseif weaponSkillType == 8 then
+        return 20
+    elseif weaponSkillType == 9 then
+        return 21
+    elseif weaponSkillType == 10 then
+        return 22
+    elseif weaponSkillType == 11 then
+        return 17
+    elseif weaponSkillType == 12 then
+        return 23
+    else
+        return 0
+    end
+end
+
+local function getFlourishAnimation(weaponSkillType)
+    if weaponSkillType <= 1 then
+        return 25
+    elseif weaponSkillType <= 3 then
+        return 24
+    elseif weaponSkillType == 4 then
+        return 29
+    elseif weaponSkillType == 5 then
+        return 26
+    elseif weaponSkillType <= 7 then
+        return 28
+    elseif weaponSkillType == 8 then
+        return 30
+    elseif weaponSkillType == 9 then
+        return 31
+    elseif weaponSkillType == 10 then
+        return 32
+    elseif weaponSkillType == 11 then
+        return 27
+    elseif weaponSkillType == 12 then
+        return 33
+    else
+        return 0
+    end
+end
 
 -----------------------------------
 -- Ability Check.

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -553,8 +553,8 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         local nativecrit = 0
         critrate = fTP(tp, wsParams.crit100, wsParams.crit200, wsParams.crit300)
 
-        if calcParams.flourishEffect and calcParams.flourishEffect:getPower() > 1 then
-            critrate = critrate + (10 + calcParams.flourishEffect:getSubPower() / 2) / 100
+        if calcParams.flourishEffect and calcParams.flourishEffect:getPower() >= 3 then  -- 3 Finishing Moves used.
+            critrate = critrate + (10 + calcParams.flourishEffect:getSubPower()) / 100
         end
 
         local fencerBonusVal = calcParams.fencerBonus or 0
@@ -1032,17 +1032,17 @@ function getMeleeDmg(attacker, weaponType, kick)
 end
 
 function getHitRate(attacker, target, capHitRate, bonus)
-    local flourisheffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+    local flourishEffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-    if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
-        attacker:addMod(xi.mod.ACC, 20 + flourisheffect:getSubPower())
+    if flourishEffect ~= nil and flourishEffect:getPower() >= 1 then -- 1 or more Finishing moves used.
+        attacker:addMod(xi.mod.ACC, 40 + flourishEffect:getSubPower() * 2)
     end
 
     local acc = attacker:getACC()
     local eva = target:getEVA()
 
-    if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
-        attacker:delMod(xi.mod.ACC, 20 + flourisheffect:getSubPower())
+    if flourishEffect ~= nil and flourishEffect:getPower() >= 1 then -- 1 or more Finishing moves used.
+        attacker:delMod(xi.mod.ACC, 40 + flourishEffect:getSubPower() * 2)
     end
 
     if bonus == nil then
@@ -1130,10 +1130,10 @@ end
 
 -- Given the raw ratio value (atk/def) and levels, returns the cRatio (min then max)
 function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
-    local flourisheffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
+    local flourishEffect = attacker:getStatusEffect(xi.effect.BUILDING_FLOURISH)
 
-    if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
-        attacker:addMod(xi.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
+    if flourishEffect ~= nil and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+        attacker:addMod(xi.mod.ATTP, 25 + flourishEffect:getSubPower())
     end
 
     local atkmulti = fTP(tp, params.atk100, params.atk200, params.atk300)
@@ -1141,8 +1141,8 @@ function cMeleeRatio(attacker, defender, params, ignoredDef, tp)
 
     cratio = utils.clamp(cratio, 0, 2.25)
 
-    if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
-        attacker:delMod(xi.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
+    if flourishEffect ~= nil and flourishEffect:getPower() >= 2 then -- 2 or more Finishing Moves used.
+        attacker:delMod(xi.mod.ATTP, 25 + flourishEffect:getSubPower())
     end
 
     local levelCorrection = 0

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -1300,58 +1300,6 @@ function generatePdif (cratiomin, cratiomax, melee)
     return pdif
 end
 
-function getStepAnimation(skill)
-    if skill <= 1 then
-        return 15
-    elseif skill <= 3 then
-        return 14
-    elseif skill == 4 then
-        return 19
-    elseif skill == 5 then
-        return 16
-    elseif skill <= 7 then
-        return 18
-    elseif skill == 8 then
-        return 20
-    elseif skill == 9 then
-        return 21
-    elseif skill == 10 then
-        return 22
-    elseif skill == 11 then
-        return 17
-    elseif skill == 12 then
-        return 23
-    else
-        return 0
-    end
-end
-
-function getFlourishAnimation(skill)
-    if skill <= 1 then
-        return 25
-    elseif skill <= 3 then
-        return 24
-    elseif skill == 4 then
-        return 29
-    elseif skill == 5 then
-        return 26
-    elseif skill <= 7 then
-        return 28
-    elseif skill == 8 then
-        return 30
-    elseif skill == 9 then
-        return 31
-    elseif skill == 10 then
-        return 32
-    elseif skill == 11 then
-        return 27
-    elseif skill == 12 then
-        return 33
-    else
-        return 0
-    end
-end
-
 function handleWSGorgetBelt(attacker)
     local ftpBonus = 0
     local accBonus = 0

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -166,7 +166,7 @@ INSERT INTO `merits` VALUES (1480,'repair_recast',5,6,131072,6,22);
 INSERT INTO `merits` VALUES (1536,'step_accuracy',5,3,262144,6,23);
 INSERT INTO `merits` VALUES (1538,'haste_samba_effect',5,100,262144,6,23);
 INSERT INTO `merits` VALUES (1540,'reverse_flourish_effect',5,3,262144,6,23);
-INSERT INTO `merits` VALUES (1542,'building_flourish_effect',5,2,262144,6,23);
+INSERT INTO `merits` VALUES (1542,'building_flourish_effect',5,1,262144,6,23);
 INSERT INTO `merits` VALUES (1600,'grimoire_recast',5,2,524288,6,24);
 INSERT INTO `merits` VALUES (1602,'modus_veritas_duration',5,1,524288,6,24);
 INSERT INTO `merits` VALUES (1604,'helix_magic_acc_att',5,1,524288,6,24);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Imports some of the changes from PR #3589 

- Reorganizes Dancer job_utils script, so local functions, check functions and use functions are together.
- Moves logic from Building Flourish, Wild Flourish and Contradance to Dancer job_utils
- Updates logic for Flourishes check functions, since we no longer use diferent status effects to count finishing moves, and makes them all use the same one.
- Properly implements Building and Wild Flourishes.

## Steps to test these changes

Better reviewed by commit:

1st - No existing logic changes. Moves code arround inside the same script. Only notable change is renaming a function so it's in line with how the rest are named.
2nd - No existing logic changes. Moves code from ability scripts to job_utils script.
3rd - Updates existing logic in ability check functions, so we only check for 1 status effect and it's power.
4th - Makes all flourishes use the same check function.
5th - Corrects Building and Wild Flourish logic in both job_utils and weaponskills.lua. Corrected the value of Building Flourish merit.