### PR TITLE
create `facePlayer()` for use with dynamic NPCs

### DIFF
--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -124,6 +124,7 @@ public:
     bool  canUseAbilities();
 
     void lookAt(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2); // look at given position
+    void facePlayer(CLuaBaseEntity* PLuaBaseEntity, sol::object const& nonGlobal);          // specifically rotates target to player direction
     void clearTargID();                                                                     // clears target of entity
 
     bool  atPoint(sol::variadic_args va);                                          // is at given point
@@ -132,7 +133,7 @@ public:
     bool  isFollowingPath();                                                       // checks if the entity is following a path
     void  clearPath(sol::object const& pauseObj);                                  // removes current pathfind and stops moving
     void  continuePath();                                                          // resumes previous pathfind if it was paused
-    float checkDistance(sol::variadic_args va);                                    // Check Distacnce and returns distance number
+    float checkDistance(sol::variadic_args va);                                    // Check Distance and returns distance number
     void  wait(sol::object const& milliseconds);                                   // make the npc wait a number of ms and then back into roam
     // int32 WarpTo(lua_Stat* L);           // warp to the given point -- These don't exist, breaking them just in case someone uncomments
     // int32 RoamAround(lua_Stat* L);       // pick a random point to walk to


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
 When we start an event, most npc's that kick off the event face the player. In the client, **this is always tied to the correct NPC even if you fire it off from the wrong NPC**
 
This function will fake the dynamic entity doing this same facing behavior.  

If the NPC need to be restored to its original rotation via `setPosRot()` in `onEventFinish()` (we can't do that inside the `facePlayer()` because it has no idea when your event ends, but its easy enough to toss the current rot to a variable at event start)

This is different from `lookAt()` in a several ways
 - no arbitrary points
 - by default only the player interacting sees the change
 - and my reason for doing it: no changing amount of arguments to deal with

Bonus points: 
- No bobblehead effect from `m_TargID` where the NPCs head tries to follow you forever without the rest of its body.
- No regretting that the creepy stalker head can't do a full 360 rotation coz that would've been sweet for Halloween.

## Steps to test these changes
login 2 characters stand at same NPC. target it and then try:
`!exec target:facePlayer(player)`
`!exec target:facePlayer(player, true)`
`!exec target:facePlayer(player, false`)
And observe the expected behavior of defaulting to only seeing the rotation on 1 of your 2 characters unless explicitly state "false".