### PR TITLE
[sql] Fix typo in groupRate value of Animated Weapon fragment drops

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -26803,52 +26803,52 @@ INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@ALWAYS); -- Ancient Beast
 INSERT INTO `mob_droplist` VALUES (3237,0,0,1000,1875,@UNCOMMON); -- Ancient Beastcoin (Uncommon, 10%)
 
 -- ZoneID:  135 - Animated Knuckles
-INSERT INTO `mob_droplist` VALUES (3238,0,0,100,1571,@ALWAYS); -- Mystic Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3238,0,0,1000,1571,@ALWAYS); -- Mystic Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Dagger
-INSERT INTO `mob_droplist` VALUES (3239,0,0,100,1572,@ALWAYS); -- Ornate Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3239,0,0,1000,1572,@ALWAYS); -- Ornate Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Longsword
-INSERT INTO `mob_droplist` VALUES (3240,0,0,100,1573,@ALWAYS); -- Holy Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3240,0,0,1000,1573,@ALWAYS); -- Holy Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Claymore
-INSERT INTO `mob_droplist` VALUES (3241,0,0,100,1574,@ALWAYS); -- Intricate Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3241,0,0,1000,1574,@ALWAYS); -- Intricate Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Tabar
-INSERT INTO `mob_droplist` VALUES (3242,0,0,100,1575,@ALWAYS); -- Runaeic Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3242,0,0,1000,1575,@ALWAYS); -- Runaeic Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Great Axe
-INSERT INTO `mob_droplist` VALUES (3243,0,0,100,1576,@ALWAYS); -- Seraphic Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3243,0,0,1000,1576,@ALWAYS); -- Seraphic Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Scythe
-INSERT INTO `mob_droplist` VALUES (3244,0,0,100,1577,@ALWAYS); -- Tenebrous Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3244,0,0,1000,1577,@ALWAYS); -- Tenebrous Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Spear
-INSERT INTO `mob_droplist` VALUES (3245,0,0,100,1578,@ALWAYS); -- Stellar Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3245,0,0,1000,1578,@ALWAYS); -- Stellar Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Kunai
-INSERT INTO `mob_droplist` VALUES (3246,0,0,100,1579,@ALWAYS); -- Demoniac Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3246,0,0,1000,1579,@ALWAYS); -- Demoniac Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Tachi
-INSERT INTO `mob_droplist` VALUES (3247,0,0,100,1580,@ALWAYS); -- Divine Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3247,0,0,1000,1580,@ALWAYS); -- Divine Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Hammer
-INSERT INTO `mob_droplist` VALUES (3248,0,0,100,1581,@ALWAYS); -- Heavenly Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3248,0,0,1000,1581,@ALWAYS); -- Heavenly Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Staff
-INSERT INTO `mob_droplist` VALUES (3249,0,0,100,1582,@ALWAYS); -- Celestial Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3249,0,0,1000,1582,@ALWAYS); -- Celestial Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Longbow
-INSERT INTO `mob_droplist` VALUES (3250,0,0,100,1583,@ALWAYS); -- Snarled Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3250,0,0,1000,1583,@ALWAYS); -- Snarled Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Horn
-INSERT INTO `mob_droplist` VALUES (3251,0,0,100,1584,@ALWAYS); -- Mysterial Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3251,0,0,1000,1584,@ALWAYS); -- Mysterial Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Gun
-INSERT INTO `mob_droplist` VALUES (3252,0,0,100,1585,@ALWAYS); -- Ethereal Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3252,0,0,1000,1585,@ALWAYS); -- Ethereal Fragment (Always, 100%)
 
 -- ZoneID:  135 - Animated Shield
-INSERT INTO `mob_droplist` VALUES (3253,0,0,100,1822,@ALWAYS); -- Supernal Fragment (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (3253,0,0,1000,1822,@ALWAYS); -- Supernal Fragment (Always, 100%)
 
 /*!40000 ALTER TABLE `mob_droplist` ENABLE KEYS */;
 UNLOCK TABLES;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects the groupRate value of the the fragment drops of the Dynamis-Xarcabard animated weapons.

## Steps to test these changes

No difference would be noticed before or after pulling down this PR and killing the animated weapons.  The fragment will drop with the same frequency either way.

The groupRate value was incorrectly set as ``100`` (should be ``1000``) for the fragment drops from the animated weapons in Dynamis-Xarcabard in https://github.com/LandSandBoat/server/pull/3559.  As the dropType value is set to 0 (DROP_NORMAL), the value of groupRate has no impact on the drop rate (``@ALWAYS``) of the relevant fragment off their relevant Animated Weapon.

This PR simply corrects the groupRate value for the sake of continuity.
