### PR TITLE
[core] Fix level sync corrupting charmed pets

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5769,17 +5769,17 @@ uint8 CLuaBaseEntity::levelRestriction(sol::object const& level)
 
             if (PChar->PPet)
             {
-                CPetEntity* PPet = static_cast<CPetEntity*>(PChar->PPet);
-
-                if (PPet->getPetType() == PET_TYPE::CHARMED_MOB)
+                if (PChar->PPet->objtype == TYPE_MOB)
                 {
                     // Charmed mobs only detach if they are above the level restriction
-                    if (PPet->GetMLevel() > NewMLevel)
+                    if (PChar->PPet->GetMLevel() > NewMLevel)
                     {
                         petutils::DetachPet(PChar);
                     }
                     return PChar->m_LevelRestriction;
                 }
+
+                CPetEntity* PPet = static_cast<CPetEntity*>(PChar->PPet);
 
                 // Preserve pet's HP and MP
                 int32 hp = PPet->health.hp;


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the check for charmed pets to check if PMobEntity type and not immediately static casting to something it isn't

## Steps to test these changes

Charm a pet above level 18, !addeffect level_sync 18 90 on yourself and have the mob detach and not corrupt/crash the server.