### PR TITLE
Add additional null checking for zoneutils::GetZone

### DIFF
--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -216,7 +216,7 @@ CInstance* CInstanceLoader::LoadInstance()
             }
 
             // must be here first to define mobmods
-            mobutils::InitializeMob(PMob, zone);
+            mobutils::InitializeMob(PMob);
             PMob->PInstance = instance;
 
             instance->InsertMOB(PMob);

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -591,7 +591,16 @@ void CLatentEffectContainer::CheckLatentsZone()
  ************************************************************************/
 void CLatentEffectContainer::CheckLatentsWeather()
 {
-    CheckLatentsWeather(zoneutils::GetZone(m_POwner->getZone())->GetWeather());
+    uint16 zoneId = m_POwner->getZone();
+    CZone* PZone  = zoneutils::GetZone(zoneId);
+
+    if (PZone == nullptr)
+    {
+        ShowWarning("PZone was null for Zone ID %d.", zoneId);
+        return;
+    }
+
+    CheckLatentsWeather(PZone->GetWeather());
 }
 
 void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10467,17 +10467,23 @@ uint8 CLuaBaseEntity::registerBattlefield(sol::object const& arg0, sol::object c
     if (m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
     {
         ShowWarning("m_BattlefieldHandler was null for %s.", m_PBaseEntity->GetName());
-        return 0;
+        return BATTLEFIELD_RETURN_CODE_BATTLEFIELD_FULL;
     }
 
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
         ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->GetName());
-        return 0;
+        return BATTLEFIELD_RETURN_CODE_BATTLEFIELD_FULL;
     }
 
     auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     auto* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
+
+    if (PZone == nullptr)
+    {
+        ShowWarning("PZone was null for ZoneID %d.", PChar->loc.destination);
+        return BATTLEFIELD_RETURN_CODE_BATTLEFIELD_FULL;
+    }
 
     // TODO: Verify what happens if -1 makes it to the cast below
     if (arg0 == sol::lua_nil)
@@ -10511,7 +10517,7 @@ bool CLuaBaseEntity::battlefieldAtCapacity(int battlefieldID)
     if (m_PBaseEntity->loc.zone->m_BattlefieldHandler == nullptr)
     {
         ShowWarning("m_BattlefieldHandler was null for %s.", m_PBaseEntity->GetName());
-        return 0;
+        return true;
     }
 
     if (m_PBaseEntity->objtype != TYPE_PC)

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -230,6 +230,13 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         PEntity = mobutils::InstantiateDynamicMob(groupId, groupZoneId, m_pLuaZone->GetID());
     }
 
+    // This can happen if the Target's Zone ID is invalid.
+    if (PEntity == nullptr)
+    {
+        ShowWarning("Failed to insert Dynamic Entity.");
+        return std::nullopt;
+    }
+
     // NOTE: Mob allegiance is the default for NPCs
     PEntity->allegiance = static_cast<ALLEGIANCE_TYPE>(table.get_or<uint8>("allegiance", ALLEGIANCE_TYPE::MOB));
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1773,8 +1773,14 @@ namespace luautils
         TracyZoneScoped;
 
         CZone* PZone = zoneutils::GetZone(ZoneID);
-        auto   name  = PZone->GetName();
 
+        if (PZone == nullptr)
+        {
+            ShowWarning("Skipping init for disabled zone %d.", ZoneID);
+            return -1;
+        }
+
+        auto name     = PZone->GetName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
         CacheLuaObjectFromFile(filename);
@@ -1806,8 +1812,7 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto name = PZone->GetName();
-
+        auto name     = PZone->GetName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
         auto onZoneTick = GetCacheEntryFromFilename(filename)["onZoneTick"];
@@ -1863,7 +1868,14 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto name     = PChar->m_moghouseID ? "Residential_Area" : zoneutils::GetZone(PChar->loc.destination)->GetName();
+        CZone* destinationZone = zoneutils::GetZone(PChar->loc.destination);
+        if (!PChar->m_moghouseID && destinationZone == nullptr)
+        {
+            ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
+            return;
+        }
+
+        auto name     = PChar->m_moghouseID ? "Residential_Area" : destinationZone->GetName();
         auto filename = fmt::format("./scripts/zones/{}/Zone.lua", name);
 
         auto onZoneInFramework = lua["xi"]["globals"]["interaction"]["interaction_global"]["onZoneIn"];
@@ -3695,7 +3707,7 @@ namespace luautils
     }
 
     /************************************************************************
-     *   OnGameDayAutomatisation()                                           *
+     *   OnGameDay()                                           *
      *   used for creating action of npc every game day                      *
      *                                                                       *
      ************************************************************************/
@@ -3724,7 +3736,7 @@ namespace luautils
     }
 
     /************************************************************************
-     *   OnGameHourAutomatisation()                                          *
+     *   OnGameHour()                                          *
      *   used for creating action of npc every game hour                     *
      *                                                                       *
      ************************************************************************/
@@ -3756,7 +3768,14 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto name = zoneutils::GetZone(ZoneID)->GetName();
+        CZone* PZone = zoneutils::GetZone(ZoneID);
+        if (PZone == nullptr)
+        {
+            ShowWarning("Invalid ZoneID passed to function (%d).", ZoneID);
+            return -1;
+        }
+
+        auto name = PZone->GetName();
 
         auto onZoneWeatherChange = lua["xi"]["zones"][name]["Zone"]["onZoneWeatherChange"];
         if (!onZoneWeatherChange.valid())
