### PR TITLE
[core] Fix and cleanup dbox checking

### DIFF
--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -53,4 +53,5 @@ xi.settings.logging =
     DEBUG_ID_LOOKUP      = false, -- Calls in C++: DebugIDLookup(...)
     DEBUG_MODULES        = false, -- Calls in C++: DebugModules(...)
     DEBUG_PACKET_BACKLOG = false, -- Special logic in map.cpp::send_parse
+    DEBUG_DELIVERY_BOX   = false, -- Special logic in packet_system.cpp::SmallPacket0x04D
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Shouldn't have snuck in an additional check into https://github.com/LandSandBoat/server/pull/3613, it was too stringent
