### PR TITLE
[Fix] Correct max merit count in HP/MP category

### DIFF
--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -91,7 +91,7 @@ struct MeritCategoryInfo_t
 };
 
 static const MeritCategoryInfo_t meritCatInfo[] = {
-    { 3, 45, 0 },   // MCATEGORY_HP_MP       catNumber 00
+    { 3, 75, 0 },   // MCATEGORY_HP_MP       catNumber 00 (HP 15, MP 15, Max_merits 45)
     { 7, 105, 1 },  // MCATEGORY_ATTRIBUTES  catNumber 01
     { 19, 152, 2 }, // MCATEGORY_COMBAT      catNumber 02
     { 14, 112, 4 }, // MCATEGORY_MAGIC       catNumber 03


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts incorrect value in max merit count for category 0 (HP/MP category)

https://www.bg-wiki.com/ffxi/Merit_Points#Using_Merit_Points_to_enhance_your_Character

Discussion: #3682

## Steps to test these changes

Use !setmerit
Add merits to HP/MP category. Be able to max it out
