### PR TITLE
[core] Add some safety to Treasure/Party/Alliance

### DIFF
--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -79,6 +79,12 @@ void CTreasurePool::AddMember(CCharEntity* PChar)
         return;
     }
 
+    if (std::find(members.begin(), members.end(), PChar) != members.end())
+    {
+        ShowWarning("CTreasurePool::AddMember() - PChar was already in the members list!");
+        return;
+    }
+
     members.push_back(PChar);
 
     if (m_TreasurePoolType == TREASUREPOOL_SOLO && members.size() > 1)
@@ -112,25 +118,24 @@ void CTreasurePool::DelMember(CCharEntity* PChar)
     {
         if (!m_PoolItems[i].Lotters.empty())
         {
-            for (size_t j = 0; j < m_PoolItems[i].Lotters.size(); j++)
+            auto lotterIterator = m_PoolItems[i].Lotters.begin();
+            while (lotterIterator != m_PoolItems[i].Lotters.end())
             {
                 // remove their lot info
-                if (PChar->id == m_PoolItems[i].Lotters[j].member->id)
+                LotInfo* info = &(*lotterIterator);
+                if (PChar->id == info->member->id)
                 {
-                    m_PoolItems[i].Lotters.erase(m_PoolItems[i].Lotters.begin() + j);
+                    lotterIterator = m_PoolItems[i].Lotters.erase(lotterIterator);
                 }
             }
         }
     }
 
-    for (uint32 i = 0; i < members.size(); ++i)
+    auto memberToDelete = std::find(members.begin(), members.end(), PChar);
+    if (memberToDelete != members.end())
     {
-        if (PChar == members.at(i))
-        {
-            PChar->PTreasurePool = nullptr;
-            members.erase(members.begin() + i);
-            break;
-        }
+        PChar->PTreasurePool = nullptr;
+        members.erase(memberToDelete);
     }
 
     if ((m_TreasurePoolType == TREASUREPOOL_PARTY || m_TreasurePoolType == TREASUREPOOL_ALLIANCE) && members.size() == 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds some safety to Treasure Pools, Party and Alliance code.

Mostly replaces suspicious searches to std::find and self modifying loops with syntax that supports doing that and adds a few sanity checks as well as a crucial missing zonewide treasurepool check that could cause crashes if ever used and people d/c or otherwise shutdown and log back in

## Steps to test these changes

Get in a party/alliance, lot items, zone a character out and see no errors
Get in an alliance of two partys with one party with a single member who is the leader of the alliance and /shutdown with no errors
Zone in a party/alliance with no errors
Use a zonewide treasure pool and be able to leave an alliance without creating a new treasure pool briefly (see `CAlliance::delParty`)