### PR TITLE
Move LoadSetSpells() back before BuildingCharTraitsTable() in LoadChar()

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -860,13 +860,13 @@ namespace charutils
         charutils::LoadInventory(PChar);
 
         CalculateStats(PChar);
+        blueutils::LoadSetSpells(PChar);
         BuildingCharSkillsTable(PChar);
         BuildingCharAbilityTable(PChar);
         BuildingCharTraitsTable(PChar);
         jobpointutils::RefreshGiftMods(PChar);
 
         // Order matters as these use merits and JP gifts
-        blueutils::LoadSetSpells(PChar);
         puppetutils::LoadAutomaton(PChar);
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -860,13 +860,16 @@ namespace charutils
         charutils::LoadInventory(PChar);
 
         CalculateStats(PChar);
+        jobpointutils::RefreshGiftMods(PChar);
+
+        // This must come after refreshing gift modifiers, but before loading job traits.
         blueutils::LoadSetSpells(PChar);
+
         BuildingCharSkillsTable(PChar);
         BuildingCharAbilityTable(PChar);
         BuildingCharTraitsTable(PChar);
-        jobpointutils::RefreshGiftMods(PChar);
 
-        // Order matters as these use merits and JP gifts
+        // Order matters as this uses merits and JP gifts.
         puppetutils::LoadAutomaton(PChar);
 
         PChar->animation = (HP == 0 ? ANIMATION_DEATH : ANIMATION_NONE);


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This was moved in c652ebdec7a0fa212dc34eb2545266cdea8275e1 which meant that PChar->m_SetBlueSpells is still all 0 in blueutils::CalculateTraits(), resulting in Blue Mage players logging in with their BLU traits missing.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !addspell 612 \<me\>
2. !addspell 615 \<me\>
3. Equip both spells to get auto-refresh, observe how the trait is lost after logging out/zoning
4. Apply this patch
5. Observe how the trait now appears after logging in/zoning
<!-- Clear and detailed steps to test your changes here -->
