### PR TITLE
Change Learned Weaponskill parameter names, add safety

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9332,11 +9332,11 @@ uint16 CLuaBaseEntity::getCharSkillLevel(uint8 skillID)
 /************************************************************************
  *  Function: addLearnedWeaponskill()
  *  Purpose : Manually add a new weaponskill for the player using WSID
- *  Example : player:addLearnedWeaponskill(xi.weaponskill.DECIMATION)
+ *  Example : player:addLearnedWeaponskill(xi.ws_unlock.DECIMATION)
  *  Notes   : Do not see implemented in any script
  ************************************************************************/
 
-void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsID)
+void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsUnlockId)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -9346,7 +9346,7 @@ void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsID)
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
-    charutils::addLearnedWeaponskill(PChar, wsID);
+    charutils::addLearnedWeaponskill(PChar, wsUnlockId);
     charutils::BuildingCharWeaponSkills(PChar);
     charutils::SaveLearnedAbilities(PChar);
     PChar->pushPacket(new CCharAbilitiesPacket(PChar));
@@ -9355,11 +9355,11 @@ void CLuaBaseEntity::addLearnedWeaponskill(uint8 wsID)
 /************************************************************************
  *  Function: hasLearnedWeaponskill()
  *  Purpose : Returns true if a player has learned a particular weaponskill
- *  Example : if player:hasLearnedWeaponskill(xi.weaponskill.DECIMATION) then
+ *  Example : if player:hasLearnedWeaponskill(xi.ws_unlock.DECIMATION) then
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::hasLearnedWeaponskill(uint8 wsID)
+bool CLuaBaseEntity::hasLearnedWeaponskill(uint8 wsUnlockId)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -9367,17 +9367,17 @@ bool CLuaBaseEntity::hasLearnedWeaponskill(uint8 wsID)
         return false;
     }
 
-    return (charutils::hasLearnedWeaponskill(static_cast<CCharEntity*>(m_PBaseEntity), wsID) != 0);
+    return (charutils::hasLearnedWeaponskill(static_cast<CCharEntity*>(m_PBaseEntity), wsUnlockId) != 0);
 }
 
 /************************************************************************
  *  Function: delLearnedWeaponskill()
  *  Purpose : Removes a learned weaponskill from the player
- *  Example : player:delLearnedWeaponskill(xi.weaponskill.ASURAN_FISTS)
+ *  Example : player:delLearnedWeaponskill(xi.ws_unlock.ASURAN_FISTS)
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::delLearnedWeaponskill(uint8 wsID)
+void CLuaBaseEntity::delLearnedWeaponskill(uint8 wsUnlockId)
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -9387,7 +9387,7 @@ void CLuaBaseEntity::delLearnedWeaponskill(uint8 wsID)
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
-    charutils::delLearnedWeaponskill(PChar, wsID);
+    charutils::delLearnedWeaponskill(PChar, wsUnlockId);
     charutils::BuildingCharWeaponSkills(PChar);
     charutils::SaveLearnedAbilities(PChar);
     PChar->pushPacket(new CCharAbilitiesPacket(PChar));

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -471,9 +471,9 @@ public:
     void   setSkillRank(uint8 skillID, uint8 newrank);                // Set new skill craft rank
     uint16 getCharSkillLevel(uint8 skillID);                          // Get char skill level
 
-    void addLearnedWeaponskill(uint8 wsID);
-    bool hasLearnedWeaponskill(uint8 wsID);
-    void delLearnedWeaponskill(uint8 wsID);
+    void addLearnedWeaponskill(uint8 wsUnlockId);
+    bool hasLearnedWeaponskill(uint8 wsUnlockId);
+    void delLearnedWeaponskill(uint8 wsUnlockId);
 
     void trySkillUp(uint8 skill, uint8 level, sol::object const& forceSkillUpObj, sol::object const& useSubSkillObj);
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3474,19 +3474,55 @@ namespace charutils
      *                                                                       *
      ************************************************************************/
 
-    bool hasLearnedWeaponskill(CCharEntity* PChar, uint8 wsid)
+    bool hasLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId)
     {
-        return PChar->m_LearnedWeaponskills[wsid];
+        if (PChar == nullptr)
+        {
+            ShowError("PChar is null.");
+            return false;
+        }
+
+        if (wsUnlockId > std::size(PChar->m_LearnedWeaponskills) - 1)
+        {
+            ShowError("wsUnlockId is greater than learned weaponskill bitset.");
+            return false;
+        }
+
+        return PChar->m_LearnedWeaponskills[wsUnlockId];
     }
 
-    void addLearnedWeaponskill(CCharEntity* PChar, uint8 wsid)
+    void addLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId)
     {
-        PChar->m_LearnedWeaponskills[wsid] = true;
+        if (PChar == nullptr)
+        {
+            ShowError("PChar is null.");
+            return;
+        }
+
+        if (wsUnlockId > std::size(PChar->m_LearnedWeaponskills) - 1)
+        {
+            ShowError("wsUnlockId is greater than learned weaponskill bitset.");
+            return;
+        }
+
+        PChar->m_LearnedWeaponskills[wsUnlockId] = true;
     }
 
-    void delLearnedWeaponskill(CCharEntity* PChar, uint8 wsid)
+    void delLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId)
     {
-        PChar->m_LearnedWeaponskills[wsid] = false;
+        if (PChar == nullptr)
+        {
+            ShowError("PChar is null.");
+            return;
+        }
+
+        if (wsUnlockId > std::size(PChar->m_LearnedWeaponskills) - 1)
+        {
+            ShowError("wsUnlockId is greater than learned weaponskill bitset.");
+            return;
+        }
+
+        PChar->m_LearnedWeaponskills[wsUnlockId] = false;
     }
 
     /************************************************************************

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -143,9 +143,9 @@ namespace charutils
     int32 addLearnedAbility(CCharEntity* PChar, uint16 AbilityID); // добавляем заклинание
     int32 delLearnedAbility(CCharEntity* PChar, uint16 AbilityID); // улаляем заклинание
 
-    bool hasLearnedWeaponskill(CCharEntity* PChar, uint8 wsid);
-    void addLearnedWeaponskill(CCharEntity* PChar, uint8 wsid);
-    void delLearnedWeaponskill(CCharEntity* PChar, uint8 wsid);
+    bool hasLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId);
+    void addLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId);
+    void delLearnedWeaponskill(CCharEntity* PChar, uint8 wsUnlockId);
 
     int32 hasAbility(CCharEntity* PChar, uint16 AbilityID); // проверяем наличие ключевого предмета
     int32 addAbility(CCharEntity* PChar, uint16 AbilityID); // добавляем ключевой предмет


### PR DESCRIPTION
Fix logic error

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Updates learned weaponskill functions based on issues I had recently when fixing merit WS's.
* Changes parameter names from wsid to wsUnlockId to properly reflect what the function accepts
* Adds safety for out of range wsId's and null checking along with logging

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Nothing visible should occur, but we should no longer crash on invalid values.
<!-- Clear and detailed steps to test your changes here -->
