### PR TITLE
 Move individual mobkill RoE objectives to mob scripts

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -3027,8 +3027,6 @@ function getRoeRecords(triggers)
 
         [216] =
         { -- Subjugation: Jaggedy-Eared Jack
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17187111 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3043,8 +3041,6 @@ function getRoeRecords(triggers)
 
         [218] =
         { -- Subjugation: Swamfisk
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17191189, 17191291 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3059,8 +3055,6 @@ function getRoeRecords(triggers)
 
         [220] =
         { -- Subjugation: Thousandarm Deshglesh
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17350826 } },
             reward = { sparks = 250, xp = 550 },
         },
 
@@ -3075,8 +3069,6 @@ function getRoeRecords(triggers)
 
         [222] =
         { -- Subjugation: Hundredscar Hajwaj
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17354828 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3091,8 +3083,6 @@ function getRoeRecords(triggers)
 
         [224] =
         { -- Subjugation: Ashmaker Gotblut
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17358932 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3107,8 +3097,6 @@ function getRoeRecords(triggers)
 
         [226] =
         { -- Subjugation: Barbastelle
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17555721 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3123,8 +3111,6 @@ function getRoeRecords(triggers)
 
         [228] =
         { -- Subjugation: Bloodsucker
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17461478 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3139,8 +3125,6 @@ function getRoeRecords(triggers)
 
         [230] =
         { -- Subjugation: Valkurm Emperor
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17199438 } },
             reward = { sparks = 250, xp = 550 },
         },
 
@@ -3155,8 +3139,6 @@ function getRoeRecords(triggers)
 
         [232] =
         { -- Subjugation: Bendigeit Vran
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17220001 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3171,8 +3153,6 @@ function getRoeRecords(triggers)
 
         [234] =
         { -- Subjugation: Juggler Hecatomb
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17580248 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3187,8 +3167,6 @@ function getRoeRecords(triggers)
 
         [236] =
         { -- Subjugation: Bloodtear Baldurf
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17195318 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3203,8 +3181,6 @@ function getRoeRecords(triggers)
 
         [238] =
         { -- Subjugation: Morbolger
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17568127 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3223,8 +3199,6 @@ function getRoeRecords(triggers)
 
         [240] =
         { -- Subjugation: King Arthro
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17203216 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3239,8 +3213,6 @@ function getRoeRecords(triggers)
 
         [242] =
         { -- Subjugation: Lumber Jack
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17207308 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3255,8 +3227,6 @@ function getRoeRecords(triggers)
 
         [244] =
         { -- Subjugation: Cwn Cyrff
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17576054 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3271,8 +3241,6 @@ function getRoeRecords(triggers)
 
         [246] =
         { -- Subjugation: Hawkeyed Dnatbat
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17387567 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3287,8 +3255,6 @@ function getRoeRecords(triggers)
 
         [248] =
         { -- Subjugation: Maighdean Uaine
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17211702, 17211714 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3303,8 +3269,6 @@ function getRoeRecords(triggers)
 
         [250] =
         { -- Subjugation: Carnero
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17215613, 17215626 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3328,8 +3292,6 @@ function getRoeRecords(triggers)
 
         [253] =
         { -- Subjugation: Zi-Ghi Bone-eater
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17363208 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3344,8 +3306,6 @@ function getRoeRecords(triggers)
 
         [255] =
         { -- Subjugation: Teporingo
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17559584 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3360,8 +3320,6 @@ function getRoeRecords(triggers)
 
         [257] =
         { -- Subjugation: Ni'Zho Bladebender
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17223797 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3376,8 +3334,6 @@ function getRoeRecords(triggers)
 
         [259] =
         { -- Subjugation: Simurgh
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17228242 } },
             reward = { sparks = 250, xp = 1000 },
         },
 
@@ -3392,8 +3348,6 @@ function getRoeRecords(triggers)
 
         [261] =
         { -- Subjugation: Demonic Tiphia
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17584398 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3408,8 +3362,6 @@ function getRoeRecords(triggers)
 
         [263] =
         { -- Subjugation: Zo'Khu Blackcloud
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17379564 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3428,8 +3380,6 @@ function getRoeRecords(triggers)
 
         [265] =
         { -- Subjugation: Nunyenunc
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17248517 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3444,8 +3394,6 @@ function getRoeRecords(triggers)
 
         [267] =
         { -- Subjugation: Spiny Spipi
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17252657 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3460,8 +3408,6 @@ function getRoeRecords(triggers)
 
         [269] =
         { -- Subjugation: Hoo Mjuu the Torrent
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17371515 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3476,8 +3422,6 @@ function getRoeRecords(triggers)
 
         [271] =
         { -- Subjugation: Oni Carcass
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17469587 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3492,8 +3436,6 @@ function getRoeRecords(triggers)
 
         [273] =
         { -- Subjugation: Maltha
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17563749 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3508,8 +3450,6 @@ function getRoeRecords(triggers)
 
         [275] =
         { -- Subjugation: Bomb King
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17572094, 17572142, 17572146 } },
             reward = { sparks = 250, xp = 500 },
         },
 
@@ -3524,8 +3464,6 @@ function getRoeRecords(triggers)
 
         [277] =
         { -- Subjugation: Helldiver
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17260907 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3540,8 +3478,6 @@ function getRoeRecords(triggers)
 
         [279] =
         { -- Subjugation: Serpopard Ishtar
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17256563, 17256690 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3556,8 +3492,6 @@ function getRoeRecords(triggers)
 
         [281] =
         { -- Subjugation: Argus
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17588674 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3572,8 +3506,6 @@ function getRoeRecords(triggers)
 
         [283] =
         { -- Subjugation: Daggerclaw Dracos
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17264818 } },
             reward = { sparks = 250, xp = 600 },
         },
 
@@ -3588,8 +3520,6 @@ function getRoeRecords(triggers)
 
         [285] =
         { -- Subjugation: Roc
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17269106 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3604,8 +3534,6 @@ function getRoeRecords(triggers)
 
         [287] =
         { -- Subjugation: Serket
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17596720 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3620,8 +3548,6 @@ function getRoeRecords(triggers)
 
         [289] =
         { -- Subjugation: Lii Jixa the Somnolist
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17395896 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3640,8 +3566,6 @@ function getRoeRecords(triggers)
 
         [291] =
         { -- Subjugation: Nue
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17231971 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3656,8 +3580,6 @@ function getRoeRecords(triggers)
 
         [293] =
         { -- Subjugation: Gloom Eye
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17457204 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3672,8 +3594,6 @@ function getRoeRecords(triggers)
 
         [295] =
         { -- Subjugation: Goliath
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17613046, 17613048, 17613052, 17613054 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3688,8 +3608,6 @@ function getRoeRecords(triggers)
 
         [297] =
         { -- Subjugation: Biast
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17235988 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3704,8 +3622,6 @@ function getRoeRecords(triggers)
 
         [299] =
         { -- Subjugation: Duke Haborym
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17436923 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3720,8 +3636,6 @@ function getRoeRecords(triggers)
 
         [301] =
         { -- Subjugation: Baron Vapula
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17440963 } },
             reward = { sparks = 250, xp = 800 },
         },
 
@@ -3736,8 +3650,6 @@ function getRoeRecords(triggers)
 
         [303] =
         { -- Subjugation: Dosetsu Tree
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17293640 } },
             reward = { sparks = 500, xp = 1000 },
         },
 
@@ -3752,8 +3664,6 @@ function getRoeRecords(triggers)
 
         [305] =
         { -- Subjugation: Epialtes
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17530881 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3768,8 +3678,6 @@ function getRoeRecords(triggers)
 
         [307] =
         { -- Subjugation: Ogygos
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17420592 } },
             reward = { sparks = 250, xp = 700 },
         },
 
@@ -3784,8 +3692,6 @@ function getRoeRecords(triggers)
 
         [309] =
         { -- Subjugation: Enkelados
-            trigger = triggers.mobKill,
-            reqs = { mobID = set { 17424385, 17424423 } },
             reward = { sparks = 250, xp = 800 },
         },
 

--- a/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
@@ -4,6 +4,7 @@
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
 require("scripts/globals/mobs")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -24,6 +25,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     mob:setLocalVar("death", 1)
+    xi.roe.onRecordTrigger(player, 242)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Beadeaux/mobs/ZoKhu_Blackcloud.lua
+++ b/scripts/zones/Beadeaux/mobs/ZoKhu_Blackcloud.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 242)
+    xi.roe.onRecordTrigger(player, 263)
 end
 
 return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Nue.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Nue.lua
@@ -1,10 +1,13 @@
 -----------------------------------
--- Area: Beaucedine Glacier (111)
+-- Area: Beaucedine Glacier
 --   NM: Nue
+-----------------------------------
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 291)
 end
 
 return entity

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker.lua
@@ -7,6 +7,7 @@
 local ID = require("scripts/zones/Bostaunieux_Oubliette/IDs")
 require("scripts/globals/regimes")
 require("scripts/globals/mobs")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -22,6 +23,9 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 613, 1, xi.regime.type.GROUNDS)
+    if mob:getID() == ID.mob.BLOODSUCKER then
+        xi.roe.onRecordTrigger(player, 228)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Buburimu_Peninsula/mobs/Helldiver.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Helldiver.lua
@@ -3,11 +3,13 @@
 --  Mob: Helldiver
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 262)
+    xi.roe.onRecordTrigger(player, 277)
 end
 
 return entity

--- a/scripts/zones/Castle_Oztroja/mobs/Lii_Jixa_the_Somnolist.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Lii_Jixa_the_Somnolist.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 306)
+    xi.roe.onRecordTrigger(player, 289)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Duke_Haborym.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Duke_Haborym.lua
@@ -2,9 +2,12 @@
 -- Area: Castle Zvahl Baileys (161)
 --   NM: Duke Haborym
 -----------------------------------
+require("scripts/globals/roe")
+-----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 299)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Baron_Vapula.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Baron_Vapula.lua
@@ -3,13 +3,15 @@
 --  Mob: Baron Vapula
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 354)
     player:addTitle(xi.title.HELLSBANE)
+    xi.hunts.checkHunt(mob, player, 354)
+    xi.roe.onRecordTrigger(player, 301)
 end
 
 return entity

--- a/scripts/zones/Crawlers_Nest/mobs/Demonic_Tiphia.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Demonic_Tiphia.lua
@@ -3,11 +3,13 @@
 --  Mob: Demonic Tiphia
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 236)
+    xi.roe.onRecordTrigger(player, 261)
 end
 
 return entity

--- a/scripts/zones/Dangruf_Wadi/mobs/Teporingo.lua
+++ b/scripts/zones/Dangruf_Wadi/mobs/Teporingo.lua
@@ -3,11 +3,13 @@
 --   NM: Teporingo
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 223)
+    xi.roe.onRecordTrigger(player, 255)
 end
 
 return entity

--- a/scripts/zones/Davoi/mobs/Hawkeyed_Dnatbat.lua
+++ b/scripts/zones/Davoi/mobs/Hawkeyed_Dnatbat.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 192)
+    xi.roe.onRecordTrigger(player, 246)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Swamfisk.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Swamfisk.lua
@@ -3,11 +3,13 @@
 --   NM: Swamfisk
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 150)
+    xi.roe.onRecordTrigger(player, 218)
 end
 
 return entity

--- a/scripts/zones/East_Sarutabaruta/mobs/Spiny_Spipi.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Spiny_Spipi.lua
@@ -3,11 +3,13 @@
 --   NM: Spiny Spipi
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 253)
+    xi.roe.onRecordTrigger(player, 267)
 end
 
 return entity

--- a/scripts/zones/FeiYin/mobs/Goliath.lua
+++ b/scripts/zones/FeiYin/mobs/Goliath.lua
@@ -2,12 +2,14 @@
 -- Area: Fei'Yin
 --   NM: Goliath
 -----------------------------------
+require("scripts/globals/roe")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.GOLIATH_KILLER)
+    xi.roe.onRecordTrigger(player, 295)
 end
 
 return entity

--- a/scripts/zones/Fort_Ghelsba/mobs/Hundredscar_Hajwaj.lua
+++ b/scripts/zones/Fort_Ghelsba/mobs/Hundredscar_Hajwaj.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 172)
+    xi.roe.onRecordTrigger(player, 222)
 end
 
 return entity

--- a/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Serket.lua
@@ -3,6 +3,7 @@
 --   NM: Serket
 -----------------------------------
 mixins = { require("scripts/mixins/rage") }
+require("scripts/globals/roe")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
@@ -18,6 +19,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.SERKET_BREAKER)
+    xi.roe.onRecordTrigger(player, 287)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Ghelsba_Outpost/mobs/Thousandarm_Deshglesh.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Thousandarm_Deshglesh.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 170)
+    xi.roe.onRecordTrigger(player, 220)
 end
 
 return entity

--- a/scripts/zones/Giddeus/mobs/Hoo_Mjuu_the_Torrent.lua
+++ b/scripts/zones/Giddeus/mobs/Hoo_Mjuu_the_Torrent.lua
@@ -4,6 +4,7 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -18,6 +19,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 281)
+    xi.roe.onRecordTrigger(player, 269)
 end
 
 return entity

--- a/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
@@ -2,9 +2,12 @@
 -- Area: Gusgen Mines
 --   NM: Juggler Hecatomb
 -----------------------------------
+require("scripts/globals/roe")
+-----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 234)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Maltha.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Maltha.lua
@@ -3,11 +3,13 @@
 --   NM: Maltha
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 288)
+    xi.roe.onRecordTrigger(player, 273)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -8,6 +8,7 @@ mixins =
     require("scripts/mixins/rage")
 }
 require("scripts/globals/mobs")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -34,6 +35,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 240)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Barbastelle.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Barbastelle.lua
@@ -3,11 +3,13 @@
 --   NM: Barbastelle
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 175)
+    xi.roe.onRecordTrigger(player, 226)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
@@ -4,6 +4,7 @@
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/mobs")
+require("scripts/globals/roe")
 require("scripts/quests/tutorial")
 -----------------------------------
 local entity = {}
