### PR TITLE
Add missing bcnm calls to riverne

### DIFF
--- a/scripts/zones/Riverne-Site_A01/npcs/Unstable_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Unstable_Displacement.lua
@@ -14,7 +14,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.A_GLOWING_MIST)
+    if not xi.bcnm.onTrigger(player, npc) then
+        player:messageSpecial(ID.text.A_GLOWING_MIST)
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option, extras)
@@ -22,6 +24,7 @@ entity.onEventUpdate = function(player, csid, option, extras)
 end
 
 entity.onEventFinish = function(player, csid, option)
+    xi.bcnm.onEventFinish(player, csid, option)
 end
 
 return entity

--- a/scripts/zones/Riverne-Site_B01/npcs/Unstable_Displacement.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/Unstable_Displacement.lua
@@ -33,6 +33,8 @@ entity.onEventFinish = function(player, csid, option)
     if csid == 1 then
         player:setCharVar('StormsOfFate', 2)
     end
+
+    xi.bcnm.onEventFinish(player, csid, option)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing BCNM calls to Riverne A01 and B01 BCNM entry objects

## Steps to test these changes

A01:
N/A as Ouryu Cometh is not available yet on LSB, but this would allow back ports to work. Currently, only one player could enter the BC if `if not xi.bcnm.onTrigger(player, npc) then` is missing because they have battlefield status and need to trigger the NPC but could only do so via trade and thusly get rejected because they already have battlefield status

B01:
!addquest 3 86
!exec player:setCharVar('StormsOfFate', 2)
!pos -612.800 1.750 693.190 29
click the unstable displacement,

Enter Storms of Fate, exit Storms of Fate, re-enter Storms of Fate, beat Storms of Fate as usual. Preferably with a party size > 1.
