### PR TITLE
Add back target:getMod() in xi.magic.getEffectResistance()

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -635,7 +635,7 @@ xi.magic.getEffectResistance = function(target, effectId)
     local statusResistance = target:getMod(xi.mod.STATUSRES)
 
     if effectToResistanceMod[effectId] then
-        statusResistance = statusResistance + effectToResistanceMod[effectId]
+        statusResistance = statusResistance + target:getMod(effectToResistanceMod[effectId])
     end
 
     return statusResistance


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This was removed in af7d94bcbbfc2c2cfe2fed872faf679e7c05dee7 resulting in xi.magic.getEffectResistance() returning very high resistance.

## Steps to test these changes
I noticed this on BLU so:
1. !changejob blu
2. !addallspells
3. Equip Head Butt and use it
4. Notice how the stun almost never lands
5. Apply this patch
6. Stun should now land
<!-- Clear and detailed steps to test your changes here -->
