### PR TITLE
[sql] Fix minstrel ring latent

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -439,7 +439,7 @@ INSERT INTO `item_latents` VALUES (13294,238,3,2,75);    -- Enhances "Luminion K
 -- -------------------------------------------------------
 -- Minstrel's Ring
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES (13295,455,-25,2,75);  -- "Shield Bash"+10 while HP <=75% and TP <=100%
+INSERT INTO `item_latents` VALUES (13295,455,25,2,75);  -- Song Spellcast -25% while HP <=75% and TP <=100%
 
 -- -------------------------------------------------------
 -- Tracker's Ring


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mintstrel ring latent shoudl be +25 not -25,  see
```
        uint16 songcasting = m_PEntity->getMod(MOD_SONG_SPELLCASTING_TIME);
        cast = cast * (1.0f - ((songcasting > 50 ? 50 : songcasting) / 100.0f));
 ```
`uint16` would wrap and be very bad

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Get -25% song casting time with !getmod 445 showing +25 when latent is active