### PR TITLE
[lua] [COR] Always remove double up effect on bust

### DIFF
--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -270,7 +270,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
             roll = roll + math.random(1, 6)
         end
 
-        if roll > 12 then -- bust
+        if roll >= 12 then -- bust
             roll = 12
             caster:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes double up effect on a bust on a roll of exactly 12

## Steps to test these changes

Double up until you roll exactly 12, still remove doubleup effect