### PR TITLE
[Fix] [dbTool] Add check for .sql files

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -361,14 +361,16 @@ def fetch_files(express=False):
     else:
         for (_, _, filenames) in os.walk(from_server_path("sql/")):
             for filename in sorted(filenames):
-                import_files.append(from_server_path("sql/" + filename))
+                if filename.endswith('.sql'):
+                    import_files.append(from_server_path("sql/" + filename))
             break
     check_protected()
     backups.clear()
     for (_, _, filenames) in os.walk(from_server_path("sql/backups/")):
         for file in sorted(filenames):
             if not ".gitignore" in file:
-                backups.append(from_server_path("sql/backups/" + file))
+                if file.endswith('.sql'):
+                    backups.append(from_server_path("sql/backups/" + file))
         break
     backups.sort()
     import_files.sort()


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

Well, Teo has.

## What does this pull request do?

Adds a check (two, actually) for .sql file extension before importing files, so we don't try to import non-sql files.
Closes #3922 

## Steps to test these changes

Have a non-sql file in the sql folder and try to import it with db tool
