### PR TITLE
[QUEST] Unbridled Passion - Add alternative CS in Xarcabard

### DIFF
--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -151,6 +151,7 @@ local destinations =
     [ids.ESCHA_RUAUN]           = {   -0.371,  -34.279, -466.980, 192, 289 },
     [ids.MISAREAUX_CONFLUENCE]  = {  -57.385,  -21.460,  568.941, 160,  25 }
 }
+xi.teleport.destination = destinations
 
 xi.teleport.type =
 {

--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -87,7 +87,7 @@ xi.teleport.id = ids
 -- TELEPORT TO SINGLE DESTINATION
 -----------------------------------
 
-local destinations =
+xi.teleport.destination =
 {
     [ids.DEM]                   = {  220.000,   19.104,  300.000,   0, 108 }, -- (R)
     [ids.HOLLA]                 = {  420.000,   19.104,   20.000,   0, 102 }, -- (R)
@@ -151,7 +151,6 @@ local destinations =
     [ids.ESCHA_RUAUN]           = {   -0.371,  -34.279, -466.980, 192, 289 },
     [ids.MISAREAUX_CONFLUENCE]  = {  -57.385,  -21.460,  568.941, 160,  25 }
 }
-xi.teleport.destination = destinations
 
 xi.teleport.type =
 {
@@ -180,7 +179,7 @@ xi.teleport.runic_portal =
 }
 
 xi.teleport.to = function(player, destination)
-    local dest = destinations[destination]
+    local dest = xi.teleport.destination[destination]
     if dest then
         player:setPos(unpack(dest))
     end
@@ -295,9 +294,9 @@ end
 
 xi.teleport.toAlliedNation = function(player)
     local allegiance = player:getCampaignAllegiance()
-    local sandoriaPos = destinations[ids.SOUTHERN_SAN_DORIA_S]
-    local bastokPos = destinations[ids.BASTOK_MARKETS_S]
-    local windurstPos = destinations[ids.WINDURST_WATERS_S]
+    local sandoriaPos = xi.teleport.destination[ids.SOUTHERN_SAN_DORIA_S]
+    local bastokPos = xi.teleport.destination[ids.BASTOK_MARKETS_S]
+    local windurstPos = xi.teleport.destination[ids.WINDURST_WATERS_S]
 
     if allegiance == xi.alliedNation.SANDORIA then
         player:setPos(unpack(sandoriaPos))

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -5,6 +5,7 @@ local ID = require('scripts/zones/Xarcabard/IDs')
 require('scripts/quests/i_can_hear_a_rainbow')
 require('scripts/globals/conquest')
 require('scripts/globals/keyitems')
+require("scripts/globals/teleports")
 require('scripts/globals/utils')
 require('scripts/globals/zone')
 -----------------------------------
@@ -20,15 +21,14 @@ zoneObject.onZoneIn = function(player, prevZone)
     local dynamisMask = player:getCharVar("Dynamis_Status")
 
     local unbridledPassionCS = player:getCharVar("unbridledPassion")
+    local pos = player:getPos()
 
     if prevZone == xi.zone.DYNAMIS_XARCABARD then -- warp player to a correct position after dynamis
         player:setPos(569.312, -0.098, -270.158, 90)
     end
 
     if
-        player:getXPos() == 0 and
-        player:getYPos() == 0 and
-        player:getZPos() == 0
+        pos.x == 0 and pos.y == 0 and pos.z == 0
     then
         player:setPos(158, -21, -44, 132)
     end
@@ -43,7 +43,15 @@ zoneObject.onZoneIn = function(player, prevZone)
     elseif quests.rainbow.onZoneIn(player) then
         cs = 9
     elseif unbridledPassionCS == 3 then
-        cs = 4
+        if
+            math.floor(pos.x) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][1]) and
+            math.floor(pos.y) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][2]) and
+            math.floor(pos.z) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][3])
+        then
+            cs = 5
+        else
+            cs = 4
+        end
     end
 
     return cs

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -5,7 +5,7 @@ local ID = require('scripts/zones/Xarcabard/IDs')
 require('scripts/quests/i_can_hear_a_rainbow')
 require('scripts/globals/conquest')
 require('scripts/globals/keyitems')
-require("scripts/globals/teleports")
+require('scripts/globals/teleports')
 require('scripts/globals/utils')
 require('scripts/globals/zone')
 -----------------------------------
@@ -44,9 +44,9 @@ zoneObject.onZoneIn = function(player, prevZone)
         cs = 9
     elseif unbridledPassionCS == 3 then
         if
-            math.floor(pos.x) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][1]) and
-            math.floor(pos.y) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][2]) and
-            math.floor(pos.z) == math.floor(xi.teleport.destination[xi.teleport.id.VAHZL][3])
+            math.abs(pos.x - xi.teleport.destination[xi.teleport.id.VAHZL][1]) < 0.1 and
+            math.abs(pos.y - xi.teleport.destination[xi.teleport.id.VAHZL][2]) < 0.1 and
+            math.abs(pos.z - xi.teleport.destination[xi.teleport.id.VAHZL][3]) < 0.1
         then
             cs = 5
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* assigns destinations table to xi.teleport.destination, to avoid referring to magic numbers when checking the player's position with the destination in a script.
* adds missing cs for Unbriddled Passion quest, there is a different CS if you zone into the area by means of teleport Vahzl

## Steps to test these changes

set charvar 'unbridledPassion' to 3
use teleport vahzl spell and watch the cs show.

