### PR TITLE
[Abyssea] Set event 2180 when timer is over and move set pos in onEventFinish

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -1098,6 +1098,13 @@ xi.abyssea.onZoneIn = function(player)
     end
 end
 
+xi.abyssea.onEventFinish = function(player, csid, option)
+    if csid == 2180 then
+        local zoneID = player:getZoneID()
+        player:setPos(unpack(xi.abyssea.exitPositions[zoneID]))
+    end
+end
+
 xi.abyssea.afterZoneIn = function(player)
     local zoneID = player:getZoneID()
     local ID = zones[zoneID]

--- a/scripts/globals/effects/visitant.lua
+++ b/scripts/globals/effects/visitant.lua
@@ -6,7 +6,7 @@ require("scripts/globals/zone")
 -----------------------------------
 local effectObject = {}
 
-local remainingTimeLimits = { 300, 120, 60, 30, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 }
+local remainingTimeLimits = { 300, 240, 180, 120, 60, 30, 10, 5, 4, 3, 2, 1 }
 
 -- NOTE: Update the last
 local reportTimeRemaining
@@ -109,7 +109,7 @@ effectObject.onEffectLose = function(target, effect)
     then
         target:setLocalVar('finalCountdown', 0)
         target:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 8)
-        target:setPos(unpack(xi.abyssea.exitPositions[zoneID]))
+        target:startEvent(2180)
     elseif effect:getIcon() == xi.effect.VISITANT then
         -- Player exited willingly, set their time stored as seconds remaining.  Cap at 120 minutes,
         -- and remove the 4 seconds that was granted as a buffer time.

--- a/scripts/zones/Abyssea-Altepa/Zone.lua
+++ b/scripts/zones/Abyssea-Altepa/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Attohwa/Zone.lua
+++ b/scripts/zones/Abyssea-Attohwa/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Grauberg/Zone.lua
+++ b/scripts/zones/Abyssea-Grauberg/Zone.lua
@@ -54,6 +54,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Konschtat/Zone.lua
+++ b/scripts/zones/Abyssea-Konschtat/Zone.lua
@@ -58,6 +58,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-La_Theine/Zone.lua
+++ b/scripts/zones/Abyssea-La_Theine/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Misareaux/Zone.lua
+++ b/scripts/zones/Abyssea-Misareaux/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Tahrongi/Zone.lua
+++ b/scripts/zones/Abyssea-Tahrongi/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Uleguerand/Zone.lua
+++ b/scripts/zones/Abyssea-Uleguerand/Zone.lua
@@ -52,6 +52,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject

--- a/scripts/zones/Abyssea-Vunkerl/Zone.lua
+++ b/scripts/zones/Abyssea-Vunkerl/Zone.lua
@@ -54,6 +54,7 @@ zoneObject.onEventUpdate = function(player, csid, option)
 end
 
 zoneObject.onEventFinish = function(player, csid, option)
+    xi.abyssea.onEventFinish(player, csid, option)
 end
 
 return zoneObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set event 2180 when timer is over and move set pos in onEventFinish

review of the time display at the end of the timer (see it on retail)

## Steps to test these changes

Enter in abyssea and do not take visitant status 

Wait 5 minutes 
