### PR TITLE
[FIX] Boiling blood

### DIFF
--- a/scripts/globals/mobskills/boiling_blood.lua
+++ b/scripts/globals/mobskills/boiling_blood.lua
@@ -17,7 +17,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 2500, 0, 60)
-    xi.mobskills.mobBuffMove(mob, xi.effect.BERSERK, 5000, 0, 60)
+    xi.mobskills.mobBuffMove(mob, xi.effect.BERSERK, 50, 0, 60)
     skill:setMsg(xi.msg.basic.NONE)
     return 0
 end


### PR DESCRIPTION
When mobs use mob skill Boiling Blood, attack and defense increased excessively.

![WhatsApp Image 2023-04-07 à 13 22 36](https://user-images.githubusercontent.com/1618002/230602482-3cd454cc-90bb-4fdf-bdbd-c6632720f172.jpg)


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In this merge request, I correct the power parameter sent in the  mobBuffMove method to 25 for haste and 50 berserk
instead of 2500 and 5000

## Steps to test these changes

Give TP to Mesa wivre in Abyssea Konstchat until using the mob skill Boiling blood.

I check these stats with the command !getstats


Result for me: 

![image](https://user-images.githubusercontent.com/1618002/230602622-5319e320-63b8-44d0-ac0a-03ff7a240d7b.png)

