### PR TITLE
[lua] Implement Dynamis-Jeuno Lottery NMs

### DIFF
--- a/scripts/zones/Dynamis-Jeuno/IDs.lua
+++ b/scripts/zones/Dynamis-Jeuno/IDs.lua
@@ -103,9 +103,6 @@ zones[xi.zone.DYNAMIS_JEUNO] =
             [17547512] = { trade = { { item = 3394, mob = 17547496 } } }, -- Scourquix Scaleskin
             [17547513] = { trade = { { item = 3395, mob = 17547498 } } }, -- Wilywox Tenderpalm
         },
-
-    SCRUFFIX_SHAGGYCHEST_PH      = { [17547481] = 17547485 }, -- Vanguard_Armorer
-
     },
 }
 

--- a/scripts/zones/Dynamis-Jeuno/IDs.lua
+++ b/scripts/zones/Dynamis-Jeuno/IDs.lua
@@ -65,8 +65,26 @@ zones[xi.zone.DYNAMIS_JEUNO] =
                 { mob = 17547458, eye = xi.dynamis.eye.GREEN },
             },
         },
-    },
 
+        GABBLOX_MAGPIETONGUE_PH    = { [17547275] = 17547277 }, -- Vanguard_Armorer 2.179 8.5 -61.613
+        TUFFLIX_LOGLIMBS_PH        = { [17547289] = 17547291 }, -- Vanguard_Armorer 15.499 8.384 -36.562
+        CLOKTIX_LONGNAIL_PH        = { [17547292] = 17547294 }, -- Vanguard_Armorer -17.690 8.321 -51.944
+        HERMITRIX_TOOTHROT_PH      = { [17547310] = 17547311 }, -- Vanguard_Enchanter 31.808 -0.566 -25.768
+        WYRMWIX_SNAKESPECS_PH      = { [17547321] = 17547312 }, -- Vanguard_Enchanter 21.160 0.000 -7.386
+        MORTILOX_WARTPAWS_PH       = { [17547443] = 17547438 }, -- Vanguard_Necromancer -9.120 1.400 67.003
+        RUTRIX_HAMGAMS_PH          = { [17547452] = 17547454 }, -- Vanguard_Dragontamer 0.144 1.756 43.922
+        ANVILIX_SOOTWRISTS_PH      = { [17547469] = 17547472 }, -- Vanguard_Smithy -2.563 2.706 112.752
+        BOOTRIX_JAGGEDELBOW_PH     = { [17547470] = 17547473 }, -- Vanguard_Pitfighter -2.487 2.418 106.984
+        MOBPIX_MUCOUSMOUTH_PH      = { [17547471] = 17547474 }, -- Vanguard_Welldigger -0.508 2.499 112.929
+        DISTILIX_STICKYTOES_PH     = { [17547475] = 17547478 }, -- Vanguard_Alchemist -2.164 2.5 106.255
+        EREMIX_SNOTTYNOSTRIL_PH    = { [17547476] = 17547479 }, -- Vanguard_Shaman 1.584 2.499 111.664
+        JABBROX_GRANNYGUISE_PH     = { [17547477] = 17547480 }, -- Vanguard_Enchanter 0.371 2.663 115.674
+        PROWLOX_BARRELBELLY_PH     = { [17547489] = 17547490 }, -- Vanguard_Ambusher 7.509 2.500 118.109
+        SCRUFFIX_SHAGGYCHEST_PH    = { [17547481] = 17547485 }, -- Vanguard_Armorer -0.428 2.599 117.675
+        TYMEXOX_NINEFINGERS_PH     = { [17547482] = 17547486 }, -- Vanguard_Tinkerer 2.257 2.489 117.621
+        BLAZOX_BONEYBOD_PH         = { [17547483] = 17547487 }, -- Vanguard_Pathfinder -1.698 2.493 116.454
+        SLYSTIX_MEGAPEEPERS_PH     = { [17547491] = 17547492 }, -- Vanguard_Hitman -8.440 2.500 118.349
+    },
     npc =
     {
         QM =
@@ -85,6 +103,9 @@ zones[xi.zone.DYNAMIS_JEUNO] =
             [17547512] = { trade = { { item = 3394, mob = 17547496 } } }, -- Scourquix Scaleskin
             [17547513] = { trade = { { item = 3395, mob = 17547498 } } }, -- Wilywox Tenderpalm
         },
