### PR TITLE
[Fix] Prevent trusts from healing if master has enmity

### DIFF
--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -32,6 +32,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../../entities/trustentity.h"
 #include "../../items/item_weapon.h"
 #include "../../mob_spell_container.h"
+#include "../../notoriety_container.h"
 #include "../../packets/char.h"
 #include "../../recast_container.h"
 #include "../../status_effect_container.h"
@@ -277,7 +278,7 @@ void CTrustController::DoRoamTick(time_point tick)
     }
 
     if (POwner->CanRest() && m_Tick - POwner->LastAttacked > m_tickDelays.at(0) && m_Tick - m_CombatEndTime > m_tickDelays.at(0) &&
-        m_Tick - m_LastHealTickTime > m_tickDelays.at(m_NumHealingTicks))
+        m_Tick - m_LastHealTickTime > m_tickDelays.at(m_NumHealingTicks) && !POwner->PMaster->PNotorietyContainer->hasEnmity())
     {
         if (POwner->health.hp != POwner->health.maxhp || POwner->health.mp != POwner->health.maxmp)
         {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As title suggests.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Summon any trust.
!inmortal yourself, a mob and your trust.

Engage a mob, !hp 1 your trustand turn arround and/or disengage.

Whats the trust not heal until mob is dead or enmity is lost.