### PR TITLE
[FIX] QM Pop Ashtaerh and level

### DIFF
--- a/scripts/zones/Abyssea-Konschtat/npcs/qm_ashtaerh.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/qm_ashtaerh.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Zone: Abyssea-Konschtat
---  NPC: qm_ashtaerh_the_gallvexed (???)
+--  NPC: qm_ashtaerh (???)
 -- Spawns Ashtaerh the Gallvexed
 -- !pos 360.000 -16.043 -400.000 15
 -----------------------------------

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -596,7 +596,7 @@ INSERT INTO `mob_groups` VALUES (10,2404,15,'Ley_Clionid',300,0,1516,5000,999,74
 INSERT INTO `mob_groups` VALUES (11,1244,15,'Ephemeral_Clionid',300,0,781,5000,1000,74,75,0);
 INSERT INTO `mob_groups` VALUES (12,3696,15,'Sods_Limule',300,0,2291,0,1000,74,75,0);
 INSERT INTO `mob_groups` VALUES (13,1245,15,'Ephemeral_Limule',300,0,783,5000,1000,74,75,0);
-INSERT INTO `mob_groups` VALUES (14,261,15,'Ashtaerh_the_Gallvexed',0,128,0,0,0,0,0,0);
+INSERT INTO `mob_groups` VALUES (14,261,15,'Ashtaerh_the_Gallvexed',0,128,0,0,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (15,1457,15,'Gangly_Gean',900,0,928,0,999,80,83,0);
 INSERT INTO `mob_groups` VALUES (16,3334,15,'Razorback',300,0,2079,0,0,78,88,0);
 INSERT INTO `mob_groups` VALUES (17,3466,15,'Sarcophilus',0,128,2163,0,0,78,88,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rename file:  qm_ashtaerh_the_gallvexed.lua --> qm_ashtaerh.lua because the name is too long compared to the length of the name field of the npc_list table

Set level for Ashtaerh the Gallvexed with my capture:
`    [16838718] = {['id']=16838718, ['name']="AshtaerhtheGa",           ['polutils_name']="Ashtaerh the Gallvexed",             ['type']="Simple NPC",   ['index']=62,  ['level']=85,  ['x']=360.000,  ['y']=-16.500,  ['z']=-400.000, ['r']=223, ['flag']=46,     ['speed']=40, ['speedsub']=40, ['animation']=1,  ['animationsub']=4,  ['namevis']=0,   ['status']=1,  ['flags']=1183,    ['name_prefix']=32,  ['look']="0000EF06",                                 ['raw_packet']="0E2406043EF000013E000FDF0000B443000084C10000C8C32E00000028286401019F04000019002020000400CFFF07000000EF064173687461657268746865476100000000000000",},
`
`      [16838718] = {['id']=16838718, ['name']="AshtaerhtheGa",           ['polutils_name']="Ashtaerh the Gallvexed",             ['type']="Simple NPC",   ['index']=62,  ['level']=85,  ['x']=360.000,  ['y']=-16.500,  ['z']=-400.000, ['r']=108, ['flag']=1102,   ['speed']=40, ['speedsub']=40, ['animation']=3,  ['animationsub']=4,  ['namevis']=0,   ['status']=7,  ['flags']=1183,    ['name_prefix']=32,  ['look']="0000EF06",                                 ['raw_packet']="0E24D20A3EF000013E000F6C0000B443000084C10000C8C34E04000028280003079F04000019002020000400CFFF07000000EF064173687461657268746865476100000000000000",},
`

   ` [16838718] = {['id']=16838718, ['name']="AshtaerhtheGa",           ['polutils_name']="Ashtaerh the Gallvexed",             ['type']="Simple NPC",   ['index']=62,  ['level']=85,  ['x']=360.000,  ['y']=-16.500,  ['z']=-400.000, ['r']=158, ['flag']=3637,   ['speed']=40, ['speedsub']=40, ['animation']=3,  ['animationsub']=4,  ['namevis']=0,   ['status']=7,  ['flags']=1183,    ['name_prefix']=32,  ['look']="0000EF06",                                 ['raw_packet']="0E24D80F3EF000013E000F9E0000B443000084C10000C8C3350E000028280003079F04000019002020000400CFFF07000000EF064173687461657268746865476100000000000000",},`


## Steps to test these changes

Pop  Ashtaerh the Gallvexed with item 2914