@@ -25,6 +26,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.tutorial.onMobDeath(player)
+    xi.roe.onRecordTrigger(player, 232)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
@@ -3,6 +3,7 @@
 --   NM: Bloodtear Baldurf
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 require("scripts/quests/tutorial")
@@ -26,6 +27,7 @@ end
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.THE_HORNSPLITTER)
     xi.tutorial.onMobDeath(player)
+    xi.roe.onRecordTrigger(player, 236)
 end
 
 return entity

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Epialtes.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Epialtes.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 340)
+    xi.roe.onRecordTrigger(player, 305)
 end
 
 return entity

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
@@ -3,10 +3,12 @@
 --   NM: Argus
 -----------------------------------
 local ID = require("scripts/zones/Maze_of_Shakhrami/IDs")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 281)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Meriphataud_Mountains/mobs/Daggerclaw_Dracos.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Daggerclaw_Dracos.lua
@@ -4,12 +4,14 @@
 -----------------------------------
 require("scripts/globals/hunts")
 require("scripts/globals/regimes")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 268)
     xi.regime.checkRegime(player, mob, 39, 1, xi.regime.type.FIELDS)
+    xi.roe.onRecordTrigger(player, 283)
 end
 
 return entity

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Ogygos.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Ogygos.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 339)
+    xi.roe.onRecordTrigger(player, 307)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Maighdean_Uaine.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Maighdean_Uaine.lua
@@ -3,11 +3,13 @@
 --   NM: Maighdean Uaine
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 198)
+    xi.roe.onRecordTrigger(player, 248)
 end
 
 return entity

