### PR TITLE
[Fix] Correct status resistance moghancements and implement missing ones

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2587,23 +2587,29 @@ void CCharEntity::changeMoghancement(uint16 moghancementID, bool isAdding)
             break;
 
         // NOTE: Exact values for resistances is unknown
+        case MOGLIFICATION_RESIST_DEATH:
+            addModifier(Mod::DEATHRES, 10 * multiplier);
+            break;
+        case MOGLIFICATION_RESIST_SLEEP:
+            addModifier(Mod::SLEEPRES, 10 * multiplier);
+            break;
         case MOGLIFICATION_RESIST_POISON:
-            addModifier(Mod::POISONRES, 20 * multiplier);
+            addModifier(Mod::POISONRES, 10 * multiplier);
             break;
         case MOGLIFICATION_RESIST_PARALYSIS:
-            addModifier(Mod::SILENCERES, 20 * multiplier);
+            addModifier(Mod::PARALYZERES, 10 * multiplier);
             break;
         case MOGLIFICATION_RESIST_SILENCE:
-            addModifier(Mod::SILENCERES, 20 * multiplier);
+            addModifier(Mod::SILENCERES, 10 * multiplier);
             break;
         case MOGLIFICATION_RESIST_PETRIFICATION:
-            addModifier(Mod::PETRIFYRES, 20 * multiplier);
+            addModifier(Mod::PETRIFYRES, 10 * multiplier);
             break;
         case MOGLIFICATION_RESIST_VIRUS:
-            addModifier(Mod::VIRUSRES, 20 * multiplier);
+            addModifier(Mod::VIRUSRES, 10 * multiplier);
             break;
         case MOGLIFICATION_RESIST_CURSE:
-            addModifier(Mod::CURSERES, 20 * multiplier);
+            addModifier(Mod::CURSERES, 10 * multiplier);
             break;
         default:
             break;

--- a/src/map/items/item_furnishing.h
+++ b/src/map/items/item_furnishing.h
@@ -90,6 +90,8 @@ enum MOGHANCEMENT_TYPE
     MOGLIFICATION_EXPERIENCE_BOOST = 562, // Increases the rate of gaining experience by 15%
     MOGLIFICATION_CAPACITY_BOOST   = 563, // Increases the rate of gaining capacity points by 15%
 
+    MOGLIFICATION_RESIST_DEATH         = 566,  // Slightly improves your resistance to death effects
+    MOGLIFICATION_RESIST_SLEEP         = 2848, // Slightly improves your resistance to sleep effects
     MOGLIFICATION_RESIST_POISON        = 2849, // Slightly improves your resistance to poison effects
     MOGLIFICATION_RESIST_PARALYSIS     = 2850, // Slightly improves your resistance to paralysis effects
     MOGLIFICATION_RESIST_SILENCE       = 2852, // Slightly improves your resistance to silence effects


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrects incorrect modifier for "Resist paralysis Moglification"
- Corrects resistance modifiers values. From 20 to 10. Each resist job trait tier is a flat 10% and this should be aswell.
- Implements missing "resist death" and "resist sleep" moglifications.

Closes #3755 

## Steps to test these changes

Get the specific moghancement you want to test.
Get hit by the status effect repeatedly. Randomly resist it.
NOTE: If the origin of the status effect is an spell, watch the `Resist!` message trigger.