### PR TITLE
[core] xi_world party system

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -127,6 +127,8 @@ enum CHATFILTERTYPE : uint64
     // Filter level is 0-3
 };
 
+// TODO: Move all messaging types to their own file
+
 enum MSGSERVTYPE : uint8
 {
     MSG_LOGIN,
@@ -153,6 +155,12 @@ enum MSGSERVTYPE : uint8
     // rpc
     MSG_RPC_SEND, // sent by sender -> reciever
     MSG_RPC_RECV, // sent by reciever -> sender
+
+    // map to world server
+    MSG_M2W_PARTY_INVITE,
+
+    // world to map server
+    MSG_W2M_PARTY_INVITE,
 };
 
 constexpr auto msgTypeToStr = [](uint8 msgtype)
@@ -202,6 +210,24 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
         default:
             return "Unknown";
     };
+};
+
+struct M2W_PartyInvite
+{
+    uint8  inviteType;
+    uint32 recipientWorldId;
+    uint16 recipientZoneIndex;
+    uint32 senderWorldId;
+    uint16 senderZoneIndex;
+};
+
+struct W2M_PartyInvite
+{
+    uint8  inviteType;
+    uint32 recipientWorldId;
+    uint16 recipientZoneIndex;
+    uint32 senderWorldId;
+    uint16 senderZoneIndex;
 };
 
 // For characters, the size is stored in `size`.

--- a/src/map/message.h
+++ b/src/map/message.h
@@ -75,6 +75,16 @@ namespace message
     void send(uint16 zone, std::string const& luaFunc);
     void send(uint32 playerId, CBasicPacket* packet);
     void send(std::string const& playerName, CBasicPacket* packet);
+
+    template <typename T>
+    void send(T payload)
+    {
+        // TODO: Lookup message type based on T
+        MSGSERVTYPE messageType = MSG_M2W_PARTY_INVITE;
+
+        send(messageType, &payload, sizeof(payload));
+    }
+
     void send_charvar_update(uint32 charId, std::string const& varName, uint32 value);
     void rpc_send(uint16 sendZone, uint16 recvZone, std::string const& sendStr, sol::function recvFunc);
 

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SOURCES
     main.cpp
     message_server.cpp
     message_server.h
+    party_system.cpp
+    party_system.h
     world_server.cpp
     world_server.h)
 

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "common/logging.h"
 #include "message_server.h"
+#include "party_system.h"
 
 zmq::context_t                 zContext;
 std::unique_ptr<zmq::socket_t> zSocket;
@@ -163,6 +164,12 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
             // no op
             break;
         }
+        case MSG_M2W_PARTY_INVITE:
+        {
+            // TODO: Use a real singleton, or a dependency container.
+            PartySystem::HandleIncoming(from, packet);
+            break;
+        }
         default:
         {
             ShowDebug(fmt::format("Message: unknown type received: {} from {}:{}", static_cast<uint8>(type), from_address, from_port));
@@ -170,6 +177,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
     }
 
+    // NOTE: If ret hasn't been altered or assigned, this block won't fire
     if (ret != SQL_ERROR)
     {
         ShowDebug(fmt::format("Message: Received message {} ({}) from {}:{}",

--- a/src/world/party_system.cpp
+++ b/src/world/party_system.cpp
@@ -1,0 +1,22 @@
+/*
+===========================================================================
+
+Copyright (c) 2023 LandSandBoat Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "party_system.h"

--- a/src/world/party_system.h
+++ b/src/world/party_system.h
@@ -1,0 +1,117 @@
+/*
+===========================================================================
+
+Copyright (c) 2023 LandSandBoat Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+#pragma once
+
+#include "message_server.h"
+
+#include "common/mmo.h"
+
+struct PartyEntry
+{
+    uint32 worldId;
+    uint16 zoneIndex;
+    uint16 zone;
+    uint32 partyId;
+
+    std::string name;
+
+    uint8 mainLevel;
+};
+
+struct Party
+{
+    uint32 partyId;
+
+    std::vector<PartyEntry> members;
+
+    // TODO: Leader
+    // TODO: Quartermaster
+    // TODO: LevelSync
+    // TODO: Trusts
+    // TODO: TreasurePool
+};
+
+struct AllianceEntry
+{
+
+};
+
+struct Alliance
+{
+
+};
+
+class PartySystem
+{
+public:
+    PartySystem()  = default;
+    ~PartySystem() = default;
+
+    void HandleIncoming(zmq::message_t* from, zmq::message_t* message)
+    {
+        // TODO: Forward to relevant handler
+        auto payload = *reinterpret_cast<M2W_PartyInvite*>(message->data());
+
+        // Party Invite Handler
+
+        // TODO: Using information from payload, look up the character making the request,
+        //     : and any party information related to them that we might not already have
+        //     : cached.
+        auto maybeParty = FindPartyByMemberWorldId(payload.senderWorldId);
+        if (maybeParty.has_value())
+        {
+            auto party = *maybeParty;
+        }
+
+        // TODO: Ensure recipient doesn't already have a party
+
+        // TODO: Find out which process the recipient is currently on
+
+        W2M_PartyInvite reply;
+
+        // TODO: Populate
+        // reply.
+
+        // TODO: Send to relevant map server
+        message::send(MSG_W2M_PARTY_INVITE, );
+    }
+
+private:
+    std::optional<Party> FindPartyByMemberWorldId(uint32 worldId)
+    {
+        // TODO: Do a better search than this
+        for (auto& party : parties)
+        {
+            for (auto& member : party.members)
+            {
+                if (member.worldId == worldId)
+                {
+                    return party;
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
+    // TODO: A container which makes parties searchable by member Id, but also
+    //     : by other dimensions too.
+    std::vector<Party> parties;
+};

--- a/src/world/world_server.h
+++ b/src/world/world_server.h
@@ -29,6 +29,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "conquest_system.h"
 #include "http_server.h"
 #include "message_server.h"
+#include "party_system.h"
 
 class WorldServer final : public Application
 {
@@ -40,6 +41,8 @@ public:
 
 private:
     std::unique_ptr<message_server_wrapper_t> messageServer;
+
+    std::unique_ptr<PartySystem> partySystem;
 
     std::unique_ptr<ConquestSystem>     conquestSystem;
     std::unique_ptr<BesiegedSystem>     besiegedSystem;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

HEAVILY IN PROGRESS

Things to consider:
- All logic for managing a party/alliance/treasure pool "object" should exist in xi_world
- the party/alliance/treasure pool implementations on xi_map should be a thin shell that just forwards inputs to xi_world, and responds to ZMQ messages to turn into packets for the client
- We're banking on xi_world being correct and bulletproof, so we don't necessarily need to back everything into the db
- Though, if we have xi_world as a single point of access, having everything backed by the db becomes safe and sane again
- If xi_world DID go down, it comes back up very quickly, so if things were backed into the db we could re-broadcast party definition packets and there'd be no disruption to players
- Similarly, if xi_map goes down, as soon as it's back up and players start logging back in, there can be logic to rebuild the party they were in - with a timeout of course