### PR TITLE
[lua] [drg] Add wyvern's current HP to master's HP upon Spirit Surge

### DIFF
--- a/scripts/globals/effects/spirit_surge.lua
+++ b/scripts/globals/effects/spirit_surge.lua
@@ -12,7 +12,6 @@ effectObject.onEffectGain = function(target, effect)
     -- The dragoon's MAX HP increases by % of wyvern MaxHP
     target:addMod(xi.mod.HP, effect:getPower())
     target:updateHealth()
-    target:addHP(effect:getPower())
 
     -- The dragoon gets a Strength boost relative to his level
     target:addMod(xi.mod.STR, effect:getSubPower())

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -216,6 +216,7 @@ end
 xi.job_utils.dragoon.useSpiritSurge = function(player, target, ability)
     local wyvern = player:getPet()
     local petTP = wyvern:getTP()
+    local petHP = wyvern:getHP()
     local duration = 60
 
     -- Spirit Surge increases dragoon's MAX HP increases by 25% of wyvern MaxHP
@@ -237,6 +238,7 @@ xi.job_utils.dragoon.useSpiritSurge = function(player, target, ability)
     target:resetRecast(xi.recast.ABILITY, 160) -- Super Jump
 
     target:addStatusEffect(xi.effect.SPIRIT_SURGE, maxHPBoost, 0, duration, 0, strBoost)
+    target:addHP(petHP) -- Add in wyvern's remaining HP before the wyvern was despawned
 end
 
 xi.job_utils.dragoon.useCallWyvern = function(player, target, ability)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin, wyvern's current HP transfers to the wyvern
https://www.bg-wiki.com/ffxi/Spirit_Surge

## Steps to test these changes
Use spirit surge and get the remaining HP of wyvern transferred to you