@@ -3779,7 +3798,14 @@ namespace luautils
     {
         TracyZoneScoped;
 
-        auto name = zoneutils::GetZone(ZoneID)->GetName();
+        CZone* PZone = zoneutils::GetZone(ZoneID);
+        if (PZone == nullptr)
+        {
+            ShowWarning("Invalid ZoneID passed to function (%d).", ZoneID);
+            return -1;
+        }
+
+        auto name = PZone->GetName();
 
         auto onTOTDChange = lua["xi"]["zones"][name]["Zone"]["onTOTDChange"];
         if (!onTOTDChange.valid())
@@ -4749,6 +4775,15 @@ namespace luautils
 
         CZone* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
 
+        if (PZone == nullptr)
+        {
+            // Show log for the ID passed from GetZone, since the only way PZone can be null here is if
+            // loc.zone was null in the previous check.
+
+            ShowWarning("PZone was null for ZoneID %d.", PChar->loc.destination);
+            return;
+        }
+
         auto zone = PZone->GetName();
         auto name = PBattlefield->GetName();
 
@@ -4782,6 +4817,15 @@ namespace luautils
         TracyZoneScoped;
 
         CZone* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
+
+        if (PZone == nullptr)
+        {
+            // Show log for the ID passed from GetZone, since the only way PZone can be null here is if
+            // loc.zone was null in the previous check.
+
+            ShowWarning("PZone was null for ZoneID %d.", PChar->loc.destination);
+            return;
+        }
 
         auto filename = fmt::format("./scripts/zones/{}/bcnms/{}.lua", PZone->GetName(), PBattlefield->GetName());
 
@@ -4832,6 +4876,15 @@ namespace luautils
         TracyZoneScoped;
 
         CZone* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
+
+        if (PZone == nullptr)
+        {
+            // Show log for the ID passed from GetZone, since the only way PZone can be null here is if
+            // loc.zone was null in the previous check.
+
+            ShowWarning("PZone was null for ZoneID %d.", PChar->loc.destination);
+            return;
+        }
 
         auto zone = PZone->GetName();
         auto name = PBattlefield->GetName();

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1850,7 +1850,8 @@ namespace fishingutils
         }
 
         // Not in City bonus
-        if (zoneutils::GetZone(PChar->getZone())->GetType() > ZONE_TYPE::CITY)
+        CZone* PZone = zoneutils::GetZone(PChar->getZone());
+        if (PZone && PZone->GetType() > ZONE_TYPE::CITY)
         {
             skillRoll -= 10;
         }
@@ -2122,7 +2123,8 @@ namespace fishingutils
         float  mobPoolMoonModifier  = MOONPATTERN_3(GetMoonPhase());
         float  noCatchMoonModifier  = MOONPATTERN_5(GetMoonPhase());
 
-        if (zoneutils::GetZone(PChar->getZone())->GetType() <= ZONE_TYPE::CITY)
+        CZone* PZone = zoneutils::GetZone(PChar->getZone());
+        if (PZone && PZone->GetType() <= ZONE_TYPE::CITY)
         {
             FishPoolWeight = (uint16)std::floor(15 * fishPoolMoonModifier);
             ItemPoolWeight = 25 + (uint16)std::floor(20 * itemPoolMoonModifier);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -962,7 +962,7 @@ namespace mobutils
         RecalculateSpellContainer(PMob);
     }
 
-    void InitializeMob(CMobEntity* PMob, CZone* PZone)
+    void InitializeMob(CMobEntity* PMob)
     {
         // add special mob mods
 
@@ -1383,7 +1383,7 @@ Usage:
                 newZone->GetZoneEntities()->m_mobList[PMob->targid] = PMob;
 
                 // must be here first to define mobmods
-                mobutils::InitializeMob(PMob, zoneutils::GetZone(zoneID));
+                mobutils::InitializeMob(PMob);
 
                 luautils::OnEntityLoad(PMob);
 
@@ -1520,8 +1520,7 @@ Usage:
                 PMob->m_TrueDetection = sql->GetUIntData(68);
                 PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(69));
 
-                // must be here first to define mobmods
-                mobutils::InitializeMob(PMob, zoneutils::GetZone(targetZoneId));
+                mobutils::InitializeMob(PMob);
             }
         }
         return PMob;

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -70,7 +70,7 @@ namespace mobutils
     uint16 GetBase(CMobEntity* PMob, uint8 rank);
     uint16 GetBaseToRank(uint8 rank, uint16 level);
     void   GetAvailableSpells(CMobEntity* PMob);
-    void   InitializeMob(CMobEntity* PMob, CZone* PZone);
+    void   InitializeMob(CMobEntity* PMob);
     void   LoadCustomMods();
 
     // get modifiers for pool / family / spawn

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -578,7 +578,7 @@ namespace zoneutils
                                 }
 
                                 // must be here first to define mobmods
-                                mobutils::InitializeMob(PMob, PMob->loc.zone);
+                                mobutils::InitializeMob(PMob);
 
                                 PZone->InsertMOB(PMob);
                             }

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -259,7 +259,15 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
 
         uint16 zoneid = luautils::OnInstanceLoadFailed(this);
 
-        zoneutils::GetZone(zoneid >= MAX_ZONEID ? PChar->loc.prevzone : zoneid)->IncreaseZoneCounter(PChar);
+        CZone* PZone = zoneutils::GetZone(zoneid);
+        if (PZone)
+        {
+            PZone->IncreaseZoneCounter(PChar);
+        }
+        else
+        {
+            zoneutils::GetZone(PChar->loc.prevzone)->IncreaseZoneCounter(PChar);
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds additional null checks to zoneutils::GetZone() returns
* Removes unused parameter in mobutils::InitializeMob
* Corrects some returns from debug break changes in lua_baseentity.cpp

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Unless something goes wrong, no changes should be observed
<!-- Clear and detailed steps to test your changes here -->
