### PR TITLE
[core] Implement "time left" message when using a JA on recast.

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -124,7 +124,13 @@ bool CPlayerController::Ability(uint16 targid, uint16 abilityid)
         }
         if (PChar->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
         {
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
+            Recast_t* recast = PChar->PRecastContainer->GetRecast(RECAST_ABILITY, PAbility->getRecastId());
+            // Set recast time in seconds to the normal recast time minus any charge time with the difference of the current time minus when the recast was set.
+            // Abilities without a charge will have zero chargeTime
+            uint32 recastSeconds = recast->RecastTime - recast->chargeTime - ((uint32)time(nullptr) - recast->TimeStamp);
+
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_UNABLE_TO_USE_JA2));
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, recastSeconds, 0, MSGBASIC_TIME_LEFT));
             return false;
         }
         if (auto target = PChar->GetEntity(targid); target && target->PAI->IsUntargetable())

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -58,6 +58,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_USES_JA2              = 101, /* The <player> uses .. */
     MSGBASIC_USES_RECOVERS_HP      = 102, /* The <player> uses .. <target> recovers .. HP. */
     MSGBASIC_SKILL_RECOVERS_HP     = 103, /* The <player> uses .. <target> recovers .. HP. */
+    MSGBASIC_TIME_LEFT             = 202, /* Time left: (h:mm:ss) */
     MSGBASIC_IS_STATUS             = 203, /* <target> is <status>. */
 
     MSGBASIC_USES_JA_TAKE_DAMAGE      = 317, /* The <player> uses .. <target> takes .. points of damage. */


### PR DESCRIPTION
* This also corrects a wrong message ID when a JA is on recast.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the correct retail messaging when a JA is on recast, see below:
![image](https://user-images.githubusercontent.com/60417494/230633222-5f552e5f-5fda-4c4d-bd10-be0d28604d19.png)

## Steps to test these changes

/ja "Ability" <me> twice in a row and see a correct recast time left message.
Be sure to test it with charged abilities such as stratagems or quick draw.