### PR TITLE
Patch minor exploit opened by module.

### DIFF
--- a/modules/custom/cpp/ah_pagination.cpp
+++ b/modules/custom/cpp/ah_pagination.cpp
@@ -35,6 +35,12 @@ class AHPaginationModule : public CPPModule
         {
             TracyZoneScoped;
 
+            if (PChar->m_GMlevel == 0 && !PChar->loc.zone->CanUseMisc(MISC_AH))
+            {
+                ShowWarning("%s is trying to use the auction house in a disallowed zone [%s]", PChar->GetName(), PChar->loc.zone->GetName());
+                return;
+            }
+
             // Only intercept for action 0x05: Open List Of Sales / Wait
             auto action = data.ref<uint8>(0x04);
             if (action == 0x05)

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3099,7 +3099,7 @@ void SmallPacket0x04E(map_session_data_t* const PSession, CCharEntity* const PCh
 
     if (PChar->m_GMlevel == 0 && !PChar->loc.zone->CanUseMisc(MISC_AH))
     {
-        ShowDebug("%s is trying to use the auction house in a disallowed zone [%s]", PChar->GetName(), PChar->loc.zone->GetName());
+        ShowWarning("%s is trying to use the auction house in a disallowed zone [%s]", PChar->GetName(), PChar->loc.zone->GetName());
         return;
     }
 


### PR DESCRIPTION
Also change message type to warning to match other exploit checks.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
prevents using addons to bypass restrictions on what zone the AH menu can open in.

## Steps to test these changes
1. Enable the pagination module
2. on a non-gm character, load ahgo in ashita
3. `/ah` and buy something. it should hang and eventually die. before this change it would succeed.
