### PR TITLE
Remove Mandragora default event from Windurst M9-1

### DIFF
--- a/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
+++ b/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
@@ -155,8 +155,6 @@ mission.sections =
                     if missionStatus == 4 or missionStatus == 5 then
                         player:messageText(npc, boyahdaTreeID.text.WARDEN_SPEECH)
                         return mission:messageSpecial(boyahdaTreeID.text.WARDEN_TRANSLATION)
-                    else
-                        return mission:progressEvent(10)
                     end
                 end,
             },

--- a/scripts/zones/The_Boyahda_Tree/DefaultActions.lua
+++ b/scripts/zones/The_Boyahda_Tree/DefaultActions.lua
@@ -1,5 +1,6 @@
 local ID = require("scripts/zones/The_Boyahda_Tree/IDs")
 
 return {
-    ['qm1'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Mandragora_Warden'] = { event = 10 },
+    ['qm1']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }


### PR DESCRIPTION
Moves to DefaultActions.lua for Boyahda Tree

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3740 

Mandragora Warden default event was errantly moved with the conversion of Windurst M9-1.  This removes from that mission, and puts in in Default Actions.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Talk to Mandragora Warden, see Event 10 (without Win9-1 active)
<!-- Clear and detailed steps to test your changes here -->
