### PR TITLE
Move all OVERSEER_BASE definitions to GetFirstID()

### DIFF
--- a/scripts/zones/Beaucedine_Glacier/IDs.lua
+++ b/scripts/zones/Beaucedine_Glacier/IDs.lua
@@ -106,8 +106,8 @@ zones[xi.zone.BEAUCEDINE_GLACIER] =
 
     npc =
     {
-        MIRROR_POND_J8  = 17232206, -- Mirror_Pond_1 in npc_list
-        OVERSEER_BASE   = 17232217, -- Parledaire_RK in npc_list
+        MIRROR_POND_J8 = 17232206, -- Mirror_Pond_1 in npc_list
+        OVERSEER_BASE  = GetFirstID('Parledaire_RK'),
     },
 }
 

--- a/scripts/zones/Buburimu_Peninsula/IDs.lua
+++ b/scripts/zones/Buburimu_Peninsula/IDs.lua
@@ -65,7 +65,7 @@ zones[xi.zone.BUBURIMU_PENINSULA] =
     },
     npc =
     {
-        OVERSEER_BASE   = 17261150, -- Bonbavour_RK in npc_list
+        OVERSEER_BASE   = GetFirstID('Bonbavour_RK'),
         SIGNPOST_OFFSET = 17261165,
         LOGGING =
         {

--- a/scripts/zones/Cape_Teriggan/IDs.lua
+++ b/scripts/zones/Cape_Teriggan/IDs.lua
@@ -62,7 +62,7 @@ zones[xi.zone.CAPE_TERIGGAN] =
     },
     npc =
     {
-        OVERSEER_BASE    = 17240472,
+        OVERSEER_BASE    = GetFirstID('Salimardi_RK'),
         CERMET_HEADSTONE = 17240497,
     },
 }

--- a/scripts/zones/Eastern_Altepa_Desert/IDs.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/IDs.lua
@@ -59,7 +59,7 @@ zones[xi.zone.EASTERN_ALTEPA_DESERT] =
     },
     npc =
     {
-        OVERSEER_BASE = 17244627, -- Eaulevisat_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Eaulevisat_RK'),
     },
 }
 

--- a/scripts/zones/Jugner_Forest/IDs.lua
+++ b/scripts/zones/Jugner_Forest/IDs.lua
@@ -112,7 +112,7 @@ zones[xi.zone.JUGNER_FOREST] =
 
     npc =
     {
-        OVERSEER_BASE = 17203848, -- Chaplion_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Chaplion_RK'),
         LOGGING =
         {
             17203864,

--- a/scripts/zones/Lufaise_Meadows/IDs.lua
+++ b/scripts/zones/Lufaise_Meadows/IDs.lua
@@ -56,7 +56,7 @@ zones[xi.zone.LUFAISE_MEADOWS] =
     },
     npc =
     {
-        OVERSEER_BASE = 16875865, -- Jemmoquel_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Jemmoquel_RK'),
         LOGGING       =
         {
             16875883,

--- a/scripts/zones/Meriphataud_Mountains/IDs.lua
+++ b/scripts/zones/Meriphataud_Mountains/IDs.lua
@@ -107,7 +107,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS] =
 
     npc =
     {
-        OVERSEER_BASE = 17265271, -- Chegourt_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Chegourt_RK'),
     },
 }
 

--- a/scripts/zones/North_Gustaberg/IDs.lua
+++ b/scripts/zones/North_Gustaberg/IDs.lua
@@ -135,7 +135,7 @@ zones[xi.zone.NORTH_GUSTABERG] =
 
     npc =
     {
-        OVERSEER_BASE = 17212060, -- Ennigreaud_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Ennigreaud_RK'),
     },
 }
 

--- a/scripts/zones/Oldton_Movalpolos/IDs.lua
+++ b/scripts/zones/Oldton_Movalpolos/IDs.lua
@@ -38,7 +38,7 @@ zones[xi.zone.OLDTON_MOVALPOLOS] =
     npc =
     {
         SCRAWLED_WRITING = 16822469,
-        OVERSEER_BASE    = 16822509, -- first Conquest_Banner in npc_list
+        OVERSEER_BASE    = GetFirstID('Conquest_Banner'),
         TREASURE_CHEST   = 16822531,
         MINING =
         {

--- a/scripts/zones/Pashhow_Marshlands/IDs.lua
+++ b/scripts/zones/Pashhow_Marshlands/IDs.lua
@@ -117,7 +117,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS] =
 
     npc =
     {
-        OVERSEER_BASE = 17224326, -- Mesachedeau_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Mesachedeau_RK'),
     },
 }
 

