### PR TITLE
[Escha] Add Ethereal droplet npcs and logic

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -1770,6 +1770,7 @@ xi.items =
     CYLLENIAN_ABJURATION_HANDS      = 9127,
     CYLLENIAN_ABJURATION_LEGS       = 9128,
     CYLLENIAN_ABJURATION_FEET       = 9129,
+    ETHEREAL_DROPLET                = 9202,
     DIAL_KEY_AB                     = 9217,
     DIAL_KEY_FO                     = 9218,
     DIAL_KEY_ANV                    = 9274,

--- a/scripts/globals/teleports/eschan_portals.lua
+++ b/scripts/globals/teleports/eschan_portals.lua
@@ -1,10 +1,11 @@
 -------------------------------------------
 -- Escha/Reisenjima Portals Global
 -------------------------------------------
-require("scripts/globals/teleports")
+require("scripts/globals/items")
 require("scripts/globals/keyitems")
 require("scripts/globals/npc_util")
 require("scripts/globals/status")
+require("scripts/globals/teleports")
 require("scripts/globals/utils")
 -------------------------------------------
 xi = xi or {}
@@ -13,18 +14,18 @@ xi.escha.portals = xi.escha.portals or {}
 
 local costReduction = -- Based on Luck+ Vorseal power
 {-- Power, reduction (percentage based, will always be (100 minus reduction))
-    [ 0] =  0,
-    [ 1] =  5,
-    [ 2] = 10,
-    [ 3] = 15,
-    [ 4] = 20,
-    [ 5] = 25,
-    [ 6] = 30,
-    [ 7] = 35,
-    [ 8] = 40,
-    [ 9] = 45,
-    [10] = 50,
-    [11] = 55,
+    [ 0] = 100,
+    [ 1] =  95,
+    [ 2] =  90,
+    [ 3] =  85,
+    [ 4] =  80,
+    [ 5] =  75,
+    [ 6] =  70,
+    [ 7] =  65,
+    [ 8] =  60,
+    [ 9] =  55,
+    [10] =  50,
+    [11] =  45,
 }
 
 local portalOffsets =
@@ -37,17 +38,18 @@ local portalOffsets =
 
 -------------------------------------------------------------------------------------------------------------
 -- Notes:
--- Portal base cost is 100 in every escha zone.
+-- Portal base cost is 50 in every escha zone.
 -- Vorseal Luck+ (Portal Cost per unpgrade) -5%, -10%, -15%, -20%, -25%, -30%, -35%, -40%, -45%, -50%, -55%
 -- Vorseal status effect = 602
 -------------------------------------------------------------------------------------------------------------
 local function getPortalCost(player)
-    local cost             = 100
+    local cost             = 50
     local luckVorsealPower = 0
 
-    --TODO: get Vorseal Luck+ power amount.
+    -- TODO: get Vorseal Luck+ power amount.
+    -- Note: Rounded down. Base 50 with luck+ 3 (-15%) results in 42. (17/march/2023)
 
-    cost = cost - costReduction[luckVorsealPower]
+    cost = math.floor(cost * costReduction[luckVorsealPower] / 100)
 
     return cost
 end
@@ -58,20 +60,19 @@ xi.escha.portals.eschanPortalOnTrigger = function(player, npc, portalGlobalNumbe
     local lockValue           = 0                                                  -- Param 5.
     local zonePortalsUnlocked = 0
 
-    -- Reisenjima portal #10. Unlocked with Key Item.
-    if
-        zoneId == xi.zone.REISENJIMA and
-        player:hasKeyItem(xi.ki.SCINTILLATING_RHAPSODY)
-    then
-        lockValue           = 4
-        zonePortalsUnlocked = 1
-    end
+    -- Reisenjima only.
+    if zoneId == xi.zone.REISENJIMA then
+        -- Scintillating Rhapsody. Unlocks Portal #8 and #10.
+        if player:hasKeyItem(xi.ki.SCINTILLATING_RHAPSODY) then
+            lockValue           = lockValue + 4
+            zonePortalsUnlocked = zonePortalsUnlocked + 1
+        end
 
-    -- Ethereal droplet.
-    -- TODO: Confirm Ethereal droplet logic. Adds +2 to lockValue when in possesion of one.
-    -- if player:hasItem(9202, 0) then
-    --     lockValue = lockValue + 2
-    -- end
+        -- Ethereal droplet. Warps you to Portal #1.
+        if player:hasItem(xi.items.ETHEREAL_DROPLET, xi.inv.TEMPITEMS) then
+            lockValue = lockValue + 2
+        end
+    end
 
     -- Player has not activated this Portal.
     if
@@ -113,8 +114,12 @@ end
 xi.escha.portals.eschanPortalEventFinish = function(player, csid, option, npc)
     local portalCost = getPortalCost(player)
 
-    if
+    if option == 3 then-- Ethereal droplet usage.
+        player:delItem(xi.items.ETHEREAL_DROPLET, 1, xi.inv.TEMPITEMS)
+        player:messageSpecial(ID.text.YOU_HAVE_USED, xi.items.ETHEREAL_DROPLET)
+    elseif
         option ~= 0 and
+        option ~= 4 and -- Scintillating Rhapsody usage.
         option ~= 1073741824
     then
         player:delCurrency("escha_silt", portalCost)

--- a/scripts/zones/Reisenjima/IDs.lua
+++ b/scripts/zones/Reisenjima/IDs.lua
@@ -15,10 +15,12 @@ zones[xi.zone.REISENJIMA] =
         GIL_OBTAINED                  = 6391, -- Obtained <number> gil.
         KEYITEM_OBTAINED              = 6393, -- Obtained key item: <keyitem>.
         ITEMS_OBTAINED                = 6399, -- You obtain <number> <item>!
+        NOTHING_OUT_OF_ORDINARY       = 6404, -- There is nothing out of the ordinary here.
         CARRIED_OVER_POINTS           = 7001, -- You have carried over <number> login point[/s].
         LOGIN_CAMPAIGN_UNDERWAY       = 7002, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
+        YOU_HAVE_USED                 = 7609, -- You have used <item>.
     },
     mob =
     {

--- a/scripts/zones/Reisenjima/npcs/qm_ethereal_droplet.lua
+++ b/scripts/zones/Reisenjima/npcs/qm_ethereal_droplet.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Area: Reisenjima (291)
+-- NPC: ???
+-- Notes: Grants "Ethereal droplet" temporary item.
+-----------------------------------
+local ID = require("scripts/zones/Reisenjima/IDs")
+require("scripts/globals/items")
+require("scripts/globals/status")
+-----------------------------------
+
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    if player:hasItem(xi.items.ETHEREAL_DROPLET, xi.inv.TEMPITEMS) then
+        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+    else
+        player:addTempItem(xi.items.ETHEREAL_DROPLET, 1)
+        player:messageSpecial(ID.text.ITEM_OBTAINED, xi.items.ETHEREAL_DROPLET)
+    end
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+end
+
+return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Tables Ethereal droplet item.
- Corrects some npc IDs and positions.
- Adds logic to npcs that grant Ethereal droplet temporal item.
- Adds logic for ethereal droplet usage.

## Steps to test these changes

Go to Reisenjima `!zone 291`
Examine the ??? npcs near Portals 7, 8, 9 and 10 to recive an Ethereal droplet.
Use Ethereal droplet or Rhapsody without consuming Escha Silt.
