### PR TITLE
[Fix] Wrong modifier name in "Brazen Rush" effect.

### DIFF
--- a/scripts/globals/effects/brazen_rush.lua
+++ b/scripts/globals/effects/brazen_rush.lua
@@ -9,7 +9,7 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     local jpLevel = target:getJobPointLevel(xi.jp.BRAZEN_RUSH_EFFECT)
 
-    target:addMod(xi.mod.ATTACK, 4 * jpLevel)
+    target:addMod(xi.mod.ATT, 4 * jpLevel)
     target:addMod(xi.mod.DOUBLE_ATTACK, effect:getPower())
 end
 
@@ -25,7 +25,7 @@ end
 effectObject.onEffectLose = function(target, effect)
     local jpLevel = target:getJobPointLevel(xi.jp.BRAZEN_RUSH_EFFECT)
 
-    target:delMod(xi.mod.ATTACK, 4 * jpLevel)
+    target:delMod(xi.mod.ATT, 4 * jpLevel)
     target:delMod(xi.mod.DOUBLE_ATTACK, effect:getPower())
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a wrong modifier reference inside brazen_rush.lua script-

Closes #3638 

## Steps to test these changes

Use Brazen Rush (Warrior Job Ability) and get no errors.
