### PR TITLE
[Magic] Simplify arguments in magic functions

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -289,7 +289,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     local finalD = ((initialD + wsc) * (params.multiplier + azureBonus + correlationMultiplier)) + statBonus
 
     -- Multitarget damage reduction
-    local finaldmg = math.floor(finalD * xi.spells.damage.calculateMTDR(caster, target, spell))
+    local finaldmg = math.floor(finalD * xi.spells.damage.calculateMTDR(spell))
 
     -- Resistance
     finaldmg = math.floor(finaldmg * applyResistance(caster, target, spell, params))
@@ -390,7 +390,7 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params)
 
     -- handle MDT, One For All, Liement
     if attackType == xi.attackType.MAGICAL then
-        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(caster, target, damageType) -- Apply checks for Liement, MDT/MDTII/DT
+        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, damageType) -- Apply checks for Liement, MDT/MDTII/DT
         dmg = math.floor(dmg * targetMagicDamageAdjustment)
         if dmg < 0 then
             target:takeSpellDamage(caster, spell, dmg, attackType, damageType)

--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -18,10 +18,9 @@ local elementTable =
 }
 
 -- Actor Magic Accuracy
-xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spell, skillType, spellElement, statUsed, bonusMacc)
+xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
     local actorJob     = actor:getMainJob()
     local actorWeather = actor:getWeather()
-    local spellGroup   = spell and spell:getSpellGroup() or xi.magic.spellGroup.NONE
     local statDiff     = actor:getStat(statUsed) - target:getStat(statUsed)
     local magicAcc     = actor:getMod(xi.mod.MACC) + actor:getILvlMacc(xi.slot.MAIN)
 

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -709,13 +709,13 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     end
 
     local bonusMacc = strafeMeritPower + master:getMod(xi.mod.WYVERN_BREATH_MACC)
-    local element = damageType - xi.damageType.ELEMENTAL
+    local element   = damageType - xi.damageType.ELEMENTAL
 
     -- "Breath accuracy is directly affected by a wyvern's current HP", but no data exists.
     local resist              = xi.spells.damage.calculateResist(wyvern, target, 0, 0, element, 0, bonusMacc)
-    local sdt                 = xi.spells.damage.calculateSDT(wyvern, target, nil, element)
-    local magicBurst          = xi.spells.damage.calculateIfMagicBurst(wyvern, target,  0, element)
-    local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(wyvern, target, nil, element)
+    local sdt                 = xi.spells.damage.calculateSDT(target, element)
+    local magicBurst          = xi.spells.damage.calculateIfMagicBurst(target, element)
+    local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)
 
     -- It appears that MB breaths don't do more damage based on testing.
     damage = damage * resist * sdt * nukeAbsorbOrNullify

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -712,7 +712,7 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
     local element = damageType - xi.damageType.ELEMENTAL
 
     -- "Breath accuracy is directly affected by a wyvern's current HP", but no data exists.
-    local resist              = xi.spells.damage.calculateResist(wyvern, target,  nil, 0, element, 0, bonusMacc)
+    local resist              = xi.spells.damage.calculateResist(wyvern, target, 0, 0, element, 0, bonusMacc)
     local sdt                 = xi.spells.damage.calculateSDT(wyvern, target, nil, element)
     local magicBurst          = xi.spells.damage.calculateIfMagicBurst(wyvern, target,  0, element)
     local nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(wyvern, target, nil, element)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -492,16 +492,16 @@ end
 local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc) -- get these multipliers once and store them
     local multipliers = {}
 
-    multipliers.eleStaffBonus       = xi.spells.damage.calculateEleStaffBonus(player, nil, element)
-    multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity(player, nil)         -- presumed but untested
-    multipliers.SDT                 = xi.spells.damage.calculateSDT(player, target, nil, element)
+    multipliers.eleStaffBonus       = xi.spells.damage.calculateEleStaffBonus(player, element)
+    multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity() -- Presumed but untested.
+    multipliers.SDT                 = xi.spells.damage.calculateSDT(target, element)
     multipliers.resist              = xi.spells.damage.calculateResist(player, target, 0, 0, element, 0, bonusMacc)
