### PR TITLE
Use npcUtil to simplify Abyssea giveNMDrops function

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -3,6 +3,7 @@
 -----------------------------------
 require("scripts/globals/spell_data")
 require("scripts/globals/keyitems")
+require("scripts/globals/npc_util")
 require("scripts/globals/quests")
 require("scripts/globals/status")
 require("scripts/globals/utils")
@@ -719,26 +720,23 @@ xi.abyssea.giveNMDrops = function(mob, player, ID)
     local normalDrops = xi.abyssea.mob[mob:getName()]['Normal']
     local playerClaimed = GetPlayerByID(mob:getLocalVar("[ClaimedBy]"))
 
-    for k, v in pairs(normalDrops) do
+    for _, keyItemId in pairs(normalDrops) do
         if xi.abyssea.canGiveNMKI(mob, 20) then
-            playerClaimed:addKeyItem(v)
-            playerClaimed:messageSpecial(ID.text.PLAYER_KEYITEM_OBTAINED, v)
+            npcUtil.giveKeyItem(playerClaimed, keyItemId)
         end
     end
 
-    for k, v in pairs(atmaDrops) do
+    for _, keyItemId in pairs(atmaDrops) do
         local ally = playerClaimed:getAlliance()
 
         for _, member in ipairs(ally) do
-            if not member:hasKeyItem(v) and xi.abyssea.canGiveNMKI(mob, 10) then
-                member:addKeyItem(v)
-                member:messageSpecial(ID.text.PLAYER_KEYITEM_OBTAINED, v)
+            if not member:hasKeyItem(keyItemId) and xi.abyssea.canGiveNMKI(mob, 10) then
+                npcUtil.giveKeyItem(member, keyItemId)
             end
         end
 
-        if not playerClaimed:hasKeyItem(v) then
-            playerClaimed:addKeyItem(v)
-            playerClaimed:messageSpecial(ID.text.PLAYER_KEYITEM_OBTAINED, v)
+        if not playerClaimed:hasKeyItem(keyItemId) then
+            npcUtil.giveKeyItem(playerClaimed, keyItemId)
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Cleans up Abyssea function to use npcUtil and sanely names loop variables
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
