### PR TITLE
[Fix] Waltz recast time underflowing.

### DIFF
--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -181,22 +181,27 @@ xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
     elseif player:getTP() < waltzInfo[1] then
         return xi.msg.basic.NOT_ENOUGH_TP, 0
     else
-        -- Waltz Delay (-1s per mod value)
+        local newRecast = ability:getRecast()
+
+        -- Apply Waltz Delay Modifier (-1s per mod value)
         local recastMod = player:getMod(xi.mod.WALTZ_DELAY)
+
         if recastMod ~= 0 then
-            local newRecast = ability:getRecast() + recastMod
-            ability:setRecast(utils.clamp(newRecast, 0, newRecast))
+            newRecast = newRecast + recastMod
         end
 
         -- Apply "Fan Dance" Waltz recast reduction.  All tiers above 1 grant 5%
         -- recast reduction each.
-        local fanDanceMerits = target:getMerit(xi.merit.FAN_DANCE)
+        local fanDanceMeritValue = player:getMerit(xi.merit.FAN_DANCE) -- Get's merit number * merit value (5 in db).
+
         if
             player:hasStatusEffect(xi.effect.FAN_DANCE) and
-            fanDanceMerits > 1
+            fanDanceMeritValue > 5 -- 1 merit = Value of 5.
         then
-            ability:setRecast(ability:getRecast() * (1 - 0.05 * (fanDanceMerits - 1)))
+            newRecast = newRecast * (105 - fanDanceMeritValue) / 100
         end
+
+        ability:setRecast(utils.clamp(newRecast, 0, newRecast))
 
         return 0, 0
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes certain cases where a combination of Waltz's recast flat reduction, combined with Fan Dance recast reduction multiplier would result in waltzes recast time being set to ludicrous hours of wait time.

This was caused, concretely, at merit value of 5 / 5.
When getting a merit value, we get the number of merits stored multiplied by a value set in database.
This resulted in fetching a value of 25 when at 5/5, instead of a value of 5, which caused the math to make the recast timer go negative.

## Steps to test these changes

Max fan dance merits and equip as much waltz recast reduction gear as possible.
Use Waltzes without recast timer going to 18 hours+
