### PR TITLE
Add latch to Magian Player Cache to force reload on zoning

### DIFF
--- a/scripts/globals/magiantrials.lua
+++ b/scripts/globals/magiantrials.lua
@@ -14,7 +14,10 @@ xi.magian.trialCache = xi.magian.trialCache or {}
 local function getPlayerTrials(player)
     local activeTrials = xi.magian.trialCache[player:getID()]
 
-    if activeTrials then
+    if
+        activeTrials and
+        player:getLocalVar('magianUpdated') == 1
+    then
         return activeTrials
     end
 
@@ -30,6 +33,8 @@ local function getPlayerTrials(player)
     end
 
     xi.magian.trialCache[player:getID()] = activeTrials
+
+    player:setLocalVar('magianUpdated', 1)
 
     return activeTrials
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3615

Adds a localvar to returning cached magian data, and if zero (meaning the player has zoned), it is forced to reload data.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Zone between different map instances, and see that data is correct
<!-- Clear and detailed steps to test your changes here -->
