### PR TITLE
correct line between player ws & mob tp attacks for trust type entities

### DIFF
--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -734,7 +734,7 @@ namespace trustutils
         for (uint16 skill_id : skillList)
         {
             TrustSkill_t skill;
-            if (skill_id <= 240) // Player WSs
+            if (skill_id <= 255) // Player WSs
             {
                 CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(skill_id);
                 if (!PWeaponSkill)


### PR DESCRIPTION
Anything above 255 is a mobskill, anything below 256 is a player ws - this even includes fomor/shadow skill

While no trust currently uses those, if one were to ever be added it would fail from being considered the wrong type

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects the dividing point between player style ws and mob tp attacks for trust type entities

References:
 - ROM\27\80.dat showing first mob tp attack in its index:  
  `00001	Foot Kick`  
  (note: we currently use the "zeroth" ID as a dummy for another copy of self destruct, no idea why but possibly a mistake as self destruct is 255 which would be 511 with the offset, and we already have a copy at 511.. )
 - our database showing we add 256 to avoid WS ID collision:  
  `INSERT INTO mob_skills VALUES (257,1,'foot_kick',0,7.0,2000,1500,4,0,0,0,0,0,0);`

## Steps to test these changes
Give a trust the right model for it (player type or _maybe_ one that already has a gun) and a new skill list with Vulcan Shot in it. If the model isn't right it won't animate as expected but should say the correct skill name in the chat. 
