### PR TITLE
Roaming distance

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -470,13 +470,15 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
 
     auto m_turnLength = xirand::GetRandomNumber((int)maxTurns) + 1;
 
-    position_t startPosition = start;
+    // Seemingly arbitrary value to pass for maxRadius, all values seem to give similar results, likely due to navmesh polygons being too dense?
+    float maxRadiusForPolyQuery = maxRadius / 10.f;
+    position_t startPosition    = start;
 
-    // find end points for turns
-    for (int i = 0; i < m_turnLength; i++)
+    // find end points for turns, iterate potentially twice as many times to account for erroneous turnPoints
+    for (int i = 0; i < m_turnLength * 2; i++)
     {
-        // look for new point centered around the last point
-        auto status = m_POwner->loc.zone->m_navMesh->findRandomPosition(startPosition, maxRadius);
+        // look for new turnPoint. findRandomPosition doesn't guarantee the new point is within the radius
+        auto status = m_POwner->loc.zone->m_navMesh->findRandomPosition(startPosition, maxRadiusForPolyQuery);
 
         // couldn't find one point so just break out
         if (status.first != 0)
@@ -484,12 +486,24 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
             return false;
         }
 
-        m_turnPoints.push_back(status.second);
-        // setting this chains the roaming points, drawing circles around each subsequent roaming turn
-        // startPosition = m_turnPoints[i];
+        float distSq = distanceSquared(startPosition, status.second, true);
+        // only add the roam point if it's _actually_ within range of the spawn point...
+        if (distSq < maxRadius * maxRadius)
+        {
+            m_turnPoints.push_back(status.second);
+        }
+        // else
+        // {
+        //     ShowDebug("CPathFind::FindRandomPath (%s - %d) random point too far: sq distance (%f)", m_POwner->GetName(), m_POwner->id, distSq);
+        // }
+        if (m_turnPoints.size() >= m_turnLength)
+            break;
     }
-    m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
-    m_currentPoint = 0;
+    if (m_turnPoints.size() > 0)
+    {
+        m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
+        m_currentPoint = 0;
+    }
 
     return !m_points.empty();
 }

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -468,7 +468,7 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
         return false;
     }
 
-    auto m_turnLength = xirand::GetRandomNumber((int)maxTurns) + 1;
+    auto m_turnLength = static_cast<uint8>(xirand::GetRandomNumber<uint32>(maxTurns)) + 1;
 
     // Seemingly arbitrary value to pass for maxRadius, all values seem to give similar results, likely due to navmesh polygons being too dense?
     float      maxRadiusForPolyQuery = maxRadius / 10.f;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -471,8 +471,8 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
     auto m_turnLength = xirand::GetRandomNumber((int)maxTurns) + 1;
 
     // Seemingly arbitrary value to pass for maxRadius, all values seem to give similar results, likely due to navmesh polygons being too dense?
-    float maxRadiusForPolyQuery = maxRadius / 10.f;
-    position_t startPosition    = start;
+    float      maxRadiusForPolyQuery = maxRadius / 10.f;
+    position_t startPosition         = start;
 
     // find end points for turns, iterate potentially twice as many times to account for erroneous turnPoints
     for (int i = 0; i < m_turnLength * 2; i++)

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -468,7 +468,7 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
         return false;
     }
 
-    auto m_turnLength = static_cast<uint8>(xirand::GetRandomNumber<uint32>(maxTurns)) + 1;
+    auto m_turnLength = static_cast<uint8_t>(xirand::GetRandomNumber<uint32>(maxTurns) + 1);
 
     // Seemingly arbitrary value to pass for maxRadius, all values seem to give similar results, likely due to navmesh polygons being too dense?
     float      maxRadiusForPolyQuery = maxRadius / 10.f;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -485,7 +485,8 @@ bool CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
         }
 
         m_turnPoints.push_back(status.second);
-        startPosition = m_turnPoints[i];
+        // setting this chains the roaming points, drawing circles around each subsequent roaming turn
+        // startPosition = m_turnPoints[i];
     }
     m_points       = m_POwner->loc.zone->m_navMesh->findPath(start, m_turnPoints[0]);
     m_currentPoint = 0;

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -507,7 +507,7 @@ void CMobEntity::PostTick()
 
 float CMobEntity::GetRoamDistance()
 {
-    return (float)getMobMod(MOBMOD_ROAM_DISTANCE) / 10.0f;
+    return (float)getMobMod(MOBMOD_ROAM_DISTANCE);
 }
 
 float CMobEntity::GetRoamRate()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mob roaming was noticed to wander much further than the value of `MOBMOD_ROAM_DISTANCE`. After some digging it seemed to just be an issue with the navmesh query `findRandomPointAroundCircle`, but after some poking I noticed that the pathfind function `FindRandomPath` was adjusting `startPosition` every iteration of turns. This meant that for mobs with `MOBMOD_ROAM_TURNS` greater than 1, they could effectively chain their roaming points further and further from their spawn point. I'm not sure if this is by design or not, but it seems inaccurate.

After making each roam turn choose a point centered around the spawn position, it was still noticed that roaming was too wide. Seemed like perhaps the units of the radius are off. Traced down `PMob->GetRoamDistance()` only ever being called in the `mob_controller` roam code when calling the aforementioned random roaming circle radius. Removed the arbitrary division by 10 and stored a separate value for the `findRandomPath` call. I am completely ignorant on the units of the detour library and navmesh pointmaps... I've tried various divisors for the `maxRadius` parameter for `findRandomPosition` and nothing seems to make a difference. 

The mobs just roam less frequently with this change, as any points returned by pathfind outside of their roaming radius are just ignored. I know it's inefficient. I know it should be better, I'm just not sure how to improve it.

According to [this comment](https://github.com/recastnavigation/recastnavigation/issues/236#issuecomment-248862072), the max radius doesn't limit the distance the picked point is from the start, it limits the polygons selected for the query. It seems [very complex](https://github.com/recastnavigation/recastnavigation/discussions/606) to fully limit the area for a dtQuery. 

Curious if this is a "good enough" solution to the problem of limiting roam range? This solution results in 
 - what seems like similar roaming frequency
 - more calls to `m_navMesh->findRandomPosition` on average, since erroneous turnPoints are discarded
 - guaranteed roaming turnPoints within the `roam_distance` mobmod

## Steps to test these changes

I used a particular spot as a test before and after, mobid 17199307 in valk dunes.
 - !despawnmob 17199307 
 - !spawnmob 17199307 
 - !gotoid 17199307 
 - This puts you on the mob's spawn point. Select the mob and lock on with the distance addon.
 - to speed up the testing, you can `!setmod move 100` and `!setmobmod roam_cool 1`