### PR TITLE
Correct Abyssea Blue Weakness Enum (Shadowstitch)

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -509,7 +509,7 @@ local blueWeakness =
         xi.weaponskill.BLAST_SHOT,
         xi.weaponskill.HEAVY_SHOT,
         xi.weaponskill.DETONATOR,
-        xi.weaponskill.SHADOWSTICH,
+        xi.weaponskill.SHADOWSTITCH,
         xi.weaponskill.DANCING_EDGE,
         xi.weaponskill.SHARK_BITE,
         xi.weaponskill.EVISCERATION,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes spelling for blueWeakness enum in Abyssea global (`SHADOWSTITCH`).  This was presenting as startup errors for the abyssea_weakness mixin, and is a result of the updates to xi.weaponskills enum where corrections were made.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Start server several times, see that when Shadowstitch is selected, no error occurs.
<!-- Clear and detailed steps to test your changes here -->
