### PR TITLE
Set homepoint when initial cutscene is skipped

### DIFF
--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -139,8 +139,9 @@ xi.player.charCreate = function(player)
         player:setGil(xi.settings.main.START_GIL)
     end
 
-    if xi.settings.main.NEW_CHARACTER_CUTSCENE == 0 then -- Add coupon that would normally be added in cutscene.
+    if xi.settings.main.NEW_CHARACTER_CUTSCENE == 0 then -- Do things that would normally be done in opening cutscene.
         player:addItem(xi.items.ADVENTURERS_COUPON)
+        player:setHomePoint()
     end
 
     player:addTitle(xi.title.NEW_ADVENTURER)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

closes #3417 by setting the homepoint during char creation if initial cutscene is skipped.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

 - create a character while `xi.settings.main.NEW_CHARACTER_CUTSCENE == 0`
 - check the `chars` db table for that character's `home_*` values being nonzero.
 - `!hp 0` the new character and return to home point for good measure.
