### PR TITLE
Fix missing `OVERSEER_BASE` in Qufim NPC enum

### DIFF
--- a/scripts/zones/Qufim_Island/IDs.lua
+++ b/scripts/zones/Qufim_Island/IDs.lua
@@ -49,6 +49,7 @@ zones[xi.zone.QUFIM_ISLAND] =
         COMMON_SENSE_SURVIVAL          = 12665, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
         HOMEPOINT_SET                  = 12707, -- Home point set!
     },
+
     mob =
     {
         SLIPPERY_SUCKER_PH =
@@ -67,8 +68,10 @@ zones[xi.zone.QUFIM_ISLAND] =
         },
         OPHIOTAURUS = 17293666
     },
+
     npc =
     {
+        OVERSEER_BASE = GetFirstID('Pitoire_RK'),
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds `OVERSEER_BASE` to Qufim NPC enum.  Fixes CI issue from previous PR
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to Qufim, see the appropriate NPCs
<!-- Clear and detailed steps to test your changes here -->