--- a/scripts/zones/RuAun_Gardens/IDs.lua
+++ b/scripts/zones/RuAun_Gardens/IDs.lua
@@ -128,7 +128,7 @@ zones[xi.zone.RUAUN_GARDENS] =
             { coords = {    142, -41,   -156,    145, -39,   -153 }, green = true },
         },
 
-        OVERSEER_BASE   = 17310080,
+        OVERSEER_BASE = GetFirstID('Conquest_Banner'),
     },
 }
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/IDs.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/IDs.lua
@@ -76,7 +76,7 @@ zones[xi.zone.THE_SANCTUARY_OF_ZITAH] =
     },
     npc =
     {
-        OVERSEER_BASE    = 17273365, -- Credaurion_RK in npc_list
+        OVERSEER_BASE    = GetFirstID('Credaurion_RK'),
         CERMET_HEADSTONE = 17273390,
     },
 }

--- a/scripts/zones/Valkurm_Dunes/IDs.lua
+++ b/scripts/zones/Valkurm_Dunes/IDs.lua
@@ -69,7 +69,7 @@ zones[xi.zone.VALKURM_DUNES] =
     npc =
     {
         SUNSAND_QM    = 17199699, -- qm1 in npc_list
-        OVERSEER_BASE = 17199709, -- Quanteilleron_RK in npc_list
+        OVERSEER_BASE = GetFirstID('Quanteilleron_RK'),
     },
 }
 

--- a/scripts/zones/West_Ronfaure/IDs.lua
+++ b/scripts/zones/West_Ronfaure/IDs.lua
@@ -66,7 +66,7 @@ zones[xi.zone.WEST_RONFAURE] =
     npc =
     {
         SIGNPOST_OFFSET = 17187505,
-        OVERSEER_BASE   = 17187525, -- Doladepaiton_RK in npc_list
+        OVERSEER_BASE   = GetFirstID('Doladepaiton_RK'),
     },
 }
 

--- a/scripts/zones/West_Sarutabaruta/IDs.lua
+++ b/scripts/zones/West_Sarutabaruta/IDs.lua
@@ -121,7 +121,7 @@ zones[xi.zone.WEST_SARUTABARUTA] =
     npc =
     {
         SIGNPOST_OFFSET = 17248797,
-        OVERSEER_BASE   = 17248830, -- Naguipeillont_RK in npc_list
+        OVERSEER_BASE   = GetFirstID('Naguipeillont_RK'),
 
         HARVESTING =
         {

--- a/scripts/zones/Yhoator_Jungle/IDs.lua
+++ b/scripts/zones/Yhoator_Jungle/IDs.lua
@@ -65,7 +65,7 @@ zones[xi.zone.YHOATOR_JUNGLE] =
     },
     npc =
     {
-        OVERSEER_BASE     = 17285650, -- Ilieumort_RK in npc_list
+        OVERSEER_BASE     = GetFirstID('Ilieumort_RK'),
         PEDDLESTOX        = 17285686,
         BEASTMEN_TREASURE =
         {

--- a/scripts/zones/Yuhtunga_Jungle/IDs.lua
+++ b/scripts/zones/Yuhtunga_Jungle/IDs.lua
@@ -74,7 +74,7 @@ zones[xi.zone.YUHTUNGA_JUNGLE] =
     {
         BLUE_RAFFLESIA_OFFSET = 17281586,
         TUNING_OUT_QM         = 17281590, -- qm2 in npc_list
-        OVERSEER_BASE         = 17281600, -- Zorchorevi_RK in npc_list
+        OVERSEER_BASE         = GetFirstID('Zorchorevi_RK'),
         CERMET_HEADSTONE      = 17281625,
         PEDDLESTOX            = 17281640,
         BEASTMEN_TREASURE     =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #2887 

Moves all OVERSEER_BASE (Conquest offset) NPCs to dynamic lookup using GetFirstID()
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Check zones, see proper NPCs being displayed based on conquest
<!-- Clear and detailed steps to test your changes here -->
