### PR TITLE
[FIX] Siranpa-Kamuy level and return out of function for NM that does not drop Atma or KI

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -711,6 +711,10 @@ xi.abyssea.canGiveNMKI = function(mob, dropChance)
 end
 
 xi.abyssea.giveNMDrops = function(mob, player, ID)
+    if not xi.abyssea.mob[mob:getName()] then
+        return
+    end
+
     local atmaDrops = xi.abyssea.mob[mob:getName()]['Atma']
     local normalDrops = xi.abyssea.mob[mob:getName()]['Normal']
     local playerClaimed = GetPlayerByID(mob:getLocalVar("[ClaimedBy]"))

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -622,7 +622,7 @@ INSERT INTO `mob_groups` VALUES (36,3235,15,'Pustule',0,128,0,0,0,78,88,0);
 INSERT INTO `mob_groups` VALUES (37,2743,15,'Morboling',300,0,1737,0,0,79,80,0);
 INSERT INTO `mob_groups` VALUES (38,742,15,'Clingy_Clare',0,128,479,0,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (39,1943,15,'Highland_Treant',300,0,1306,0,0,78,88,0);
-INSERT INTO `mob_groups` VALUES (40,3633,15,'Siranpa-kamuy',0,128,0,0,0,78,88,0);
+INSERT INTO `mob_groups` VALUES (40,3633,15,'Siranpa-kamuy',0,128,0,0,0,85,85,0);
 INSERT INTO `mob_groups` VALUES (41,4480,15,'Ypotryll',300,0,2792,0,0,79,80,0);
 INSERT INTO `mob_groups` VALUES (42,86,15,'Alkonost',0,128,49,25000,0,0,0,0);
 INSERT INTO `mob_groups` VALUES (43,951,15,'Deep_Eye',300,0,592,0,0,79,80,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set level 85 to Siranpa-Kamuy
`
    [16838962] = {['id']=16838962, ['name']="Siranpa-kamuy",           ['polutils_name']="Siranpa-kamuy",                      ['type']="Simple NPC",   ['index']=306, ['level']=85,  ['x']=370.000,  ['y']=1.124,    ['z']=10.000,   ['r']=192, ['flag']=33,     ['speed']=40, ['speedsub']=40, ['animation']=1,  ['animationsub']=0,  ['namevis']=0,   ['status']=1,  ['flags']=159,     ['name_prefix']=32,  ['look']="00008701",                                 ['raw_packet']="0E24990132F1000132010FC00000B9433BDF8F3F000020412100000028286401019F00000035002020000000CFFF070000008701536972616E70612D6B616D757900000000000000",},
`
`
    [16838962] = {['id']=16838962, ['name']="Siranpa-kamuy",           ['polutils_name']="Siranpa-kamuy",                      ['type']="Simple NPC",   ['index']=306, ['level']=85,  ['x']=370.000,  ['y']=1.124,    ['z']=10.000,   ['r']=244, ['flag']=2105,   ['speed']=40, ['speedsub']=40, ['animation']=3,  ['animationsub']=0,  ['namevis']=0,   ['status']=7,  ['flags']=159,     ['name_prefix']=32,  ['look']="00008701",                                 ['raw_packet']="0E248B0832F1000132010FF40000B9433BDF8F3F000020413908000028280003079F00000035002020000000CFFF070000008701536972616E70612D6B616D757900000000000000",},
`
`
    [16838962] = {['id']=16838962, ['name']="Siranpa-kamuy",           ['polutils_name']="Siranpa-kamuy",                      ['type']="Equipped NPC", ['index']=306, ['level']=85,  ['x']=370.000,  ['y']=1.124,    ['z']=10.000,   ['r']=165, ['flag']=4376,   ['speed']=40, ['speedsub']=40, ['animation']=1,  ['animationsub']=0,  ['namevis']=0,   ['status']=1,  ['flags']=159,     ['name_prefix']=32,  ['look']="00008701",                                 ['raw_packet']="0E1C900632F10001320107A50000B9433BDF8F3F000020411811000028280101019F00000035002020000000CFFF07000000870100000000",},
`

add a print and a return for nm who does not drop Atma or KI. This condition avoids having this error in the logs:

[04/10/23 06:21:46:046][map][error] Error in listener event DEATH: ./scripts/globals/abyssea.lua:717: attempt to index a nil value
stack traceback:
        ./scripts/globals/abyssea.lua:717: in function 'giveNMDrops'
        ./scripts/mixins/abyssea_weakness.lua:48: in function <./scripts/mixins/abyssea_weakness.lua:47> (triggerListener:65)


## Steps to test these changes

Pop Siranpa-kamuy with item id : 2906
