### PR TITLE
Fix page count in ah_pagination module

### DIFF
--- a/modules/custom/cpp/ah_pagination.cpp
+++ b/modules/custom/cpp/ah_pagination.cpp
@@ -50,7 +50,7 @@ class AHPaginationModule : public CPPModule
                 {
                     // This will get wiped on zoning
                     auto currentAHPage = PChar->GetLocalVar("AH_PAGE");
-                    PChar->SetLocalVar("AH_PAGE", (currentAHPage + 1) % ITEMS_PER_PAGE);
+                    PChar->SetLocalVar("AH_PAGE", (currentAHPage + 1) % TOTAL_PAGES);
 
                     PChar->m_ah_history.clear();
                     PChar->m_AHHistoryTimestamp = curTick;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects the page counting so that it doesn't cycle back to page 1 before it should.

## Steps to test these changes
1. Enable AH pagination module.
2. Load up some junk on the AH, more than your max items per page.
3. Check your sales status enough times to cycle back to page one, verify it showed all of your pages before doing so.
