### PR TITLE
Deprecate vanaDay() in favor of VanadielUniqueDay()

### DIFF
--- a/scripts/globals/common.lua
+++ b/scripts/globals/common.lua
@@ -79,11 +79,3 @@ function getConquestTally()
     local daysToTally = 6 - lastTally
     return getMidnight() + (daysToTally * (60 * 60 * 24))
 end
-
------------------------------------
---  vanaDay()
---  Small function to make it easier to store the current date
------------------------------------
-function vanaDay()
-    return VanadielYear() * 360 + VanadielDayOfTheYear()
-end

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -155,7 +155,7 @@ end
 local function suppliesAvailableBitmask(player, nation)
     local mask = 0x7F00001F
 
-    if player:getCharVar("supplyQuest_started") == vanaDay() then
+    if player:getCharVar("supplyQuest_started") == VanadielUniqueDay() then
         mask = 0xFFFFFFFF -- Need to wait 1 vanadiel day
     end
 
@@ -1304,7 +1304,7 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
 
         if outpost ~= nil then
             npcUtil.giveKeyItem(player, outpost.ki)
-            player:setCharVar("supplyQuest_started", vanaDay())
+            player:setCharVar("supplyQuest_started", VanadielUniqueDay())
             player:setCharVar("supplyQuest_region", region)
             player:setCharVar("supplyQuest_fresh", getConquestTally())
         end

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1491,7 +1491,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- award gil and tabs once per day, or at every page completion if REGIME_WAIT is 0 in settings.lua
-    local vanadielEpoch = vanaDay()
+    local vanadielEpoch = VanadielUniqueDay()
     if
         xi.settings.main.REGIME_WAIT == 0 or
         player:getCharVar("[regime]lastReward") < vanadielEpoch

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Lathuya.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Lathuya.lua
@@ -73,7 +73,7 @@ entity.onTrigger = function(player, npc)
         local artifactOffset = 8 * totalCraftedPieces
 
         if currentTask == 0 and totalCraftedPieces ~= 3 then
-            if vanaDay() > player:getCharVar("[BLUAF]RestingDay") then
+            if VanadielUniqueDay() > player:getCharVar("[BLUAF]RestingDay") then
                 if totalCraftedPieces == 2 then
                     currentTask = math.floor(remainingBLUAF / 2) + 1
                     player:startEvent(746, 0, 0, 0, 0, 0, 0, 0, currentTask)
@@ -85,7 +85,7 @@ entity.onTrigger = function(player, npc)
                 player:startEvent(737 + (artifactOffset - 8)) -- Asleep message, wait until 1 day passes
             end
         elseif currentTask > 0 then
-            local pickupReady = vanaDay() > player:getCharVar("[BLUAF]PaymentDay")
+            local pickupReady = VanadielUniqueDay() > player:getCharVar("[BLUAF]PaymentDay")
             local item = craftingItems[currentTask]
             if craftingStage == 0 then
                 player:startEvent(731 + artifactOffset, 0, item.currency, item.currencyAmt)
@@ -142,7 +142,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 734 + artifactOffset then
         player:confirmTrade()
         player:setCharVar("[BLUAF]CraftingStage", 2)
-        player:setCharVar("[BLUAF]PaymentDay", vanaDay())
+        player:setCharVar("[BLUAF]PaymentDay", VanadielUniqueDay())
         npcUtil.giveKeyItem(player, xi.ki.MAGUS_ORDER_SLIP)
     elseif csid == 736 + artifactOffset and currentTask > 0 then
         if npcUtil.giveItem(player, craftingItems[currentTask].result) then
@@ -155,7 +155,7 @@ entity.onEventFinish = function(player, csid, option)
                 -- Player is finished with Lathuya
                 player:setCharVar("[BLUAF]RestingDay", 0)
             else
-                player:setCharVar("[BLUAF]RestingDay", vanaDay())
+                player:setCharVar("[BLUAF]RestingDay", VanadielUniqueDay())
             end
 
             player:delKeyItem(xi.ki.MAGUS_ORDER_SLIP)

