### PR TITLE
[lua] [PLD] Adjust cover duration formula to match retail

### DIFF
--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -75,9 +75,10 @@ xi.job_utils.paladin.useChivalry = function(player, target, ability)
     return target:addMP(amount)
 end
 
+-- Duration bonus is dVIT (user VIT - target MND)/3
 xi.job_utils.paladin.useCover = function(player, target, ability)
     local baseDuration = 15
-    local bonusTime    = utils.clamp(math.floor((player:getStat(xi.mod.VIT) + player:getStat(xi.mod.MND) - target:getStat(xi.mod.VIT) * 2) / 4), 0, 15)
+    local bonusTime    = utils.clamp(math.floor((player:getStat(xi.mod.VIT) - target:getStat(xi.mod.MND)) / 3), 0, 15)
     local jpValue      = player:getJobPointLevel(xi.jp.COVER_DURATION)
     local duration     = baseDuration + bonusTime + player:getMerit(xi.merit.COVER_EFFECT_LENGTH) + player:getMod(xi.mod.COVER_DURATION) + jpValue
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

verified on retail:
* This formula is dVIT (user VIT - target MND) in seconds
* https://wiki.ffo.jp/html/2612.html

## Steps to test these changes

Use Cover, see bonus duration of 1 second per dVIT