--- a/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
@@ -2,6 +2,7 @@
 -- Area: Ordelles Caves (193)
 --   NM: Morbolger
 -----------------------------------
+require("scripts/globals/roe")
 require("scripts/globals/status")
 require("scripts/globals/titles")
 -----------------------------------
@@ -13,6 +14,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.MORBOLBANE)
+    xi.roe.onRecordTrigger(player, 238)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Bomb_King.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Bomb_King.lua
@@ -2,9 +2,12 @@
 -- Area: Outer Horutoto Ruins (194)
 --   NM: Bomb King
 -----------------------------------
+require("scripts/globals/roe")
+-----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 275)
 end
 
 return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/NiZho_Bladebender.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/NiZho_Bladebender.lua
@@ -2,14 +2,16 @@
 -- Area: Pashhow Marshlands
 --   NM: Ni'Zho Bladebender
 -----------------------------------
-require("scripts/globals/regimes")
 require("scripts/globals/hunts")
+require("scripts/globals/regimes")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 60, 1, xi.regime.type.FIELDS)
     xi.hunts.checkHunt(mob, player, 214)
+    xi.regime.checkRegime(player, mob, 60, 1, xi.regime.type.FIELDS)
+    xi.roe.onRecordTrigger(player, 257)
 end
 
 return entity