--- a/scripts/zones/Bastok_Mines/npcs/Door_House.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Door_House.lua
@@ -43,7 +43,7 @@ entity.onTrigger = function(player, npc)
             player:startEvent(535) -- i'm waiting for 4 imperial mythril pieces
 
         elseif letterBlue == 4 then
-            if vanaDay() > player:getCharVar("corAfSubmitDay") then
+            if VanadielUniqueDay() > player:getCharVar("corAfSubmitDay") then
                 player:startEvent(522) -- here's your cor bottes
             else
                 player:startEvent(523) -- patience. need to wait for vana'diel day
@@ -67,7 +67,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 524 then
         player:confirmTrade()
         player:setCharVar("LeleroonsletterBlue", 4)
-        player:setCharVar("corAfSubmitDay", vanaDay())
+        player:setCharVar("corAfSubmitDay", VanadielUniqueDay())
 
     elseif
         csid == 522 and

--- a/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
     elseif letterRed == 3 then
         player:startEvent(761) -- i'm waiting for imperial gold piece
     elseif letterRed == 4 then
-        if vanaDay() > player:getCharVar("corAfSubmitDay") then
+        if VanadielUniqueDay() > player:getCharVar("corAfSubmitDay") then
             player:startEvent(756) -- here's your cor frac
         else
             player:startEvent(757) -- patience. need to wait for vana'diel day
@@ -66,7 +66,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 760 then
         player:tradeComplete()
         player:setCharVar("LeleroonsLetterRed", 4)
-        player:setCharVar("corAfSubmitDay", vanaDay())
+        player:setCharVar("corAfSubmitDay", VanadielUniqueDay())
     elseif csid == 756 then
         player:setCharVar("LeleroonsLetterRed", 5)
         player:addItem(14522) -- corsair's frac

--- a/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
@@ -65,7 +65,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 5089 then
         player:confirmTrade()
         player:setCharVar("VVC_Status", 2)
-        player:setCharVar("VVC_Gameday_Wait", vanaDay())
+        player:setCharVar("VVC_Gameday_Wait", VanadielUniqueDay())
     end
 end
 

--- a/scripts/zones/Western_Adoulin/npcs/Westerly_Breeze.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Westerly_Breeze.lua
@@ -60,7 +60,7 @@ entity.onTrigger = function(player, npc)
 
     if
         player:getFameLevel(xi.quest.fame_area.ADOULIN) >= 2 and
-        not player:needToZone() and vanaDay() > player:getCharVar("Westerly_Breeze_Wait")
+        not player:needToZone() and VanadielUniqueDay() > player:getCharVar("Westerly_Breeze_Wait")
     then
         if
             amqtr ~= QUEST_COMPLETED and

--- a/scripts/zones/Windurst_Waters/npcs/Door_House.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Door_House.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
         elseif letterGreen == 3 then
             player:startEvent(954) -- i'm waiting for 4 imperial mythril pieces
         elseif letterGreen == 4 then
-            if vanaDay() > player:getCharVar("corAfSubmitDay") then
+            if VanadielUniqueDay() > player:getCharVar("corAfSubmitDay") then
                 player:startEvent(944) -- here's your cor gants
             else
                 player:startEvent(945) -- patience. need to wait for vana'diel day
@@ -69,7 +69,7 @@ entity.onEventFinish = function(player, csid, option)
     elseif csid == 946 then
         player:tradeComplete()
         player:setCharVar("LeleroonsletterGreen", 4)
-        player:setCharVar("corAfSubmitDay", vanaDay())
+        player:setCharVar("corAfSubmitDay", VanadielUniqueDay())
     elseif csid == 944 then
         player:setCharVar("LeleroonsletterGreen", 5)
         player:addItem(14929) -- corsair's gants

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -48,7 +48,6 @@ global_objects=(
     getVanaMidnight
     getMidnight
     getConquestTally
-    vanaDay
 
     mission
     Mission


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes duplicate function vanaDay() defined in common.lua, and replaces all references with VanadielUniqueDay() binding.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No differences should be observed.
<!-- Clear and detailed steps to test your changes here -->
