### PR TITLE
Make Kurrea Able to Spawn Again

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -1457,6 +1457,7 @@ xi.items =
     VEYDAL_WRASSE                   = 5141,
     SLICE_OF_BUFFALO_MEAT           = 5152,
     JAR_OF_GROUND_WASABI            = 5164,
+    BOWL_OF_ADAMANTOISE_SOUP        = 5210,
     PITCHER_OF_HOMEMADE_HERBAL_TEA  = 5221,
     BOWL_OF_HOMEMADE_STEW           = 5222,
     CONE_OF_HOMEMADE_GELATO         = 5223,

--- a/scripts/zones/Lufaise_Meadows/IDs.lua
+++ b/scripts/zones/Lufaise_Meadows/IDs.lua
@@ -30,6 +30,7 @@ zones[xi.zone.LUFAISE_MEADOWS] =
         MURDEROUS_PRESENCE            = 7747, -- Wait, you sense a murderous presence...!
         YOU_CAN_SEE_FOR_MALMS         = 7748, -- You can see for malms in every direction.
         SPINE_CHILLING_PRESENCE       = 7750, -- You sense a spine-chilling presence!
+        KURREA_TEXT                   = 7793, -- The stench of rotten flesh fills the air around you. Some scavenger must have made this place its territory.
         COMMON_SENSE_SURVIVAL         = 8745, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
         UNITY_WANTED_BATTLE_INTERACT  = 8809, -- Those who have accepted % must pay # Unity accolades to participate. The content for this Wanted battle is #. [Ready to begin?/You do not have the appropriate object set, so your rewards will be limited.]
     },

--- a/scripts/zones/Lufaise_Meadows/npcs/qm_kurrea.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/qm_kurrea.lua
@@ -4,6 +4,7 @@
 -- !pos -249.320 -16.189 41.497 24
 -----------------------------------
 local ID = require("scripts/zones/Lufaise_Meadows/IDs")
+require('scripts/globals/items')
 require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}
@@ -14,12 +15,13 @@ entity.onTrade = function(player, npc, trade)
         npcUtil.popFromQM(player, npc, ID.mob.KURREA)
     then
         -- Adamantoise Soup
+        player:messageSpecial(ID.text.KURREA_TEXT + 1, xi.items.BOWL_OF_ADAMANTOISE_SOUP)
         player:confirmTrade()
     end
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+    player:messageSpecial(ID.text.KURREA_TEXT)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Kurrea was not spawning if players traded the appropriate item. This PR adds the NM's spawn point from a capture on the captures Discord, along with the spawn text and the correct text for when the QM are examined (latter confirmed on retail, former in the capture video).

## Steps to test these changes

1) !pos -249.320 -16.189 41.497 24
2) !additem 5210
3) Trade Adamantoise Soup to QM.
4) Kill NM that needs a lot of work to make it as awesome as the devs originally did. A lot of cool flavor text and abilities!