-    multipliers.magicBurst          = xi.spells.damage.calculateIfMagicBurst(player, target,  0, element)
+    multipliers.magicBurst          = xi.spells.damage.calculateIfMagicBurst(target, element)
     multipliers.magicBurstBonus     = xi.spells.damage.calculateIfMagicBurstBonus(player, target, 0, 0, element)
-    multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, target, nil, 0, element)
-    multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, nil, 0, 0, element)
-    multipliers.TMDA                = xi.spells.damage.calculateTMDA(player, target, xi.damageType.ELEMENTAL + element)
-    multipliers.nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(player, target, nil, element)
+    multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, 0, element)
+    multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element)
+    multipliers.TMDA                = xi.spells.damage.calculateTMDA(target, element)
+    multipliers.nukeAbsorbOrNullify = xi.spells.damage.calculateNukeAbsorbOrNullify(target, element)
 
     return multipliers
 end

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -495,9 +495,9 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.eleStaffBonus       = xi.spells.damage.calculateEleStaffBonus(player, nil, element)
     multipliers.magianAffinity      = xi.spells.damage.calculateMagianAffinity(player, nil)         -- presumed but untested
     multipliers.SDT                 = xi.spells.damage.calculateSDT(player, target, nil, element)
-    multipliers.resist              = xi.spells.damage.calculateResist(player, target,  nil, 0, element, 0, bonusMacc)
+    multipliers.resist              = xi.spells.damage.calculateResist(player, target, 0, 0, element, 0, bonusMacc)
     multipliers.magicBurst          = xi.spells.damage.calculateIfMagicBurst(player, target,  0, element)
-    multipliers.magicBurstBonus     = xi.spells.damage.calculateIfMagicBurstBonus(player, target, nil, 0, element)
+    multipliers.magicBurstBonus     = xi.spells.damage.calculateIfMagicBurstBonus(player, target, 0, 0, element)
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, target, nil, 0, element)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, nil, 0, 0, element)
     multipliers.TMDA                = xi.spells.damage.calculateTMDA(player, target, xi.damageType.ELEMENTAL + element)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -202,7 +202,7 @@ local pTable =
 -----------------------------------
 -- Basic Functions
 -----------------------------------
-xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, skillType, statUsed)
+xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, skillType, statUsed)
     local spellDamage          = 0 -- The variable we want to calculate
     local baseSpellDamage      = 0 -- (V) In Wiki.
     local baseSpellDamageBonus = 0 -- (mDMG) In Wiki. Get from equipment, status, etc
@@ -314,7 +314,7 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spell, spellId, 
 end
 
 -- Calculate: Multiple Target Damage Reduction (MTDR)
-xi.spells.damage.calculateMTDR = function(caster, target, spell)
+xi.spells.damage.calculateMTDR = function(spell)
     local multipleTargetReduction = 1 -- The variable we want to calculate.
     local targets                 = spell:getTotalTargets()
 
@@ -329,7 +329,7 @@ xi.spells.damage.calculateMTDR = function(caster, target, spell)
     return multipleTargetReduction
 end
 
-xi.spells.damage.calculateEleStaffBonus = function(caster, spell, spellElement)
+xi.spells.damage.calculateEleStaffBonus = function(caster, spellElement)
     local eleStaffBonus = caster:getMod(strongAffinityDmg[spellElement])
 
     if eleStaffBonus > 0 then
@@ -341,7 +341,7 @@ xi.spells.damage.calculateEleStaffBonus = function(caster, spell, spellElement)
     return eleStaffBonus
 end
 
-xi.spells.damage.calculateMagianAffinity = function(caster, spell)
+xi.spells.damage.calculateMagianAffinity = function()
     -- TODO: IMPLEMENT MAGIAN TRIALS AFFINITY SYSTEM, which could be as simple as introducing a new modifier. Out of the scope of this rewrite, for now
     local magianAffinity = 1
 
@@ -352,7 +352,7 @@ xi.spells.damage.calculateMagianAffinity = function(caster, spell)
 end
 
 -- Elemental Specific Damage Taken (Elemental SDT)
