### PR TITLE
[lua] Improve Gusgen Mines lever doors to be more retail accurate

### DIFF
--- a/scripts/zones/Gusgen_Mines/npcs/_5ga.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5ga.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 6):setAnimation(8) --open door C (_5g0)
-        GetNPCByID(lever - 5):setAnimation(9) --close door B (_5g1)
-        GetNPCByID(lever - 4):setAnimation(9) --close door A (_5g2)
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 6):setAnimation(8) --open door C (_5g0)
+            GetNPCByID(lever - 5):setAnimation(9) --close door B (_5g1)
+            GetNPCByID(lever - 4):setAnimation(9) --close door A (_5g2)
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gb.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gb.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 7):setAnimation(9) --close door C
-        GetNPCByID(lever - 6):setAnimation(8) --open door B
-        GetNPCByID(lever - 5):setAnimation(9) --close door A
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 7):setAnimation(9) --close door C
+            GetNPCByID(lever - 6):setAnimation(8) --open door B
+            GetNPCByID(lever - 5):setAnimation(9) --close door A
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gc.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gc.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 8):setAnimation(9) -- close door C
-        GetNPCByID(lever - 7):setAnimation(9) -- close door B
-        GetNPCByID(lever - 6):setAnimation(8) -- open door A
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 8):setAnimation(9) -- close door C
+            GetNPCByID(lever - 7):setAnimation(9) -- close door B
+            GetNPCByID(lever - 6):setAnimation(8) -- open door A
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gd.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gd.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 6):setAnimation(8) -- open door F
-        GetNPCByID(lever - 5):setAnimation(9) -- close door E
-        GetNPCByID(lever - 4):setAnimation(9) -- close door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 6):setAnimation(8) -- open door F
+            GetNPCByID(lever - 5):setAnimation(9) -- close door E
+            GetNPCByID(lever - 4):setAnimation(9) -- close door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5ge.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5ge.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 7):setAnimation(9) -- close door F
-        GetNPCByID(lever - 6):setAnimation(8) -- open door E
-        GetNPCByID(lever - 5):setAnimation(9) -- close door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 7):setAnimation(9) -- close door F
+            GetNPCByID(lever - 6):setAnimation(8) -- open door E
+            GetNPCByID(lever - 5):setAnimation(9) -- close door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)

--- a/scripts/zones/Gusgen_Mines/npcs/_5gf.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/_5gf.lua
@@ -9,14 +9,20 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local lever = npc:getID()
-
     npc:openDoor(2) -- Lever animation
-    if GetNPCByID(lever - 6):getAnimation() == 9 then
-        GetNPCByID(lever - 8):setAnimation(9) -- close door F
-        GetNPCByID(lever - 7):setAnimation(9) -- close door E
-        GetNPCByID(lever - 6):setAnimation(8) -- open door D
-    end
+
+    npc:timer(750, function(npcArg)
+        local lever = npcArg:getID()
+
+        if GetNPCByID(lever - 6):getAnimation() == 9 then
+            -- send dustcloud animation
+            SendEntityVisualPacket(GetNPCByID(lever - 6):getID(), "kem1")
+
+            GetNPCByID(lever - 8):setAnimation(9) -- close door F
+            GetNPCByID(lever - 7):setAnimation(9) -- close door E
+            GetNPCByID(lever - 6):setAnimation(8) -- open door D
+        end
+    end)
 end
 
 entity.onEventUpdate = function(player, csid, option)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add missing dustcloud animation, slight delay on lever pull.

## Steps to test these changes

Pull levers, see slight delay, dustcloud when doors open