### PR TITLE
Fix zone and item type in helpers.lua for LENGTH_OF_JUGNER_IVY

### DIFF
--- a/scripts/missions/wotg/helpers.lua
+++ b/scripts/missions/wotg/helpers.lua
@@ -102,11 +102,11 @@ xi.wotg.helpers.helmTrade = function(player, helmType, broke)
             npcUtil.giveKeyItem(player, xi.ki.RONFAURE_MAPLE_SYRUP)
             return true
         elseif
-            zoneId == xi.zone.EAST_RONFAURE_S and
+            zoneId == xi.zone.JUGNER_FOREST_S and
             not player:hasKeyItem(xi.ki.LENGTH_OF_JUGNER_IVY) and
             xi.quest.getVar(player, xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.BONDS_THAT_NEVER_DIE, 'Prog') == 1
         then
-            npcUtil.giveItem(player, xi.ki.LENGTH_OF_JUGNER_IVY)
+            npcUtil.giveKeyItem(player, xi.ki.LENGTH_OF_JUGNER_IVY)
             return true
         end
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #3726 

## Steps to test these changes

Try logging in Jugner Forest S for Length of Jugner Ivy
Receive Key Item Length of Jugner Ivy from logging in Jugner Forest S