--- a/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
+++ b/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
@@ -1,16 +1,13 @@
 -----------------------------------
--- Area: Palborough Mines
---   NM: Zi'Ghi Boneeater
+-- Area: Qufim Island
+--   NM: Dosetsu Tree
 -----------------------------------
-mixins = { require("scripts/mixins/job_special") }
-require("scripts/globals/hunts")
 require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 220)
-    xi.roe.onRecordTrigger(player, 253)
+    xi.roe.onRecordTrigger(player, 303)
 end
 
 return entity

--- a/scripts/zones/Ranguemont_Pass/mobs/Gloom_Eye.lua
+++ b/scripts/zones/Ranguemont_Pass/mobs/Gloom_Eye.lua
@@ -3,6 +3,7 @@
 --   NM: Gloom Eye
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 require("scripts/globals/status")
 require("scripts/globals/utils")
 -----------------------------------
@@ -27,6 +28,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 346)
+    xi.roe.onRecordTrigger(player, 293)
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Simurgh.lua
@@ -3,12 +3,14 @@
 --  HNM: Simurgh
 -----------------------------------
 mixins = { require("scripts/mixins/rage") }
+require("scripts/globals/roe")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.SIMURGH_POACHER)
+    xi.roe.onRecordTrigger(player, 259)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Roc.lua
@@ -3,12 +3,14 @@
 --  HNM: Roc
 -----------------------------------
 mixins = { require("scripts/mixins/rage") }