-xi.spells.damage.calculateSDT = function(caster, target, spell, spellElement)
+xi.spells.damage.calculateSDT = function(target, spellElement)
     local sdt    = 1 -- The variable we want to calculate
     local sdtMod = 0
 
@@ -398,7 +398,7 @@ xi.spells.damage.calculateResist = function(caster, target, spellGroup, skillTyp
     return resist
 end
 
-xi.spells.damage.calculateIfMagicBurst = function(caster, target, spell, spellElement)
+xi.spells.damage.calculateIfMagicBurst = function(target, spellElement)
     local magicBurst         = 1 -- The variable we want to calculate
     local _, skillchainCount = FormMagicBurst(spellElement, target) -- External function. Not present in magic.lua.
 
@@ -472,7 +472,7 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spellId, 
     return magicBurstBonus
 end
 
-xi.spells.damage.calculateDayAndWeather = function(caster, target, spell, spellId, spellElement)
+xi.spells.damage.calculateDayAndWeather = function(caster, spellId, spellElement)
     local dayAndWeather = 1 -- The variable we want to calculate
     local weather       = caster:getWeather()
     local dayElement    = VanadielDayElement()
@@ -535,7 +535,7 @@ xi.spells.damage.calculateDayAndWeather = function(caster, target, spell, spellI
 end
 
 -- Magic Attack Bonus VS Magic Defense Bonus
-xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spell, spellId, skillType, spellElement)
+xi.spells.damage.calculateMagicBonusDiff = function(caster, target, spellId, skillType, spellElement)
     local magicBonusDiff = 1 -- The variable we want to calculate
     local casterJob      = caster:getMainJob()
     local mab            = caster:getMod(xi.mod.MATT)
@@ -623,7 +623,7 @@ end
 -- Calculate: Target Magic Damage Adjustment (TMDA)
 -- SDT follow-up. This time for specific modifiers.
 -- Referred to on item as "Magic Damage Taken -%", "Damage Taken -%" (Ex. Defending Ring) and "Magic Damage Taken II -%" (Aegis)
-xi.spells.damage.calculateTMDA = function(caster, target, spellElement)
+xi.spells.damage.calculateTMDA = function(target, spellElement)
     local damageType                  = xi.damageType.ELEMENTAL + spellElement
     local targetMagicDamageAdjustment = target:checkLiementAbsorb(damageType) -- Check for Liement.
 
@@ -649,7 +649,7 @@ xi.spells.damage.calculateTMDA = function(caster, target, spellElement)
 end
 
 -- Divine Emblem applies its own damage multiplier.
-xi.spells.damage.calculateDivineEmblemMultiplier = function(caster, target, spell)
+xi.spells.damage.calculateDivineEmblemMultiplier = function(caster)
     local divineEmblemMultiplier = 1
 
     if caster:hasStatusEffect(xi.effect.DIVINE_EMBLEM) then
@@ -661,7 +661,7 @@ xi.spells.damage.calculateDivineEmblemMultiplier = function(caster, target, spel
 end
 
 -- Ebullience applies an entirely separate multiplier.
-xi.spells.damage.calculateEbullienceMultiplier = function(caster, target, spell)
+xi.spells.damage.calculateEbullienceMultiplier = function(caster)
     local ebullienceMultiplier = 1
 
     if caster:hasStatusEffect(xi.effect.EBULLIENCE) then
@@ -673,7 +673,7 @@ xi.spells.damage.calculateEbullienceMultiplier = function(caster, target, spell)
 end
 
 -- CUSTOM function supported in scripts/globals/settings.lua
-xi.spells.damage.calculateSkillTypeMultiplier = function(caster, target, spell, skillType)
+xi.spells.damage.calculateSkillTypeMultiplier = function(skillType)
     local skillTypeMultiplier = 1
 
     if skillType == xi.skill.ELEMENTAL_MAGIC then
@@ -689,7 +689,7 @@ xi.spells.damage.calculateSkillTypeMultiplier = function(caster, target, spell, 
     return skillTypeMultiplier
 end
 
-xi.spells.damage.calculateNinSkillBonus = function(caster, target, spell, spellId, skillType)
+xi.spells.damage.calculateNinSkillBonus = function(caster, spellId, skillType)
     local ninSkillBonus = 1
 
     if skillType == xi.skill.NINJUTSU and caster:getMainJob() == xi.job.NIN then
@@ -707,7 +707,7 @@ xi.spells.damage.calculateNinSkillBonus = function(caster, target, spell, spellI
     return ninSkillBonus
 end
 
-xi.spells.damage.calculateNinFutaeBonus = function(caster, target, spell, skillType)
+xi.spells.damage.calculateNinFutaeBonus = function(caster, skillType)
     local ninFutaeBonus = 1
 
     if
@@ -721,7 +721,7 @@ xi.spells.damage.calculateNinFutaeBonus = function(caster, target, spell, skillT
     return ninFutaeBonus
 end
 
-xi.spells.damage.calculateUndeadDivinePenalty = function(caster, target, spell, skillType)
+xi.spells.damage.calculateUndeadDivinePenalty = function(target, skillType)
     local undeadDivinePenalty = 1
 
     if target:isUndead() and skillType == xi.skill.DIVINE_MAGIC then
@@ -744,7 +744,7 @@ xi.spells.damage.calculateScarletDeliriumMultiplier = function(caster)
     return scarletDeliriumMultiplier
 end
 
-xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, spellElement)
+xi.spells.damage.calculateNukeAbsorbOrNullify = function(target, spellElement)
     local nukeAbsorbOrNullify = 1
 
     -- Calculate chance for spell absorption.
@@ -765,7 +765,7 @@ xi.spells.damage.calculateNukeAbsorbOrNullify = function(caster, target, spell, 
 end
 
 -- Consecutive Elemental Damage Penalty. Most commonly known as "Nuke Wall".
-xi.spells.damage.calculateNukeWallFactor = function(caster, target, spell, spellElement, finalDamage)
+xi.spells.damage.calculateNukeWallFactor = function(target, spellElement, finalDamage)
     local nukeWallFactor = 1
 
     -- Initial check.
@@ -822,27 +822,26 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local statUsed     = pTable[spellId][stat]
     local bonusMacc    = pTable[spellId][bonusSpellMacc]
 
-
     -- Variables/steps to calculate finalDamage.
-    local spellDamage                 = xi.spells.damage.calculateBaseDamage(caster, target, spell, spellId, skillType, statUsed)
-    local multipleTargetReduction     = xi.spells.damage.calculateMTDR(caster, target, spell)
-    local eleStaffBonus               = xi.spells.damage.calculateEleStaffBonus(caster, spell, spellElement)
-    local magianAffinity              = xi.spells.damage.calculateMagianAffinity(caster, spell)
-    local sdt                         = xi.spells.damage.calculateSDT(caster, target, spell, spellElement)
+    local spellDamage                 = xi.spells.damage.calculateBaseDamage(caster, target, spellId, skillType, statUsed)
+    local multipleTargetReduction     = xi.spells.damage.calculateMTDR(spell)
+    local eleStaffBonus               = xi.spells.damage.calculateEleStaffBonus(caster, spellElement)
+    local magianAffinity              = xi.spells.damage.calculateMagianAffinity()
+    local sdt                         = xi.spells.damage.calculateSDT(target, spellElement)
     local resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
-    local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(caster, target, spell, spellElement)
+    local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(target, spellElement)
     local magicBurstBonus             = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, spellGroup, spellElement)
-    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, target, spell, spellId, spellElement)
-    local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(caster, target, spell, spellId, skillType, spellElement)
-    local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(caster, target, spellElement)
-    local divineEmblemMultiplier      = xi.spells.damage.calculateDivineEmblemMultiplier(caster, target, spell)
-    local ebullienceMultiplier        = xi.spells.damage.calculateEbullienceMultiplier(caster, target, spell)
-    local skillTypeMultiplier         = xi.spells.damage.calculateSkillTypeMultiplier(caster, target, spell, skillType)
-    local ninSkillBonus               = xi.spells.damage.calculateNinSkillBonus(caster, target, spell, spellId, skillType)
-    local ninFutaeBonus               = xi.spells.damage.calculateNinFutaeBonus(caster, target, spell, skillType)
-    local undeadDivinePenalty         = xi.spells.damage.calculateUndeadDivinePenalty(caster, target, spell, skillType)
+    local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, spellId, spellElement)
+    local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement)
+    local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, spellElement)
+    local divineEmblemMultiplier      = xi.spells.damage.calculateDivineEmblemMultiplier(caster)
+    local ebullienceMultiplier        = xi.spells.damage.calculateEbullienceMultiplier(caster)
+    local skillTypeMultiplier         = xi.spells.damage.calculateSkillTypeMultiplier(skillType)
+    local ninSkillBonus               = xi.spells.damage.calculateNinSkillBonus(caster, spellId, skillType)
+    local ninFutaeBonus               = xi.spells.damage.calculateNinFutaeBonus(caster, skillType)
+    local undeadDivinePenalty         = xi.spells.damage.calculateUndeadDivinePenalty(target, skillType)
     local scarletDeliriumMultiplier   = xi.spells.damage.calculateScarletDeliriumMultiplier(caster)
