### PR TITLE
[build] Add linker exception for R.Pi 32-bit

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -111,3 +111,14 @@ function(disable_lto target)
     target_compile_options(${target} PRIVATE -fno-lto)
     target_link_options(${target} PRIVATE -fno-lto)
 endfunction()
+
+# If we're on Unix and the system is 32-bit (void* is 4-bytes wide),
+# then there's a good chance we're compiling for Raspberry Pi.
+# Currently, CMake doesn't detect this properly and needs some help
+# to link libatomic.
+# Source: https://gitlab.kitware.com/cmake/cmake/-/issues/21174
+#
+# TODO: Use include(CheckCXXSourceCompiles) to make this check better.
+if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
+endif()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Should fix: https://github.com/LandSandBoat/server/issues/3618

As I linked https://gitlab.kitware.com/cmake/cmake/-/issues/21174 in the issue, this is the quickest and easiest way to force libatomic to be linked on RPi, if CMake can't do it on its own