### PR TITLE
[lua] Aern mixin fixes

### DIFF
--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -31,17 +31,33 @@ g_mixins.families.aern = function(aernMob)
             mob:setMobMod(xi.mobMod.NO_DROPS, 1)
         end
 
-        local target = mob:getTarget()
+        local target   = mob:getTarget()
+        local targetID = 0
+        local masterID = 0
 
-        if
-            target and
-            target:isPet() and
-            not target:isAlive()
-        then
-            target = target:getMaster()
+        if target then
+            targetID = target:getID()
+        end
+
+        if target:isPet() and target:getMaster() then
+            masterID = target:getMaster():getID()
         end
 
         mob:timer(12000, function(mobArg)
+            target = GetPlayerByID(targetID)
+            if target == nil then
+                -- try mob
+                target = GetEntityByID(targetID, mobArg:getInstance(), true)
+            end
+
+            if target == nil and masterID ~= 0 then
+                target = GetPlayerByID(masterID)
+                if target == nil then
+                    -- try mob
+                    target = GetEntityByID(masterID, mobArg:getInstance(), true)
+                end
+            end
+
             mobArg:setHP(mob:getMaxHP())
             mobArg:setAnimationSub(3)
             mobArg:setLocalVar("AERN_RERAISES", currReraise + 1)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1032,7 +1032,7 @@ namespace luautils
         return std::optional<CLuaBaseEntity>(PMob);
     }
 
-    std::optional<CLuaBaseEntity> GetEntityByID(uint32 entityid, sol::object const& instanceObj)
+    std::optional<CLuaBaseEntity> GetEntityByID(uint32 entityid, sol::object const& instanceObj, sol::object const& arg3)
     {
         TracyZoneScoped;
 
@@ -1041,6 +1041,8 @@ namespace luautils
         {
             PInstance = instanceObj.as<CLuaInstance>().GetInstance();
         }
+
+        bool silenceWarning = arg3.get_type() == sol::type::boolean ? arg3.as<bool>() : false;
 
         CBaseEntity* PEntity{ nullptr };
 
@@ -1055,7 +1057,10 @@ namespace luautils
 
         if (!PEntity)
         {
-            ShowWarning("luautils::GetEntityByID Mob doesn't exist (%d)", entityid);
+            if (!silenceWarning)
+            {
+                ShowWarning("luautils::GetEntityByID Mob doesn't exist (%d)", entityid);
+            }
             return std::nullopt;
         }
 

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -137,7 +137,7 @@ namespace luautils
     auto GetZone(uint16 zoneId) -> std::optional<CLuaZone>;
     auto GetNPCByID(uint32 npcid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
     auto GetMobByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
-    auto GetEntityByID(uint32 mobid, sol::object const& instanceObj) -> std::optional<CLuaBaseEntity>;
+    auto GetEntityByID(uint32 mobid, sol::object const& instanceObj, sol::object const& arg3) -> std::optional<CLuaBaseEntity>;
 
     void  WeekUpdateConquest(sol::variadic_args va);
     uint8 GetRegionOwner(uint8 type);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts luautils.cpp GetEntityByID to have an optional silenceWarning param in case a failure can be expected.
Change Aern mix to use IDs instead of storing CLuaBaseEntity references to target player/pet after reraise. This resolves a crash.

## Steps to test these changes

Go to Sea, summon Ifrit, assault a aern, use Flaming Crush to kill an aern, immediately release when it's hp is 0 and do not crash.
Crash is observed on Linux, at least.