### PR TITLE
[Combat] Create global functions for fSTR and fSTR2

### DIFF
--- a/scripts/globals/damage/physical_utilities.lua
+++ b/scripts/globals/damage/physical_utilities.lua
@@ -1,0 +1,103 @@
+-----------------------------------
+-- Global, independent functions for physical calculations.
+-- Includes:
+-- fSTR, fSTR2
+-----------------------------------
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.physical = xi.combat.physical or {}
+-----------------------------------
+
+-- "fSTR" in English Wikis. "SV function" in JP wiki and Studio Gobli.
+-- BG wiki: https://www.bg-wiki.com/ffxi/FSTR
+-- Gobli Wiki: https://w-atwiki-jp.translate.goog/studiogobli/pages/14.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
+xi.combat.physical.calculateMeleeStatFactor = function(actor, target)
+    local fSTR = 0 -- The variable we want to calculate.
+
+    -- Calculate statDiff.
+    local statDiff     = actor:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
+    local weaponRank   = actor:getWeaponDmgRank()
+    local statLowerCap = (7 + weaponRank * 2) * -2
+    local statUpperCap = (14 + weaponRank * 2) * 2
+
+    statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
+
+    -- Calculate fSTR based on stat difference.
+    if statDiff >= 12 then
+        fSTR = statDiff + 4
+    elseif statDiff >= 6 then
+        fSTR = statDiff + 6
+    elseif statDiff >= 1 then
+        fSTR = statDiff + 7
+    elseif statDiff >= -2 then
+        fSTR = statDiff + 8
+    elseif statDiff >= -7 then
+        fSTR = statDiff + 9
+    elseif statDiff >= -15 then
+        fSTR = statDiff + 10
+    elseif statDiff >= -21 then
+        fSTR = statDiff + 12
+    else
+        fSTR = statDiff + 13
+    end
+
+    -- Clamp fSTR.
+    local fSTRupperCap = weaponRank + 8
+    local fSTRlowerCap = weaponRank * -1
+
+    if weaponRank == 0 then
+        fSTRlowerCap = -1
+    end
+
+    fSTR = utils.clamp(fSTR / 4, fSTRlowerCap, fSTRupperCap)
+
+    return fSTR
+end
+
+-- "fSTR2" in English Wikis. "SV function" in JP wiki and Studio Gobli.
+-- BG wiki: https://www.bg-wiki.com/ffxi/FSTR
+-- Gobli Wiki: https://w-atwiki-jp.translate.goog/studiogobli/pages/14.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
+xi.combat.physical.calculateRangedStatFactor = function(actor, target)
+    local fSTR = 0 -- The variable we want to calculate.
+
+    -- Calculate statDiff.
+    local statDiff     = actor:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
+    local weaponRank   = actor:getWeaponDmgRank()
+    local statLowerCap = (7 + weaponRank * 2) * -2
+    local statUpperCap = (14 + weaponRank * 2) * 2
+
+    statDiff = utils.clamp(statDiff, statLowerCap, statUpperCap)
+
+    -- Calculate fSTR based on stat difference.
+    if statDiff >= 12 then
+        fSTR = statDiff + 4
+    elseif statDiff >= 6 then
+        fSTR = statDiff + 6
+    elseif statDiff >= 1 then
+        fSTR = statDiff + 7
+    elseif statDiff >= -2 then
+        fSTR = statDiff + 8
+    elseif statDiff >= -7 then
+        fSTR = statDiff + 9
+    elseif statDiff >= -15 then
+        fSTR = statDiff + 10
+    elseif statDiff >= -21 then
+        fSTR = statDiff + 12
+    else
+        fSTR = statDiff + 13
+    end
+
+    -- Clamp fSTR.
+    local fSTRupperCap = (weaponRank + 8) * 2
+    local fSTRlowerCap = weaponRank * -2
+
+    if weaponRank == 0 then
+        fSTRlowerCap = -2
+    elseif weaponRank == 1 then
+        fSTRlowerCap = -3
+    end
+
+    fSTR = utils.clamp(fSTR2 / 2, fSTRlowerCap, fSTRupperCap)
+
+    return fSTR
+end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Creates global functions for fSTR and for fSTR2. This is done so they can be used by any skill (upcoming WS rewrite)
This new fie will contain functions for more physical stuff,like acc calculations, critical rate, etc... which could be used by more things other than Weaponskills, like certain Mobskills, job abilities (shield bash), etc...

This, however, also incorporates new caps for STR-VIT diff which I don't see in current weaponskills.lua file.

## Steps to test these changes

None yet. You can call them. They will return a value so long as you feed them 2 combat-prepared entities.
