### PR TITLE
Replace XI_DEBUG_BREAK_IF references with logging and returns

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -1,4 +1,4 @@
-﻿#ifndef _CBASETYPES_H_
+#ifndef _CBASETYPES_H_
 #define _CBASETYPES_H_
 
 #include <algorithm>

--- a/src/map/ability.cpp
+++ b/src/map/ability.cpp
@@ -459,79 +459,82 @@ namespace ability
 
     CAbility* GetTwoHourAbility(JOBTYPE JobID)
     {
-        XI_DEBUG_BREAK_IF(JobID < JOB_WAR || JobID >= MAX_JOBTYPE);
-
-        switch (JobID)
+        if (JobID >= JOB_WAR || JobID <= MAX_JOBTYPE)
         {
-            case JOB_WAR:
-                return PAbilityList[ABILITY_MIGHTY_STRIKES];
-                break;
-            case JOB_MNK:
-                return PAbilityList[ABILITY_HUNDRED_FISTS];
-                break;
-            case JOB_WHM:
-                return PAbilityList[ABILITY_BENEDICTION];
-                break;
-            case JOB_BLM:
-                return PAbilityList[ABILITY_MANAFONT];
-                break;
-            case JOB_RDM:
-                return PAbilityList[ABILITY_CHAINSPELL];
-                break;
-            case JOB_THF:
-                return PAbilityList[ABILITY_PERFECT_DODGE];
-                break;
-            case JOB_PLD:
-                return PAbilityList[ABILITY_INVINCIBLE];
-                break;
-            case JOB_DRK:
-                return PAbilityList[ABILITY_BLOOD_WEAPON];
-                break;
-            case JOB_BST:
-                return PAbilityList[ABILITY_FAMILIAR];
-                break;
-            case JOB_BRD:
-                return PAbilityList[ABILITY_SOUL_VOICE];
-                break;
-            case JOB_RNG:
-                return PAbilityList[ABILITY_EAGLE_EYE_SHOT];
-                break;
-            case JOB_SAM:
-                return PAbilityList[ABILITY_MEIKYO_SHISUI];
-                break;
-            case JOB_NIN:
-                return PAbilityList[ABILITY_MIJIN_GAKURE];
-                break;
-            case JOB_DRG:
-                return PAbilityList[ABILITY_SPIRIT_SURGE];
-                break;
-            case JOB_SMN:
-                return PAbilityList[ABILITY_ASTRAL_FLOW];
-                break;
-            case JOB_BLU:
-                return PAbilityList[ABILITY_AZURE_LORE];
-                break;
-            case JOB_COR:
-                return PAbilityList[ABILITY_WILD_CARD];
-                break;
-            case JOB_PUP:
-                return PAbilityList[ABILITY_OVERDRIVE];
-                break;
-            case JOB_DNC:
-                return PAbilityList[ABILITY_TRANCE];
-                break;
-            case JOB_SCH:
-                return PAbilityList[ABILITY_TABULA_RASA];
-                break;
-            case JOB_GEO:
-                return PAbilityList[ABILITY_BOLSTER];
-                break;
-            case JOB_RUN:
-                return PAbilityList[ABILITY_ELEMENTAL_SFORZO];
-                break;
-            default:
-                break;
+            switch (JobID)
+            {
+                case JOB_WAR:
+                    return PAbilityList[ABILITY_MIGHTY_STRIKES];
+                    break;
+                case JOB_MNK:
+                    return PAbilityList[ABILITY_HUNDRED_FISTS];
+                    break;
+                case JOB_WHM:
+                    return PAbilityList[ABILITY_BENEDICTION];
+                    break;
+                case JOB_BLM:
+                    return PAbilityList[ABILITY_MANAFONT];
+                    break;
+                case JOB_RDM:
+                    return PAbilityList[ABILITY_CHAINSPELL];
+                    break;
+                case JOB_THF:
+                    return PAbilityList[ABILITY_PERFECT_DODGE];
+                    break;
+                case JOB_PLD:
+                    return PAbilityList[ABILITY_INVINCIBLE];
+                    break;
+                case JOB_DRK:
+                    return PAbilityList[ABILITY_BLOOD_WEAPON];
+                    break;
+                case JOB_BST:
+                    return PAbilityList[ABILITY_FAMILIAR];
+                    break;
+                case JOB_BRD:
+                    return PAbilityList[ABILITY_SOUL_VOICE];
+                    break;
+                case JOB_RNG:
+                    return PAbilityList[ABILITY_EAGLE_EYE_SHOT];
+                    break;
+                case JOB_SAM:
+                    return PAbilityList[ABILITY_MEIKYO_SHISUI];
+                    break;
+                case JOB_NIN:
+                    return PAbilityList[ABILITY_MIJIN_GAKURE];
+                    break;
+                case JOB_DRG:
+                    return PAbilityList[ABILITY_SPIRIT_SURGE];
+                    break;
+                case JOB_SMN:
+                    return PAbilityList[ABILITY_ASTRAL_FLOW];
+                    break;
+                case JOB_BLU:
+                    return PAbilityList[ABILITY_AZURE_LORE];
+                    break;
+                case JOB_COR:
+                    return PAbilityList[ABILITY_WILD_CARD];
+                    break;
+                case JOB_PUP:
+                    return PAbilityList[ABILITY_OVERDRIVE];
+                    break;
+                case JOB_DNC:
+                    return PAbilityList[ABILITY_TRANCE];
+                    break;
+                case JOB_SCH:
+                    return PAbilityList[ABILITY_TABULA_RASA];
+                    break;
+                case JOB_GEO:
+                    return PAbilityList[ABILITY_BOLSTER];
+                    break;
+                case JOB_RUN:
+                    return PAbilityList[ABILITY_ELEMENTAL_SFORZO];
+                    break;
+                default:
+                    break;
+            }
         }
+
+        ShowWarning("Attempt to get two hour ability with invalid JOBTYPE %d.", JobID);
         return nullptr;
     }
 

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -144,7 +144,12 @@ protected:
     template <typename T, typename... Args>
     bool ChangeState(Args&&... args)
     {
-        XI_DEBUG_BREAK_IF(m_stateStack.size() > 10);
+        if (m_stateStack.size() > 10)
+        {
+            ShowWarning("State Stack size exceeds maximum.");
+            return false;
+        }
+
         if (CanChangeState())
         {
             try
@@ -163,7 +168,12 @@ protected:
     template <typename T, typename... Args>
     bool ForceChangeState(Args&&... args)
     {
-        XI_DEBUG_BREAK_IF(m_stateStack.size() > 10);
+        if (m_stateStack.size() > 10)
+        {
+            ShowWarning("State Stack size exceeds maximum.");
+            return false;
+        }
+
         try
         {
             CheckCompletedStates();

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -42,7 +42,11 @@
 
 CAlliance::CAlliance(CBattleEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(PEntity->PParty == nullptr);
+    if (PEntity->PParty == nullptr)
+    {
+        ShowError("Attempt to construct Alliance with a null Party (%s).", PEntity->GetName());
+        return;
+    }
 
     m_AllianceID = PEntity->PParty->GetPartyID();
 

--- a/src/map/char_recast_container.cpp
+++ b/src/map/char_recast_container.cpp
@@ -35,7 +35,10 @@ CCharRecastContainer::CCharRecastContainer(CCharEntity* PChar)
 : CRecastContainer(PChar)
 , m_PChar(PChar)
 {
-    XI_DEBUG_BREAK_IF(m_PChar == nullptr || m_PChar->objtype != TYPE_PC);
+    if (m_PChar == nullptr || m_PChar->objtype != TYPE_PC)
+    {
+        ShowError("m_PChar is null or not a Player.");
+    }
 }
 
 /************************************************************************
@@ -145,7 +148,7 @@ RecastList_t* CCharRecastContainer::GetRecastList(RECASTTYPE type)
             return &RecastLootList;
     }
     // Unhandled Scenario
-    XI_DEBUG_BREAK_IF(true);
+    ShowError("Invalid RECASTTYPE received, returning nullptr.");
     return nullptr;
 }
 

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -861,14 +861,22 @@ uint8 CBattleEntity::GetSLevel() const
 
 void CBattleEntity::SetMJob(uint8 mjob)
 {
-    XI_DEBUG_BREAK_IF(mjob == 0 || mjob >= MAX_JOBTYPE); // выход за пределы доступных профессий
+    if (mjob == 0 || mjob >= MAX_JOBTYPE)
+    {
+        ShowWarning("Invalid Job Type passed to function (%d).", mjob);
+        return;
+    }
 
     m_mjob = (JOBTYPE)mjob;
 }
 
 void CBattleEntity::SetSJob(uint8 sjob)
 {
-    XI_DEBUG_BREAK_IF(sjob >= MAX_JOBTYPE); // выход за пределы доступных профессий
+    if (sjob >= MAX_JOBTYPE)
+    {
+        ShowWarning("sjob (%d) exceeds MAX_JOBTYPE", sjob);
+        return;
+    }
 
     m_sjob = (JOBTYPE)sjob;
 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -548,7 +548,7 @@ CItemContainer* CCharEntity::getStorage(uint8 LocationID)
             return m_RecycleBin.get();
     }
 
-    XI_DEBUG_BREAK_IF(LocationID >= CONTAINER_ID::MAX_CONTAINER_ID); // Unresolved storage ID
+    ShowWarning("Unhandled or Invalid Location ID (%d) passed to function.", LocationID);
     return nullptr;
 }
 

--- a/src/map/entities/petentity.cpp
+++ b/src/map/entities/petentity.cpp
@@ -83,7 +83,11 @@ bool CPetEntity::isBstPet()
 
 int32 CPetEntity::getJugSpawnTime()
 {
-    XI_DEBUG_BREAK_IF(m_PetType != PET_TYPE::JUG_PET)
+    if (m_PetType != PET_TYPE::JUG_PET)
+    {
+        ShowWarning("Non-Jug Pet calling function (%d).", static_cast<uint8>(m_PetType));
+        return 0;
+    }
 
     const auto epoch = m_jugSpawnTime.time_since_epoch();
     return static_cast<int32>(std::chrono::duration_cast<std::chrono::seconds>(epoch).count());
@@ -91,21 +95,33 @@ int32 CPetEntity::getJugSpawnTime()
 
 void CPetEntity::setJugSpawnTime(int32 spawnTime)
 {
-    XI_DEBUG_BREAK_IF(m_PetType != PET_TYPE::JUG_PET);
+    if (m_PetType != PET_TYPE::JUG_PET)
+    {
+        ShowWarning("Non-Jug Pet calling function (%d).", static_cast<uint8>(m_PetType));
+        return;
+    }
 
     m_jugSpawnTime = std::chrono::system_clock::time_point(std::chrono::duration<int>(spawnTime));
 }
 
 int32 CPetEntity::getJugDuration()
 {
-    XI_DEBUG_BREAK_IF(m_PetType != PET_TYPE::JUG_PET);
+    if (m_PetType != PET_TYPE::JUG_PET)
+    {
+        ShowWarning("Non-Jug Pet calling function (%d).", static_cast<uint8>(m_PetType));
+        return 0;
+    }
 
     return static_cast<int32>(std::chrono::duration_cast<std::chrono::seconds>(m_jugDuration).count());
 }
 
 void CPetEntity::setJugDuration(int32 seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PetType != PET_TYPE::JUG_PET);
+    if (m_PetType != PET_TYPE::JUG_PET)
+    {
+        ShowWarning("Non-Jug Pet calling function (%d).", static_cast<uint8>(m_PetType));
+        return;
+    }
 
     m_jugDuration = std::chrono::seconds(seconds);
 }
@@ -146,7 +162,11 @@ const std::string CPetEntity::GetScriptName()
 
 WYVERN_TYPE CPetEntity::getWyvernType()
 {
-    XI_DEBUG_BREAK_IF(PMaster == nullptr);
+    if (PMaster == nullptr)
+    {
+        ShowWarning("PMaster is null.");
+        return WYVERN_TYPE::NONE;
+    }
 
     switch (PMaster->GetSJob())
     {
@@ -271,7 +291,11 @@ bool CPetEntity::shouldDespawn(time_point tick)
 
 void CPetEntity::loadPetZoningInfo()
 {
-    XI_DEBUG_BREAK_IF(!PAI->IsSpawned())
+    if (!PAI->IsSpawned())
+    {
+        ShowWarning("Attempt to load info without Pet spawned.");
+        return;
+    }
 
     if (auto* master = dynamic_cast<CCharEntity*>(PMaster))
     {

--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -134,7 +134,11 @@ uint8 CItemContainer::AddSize(int8 size)
 
 uint8 CItemContainer::InsertItem(CItem* PItem)
 {
-    XI_DEBUG_BREAK_IF(PItem == nullptr);
+    if (PItem == nullptr)
+    {
+        ShowWarning("Null item passed into function.");
+        return ERROR_SLOTID;
+    }
 
     for (uint8 SlotID = 1; SlotID <= m_size; ++SlotID)
     {

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -402,7 +402,12 @@ namespace linkshell
     // add character to online linkshell list, used to send messages
     bool AddOnlineMember(CCharEntity* PChar, CItemLinkshell* PItemLinkshell, uint8 lsNum)
     {
-        XI_DEBUG_BREAK_IF(PChar == nullptr);
+        if (PChar == nullptr)
+        {
+            ShowWarning("PChar is null.");
+            return false;
+        }
+
         if (PItemLinkshell != nullptr && PItemLinkshell->isType(ITEM_LINKSHELL))
         {
             CLinkshell* PLinkshell = nullptr;
@@ -425,7 +430,12 @@ namespace linkshell
     // remove online member so we don't try to send messages to them
     bool DelOnlineMember(CCharEntity* PChar, CItemLinkshell* PItemLinkshell)
     {
-        XI_DEBUG_BREAK_IF(PChar == nullptr);
+        if (PChar == nullptr)
+        {
+            ShowWarning("PChar is null.");
+            return false;
+        }
+
         if (PItemLinkshell != nullptr && PItemLinkshell->isType(ITEM_LINKSHELL))
         {
             try

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -678,7 +678,11 @@ void CLuaBaseEntity::clearVarsWithPrefix(std::string const& prefix)
 
 uint32 CLuaBaseEntity::getLastOnline()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -697,7 +701,11 @@ uint32 CLuaBaseEntity::getLastOnline()
 
 void CLuaBaseEntity::injectPacket(std::string const& filename)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     uint8 size = 0;
     FILE* File = fopen(filename.c_str(), "rb");
@@ -772,7 +780,11 @@ void CLuaBaseEntity::injectActionPacket(uint32 inTargetID, uint16 inCategory, ui
 
 void CLuaBaseEntity::entityVisualPacket(std::string const& command, sol::object const& entity)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CBaseEntity* PNpc = nullptr;
     if (entity != sol::lua_nil)
@@ -1005,7 +1017,11 @@ void CLuaBaseEntity::startOptionalCutscene(int32 EventID, sol::variadic_args va)
 
 void CLuaBaseEntity::updateEvent(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     std::vector<std::pair<uint8, uint32>> params;
 
@@ -1044,7 +1060,11 @@ void CLuaBaseEntity::updateEvent(sol::variadic_args va)
 
 void CLuaBaseEntity::updateEventString(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     std::string string0 = va.get_type(0) == sol::type::string ? va.get<std::string>(0) : "";
     std::string string1 = va.get_type(1) == sol::type::string ? va.get<std::string>(1) : "";
@@ -1074,7 +1094,11 @@ void CLuaBaseEntity::updateEventString(sol::variadic_args va)
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::getEventTarget()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     auto* PChar = (CCharEntity*)m_PBaseEntity;
     if (PChar->currentEvent->targetEntity == nullptr)
@@ -1112,7 +1136,11 @@ bool CLuaBaseEntity::isInEvent()
 
 void CLuaBaseEntity::release()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -1194,7 +1222,11 @@ void CLuaBaseEntity::resetGotMessage()
 
 void CLuaBaseEntity::setFlag(uint32 flags)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CCharEntity*>(m_PBaseEntity)->nameflags.flags ^= flags;
     m_PBaseEntity->updatemask |= UPDATE_HP;
@@ -1209,7 +1241,11 @@ void CLuaBaseEntity::setFlag(uint32 flags)
 
 uint16 CLuaBaseEntity::getMoghouseFlag()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -1228,7 +1264,11 @@ uint16 CLuaBaseEntity::getMoghouseFlag()
 
 void CLuaBaseEntity::setMoghouseFlag(uint16 flag)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -1380,7 +1420,11 @@ bool CLuaBaseEntity::isAlly()
 
 void CLuaBaseEntity::initNpcAi()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to init NPC AI for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     m_PBaseEntity->PAI = std::make_unique<CAIContainer>(m_PBaseEntity, std::make_unique<CPathFind>(m_PBaseEntity), nullptr, nullptr);
 }
@@ -1432,7 +1476,11 @@ void CLuaBaseEntity::setStatus(uint8 status)
 
 uint8 CLuaBaseEntity::getCurrentAction()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint8 action = 0;
 
@@ -1621,8 +1669,6 @@ void CLuaBaseEntity::clearTargID()
 
 bool CLuaBaseEntity::atPoint(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-
     position_t pos;
 
     if (va.get_type(0) == sol::type::number)
@@ -1653,7 +1699,11 @@ bool CLuaBaseEntity::atPoint(sol::variadic_args va)
 
 void CLuaBaseEntity::pathTo(float x, float y, float z, sol::object const& flags)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        ShowWarning("Invalid entity (Player: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     position_t point;
     point.x = x;
@@ -1677,8 +1727,6 @@ void CLuaBaseEntity::pathTo(float x, float y, float z, sol::object const& flags)
 
 bool CLuaBaseEntity::pathThrough(sol::table const& pointsTable, sol::object const& flagsObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-
     uint8 flags = 0;
 
     if (flagsObj.is<uint8>())
@@ -1846,7 +1894,11 @@ float CLuaBaseEntity::checkDistance(sol::variadic_args va)
 
 void CLuaBaseEntity::wait(sol::object const& milliseconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_PC);
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        ShowWarning("Invalid entity (Player: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattle  = static_cast<CBattleEntity*>(m_PBaseEntity);
     int32 waitTime = (milliseconds != sol::lua_nil) ? milliseconds.as<uint32>() : 4000;
@@ -1877,7 +1929,11 @@ void CLuaBaseEntity::setCarefulPathing(bool careful)
 
 void CLuaBaseEntity::openDoor(sol::object const& seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to open door with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (m_PBaseEntity->animation == ANIMATION_CLOSE_DOOR)
     {
@@ -1935,7 +1991,11 @@ void CLuaBaseEntity::setElevator(uint8 id, uint32 lowerDoor, uint32 upperDoor, u
 {
     // Usage: setElevator(id, lower door id, upper door id, elevator platform id, animations reversed bool)
     // If giving the elevator ANIMATION_ELEVATOR_UP makes it go down, set this bool to true
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to set elevator with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     Elevator_t elevator = {};
 
@@ -1980,7 +2040,11 @@ void CLuaBaseEntity::addPeriodicTrigger(uint8 id, uint16 period, uint16 minOffse
     // period is the time in vanadiel minutes that separates two triggers of the event
     // minute offset is the time in vanadiel minutes after the se epoch that the trigger period should synchronize to
 
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to add periodic trigger to invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     Trigger_t trigger;
 
@@ -2008,7 +2072,11 @@ void CLuaBaseEntity::addPeriodicTrigger(uint8 id, uint16 period, uint16 minOffse
 
 void CLuaBaseEntity::showNPC(sol::object const& seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to show NPC with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     uint32 showTime = (seconds != sol::lua_nil) ? seconds.as<uint32>() * 1000 : 15000;
 
@@ -2030,7 +2098,11 @@ void CLuaBaseEntity::showNPC(sol::object const& seconds)
 
 void CLuaBaseEntity::hideNPC(sol::object const& seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to hide NPC with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (m_PBaseEntity->status == STATUS_TYPE::NORMAL)
     {
@@ -2055,7 +2127,11 @@ void CLuaBaseEntity::hideNPC(sol::object const& seconds)
 
 void CLuaBaseEntity::updateNPCHideTime(sol::object const& seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to update NPC hide time with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (m_PBaseEntity->status == STATUS_TYPE::DISAPPEAR)
     {
@@ -2115,7 +2191,11 @@ void CLuaBaseEntity::setWeather(uint8 weatherType)
 
 void CLuaBaseEntity::changeMusic(uint8 blockID, uint8 musicTrackID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     PChar->pushPacket(new CChangeMusicPacket(blockID, musicTrackID));
@@ -2129,7 +2209,11 @@ void CLuaBaseEntity::changeMusic(uint8 blockID, uint8 musicTrackID)
 
 void CLuaBaseEntity::sendMenu(uint32 menu)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -2160,8 +2244,17 @@ void CLuaBaseEntity::sendMenu(uint32 menu)
 
 bool CLuaBaseEntity::sendGuild(uint16 guildID, uint8 open, uint8 close, uint8 holiday)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-    XI_DEBUG_BREAK_IF(open > close);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return GUILD_OPEN;
+    }
+
+    if (open > close)
+    {
+        ShowWarning("Open Time (%d) exceeds Close Time (%d)", open, close);
+        return GUILD_OPEN;
+    }
 
     uint8 VanadielHour = (uint8)CVanaTime::getInstance()->getHour();
 
@@ -2217,7 +2310,11 @@ void CLuaBaseEntity::openSendBox()
 
 void CLuaBaseEntity::leaveGame()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -2234,7 +2331,11 @@ void CLuaBaseEntity::leaveGame()
 
 void CLuaBaseEntity::sendEmote(CLuaBaseEntity* target, uint8 emID, uint8 emMode)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC)
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (target)
     {
@@ -2413,9 +2514,13 @@ uint16 CLuaBaseEntity::getZoneID()
  *  Notes   : Highly useful for the above example
  ************************************************************************/
 
-auto CLuaBaseEntity::getZoneName() -> const std::string&
+auto CLuaBaseEntity::getZoneName() -> std::string
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->loc.zone == nullptr);
+    if (m_PBaseEntity->loc.zone == nullptr)
+    {
+        ShowWarning("Attempting to get Zone Name when player's zone is null.");
+        return {};
+    }
 
     return m_PBaseEntity->loc.zone->GetName();
 }
@@ -2429,7 +2534,11 @@ auto CLuaBaseEntity::getZoneName() -> const std::string&
 
 bool CLuaBaseEntity::hasVisitedZone(uint16 zone)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return hasBit(zone, PChar->m_ZonesList, sizeof(PChar->m_ZonesList));
@@ -2480,7 +2589,11 @@ uint8 CLuaBaseEntity::getContinentID()
 
 bool CLuaBaseEntity::isInMogHouse()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->m_moghouseID;
 }
@@ -2494,7 +2607,11 @@ bool CLuaBaseEntity::isInMogHouse()
 ************************************************************************/
 uint32 CLuaBaseEntity::getPlayerTriggerAreaInZone()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->m_InsideTriggerAreaID;
@@ -2509,7 +2626,11 @@ uint32 CLuaBaseEntity::getPlayerTriggerAreaInZone()
 ************************************************************************/
 void CLuaBaseEntity::updateToEntireZone(uint8 statusID, uint8 animation, sol::object const& matchTime)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempting to update NPC to entire zone with invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PNpc          = static_cast<CNpcEntity*>(m_PBaseEntity);
     bool  updateForTime = (matchTime != sol::lua_nil) ? matchTime.as<bool>() : false;
@@ -2567,7 +2688,11 @@ auto CLuaBaseEntity::getPos() -> sol::table
 
 void CLuaBaseEntity::showPosition()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     // TODO: Fix c-style cast
     static_cast<CCharEntity*>(m_PBaseEntity)
@@ -2745,7 +2870,11 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
 
 void CLuaBaseEntity::warp()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -2938,7 +3067,11 @@ uint32 CLuaBaseEntity::getTeleport(uint8 type, sol::object const& abysseaRegionO
 
 sol::table CLuaBaseEntity::getTeleportTable(uint8 type)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     sol::table teleTable = lua.create_table();
 
@@ -2984,7 +3117,11 @@ sol::table CLuaBaseEntity::getTeleportTable(uint8 type)
 
 bool CLuaBaseEntity::hasTeleport(uint8 tType, uint8 bit, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -3067,7 +3204,11 @@ bool CLuaBaseEntity::hasTeleport(uint8 tType, uint8 bit, sol::object const& arg2
 
 void CLuaBaseEntity::setTeleportMenu(uint16 type, sol::object const& teleportObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity*  PChar    = static_cast<CCharEntity*>(m_PBaseEntity);
     TELEPORT_TYPE teleType = static_cast<TELEPORT_TYPE>(type);
@@ -3128,7 +3269,11 @@ void CLuaBaseEntity::setTeleportMenu(uint16 type, sol::object const& teleportObj
 
 sol::table CLuaBaseEntity::getTeleportMenu(uint8 type)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     CCharEntity*  PChar    = static_cast<CCharEntity*>(m_PBaseEntity);
     TELEPORT_TYPE teleType = static_cast<TELEPORT_TYPE>(type);
@@ -3184,7 +3329,11 @@ sol::table CLuaBaseEntity::getTeleportMenu(uint8 type)
 
 void CLuaBaseEntity::setHomePoint()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -3268,7 +3417,11 @@ void CLuaBaseEntity::resetPlayer(const char* charName)
 
 void CLuaBaseEntity::goToEntity(uint32 targetID, sol::object const& option)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -3375,7 +3528,11 @@ uint16 CLuaBaseEntity::getEquipID(SLOTTYPE slot)
 {
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        XI_DEBUG_BREAK_IF(slot > 15);
+        if (slot > 15)
+        {
+            ShowWarning("Invalid slot passed to function.");
+            return 0;
+        }
 
         CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
         CItem*       PItem = PChar->getEquip(slot);
@@ -3400,7 +3557,11 @@ std::optional<CLuaItem> CLuaBaseEntity::getEquippedItem(uint8 slot)
 {
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        XI_DEBUG_BREAK_IF(slot > 15);
+        if (slot > 15)
+        {
+            ShowWarning("Invalid slot passed to function.");
+            return std::nullopt;
+        }
 
         auto* PChar    = static_cast<CCharEntity*>(m_PBaseEntity);
         auto* slotItem = PChar->getEquip(static_cast<SLOTTYPE>(slot));
@@ -3452,7 +3613,11 @@ bool CLuaBaseEntity::hasItem(uint16 itemID, sol::object const& location)
 
 bool CLuaBaseEntity::addItem(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     uint8 SlotID = ERROR_SLOTID;
 
@@ -3666,7 +3831,11 @@ bool CLuaBaseEntity::addItem(sol::variadic_args va)
 
 bool CLuaBaseEntity::delItem(uint16 itemID, int32 quantity, sol::object const& containerID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     uint8 location = containerID.get_type() == sol::type::number ? containerID.as<uint8>() : 0;
 
@@ -3698,7 +3867,11 @@ bool CLuaBaseEntity::delItem(uint16 itemID, int32 quantity, sol::object const& c
 
 bool CLuaBaseEntity::addUsedItem(uint16 itemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 SlotID = ERROR_SLOTID;
@@ -3807,7 +3980,11 @@ uint8 CLuaBaseEntity::incrementItemWear(uint16 itemID)
 
 bool CLuaBaseEntity::addTempItem(uint16 itemID, sol::object const& arg1)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     uint32 quantity = (arg1 != sol::lua_nil) ? arg1.as<uint32>() : 1;
     uint8  SlotID   = ERROR_SLOTID;
@@ -3890,7 +4067,11 @@ std::optional<CLuaItem> CLuaBaseEntity::findItem(uint16 itemID, sol::object cons
 
 void CLuaBaseEntity::createShop(uint8 size, sol::object const& arg1)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -3914,7 +4095,11 @@ void CLuaBaseEntity::createShop(uint8 size, sol::object const& arg1)
 
 void CLuaBaseEntity::addShopItem(uint16 itemID, double rawPrice, sol::object const& arg2, sol::object const& arg3)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8        slotID = PChar->Container->getItemsCount();
@@ -3945,7 +4130,11 @@ void CLuaBaseEntity::addShopItem(uint16 itemID, double rawPrice, sol::object con
 
 auto CLuaBaseEntity::getCurrentGPItem(uint8 guildID) -> std::tuple<uint16, uint16>
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return { 0, 0 };
+    }
 
     CGuild*      PGuild = guildutils::GetGuild(guildID);
     CCharEntity* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
@@ -4000,7 +4189,12 @@ bool CLuaBaseEntity::breakLinkshell(std::string const& lsname)
 
 bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
+
     CCharEntity*    PChar          = (CCharEntity*)m_PBaseEntity;
     CItemLinkshell* PItemLinkPearl = PChar->m_GMlevel > 0 ? (CItemLinkshell*)itemutils::GetItem(514) : (CItemLinkshell*)itemutils::GetItem(515);
     LSTYPE          lstype         = PChar->m_GMlevel > 0 ? LSTYPE_PEARLSACK : LSTYPE_LINKPEARL;
@@ -4045,7 +4239,11 @@ bool CLuaBaseEntity::addLinkpearl(std::string const& lsname, bool equip)
 
 auto CLuaBaseEntity::addSoulPlate(std::string const& name, uint16 mobFamily, uint8 zeni, uint16 skillIndex, uint8 fp) -> std::optional<CLuaItem>
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -4084,7 +4282,11 @@ auto CLuaBaseEntity::addSoulPlate(std::string const& name, uint16 mobFamily, uin
 
 uint8 CLuaBaseEntity::getContainerSize(uint8 locationID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->getStorage(locationID)->GetSize();
@@ -4099,7 +4301,11 @@ uint8 CLuaBaseEntity::getContainerSize(uint8 locationID)
 
 void CLuaBaseEntity::changeContainerSize(uint8 locationID, int8 newSize)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (locationID < CONTAINER_ID::MAX_CONTAINER_ID)
     {
@@ -4124,7 +4330,11 @@ void CLuaBaseEntity::changeContainerSize(uint8 locationID, int8 newSize)
 
 uint8 CLuaBaseEntity::getFreeSlotsCount(sol::object const& locID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint8 locationID = (locID != sol::lua_nil) ? locID.as<CONTAINER_ID>() : LOC_INVENTORY;
     return static_cast<CCharEntity*>(m_PBaseEntity)->getStorage(locationID)->GetFreeSlotsCount();
@@ -4139,7 +4349,11 @@ uint8 CLuaBaseEntity::getFreeSlotsCount(sol::object const& locID)
 
 void CLuaBaseEntity::confirmTrade()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4174,7 +4388,11 @@ void CLuaBaseEntity::confirmTrade()
 
 void CLuaBaseEntity::tradeComplete()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4198,7 +4416,12 @@ void CLuaBaseEntity::tradeComplete()
 
 std::optional<CLuaTradeContainer> CLuaBaseEntity::getTrade()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
+
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return std::optional<CLuaTradeContainer>(PChar->TradeContainer);
 }
@@ -4212,8 +4435,16 @@ std::optional<CLuaTradeContainer> CLuaBaseEntity::getTrade()
 
 bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-    XI_DEBUG_BREAK_IF(itemID > MAX_ITEMID);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to check equippable item with non-player (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
+
+    if (itemID > MAX_ITEMID)
+    {
+        ShowWarning("ItemID exceeds MAX_ITEMID (%d).", itemID);
+    }
 
     bool checkLevel = (chkLevel != sol::lua_nil) ? chkLevel.as<bool>() : false;
 
@@ -4247,7 +4478,11 @@ bool CLuaBaseEntity::canEquipItem(uint16 itemID, sol::object const& chkLevel)
 
 void CLuaBaseEntity::equipItem(uint16 itemID, sol::object const& container)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4307,8 +4542,17 @@ void CLuaBaseEntity::setEquipBlock(uint16 equipBlock)
 
 void CLuaBaseEntity::lockEquipSlot(uint8 slot)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-    XI_DEBUG_BREAK_IF(slot > 15);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
+
+    if (slot > 15)
+    {
+        ShowWarning("Invalid slot passed to function.");
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4330,8 +4574,17 @@ void CLuaBaseEntity::lockEquipSlot(uint8 slot)
 
 void CLuaBaseEntity::unlockEquipSlot(uint8 slot)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-    XI_DEBUG_BREAK_IF(slot > 15);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
+
+    if (slot > 15)
+    {
+        ShowWarning("Invalid slot passed to function.");
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4348,7 +4601,12 @@ void CLuaBaseEntity::unlockEquipSlot(uint8 slot)
 
 int8 CLuaBaseEntity::getShieldSize()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC && m_PBaseEntity->objtype != TYPE_PET);
+    // TODO: Why is TYPE_PET being checked below, when we only act on TYPE_PC?
+    if (m_PBaseEntity->objtype != TYPE_PC && m_PBaseEntity->objtype != TYPE_PET)
+    {
+        ShowWarning("Entity is not a Player or Pet type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
@@ -4539,7 +4797,11 @@ uint8 CLuaBaseEntity::storeWithPorterMoogle(uint16 slipId, sol::table const& ext
 
 sol::table CLuaBaseEntity::getRetrievableItemsForSlip(uint16 slipId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return {};
+    }
 
     CCharEntity* PChar      = (CCharEntity*)m_PBaseEntity;
     auto         slipSlotId = PChar->getStorage(LOC_INVENTORY)->SearchItem(slipId);
@@ -4576,7 +4838,11 @@ sol::table CLuaBaseEntity::getRetrievableItemsForSlip(uint16 slipId)
 
 void CLuaBaseEntity::retrieveItemFromSlip(uint16 slipId, uint16 itemId, uint16 extraId, uint8 extraData)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar      = static_cast<CCharEntity*>(m_PBaseEntity);
     auto  slipSlotId = PChar->getStorage(LOC_INVENTORY)->SearchItem(slipId);
@@ -4618,7 +4884,11 @@ void CLuaBaseEntity::retrieveItemFromSlip(uint16 slipId, uint16 itemId, uint16 e
 
 uint8 CLuaBaseEntity::getRace()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->look.race;
 }
@@ -4632,7 +4902,11 @@ uint8 CLuaBaseEntity::getRace()
 
 uint8 CLuaBaseEntity::getGender()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4708,7 +4982,11 @@ void CLuaBaseEntity::hideName(bool isHidden)
 
 bool CLuaBaseEntity::checkNameFlags(uint32 flags)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4793,7 +5071,11 @@ void CLuaBaseEntity::setModelId(uint16 modelId, sol::object const& slotObj)
 
 void CLuaBaseEntity::setCostume(uint16 costume)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4813,7 +5095,11 @@ void CLuaBaseEntity::setCostume(uint16 costume)
 
 uint16 CLuaBaseEntity::getCostume()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4829,7 +5115,11 @@ uint16 CLuaBaseEntity::getCostume()
 
 uint16 CLuaBaseEntity::getCostume2()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->m_Monstrosity;
@@ -4844,7 +5134,11 @@ uint16 CLuaBaseEntity::getCostume2()
 
 void CLuaBaseEntity::setCostume2(uint16 costume)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -4997,7 +5291,11 @@ void CLuaBaseEntity::setCallForHelpBlocked(bool blocked)
 
 uint8 CLuaBaseEntity::getNation()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->profile.nation;
 }
@@ -5011,7 +5309,11 @@ uint8 CLuaBaseEntity::getNation()
 
 void CLuaBaseEntity::setNation(uint8 nation)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5051,7 +5353,11 @@ void CLuaBaseEntity::setAllegiance(uint8 allegiance)
 
 uint8 CLuaBaseEntity::getCampaignAllegiance()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->profile.campaign_allegiance;
 }
@@ -5064,7 +5370,11 @@ uint8 CLuaBaseEntity::getCampaignAllegiance()
 
 void CLuaBaseEntity::setCampaignAllegiance(uint8 allegiance)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5080,7 +5390,11 @@ void CLuaBaseEntity::setCampaignAllegiance(uint8 allegiance)
 
 bool CLuaBaseEntity::isSeekingParty()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return (static_cast<CCharEntity*>(m_PBaseEntity)->nameflags.flags & FLAG_INVITE);
 }
@@ -5093,7 +5407,11 @@ bool CLuaBaseEntity::isSeekingParty()
 
 bool CLuaBaseEntity::getNewPlayer()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return (static_cast<CCharEntity*>(m_PBaseEntity)->menuConfigFlags.flags & NFLAG_NEWPLAYER) == 0;
 }
@@ -5136,7 +5454,11 @@ void CLuaBaseEntity::setNewPlayer(bool newplayer)
 
 bool CLuaBaseEntity::getMentor()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->m_mentorUnlocked ? true : false;
@@ -5150,7 +5472,11 @@ bool CLuaBaseEntity::getMentor()
 
 void CLuaBaseEntity::setMentor(bool mentor)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity* PChar      = static_cast<CCharEntity*>(m_PBaseEntity);
     PChar->m_mentorUnlocked = mentor;
@@ -5167,7 +5493,11 @@ void CLuaBaseEntity::setMentor(bool mentor)
 
 uint8 CLuaBaseEntity::getGMLevel()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->m_GMlevel;
@@ -5181,7 +5511,11 @@ uint8 CLuaBaseEntity::getGMLevel()
 
 void CLuaBaseEntity::setGMLevel(uint8 level)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5197,7 +5531,11 @@ void CLuaBaseEntity::setGMLevel(uint8 level)
 
 bool CLuaBaseEntity::getGMHidden()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->m_isGMHidden;
@@ -5211,7 +5549,11 @@ bool CLuaBaseEntity::getGMHidden()
 
 void CLuaBaseEntity::setGMHidden(bool isHidden)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar         = static_cast<CCharEntity*>(m_PBaseEntity);
     PChar->m_isGMHidden = isHidden;
@@ -5237,7 +5579,11 @@ void CLuaBaseEntity::setGMHidden(bool isHidden)
 
 bool CLuaBaseEntity::isJailed()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return jailutils::InPrison(static_cast<CCharEntity*>(m_PBaseEntity));
 }
@@ -5250,7 +5596,11 @@ bool CLuaBaseEntity::isJailed()
 
 void CLuaBaseEntity::jail()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     jailutils::Add(static_cast<CCharEntity*>(m_PBaseEntity));
 }
@@ -5264,7 +5614,11 @@ void CLuaBaseEntity::jail()
 
 bool CLuaBaseEntity::canUseMisc(uint16 misc)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->loc.zone == nullptr);
+    if (m_PBaseEntity->loc.zone == nullptr)
+    {
+        ShowWarning("Player zone is null.");
+        return false;
+    }
 
     return m_PBaseEntity->loc.zone->CanUseMisc(misc);
 }
@@ -5317,7 +5671,11 @@ void CLuaBaseEntity::setSpeed(uint8 speedVal)
 
 uint32 CLuaBaseEntity::getPlaytime(sol::object const& shouldUpdate)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     bool  update = (shouldUpdate != sol::lua_nil) ? shouldUpdate.as<bool>() : true;
     auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
@@ -5333,7 +5691,11 @@ uint32 CLuaBaseEntity::getPlaytime(sol::object const& shouldUpdate)
 
 int32 CLuaBaseEntity::getTimeCreated()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5349,7 +5711,11 @@ int32 CLuaBaseEntity::getTimeCreated()
 
 uint8 CLuaBaseEntity::getMainJob()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMJob();
 }
@@ -5363,7 +5729,11 @@ uint8 CLuaBaseEntity::getMainJob()
 
 uint8 CLuaBaseEntity::getSubJob()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSJob();
 }
@@ -5451,7 +5821,11 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
 
 void CLuaBaseEntity::changesJob(uint8 subJob)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5534,7 +5908,11 @@ bool CLuaBaseEntity::hasJob(uint8 job)
 
 uint8 CLuaBaseEntity::getMainLvl()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMLevel();
 }
@@ -5547,7 +5925,11 @@ uint8 CLuaBaseEntity::getMainLvl()
 
 uint8 CLuaBaseEntity::getSubLvl()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSLevel();
 }
@@ -5579,9 +5961,17 @@ uint8 CLuaBaseEntity::getJobLevel(uint8 JobID)
 
 void CLuaBaseEntity::setLevel(uint8 level)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to change Main Job level for non-PC (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
-    XI_DEBUG_BREAK_IF(level > 99);
+    if (level > 99)
+    {
+        ShowWarning("Attempt to set player level (%d) that exceeds maximum.", level);
+        return;
+    }
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -5630,8 +6020,17 @@ void CLuaBaseEntity::setLevel(uint8 level)
 
 void CLuaBaseEntity::setsLevel(uint8 slevel)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-    XI_DEBUG_BREAK_IF(slevel > 99);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
+
+    if (slevel > 99)
+    {
+        ShowWarning("Invalid slevel (%d) passed to function.", slevel);
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5676,7 +6075,11 @@ void CLuaBaseEntity::setsLevel(uint8 slevel)
 
 uint8 CLuaBaseEntity::getLevelCap()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->jobs.genkai;
@@ -5690,7 +6093,11 @@ uint8 CLuaBaseEntity::getLevelCap()
 
 void CLuaBaseEntity::setLevelCap(uint8 cap)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -5866,7 +6273,11 @@ void CLuaBaseEntity::addJobTraits(uint8 jobID, uint8 level)
 
 uint16 CLuaBaseEntity::getTitle()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->profile.title;
 }
@@ -5879,7 +6290,11 @@ uint16 CLuaBaseEntity::getTitle()
 
 bool CLuaBaseEntity::hasTitle(uint16 titleID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return charutils::hasTitle(static_cast<CCharEntity*>(m_PBaseEntity), titleID) != 0;
 }
@@ -5963,7 +6378,11 @@ void CLuaBaseEntity::delTitle(uint16 titleID)
 
 uint16 CLuaBaseEntity::getFame(sol::object const& areaObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint8  fameArea = areaObj.is<sol::table>() ? areaObj.as<sol::table>()["fame_area"] : areaObj.as<uint8>();
     uint16 fame     = 0;
@@ -6023,7 +6442,11 @@ uint16 CLuaBaseEntity::getFame(sol::object const& areaObj)
 
 void CLuaBaseEntity::addFame(sol::object const& areaObj, uint16 fame)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     uint8 fameArea = areaObj.is<sol::table>() ? areaObj.as<sol::table>()["fame_area"] : areaObj.as<uint8>();
 
@@ -6081,7 +6504,11 @@ void CLuaBaseEntity::addFame(sol::object const& areaObj, uint16 fame)
 
 void CLuaBaseEntity::setFame(sol::object const& areaObj, uint16 fame)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     uint8 fameArea = areaObj.is<sol::table>() ? areaObj.as<sol::table>()["fame_area"] : areaObj.as<uint8>();
 
@@ -6140,7 +6567,11 @@ void CLuaBaseEntity::setFame(sol::object const& areaObj, uint16 fame)
 
 uint8 CLuaBaseEntity::getFameLevel(sol::object const& areaObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint8 fameArea  = areaObj.is<sol::table>() ? areaObj.as<sol::table>()["fame_area"] : areaObj.as<uint8>();
     uint8 fameLevel = 1;
@@ -6203,7 +6634,11 @@ uint8 CLuaBaseEntity::getFameLevel(sol::object const& areaObj)
 
 uint8 CLuaBaseEntity::getRank(uint8 nation)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6218,7 +6653,11 @@ uint8 CLuaBaseEntity::getRank(uint8 nation)
 
 void CLuaBaseEntity::setRank(uint8 rank)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6235,7 +6674,11 @@ void CLuaBaseEntity::setRank(uint8 rank)
 
 uint16 CLuaBaseEntity::getRankPoints()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->profile.rankpoints;
 }
@@ -6249,7 +6692,11 @@ uint16 CLuaBaseEntity::getRankPoints()
 
 void CLuaBaseEntity::addRankPoints(uint16 rankPoints)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6267,7 +6714,11 @@ void CLuaBaseEntity::addRankPoints(uint16 rankPoints)
 
 void CLuaBaseEntity::setRankPoints(uint16 rankPoints)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6286,7 +6737,11 @@ void CLuaBaseEntity::setRankPoints(uint16 rankPoints)
 
 void CLuaBaseEntity::addQuest(uint8 questLogID, uint16 questID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6318,7 +6773,11 @@ void CLuaBaseEntity::addQuest(uint8 questLogID, uint16 questID)
 
 void CLuaBaseEntity::delQuest(uint8 questLogID, uint16 questID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6352,7 +6811,11 @@ void CLuaBaseEntity::delQuest(uint8 questLogID, uint16 questID)
 
 uint8 CLuaBaseEntity::getQuestStatus(uint8 questLogID, uint16 questID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (questLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -6365,10 +6828,8 @@ uint8 CLuaBaseEntity::getQuestStatus(uint8 questLogID, uint16 questID)
     else
     {
         ShowError("Lua::getQuestStatus: questLogID %i or QuestID %i is invalid", questLogID, questID);
+        return 0;
     }
-
-    XI_DEBUG_BREAK_IF(true); // We shouldn't get here.  If you did, fix the lua call.
-    return 0;
 }
 
 /************************************************************************
@@ -6379,7 +6840,11 @@ uint8 CLuaBaseEntity::getQuestStatus(uint8 questLogID, uint16 questID)
 
 bool CLuaBaseEntity::hasCompletedQuest(uint8 questLogID, uint16 questID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     if (questLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -6401,7 +6866,11 @@ bool CLuaBaseEntity::hasCompletedQuest(uint8 questLogID, uint16 questID)
 
 void CLuaBaseEntity::completeQuest(uint8 questLogID, uint16 questID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6470,7 +6939,11 @@ void CLuaBaseEntity::addMission(uint8 missionLogID, uint16 missionID)
 
 void CLuaBaseEntity::delMission(uint8 missionLogID, uint16 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (missionLogID < MAX_MISSIONAREA && missionID < MAX_MISSIONID)
     {
@@ -6506,7 +6979,11 @@ void CLuaBaseEntity::delMission(uint8 missionLogID, uint16 missionID)
 
 uint16 CLuaBaseEntity::getCurrentMission(sol::object const& missionLogObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
     if (!PChar)
@@ -6547,7 +7024,11 @@ uint16 CLuaBaseEntity::getCurrentMission(sol::object const& missionLogObj)
 
 bool CLuaBaseEntity::hasCompletedMission(uint8 missionLogID, uint16 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     bool complete = false;
 
@@ -6574,7 +7055,11 @@ bool CLuaBaseEntity::hasCompletedMission(uint8 missionLogID, uint16 missionID)
 
 void CLuaBaseEntity::completeMission(uint8 missionLogID, uint16 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (missionLogID < MAX_MISSIONAREA && missionID < MAX_MISSIONID)
     {
@@ -6614,7 +7099,11 @@ void CLuaBaseEntity::completeMission(uint8 missionLogID, uint16 missionID)
 
 void CLuaBaseEntity::setMissionStatus(uint8 missionLogID, sol::object const& arg2Obj, sol::object const& arg3Obj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
@@ -6666,7 +7155,11 @@ void CLuaBaseEntity::setMissionStatus(uint8 missionLogID, sol::object const& arg
 
 uint32 CLuaBaseEntity::getMissionStatus(uint8 missionLogID, sol::object const& missionStatusPosObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
     if (missionLogID < MAX_MISSIONAREA)
@@ -6702,7 +7195,11 @@ uint32 CLuaBaseEntity::getMissionStatus(uint8 missionLogID, sol::object const& m
 
 void CLuaBaseEntity::setEminenceCompleted(uint16 recordID, sol::object const& arg1, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6730,7 +7227,11 @@ void CLuaBaseEntity::setEminenceCompleted(uint16 recordID, sol::object const& ar
 
 bool CLuaBaseEntity::getEminenceCompleted(uint16 recordID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6739,7 +7240,11 @@ bool CLuaBaseEntity::getEminenceCompleted(uint16 recordID)
 
 uint16 CLuaBaseEntity::getNumEminenceCompleted()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6755,7 +7260,11 @@ uint16 CLuaBaseEntity::getNumEminenceCompleted()
 
 bool CLuaBaseEntity::setEminenceProgress(uint16 recordID, uint32 progress, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto*  PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint32 total = arg2.get_type() == sol::type::number ? arg2.as<uint32>() : 0;
@@ -6789,10 +7298,9 @@ bool CLuaBaseEntity::setEminenceProgress(uint16 recordID, uint32 progress, sol::
 
 std::optional<uint32> CLuaBaseEntity::getEminenceProgress(uint16 recordID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
-
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
         return std::nullopt;
     }
 
@@ -6815,7 +7323,11 @@ std::optional<uint32> CLuaBaseEntity::getEminenceProgress(uint16 recordID)
 
 bool CLuaBaseEntity::hasEminenceRecord(uint16 recordID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return roeutils::HasEminenceRecord(PChar, recordID);
@@ -6868,7 +7380,11 @@ void CLuaBaseEntity::triggerRoeEvent(uint8 eventNum, sol::object const& reqTable
 
 void CLuaBaseEntity::setUnityLeader(uint8 leaderID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -6892,7 +7408,11 @@ void CLuaBaseEntity::setUnityLeader(uint8 leaderID)
 
 uint8 CLuaBaseEntity::getUnityLeader()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return PChar->profile.unity_leader;
@@ -6907,7 +7427,11 @@ uint8 CLuaBaseEntity::getUnityLeader()
 
 std::optional<uint8> CLuaBaseEntity::getUnityRank(sol::object const& unityObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 unity = (unityObj != sol::lua_nil) ? unityObj.as<uint8>() : PChar->profile.unity_leader;
@@ -7037,7 +7561,11 @@ void CLuaBaseEntity::resetClaimedDeeds()
 
 void CLuaBaseEntity::addAssault(uint8 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7060,7 +7588,11 @@ void CLuaBaseEntity::addAssault(uint8 missionID)
 
 void CLuaBaseEntity::delAssault(uint8 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar   = static_cast<CCharEntity*>(m_PBaseEntity);
     auto  current = static_cast<uint8>(PChar->m_assaultLog.current);
@@ -7083,7 +7615,11 @@ void CLuaBaseEntity::delAssault(uint8 missionID)
 
 uint8 CLuaBaseEntity::getCurrentAssault()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return static_cast<uint8>(PChar->m_assaultLog.current);
@@ -7098,7 +7634,11 @@ uint8 CLuaBaseEntity::getCurrentAssault()
 
 bool CLuaBaseEntity::hasCompletedAssault(uint8 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CCharEntity*>(m_PBaseEntity)->m_assaultLog.complete[missionID];
 }
@@ -7112,7 +7652,11 @@ bool CLuaBaseEntity::hasCompletedAssault(uint8 missionID)
 
 void CLuaBaseEntity::completeAssault(uint8 missionID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7138,7 +7682,11 @@ void CLuaBaseEntity::completeAssault(uint8 missionID)
 
 void CLuaBaseEntity::addKeyItem(uint16 keyItemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = keyItemID >> 9;
@@ -7170,7 +7718,11 @@ void CLuaBaseEntity::addKeyItem(uint16 keyItemID)
 
 bool CLuaBaseEntity::hasKeyItem(uint16 keyItemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return charutils::hasKeyItem(static_cast<CCharEntity*>(m_PBaseEntity), keyItemID) != 0;
 }
@@ -7184,7 +7736,11 @@ bool CLuaBaseEntity::hasKeyItem(uint16 keyItemID)
 
 void CLuaBaseEntity::delKeyItem(uint16 keyItemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = keyItemID >> 9;
@@ -7211,7 +7767,11 @@ void CLuaBaseEntity::delKeyItem(uint16 keyItemID)
 
 bool CLuaBaseEntity::seenKeyItem(uint16 keyItemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return charutils::seenKeyItem(static_cast<CCharEntity*>(m_PBaseEntity), keyItemID) != 0;
 }
@@ -7225,7 +7785,11 @@ bool CLuaBaseEntity::seenKeyItem(uint16 keyItemID)
 
 void CLuaBaseEntity::unseenKeyItem(uint16 keyItemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     uint8 table = keyItemID >> 9;
@@ -7252,7 +7816,11 @@ void CLuaBaseEntity::unseenKeyItem(uint16 keyItemID)
 
 void CLuaBaseEntity::addExp(uint32 exp)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7287,7 +7855,11 @@ void CLuaBaseEntity::addCapacityPoints(uint32 capacity)
 
 void CLuaBaseEntity::delExp(uint32 exp)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7341,7 +7913,11 @@ uint8 CLuaBaseEntity::getMeritCount()
 
 void CLuaBaseEntity::setMerits(uint8 numPoints)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7516,7 +8092,11 @@ uint32 CLuaBaseEntity::getGil()
 
 void CLuaBaseEntity::addGil(int32 gil)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CItem* item = static_cast<CCharEntity*>(m_PBaseEntity)->getStorage(LOC_INVENTORY)->GetItem(0);
 
@@ -7539,7 +8119,11 @@ void CLuaBaseEntity::addGil(int32 gil)
 
 void CLuaBaseEntity::setGil(int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CItem* item = static_cast<CCharEntity*>(m_PBaseEntity)->getStorage(LOC_INVENTORY)->GetItem(0);
 
@@ -7564,7 +8148,11 @@ void CLuaBaseEntity::setGil(int32 amount)
 
 bool CLuaBaseEntity::delGil(int32 gil)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     bool result = false;
 
@@ -7592,7 +8180,11 @@ bool CLuaBaseEntity::delGil(int32 gil)
 
 int32 CLuaBaseEntity::getCurrency(std::string const& currencyType)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return charutils::GetPoints(PChar, currencyType.c_str());
@@ -7607,7 +8199,11 @@ int32 CLuaBaseEntity::getCurrency(std::string const& currencyType)
 
 void CLuaBaseEntity::addCurrency(std::string const& currencyType, int32 amount, sol::object const& maxObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     int32 maxPoints = maxObj.get_type() == sol::type::number ? maxObj.as<int32>() : std::numeric_limits<int32>::max();
 
@@ -7624,7 +8220,11 @@ void CLuaBaseEntity::addCurrency(std::string const& currencyType, int32 amount, 
 
 void CLuaBaseEntity::setCurrency(std::string const& currencyType, int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     charutils::SetPoints(PChar, currencyType.c_str(), amount);
@@ -7639,7 +8239,11 @@ void CLuaBaseEntity::setCurrency(std::string const& currencyType, int32 amount)
 
 void CLuaBaseEntity::delCurrency(std::string const& currencyType, int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     charutils::AddPoints(PChar, currencyType.c_str(), -amount);
@@ -7654,7 +8258,11 @@ void CLuaBaseEntity::delCurrency(std::string const& currencyType, int32 amount)
 
 int32 CLuaBaseEntity::getCP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return charutils::GetPoints(PChar, charutils::GetConquestPointsName(PChar).c_str());
@@ -7669,7 +8277,11 @@ int32 CLuaBaseEntity::getCP()
 
 void CLuaBaseEntity::addCP(int32 cp)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7686,7 +8298,11 @@ void CLuaBaseEntity::addCP(int32 cp)
 
 void CLuaBaseEntity::delCP(int32 cp)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7703,7 +8319,11 @@ void CLuaBaseEntity::delCP(int32 cp)
 
 int32 CLuaBaseEntity::getSeals(uint8 sealType)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
     int32 amount = 0;
@@ -7741,7 +8361,11 @@ int32 CLuaBaseEntity::getSeals(uint8 sealType)
 
 void CLuaBaseEntity::addSeals(int32 points, uint8 sealType)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7776,7 +8400,11 @@ void CLuaBaseEntity::addSeals(int32 points, uint8 sealType)
 
 void CLuaBaseEntity::delSeals(int32 points, uint8 sealType)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7811,7 +8439,11 @@ void CLuaBaseEntity::delSeals(int32 points, uint8 sealType)
 
 int32 CLuaBaseEntity::getAssaultPoint(uint8 region)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
     int32 points = 0;
@@ -7849,7 +8481,11 @@ int32 CLuaBaseEntity::getAssaultPoint(uint8 region)
 
 void CLuaBaseEntity::addAssaultPoint(uint8 region, int32 points)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7884,7 +8520,11 @@ void CLuaBaseEntity::addAssaultPoint(uint8 region, int32 points)
 
 void CLuaBaseEntity::delAssaultPoint(uint8 region, int32 points)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -7919,7 +8559,11 @@ void CLuaBaseEntity::delAssaultPoint(uint8 region, int32 points)
 
 auto CLuaBaseEntity::addGuildPoints(uint8 guildID, uint8 slotID) -> std::tuple<uint8, int16>
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return { 0, 0 };
+    }
 
     CGuild* PGuild = guildutils::GetGuild(guildID);
     auto*   PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
@@ -7938,7 +8582,11 @@ auto CLuaBaseEntity::addGuildPoints(uint8 guildID, uint8 slotID) -> std::tuple<u
 
 int32 CLuaBaseEntity::getHP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->health.hp;
 }
@@ -7952,7 +8600,11 @@ int32 CLuaBaseEntity::getHP()
 
 uint8 CLuaBaseEntity::getHPP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetHPP();
 }
@@ -7966,7 +8618,11 @@ uint8 CLuaBaseEntity::getHPP()
 
 int32 CLuaBaseEntity::getMaxHP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMaxHP();
 }
@@ -7980,7 +8636,11 @@ int32 CLuaBaseEntity::getMaxHP()
 
 int32 CLuaBaseEntity::getBaseHP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -7996,7 +8656,11 @@ int32 CLuaBaseEntity::getBaseHP()
 
 int32 CLuaBaseEntity::addHP(int32 hpAdd)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -8019,7 +8683,11 @@ int32 CLuaBaseEntity::addHP(int32 hpAdd)
 
 int32 CLuaBaseEntity::addHPLeaveSleeping(int32 hpAdd)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -8035,7 +8703,11 @@ int32 CLuaBaseEntity::addHPLeaveSleeping(int32 hpAdd)
 
 void CLuaBaseEntity::setHP(int32 value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -8059,7 +8731,11 @@ void CLuaBaseEntity::setHP(int32 value)
 
 int32 CLuaBaseEntity::restoreHP(int32 restoreAmt)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (m_PBaseEntity->animation != ANIMATION_DEATH)
     {
@@ -8080,7 +8756,11 @@ int32 CLuaBaseEntity::restoreHP(int32 restoreAmt)
 
 void CLuaBaseEntity::delHP(int32 delAmt)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->takeDamage(delAmt);
 }
@@ -8093,7 +8773,11 @@ void CLuaBaseEntity::delHP(int32 delAmt)
 
 void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::object const& atkType, sol::object const& dmgType, sol::object const& flags)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     // Attempt to retrieve the attacker
     CBattleEntity* PAttacker = nullptr;
@@ -8169,7 +8853,11 @@ void CLuaBaseEntity::takeDamage(int32 damage, sol::object const& attacker, sol::
 
 void CLuaBaseEntity::hideHP(bool value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempt to hide HP for invalid entity (%s)", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_MOB)
     {
@@ -8200,7 +8888,11 @@ void CLuaBaseEntity::setDeathType(int32 value)
 
 int32 CLuaBaseEntity::getMP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->health.mp;
 }
@@ -8214,7 +8906,11 @@ int32 CLuaBaseEntity::getMP()
 
 uint8 CLuaBaseEntity::getMPP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMPP();
 }
@@ -8227,7 +8923,11 @@ uint8 CLuaBaseEntity::getMPP()
 
 int32 CLuaBaseEntity::getMaxMP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMaxMP();
 }
@@ -8240,7 +8940,11 @@ int32 CLuaBaseEntity::getMaxMP()
 
 int32 CLuaBaseEntity::getBaseMP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return PEntity->health.maxmp;
@@ -8254,7 +8958,11 @@ int32 CLuaBaseEntity::getBaseMP()
 
 int32 CLuaBaseEntity::addMP(int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->addMP(amount);
 }
@@ -8267,7 +8975,11 @@ int32 CLuaBaseEntity::addMP(int32 amount)
 
 void CLuaBaseEntity::setMP(int32 value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -8284,7 +8996,11 @@ void CLuaBaseEntity::setMP(int32 value)
 
 int32 CLuaBaseEntity::restoreMP(int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (m_PBaseEntity->animation != ANIMATION_DEATH)
     {
@@ -8302,7 +9018,11 @@ int32 CLuaBaseEntity::restoreMP(int32 amount)
 
 int32 CLuaBaseEntity::delMP(int32 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->addMP(-amount);
 }
@@ -8315,7 +9035,11 @@ int32 CLuaBaseEntity::delMP(int32 amount)
 
 float CLuaBaseEntity::getTP()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
     return static_cast<float>(PBattle->health.tp);
@@ -8329,7 +9053,11 @@ float CLuaBaseEntity::getTP()
 
 int16 CLuaBaseEntity::addTP(int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->addTP(amount);
 }
@@ -8357,7 +9085,11 @@ void CLuaBaseEntity::setTP(int16 value)
 
 int16 CLuaBaseEntity::delTP(int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->addTP(-amount);
 }
@@ -8443,7 +9175,11 @@ void CLuaBaseEntity::capSkill(uint8 skill)
 
 void CLuaBaseEntity::capAllSkills()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8477,9 +9213,17 @@ void CLuaBaseEntity::capAllSkills()
 
 uint16 CLuaBaseEntity::getSkillLevel(uint16 skillId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype & TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid entity calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
-    XI_DEBUG_BREAK_IF(skillId >= MAX_SKILLTYPE);
+    if (skillId >= MAX_SKILLTYPE)
+    {
+        ShowWarning("skillId (%d) exceeds MAX_SKILLTYPE.", skillId);
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSkill(skillId);
 }
@@ -8594,7 +9338,11 @@ uint16 CLuaBaseEntity::getCharSkillLevel(uint8 skillID)
 
 void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8613,7 +9361,11 @@ void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsID)
 
 bool CLuaBaseEntity::hasLearnedWeaponskill(uint8 wsID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return (charutils::hasLearnedWeaponskill(static_cast<CCharEntity*>(m_PBaseEntity), wsID) != 0);
 }
@@ -8627,7 +9379,11 @@ bool CLuaBaseEntity::hasLearnedWeaponskill(uint8 wsID)
 
 void CLuaBaseEntity::delLearnedWeaponskill(uint8 wsID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8668,7 +9424,11 @@ void CLuaBaseEntity::trySkillUp(uint8 skill, uint8 level, sol::object const& for
 
 bool CLuaBaseEntity::addWeaponSkillPoints(uint8 slotID, uint16 points)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     auto  slot  = static_cast<SLOTTYPE>(slotID);
@@ -8685,7 +9445,11 @@ bool CLuaBaseEntity::addWeaponSkillPoints(uint8 slotID, uint16 points)
 
 void CLuaBaseEntity::addLearnedAbility(uint16 abilityID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8707,7 +9471,11 @@ void CLuaBaseEntity::addLearnedAbility(uint16 abilityID)
 
 bool CLuaBaseEntity::hasLearnedAbility(uint16 abilityID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return charutils::hasLearnedAbility(static_cast<CCharEntity*>(m_PBaseEntity), abilityID) != 0;
 }
@@ -8722,7 +9490,11 @@ bool CLuaBaseEntity::hasLearnedAbility(uint16 abilityID)
 
 uint32 CLuaBaseEntity::canLearnAbility(uint16 abilityID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint32 Message = 0;
 
@@ -8747,7 +9519,11 @@ uint32 CLuaBaseEntity::canLearnAbility(uint16 abilityID)
 
 void CLuaBaseEntity::delLearnedAbility(uint16 abilityID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8767,7 +9543,11 @@ void CLuaBaseEntity::delLearnedAbility(uint16 abilityID)
 
 void CLuaBaseEntity::addSpell(uint16 spellID, sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8803,7 +9583,11 @@ void CLuaBaseEntity::addSpell(uint16 spellID, sol::variadic_args va)
 
 bool CLuaBaseEntity::hasSpell(uint16 spellID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return charutils::hasSpell(static_cast<CCharEntity*>(m_PBaseEntity), spellID) != 0;
 }
@@ -8817,7 +9601,11 @@ bool CLuaBaseEntity::hasSpell(uint16 spellID)
 
 uint32 CLuaBaseEntity::canLearnSpell(uint16 spellID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto*  PChar   = static_cast<CCharEntity*>(m_PBaseEntity);
     uint32 Message = 0;
@@ -8842,7 +9630,11 @@ uint32 CLuaBaseEntity::canLearnSpell(uint16 spellID)
 
 void CLuaBaseEntity::delSpell(uint16 spellID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8862,7 +9654,11 @@ void CLuaBaseEntity::delSpell(uint16 spellID)
 
 void CLuaBaseEntity::recalculateSkillsTable()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC)
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8883,7 +9679,11 @@ void CLuaBaseEntity::recalculateSkillsTable()
 
 void CLuaBaseEntity::recalculateAbilitiesTable()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC)
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -8910,7 +9710,11 @@ void CLuaBaseEntity::recalculateAbilitiesTable()
 
 sol::table CLuaBaseEntity::getParty()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     // clang-format off
     auto table = lua.create_table();
@@ -8932,7 +9736,11 @@ sol::table CLuaBaseEntity::getParty()
 
 sol::table CLuaBaseEntity::getPartyWithTrusts()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     // clang-format off
     auto table = lua.create_table();
@@ -8954,7 +9762,11 @@ sol::table CLuaBaseEntity::getPartyWithTrusts()
 
 uint8 CLuaBaseEntity::getPartySize(sol::object const& arg0)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     uint8 allianceparty = (arg0 == sol::lua_nil) ? 0 : arg0.as<uint8>();
     uint8 partysize     = 1;
@@ -9262,7 +10074,11 @@ uint8 CLuaBaseEntity::getAllianceSize()
 
 uint32 CLuaBaseEntity::getLeaderID()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (const CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
@@ -9279,7 +10095,6 @@ uint32 CLuaBaseEntity::getLeaderID()
         return PChar->id;
     }
 
-    XI_DEBUG_BREAK_IF(true); // Only a failed cast should get us here, examine why
     return 0;
 }
 
@@ -9292,7 +10107,11 @@ uint32 CLuaBaseEntity::getLeaderID()
 
 uint32 CLuaBaseEntity::getPartyLastMemberJoinedTime()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9313,7 +10132,11 @@ uint32 CLuaBaseEntity::getPartyLastMemberJoinedTime()
 
 void CLuaBaseEntity::reloadParty()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CCharEntity*>(m_PBaseEntity)->ReloadPartyInc();
 }
@@ -9327,7 +10150,11 @@ void CLuaBaseEntity::reloadParty()
 
 void CLuaBaseEntity::disableLevelSync()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9355,7 +10182,11 @@ void CLuaBaseEntity::disableLevelSync()
 
 bool CLuaBaseEntity::isLevelSync()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9376,7 +10207,11 @@ bool CLuaBaseEntity::isLevelSync()
 
 uint8 CLuaBaseEntity::checkSoloPartyAlliance()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9484,7 +10319,11 @@ std::optional<CLuaInstance> CLuaBaseEntity::getInstance()
 
 void CLuaBaseEntity::setInstance(CLuaInstance* PLuaInstance)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CInstance*   PInstance   = PLuaInstance->GetInstance();
     CCharEntity* PChar       = dynamic_cast<CCharEntity*>(m_PBaseEntity);
@@ -9505,7 +10344,11 @@ void CLuaBaseEntity::setInstance(CLuaInstance* PLuaInstance)
 
 void CLuaBaseEntity::createInstance(uint16 instanceID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (!instanceutils::IsValidInstanceID(instanceID))
     {
@@ -9525,7 +10368,11 @@ void CLuaBaseEntity::createInstance(uint16 instanceID)
 
 void CLuaBaseEntity::instanceEntry(CLuaBaseEntity* PLuaBaseEntity, uint32 response)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CBaseEntity* PTarget = PLuaBaseEntity->m_PBaseEntity;
 
@@ -9541,7 +10388,11 @@ void CLuaBaseEntity::instanceEntry(CLuaBaseEntity* PLuaBaseEntity, uint32 respon
 
 uint16 CLuaBaseEntity::getConfrontationEffect()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->StatusEffectContainer->GetConfrontationEffect();
 }
@@ -9555,7 +10406,11 @@ uint16 CLuaBaseEntity::getConfrontationEffect()
 
 uint16 CLuaBaseEntity::copyConfrontationEffect(uint16 targetID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto*  PEntity = static_cast<CBattleEntity*>(m_PBaseEntity->GetEntity(targetID, TYPE_PC | TYPE_MOB));
     uint16 power   = 0;
@@ -9609,8 +10464,17 @@ int32 CLuaBaseEntity::getBattlefieldID()
 
 uint8 CLuaBaseEntity::registerBattlefield(sol::object const& arg0, sol::object const& arg1, sol::object const& arg2, sol::object const& arg3)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
+    {
+        ShowWarning("m_BattlefieldHandler was null for %s.", m_PBaseEntity->GetName());
+        return 0;
+    }
+
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     auto* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
@@ -9644,8 +10508,17 @@ uint8 CLuaBaseEntity::registerBattlefield(sol::object const& arg0, sol::object c
 
 bool CLuaBaseEntity::battlefieldAtCapacity(int battlefieldID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr);
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
+    {
+        ShowWarning("m_BattlefieldHandler was null for %s.", m_PBaseEntity->GetName());
+        return 0;
+    }
+
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return true;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     auto* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
@@ -9720,7 +10593,11 @@ bool CLuaBaseEntity::leaveBattlefield(uint8 leavecode)
 
 bool CLuaBaseEntity::isInDynamis()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->isInDynamis();
 }
@@ -9734,7 +10611,11 @@ bool CLuaBaseEntity::isInDynamis()
 
 void CLuaBaseEntity::setEnteredBattlefield(bool entered)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
@@ -9752,7 +10633,11 @@ void CLuaBaseEntity::setEnteredBattlefield(bool entered)
 
 bool CLuaBaseEntity::hasEnteredBattlefield()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     return CBattlefield::hasPlayerEntered(PChar);
@@ -9791,7 +10676,11 @@ bool CLuaBaseEntity::isDead()
 
 void CLuaBaseEntity::sendRaise(uint8 raiseLevel)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9819,7 +10708,11 @@ void CLuaBaseEntity::sendRaise(uint8 raiseLevel)
 
 void CLuaBaseEntity::sendReraise(uint8 raiseLevel)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9842,7 +10735,11 @@ void CLuaBaseEntity::sendReraise(uint8 raiseLevel)
 
 void CLuaBaseEntity::sendTractor(float xPos, float yPos, float zPos, uint8 rotation)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -9869,7 +10766,11 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj,
                                sol::object const& bar1NameObj, sol::object const& bar1ValObj,
                                sol::object const& bar2NameObj, sol::object const& bar2ValObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity* PChar  = (CCharEntity*)m_PBaseEntity;
     auto*        packet = new CTimerBarUtilPacket();
@@ -10166,7 +11067,11 @@ bool CLuaBaseEntity::canChangeState()
 
 void CLuaBaseEntity::wakeUp()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -10184,7 +11089,11 @@ void CLuaBaseEntity::wakeUp()
 
 void CLuaBaseEntity::setBattleID(uint16 battleID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     PEntity->setBattleID(battleID);
@@ -10199,7 +11108,11 @@ void CLuaBaseEntity::setBattleID(uint16 battleID)
 
 uint16 CLuaBaseEntity::getBattleID()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return PEntity->getBattleID();
@@ -10249,7 +11162,11 @@ void CLuaBaseEntity::recalculateStats()
 
 bool CLuaBaseEntity::checkImbuedItems()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar{ static_cast<CCharEntity*>(m_PBaseEntity) };
 
@@ -10454,7 +11371,11 @@ float CLuaBaseEntity::checkLiementAbsorb(uint16 damageType)
 
 int32 CLuaBaseEntity::getCE(CLuaBaseEntity const* target)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get CE for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CMobEntity*>(m_PBaseEntity)->PEnmityContainer->GetCE(static_cast<CBattleEntity*>(target->GetBaseEntity()));
 }
@@ -10468,7 +11389,11 @@ int32 CLuaBaseEntity::getCE(CLuaBaseEntity const* target)
 
 int32 CLuaBaseEntity::getVE(CLuaBaseEntity const* target)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get VE for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CMobEntity*>(m_PBaseEntity)->PEnmityContainer->GetVE(static_cast<CBattleEntity*>(target->GetBaseEntity()));
 }
@@ -10482,7 +11407,11 @@ int32 CLuaBaseEntity::getVE(CLuaBaseEntity const* target)
 
 void CLuaBaseEntity::setCE(CLuaBaseEntity* target, uint16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set CE for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->PEnmityContainer->SetCE(static_cast<CBattleEntity*>(target->GetBaseEntity()), amount);
 }
@@ -10496,7 +11425,11 @@ void CLuaBaseEntity::setCE(CLuaBaseEntity* target, uint16 amount)
 
 void CLuaBaseEntity::setVE(CLuaBaseEntity* target, uint16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set VE for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->PEnmityContainer->SetVE(static_cast<CBattleEntity*>(target->GetBaseEntity()), amount);
 }
@@ -10537,7 +11470,11 @@ void CLuaBaseEntity::addEnmity(CLuaBaseEntity* PEntity, int32 CE, int32 VE)
 
 void CLuaBaseEntity::lowerEnmity(CLuaBaseEntity* PEntity, uint8 percent)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to lower enmnity for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (PEntity != nullptr && PEntity->GetBaseEntity()->objtype != TYPE_NPC)
     {
@@ -10554,7 +11491,11 @@ void CLuaBaseEntity::lowerEnmity(CLuaBaseEntity* PEntity, uint8 percent)
 
 void CLuaBaseEntity::updateEnmity(CLuaBaseEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to update enmnity for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (PEntity != nullptr && PEntity->GetBaseEntity()->objtype != TYPE_NPC)
     {
@@ -10653,7 +11594,11 @@ void CLuaBaseEntity::updateEnmityFromDamage(CLuaBaseEntity* PEntity, int32 damag
 
 void CLuaBaseEntity::updateEnmityFromCure(CLuaBaseEntity* PEntity, int32 amount)
 {
-    XI_DEBUG_BREAK_IF(amount < 0);
+    if (amount < 0)
+    {
+        ShowWarning("Received negative cure amount.");
+        return;
+    }
 
     // clang-format off
     auto* PCurer = [&]() -> CBattleEntity*
@@ -10689,7 +11634,11 @@ void CLuaBaseEntity::updateEnmityFromCure(CLuaBaseEntity* PEntity, int32 amount)
 
 void CLuaBaseEntity::resetEnmity(CLuaBaseEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to reset enmnity for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (PEntity != nullptr && PEntity->GetBaseEntity()->objtype != TYPE_NPC)
     {
@@ -10735,7 +11684,11 @@ void CLuaBaseEntity::updateClaim(sol::object const& entity)
 
 bool CLuaBaseEntity::hasEnmity()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->PNotorietyContainer->hasEnmity();
 }
@@ -10749,7 +11702,11 @@ bool CLuaBaseEntity::hasEnmity()
 
 sol::table CLuaBaseEntity::getNotorietyList()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     auto& notorietyContainer = static_cast<CBattleEntity*>(m_PBaseEntity)->PNotorietyContainer;
 
@@ -10936,12 +11893,16 @@ bool CLuaBaseEntity::addStatusEffectEx(sol::variadic_args va)
 
 std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID, sol::object const& SubID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
     {
-        return nullptr;
+        return std::nullopt;
     }
 
     CStatusEffect* PStatusEffect   = nullptr;
@@ -10974,7 +11935,11 @@ std::optional<CLuaStatusEffect> CLuaBaseEntity::getStatusEffect(uint16 StatusID,
 
 sol::table CLuaBaseEntity::getStatusEffects()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11003,7 +11968,11 @@ sol::table CLuaBaseEntity::getStatusEffects()
 
 int16 CLuaBaseEntity::getStatusEffectElement(uint16 statusId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return effects::GetEffectElement(statusId);
 }
@@ -11017,7 +11986,11 @@ int16 CLuaBaseEntity::getStatusEffectElement(uint16 statusId)
 
 bool CLuaBaseEntity::canGainStatusEffect(uint16 effect, sol::object const& powerObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     uint16 power = powerObj.is<uint16>() ? powerObj.as<uint16>() : 0;
 
@@ -11041,7 +12014,11 @@ bool CLuaBaseEntity::canGainStatusEffect(uint16 effect, sol::object const& power
 
 bool CLuaBaseEntity::hasStatusEffect(uint16 StatusID, sol::object const& SubID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11074,7 +12051,11 @@ bool CLuaBaseEntity::hasStatusEffect(uint16 StatusID, sol::object const& SubID)
 
 uint16 CLuaBaseEntity::hasStatusEffectByFlag(uint16 StatusID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11095,7 +12076,11 @@ uint16 CLuaBaseEntity::hasStatusEffectByFlag(uint16 StatusID)
 
 uint8 CLuaBaseEntity::countEffect(uint16 StatusID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11116,7 +12101,11 @@ uint8 CLuaBaseEntity::countEffect(uint16 StatusID)
 
 bool CLuaBaseEntity::delStatusEffect(uint16 StatusID, sol::object const& SubID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11150,7 +12139,11 @@ bool CLuaBaseEntity::delStatusEffect(uint16 StatusID, sol::object const& SubID)
 
 void CLuaBaseEntity::delStatusEffectsByFlag(uint32 flag, sol::object const& silent)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11172,7 +12165,11 @@ void CLuaBaseEntity::delStatusEffectsByFlag(uint32 flag, sol::object const& sile
 
 bool CLuaBaseEntity::delStatusEffectSilent(uint16 StatusID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11193,7 +12190,11 @@ bool CLuaBaseEntity::delStatusEffectSilent(uint16 StatusID)
 
 uint16 CLuaBaseEntity::eraseStatusEffect()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11214,7 +12215,11 @@ uint16 CLuaBaseEntity::eraseStatusEffect()
 
 uint8 CLuaBaseEntity::eraseAllStatusEffect()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11234,7 +12239,11 @@ uint8 CLuaBaseEntity::eraseAllStatusEffect()
 
 int32 CLuaBaseEntity::dispelStatusEffect(sol::object const& flagObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11256,7 +12265,11 @@ int32 CLuaBaseEntity::dispelStatusEffect(sol::object const& flagObj)
 
 uint8 CLuaBaseEntity::dispelAllStatusEffect(sol::object const& flagObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11278,7 +12291,11 @@ uint8 CLuaBaseEntity::dispelAllStatusEffect(sol::object const& flagObj)
 
 uint16 CLuaBaseEntity::stealStatusEffect(CLuaBaseEntity* PTargetEntity, sol::object const& flagObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11314,7 +12331,11 @@ uint16 CLuaBaseEntity::stealStatusEffect(CLuaBaseEntity* PTargetEntity, sol::obj
 
 void CLuaBaseEntity::addMod(uint16 type, int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PBattleEntity)
@@ -11334,7 +12355,11 @@ void CLuaBaseEntity::addMod(uint16 type, int16 amount)
 
 int16 CLuaBaseEntity::getMod(uint16 modID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->getMod(static_cast<Mod>(modID));
 }
@@ -11348,7 +12373,11 @@ int16 CLuaBaseEntity::getMod(uint16 modID)
 
 void CLuaBaseEntity::setMod(uint16 modID, int16 value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->setModifier(static_cast<Mod>(modID), value);
 }
@@ -11362,7 +12391,11 @@ void CLuaBaseEntity::setMod(uint16 modID, int16 value)
 
 void CLuaBaseEntity::delMod(uint16 modID, int16 value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->delModifier(static_cast<Mod>(modID), value);
 }
@@ -11375,7 +12408,11 @@ void CLuaBaseEntity::delMod(uint16 modID, int16 value)
 
 void CLuaBaseEntity::addLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     LATENT conditionID = static_cast<LATENT>(condID);
     Mod    modID       = static_cast<Mod>(mID);
@@ -11392,7 +12429,11 @@ void CLuaBaseEntity::addLatent(uint16 condID, uint16 conditionValue, uint16 mID,
 
 bool CLuaBaseEntity::delLatent(uint16 condID, uint16 conditionValue, uint16 mID, int16 modValue)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     LATENT conditionID = static_cast<LATENT>(condID);
     Mod    modID       = static_cast<Mod>(mID);
@@ -11455,7 +12496,11 @@ void CLuaBaseEntity::fold()
 
 void CLuaBaseEntity::doWildCard(CLuaBaseEntity* PEntity, uint8 total)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     battleutils::DoWildCardToEntity(static_cast<CCharEntity*>(m_PBaseEntity), static_cast<CCharEntity*>(PEntity->m_PBaseEntity), total);
 }
@@ -11469,7 +12514,11 @@ void CLuaBaseEntity::doWildCard(CLuaBaseEntity* PEntity, uint8 total)
 
 bool CLuaBaseEntity::addCorsairRoll(uint8 casterJob, uint8 bustDuration, uint16 effectID, uint16 power, uint32 tick, uint32 duration, sol::object const& arg6, sol::object const& arg7, sol::object const& arg8)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     CStatusEffect* PEffect = new CStatusEffect(static_cast<EFFECT>(effectID),                  // Effect ID
                                                effectID,                                       // Effect Icon (Associated with ID)
@@ -11514,7 +12563,11 @@ bool CLuaBaseEntity::hasCorsairEffect()
 
 bool CLuaBaseEntity::hasBustEffect(uint16 id)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PBattleEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return PBattleEntity->StatusEffectContainer->HasBustEffect(static_cast<EFFECT>(id));
@@ -11529,7 +12582,11 @@ bool CLuaBaseEntity::hasBustEffect(uint16 id)
 
 uint8 CLuaBaseEntity::numBustEffects()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return PBattleEntity->StatusEffectContainer->GetEffectsCount(EFFECT_BUST);
@@ -11544,7 +12601,11 @@ uint8 CLuaBaseEntity::numBustEffects()
 
 uint16 CLuaBaseEntity::healingWaltz()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattleEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return static_cast<uint16>(PBattleEntity->StatusEffectContainer->HealingWaltz());
@@ -11672,7 +12733,11 @@ void CLuaBaseEntity::setStatDebilitation(uint16 statDebil)
 
 uint16 CLuaBaseEntity::getStat(uint16 statId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto*  PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     uint16 value   = 0;
@@ -11727,7 +12792,11 @@ uint16 CLuaBaseEntity::getStat(uint16 statId)
 
 uint16 CLuaBaseEntity::getACC()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PEntity = static_cast<CBattleEntity*>(m_PBaseEntity);
     return PEntity->ACC(0, 0); // (attackNumber = 0, offsetAcc = 0)
@@ -11790,7 +12859,11 @@ int CLuaBaseEntity::getRACC()
 
 uint16 CLuaBaseEntity::getRATT()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* weapon = dynamic_cast<CItemWeapon*>(static_cast<CBattleEntity*>(m_PBaseEntity)->m_Weapons[SLOT_RANGED]);
 
@@ -11867,7 +12940,11 @@ bool CLuaBaseEntity::isSpellAoE(uint16 spellId)
 
 int32 CLuaBaseEntity::physicalDmgTaken(double damage, sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
 
@@ -11883,7 +12960,11 @@ int32 CLuaBaseEntity::physicalDmgTaken(double damage, sol::variadic_args va)
 
 int32 CLuaBaseEntity::magicDmgTaken(double damage, sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     ELEMENT elementType = va[0].is<uint32>() ? va[0].as<ELEMENT>() : ELEMENT_NONE;
 
@@ -11899,7 +12980,11 @@ int32 CLuaBaseEntity::magicDmgTaken(double damage, sol::variadic_args va)
 
 int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     DAMAGE_TYPE damageType = va[0].is<uint32>() ? va[0].as<DAMAGE_TYPE>() : DAMAGE_TYPE::NONE;
 
@@ -11915,7 +13000,11 @@ int32 CLuaBaseEntity::rangedDmgTaken(double damage, sol::variadic_args va)
 
 int32 CLuaBaseEntity::breathDmgTaken(double damage)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return battleutils::BreathDmgTaken(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage));
 }
@@ -11929,7 +13018,11 @@ int32 CLuaBaseEntity::breathDmgTaken(double damage)
 
 void CLuaBaseEntity::handleAfflatusMiseryDamage(double damage)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     battleutils::HandleAfflatusMiseryDamage(static_cast<CBattleEntity*>(m_PBaseEntity), static_cast<int32>(damage));
 }
@@ -11943,7 +13036,11 @@ void CLuaBaseEntity::handleAfflatusMiseryDamage(double damage)
 
 bool CLuaBaseEntity::isWeaponTwoHanded()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* weapon = dynamic_cast<CItemWeapon*>(static_cast<CBattleEntity*>(m_PBaseEntity)->m_Weapons[SLOT_MAIN]);
 
@@ -11967,7 +13064,11 @@ bool CLuaBaseEntity::isWeaponTwoHanded()
 
 int CLuaBaseEntity::getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::object const& arg1)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     CBattleEntity* PAttacker = static_cast<CBattleEntity*>(m_PBaseEntity);
     CBattleEntity* PDefender = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
@@ -11994,7 +13095,11 @@ int CLuaBaseEntity::getMeleeHitDamage(CLuaBaseEntity* PLuaBaseEntity, sol::objec
 
 uint16 CLuaBaseEntity::getWeaponDmg()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMainWeaponDmg();
 }
@@ -12008,7 +13113,11 @@ uint16 CLuaBaseEntity::getWeaponDmg()
 
 uint16 CLuaBaseEntity::getWeaponDmgRank()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMainWeaponRank();
 }
@@ -12022,7 +13131,11 @@ uint16 CLuaBaseEntity::getWeaponDmgRank()
 
 uint16 CLuaBaseEntity::getOffhandDmg()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSubWeaponDmg();
 }
@@ -12036,7 +13149,11 @@ uint16 CLuaBaseEntity::getOffhandDmg()
 
 uint16 CLuaBaseEntity::getOffhandDmgRank()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSubWeaponRank();
 }
@@ -12050,7 +13167,11 @@ uint16 CLuaBaseEntity::getOffhandDmgRank()
 
 uint16 CLuaBaseEntity::getRangedDmg()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetRangedWeaponDmg();
 }
@@ -12064,7 +13185,11 @@ uint16 CLuaBaseEntity::getRangedDmg()
 
 uint16 CLuaBaseEntity::getRangedDmgRank()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->GetRangedWeaponRank();
 }
@@ -12078,7 +13203,11 @@ uint16 CLuaBaseEntity::getRangedDmgRank()
 
 uint16 CLuaBaseEntity::getAmmoDmg()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
     auto* weapon  = dynamic_cast<CItemWeapon*>(PBattle->m_Weapons[SLOT_AMMO]);
@@ -12101,7 +13230,11 @@ uint16 CLuaBaseEntity::getAmmoDmg()
 
 void CLuaBaseEntity::removeAmmo()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     battleutils::RemoveAmmo(static_cast<CCharEntity*>(m_PBaseEntity));
 }
@@ -12115,11 +13248,19 @@ void CLuaBaseEntity::removeAmmo()
 
 uint16 CLuaBaseEntity::getWeaponSkillLevel(uint8 slotID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        XI_DEBUG_BREAK_IF(slotID > 3);
+        if (slotID > 3)
+        {
+            ShowWarning("Invalid slotID (%d) passed to function.", slotID);
+            return 0;
+        }
 
         auto* PChar   = static_cast<CCharEntity*>(m_PBaseEntity);
         auto* PWeapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[slotID]);
@@ -12142,7 +13283,11 @@ uint16 CLuaBaseEntity::getWeaponSkillLevel(uint8 slotID)
 
 uint16 CLuaBaseEntity::getWeaponDamageType(uint8 slotID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (slotID <= 3)
     {
@@ -12168,7 +13313,11 @@ uint16 CLuaBaseEntity::getWeaponDamageType(uint8 slotID)
 
 uint8 CLuaBaseEntity::getWeaponSkillType(uint8 slotID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (slotID <= 3)
     {
@@ -12194,7 +13343,11 @@ uint8 CLuaBaseEntity::getWeaponSkillType(uint8 slotID)
 
 uint8 CLuaBaseEntity::getWeaponSubSkillType(uint8 slotID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (slotID <= 3)
     {
@@ -12222,7 +13375,11 @@ uint8 CLuaBaseEntity::getWeaponSubSkillType(uint8 slotID)
 
 auto CLuaBaseEntity::getWSSkillchainProp() -> std::tuple<uint8, uint8, uint8>
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return { 0, 0, 0 };
+    }
 
     auto* state = dynamic_cast<CWeaponSkillState*>(m_PBaseEntity->PAI->GetCurrentState());
 
@@ -12363,7 +13520,11 @@ void CLuaBaseEntity::spawnPet(sol::object const& arg0)
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::spawnTrust(uint16 trustId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC); // only PCs can spawn trusts
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     return CLuaBaseEntity(trustutils::SpawnTrust(static_cast<CCharEntity*>(m_PBaseEntity), trustId));
 }
@@ -12376,7 +13537,11 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::spawnTrust(uint16 trustId)
 
 void CLuaBaseEntity::clearTrusts()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC); // only PCs can spawn trusts
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CCharEntity*>(m_PBaseEntity)->ClearTrusts();
 }
@@ -12389,7 +13554,11 @@ void CLuaBaseEntity::clearTrusts()
 
 uint32 CLuaBaseEntity::getTrustID()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CTrustEntity*>(m_PBaseEntity)->m_TrustID;
 }
@@ -12402,7 +13571,11 @@ uint32 CLuaBaseEntity::getTrustID()
 
 void CLuaBaseEntity::trustPartyMessage(uint32 message_id)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PTrust = static_cast<CTrustEntity*>(m_PBaseEntity);
     if (auto* PMaster = dynamic_cast<CCharEntity*>(PTrust->PMaster))
@@ -12426,7 +13599,11 @@ void CLuaBaseEntity::trustPartyMessage(uint32 message_id)
 
 std::string CLuaBaseEntity::addSimpleGambit(uint16 targ, uint16 cond, uint32 condition_arg, uint16 react, uint16 select, uint32 selector_arg, sol::object const& retry)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return {};
+    }
 
     using namespace gambits;
 
@@ -12461,7 +13638,11 @@ std::string CLuaBaseEntity::addSimpleGambit(uint16 targ, uint16 cond, uint32 con
 
 void CLuaBaseEntity::removeSimpleGambit(std::string const& id)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* trust      = static_cast<CTrustEntity*>(m_PBaseEntity);
     auto* controller = static_cast<CTrustController*>(trust->PAI->GetController());
@@ -12478,7 +13659,11 @@ void CLuaBaseEntity::removeSimpleGambit(std::string const& id)
 
 void CLuaBaseEntity::removeAllSimpleGambits()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* trust      = static_cast<CTrustEntity*>(m_PBaseEntity);
     auto* controller = static_cast<CTrustController*>(trust->PAI->GetController());
@@ -12495,7 +13680,11 @@ void CLuaBaseEntity::removeAllSimpleGambits()
 
 void CLuaBaseEntity::setTrustTPSkillSettings(uint16 trigger, uint16 select, sol::object const& value)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST);
+    if (m_PBaseEntity->objtype != TYPE_TRUST)
+    {
+        ShowWarning("Invalid Entity calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     using namespace gambits;
 
@@ -12519,7 +13708,11 @@ void CLuaBaseEntity::setTrustTPSkillSettings(uint16 trigger, uint16 select, sol:
 
 void CLuaBaseEntity::despawnPet()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12557,7 +13750,11 @@ bool CLuaBaseEntity::isJugPet()
 
 bool CLuaBaseEntity::hasValidJugPetItem()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     CItemWeapon* PItem = static_cast<CItemWeapon*>(static_cast<CCharEntity*>(m_PBaseEntity)->getEquip(SLOT_AMMO));
 
@@ -12578,7 +13775,11 @@ bool CLuaBaseEntity::hasValidJugPetItem()
 
 bool CLuaBaseEntity::hasPet()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PTarget = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12672,7 +13873,11 @@ bool CLuaBaseEntity::isAvatar()
 
 uint8 CLuaBaseEntity::getPetElement()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12729,7 +13934,11 @@ void CLuaBaseEntity::setPet(sol::object const& petObj)
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::getMaster()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12751,7 +13960,11 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::getMaster()
 
 auto CLuaBaseEntity::getPetName() -> const std::string
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return {};
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12760,7 +13973,8 @@ auto CLuaBaseEntity::getPetName() -> const std::string
         return PBattle->PPet->name;
     }
 
-    return ""; // Check this!
+    ShowWarning("PPet does not exist.");
+    return {}; // Check this!
 }
 
 /************************************************************************
@@ -12772,7 +13986,11 @@ auto CLuaBaseEntity::getPetName() -> const std::string
 
 void CLuaBaseEntity::setPetName(uint8 pType, uint16 value, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     PET_TYPE petType = static_cast<PET_TYPE>(pType);
 
@@ -12829,7 +14047,11 @@ void CLuaBaseEntity::registerChocobo(uint32 value)
 
 float CLuaBaseEntity::getCharmChance(CLuaBaseEntity const* target, sol::object const& mods)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PCharmer = static_cast<CBattleEntity*>(m_PBaseEntity);
     auto* PTarget  = static_cast<CBattleEntity*>(target->GetBaseEntity());
@@ -12864,7 +14086,11 @@ void CLuaBaseEntity::charmPet(CLuaBaseEntity const* target)
 
 void CLuaBaseEntity::petAttack(CLuaBaseEntity* PEntity)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (static_cast<CBattleEntity*>(m_PBaseEntity)->PPet != nullptr)
     {
@@ -12893,7 +14119,11 @@ void CLuaBaseEntity::petAbility(uint16 abilityID)
 
 void CLuaBaseEntity::petRetreat()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
 
@@ -12929,7 +14159,11 @@ void CLuaBaseEntity::familiar()
 
 void CLuaBaseEntity::addPetMod(uint16 modID, int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->addPetModifier(static_cast<Mod>(modID), PetModType::All, amount);
 }
@@ -12943,7 +14177,11 @@ void CLuaBaseEntity::addPetMod(uint16 modID, int16 amount)
 
 void CLuaBaseEntity::setPetMod(uint16 modID, int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->setPetModifier(static_cast<Mod>(modID), PetModType::All, amount);
 }
@@ -12957,7 +14195,11 @@ void CLuaBaseEntity::setPetMod(uint16 modID, int16 amount)
 
 void CLuaBaseEntity::delPetMod(uint16 modID, int16 amount)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CBattleEntity*>(m_PBaseEntity)->delPetModifier(static_cast<Mod>(modID), PetModType::All, amount);
 }
@@ -12971,7 +14213,11 @@ void CLuaBaseEntity::delPetMod(uint16 modID, int16 amount)
 
 bool CLuaBaseEntity::hasAttachment(uint16 itemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     CItem* PItem = itemutils::GetItem(itemID);
     return puppetutils::HasAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
@@ -12986,7 +14232,12 @@ bool CLuaBaseEntity::hasAttachment(uint16 itemID)
 
 auto CLuaBaseEntity::getAutomatonName() -> std::string
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return {};
+    }
+
     const char* Query = "SELECT name FROM "
                         "char_pet LEFT JOIN pet_name ON automatonid = id "
                         "WHERE charid = %u;";
@@ -12998,7 +14249,7 @@ auto CLuaBaseEntity::getAutomatonName() -> std::string
         return sql->GetStringData(0);
     }
 
-    return ""; // TODO: Verify this case
+    return {}; // TODO: Verify this case
 }
 
 /************************************************************************
@@ -13048,7 +14299,11 @@ uint8 CLuaBaseEntity::getAutomatonHead()
 
 bool CLuaBaseEntity::unlockAttachment(uint16 itemID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     CItem* PItem = itemutils::GetItem(itemID);
     return puppetutils::UnlockAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
@@ -13105,7 +14360,11 @@ void CLuaBaseEntity::removeAllManeuvers()
 
 void CLuaBaseEntity::updateAttachments()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PEntity = static_cast<CCharEntity*>(m_PBaseEntity);
     puppetutils::UpdateAttachments(PEntity);
@@ -13121,7 +14380,11 @@ void CLuaBaseEntity::updateAttachments()
 
 void CLuaBaseEntity::reduceBurden(float percentReduction, sol::object const& intReductionObj)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PEntity    = static_cast<CCharEntity*>(m_PBaseEntity);
     auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(PEntity->PPet);
@@ -13151,7 +14414,11 @@ void CLuaBaseEntity::reduceBurden(float percentReduction, sol::object const& int
 
 bool CLuaBaseEntity::isExceedingElementalCapacity()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -13279,7 +14546,11 @@ void CLuaBaseEntity::removeAllRunes()
 
 void CLuaBaseEntity::setMobLevel(uint8 level)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set mob level for invalid entity type (%s, %d).", m_PBaseEntity->GetName(), level);
+        return;
+    }
 
     if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
     {
@@ -13298,7 +14569,11 @@ void CLuaBaseEntity::setMobLevel(uint8 level)
 
 uint8 CLuaBaseEntity::getEcosystem()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PBattle = static_cast<CBattleEntity*>(m_PBaseEntity);
     return static_cast<uint8>(PBattle->m_EcoSystem);
@@ -13372,7 +14647,11 @@ bool CLuaBaseEntity::isMobType(uint8 mobType)
 
 bool CLuaBaseEntity::isUndead()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->m_EcoSystem == ECOSYSTEM::UNDEAD;
 }
@@ -13417,7 +14696,11 @@ uint8 CLuaBaseEntity::getModelSize()
 
 void CLuaBaseEntity::setMobFlags(uint32 flags, sol::object const& mobId)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to set Mob Flags for invalid entity (%s)", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (mobId != sol::lua_nil)
     {
@@ -13460,7 +14743,11 @@ void CLuaBaseEntity::setMobFlags(uint32 flags, sol::object const& mobId)
  ************************************************************************/
 uint32 CLuaBaseEntity::getMobFlags()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get mob flags for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     if (auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity))
     {
@@ -13502,7 +14789,11 @@ void CLuaBaseEntity::setNpcFlags(uint32 flags)
 
 void CLuaBaseEntity::spawn(sol::object const& despawnSec, sol::object const& respawnSec)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to spawn invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -13560,7 +14851,11 @@ bool CLuaBaseEntity::isSpawned()
 
 auto CLuaBaseEntity::getSpawnPos() -> std::map<std::string, float>
 {
-    XI_DEBUG_BREAK_IF(!(m_PBaseEntity->objtype & TYPE_MOB));
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Calling entity is not a Mob (%s).", m_PBaseEntity->GetName());
+        return {};
+    }
 
     auto*                        PMob = static_cast<CMobEntity*>(m_PBaseEntity);
     std::map<std::string, float> pos;
@@ -13582,7 +14877,11 @@ auto CLuaBaseEntity::getSpawnPos() -> std::map<std::string, float>
 
 void CLuaBaseEntity::setSpawn(float x, float y, float z, sol::object const& rot)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set spawn for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -13601,7 +14900,11 @@ void CLuaBaseEntity::setSpawn(float x, float y, float z, sol::object const& rot)
 
 uint32 CLuaBaseEntity::getRespawnTime()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get respawn time for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     CMobEntity* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -13628,7 +14931,11 @@ uint32 CLuaBaseEntity::getRespawnTime()
 
 void CLuaBaseEntity::setRespawnTime(uint32 seconds)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set respawn time for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -13650,7 +14957,11 @@ void CLuaBaseEntity::setRespawnTime(uint32 seconds)
 
 void CLuaBaseEntity::instantiateMob(uint32 groupID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CMobEntity* newMob = mobutils::InstantiateAlly(groupID, m_PBaseEntity->getZone());
 
@@ -13726,7 +15037,11 @@ void CLuaBaseEntity::delImmunity(uint32 immunityID)
 
 void CLuaBaseEntity::setAggressive(bool aggressive)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set aggressive for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_Aggro = aggressive;
 }
@@ -13739,7 +15054,11 @@ void CLuaBaseEntity::setAggressive(bool aggressive)
 
 void CLuaBaseEntity::setTrueDetection(bool truedetection)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set true detection for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_TrueDetection = truedetection;
 }
@@ -13768,7 +15087,11 @@ void CLuaBaseEntity::setUnkillable(bool unkillable)
 
 void CLuaBaseEntity::setUntargetable(bool untargetable)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempt to set untargetable for invalid entity (%s)", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_MOB)
     {
@@ -13791,7 +15114,11 @@ void CLuaBaseEntity::setUntargetable(bool untargetable)
 
 bool CLuaBaseEntity::getUntargetable()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC);
+    if (m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC)
+    {
+        ShowWarning("Attempt to get untargetable for invalid entity (%s)", m_PBaseEntity->GetName());
+        return false;
+    }
 
     if (m_PBaseEntity->objtype == TYPE_MOB)
     {
@@ -13814,7 +15141,12 @@ bool CLuaBaseEntity::getUntargetable()
 
 void CLuaBaseEntity::setIsAggroable(bool isAggroable)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set is Aggroable for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
+
     static_cast<CMobEntity*>(m_PBaseEntity)->m_isAggroable = isAggroable;
 }
 
@@ -13827,7 +15159,12 @@ void CLuaBaseEntity::setIsAggroable(bool isAggroable)
 
 bool CLuaBaseEntity::isAggroable()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get is aggroable for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
+
     return static_cast<CMobEntity*>(m_PBaseEntity)->m_isAggroable;
 }
 
@@ -14055,7 +15392,11 @@ void CLuaBaseEntity::delMobMod(uint16 mobModID, int16 value)
 
 uint32 CLuaBaseEntity::getBattleTime()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<uint32>(std::chrono::duration_cast<std::chrono::seconds>(((CBattleEntity*)m_PBaseEntity)->GetBattleTime()).count());
 }
@@ -14069,7 +15410,11 @@ uint32 CLuaBaseEntity::getBattleTime()
 
 uint16 CLuaBaseEntity::getBehaviour()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get behaviour for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CMobEntity*>(m_PBaseEntity)->m_Behaviour;
 }
@@ -14083,7 +15428,11 @@ uint16 CLuaBaseEntity::getBehaviour()
 
 void CLuaBaseEntity::setBehaviour(uint16 behavior)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set behaviour for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_Behaviour = behavior;
 }
@@ -14096,7 +15445,11 @@ void CLuaBaseEntity::setBehaviour(uint16 behavior)
 
 uint16 CLuaBaseEntity::getRoamFlags()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get roam flags for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CMobEntity*>(m_PBaseEntity)->m_roamFlags;
 }
@@ -14109,7 +15462,11 @@ uint16 CLuaBaseEntity::getRoamFlags()
 
 void CLuaBaseEntity::setRoamFlags(uint16 newRoamFlags)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set roam flags for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_roamFlags = newRoamFlags;
 }
@@ -14123,7 +15480,11 @@ void CLuaBaseEntity::setRoamFlags(uint16 newRoamFlags)
 
 std::optional<CLuaBaseEntity> CLuaBaseEntity::getTarget()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return std::nullopt;
+    }
 
     auto* PBattleTarget{ m_PBaseEntity->GetEntity(static_cast<CBattleEntity*>(m_PBaseEntity)->GetBattleTargetID()) };
 
@@ -14144,7 +15505,11 @@ std::optional<CLuaBaseEntity> CLuaBaseEntity::getTarget()
 
 void CLuaBaseEntity::updateTarget()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to update target for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto*          PMobEntity = static_cast<CMobEntity*>(m_PBaseEntity);
     CBattleEntity* PTarget    = PMobEntity->PEnmityContainer->GetHighestEnmity();
@@ -14164,7 +15529,11 @@ void CLuaBaseEntity::updateTarget()
 
 sol::table CLuaBaseEntity::getEnmityList()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get enmity list for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return sol::lua_nil;
+    }
 
     EnmityList_t* enmityList = ((CMobEntity*)m_PBaseEntity)->PEnmityContainer->GetEnmityList();
 
@@ -14289,8 +15658,6 @@ void CLuaBaseEntity::castSpell(sol::object const& spell, sol::object entity)
 
 void CLuaBaseEntity::useJobAbility(uint16 skillID, sol::object const& pet)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-
     CBattleEntity* PTarget{ nullptr };
 
     if ((pet != sol::lua_nil) && pet.is<CLuaBaseEntity*>())
@@ -14326,7 +15693,11 @@ void CLuaBaseEntity::useJobAbility(uint16 skillID, sol::object const& pet)
 
 void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_TRUST && m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_PET);
+    if (m_PBaseEntity->objtype != TYPE_TRUST && m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_PET)
+    {
+        ShowWarning("Entity is not a Trust, Mob, or Pet (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     if (va.size() == 0)
     {
@@ -14387,7 +15758,11 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
 
 bool CLuaBaseEntity::hasTPMoves()
 {
-    XI_DEBUG_BREAK_IF((m_PBaseEntity->objtype == TYPE_NPC) || (m_PBaseEntity->objtype == TYPE_PC));
+    if ((m_PBaseEntity->objtype == TYPE_NPC) || (m_PBaseEntity->objtype == TYPE_PC))
+    {
+        ShowWarning("Non-Mob passed into function.");
+        return false;
+    }
 
     uint16 familyID = 0;
 
@@ -14413,7 +15788,11 @@ bool CLuaBaseEntity::hasTPMoves()
 
 void CLuaBaseEntity::weaknessTrigger(uint8 level)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to trigger weakness for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     mobutils::WeaknessTrigger(m_PBaseEntity, static_cast<WeaknessType>(level));
 }
@@ -14481,7 +15860,11 @@ void CLuaBaseEntity::restoreFromChest(CLuaBaseEntity* PLuaBaseEntity, uint32 res
 
 bool CLuaBaseEntity::hasPreventActionEffect()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+    if (m_PBaseEntity->objtype == TYPE_NPC)
+    {
+        ShowWarning("Invalid Entity (NPC: %s) calling function.", m_PBaseEntity->GetName());
+        return false;
+    }
 
     return static_cast<CBattleEntity*>(m_PBaseEntity)->StatusEffectContainer->HasPreventActionEffect();
 }
@@ -14526,7 +15909,6 @@ uint32 CLuaBaseEntity::getPool()
         return PMob->m_Pool;
     }
 
-    XI_DEBUG_BREAK_IF(true); // TODO: Examine impact of returning 0
     return 0;
 }
 
@@ -14538,7 +15920,11 @@ uint32 CLuaBaseEntity::getPool()
 
 uint32 CLuaBaseEntity::getDropID()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get drop id for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     return static_cast<CMobEntity*>(m_PBaseEntity)->m_DropID;
 }
@@ -14553,7 +15939,11 @@ uint32 CLuaBaseEntity::getDropID()
 
 void CLuaBaseEntity::setDropID(uint32 dropID)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to set drop id for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     auto* PMob = static_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -14568,7 +15958,11 @@ void CLuaBaseEntity::setDropID(uint32 dropID)
 
 void CLuaBaseEntity::addTreasure(uint16 itemID, sol::object const& arg1, sol::object const& arg2)
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
+        return;
+    }
 
     CCharEntity* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -14607,7 +16001,11 @@ void CLuaBaseEntity::addTreasure(uint16 itemID, sol::object const& arg1, sol::ob
 
 uint16 CLuaBaseEntity::getStealItem()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get steal item for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -14647,7 +16045,11 @@ uint16 CLuaBaseEntity::getStealItem()
 
 uint16 CLuaBaseEntity::getDespoilItem()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get despoil item for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return 0;
+    }
 
     auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
 
@@ -14691,7 +16093,11 @@ uint16 CLuaBaseEntity::getDespoilDebuff(uint16 itemID)
 
 bool CLuaBaseEntity::itemStolen()
 {
-    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to flag stolen item for invalid entity type (%s).", m_PBaseEntity->GetName());
+        return false;
+    }
 
     static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemStolen = true;
     return true;

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -170,7 +170,7 @@ public:
 
     auto   getZone(sol::object const& arg0) -> std::optional<CLuaZone>; // Get Entity zone
     uint16 getZoneID();                                                 // Get Entity zone ID
-    auto   getZoneName() -> const std::string&;                         // Get Entity zone name
+    auto   getZoneName() -> std::string;                                // Get Entity zone name
     bool   hasVisitedZone(uint16 zone);                                 // true if player has previously entered zone
     uint16 getPreviousZone();                                           // Get Entity previous zone
     uint8  getCurrentRegion();                                          // Get Entity conquest region

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -438,7 +438,13 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
                 // Mob IDs need to be in the format of { { id, ... }, { ... } } with each subtable being an area
                 auto  mobIds = groupMobIds.get<std::vector<std::vector<uint32>>>();
                 uint8 area   = m_PLuaBattlefield->GetArea() - 1;
-                XI_DEBUG_BREAK_IF(area >= mobIds.size());
+
+                if (area >= mobIds.size())
+                {
+                    ShowWarning("Battlefield Area is greated than groupMobIds size.");
+                    return;
+                }
+
                 addMobIdsForArea(mobIds[area]);
             }
             else
@@ -452,7 +458,11 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
         for (CBaseEntity* entity : groupEntities)
         {
             auto PMob = dynamic_cast<CMobEntity*>(entity);
-            XI_DEBUG_BREAK_IF(PMob == nullptr);
+            if (PMob == nullptr)
+            {
+                ShowError("PMob is null.");
+                return;
+            }
 
             // Restore modifiers here since we save the modifiers below but don't want any previous modifiers persisting
             PMob->restoreModifiers();
@@ -473,7 +483,11 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
 
                 // Leave existing party first before joining this new one
                 if (PMob->PParty != nullptr)
@@ -499,7 +513,12 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
+
                 PMob->setMobMod(MOBMOD_SUPERLINK, superlinkId);
                 PMob->saveMobModifiers();
             }
@@ -511,7 +530,12 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
+
                 PMob->setMobMod(MOBMOD_ROAM_RESET_FACING, 1);
                 PMob->m_maxRoamDistance = 0.5f;
                 PMob->m_roamFlags |= ROAMFLAG_SCRIPTED;
@@ -525,7 +549,12 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
+
                 for (auto modifier : mods.get<sol::table>())
                 {
                     PMob->setModifier(modifier.first.as<Mod>(), modifier.second.as<uint16>());
@@ -540,7 +569,12 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
+
                 for (auto modifier : mobMods.get<sol::table>())
                 {
                     PMob->setMobMod(modifier.first.as<uint16>(), modifier.second.as<uint16>());
@@ -581,7 +615,12 @@ void CLuaBattlefield::addGroups(sol::table groups, bool hasMultipleArenas)
             for (CBaseEntity* entity : groupEntities)
             {
                 auto PMob = dynamic_cast<CMobEntity*>(entity);
-                XI_DEBUG_BREAK_IF(PMob == nullptr);
+                if (PMob == nullptr)
+                {
+                    ShowError("PMob is null.");
+                    return;
+                }
+
                 PMob->saveModifiers();
                 PMob->saveMobModifiers();
             }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2085,7 +2085,8 @@ namespace luautils
                 break;
             default:
                 // Should never hit this
-                XI_DEBUG_BREAK_IF(true);
+                ShowError("Invalid objtype for entity received.");
+                return -1;
         }
         auto filename = fmt::format(pathFormat, zone, name);
 
@@ -4329,7 +4330,11 @@ namespace luautils
 
     void AfterInstanceRegister(CBaseEntity* PChar)
     {
-        XI_DEBUG_BREAK_IF(!PChar->PInstance);
+        if (!PChar->PInstance)
+        {
+            ShowWarning("PInstance is null.");
+            return;
+        }
 
         TracyZoneScoped;
 

--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -165,7 +165,11 @@ static const MeritCategoryInfo_t meritCatInfo[] = {
 
 CMeritPoints::CMeritPoints(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(sizeof(merits) != sizeof(meritNameSpace::GMeritsTemplate));
+    if (sizeof(merits) != sizeof(meritNameSpace::GMeritsTemplate))
+    {
+        ShowWarning("Size mismatch between merits and GMeritsTemplate for %s.", PChar->GetName());
+        return;
+    }
 
     memcpy(merits, meritNameSpace::GMeritsTemplate, sizeof(merits));
 
@@ -399,7 +403,11 @@ const Merit_t* CMeritPoints::GetMerit(MERIT_TYPE merit)
 
 const Merit_t* CMeritPoints::GetMeritByIndex(uint16 index)
 {
-    XI_DEBUG_BREAK_IF(index >= MERITS_COUNT);
+    if (index >= MERITS_COUNT)
+    {
+        ShowWarning("Invalid Merit Index (%d) passed to function.", index);
+        return nullptr;
+    }
 
     return &merits[index];
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -7370,8 +7370,17 @@ void SmallPacket0x104(map_session_data_t* const PSession, CCharEntity* const PCh
 void SmallPacket0x105(map_session_data_t* const PSession, CCharEntity* const PChar, CBasicPacket data)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(PChar->BazaarID.id != 0);
-    XI_DEBUG_BREAK_IF(PChar->BazaarID.targid != 0);
+    if (PChar->BazaarID.id != 0)
+    {
+        ShowWarning("BazaarID.id is not equal to zero.");
+        return;
+    }
+
+    if (PChar->BazaarID.targid != 0)
+    {
+        ShowWarning("BazaarID.targid is not equal to zero.");
+        return;
+    }
 
     uint32 charid = data.ref<uint32>(0x04);
 

--- a/src/map/packets/guild_menu_buy_update.cpp
+++ b/src/map/packets/guild_menu_buy_update.cpp
@@ -35,7 +35,11 @@ CGuildMenuBuyUpdatePacket::CGuildMenuBuyUpdatePacket(CCharEntity* PChar, uint8 s
     this->setType(0x82);
     this->setSize(0x08);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
+    if (PChar == nullptr)
+    {
+        ShowWarning("PChar is null.");
+        return;
+    }
 
     ref<uint16>(0x04) = itemID;
     ref<uint8>(0x06)  = stock;

--- a/src/map/packets/guild_menu_sell_update.cpp
+++ b/src/map/packets/guild_menu_sell_update.cpp
@@ -35,7 +35,11 @@ CGuildMenuSellUpdatePacket::CGuildMenuSellUpdatePacket(CCharEntity* PChar, uint8
     this->setType(0x84);
     this->setSize(0x08);
 
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
+    if (PChar == nullptr)
+    {
+        ShowWarning("PChar is null.");
+        return;
+    }
 
     ref<uint16>(0x04) = itemID;
     ref<uint8>(0x06)  = stock;

--- a/src/map/packets/key_items.cpp
+++ b/src/map/packets/key_items.cpp
@@ -31,7 +31,11 @@ CKeyItemsPacket::CKeyItemsPacket(CCharEntity* PChar, KEYS_TABLE KeyTable)
     this->setType(0x55);
     this->setSize(0x88);
 
-    XI_DEBUG_BREAK_IF(KeyTable >= MAX_KEYS_TABLE);
+    if (KeyTable >= MAX_KEYS_TABLE)
+    {
+        ShowWarning("KeyTable (%d) exceeds MAX_KEYS_TABLE.", KeyTable);
+        return;
+    }
 
     memcpy(data + (0x04), &(PChar->keys.tables[KeyTable].keyList), 0x40);
     memcpy(data + (0x44), &(PChar->keys.tables[KeyTable].seenList), 0x40);

--- a/src/map/packets/party_effects.cpp
+++ b/src/map/packets/party_effects.cpp
@@ -32,7 +32,12 @@ CPartyEffectsPacket::CPartyEffectsPacket()
 
 void CPartyEffectsPacket::AddMemberEffects(CBattleEntity* PMember)
 {
-    XI_DEBUG_BREAK_IF(members == 5);
+    if (members == 5)
+    {
+        ShowWarning("Member count exceeds packet maximum.");
+        return;
+    }
+
     ref<uint32>(members * 0x30 + 0x04) = PMember->id;
     ref<uint16>(members * 0x30 + 0x08) = PMember->targid;
     ref<uint64>(members * 0x30 + 0x0C) = PMember->StatusEffectContainer->m_Flags;

--- a/src/map/packets/world_pass.cpp
+++ b/src/map/packets/world_pass.cpp
@@ -45,7 +45,12 @@ CWorldPassPacket::CWorldPassPacket(uint32 WorldPass)
 
         /* Assumption made: MAX u32 value is 10 digits */
         std::string strbuff = fmt::sprintf("%" PRIu32, WorldPass);
-        XI_DEBUG_BREAK_IF(strbuff.length() > 10);
+        if (strbuff.length() > 10)
+        {
+            ShowWarning("String exceeds maximum (Expected: 10, Actual: %d)", strbuff.length());
+            return;
+        }
+
         memset(data + 0x10, 0, 10);
         memcpy(data + 0x10, strbuff.c_str(), strbuff.length());
     }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -173,7 +173,11 @@ void CParty::DisbandParty(bool playerInitiated)
 // Assign roles to group members (players only)
 void CParty::AssignPartyRole(const std::string& MemberName, uint8 role)
 {
-    XI_DEBUG_BREAK_IF(m_PartyType != PARTY_PCS);
+    if (m_PartyType != PARTY_PCS)
+    {
+        ShowWarning("Attempting to assign role (%d) to %s in Mob Party.", role, MemberName);
+        return;
+    }
 
     // Make sure that the the character is actually a part of this party
     int ret = sql->Query("SELECT chars.charid FROM chars \
@@ -235,7 +239,11 @@ uint8 CParty::MemberCount(uint16 ZoneID)
 // Returns entity pointer to party member by name (used for /pcmd kick or otherwise)
 CBattleEntity* CParty::GetMemberByName(const std::string& memberName)
 {
-    XI_DEBUG_BREAK_IF(m_PartyType != PARTY_PCS);
+    if (m_PartyType != PARTY_PCS)
+    {
+        ShowWarning("Attempting to get Member data for %s in Mob Party.", memberName);
+        return nullptr;
+    }
 
     if (memberName == "")
     {
@@ -542,7 +550,11 @@ void CParty::AddMember(CBattleEntity* PEntity)
 
     if (m_PartyType == PARTY_PCS)
     {
-        XI_DEBUG_BREAK_IF(PEntity->objtype != TYPE_PC);
+        if (PEntity->objtype != TYPE_PC)
+        {
+            ShowWarning("Non-Player passed into function (%s).", PEntity->GetName());
+            return;
+        }
 
         CCharEntity* PChar = (CCharEntity*)PEntity;
 

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -38,7 +38,11 @@
 CRecastContainer::CRecastContainer(CBattleEntity* PEntity)
 : m_PEntity(PEntity)
 {
-    XI_DEBUG_BREAK_IF(m_PEntity == nullptr)
+    if (m_PEntity == nullptr)
+    {
+        ShowError("m_PEntity is null.");
+    }
+
     std::ignore = m_PEntity;
 }
 
@@ -60,7 +64,7 @@ RecastList_t* CRecastContainer::GetRecastList(RECASTTYPE type)
             break;
     }
     // Unhandled Scenario
-    XI_DEBUG_BREAK_IF(true);
+    ShowError("Invalid RECASTTYPE received, returning nullptr.");
     return nullptr;
 }
 

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -658,11 +658,10 @@ namespace spell
     // Get Spell By ID
     CSpell* GetSpell(SpellID SpellID)
     {
-        XI_DEBUG_BREAK_IF(static_cast<uint16>(SpellID) >= MAX_SPELL_ID);
-
         auto id = static_cast<uint16>(SpellID);
         if (id >= MAX_SPELL_ID)
         {
+            ShowWarning("Spell ID (%d) exceeds MAX_SPELL_ID.", static_cast<uint16>(SpellID));
             return nullptr;
         }
         // False positive: this is CSpell*, so it's OK

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -138,7 +138,11 @@ void CStatusEffect::UnsetFlag(uint32 flag)
 
 void CStatusEffect::SetIcon(uint16 Icon)
 {
-    XI_DEBUG_BREAK_IF(m_POwner == nullptr);
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("m_POwner was null.");
+        return;
+    }
 
     m_Icon = Icon;
     m_POwner->StatusEffectContainer->UpdateStatusIcons();

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -217,7 +217,12 @@ CStatusEffectContainer::CStatusEffectContainer(CBattleEntity* PEntity)
 : m_StatusEffectSet(statusOrdering)
 {
     m_POwner = PEntity;
-    XI_DEBUG_BREAK_IF(m_POwner == nullptr);
+
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("m_POwner was null.");
+        return;
+    }
 
     memset(m_StatusIcons, 0xFF, sizeof(m_StatusIcons));
 }
@@ -1467,9 +1472,23 @@ void CStatusEffectContainer::RemoveAllStatusEffectsInIDRange(EFFECT start, EFFEC
 
 void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
 {
-    XI_DEBUG_BREAK_IF(StatusEffect->GetStatusID() >= MAX_EFFECTID);
-    XI_DEBUG_BREAK_IF(StatusEffect->GetStatusID() == EFFECT_FOOD && StatusEffect->GetSubID() == 0);
-    XI_DEBUG_BREAK_IF(StatusEffect->GetStatusID() == EFFECT_NONE && StatusEffect->GetSubID() == 0);
+    if (StatusEffect->GetStatusID() >= MAX_EFFECTID)
+    {
+        ShowWarning("Status Effect ID (%d) exceeds MAX_EFFECTID", StatusEffect->GetStatusID());
+        return;
+    }
+
+    if (StatusEffect->GetStatusID() == EFFECT_FOOD && StatusEffect->GetSubID() == 0)
+    {
+        ShowWarning("Food Effect has SubID of 0.");
+        return;
+    }
+
+    if (StatusEffect->GetStatusID() == EFFECT_NONE && StatusEffect->GetSubID() == 0)
+    {
+        ShowWarning("None-type Effect has SubID of 0");
+        return;
+    }
 
     std::string name;
     EFFECT      effect = StatusEffect->GetStatusID();
@@ -1542,7 +1561,11 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
 
 void CStatusEffectContainer::LoadStatusEffects()
 {
-    XI_DEBUG_BREAK_IF(m_POwner->objtype != TYPE_PC);
+    if (m_POwner->objtype != TYPE_PC)
+    {
+        ShowWarning("Non-PC calling function (%s).", m_POwner->GetName());
+        return;
+    }
 
     const char* Query = "SELECT "
                         "effectid,"
@@ -1709,7 +1732,12 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 
 void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
 {
-    XI_DEBUG_BREAK_IF(m_POwner == nullptr);
+    if (m_POwner == nullptr)
+    {
+        ShowWarning("m_POwner was null.");
+        return;
+    }
+
     TracyZoneScoped;
 
     for (CStatusEffect* PStatusEffect : m_StatusEffectSet)

--- a/src/map/trait.cpp
+++ b/src/map/trait.cpp
@@ -118,7 +118,11 @@ namespace traits
 
     TraitList_t* GetTraits(uint8 JobID)
     {
-        XI_DEBUG_BREAK_IF(JobID >= MAX_JOBTYPE);
+        if (JobID >= MAX_JOBTYPE)
+        {
+            ShowWarning("JobID (%d) exceeds MAX_JOBTYPE.", JobID);
+            return nullptr;
+        }
 
         return &PTraitsList[JobID];
     }

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -124,7 +124,11 @@ void Elevator_t::closeDoor(CNpcEntity* npc) const
 
 void CTransportHandler::InitializeTransport()
 {
-    XI_DEBUG_BREAK_IF(townZoneList.size() != 0);
+    if (townZoneList.size() != 0)
+    {
+        ShowError("townZoneList is not empty.");
+        return;
+    }
 
     const char* fmtQuery = "SELECT id, transport, door, dock_x, dock_y, dock_z, dock_rot, \
                             boundary, zone, anim_arrive, anim_depart, time_offset, time_interval, \
@@ -433,7 +437,8 @@ void CTransportHandler::insertElevator(Elevator_t elevator)
 
         if (PElevator->Elevator->GetName() == elevator.Elevator->GetName() && PElevator->zoneID == elevator.zoneID)
         {
-            XI_DEBUG_BREAK_IF(true);
+            ShowError("Elevator already exists.");
+            return;
         }
     }
 

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -591,7 +591,11 @@ void CTreasurePool::TreasureError(CCharEntity* winner, uint8 SlotID)
 
 void CTreasurePool::TreasureLost(uint8 SlotID)
 {
-    XI_DEBUG_BREAK_IF(m_PoolItems[SlotID].ID == 0);
+    if (m_PoolItems[SlotID].ID == 0)
+    {
+        ShowWarning("Pool Items for SlotID (%d) was 0.", SlotID);
+        return;
+    }
 
     m_PoolItems[SlotID].TimeStamp = get_server_start_time();
 

--- a/src/map/unitychat.cpp
+++ b/src/map/unitychat.cpp
@@ -90,7 +90,12 @@ namespace unitychat
 
     bool AddOnlineMember(CCharEntity* PChar, uint32 leader)
     {
-        XI_DEBUG_BREAK_IF(PChar == nullptr);
+        if (PChar == nullptr)
+        {
+            ShowWarning("PChar is null.");
+            return false;
+        }
+
         CUnityChat* PUnity = nullptr;
         if (auto UnityChatListUnity = UnityChatList.find(leader); UnityChatListUnity != UnityChatList.end())
         {
@@ -109,7 +114,12 @@ namespace unitychat
 
     bool DelOnlineMember(CCharEntity* PChar, uint32 leader)
     {
-        XI_DEBUG_BREAK_IF(PChar == nullptr);
+        if (PChar == nullptr)
+        {
+            ShowWarning("PChar is null.");
+            return false;
+        }
+
         try
         {
             CUnityChat* PUnityChat = UnityChatList.at(leader).get();

--- a/src/map/universal_container.cpp
+++ b/src/map/universal_container.cpp
@@ -115,7 +115,11 @@ UCONTAINERTYPE CUContainer::GetType()
 
 void CUContainer::SetType(UCONTAINERTYPE Type)
 {
-    XI_DEBUG_BREAK_IF(m_ContainerType != UCONTAINER_EMPTY);
+    if (m_ContainerType != UCONTAINER_EMPTY)
+    {
+        ShowWarning("Attempting to set Type of container that has previous value configured.");
+        return;
+    }
 
     m_ContainerType = Type;
 }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -446,9 +446,9 @@ namespace battleutils
 
     CWeaponSkill* GetWeaponSkill(uint16 WSkillID)
     {
-        XI_DEBUG_BREAK_IF(WSkillID >= MAX_WEAPONSKILL_ID);
         if (WSkillID >= MAX_WEAPONSKILL_ID)
         {
+            ShowError("WSkillID (%d) exceeds MAX_WEAPONSKILL_ID.", WSkillID);
             return nullptr;
         }
 
@@ -465,7 +465,11 @@ namespace battleutils
 
     const std::list<CWeaponSkill*>& GetWeaponSkills(uint8 skill)
     {
-        XI_DEBUG_BREAK_IF(skill >= MAX_SKILLTYPE);
+        if (skill >= MAX_SKILLTYPE)
+        {
+            ShowWarning("Skill (%d) exceeds MAX_SKILLTYPE", skill);
+            return g_PWeaponSkillsList[SKILL_NONE];
+        }
 
         return g_PWeaponSkillsList[skill];
     }
@@ -3800,7 +3804,12 @@ namespace battleutils
             {
                 if (PSCEffect->GetTier() == 0)
                 {
-                    XI_DEBUG_BREAK_IF(!PSCEffect->GetPower());
+                    if (!PSCEffect->GetPower())
+                    {
+                        ShowWarning("PSCEffect Power was 0.");
+                        return SUBEFFECT_NONE;
+                    }
+
                     // Previous effect is an opening effect, meaning the power is
                     // actually the ID of the opening weaponskill.  We need all 3
                     // of the possible skillchain properties on the initial link.
@@ -3920,7 +3929,7 @@ namespace battleutils
                 break;
 
             default:
-                XI_DEBUG_BREAK_IF(true);
+                ShowWarning("Invalid Skillchain Type received (%d).", element);
                 return 0;
                 break;
         }
@@ -4008,7 +4017,11 @@ namespace battleutils
         ELEMENT            appliedEle = ELEMENT_NONE;
         int16              resistance = GetSkillchainMinimumResistance(skillchain, PDefender, &appliedEle);
 
-        XI_DEBUG_BREAK_IF(chainLevel <= 0 || chainLevel > 4 || chainCount <= 0 || chainCount > 5);
+        if (chainLevel <= 0 || chainLevel > 4 || chainCount <= 0 || chainCount > 5)
+        {
+            ShowWarning("chainLevel (%d) or chainCount (%d) exceeds bounds.", chainLevel, chainCount);
+            return 0;
+        }
 
         // Skill chain damage = (Closing Damage)
         //                      × (Skill chain Level/Number from Table)
@@ -4073,12 +4086,17 @@ namespace battleutils
 
     CItemEquipment* GetEntityArmor(CBattleEntity* PEntity, SLOTTYPE Slot)
     {
-        XI_DEBUG_BREAK_IF(Slot < SLOT_HEAD || Slot > SLOT_LINK2);
+        if (Slot < SLOT_HEAD || Slot > SLOT_LINK2)
+        {
+            ShowWarning("Invalid Slot Type (%d) passed to function.", static_cast<uint8>(Slot));
+            return nullptr;
+        }
 
         if (PEntity->objtype == TYPE_PC)
         {
             return (((CCharEntity*)PEntity)->getEquip(Slot));
         }
+
         return nullptr;
     }
 
@@ -6262,7 +6280,12 @@ namespace battleutils
 
     bool HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget)
     {
-        XI_DEBUG_BREAK_IF(PTarget == nullptr);
+        if (PTarget == nullptr)
+        {
+            ShowWarning("PTarget is null.");
+            return false;
+        }
+
         CBattleEntity* PMaster = PEntity;
 
         if (PEntity->PMaster != nullptr)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2758,7 +2758,11 @@ namespace charutils
 
     void BuildingCharPetAbilityTable(CCharEntity* PChar, CPetEntity* PPet, uint32 PetID)
     {
-        XI_DEBUG_BREAK_IF(PPet == nullptr || PChar == nullptr);
+        if (PPet == nullptr || PChar == nullptr)
+        {
+            ShowWarning("PPet or PChar was null.");
+            return;
+        }
 
         memset(&PChar->m_PetCommands, 0, sizeof(PChar->m_PetCommands));
 
@@ -3149,11 +3153,16 @@ namespace charutils
         TracyZoneScoped;
 
         // This usually happens after a crash
-        XI_DEBUG_BREAK_IF((unsigned int)SkillID >= MAX_SKILLTYPE); // выход за пределы допустимых умений
-
-        if (((PChar->WorkingSkills.rank[SkillID] != 0) && !(PChar->WorkingSkills.skill[SkillID] & 0x8000)) || useSubSkill)
+        uint8 rawSkillID = static_cast<uint8>(SkillID);
+        if (rawSkillID >= MAX_SKILLTYPE)
         {
-            uint16 CurSkill     = PChar->RealSkills.skill[SkillID];
+            ShowWarning("SkillID (%d) exceeds MAX_SKILLTYPE.", rawSkillID);
+            return;
+        }
+
+        if (((PChar->WorkingSkills.rank[rawSkillID] != 0) && !(PChar->WorkingSkills.skill[rawSkillID] & 0x8000)) || useSubSkill)
+        {
+            uint16 CurSkill     = PChar->RealSkills.skill[rawSkillID];
             uint16 MainCapSkill = battleutils::GetMaxSkill(SkillID, PChar->GetMJob(), PChar->GetMLevel());
             uint16 SubCapSkill  = battleutils::GetMaxSkill(SkillID, PChar->GetSJob(), PChar->GetSLevel());
             uint16 MainMaxSkill = battleutils::GetMaxSkill(SkillID, PChar->GetMJob(), std::min(PChar->GetMLevel(), lvl));
@@ -4464,8 +4473,17 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        XI_DEBUG_BREAK_IF(retainPercent > 1.0f || retainPercent < 0.0f);
-        XI_DEBUG_BREAK_IF(settings::get<uint8>("map.EXP_LOSS_LEVEL") > 99 || settings::get<uint8>("map.EXP_LOSS_LEVEL") < 1);
+        if (retainPercent > 1.0f || retainPercent < 0.0f)
+        {
+            ShowWarning("Invalid retainPercent value (%f) received.", retainPercent);
+            return;
+        }
+
+        if (settings::get<uint8>("map.EXP_LOSS_LEVEL") > 99 || settings::get<uint8>("map.EXP_LOSS_LEVEL") < 1)
+        {
+            ShowWarning("Invalid EXP_LOSS_LEVEL setting value was obtained (%d).", settings::get<uint8>("map.EXP_LOSS_LEVEL"));
+            return;
+        }
 
         if (PChar->GetMLevel() < settings::get<uint8>("map.EXP_LOSS_LEVEL") && forcedXpLoss == 0)
         {
@@ -5264,7 +5282,11 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        XI_DEBUG_BREAK_IF(job == JOB_NON || job >= MAX_JOBTYPE);
+        if (job == JOB_NON || job >= MAX_JOBTYPE)
+        {
+            ShowWarning("Attempt to save Invalid Job with JOBTYPE %d.", job);
+            return;
+        }
 
         const char* fmtQuery;
 
@@ -5354,7 +5376,11 @@ namespace charutils
     {
         TracyZoneScoped;
 
-        XI_DEBUG_BREAK_IF(job == JOB_NON || job >= MAX_JOBTYPE);
+        if (job == JOB_NON || job >= MAX_JOBTYPE)
+        {
+            ShowWarning("Attempt to save Char XP with invalid JOBTYPE %d.", job);
+            return;
+        }
 
         const char* Query;
 
@@ -6144,7 +6170,7 @@ namespace charutils
             case 2:
                 return "windurst_cp";
             default:
-                XI_DEBUG_BREAK_IF(true);
+                ShowError("Invalid nation received, returning nullptr.");
                 return nullptr;
         }
     }

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1336,12 +1336,21 @@ namespace fishingutils
     bool BaitLoss(CCharEntity* PChar, bool RemoveFly, bool SendUpdate)
     {
         CItemWeapon* PBait = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
-        XI_DEBUG_BREAK_IF(PBait == nullptr);
-        XI_DEBUG_BREAK_IF(PBait->isType(ITEM_WEAPON) == false);
-        XI_DEBUG_BREAK_IF(PBait->getSkillType() != SKILL_FISHING);
 
         if (PBait != nullptr)
         {
+            if (!PBait->isType(ITEM_WEAPON))
+            {
+                ShowWarning("PBait is not of Weapon Type.");
+                return false;
+            }
+
+            if (PBait->getSkillType() != SKILL_FISHING)
+            {
+                ShowWarning("PBait Skilltype is not Fishing.");
+                return false;
+            }
+
             if (!RemoveFly && (PBait->getStackSize() == 1))
             {
                 return false;
@@ -1369,8 +1378,18 @@ namespace fishingutils
     {
         CItemWeapon* PRanged = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_RANGED));
         rod_t*       PRod    = FishingRods[PRanged->getID()];
-        XI_DEBUG_BREAK_IF(PRanged == nullptr);
-        XI_DEBUG_BREAK_IF(PRod == nullptr);
+
+        if (PRanged == nullptr)
+        {
+            ShowWarning("PRod was null.");
+            return;
+        }
+
+        if (PRod == nullptr)
+        {
+            ShowWarning("PRod was null.");
+            return;
+        }
 
         if (PRanged != nullptr && PRod != nullptr)
         {

--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -59,7 +59,12 @@ namespace guildutils
                 g_PGuildList.push_back(new CGuild(sql->GetIntData(0), sql->GetStringData(1)));
             }
         }
-        XI_DEBUG_BREAK_IF(g_PGuildShopList.size() != 0);
+
+        if (g_PGuildShopList.size() != 0)
+        {
+            ShowWarning("g_PGuildShopList contains information prior to initialization.");
+            return;
+        }
 
         fmtQuery = "SELECT DISTINCT guildid FROM guild_shops ORDER BY guildid ASC LIMIT 256;";
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1230,7 +1230,11 @@ namespace petutils
 
     void SpawnPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone)
     {
-        XI_DEBUG_BREAK_IF(PMaster->PPet != nullptr);
+        if (PMaster->PPet != nullptr)
+        {
+            ShowWarning("Pet was not null for %s.", PMaster->GetName());
+            return;
+        }
 
         if (PMaster->objtype == TYPE_PC &&
             (PetID == PETID_HARLEQUINFRAME || PetID == PETID_VALOREDGEFRAME || PetID == PETID_SHARPSHOTFRAME || PetID == PETID_STORMWAKERFRAME))
@@ -1349,9 +1353,23 @@ namespace petutils
 
     void DetachPet(CBattleEntity* PMaster)
     {
-        XI_DEBUG_BREAK_IF(PMaster == nullptr);
-        XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
-        XI_DEBUG_BREAK_IF(PMaster->objtype != TYPE_PC);
+        if (PMaster == nullptr)
+        {
+            ShowWarning("PMaster is null.");
+            return;
+        }
+
+        if (PMaster->PPet == nullptr)
+        {
+            ShowWarning("Pet is null for %s.", PMaster->GetName());
+            return;
+        }
+
+        if (PMaster->objtype != TYPE_PC)
+        {
+            ShowWarning("Non-PC passed into function (%s)", PMaster->GetName());
+            return;
+        }
 
         CBattleEntity* PPet  = PMaster->PPet;
         CCharEntity*   PChar = static_cast<CCharEntity*>(PMaster);
@@ -1449,8 +1467,17 @@ namespace petutils
 
     void DespawnPet(CBattleEntity* PMaster)
     {
-        XI_DEBUG_BREAK_IF(PMaster == nullptr);
-        XI_DEBUG_BREAK_IF(PMaster->PPet == nullptr);
+        if (PMaster == nullptr)
+        {
+            ShowWarning("PMaster is null.");
+            return;
+        }
+
+        if (PMaster->PPet == nullptr)
+        {
+            ShowWarning("Pet is null for %s.", PMaster->GetName());
+            return;
+        }
 
         petutils::DetachPet(PMaster);
     }
@@ -1690,8 +1717,17 @@ namespace petutils
 
     void LoadPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone)
     {
-        XI_DEBUG_BREAK_IF(PMaster == nullptr);
-        XI_DEBUG_BREAK_IF(PetID >= MAX_PETID);
+        if (PMaster == nullptr)
+        {
+            ShowWarning("PMaster is null.");
+            return;
+        }
+
+        if (PetID >= MAX_PETID)
+        {
+            ShowWarning("PetID (%d) exceeds MAX_PETID", PetID);
+            return;
+        }
 
         // clang-format off
         Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -592,7 +592,11 @@ void CZone::updateCharLevelRestriction(CCharEntity* PChar)
 void CZone::SetWeather(WEATHER weather)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(weather >= MAX_WEATHER_ID);
+    if (weather >= MAX_WEATHER_ID)
+    {
+        ShowWarning("Weather value (%d) exceeds MAX_WEATHER_ID.", weather);
+        return;
+    }
 
     if (m_Weather == weather)
     {

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -215,8 +215,17 @@ void CZoneEntities::DeleteTRUST(CBaseEntity* PTrust)
 void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(PEntity == nullptr);
-    XI_DEBUG_BREAK_IF(PEntity->objtype != TYPE_MOB);
+    if (PEntity == nullptr)
+    {
+        ShowWarning("PEntity was null.");
+        return;
+    }
+
+    if (PEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Non-MOB was passed into function (%s).", PEntity->GetName());
+        return;
+    }
 
     CMobEntity* PMob = (CMobEntity*)PEntity;
 
@@ -350,8 +359,18 @@ void CZoneEntities::MusicChange(uint8 BlockID, uint8 MusicTrackID)
 
 void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
 {
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->loc.zone != m_zone);
+    if (PChar == nullptr)
+    {
+        ShowWarning("PChar is null.");
+        return;
+    }
+
+    if (PChar->loc.zone != m_zone)
+    {
+        ShowWarning("Zone mismatch for %s.", PChar->GetName());
+        return;
+    }
+
     TracyZoneScoped;
 
     battleutils::RelinquishClaim(PChar);

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -188,9 +188,23 @@ void CZoneInstance::DecreaseZoneCounter(CCharEntity* PChar)
 void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
 {
     TracyZoneScoped;
-    XI_DEBUG_BREAK_IF(PChar == nullptr);
-    XI_DEBUG_BREAK_IF(PChar->loc.zone != nullptr);
-    XI_DEBUG_BREAK_IF(PChar->PTreasurePool != nullptr);
+    if (PChar == nullptr)
+    {
+        ShowWarning("PChar is null.");
+        return;
+    }
+
+    if (PChar->loc.zone != nullptr)
+    {
+        ShowWarning("Zone was not null for %s.", PChar->GetName());
+        return;
+    }
+
+    if (PChar->PTreasurePool != nullptr)
+    {
+        ShowWarning("PTreasurePool was not empty for %s.", PChar->GetName());
+        return;
+    }
 
     // return char to instance (d/c or logout)
     if (!PChar->PInstance)

--- a/src/search/tcp_request.cpp
+++ b/src/search/tcp_request.cpp
@@ -204,7 +204,11 @@ int32 CTCPRequestPacket::CheckPacketHash()
 
 uint8 CTCPRequestPacket::GetPacketType()
 {
-    XI_DEBUG_BREAK_IF(m_data == nullptr)
+    if (m_data == nullptr)
+    {
+        ShowError("m_data is nullptr.");
+        return 0;
+    }
 
     return m_data[0x0B];
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2994 

Replaces all XI_DEBUG_BREAK_IF statements with logging and returns out of functions (if applicable).  This _may_ break some things, but have been spot checking and testing as I can, and have not had issues yet.

Items of note:
getZoneName() was replaced with returning a string instead of string reference.  This has not caused issues so far in testing, but need some additional eyes on it.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
This touches pretty much everything, so a direct test is difficult, other than play with it, and see what happens.

<!-- Clear and detailed steps to test your changes here -->