+require("scripts/globals/roe")
 require("scripts/globals/titles")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     player:addTitle(xi.title.ROC_STAR)
+    xi.roe.onRecordTrigger(player, 285)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/South_Gustaberg/mobs/Carnero.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Carnero.lua
@@ -3,11 +3,13 @@
 --   NM: Carnero
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 202)
+    xi.roe.onRecordTrigger(player, 250)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Serpopard_Ishtar.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Serpopard_Ishtar.lua
@@ -3,11 +3,13 @@
 --   NM: Serpopard Ishtar
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 257)
+    xi.roe.onRecordTrigger(player, 279)
 end
 
 return entity

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Cwn_Cyrff.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Cwn_Cyrff.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 191)
+    xi.roe.onRecordTrigger(player, 244)
 end
 
 return entity

--- a/scripts/zones/Toraimarai_Canal/mobs/Oni_Carcass.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Oni_Carcass.lua
@@ -3,10 +3,12 @@
 --   NM: Oni Carcass
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 271)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Enkelados.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Enkelados.lua
@@ -4,11 +4,13 @@
 -----------------------------------
 require("scripts/globals/hunts")
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 331)
+    xi.roe.onRecordTrigger(player, 309)
 end
 
 return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Valkurm_Emperor.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Valkurm_Emperor.lua
@@ -3,11 +3,13 @@
 --   NM: Valkurm Emperor
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 209)
+    xi.roe.onRecordTrigger(player, 230)
 end
 
 return entity

--- a/scripts/zones/West_Ronfaure/mobs/Jaggedy-Eared_Jack.lua
+++ b/scripts/zones/West_Ronfaure/mobs/Jaggedy-Eared_Jack.lua
@@ -3,11 +3,13 @@
 --   NM: Jaggedy-Eared Jack
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 148)
+    xi.roe.onRecordTrigger(player, 216)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Nunyenunc.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Nunyenunc.lua
@@ -3,6 +3,7 @@
 --   NM: Nunyenunc
 -----------------------------------
 require("scripts/globals/hunts")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -12,6 +13,7 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 251)
+    xi.roe.onRecordTrigger(player, 265)
 end
 
 return entity

--- a/scripts/zones/Xarcabard/mobs/Biast.lua
+++ b/scripts/zones/Xarcabard/mobs/Biast.lua
@@ -3,6 +3,7 @@
 --   NM: Biast
 -----------------------------------
 require("scripts/globals/mobs")
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
@@ -15,6 +16,7 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 297)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Yughott_Grotto/mobs/Ashmaker_Gotblut.lua
+++ b/scripts/zones/Yughott_Grotto/mobs/Ashmaker_Gotblut.lua
@@ -3,10 +3,12 @@
 --   NM: Ashmaker Gotblut
 -----------------------------------
 mixins = { require("scripts/mixins/job_special") }
+require("scripts/globals/roe")
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.roe.onRecordTrigger(player, 224)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Many Records of Eminence objectives are tied to specific mob IDs. In addition to presenting possible issues if the mob IDs shift, the objectives are processed on every mob killed in the game. So it was decided in a group chat that the best way forward would be to move as many of these objectives as possible into the onMobDeath function of the mob's scripts themselves. This PR will adjust as many of those as possible in this fashion unless some interesting issue appears.

## Steps to test these changes

Import changes, flag RoE, kill NM.
