### PR TITLE
[core] Add basic Lua REPL and table key printing

### DIFF
--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -4,6 +4,23 @@
 require("scripts/globals/settings")
 require("scripts/globals/utils")
 -----------------------------------
+xi = xi or {}
+xi.module = xi.module or {}
+
+-- Helpers
+
+-- Iterate through all the sections of a table-string, and instantiate them if they don't exist
+-- Example: xi.module.ensureTable("xi.aName.anotherName") will ensure the table: xi.aName.anotherName
+--        : is fully instantiated.
+-- https://github.com/LandSandBoat/server/issues/3542#issuecomment-1407190523
+xi.module.ensureTable = function(str)
+    local parts = utils.splitStr(str, '.')
+    local table = _G;
+    for _, part in ipairs(parts) do
+        table[part] = table[part] or {}
+        table = table[part]
+    end
+end
 
 -- Override Object
 Override = {}

--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -21,6 +21,8 @@
 
 #include "console_service.h"
 
+#include "lua.h"
+
 #include <sstream>
 
 #ifdef _WIN32
@@ -125,6 +127,19 @@ ConsoleService::ConsoleService()
         else
         {
             fmt::print("> Invalid inputs.\n");
+        }
+    });
+
+    RegisterCommand("lua", "Provides a Lua REPL",
+    [](std::vector<std::string> inputs)
+    {
+        if (inputs.size() >= 2)
+        {
+            // Remove "lua" from the front of the inputs
+            inputs = std::vector<std::string>(inputs.begin() + 1, inputs.end());
+
+            auto input = fmt::format("local var = {}; if type(var) ~= \"nil\" then print(var) end", fmt::join(inputs, " "));
+            lua.safe_script(input);
         }
     });
 

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -112,9 +112,16 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
 
             // Stringify everything first
             std::vector<std::string> stringVec;
-            for (auto& pair : table)
+            for (auto const& [keyObj, valObj] : table)
             {
-                stringVec.emplace_back(lua_to_string(pair.second, depth + 1));
+                if (keyObj.get_type() == sol::type::string)
+                {
+                    stringVec.emplace_back(fmt::format("{}: {}", lua_to_string(keyObj), lua_to_string(valObj, depth + 1)));
+                }
+                else
+                {
+                    stringVec.emplace_back(lua_to_string(valObj, depth + 1));
+                }
             }
 
             // Accumulate into a pretty string


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

From console system:
```
lua xi.settings.map
[03/04/23 13:06:52:245][world][lua] table{ GARDEN_DAY_MATTERS: false, GARDEN_MOONPHASE_MATTERS: false, GARDEN_POT_MATTERS: false, GARDEN_MH_AURA_MATTERS: false, CRAFT_MODERN_SYSTEM: true, CRAFT_COMMON_CAP: 700, CRAFT_SPECIALIZATION_POINTS: 400, FISHING_ENABLE: false, FISHING_SKILL_MULTIPLIER: 1, SKILLUP_BLOODPACT: true, MOB_TP_MULTIPLIER: 1, PET_TP_MULTIPLIER: 1, PLAYER_TP_MULTIPLIER: 1, TRUST_TP_MULTIPLIER: 1, FELLOW_TP_MULTIPLIER: 1, NM_HP_MULTIPLIER: 1, MOB_HP_MULTIPLIER: 1, PLAYER_HP_MULTIPLIER: 1, ALTER_EGO_HP_MULTIPLIER: 1, NM_MP_MULTIPLIER: 1, MOB_MP_MULTIPLIER: 1, PLAYER_MP_MULTIPLIER: 1, ALTER_EGO_MP_MULTIPLIER: 1, SJ_MP_DIVISOR: 2, SUBJOB_RATIO: 1, INCLUDE_MOB_SJ: false, NM_STAT_MULTIPLIER: 1, MOB_STAT_MULTIPLIER: 1, PLAYER_STAT_MULTIPLIER: 1, ALTER_EGO_STAT_MULTIPLIER: 1, ALTER_EGO_SKILL_MULTIPLIER: 1, ABILITY_RECAST_MULTIPLIER: 1, BLOOD_PACT_SHARED_TIMER: false, DROP_RATE_MULTIPLIER: 1, MOB_GIL_MULTIPLIER: 1, ALL_MOBS_GIL_BONUS: 0, MAX_GIL_BONUS: 9999, MOB_NO_DESPAWN: false, MOB_ADDITIONAL_TIME_TO_DEAGGRO: 0, PARRY_OLD_SKILLUP_STYLE: false, BLOCK_OLD_SKILLUP_STYLE: false, GUARD_OLD_SKILLUP_STYLE: false, BATTLE_CAP_TWEAK: 0, LV_CAP_MISSION_BCNM: 0, MAX_MERIT_POINTS: 30, YELL_COOLDOWN: 30, BLOCK_TELL_TO_HIDDEN_GM: false, AUDIT_GM_CMD: false, AUDIT_CHAT: false, AUDIT_SAY: false, AUDIT_SHOUT: false, AUDIT_TELL: false, AUDIT_YELL: false, AUDIT_LINKSHELL: false, AUDIT_UNITY: false, AUDIT_PARTY: false, HEALING_TICK_DELAY: 10, ANTICHEAT_ENABLED: true, ANTICHEAT_JAIL_DISABLE: false, KEEP_JUGPET_THROUGH_ZONING: false, REPORT_LUA_ERRORS_TO_PLAYER_LEVEL: 6, EXP_RATE: 1, CAPACITY_RATE: 1, MAX_TIME_LASTUPDATE: 60, SETVAR_RETRY_MAX: 3, PACKETGUARD_ENABLED: true, LIGHTLUGGAGE_BLOCK: 4, ENABLE_ITEM_RECYCLE_BIN: true, AH_BASE_FEE_SINGLE: 1, AH_BASE_FEE_STACKS: 4, AH_TAX_RATE_SINGLE: 1, AH_TAX_RATE_STACKS: 0.5, AH_MAX_FEE: 10000, AH_LIST_LIMIT: 7, EXP_LOSS_RATE: 1, EXP_PARTY_GAP_PENALTIES: true, VANADIEL_TIME_EPOCH: 0, FAME_MULTIPLIER: 1, EXP_RETAIN: 0, EXP_LOSS_LEVEL: 31, LEVEL_SYNC_ENABLE: true, DISABLE_GEAR_SCALING: false, WS_POINTS_BASE: 1, WS_POINTS_SKILLCHAIN: 1, ALL_JOBS_WIDESCAN: true, SPEED_MOD: 0, MOUNT_SPEED_MOD: 0, MOB_SPEED_MOD: 0, SKILLUP_CHANCE_MULTIPLIER: 1, CRAFT_CHANCE_MULTIPLIER: 1, SKILLUP_AMOUNT_MULTIPLIER: 1, CRAFT_AMOUNT_MULTIPLIER: 1 } (lua_print:158)
lua { 10, 20, 30 }
[03/04/23 13:06:59:674][world][lua] table{ 10, 20, 30 } (lua_print:158)
```
```
lua 10
[03/04/23 13:12:13:699][world][lua] 10 (lua_print:158)
lua Hello
lua "Hello"
[03/04/23 13:12:20:772][world][lua] Hello (lua_print:158)
lua print(10)
[03/04/23 13:12:26:423][world][lua] 10 (lua_print:158)
```

For some reason, the logger freaks out if you try to print all of xi.settings, but that's a problem for another day

Also changes our lua printing to print out the keys of tables, if the key is a string. It will ignore numeric keys
