### PR TITLE
Default to release build not debug.

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,9 +1,9 @@
 ﻿{
   "configurations": [
     {
-      "name": "x64-Debug",
+      "name": "x64-Release",
       "generator": "Ninja",
-      "configurationType": "Debug",
+      "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\build\\${name}",
       "cmakeCommandArgs": "",
@@ -13,9 +13,21 @@
       "variables": []
     },
     {
-      "name": "x64-Release",
+      "name": "x64-Release-Tracy",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\build\\${name}",
+      "installRoot": "${projectDir}\\build\\${name}",
+      "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    },
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\build\\${name}",
       "cmakeCommandArgs": "",
@@ -37,21 +49,9 @@
       "variables": []
     },
     {
-      "name": "x64-Release-Tracy",
+      "name": "x86-Release",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
-    },
-    {
-      "name": "x86-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\build\\${name}",
       "cmakeCommandArgs": "",
@@ -61,9 +61,9 @@
       "variables": []
     },
     {
-      "name": "x86-Release",
+      "name": "x86-Debug",
       "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
+      "configurationType": "Debug",
       "buildRoot": "${projectDir}\\build\\${name}",
       "installRoot": "${projectDir}\\build\\${name}",
       "cmakeCommandArgs": "",

--- a/src/map/items/item.h
+++ b/src/map/items/item.h
@@ -26,7 +26,6 @@
 #include "common/mmo.h"
 
 // The main type of item m_type
-
 enum ITEM_TYPE
 {
     ITEM_BASIC      = 0x00,
@@ -41,7 +40,6 @@ enum ITEM_TYPE
 };
 
 // Additional type of object m_subtype
-
 enum ITEM_SUBTYPE
 {
     ITEM_NORMAL    = 0x00,
@@ -52,7 +50,6 @@ enum ITEM_SUBTYPE
 };
 
 // Flags of objects
-
 enum ITEM_FLAG
 {
     ITEM_FLAG_WALLHANGING  = 0x0001,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
A fresh setup will see  x64-release pre-chosen in visual studio, instead of  x64-debug. Nobody should build debug unless actually debugging and using breakpoints.

Also removed a few extra a few line breaks in item.h

## Steps to test these changes
Clone to a new folder, open cmake in visual studio.
