### PR TITLE
[core] [lua] add function to send an entity update to a specific player, improve helm.lua for better module support

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1474,7 +1474,7 @@ local function doMove(npc, x, y, z)
     end
 end
 
-local function movePoint(npc, zoneId, info)
+local function movePoint(player, npc, zoneId, info)
     local points = info.zone[zoneId].points
     local point  = points[math.random(1, #points)]
 
@@ -1495,7 +1495,7 @@ xi.helm.initZone = function(zone, helmType)
         local npc = GetNPCByID(npcId)
         if npc then
             npc:setStatus(xi.status.NORMAL)
-            movePoint(npc, zoneId, info)
+            movePoint(nil, npc, zoneId, info)
         end
     end
 end
@@ -1532,7 +1532,7 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
             npc:setLocalVar("uses", uses)
 
             if uses == 0 then
-                movePoint(npc, zoneId, info)
+                movePoint(player, npc, zoneId, info)
             end
 
             player:triggerRoeEvent(xi.roe.triggers.helmSuccess, { ["skillType"] = helmType })

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -3199,3 +3199,28 @@ xi.itemFlag =
     EX           = 0x4000, -- NoTradePC Polutils Value
     RARE         = 0x8000,
 }
+
+-- see `enum ENTITYUPDATE` in src\map\packets\basic.h
+xi.entityUpdate =
+{
+    ENTITY_SPAWN   = 0,
+    ENTITY_SHOW    = 1,
+    ENTITY_UPDATE  = 2,
+    ENTITY_HIDE    = 3,
+    ENTITY_DESPAWN = 4,
+}
+
+-- see `enum UPDATETYPE` in src\map\entities\baseentity.h
+xi.updateType =
+{
+    UPDATE_NONE     = 0x00,
+    UPDATE_POS      = 0x01,
+    UPDATE_STATUS   = 0x02,
+    UPDATE_HP       = 0x04,
+    UPDATE_COMBAT   = 0x07,
+    UPDATE_NAME     = 0x08,
+    UPDATE_ALL_MOB  = 0x0F,
+    UPDATE_LOOK     = 0x10,
+    UPDATE_ALL_CHAR = 0x1F,
+    UPDATE_DESPAWN  = 0x20,
+}

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2478,6 +2478,17 @@ void CLuaBaseEntity::updateToEntireZone(uint8 statusID, uint8 animation, sol::ob
     PNpc->loc.zone->UpdateEntityPacket(PNpc, ENTITY_UPDATE, UPDATE_COMBAT, true);
 }
 
+// Sends an arbitrary entity update to a specific player only
+void CLuaBaseEntity::sendEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate, uint8 entityUpdate, uint8 updateMask)
+{
+    if (m_PBaseEntity->objtype == TYPE_PC && entityToUpdate->GetBaseEntity())
+    {
+        CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+        PChar->updateEntityPacket(entityToUpdate->GetBaseEntity(), static_cast<ENTITYUPDATE>(entityUpdate), updateMask);
+    }
+}
+
 /************************************************************************
  *  Function: getPos()
  *  Purpose : Returns a table of signed coordinates (x,y,z,rot)
@@ -15861,6 +15872,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("getPlayerTriggerAreaInZone", CLuaBaseEntity::getPlayerTriggerAreaInZone);
     SOL_REGISTER("updateToEntireZone", CLuaBaseEntity::updateToEntireZone);
+    SOL_REGISTER("sendEntityUpdateToPlayer", CLuaBaseEntity::sendEntityUpdateToPlayer);
 
     // Abyssea
     SOL_REGISTER("getAvailableTraverserStones", CLuaBaseEntity::getAvailableTraverserStones);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -179,6 +179,8 @@ public:
     uint32 getPlayerTriggerAreaInZone();                                                      // Returns the player's current trigger area in the zone.
     void   updateToEntireZone(uint8 statusID, uint8 animation, sol::object const& matchTime); // Forces an update packet to update the NPC entity zone-wide
 
+    void sendEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate, uint8 entityUpdate, uint8 updateMask); // sends a specific entity's update packet to a specific player only
+
     auto  getPos() -> sol::table;      // Get Entity position (x,y,z)
     void  showPosition();              // Display current position of character
     float getXPos();                   // Get Entity X position


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add CLuaBaseEntity::sendEntityUpdateToPlayer

This will send a specific entity's update packet to a specific player
You can use this to individually spawn/despawn things.

Update helm.lua to pass in player when applicable for better module support for helm.lua

## Steps to test these changes

get an entity's ID:
`!exec player:PrintToPlayer(tostring(target:getID()))`

`!exec player:sendEntityUpdateToPlayer(GetEntityByID(111111111), 0x00, 0x20)` to spawn
`!exec player:sendEntityUpdateToPlayer(GetEntityByID(111111111), 0x04, 0x20)` to despawn
these follow the normal entity update packets for the params for spawn/despawn, position updates, etc as in c++.

helm.lua:
HELM as normal and see no change. Player will be passed to the move function which isn't used but modules can use.