-    local nukeAbsorbOrNullify         = xi.spells.damage.calculateNukeAbsorbOrNullify(caster, target, spell, spellElement)
+    local nukeAbsorbOrNullify         = xi.spells.damage.calculateNukeAbsorbOrNullify(target, spellElement)
 
     -- Calculate finalDamage. It MUST be floored after EACH multiplication.
     finalDamage = math.floor(spellDamage * multipleTargetReduction)
@@ -865,7 +864,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * nukeAbsorbOrNullify)
 
     -- Handle "Nuke Wall". It must be handled after all previous calculations, but before clamp.
-    local nukeWallFactor = xi.spells.damage.calculateNukeWallFactor(caster, target, spell, spellElement, finalDamage)
+    local nukeWallFactor = xi.spells.damage.calculateNukeWallFactor(target, spellElement, finalDamage)
 
     finalDamage = math.floor(finalDamage * nukeWallFactor)
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -382,10 +382,7 @@ end
 
 -- This function is used to calculate Resist tiers. The resist tiers work differently for enfeebles (which usually affect duration, not potency) than for nukes.
 -- This is for nukes damage only. If an spell happens to do both damage and apply an status effect, they are calculated separately.
-xi.spells.damage.calculateResist = function(caster, target, spellGroup, skillType, spellElement, statUsed)
-    -- Get Bonus Magic Accruacy for the spell
-    local bonusMacc = pTable[spell:getID()][bonusSpellMacc]
-
+xi.spells.damage.calculateResist = function(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
     -- Get Caster Magic Accuracy.
     local magicAcc = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
 
@@ -823,6 +820,8 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local spellGroup   = spell:getSpellGroup()
     local spellElement = spell:getElement()
     local statUsed     = pTable[spellId][stat]
+    local bonusMacc    = pTable[spellId][bonusSpellMacc]
+
 
     -- Variables/steps to calculate finalDamage.
     local spellDamage                 = xi.spells.damage.calculateBaseDamage(caster, target, spell, spellId, skillType, statUsed)
@@ -830,7 +829,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local eleStaffBonus               = xi.spells.damage.calculateEleStaffBonus(caster, spell, spellElement)
     local magianAffinity              = xi.spells.damage.calculateMagianAffinity(caster, spell)
     local sdt                         = xi.spells.damage.calculateSDT(caster, target, spell, spellElement)
-    local resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed)
+    local resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
     local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(caster, target, spell, spellElement)
     local magicBurstBonus             = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, spellGroup, spellElement)
     local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, target, spell, spellId, spellElement)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -382,12 +382,12 @@ end
 
 -- This function is used to calculate Resist tiers. The resist tiers work differently for enfeebles (which usually affect duration, not potency) than for nukes.
 -- This is for nukes damage only. If an spell happens to do both damage and apply an status effect, they are calculated separately.
