### PR TITLE
Resolve some issues with `PrintToArea()`

### DIFF
--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -53,6 +53,7 @@ xi.msg.area =
     SHOUT       = 2, -- Will display in wide area around player
     PARTY       = 3, -- Will display to players entire party/alliance
     YELL        = 4, -- If yell is enabled in zone, will display.
+    UNITY       = 5, -- Also World Wide
 }
 
 -----------------------------------

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -336,31 +336,44 @@ void CLuaBaseEntity::PrintToArea(std::string const& message, sol::object const& 
 
     // see scripts\globals\msg.lua or src\map\packets\chat_message.h for values
     CHAT_MESSAGE_TYPE messageLook  = (arg1 == sol::lua_nil) ? MESSAGE_SYSTEM_1 : arg1.as<CHAT_MESSAGE_TYPE>();
-    uint8             messageRange = (arg2 == sol::lua_nil) ? 0 : arg2.as<uint8>();
+    uint8             messageRange = (arg2 == sol::lua_nil) ? MESSAGE_AREA_SYSTEM : arg2.as<CHAT_MESSAGE_AREA>();
     std::string       name         = (arg3 == sol::lua_nil) ? std::string() : arg3.as<std::string>();
 
-    if (messageRange == 0) // All zones world wide
+    if (messageRange == MESSAGE_AREA_SYSTEM)
     {
         message::send(MSG_CHAT_SERVMES, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
     }
-    else if (messageRange == 1) // Say range
+    else if (messageRange == MESSAGE_AREA_SAY)
     {
         PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
     }
-    else if (messageRange == 2) // Shout
+    else if (messageRange == MESSAGE_AREA_SHOUT)
     {
         PChar->loc.zone->PushPacket(PChar, CHAR_INSHOUT, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
     }
-    else if (messageRange == 3) // Party and Alliance
+    else if (messageRange == MESSAGE_AREA_PARTY)
     {
         message::send(MSG_CHAT_PARTY, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
     }
-    else if (messageRange == 4) // Yell zones only
+    else if (messageRange == MESSAGE_AREA_YELL)
     {
         message::send(MSG_CHAT_YELL, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+    }
+    else if (messageRange == MESSAGE_AREA_UNITY)
+    {
+        message::send(MSG_CHAT_UNITY, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
+        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+    }
+    else
+    {
+        ShowError("CLuaBaseEntity::PrintToArea : invalid message area/messageRange value %u given by script.", messageRange);
     }
     /*
-    Todo: Unity, LS 1 and LS 2 for the lols?
+    Todo: Assist channels
     */
 }
 

--- a/src/map/packets/chat_message.h
+++ b/src/map/packets/chat_message.h
@@ -26,6 +26,7 @@
 
 #include "basic.h"
 
+// Extracted from client.
 enum CHAT_MESSAGE_TYPE
 {
     MESSAGE_SAY       = 0,
@@ -62,6 +63,18 @@ enum CHAT_MESSAGE_TYPE
     MESSAGE_UNITY         = 33,
     MESSAGE_JP_ASSIST     = 34,
     MESSAGE_NA_ASSIST     = 35,
+};
+
+// Made up, but if you edit this to change the order,
+// You will break things that expect this order.
+enum CHAT_MESSAGE_AREA
+{
+    MESSAGE_AREA_SYSTEM = 0, // All zones world wide
+    MESSAGE_AREA_SAY    = 1, // Say range
+    MESSAGE_AREA_SHOUT  = 2, // Shout
+    MESSAGE_AREA_PARTY  = 3, // Party and Alliance
+    MESSAGE_AREA_YELL   = 4, // Yell zones only
+    MESSAGE_AREA_UNITY  = 5, // Currently -all- unities
 };
 
 class CCharEntity;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
 - Certain kinds of messaging could not be seen by the triggering entity (because at some point the message server was adjusted to omit the sending entity)
 - The values were magic numbered and not enumerated
 - There wasn't anything to indicate user error from sending invalid values, now there is
 - Unity chat wasn't supported, now it is

Co-Authored-By: claywar

Without whom I might have taken ages to realize wtf was happening.

## Steps to test these changes
log in 2 characters and do :

`!exec player:PrintToArea("test!", 4, 2, "Dummy")`

While SOLO and see every characters sees **party** chat in **shout** range of the solo character, as originally intended.

Side note: I dislike this if/else tower, and considered a switch but that just made it taller if formatted properly. If you got a better idea, feel free to PR it.