### PR TITLE
[lua] Fix Geomancy haste/slow unit scaling & ATTP/DEFP mods

### DIFF
--- a/scripts/globals/effects/geo_attack_boost.lua
+++ b/scripts/globals/effects/geo_attack_boost.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ATT, effect:getPower())
+    target:addMod(xi.mod.ATTP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ATT, effect:getPower())
+    target:delMod(xi.mod.ATTP, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/geo_attack_down.lua
+++ b/scripts/globals/effects/geo_attack_down.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ATT, -effect:getPower())
+    target:addMod(xi.mod.ATTP, -effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ATT, -effect:getPower())
+    target:delMod(xi.mod.ATTP, -effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/geo_defense_boost.lua
+++ b/scripts/globals/effects/geo_defense_boost.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.DEF, effect:getPower())
+    target:addMod(xi.mod.DEFP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.DEF, effect:getPower())
+    target:delMod(xi.mod.DEFP, effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/geo_defense_down.lua
+++ b/scripts/globals/effects/geo_defense_down.lua
@@ -6,14 +6,14 @@ require("scripts/globals/status")
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.DEF, -effect:getPower())
+    target:addMod(xi.mod.DEFP, -effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.DEF, -effect:getPower())
+    target:delMod(xi.mod.DEFP, -effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/job_utils/geomancer.lua
+++ b/scripts/globals/job_utils/geomancer.lua
@@ -219,6 +219,11 @@ local function getEffectPotency(player, effect)
         potency = potency + (geomancyMod * potencyData[effect].geoModMultiplier)
     end
 
+    -- Boost potency calculations for Haste/Slow into the no-longer-human-readable-format
+    if effect == xi.effect.GEO_HASTE or effect == xi.effect.GEO_SLOW then
+        potency = math.floor(potency * 100)
+    end
+
     return potency
 end
 
@@ -325,13 +330,7 @@ end
 -- Magic Casting Checks
 -----------------------------------
 xi.job_utils.geomancer.indiOnMagicCastingCheck = function(caster, target, spell)
-    if target:hasStatusEffect(xi.effect.COLURE_ACTIVE) then
-        local effect = target:getStatusEffect(xi.effect.COLURE_ACTIVE)
-        if effect:getSubType() == indiData[spell:getID()].effect then
-            return xi.msg.basic.EFFECT_ALREADY_ACTIVE
-        end
-    end
-
+    -- No checks known as of yet
     return 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix Geomancy haste/slow unit scaling, the math was done in human-readable scaling but needs to be converted to the haste scaling.

Also remove the check for recasting the same indi spell, since that is not retail behavior.

Change ATT/DEF mods to ATTP/DEFP on geomancy spells

## Steps to test these changes

Use geomancy, use !getmod haste_magic and see values appropriate to the scaling of both geomancy and the haste
Be able to reapply the same indi-X spell repeatedly on GEO.