+
+    SCRUFFIX_SHAGGYCHEST_PH      = { [17547481] = 17547485 }, -- Vanguard_Armorer
+
     },
 }
 

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Alchemist.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Alchemist.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.DISTILIX_STICKYTOES_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Ambusher.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Ambusher.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.PROWLOX_BARRELBELLY_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Armorer.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Armorer.lua
@@ -7,10 +7,19 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.GABBLOX_MAGPIETONGUE_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
+    xi.mob.phOnDespawn(mob, ID.mob.TUFFLIX_LOGLIMBS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
+    xi.mob.phOnDespawn(mob, ID.mob.CLOKTIX_LONGNAIL_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
+    xi.mob.phOnDespawn(mob, ID.mob.SCRUFFIX_SHAGGYCHEST_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Dragontamer.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Dragontamer.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.RUTRIX_HAMGAMS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Enchanter.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Enchanter.lua
@@ -7,10 +7,18 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.HERMITRIX_TOOTHROT_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
+    xi.mob.phOnDespawn(mob, ID.mob.WYRMWIX_SNAKESPECS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
+    xi.mob.phOnDespawn(mob, ID.mob.JABBROX_GRANNYGUISE_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Hitman.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Hitman.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.SLYSTIX_MEGAPEEPERS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Necromancer.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Necromancer.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.MORTILOX_WARTPAWS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Pathfinder.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Pathfinder.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.BLAZOX_BONEYBOD_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Pitfighter.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Pitfighter.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.BOOTRIX_JAGGEDELBOW_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Shaman.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Shaman.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.EREMIX_SNOTTYNOSTRIL_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Smithy.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Smithy.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.ANVILIX_SOOTWRISTS_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Tinkerer.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Tinkerer.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.TYMEXOX_NINEFINGERS_PH, 10, 1200) -- 20 minute cooldown and 10% lottery chance values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity

--- a/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Welldigger.lua
+++ b/scripts/zones/Dynamis-Jeuno/mobs/Vanguard_Welldigger.lua
@@ -7,10 +7,16 @@ mixins =
     require("scripts/mixins/dynamis_beastmen"),
     require("scripts/mixins/job_special")
 }
+local ID = require("scripts/zones/Dynamis-Jeuno/IDs")
+require("scripts/globals/mobs")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.mob.phOnDespawn(mob, ID.mob.MOBPIX_MUCOUSMOUTH_PH, 10, 1200) -- 10% lottery chance and 20 minute cooldown values ASSUMED same as Dynamis-Beaucedine/Xarcabard, needs final verification
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the Lottery NMs for Dynamis-Jeuno (Zone 188).
- Uses Lottery PH information from https://github.com/LandSandBoat/server/pull/1502, specifically the information regarding the specific PH MobIDs found in the IDs.lua file.
    - This PR **DOES NOT** include the group spawning or the timed spawn NM that were also found in PR#1502, it only uses the PH MobID information found in that PR.
- Adds PH code to the .lua files for the PH mobs.
    - The lottery chance percentage (**10**%) and cooldown time (20 minutes, a.k.a. **1200** seconds) values in these .lua files are **_ASSUMED_** to be the same values as those for **Dynamis-Beaucedine** and **Dynamis-Xarcabard**.  
        - Way back in https://github.com/DarkstarProject/darkstar/pull/6190 is when the lottery chance percentage and cooldown time values were added to Dynamis-Beaucedine and Dynamis-Xarcabard. 
    
**Final verification of the true and actual lottery chance percentage and cooldown time values still need to be found for all three of the above zones, as commented in the .lua files for all of the above PH mobs!!!** 

``/soapboxmode on``

This PR is being done to allow for LSB private servers to be able to fight some of the NMs that drop the item used to pop the zone boss, obtain the zone clear KI, and be able to move on to the Northlands Dynamis zones.  

Without the implementation of these NMs (both these lottery NMs and the timed respawn NM mobs (which will be implemented in a seperate PR later)), LSB private servers (and any private server that is/was based on TPZ/TPZ-N/the ending days of DSP) had to use custom methods to set players as having cleared this zone so they are not stuck at Dynamis-Jeuno or force their players to be stuck at Dynamis-Jeuno, staring at the stars, dreaming of the armor and items that could not be obtained from the Northlands Dynamis zones.

``/soapboxmode off``

## Steps to test these changes

Be a GM with ``!godmode`` enabled for both of the below scenarios.

Before pulling this PR down:
- Dream dreams that have been dreamt for years on years of Northlands Dynamis items that were just dreams.
- Occasionally zone into Dynamis-Jeuno, with your lottery ticket in hand, proceed to slaughter any and all mobs in hopes that any of the NMs spawn/are up that drop the boss pop item.
- Give up the slaughtering once you realize that no matter how many mobs you kill, the NMs just won't appear.
- /sigh, rip up that lottery ticket, and leave the zone knowing that dreams won't come true, until......

After pulling this PR down:
- Get more lottery tickets, one of them for sure will have the winning number!
- Zone into Dynamis-Jeuno (preferably on a job that can one-shot any of the PH mobs (to prevent being swarmed with link aggro))
- Proceed to kill, and kill, and kill, and kill, and kill the PHs until finally, you see a mob that you haven't ever seen before (ever since Neo Dynamis was released on DSP), it's one of the Lottery NMs!  
- Kill that Lottery NM before it runs away and hope that it drops the boss pop item (because otherwise you'll have to return to killing the PHs so that one of the Lottery NMs may spawn again).
- Rest easy once one of the Lottery NMs drops the boss pop item.
- Go kill the zone boss, obtain the trophy KI, leave the zone, go to the nearest convenience store and redeem your winning lottery ticket then begin the trek to the Northlands.....you should probably buy some warm-weather outfits with the money from the winning lottery ticket, it's pretty cold up there!