### PR TITLE
Add optional npcUtil.giveKeyItem message, fix Abyssea KI messages

### DIFF
--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -722,7 +722,7 @@ xi.abyssea.giveNMDrops = function(mob, player, ID)
 
     for _, keyItemId in pairs(normalDrops) do
         if xi.abyssea.canGiveNMKI(mob, 20) then
-            npcUtil.giveKeyItem(playerClaimed, keyItemId)
+            npcUtil.giveKeyItem(playerClaimed, keyItemId, ID.text.PLAYER_KEYITEM_OBTAINED)
         end
     end
 
@@ -731,12 +731,12 @@ xi.abyssea.giveNMDrops = function(mob, player, ID)
 
         for _, member in ipairs(ally) do
             if not member:hasKeyItem(keyItemId) and xi.abyssea.canGiveNMKI(mob, 10) then
-                npcUtil.giveKeyItem(member, keyItemId)
+                npcUtil.giveKeyItem(member, keyItemId, ID.text.PLAYER_KEYITEM_OBTAINED)
             end
         end
 
         if not playerClaimed:hasKeyItem(keyItemId) then
-            npcUtil.giveKeyItem(playerClaimed, keyItemId)
+            npcUtil.giveKeyItem(playerClaimed, keyItemId, ID.text.PLAYER_KEYITEM_OBTAINED)
         end
     end
 

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -415,7 +415,7 @@ end
         { xi.ki.PALBOROUGH_MINES_LOGS }
         { xi.ki.BLUE_ACIDITY_TESTER, xi.ki.RED_ACIDITY_TESTER }
 --]]
-function npcUtil.giveKeyItem(player, keyitems)
+function npcUtil.giveKeyItem(player, keyitems, msgId)
     local ID = zones[player:getZoneID()]
 
     -- create table of keyitems
@@ -430,10 +430,15 @@ function npcUtil.giveKeyItem(player, keyitems)
     end
 
     -- give key items to player, with message
-    for _, v in pairs(givenKeyItems) do
-        if not player:hasKeyItem(v) then
-            player:addKeyItem(v)
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED, v)
+    for _, keyItemId in ipairs(givenKeyItems) do
+        if not player:hasKeyItem(keyItemId) then
+            player:addKeyItem(keyItemId)
+
+            if msgId then
+                player:messageSpecial(msgId, keyItemId)
+            else
+                player:messageSpecial(ID.text.KEYITEM_OBTAINED, keyItemId)
+            end
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #3926 

* Adds optional 3rd parameter to npcUtil.giveKeyItem to specify message ID to use
* Fixes the error I made when simplifying Abyssea function to use the correct message again

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to Tahrongi
!exec npcUtil.giveKeyItem(player, 1, 7320)
!exec npcUtil.giveKeyItem(player, 1)

<!-- Clear and detailed steps to test your changes here -->
