### PR TITLE
Fix Foreseer Oramix placeholders

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/mobs/Goblin_Alchemist.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Goblin_Alchemist.lua
@@ -2,12 +2,18 @@
 -- Area: Ifrit's Cauldron
 --  Mob: Goblin Alchemist
 -----------------------------------
+local ID = require("scripts/zones/Ifrits_Cauldron/IDs")
 require("scripts/globals/regimes")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 757, 1, xi.regime.type.GROUNDS)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.FORESEER_ORAMIX_PH, 5, 3600) -- 1 hour
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The rest of the placeholder scaffolding is there, but the last step was never added in.

Choice of 5% and 1hr cooldown are arbitrary, based on the other lottery NMs in the zone.

Fixes #3634 

## Steps to test these changes

1. Kill the 3 Goblin Alchemists PHs until Foreseer Oramix appears (or `!despawnmob` and `!spawnmob` repeatedly).
