### PR TITLE
[core] Ensure async SQL connection is owned by async thread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,7 +330,7 @@ jobs:
         shell: cmd
         run: |
           mkdir -p build
-          cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DTRACY=ON
+          cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DENABLE_TRACY=ON
       - name: Build
         shell: cmd
         run: |

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -17,7 +17,7 @@ message(STATUS "TRACY_ENABLE: ${TRACY_ENABLE}")
 # CPM Modules
 if(TRACY_ENABLE)
     # Tracy version tag, without the leading 'v'
-    set(TRACY_VERSION 0.9)
+    set(TRACY_VERSION 0.9.1)
 
     # Download client library
     CPMAddPackage(

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -51,6 +51,7 @@ void Async::query(std::string const& query)
     // clang-format off
     _ts->schedule([query]()
     {
+        TracySetThreadName("Async Worker Thread");
         if (_sql == nullptr)
         {
             _sql = new SqlConnection();
@@ -69,6 +70,7 @@ void Async::query(std::function<void(SqlConnection*)> func)
     // clang-format off
     _ts->schedule([func]()
     {
+        TracySetThreadName("Async Worker Thread");
         if (_sql == nullptr)
         {
             _sql = new SqlConnection();
@@ -83,6 +85,7 @@ void Async::submit(std::function<void()> func)
     // clang-format off
     _ts->schedule([func]()
     {
+        TracySetThreadName("Async Worker Thread");
         func();
     });
     // clang-format on

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -24,16 +24,18 @@
 #include "sql.h"
 #include <task_system.hpp>
 
+// Allocated on and owned the main thread
 Async*           Async::_instance = nullptr;
-SqlConnection*   Async::_sql      = nullptr;
 ts::task_system* Async::_ts       = nullptr;
+
+// Allocated on and owned by by _ts
+SqlConnection* Async::_sql = nullptr;
 
 Async* Async::getInstance()
 {
     if (_instance == nullptr)
     {
         _instance = new Async();
-        _sql      = new SqlConnection();
 
         // NOTE: We only create a single worker thread in the task_system
         //     : because we're going to be using _sql, which isn't thread safe.
@@ -49,6 +51,10 @@ void Async::query(std::string const& query)
     // clang-format off
     _ts->schedule([query]()
     {
+        if (_sql == nullptr)
+        {
+            _sql = new SqlConnection();
+        }
         _sql->Query(query.c_str());
     });
     // clang-format on
@@ -63,6 +69,10 @@ void Async::query(std::function<void(SqlConnection*)> func)
     // clang-format off
     _ts->schedule([func]()
     {
+        if (_sql == nullptr)
+        {
+            _sql = new SqlConnection();
+        }
         func(_sql);
     });
     // clang-format on

--- a/src/common/kernel.cpp
+++ b/src/common/kernel.cpp
@@ -60,6 +60,7 @@ void* operator new(std::size_t count)
 {
     void* ptr = malloc(count);
     TracyAlloc(ptr, count);
+    return ptr;
 }
 
 void operator delete(void* ptr) noexcept

--- a/tools/ci/startup_checks.py
+++ b/tools/ci/startup_checks.py
@@ -4,7 +4,7 @@ import io
 import platform
 import subprocess
 import time
-
+import signal
 
 def main():
     print("Running exe startup checks...({})".format(platform.system()))
@@ -27,17 +27,13 @@ def main():
 
     time.sleep(300)
 
-    p0.kill()
-    p1.kill()
-    p2.kill()
-    p3.kill()
-
-    print("Killing exes and checking logs...")
+    print("Checking logs and killing exes...")
 
     has_seen_output = False
     error = False
     for proc in {p0, p1, p2, p3}:
         print(proc.args[0])
+        proc.send_signal(signal.SIGTERM)
         for line in io.TextIOWrapper(proc.stdout, encoding="utf-8"):
             print(line.replace("\n", ""))
             has_seen_output = True
@@ -55,6 +51,7 @@ def main():
     if error or not has_seen_output:
         exit(-1)
 
+    time.sleep(5)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the steps I mentioned here: https://github.com/LandSandBoat/server/issues/3615#issuecomment-1440410363

## Steps to test these changes

Turn on all the AUDIT_* options, send some messages, use some GM commands, and get no warnings.

Fire up with Tracy attached to see queries firing on other threads.

<img width="236" alt="image" src="https://user-images.githubusercontent.com/1389729/222096881-d9e85386-643e-4f20-9f5d-673b8ffd2b0a.png">
