### PR TITLE
Add Brass Rod to items global

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -3786,6 +3786,7 @@ xi.items =
     MAPLE_WAND                      = 17049,
     CADUCEUS                        = 17058,
     EARTH_WAND                      = 17076,
+    BRASS_ROD                       = 17081,
     TIME_HAMMER                     = 17083,
     MISERY_STAFF                    = 17116,
     SHORTBOW                        = 17152,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Brass Rod to items global, which the Windurst quest "Curses, Foiled Again!" references for the item reward upon completion. Tested quest and it now awards said item.

## Steps to test these changes

Flag quest, trade 2 bone chips and 1 bomb ash. Receive Brass Rod.