### PR TITLE
Add MOBMOD_NO_WIDESCAN & CMobEntity::isWideScannable()

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2587,6 +2587,7 @@ xi.mobMod =
     TARGET_DISTANCE_OFFSET = 73, -- Adjusts how close a mob will move to it's target. 12 = 1.2 yalm. Positive values to go closer, negative farther.
     ONE_WAY_LINKING        = 74, -- Will link with other mobs in its party (typically the same mob family) while roaming, but will not let others link with it once engaged
     CAN_PARRY              = 75, -- Check if a mob is allowed to have parry rank (Rank Value 1-5)
+    NO_WIDESCAN            = 76, -- Disables widescan for a specific mob
 }
 
 -----------------------------------

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1468,3 +1468,8 @@ bool CMobEntity::OnAttack(CAttackState& state, action_t& action)
         return CBattleEntity::OnAttack(state, action);
     }
 }
+
+bool CMobEntity::isWideScannable()
+{
+    return CBaseEntity::isWideScannable() && !getMobMod(MOBMOD_NO_WIDESCAN);
+}

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -178,6 +178,7 @@ public:
 
     virtual void Spawn() override;
     virtual void FadeOut() override;
+    virtual bool isWideScannable() override;
 
     bool   m_AllowRespawn; // if true, allow respawn
     uint32 m_RespawnTime;  // respawn time

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -104,6 +104,7 @@ enum MOBMODIFIER : int
     MOBMOD_TARGET_DISTANCE_OFFSET = 73, // Adjusts how close a mob will move to it's target. 12 = 1.2 yalm. Positive values to go closer, negative farther.
     MOBMOD_ONE_WAY_LINKING        = 74, // Will link with other mobs in its party (typically the same mob family) while roaming, but will not let others link with it once engaged
     MOBMOD_CAN_PARRY              = 75, // Check if a mob is allowed to have parry rank (Rank Value 1-5)
+    MOBMOD_NO_WIDESCAN            = 76, // Disables widescan for a specific mob
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds ability to remove mobs from widescan. 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
mob:setMobMod(xi.mobMod.MOBMOD_NO_WIDESCAN, 1)
<!-- Clear and detailed steps to test your changes here -->
