### PR TITLE
[lua] Add missing fog effect to Al'Taieu

### DIFF
--- a/scripts/zones/AlTaieu/Zone.lua
+++ b/scripts/zones/AlTaieu/Zone.lua
@@ -49,4 +49,8 @@ zoneObject.onEventFinish = function(player, csid, option)
     end
 end
 
+zoneObject.afterZoneIn = function(player)
+    player:entityVisualPacket("on00", player) -- Fog effect on zone in
+end
+
 return zoneObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sends an entity visual packet to show fog in the zone

Before packet:
![image](https://github.com/LandSandBoat/server/assets/60417494/a52c38ee-a87e-4eb9-8750-d0d62b1603e5)
after packet:
![image](https://github.com/LandSandBoat/server/assets/60417494/bbc427a2-4eef-4598-9196-34f93ad5f23f)

## Steps to test these changes

Zone into sea, and see fog (once the afterZoneIn event triggers.)
