### PR TITLE
[packets] Add upgrade/downgrade messages to merit handling

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5476,13 +5476,17 @@ void SmallPacket0x0BE(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 if (PChar->PMeritPoints->IsMeritExist(merit))
                 {
+                    const Merit_t* PMerit = PChar->PMeritPoints->GetMerit(merit);
+
                     switch (operation)
                     {
                         case 0:
                             PChar->PMeritPoints->LowerMerit(merit);
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_DECREASE));
                             break;
                         case 1:
                             PChar->PMeritPoints->RaiseMerit(merit);
+                            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, data.ref<uint16>(0x06), PMerit->count, MSGBASIC_MERIT_INCREASE));
                             break;
                     }
                     PChar->pushPacket(new CMenuMeritPacket(PChar));

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -166,6 +166,9 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_ROE_TIMED    = 705, // You have undertaken the timed record X.
     MSGBASIC_ROE_RECORD   = 697, // Records of Eminence: <record>.
     MSGBASIC_ROE_PROGRESS = 698, // Progress: <amount>/<amount>.
+    /* Merits */
+    MSGBASIC_MERIT_INCREASE = 380, // Your <merit> modification has risen to level <level>
+    MSGBASIC_MERIT_DECREASE = 381, // Your <merit> modification has dropped to level <level>
     /* DEBUG MESSAGES */
     MSGBASIC_DEBUG_RESISTED_SPELL   = 66, /* Debug: Resisted spell! */
     MSGBASIC_DEBUG_RECEIVED_STATUS  = 73, /* Debug: <target>'s status is now .. */


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

adds the following messaging when upgrading/downgrading merits
![image](https://user-images.githubusercontent.com/60417494/228702382-9585b3fe-05c8-40c6-ac03-4d1578718874.png)

## Steps to test these changes

upgrade/downgrade merits and see messages about it
