### PR TITLE
[lua] [BLU] Don't remove Burst Affinity until a blue magic nuke is cast

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -266,7 +266,6 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     local wsc = calculateWSC(caster, params)
     if caster:hasStatusEffect(xi.effect.BURST_AFFINITY) then
         wsc = wsc * 2
-        caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
     end
 
     -- INT/MND/CHR dmg bonuses

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -225,10 +225,17 @@ local function calculateMagicBurst(caster, spell, target, params)
     local modburst = 1.0
 
     if
-        spell:getSpellGroup() == 3 and
-        not (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or caster:hasStatusEffect(xi.effect.AZURE_LORE))
+        spell and
+        spell:getSpellGroup() == xi.magic.spellGroup.BLUE
     then
-        return burst
+        if
+            not (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
+            caster:hasStatusEffect(xi.effect.AZURE_LORE))
+        then
+            return burst
+        end
+
+        caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
     end
 
     -- Obtain first multiplier from gear, atma and job traits

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -436,11 +436,15 @@ xi.spells.damage.calculateIfMagicBurstBonus = function(caster, target, spellId, 
     -- MBB = 1.0 + Gear + Atma/Atmacite + AMII Merits + others -- This Caps at 1.4
     -- MBB = MBB + trait
 
-    if
-        spellGroup == xi.magic.spellGroup.BLUE and
-        not (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or caster:hasStatusEffect(xi.effect.AZURE_LORE))
-    then
-        return magicBurstBonus
+    if spellGroup == xi.magic.spellGroup.BLUE then
+        if
+            not (caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
+            caster:hasStatusEffect(xi.effect.AZURE_LORE))
+        then
+            return magicBurstBonus
+        end
+
+        caster:delStatusEffectSilent(xi.effect.BURST_AFFINITY)
     end
 
     -- Obtain multiplier from gear, atma and job traits -- Job traits should be done separately


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes  #3948

## Steps to test these changes

Use Burst Affinity and be able to get MBs with magical based blue magic spells such as bomb toss on Light SC