-xi.spells.damage.calculateResist = function(caster, target, spell, skillType, spellElement, statUsed)
+xi.spells.damage.calculateResist = function(caster, target, spellGroup, skillType, spellElement, statUsed)
     -- Get Bonus Magic Accruacy for the spell
     local bonusMacc = pTable[spell:getID()][bonusSpellMacc]
 
     -- Get Caster Magic Accuracy.
-    local magicAcc = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spell, skillType, spellElement, statUsed, bonusMacc)
+    local magicAcc = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
 
     -- Get Target Magic Evasion.
     local magicEva = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, false, 0) -- false = not an enfeeble. 0 = No meva modifier.
@@ -427,7 +427,7 @@ xi.spells.damage.calculateIfMagicBurst = function(caster, target, spell, spellEl
     return magicBurst
 end
 
-xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spell, spellId, spellElement)
+xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spellId, spellGroup, spellElement)
     local magicBurstBonus        = 1 -- The variable we want to calculate
     local modBurst               = 1
     local ancientMagicBurstBonus = 0
@@ -442,8 +442,7 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spell, sp
     -- MBB = MBB + trait
 
     if
-        spell and
-        spell:getSpellGroup() == 3 and
+        spellGroup == xi.magic.spellGroup.BLUE and
         not (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or caster:hasStatusEffect(xi.effect.AZURE_LORE))
     then
         return magicBurstBonus
