### PR TITLE
[Util] Add and use getActiveJobLevel() function

### DIFF
--- a/scripts/globals/abilities/blade_bash.lua
+++ b/scripts/globals/abilities/blade_bash.lua
@@ -7,6 +7,7 @@
 -----------------------------------
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 local abilityObject = {}
 
@@ -25,13 +26,8 @@ abilityObject.onUseAbility = function(player, target, ability)
     end
 
     -- Yes, even Blade Bash deals damage dependant of Dark Knight level
-    local damage = 0
-
-    if player:getMainJob() == xi.job.DRK then
-        damage = math.floor(((player:getMainLvl() + 11) / 4) + player:getMod(xi.mod.WEAPON_BASH))
-    elseif player:getSubJob() == xi.job.DRK then
-        damage = math.floor(((player:getSubLvl() + 11) / 4) + player:getMod(xi.mod.WEAPON_BASH))
-    end
+    local jobLevel = utils.getActiveJobLevel(player, xi.job.DRK)
+    local damage   = math.floor(player:getMod(xi.mod.WEAPON_BASH) + (jobLevel + 11) / 4)
 
     -- Calculating and applying Blade Bash damage
     damage = utils.stoneskin(target, damage)

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -1,11 +1,12 @@
 -----------------------------------
 -- Corsair Job Utilities
 -----------------------------------
-require("scripts/globals/settings")
 require("scripts/globals/ability")
 require("scripts/globals/jobpoints")
-require("scripts/globals/status")
 require("scripts/globals/msg")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------
 xi = xi or {}
 xi.job_utils = xi.job_utils or {}
