### PR TITLE
QoL Job Mastery Commands

### DIFF
--- a/scripts/commands/changejob.lua
+++ b/scripts/commands/changejob.lua
@@ -8,15 +8,15 @@ require("scripts/globals/status")
 cmdprops =
 {
     permission = 1,
-    parameters = "si"
+    parameters = "sii"
 }
 
 function error(player, msg)
     player:PrintToPlayer(msg)
-    player:PrintToPlayer("!changejob <jobID> (level)")
+    player:PrintToPlayer("!changejob <jobID> (level) (master: 0/1)")
 end
 
-function onTrigger(player, jobId, level)
+function onTrigger(player, jobId, level, master)
     -- validate jobId
     if jobId == nil then
         error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.")
@@ -43,6 +43,13 @@ function onTrigger(player, jobId, level)
         player:setLevel(level)
     end
 
+    -- master the job if addition params passed
+    local masterJob = false
+    if master and master == 1 then
+        masterJob = true
+        player:masterJob()
+    end
+
     -- invert xi.job table
     local jobNameByNum = {}
     for k, v in pairs(xi.job) do
@@ -50,5 +57,6 @@ function onTrigger(player, jobId, level)
     end
 
     -- output new job to player
-    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()))
+    local masterStr = masterJob and " (Mastered)" or ""
+    player:PrintToPlayer(string.format("You are now a %s%i/%s%i%s.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl(), masterStr))
 end

--- a/scripts/commands/masterjob.lua
+++ b/scripts/commands/masterjob.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- func: masterjob
+-- desc: Masters the player's current job
+-----------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "s"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!masterjob <player>")
+end
+
+function onTrigger(player, target)
+    local targ
+    if target and target ~= "" then
+        targ = GetPlayerByName(target)
+    else
+        targ = player
+    end
+
+    if not targ then
+        error(player, string.format("Unable to find player named '%s'", target))
+        return
+    end
+
+    targ:masterJob()
+    player:PrintToPlayer(string.format("Mastered %s's main job!", targ:getName()))
+end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7364,6 +7364,41 @@ void CLuaBaseEntity::setJobPoints(uint16 amount)
 }
 
 /************************************************************************
+ *  Function: masterJob()
+ *  Purpose : Fully masters / unlocks player's current job
+ *  Example : player:masterJob()
+ *  Notes   : Used in GM command
+ ************************************************************************/
+
+void CLuaBaseEntity::masterJob()
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowDebug("Warning: Attempt to master job for non-PC type!");
+        return;
+    }
+
+    CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+    auto jpCategory = 0x020 * PChar->GetMJob();
+    for (auto i = jpCategory; i < jpCategory + 0xA; i++)
+    {
+        auto points       = PChar->PJobPoints->GetJobPointType((JOBPOINT_TYPE)i);
+        auto pointsNeeded = 20 - points->value;
+        auto currentJP    = PChar->PJobPoints->GetJobPoints();
+
+        for (auto x = 0; x < pointsNeeded; x++)
+        {
+            auto cost = JobPointCost(points->value);
+            PChar->PJobPoints->SetJobPoints(currentJP + cost);
+            PChar->PJobPoints->RaiseJobPoint((JOBPOINT_TYPE)i);
+        }
+    }
+
+    PChar->pushPacket(new CMenuJobPointsPacket(PChar));
+}
+
+/************************************************************************
  *  Function: getGil()
  *  Purpose : Returns the total amount of a gil a player has
  *  Example : player:getGil()
@@ -15354,6 +15389,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("addCapacityPoints", CLuaBaseEntity::addCapacityPoints);
     SOL_REGISTER("setCapacityPoints", CLuaBaseEntity::setCapacityPoints);
     SOL_REGISTER("setJobPoints", CLuaBaseEntity::setJobPoints);
+    SOL_REGISTER("masterJob", CLuaBaseEntity::masterJob);
 
     SOL_REGISTER("getGil", CLuaBaseEntity::getGil);
     SOL_REGISTER("addGil", CLuaBaseEntity::addGil);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -398,6 +398,7 @@ public:
     uint8  getJobPointLevel(uint16 jpType); // Returns Value of Job Point Type
     void   setJobPoints(uint16 amount);     // Set Job Points for current job
     void   setCapacityPoints(uint16 amount);
+    void   masterJob();
 
     uint32 getGil();
     void   addGil(int32 gil);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Manually spending Job Points sucks. This adds commands to specifically master a job (without losing track of how many JP you currently have). 

- Adds `masterjob` admin command and relevant C++ bindings
- Adds `master` parameter to `changejob`, takes 1/0  `!changejob war 99 1` for example.  Defaults to nil and is ignored otherwise.  

## Steps to test these changes

- Change Job command: `!changejob war 99 1` should change your job to 99 WAR Job Mastered
- Change Job command: `!changejob war 99` should change job your to 99 WAR, Unmastered
- Master Job command: On an unmastered job, `!masterjob` should master your job regardless of progress
- Master Job command: On a mastered job, `!masterjob` should do nothing.