@@ -821,6 +820,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     -- Get Tabled Variables.
     local spellId         = spell:getID()
     local skillType       = spell:getSkillType()
+    local spellGroup      = spell:getSpellGroup()
     local spellElement    = spell:getElement()
     local statUsed        = pTable[spellId][stat]
     local spellDamageType = xi.damageType.ELEMENTAL + spellElement
@@ -831,9 +831,9 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local eleStaffBonus               = xi.spells.damage.calculateEleStaffBonus(caster, spell, spellElement)
     local magianAffinity              = xi.spells.damage.calculateMagianAffinity(caster, spell)
     local sdt                         = xi.spells.damage.calculateSDT(caster, target, spell, spellElement)
-    local resist                      = xi.spells.damage.calculateResist(caster, target, spell, skillType, spellElement, statUsed)
-    local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(caster, target,  spell, spellElement)
-    local magicBurstBonus             = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spell, spellId, spellElement)
+    local resist                      = xi.spells.damage.calculateResist(caster, target, spellGroup, skillType, spellElement, statUsed)
+    local magicBurst                  = xi.spells.damage.calculateIfMagicBurst(caster, target, spell, spellElement)
+    local magicBurstBonus             = xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, spellGroup, spellElement)
     local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, target, spell, spellId, spellElement)
     local magicBonusDiff              = xi.spells.damage.calculateMagicBonusDiff(caster, target, spell, spellId, skillType, spellElement)
     local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(caster, target, spellDamageType)

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -369,6 +369,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     ------------------------------
     local skillType    = spell:getSkillType()
     local spellElement = spell:getElement()
+    local spellGroup   = spell:getSpellGroup()
     local statUsed     = pTable[spellId][2]
     local mEvaMod      = pTable[spellId][4]
     local resistStages = pTable[spellId][8]
@@ -376,7 +377,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local bonusMacc    = pTable[spellId][13]
 
     -- Magic Hit Rate calculations.
-    local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spell, skillType, spellElement, statUsed, bonusMacc)
+    local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
     local magicEva     = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, true, mEvaMod)
     local magicHitRate = xi.combat.magicHitRate.calculateMagicHitRate(magicAcc, magicEva)
 

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -383,7 +383,7 @@ xi.summon.avatarFinalAdjustments = function(dmg, mob, skill, target, skilltype, 
 
     -- handle One For All, Liement
     if skilltype == xi.attackType.MAGICAL then
-        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(mob, target, damagetype) -- Apply checks for Liement, MDT/MDTII/DT
+        local targetMagicDamageAdjustment = xi.spells.damage.calculateTMDA(target, damagetype) -- Apply checks for Liement, MDT/MDTII/DT
 
         dmg = math.floor(dmg * targetMagicDamageAdjustment)
         if dmg < 0 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Simplifies some magic functions.
- Removes unused arguments from magic functions.
- Fixes errors thrown by certain DRG and RUN skills.

## Steps to test these changes

Cast damaging spells AND have dragoons use breaths without throwing errors.

Review by commit so you can better see what is going on in there.