### PR TITLE
Fix messaging for Chakra

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -48,15 +48,18 @@ end
 
 xi.job_utils.monk.useChakra = function(player, target, ability)
     local chakraRemoval = player:getMod(xi.mod.CHAKRA_REMOVAL)
+
     for k, v in pairs(chakraStatusEffects) do
         if bit.band(chakraRemoval, v) == v then
             player:delStatusEffect(xi.effect[k])
         end
     end
 
-    local jpLevel = target:getJobPointLevel(xi.jp.CHAKRA_EFFECT) * 10
-    local recover = player:getStat(xi.mod.VIT) * (2 + player:getMod(xi.mod.CHAKRA_MULT) / 10) -- TODO: Figure out "function of level" addition (August 2017 update)
-    player:setHP(player:getHP() + recover + jpLevel)
+    local jpModifier        = target:getJobPointLevel(xi.jp.CHAKRA_EFFECT) -- NOTE: Level is the modified value, so 10 per point spent
+    local maxRecoveryAmount = (player:getStat(xi.mod.VIT) * (2 + player:getMod(xi.mod.CHAKRA_MULT) / 10)) + jpModifier
+    local recoveryAmount    = math.min(player:getMaxHP() - player:getHP(), maxRecoveryAmount) -- TODO: Figure out "function of level" addition (August 2017 update)
+
+    player:setHP(player:getHP() + recoveryAmount)
 
     local merits = player:getMerit(xi.merit.INVIGORATE)
     if merits > 0 then
@@ -67,7 +70,7 @@ xi.job_utils.monk.useChakra = function(player, target, ability)
         player:addStatusEffect(xi.effect.REGEN, 10, 0, merits, 0, 0, 1)
     end
 
-    return recover
+    return recoveryAmount
 end
 
 xi.job_utils.monk.useChiBlast = function(player, target, ability)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Fixes Chakra messaging to only display HP restored
* Renames jpLevel to jpModifier to indicate what is being done, and adds comment for returned value from binding

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use Chakra at various HP levels and Job Points

![image](https://github.com/LandSandBoat/server/assets/81713309/7680f80e-cb22-49be-9e6c-ade117065b4e)

<!-- Clear and detailed steps to test your changes here -->
