### PR TITLE
Rewrites getAvailableTrickAttackChar to remove expensive trig operations

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4301,7 +4301,7 @@ namespace battleutils
             return false;
         };
 
-        auto checkTrusts = [&](CBattleEntity* PEntity, float& closestDistance ) -> CBattleEntity*
+        auto checkTrusts = [&](CBattleEntity* PEntity, float& closestDistance) -> CBattleEntity*
         {
             if (auto* PChar = dynamic_cast<CCharEntity*>(PEntity))
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rewrites getAvailableTrickAttackChar to remove expensive trig operations by converting to Diamond Angles and comparing angles between potential partners and the TA user. Additionally makes sure to pick the viable TA partner closest to mob instead of the first viable TA partner found. Currently the value is set to about +/-2 degrees which from my testing felt like the "must be in a straight line" expectation from retail and called out on wikis.

## Steps to test these changes

1. Find a mob
2. Summon a Trust
3. Fight mob
4. Put the Trust between you and the mob
5. Use Trick Attack
