### PR TITLE
[core] Adjust TH application handling to match retail

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1059,6 +1059,8 @@ bool CMobController::Disengage()
     PMob->updatemask |= (UPDATE_STATUS | UPDATE_HP);
     PMob->SetCallForHelpFlag(false);
     PMob->animation = ANIMATION_NONE;
+    // https://www.bluegartr.com/threads/108198-Random-Facts-Thread-Traits-and-Stats-(Player-and-Monster)?p=5670209&viewfull=1#post5670209
+    PMob->m_THLvl = 0;
 
     return CController::Disengage();
 }

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -113,7 +113,7 @@ void CEnmityContainer::AddBaseEnmity(CBattleEntity* PChar)
     {
         return;
     }
-    m_EnmityList.emplace(PChar->id, EnmityObject_t{ PChar, 0, 0, false, 0 });
+    m_EnmityList.emplace(PChar->id, EnmityObject_t{ PChar, 0, 0, false });
     PChar->PNotorietyContainer->add(m_EnmityHolder);
 }
 
@@ -149,7 +149,7 @@ float CEnmityContainer::CalculateEnmityBonus(CBattleEntity* PEntity)
  *                                                                       *
  ************************************************************************/
 
-void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster, bool tameable)
+void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster, bool tameable, bool directAction)
 {
     TracyZoneScoped;
 
@@ -163,6 +163,12 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
     {
         CE = 0;
         VE = 0;
+    }
+
+    // Apply TH only if this was a direct action
+    if (directAction && PEntity->getMod(Mod::TREASURE_HUNTER) > m_EnmityHolder->m_THLvl)
+    {
+        m_EnmityHolder->m_THLvl = PEntity->getMod(Mod::TREASURE_HUNTER);
     }
 
     auto enmity_obj = m_EnmityList.find(PEntity->id);
@@ -182,11 +188,6 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
         enmity_obj->second.CE     = std::clamp(newCE, 0, EnmityCap);
         enmity_obj->second.VE     = std::clamp(newVE, 0, EnmityCap);
         enmity_obj->second.active = true;
-
-        if (CE + VE > 0 && PEntity->getMod(Mod::TREASURE_HUNTER) > enmity_obj->second.maxTH)
-        {
-            enmity_obj->second.maxTH = PEntity->getMod(Mod::TREASURE_HUNTER);
-        }
     }
     else if (CE >= 0 && VE >= 0)
     {
@@ -200,8 +201,6 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
             }
         }
 
-        int16 maxTH = CE + VE > 0 ? PEntity->getMod(Mod::TREASURE_HUNTER) : 0;
-
         if (initial)
         {
             CE += 200;
@@ -212,7 +211,7 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, 
         CE = std::clamp((int32)(CE * bonus), 0, EnmityCap);
         VE = std::clamp((int32)(VE * bonus), 0, EnmityCap);
 
-        m_EnmityList.emplace(PEntity->id, EnmityObject_t{ PEntity, CE, VE, true, maxTH });
+        m_EnmityList.emplace(PEntity->id, EnmityObject_t{ PEntity, CE, VE, true });
         PEntity->PNotorietyContainer->add(m_EnmityHolder);
 
         if (withMaster && PEntity->PMaster != nullptr)
@@ -285,7 +284,7 @@ void CEnmityContainer::UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level,
     }
     else
     {
-        m_EnmityList.emplace(PEntity->id, EnmityObject_t{ PEntity, std::clamp(CE, 0, EnmityCap), std::clamp(VE, 0, EnmityCap), true, 0 });
+        m_EnmityList.emplace(PEntity->id, EnmityObject_t{ PEntity, std::clamp(CE, 0, EnmityCap), std::clamp(VE, 0, EnmityCap), true });
         PEntity->PNotorietyContainer->add(m_EnmityHolder);
     }
 }
@@ -482,25 +481,6 @@ bool CEnmityContainer::IsWithinEnmityRange(CBattleEntity* PEntity) const
     }
     float maxRange = square(m_EnmityHolder->m_Type == MOBTYPE_NOTORIOUS ? 28.f : 25.f);
     return distanceSquared(m_EnmityHolder->loc.p, PEntity->loc.p) <= maxRange;
-}
-
-int16 CEnmityContainer::GetHighestTH() const
-{
-    CBattleEntity* PEntity = nullptr;
-    int16          THLvl   = 0;
-
-    for (const auto& it : m_EnmityList)
-    {
-        const EnmityObject_t& PEnmityObject = it.second;
-        PEntity                             = PEnmityObject.PEnmityOwner;
-
-        if (PEntity != nullptr && !PEntity->isDead() && PEnmityObject.maxTH > THLvl)
-        {
-            THLvl = PEnmityObject.maxTH;
-        }
-    }
-
-    return THLvl;
 }
 
 EnmityList_t* CEnmityContainer::GetEnmityList()

