### PR TITLE
[app] Add exit command to base Application class

### DIFF
--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -64,7 +64,16 @@ Application::Application(std::string serverName, int argc, char** argv)
     ShowInfo("The %s-server is ready to work...", serverName);
     ShowInfo("=======================================================================");
 
+    // clang-format off
     gConsoleService = std::make_unique<ConsoleService>();
+
+    gConsoleService->RegisterCommand("exit", "Terminate the program.",
+    [&](std::vector<std::string> inputs)
+    {
+        fmt::print("> Goodbye!\n");
+        m_RequestExit = true;
+    });
+    // clang-format on
 }
 
 bool Application::IsRunning()

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -233,9 +233,14 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
 
 bool CEnmityContainer::HasID(uint32 TargetID)
 {
-    return std::find_if(m_EnmityList.begin(), m_EnmityList.end(), [TargetID](auto elem)
-                        { return elem.first == TargetID && elem.second.active; }) !=
-           m_EnmityList.end();
+    // clang-format off
+    auto maybeID = std::find_if(m_EnmityList.begin(), m_EnmityList.end(), [TargetID](auto elem)
+    {
+        return elem.first == TargetID && elem.second.active;
+    });
+    // clang-format on
+
+    return maybeID != m_EnmityList.end();
 }
 
 /************************************************************************

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -678,8 +678,13 @@ void CCharEntity::RemoveTrust(CTrustEntity* PTrust)
         return;
     }
 
+    // clang-format off
     auto trustIt = std::find_if(PTrusts.begin(), PTrusts.end(), [PTrust](auto trust)
-                                { return PTrust == trust; });
+    {
+        return PTrust == trust;
+    });
+    // clang-format on
+
     if (trustIt != PTrusts.end())
     {
         if (PTrust->animation == ANIMATION_DESPAWN)

--- a/src/map/items/item_equipment.cpp
+++ b/src/map/items/item_equipment.cpp
@@ -213,8 +213,12 @@ void CItemEquipment::addLatent(LATENT ConditionsID, uint16 ConditionsValue, Mod 
 
 bool CItemEquipment::delModifier(Mod mod, int16 modValue)
 {
+    // clang-format off
     auto it = std::find_if(modList.begin(), modList.end(), [mod, modValue](const CModifier& compare)
-                           { return compare.getModID() == mod && compare.getModAmount() == modValue; });
+    {
+        return compare.getModID() == mod && compare.getModAmount() == modValue;
+    });
+    // clang-format on
 
     if (it == modList.end())
     {
@@ -227,8 +231,12 @@ bool CItemEquipment::delModifier(Mod mod, int16 modValue)
 
 bool CItemEquipment::delPetModifier(Mod mod, PetModType petType, int16 modValue)
 {
+    // clang-format off
     auto it = std::find_if(petModList.begin(), petModList.end(), [mod, petType, modValue](const CPetModifier& compare)
-                           { return compare.getModID() == mod && compare.getPetModType() == petType && compare.getModAmount() == modValue; });
+    {
+        return compare.getModID() == mod && compare.getPetModType() == petType && compare.getModAmount() == modValue;
+    });
+    // clang-format on
 
     if (it == petModList.end())
     {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1267,13 +1267,16 @@ void SmallPacket0x01E(map_session_data_t* const PSession, CCharEntity* const PCh
 
     const uint8 HEADER_LENGTH = 4;
 
+    // clang-format off
     std::vector<char> chars;
     std::for_each(data[HEADER_LENGTH], data[HEADER_LENGTH] + (data.getSize() - HEADER_LENGTH), [&](char ch)
-                  {
+    {
         if (isascii(ch) && ch != '\0')
         {
             chars.emplace_back(ch);
-        } });
+        }
+    });
+    // clang-format on
     auto str = std::string(chars.begin(), chars.end());
     luautils::OnPlayerVolunteer(PChar, str);
 }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -220,9 +220,13 @@ uint8 CParty::MemberCount(uint16 ZoneID)
         }
         if (member->objtype == TYPE_PC)
         {
+            // clang-format off
             auto* charMember = static_cast<CCharEntity*>(member);
             std::for_each(charMember->PTrusts.begin(), charMember->PTrusts.end(), [&](CTrustEntity* trust)
-                          { count++; });
+            {
+                count++;
+            });
+            // clang-format on
         }
     }
     return count;

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -212,8 +212,14 @@ bool CRecastContainer::Has(RECASTTYPE type, uint16 id)
 {
     RecastList_t* PRecastList = GetRecastList(type);
 
-    return std::find_if(PRecastList->begin(), PRecastList->end(), [&id](auto& recast)
-                        { return recast.ID == id; }) != PRecastList->end();
+    // clang-format off
+    auto maybeRecast = std::find_if(PRecastList->begin(), PRecastList->end(), [&id](auto& recast)
+    {
+        return recast.ID == id;
+    });
+    // clang-format on
+
+    return maybeRecast != PRecastList->end();
 }
 
 /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -876,9 +876,14 @@ namespace petutils
 
     void CalculateAvatarStats(CBattleEntity* PMaster, CPetEntity* PPet)
     {
-        uint32 petID    = PPet->m_PetID;
+        uint32 petID = PPet->m_PetID;
+
+        // clang-format off
         Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
-                                        { return t->PetID == petID; });
+        {
+            return t->PetID == petID;
+        });
+        // clang-format on
 
         uint8 mLvl = PMaster->GetMLevel();
 
@@ -1051,9 +1056,14 @@ namespace petutils
 
     void CalculateJugPetStats(CBattleEntity* PMaster, CPetEntity* PPet)
     {
-        uint32 petID    = PPet->m_PetID;
+        uint32 petID = PPet->m_PetID;
+
+        // clang-format off
         Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
-                                        { return t->PetID == petID; });
+        {
+            return t->PetID == petID;
+        });
+        // clang-format on
 
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
@@ -1683,8 +1693,12 @@ namespace petutils
         XI_DEBUG_BREAK_IF(PMaster == nullptr);
         XI_DEBUG_BREAK_IF(PetID >= MAX_PETID);
 
+        // clang-format off
         Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)
-                                        { return t->PetID == PetID; });
+        {
+            return t->PetID == PetID;
+        });
+        // clang-format on
 
         if (PMaster->GetMJob() != JOB_DRG && PetID == PETID_WYVERN)
         {

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -378,9 +378,14 @@ namespace trustutils
 
     CTrustEntity* LoadTrust(CCharEntity* PMaster, uint32 TrustID)
     {
-        auto* PTrust    = new CTrustEntity(PMaster);
+        auto* PTrust = new CTrustEntity(PMaster);
+
+        // clang-format off
         auto* trustData = *std::find_if(g_PTrustList.begin(), g_PTrustList.end(), [TrustID](Trust_t* t)
-                                        { return t->trustID == TrustID; });
+        {
+            return t->trustID == TrustID;
+        });
+        // clang-format on
 
         PTrust->loc              = PMaster->loc;
         PTrust->m_OwnerID.id     = PMaster->id;

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -169,8 +169,13 @@ void CZoneInstance::DecreaseZoneCounter(CCharEntity* PChar)
             if (instance->Failed() || instance->Completed())
             {
                 ShowDebug("[CZoneInstance]DecreaseZoneCounter cleaned up Instance %s", instance->GetName());
+
+                // clang-format off
                 instanceList.erase(std::find_if(instanceList.begin(), instanceList.end(), [&instance](const auto& el)
-                                                { return el.get() == instance; }));
+                {
+                    return el.get() == instance;
+                }));
+                // clang-format on
             }
             else
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds exit command to base Application class, letting you close the application gracefully from the console.
- Does some cleanup around STL things that take predicates

## Steps to test these changes

```
[03/25/23 12:57:32:315][world][info] ======================================================================= (Application::Application:65)
[03/25/23 12:57:32:315][world][info] Console input thread is ready... (ConsoleService::ConsoleService:149)
[03/25/23 12:57:32:315][world][info] Type 'help' for a list of available commands. (ConsoleService::ConsoleService:150)
[03/25/23 12:57:32:357][world][info] Starting ZMQ Server on tcp://127.0.0.1:54003 (message_server_init:266)
[03/25/23 12:57:32:361][world][info] ZMQ Server listening... (message_server_init:277)
exit
> Goodbye!
Console input thread exiting...
```