@@ -186,17 +187,12 @@ local function applyRoll(caster, target, inAbility, action, total, isDoubleup, c
     local phantomBase = corsairRollMods[abilityId][2] -- Base increment buff
     effectpower = effectpower + (phantomBase * phantombuffMultiple(caster))
 
-    -- Check if COR Main or Sub
-    if
-        caster:getMainJob() == xi.job.COR and
-        caster:getMainLvl() < target:getMainLvl()
-    then
-        effectpower = effectpower * (caster:getMainLvl() / target:getMainLvl())
-    elseif
-        caster:getSubJob() == xi.job.COR and
-        caster:getSubLvl() < target:getMainLvl()
-    then
-        effectpower = effectpower * (caster:getSubLvl() / target:getMainLvl())
+    -- Effect Power varies depending on COR level (Main vs Sub)
+    local actorLevel  = utils.getActiveJobLevel(caster, xi.job.COR)
+    local targetLevel = target:getMainLvl()
+
+    if actorLevel < targetLevel then
+        effectpower = effectpower * actorLevel / targetLevel
     end
 
     if not target:addCorsairRoll(caster:getMainJob(), caster:getMerit(xi.merit.BUST_DURATION), corsairRollMods[abilityId][4], effectpower, 0, duration, caster:getID(), total, corsairRollMods[abilityId][5]) then

--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -2,9 +2,10 @@
 -- Dark Knight Job Utilities
 -----------------------------------
 require('scripts/globals/items')
+require("scripts/globals/msg")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/utils")
 -----------------------------------
 xi = xi or {}
 xi.job_utils = xi.job_utils or {}
@@ -121,22 +122,16 @@ end
 
 xi.job_utils.dark_knight.useWeaponBash = function(player, target, ability)
     -- Applying Weapon Bash stun. Rate is said to be near 100%, so let's say 99%.
-    if math.random() * 100 < 99 then
+    if math.random(1, 100) <= 99 then
         target:addStatusEffect(xi.effect.STUN, 1, 0, 6)
     end
 
     -- Weapon Bash deals damage dependant of Dark Knight level
-    local darkKnightLvl = 0
-
-    if player:getMainJob() == xi.job.DRK then
-        darkKnightLvl = player:getMainLvl()    -- Use Mainjob Lvl
-    elseif player:getSubJob() == xi.job.DRK then
-        darkKnightLvl = player:getSubLvl()    -- Use Subjob Lvl
-    end
+    local darkKnightLvl = utils.getActiveJobLevel(player, xi.job.DRK)
 
     -- Calculating and applying Weapon Bash damage
     local jpValue = target:getJobPointLevel(xi.jp.WEAPON_BASH_EFFECT)
-    local damage  = math.floor(((darkKnightLvl + 11) / 4) + player:getMod(xi.mod.WEAPON_BASH) + jpValue * 10)
+    local damage  = math.floor((darkKnightLvl + 11) / 4 + player:getMod(xi.mod.WEAPON_BASH) + jpValue * 10)
 
     target:takeDamage(damage, player, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(player, damage)

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -38,18 +38,6 @@ local stealableSPEffects =
 -----------------------------------
 -- Local Functions
 -----------------------------------
-local function getTHFlvl(player)
-    local thfLevel = 0
-
-    if player:getMainJob() == xi.job.THF then
-        thfLevel = player:getMainLvl()
-    else
-        thfLevel = player:getSubLvl()
-    end
-
-    return thfLevel
-end
-
 local function processDebuff(player, target, ability, debuff)
     local power = 10
 
@@ -207,7 +195,7 @@ xi.job_utils.thief.useConspirator = function(player, target, ability)
 end
 
 xi.job_utils.thief.useDespoil = function(player, target, ability, action)
-    local level         = getTHFlvl(player)
+    local level         = utils.getActiveJobLevel(player, xi.job.THF)
     local despoilMod    = player:getMod(xi.mod.DESPOIL)
     local despoilChance = 50 + despoilMod * 2 + level - target:getMainLvl() -- Same math as Steal
 
@@ -328,7 +316,7 @@ xi.job_utils.thief.useLarceny = function(player, target, ability, action)
 end
 
 xi.job_utils.thief.useMug = function(player, target, ability, action)
-    local thfLevel = getTHFlvl(player)
+    local thfLevel = utils.getActiveJobLevel(player, xi.job.THF)
     local gil      = 0
     -- TODO: Need to verify if there's a message associated with this
     local jpValue = player:getJobPointLevel(xi.jp.MUG_EFFECT)
@@ -397,7 +385,7 @@ xi.job_utils.thief.useSneakAttack = function(player, target, ability)
 end
 
 xi.job_utils.thief.useSteal = function(player, target, ability, action)
-    local thfLevel    = getTHFlvl(player)
+    local thfLevel    = utils.getActiveJobLevel(player, xi.job.THF)
     local stolen      = action:getParam(target:getID())
     local stealMod    = player:getMod(xi.mod.STEAL)
     local stealChance = 50 + stealMod * 2 + thfLevel - target:getMainLvl()

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -315,6 +315,18 @@ function utils.thirdeye(target)
     return false
 end
 
+function utils.getActiveJobLevel(actor, job)
+    local jobLevel = 0
+
+    if actor:getMainJob() == job then
+        jobLevel = actor:getMainLvl()
+    elseif actor:getSubJob() == job then
+        jobLevel = actor:getSubLvl()
+    end
+
+    return jobLevel
+end
+
 -----------------------------------
 --     SKILL LEVEL CALCULATOR
 --     Returns a skill level based on level and rating.
@@ -656,6 +668,9 @@ function utils.mobTeleport(mob, hideDuration, pos, disAnim, reapAnim)
     end)
 end
 
+------------------------------
+-- Spatial position utilities
+------------------------------
 local ffxiRotConversionFactor = 360.0 / 255.0
 
 function utils.ffxiRotToDegrees(ffxiRot)
@@ -746,7 +761,7 @@ function utils.angleWithin(origin, A, B, within)
 end
 
 local ffxiRotationToAngleFactor = 2.0 * math.pi / 256.0
-local ffxiAngleToRotationFactor  = 256.0 / (2.0 * math.pi)
+local ffxiAngleToRotationFactor = 256.0 / (2.0 * math.pi)
 
 function utils.rotationToAngle(ffxiRotation)
     return ffxiRotation * ffxiRotationToAngleFactor


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a new utility function: `getActiveJobLevel()`
- Checks if entity has a certain job equiped and returns it's level, depending on if the job is it's main or sub job.
- In mob cases, main-job will take precedence over sub-jobs (WAR/WAR cases, for example)
- If entity doesn't have checked job currently equiped, level returned will be 0.

## Steps to test these changes

Use...
- DRK: Blade Bash, Weapon Bash
- COR: Panthom Roll
- THF: Despoil, Mug, Steal

NOTE: No real logic changes were made, nor any corrections to behavior are meant to happen. If a skill isn't supposed to work the way it's currently coded, raise an issue and we can fix it in a different PR.