### PR TITLE
Hide items with no buy history until listed for first time

### DIFF
--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -11,6 +11,9 @@ xi.settings = xi.settings or {}
 
 xi.settings.search =
 {
+        -- Omit items with no buy history from auction house results
+    OMIT_NO_HISTORY = false,
+
     -- After EXPIRE_DAYS, will listed auctions expire?
     EXPIRE_AUCTIONS = true,
 

--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -11,7 +11,7 @@ xi.settings = xi.settings or {}
 
 xi.settings.search =
 {
-        -- Omit items with no buy history from auction house results
+    -- Omit items with no buy history from auction house results
     OMIT_NO_HISTORY = false,
 
     -- After EXPIRE_DAYS, will listed auctions expire?

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -146,6 +146,7 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
                         break;
                     }
                 }
+
                 if (!itemFound)
                 {
                     ahItem* PAHItem       = new ahItem;

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -93,7 +93,7 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
                            "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
                            "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
                            "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
-                           "WHERE aH = %u "
+                           "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
                            "GROUP BY item_basic.itemid "
                            "%s";
 
@@ -117,6 +117,44 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
             }
 
             ItemList.push_back(PAHItem);
+        }
+    }
+    const char* noQtyQuery = "SELECT item_basic.itemid, item_basic.stackSize "
+                             "FROM item_basic "
+                             "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid "
+                             "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
+                             "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
+                             "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
+                             "GROUP BY item_basic.itemid "
+                             "%s";
+
+    int32 noQtyRet = sql->Query(noQtyQuery, AHCategoryID, OrderByString);
+    if (noQtyRet != SQL_ERROR && sql->NumRows() != 0)
+    {
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            uint16 CurrItemID = sql->GetUIntData(0);
+            bool   itemFound  = false;
+            for (ahItem* PAHItem : ItemList)
+            {
+                if (PAHItem->ItemID == CurrItemID)
+                {
+                    itemFound = true;
+                    break;
+                }
+            }
+            if (!itemFound)
+            {
+                ahItem* PAHItem       = new ahItem;
+                PAHItem->ItemID       = CurrItemID;
+                PAHItem->SingleAmount = 0;
+                PAHItem->StackAmount  = 0;
+                if (sql->GetIntData(1) == 1)
+                {
+                    PAHItem->StackAmount = -1;
+                }
+                ItemList.push_back(PAHItem);
+            }
         }
     }
     return ItemList;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

This code was written by @OpheliaXI. I am simply porting it over to LSB.

## What does this pull request do?
This PR will hide any items from the Auction House that do not have a buy history.
This is a more realistic scenario for servers, as some gear is unobtainable or uncoded.
If the operator chooses, they can use a 3rd party tool like pydarkstar to populate their auction house.

## Steps to test these changes
Before change:
You will see every single item, whether it's been purchased before or not

After change:
Only items with a buy history are visible on the auction house.

