### PR TITLE
[Fix] Maximum merits allowed in "max merits"

### DIFF
--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -21,7 +21,7 @@ CREATE TABLE `merits` (
 
 INSERT INTO `merits` VALUES (64,'max_hp',15,10,1048575,0,0);
 INSERT INTO `merits` VALUES (66,'max_mp',15,10,1048575,0,0);
-INSERT INTO `merits` VALUES (68,'max_merits',15,1,1048575,9,0);
+INSERT INTO `merits` VALUES (68,'max_merits',45,1,1048575,9,0);
 INSERT INTO `merits` VALUES (128,'str',15,1,1048575,1,1);
 INSERT INTO `merits` VALUES (130,'dex',15,1,1048575,1,1);
 INSERT INTO `merits` VALUES (132,'vit',15,1,1048575,1,1);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Follow-up to PR #3685

Each merit category has 2 caps:
- An individual cap for that specific merit.
- A global cap for the whole category.

The mentioned PR fixed the cap for the whole category (HP/MP/Max_Merits).
However, the individual cap for the "max merits", handled in the database, remained untouched, resulting in players still not being able to increase "Max Merits" beyond 15.

Closes #3697 

## Steps to test these changes

Unlock merits and add merits to "Max Merit" category.
Should be able to raise it to 45. Eventually, after a lot of merits.