--- a/src/map/enmity_container.h
+++ b/src/map/enmity_container.h
@@ -35,7 +35,6 @@ struct EnmityObject_t
     int32          CE; // Cumulative Enmity
     int32          VE; // Volatile Enmity
     bool           active;
-    int16          maxTH; // Maximum Treasure Hunter level of this Enmity Owner
 };
 
 typedef std::unordered_map<uint32, EnmityObject_t> EnmityList_t;
@@ -54,7 +53,7 @@ public:
     void          Clear(uint32 EntityID = 0);   // Removes Entries from list
     void          LogoutReset(uint32 EntityID); // Sets entry to inactive
     void          AddBaseEnmity(CBattleEntity* PEntity);
-    void          UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster = false, bool tameable = false);
+    void          UpdateEnmity(CBattleEntity* PEntity, int32 CE, int32 VE, bool withMaster = false, bool tameable = false, bool directAction = true);
     void          UpdateEnmityFromDamage(CBattleEntity* PEntity, int32 Damage);
     void          UpdateEnmityFromCure(CBattleEntity* PEntity, uint8 level, int32 CureAmount, bool isCureV);
     void          UpdateEnmityFromAttack(CBattleEntity* PEntity, int32 Damage);
@@ -66,7 +65,6 @@ public:
     void          SetVE(CBattleEntity* PEntity, const int32 amount);
     void          DecayEnmity();
     bool          IsWithinEnmityRange(CBattleEntity* PEntity) const;
-    int16         GetHighestTH() const;
     EnmityList_t* GetEnmityList();
     bool          IsTameable() const;
     void          UpdateEnmityFromCover(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser);

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1390,7 +1390,6 @@ void CMobEntity::Die()
         PBattlefield->handleDeath(this);
     }
 
-    m_THLvl = PEnmityContainer->GetHighestTH();
     PEnmityContainer->Clear();
     PAI->ClearStateStack();
     if (PPet != nullptr && PPet->isAlive() && GetMJob() == JOB_SMN)
@@ -1416,6 +1415,7 @@ void CMobEntity::Die()
 
             DistributeRewards();
             m_OwnerID.clean();
+            m_THLvl = 0;
         }
     }));
     // clang-format on

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -14645,16 +14645,18 @@ bool CLuaBaseEntity::itemStolen()
 
 /************************************************************************
  *  Function: getTHlevel()
- *  Purpose : Return mob's current Treasure Hunter tier if alive, or its last if dead.
+ *  Purpose : Return mob's current Treasure Hunter tier
  *  Example : local TH = target:getTHlevel()
  ************************************************************************/
 
 int16 CLuaBaseEntity::getTHlevel()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
-
-    auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
-    return PMob->isDead() ? PMob->m_THLvl : PMob->PEnmityContainer->GetHighestTH();
+    if (m_PBaseEntity->objtype == TYPE_MOB)
+    {
+        CMobEntity* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
+        return PMob->m_THLvl;
+    }
+    return 0;
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4437,7 +4437,7 @@ namespace battleutils
 
                 if (PCurrentMob->m_HiPCLvl > 0 && PCurrentMob->PEnmityContainer->HasID(PSource->id))
                 {
-                    PCurrentMob->PEnmityContainer->UpdateEnmity(PSource, CE, VE);
+                    PCurrentMob->PEnmityContainer->UpdateEnmity(PSource, CE, VE, false, false, false);
                 }
             }
         }
@@ -5443,7 +5443,7 @@ namespace battleutils
             // Issekigan is Known to Grant 300 CE per parry, but unknown how it effects VE (per bgwiki). So VE is left alone for now.
             // JP is known to give 10 VE per point
             uint16 jpBonus = static_cast<CCharEntity*>(PDefender)->PJobPoints->GetJobPointValue(JP_ISSEKIGAN_EFFECT) * 10;
-            static_cast<CMobEntity*>(PAttacker)->PEnmityContainer->UpdateEnmity(PDefender, 300, 0 + jpBonus, false);
+            static_cast<CMobEntity*>(PAttacker)->PEnmityContainer->UpdateEnmity(PDefender, 300, 0 + jpBonus, false, false);
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adjusts TH handling to act like retail.
You are required to perform an aggressive action against the mob to get TH on the mob. Additionally, TH persists even if the THF zones, dies, logs out, or uninstalls the game after ragequitting.

This also cleans up some unnecessary functions given the old method is obsolete.

## Steps to test these changes

`!setmod treasure_hunter 1000` on yourself
aggro a mob, `!exec player:PrintToPlayer(tostring(target:getTHlevel()))`
it should return 0
have another player fight that mob, cure them
the previous command should still return 0
add them to your party, use an AoE job ability like Holy Circle that's a buff, reuse the command, should still return 0.
Cast a spell, auto attack, or otherwise against the mob. the command should return 1000 or your TH level.

Zone out, die, or logout, come back to the mob, the command should still return 1000 unless:

- The mob has deaggroed by any means and reset
- The mob has died and respawned by the time you got back