### PR TITLE
[core] Move CheckTriggerAreas to its own task

### DIFF
--- a/src/map/map.h
+++ b/src/map/map.h
@@ -67,6 +67,9 @@ static constexpr float server_tick_rate = 2.5f;
 // Update every 400ms
 static constexpr float server_tick_interval = 1000.0f / server_tick_rate;
 
+// Check Trigger Areas every 200ms
+static constexpr float server_trigger_area_interval = server_tick_interval / 2.0f;
+
 typedef std::map<uint64, map_session_data_t*> map_session_list_t;
 extern map_session_list_t                     map_session_list;
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -595,11 +595,10 @@ public:
     bool           IsZoneActive() const;
     CZoneEntities* GetZoneEntities();
 
-    time_point      m_TriggerAreaCheckTime;
     weatherVector_t m_WeatherVector; // the probability of each weather type
 
-    virtual void ZoneServer(time_point tick, bool checkTriggerAreas);
-    void         CheckTriggerAreas(CCharEntity* PChar);
+    virtual void ZoneServer(time_point tick);
+    void         CheckTriggerAreas();
 
     virtual void ForEachChar(std::function<void(CCharEntity*)> func);
     virtual void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> func);
@@ -660,9 +659,10 @@ private:
     std::unordered_map<std::string, QueryByNameResult_t> m_queryByNameResults;
 
 protected:
-    CTaskMgr::CTask* ZoneTimer; // The pointer to the created timer is Zoneserver.necessary for the possibility of stopping it
+    CTaskMgr::CTask* ZoneTimer;             // The pointer to the created timer is Zoneserver.necessary for the possibility of stopping it
+    CTaskMgr::CTask* ZoneTimerTriggerAreas; //
 
-    void createZoneTimer();
+    void createZoneTimers();
     void CharZoneIn(CCharEntity* PChar);
     void CharZoneOut(CCharEntity* PChar);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1312,7 +1312,7 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
     PChar->pushPacket(new CWideScanPacket(WIDESCAN_END));
 }
 
-void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
+void CZoneEntities::ZoneServer(time_point tick)
 {
     TracyZoneScoped;
     TracyZoneString(m_zone->GetName());
@@ -1530,10 +1530,6 @@ void CZoneEntities::ZoneServer(time_point tick, bool check_trigger_areas)
             }
             PChar->PAI->Tick(tick);
             PChar->PTreasurePool->CheckItems(tick);
-            if (check_trigger_areas)
-            {
-                m_zone->CheckTriggerAreas(PChar);
-            }
         }
     }
 

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -68,7 +68,7 @@ public:
 
     void PushPacket(CBaseEntity*, GLOBAL_MESSAGE_TYPE, CBasicPacket*); // отправляем глобальный пакет в пределах зоны
 
-    void ZoneServer(time_point tick, bool check_trigger_areas);
+    void ZoneServer(time_point tick);
 
     CZone* GetZone();
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -203,7 +203,7 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
     {
         if (!ZoneTimer)
         {
-            createZoneTimer();
+            createZoneTimers();
         }
 
         PChar->targid = PChar->PInstance->GetNewCharTargID();
@@ -380,7 +380,7 @@ void CZoneInstance::WideScan(CCharEntity* PChar, uint16 radius)
     }
 }
 
-void CZoneInstance::ZoneServer(time_point tick, bool check_regions)
+void CZoneInstance::ZoneServer(time_point tick)
 {
     TracyZoneScoped;
     auto it = instanceList.begin();
@@ -388,7 +388,7 @@ void CZoneInstance::ZoneServer(time_point tick, bool check_regions)
     {
         auto& instance = *it;
 
-        instance->ZoneServer(tick, check_regions);
+        instance->ZoneServer(tick);
         instance->CheckTime(tick);
 
         if ((instance->Failed() || instance->Completed()) && instance->CharListEmpty())

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -63,7 +63,7 @@ public:
     virtual void UpdateCharPacket(CCharEntity* PChar, ENTITYUPDATE type, uint8 updatemask) override;
     virtual void UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude = false) override;
 
-    virtual void ZoneServer(time_point tick, bool check_regions) override;
+    virtual void ZoneServer(time_point tick) override;
 
     virtual void ForEachChar(std::function<void(CCharEntity*)> func) override;
     virtual void ForEachCharInstance(CBaseEntity* PEntity, std::function<void(CCharEntity*)> func) override;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Moves CheckTriggerAreas to its own job, with a higher frequency than the main tick - meaning trigger areas are checked more often.
- I've tested it with tracy, each check round comes in at about 30us, with peaks of 100us, so, not all that bad. Could be improved, but meh 🤷 

## Steps to test these changes

- Add some print logging to onTriggerAreaEnter for a zone, go run into that area and see the logging.

Closes https://github.com/LandSandBoat/server/issues/3648
