### PR TITLE
[core] Make Lua table printing pretty

### DIFF
--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -110,30 +110,43 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
         {
             auto table = obj.as<sol::table>();
 
+            std::string indent = "";
+            for (int i = 0; i < depth + 1; ++i)
+            {
+                indent += "    ";
+            }
+
+            std::string unindent = "";
+            if (!indent.empty())
+            {
+                unindent = std::string(indent.begin(), indent.end() - 4);
+            }
+
             // Stringify everything first
             std::vector<std::string> stringVec;
             for (auto const& [keyObj, valObj] : table)
             {
                 if (keyObj.get_type() == sol::type::string)
                 {
-                    stringVec.emplace_back(fmt::format("{}: {}", lua_to_string(keyObj), lua_to_string(valObj, depth + 1)));
+                    stringVec.emplace_back(fmt::format("{}{}: {}", indent, lua_to_string(keyObj), lua_to_string(valObj, depth + 1)));
                 }
                 else
                 {
-                    stringVec.emplace_back(lua_to_string(valObj, depth + 1));
+                    stringVec.emplace_back(fmt::format("{}{}", indent, lua_to_string(valObj, depth + 1)));
                 }
             }
 
             // Accumulate into a pretty string
             // clang-format off
-            std::string outStr = "table{ ";
+            std::string outStr = "\n" + unindent + "{" + (stringVec.empty() ? "" : "\n");
             outStr += std::accumulate(std::begin(stringVec), std::end(stringVec), std::string(),
             [](std::string& ss, std::string& s)
             {
-                return ss.empty() ? s : ss + ", " + s;
+                return ss.empty() ? s : (ss + ",\n" + s);
             });
             // clang-format on
-            return outStr + " }";
+
+            return outStr + (stringVec.empty() ? "" : "\n") + unindent + "}";
         }
         default:
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Print a table from anywhere in Lua (console, !exec, scripts, whatever), it will print pretty now, with string keys and formatting.

```
[03/04/23 16:28:08:127][map][info] ======================================================================= (do_init:302)
[03/04/23 16:28:08:127][map][info] Console input thread is ready... (ConsoleService::ConsoleService:149)
[03/04/23 16:28:08:127][map][info] Type 'help' for a list of available commands. (ConsoleService::ConsoleService:150)
[03/04/23 16:28:08:128][map][info] CTaskMgr Active Tasks: 192 (map_garbage_collect:1161)
[03/04/23 16:28:08:130][map][info] Garbage Collected (Step) (luautils::garbageCollectStep:335)
[03/04/23 16:28:08:130][map][info] Current State Top: 0, Total Memory Used: 47656kb (luautils::garbageCollectStep:336)
lua 10
[03/04/23 16:28:10:614][map][lua] 10 (lua_print:171)
lua {}
[03/04/23 16:28:12:197][map][lua]
{} (lua_print:171)
lua { 10 }
[03/04/23 16:28:14:879][map][lua]
{
    10
} (lua_print:171)
lua xi.trust
[03/04/23 16:28:21:825][map][lua]
{
    spawn: function,
    message: function,
    onTradeCipher: function,
    teamworkMessage: function,
    dumpMessagePages: function,
    message_offset:
    {
        TEAMWORK_1: 4,
        TEAMWORK_2: 5,
        TEAMWORK_3: 6,
        TEAMWORK_4: 7,
        TEAMWORK_5: 8,
        DESPAWN: 11,
        SPAWN: 1,
        SPECIAL_MOVE_2: 19,
        SPECIAL_MOVE_1: 18,
        DEATH: 9
    },
    dumpMessages: function,
    canCast: function,
    checkBattlefieldTrustCount: function,
    hasPermit: function
} (lua_print:171)
```
