### PR TITLE
[Abyssea] Fix Conflux surveyor spend stone

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -677,7 +677,7 @@ end
 xi.abyssea.spendTravStones = function(player, spentstones)
     local numRemoved = 0
 
-    for keyItem = xi.ki.TRAVERSER_STONE6, xi.ki.TRAVERSER_STONE1 do
+    for keyItem = xi.ki.TRAVERSER_STONE6, xi.ki.TRAVERSER_STONE1, -1 do
         if numRemoved == spentstones then
             break
         elseif player:hasKeyItem(keyItem) then

--- a/scripts/globals/abyssea/conflux_surveyor.lua
+++ b/scripts/globals/abyssea/conflux_surveyor.lua
@@ -9,17 +9,21 @@ xi.abyssea = xi.abyssea or {}
 
 xi.abyssea.surveyorOnTrigger = function(player, npc)
     local timeRemaining = 0
-    local prevTime = player:getCharVar("abysseaTimeStored") -- Seconds remaining
+    local prevTime = 0
     local numStones = xi.abyssea.getHeldTraverserStones(player)
     local numSojourn = xi.abyssea.getAbyssiteTotal(player, xi.abyssea.abyssiteType.SOJOURN)
     local hasRhapsody = player:hasKeyItem(xi.ki.RHAPSODY_IN_MAUVE)
-
     local visitantEffect = player:getStatusEffect(xi.effect.VISITANT)
+    local hasVisitantStatusEffect = 0
+
     if visitantEffect and visitantEffect:getIcon() == xi.effect.VISITANT then
         timeRemaining = player:getStatusEffect(xi.effect.VISITANT):getTimeRemaining() / 1000 - 4
+        hasVisitantStatusEffect = 3
+    else
+        prevTime = player:getCharVar("abysseaTimeStored") -- Seconds remaining
     end
 
-    player:startEvent(2001, 0, timeRemaining, prevTime, numStones, numSojourn, hasRhapsody, 0, 2)
+    player:startEvent(2001, hasVisitantStatusEffect, timeRemaining, prevTime, numStones, numSojourn, hasRhapsody, 0, 0)
 end
 
 xi.abyssea.surveyorOnEventFinish = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix Conflux surveyor spend stone: missing -1 on the for loop
With capture i see 0 when doesn't have visitant status and 3 when i already have visitant status.

## Steps to test these changes

Have traverser stone on your character.

Speak to Conflux Surveyor

Take Visitant status and speak again you can add time
