### PR TITLE
[Crafting] Cleanup GP Vendors (Union Representatives)

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -218,7 +218,7 @@ end
 --------------------------------------------------
 -- Guild Point NPCs (Union Representatives)
 --------------------------------------------------
-xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildID)
+xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildID)
     local _, remainingPoints = player:getCurrentGPItem(guildID)
     local ID                 = zones[player:getZoneID()]
 
@@ -244,7 +244,7 @@ xi.crafting.unionRepresentativeTrade = function(player, npc, trade, csid, guildI
     end
 end
 
-xi.crafting.unionRepresentativeTrigger = function(player, guildId, csid, currency, keyitems)
+xi.crafting.guildPointNPConTrigger = function(player, guildId, csid, currency, keyitems)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildId)
     local rank                    = player:getSkillRank(guildId + 48)
     local cap                     = (rank + 1) * 10
@@ -261,7 +261,7 @@ xi.crafting.unionRepresentativeTrigger = function(player, guildId, csid, currenc
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-xi.crafting.unionRepresentativeTriggerFinish = function(player, option, target, guildID, currency, keyitems, items)
+xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildID, currency, keyitems, items)
     local rank     = player:getSkillRank(guildID + 48)
     local category = bit.band(bit.rshift(option, 2), 3)
     local ID       = zones[player:getZoneID()]

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -318,7 +318,7 @@ end
 -- tradeTestItem Action
 -----------------------------------
 xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
-    local guildID    = craftID - 48
+    local guildId    = craftID - 48
     local skillLvL   = player:getSkillLevel(craftID)
     local testItemId = xi.crafting.getTestItem(player, npc, craftID)
     local newRank    = 0
@@ -329,7 +329,7 @@ xi.crafting.tradeTestItem = function(player, npc, trade, craftID)
     then
         newRank = player:getSkillRank(craftID) + 1
 
-        if player:getCharVar('[GUILD]currentGuild') == guildID + 1 then
+        if player:getCharVar('[GUILD]currentGuild') == guildId + 1 then
             player:setCharVar('[GUILD]daily_points', 1)
         end
     end
@@ -419,17 +419,17 @@ end
 --------------------------------------------------
 -- Guild Point NPCs (Union Representatives)
 --------------------------------------------------
-xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildID)
-    local _, remainingPoints = player:getCurrentGPItem(guildID)
+xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildId)
+    local _, remainingPoints = player:getCurrentGPItem(guildId)
     local ID                 = zones[player:getZoneID()]
 
-    if player:getCharVar('[GUILD]currentGuild') - 1 == guildID then
+    if player:getCharVar('[GUILD]currentGuild') - 1 == guildId then
         if remainingPoints == 0 then
             player:messageText(npc, ID.text.NO_MORE_GP_ELIGIBLE)
         else
             local totalPoints = 0
             for i = 0, 8 do
-                local items, points = player:addGuildPoints(guildID, i)
+                local items, points = player:addGuildPoints(guildId, i)
 
                 if items ~= 0 and points ~= 0 then
                     totalPoints = totalPoints + points
@@ -464,23 +464,23 @@ xi.crafting.guildPointNPConTrigger = function(player, csid, guildId)
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildID)
-    local rank     = player:getSkillRank(guildTable[guildID][1])
+xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildId)
+    local rank     = player:getSkillRank(guildTable[guildId][1])
     local category = bit.band(bit.rshift(option, 2), 3)
     local ID       = zones[player:getZoneID()]
-    local currency = guildTable[guildID][2]
-    local keyitems = guildKeyItemTable[guildID]
-    local items    = guildItemTable[guildID]
+    local currency = guildTable[guildId][2]
+    local keyitems = guildKeyItemTable[guildId]
+    local items    = guildItemTable[guildId]
 
     -- Contract Dialog.
     if bit.tobit(option) == -1 and rank >= 3 then
         local oldGuild = player:getCharVar('[GUILD]currentGuild') - 1
-        player:setCharVar('[GUILD]currentGuild', guildID + 1)
+        player:setCharVar('[GUILD]currentGuild', guildId + 1)
 
         if oldGuild == -1 then
-            player:messageSpecial(ID.text.GUILD_NEW_CONTRACT, guildID)
+            player:messageSpecial(ID.text.GUILD_NEW_CONTRACT, guildId)
         else
-            player:messageSpecial(ID.text.GUILD_TERMINATE_CONTRACT, guildID, oldGuild)
+            player:messageSpecial(ID.text.GUILD_TERMINATE_CONTRACT, guildId, oldGuild)
             player:setCharVar('[GUILD]daily_points', 1)
         end
 

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -78,14 +78,15 @@ local testItemsByNPC =
 
 local hqCrystals =
 {
-    [1] = { id = xi.items.INFERNO_CRYSTAL,  cost = 200 },
-    [2] = { id = xi.items.GLACIER_CRYSTAL,  cost = 200 },
-    [3] = { id = xi.items.CYCLONE_CRYSTAL,  cost = 200 },
-    [4] = { id = xi.items.TERRA_CRYSTAL,    cost = 200 },
-    [5] = { id = xi.items.PLASMA_CRYSTAL,   cost = 200 },
-    [6] = { id = xi.items.TORRENT_CRYSTAL,  cost = 200 },
-    [7] = { id = xi.items.AURORA_CRYSTAL,   cost = 500 },
-    [8] = { id = xi.items.TWILIGHT_CRYSTAL, cost = 500 },
+    [0] = { id = xi.items.ROBBER_RIG,       cost = 1500 }, -- Robber Rig is located in category 3. Not a typo.
+    [1] = { id = xi.items.INFERNO_CRYSTAL,  cost =  200 },
+    [2] = { id = xi.items.GLACIER_CRYSTAL,  cost =  200 },
+    [3] = { id = xi.items.CYCLONE_CRYSTAL,  cost =  200 },
+    [4] = { id = xi.items.TERRA_CRYSTAL,    cost =  200 },
+    [5] = { id = xi.items.PLASMA_CRYSTAL,   cost =  200 },
+    [6] = { id = xi.items.TORRENT_CRYSTAL,  cost =  200 },
+    [7] = { id = xi.items.AURORA_CRYSTAL,   cost =  500 },
+    [8] = { id = xi.items.TWILIGHT_CRYSTAL, cost =  500 },
 }
 
 local guildTable =
@@ -182,12 +183,12 @@ local guildItemTable =
 {
     [0] = -- Fishing
     {
-        [0] = { id = xi.items.ROBBER_RIG,           rank = xi.crafting.rank.NOVICE,     cost =   1500 },
-        [1] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.APPRENTICE, cost =  10000 },
-        [2] = { id = xi.items.WADERS,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-        [3] = { id = xi.items.FISHERMANS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-        [4] = { id = xi.items.FISHING_HOLE_MAP,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-        [5] = { id = xi.items.FISHERMANS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [0] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.APPRENTICE, cost =  10000 },
+        [1] = { id = xi.items.WADERS,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.FISHERMANS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.FISHING_HOLE_MAP,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.FISHERMANS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        -- There is a blank space here. Robber Rig SHOULD be here, but it isnt. It's with the crystals.
         [6] = { id = xi.items.NET_AND_LURE,         rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
         [7] = { id = xi.items.FISHERMENS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
     },
@@ -419,7 +420,7 @@ end
 --------------------------------------------------
 -- Guild Point NPCs (Union Representatives)
 --------------------------------------------------
-xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildId)
+xi.crafting.guildPointOnTrade = function(player, npc, trade, csid, guildId)
     local ID                 = zones[player:getZoneID()]
     local _, remainingPoints = player:getCurrentGPItem(guildId)
 
@@ -445,7 +446,7 @@ xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildId)
     end
 end
 
-xi.crafting.guildPointNPConTrigger = function(player, csid, guildId)
+xi.crafting.guildPointOnTrigger = function(player, csid, guildId)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildId)
     local rank                    = player:getSkillRank(guildTable[guildId][1])
     local skillCap                = (rank + 1) * 10
@@ -464,7 +465,7 @@ xi.crafting.guildPointNPConTrigger = function(player, csid, guildId)
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, skillCap, 0, keyItemBits)
 end
 
-xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildId)
+xi.crafting.guildPointOnEventFinish = function(player, option, target, guildId)
     local ID       = zones[player:getZoneID()]
     local rank     = player:getSkillRank(guildTable[guildId][1])
     local category = bit.band(bit.rshift(option, 2), 3)

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -445,7 +445,7 @@ xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildID)
     end
 end
 
-xi.crafting.guildPointNPConTrigger = function(player, guildId, csid)
+xi.crafting.guildPointNPConTrigger = function(player, csid, guildId)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildId)
     local rank                    = player:getSkillRank(guildTable[guildId][1])
     local cap                     = (rank + 1) * 10

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -8,17 +8,19 @@ require('scripts/globals/utils')
 xi = xi or {}
 xi.crafting = {}
 
+-- Ordered by ACTUAL guild ID.
+-- I'll change the actual numbers later, once I get to guild masters and I make sure I dont break stuff.
 xi.crafting.guild =
 {
-    ALCHEMY      = 1,
-    BONECRAFT    = 2,
-    CLOTHCRAFT   = 3,
-    COOKING      = 4,
     FISHING      = 5,
-    GOLDSMITHING = 6,
-    LEATHERCRAFT = 7,
-    SMITHING     = 8,
     WOODWORKING  = 9,
+    SMITHING     = 8,
+    GOLDSMITHING = 6,
+    CLOTHCRAFT   = 3,
+    LEATHERCRAFT = 7,
+    BONECRAFT    = 2,
+    ALCHEMY      = 1,
+    COOKING      = 4,
 }
 
 xi.crafting.rank =
@@ -39,6 +41,12 @@ xi.crafting.rank =
 -- Keys are based on the player's current rank in the guild in order to be eligible
 -- for the next rank-up test.  Example: At Amateur, a value of 256 is required to
 -- be eligible for the test to move to Recruit
+
+-- This magic numbers make no sense to me. At all.
+-- Example:
+-- At rank Amateur (Very first rank): I should have (in the database) 80+ skill points, AKA, lvl 8+ to be eligible for next rank.
+-- At rank Craftsman (Last rank before the specialitation): I should have 680+ skill points, AKA lvl 68+ to be eligible for next rank.
+-- So what does 256 or 2182 even mean?
 local requiredSkillForRank =
 {
     [xi.crafting.rank.AMATEUR]    = 256,
@@ -78,6 +86,199 @@ local hqCrystals =
     [6] = { id = xi.items.TORRENT_CRYSTAL,  cost = 200 },
     [7] = { id = xi.items.AURORA_CRYSTAL,   cost = 500 },
     [8] = { id = xi.items.TWILIGHT_CRYSTAL, cost = 500 },
+}
+
+local guildTable =
+{
+    -- [guildId] = { skill used,   "currency used"      },
+    [0] = { xi.skill.FISHING,      "guild_fishing"      },
+    [1] = { xi.skill.WOODWORKING,  "guild_woodworking"  },
+    [2] = { xi.skill.SMITHING,     "guild_smithing"     },
+    [3] = { xi.skill.GOLDSMITHING, "guild_goldsmithing" },
+    [4] = { xi.skill.CLOTHCRAFT,   "guild_weaving"      },
+    [5] = { xi.skill.LEATHERCRAFT, "guild_leathercraft" },
+    [6] = { xi.skill.BONECRAFT,    "guild_bonecraft"    },
+    [7] = { xi.skill.ALCHEMY,      "guild_alchemy"      },
+    [8] = { xi.skill.COOKING,      "guild_cooking"      },
+}
+
+local guildKeyItemTable =
+{
+    [0] = -- Fishing
+    {
+        [0] = { id = xi.ki.FROG_FISHING,    rank = xi.crafting.rank.NOVICE,  cost =  30000 },
+        [1] = { id = xi.ki.SERPENT_RUMORS,  rank = xi.crafting.rank.ADEPT,   cost =  95000 },
+        [2] = { id = xi.ki.MOOCHING,        rank = xi.crafting.rank.VETERAN, cost = 115000 },
+        [3] = { id = xi.ki.ANGLERS_ALMANAC, rank = xi.crafting.rank.VETERAN, cost =  20000 },
+    },
+    [1] = -- Woodworking
+    {
+        [0] = { id = xi.ki.WOOD_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.WOOD_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.LUMBERJACK,           rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.BOLTMAKER,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [4] = { id = xi.ki.WAY_OF_THE_CARPENTER, rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [2] = -- Smithing
+    {
+        [0] = { id = xi.ki.METAL_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.METAL_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.CHAINWORK,             rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.SHEETING,              rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [4] = { id = xi.ki.WAY_OF_THE_BLACKSMITH, rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [3] = -- Goldsmithing
+    {
+        [0] = { id = xi.ki.GOLD_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.GOLD_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.CHAINWORK,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.SHEETING,             rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [4] = { id = xi.ki.CLOCKMAKING,          rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [5] = { id = xi.ki.WAY_OF_THE_GOLDSMITH, rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [4] = -- Clothcraft
+    {
+        [0] = { id = xi.ki.CLOTH_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.CLOTH_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.SPINNING,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.FLETCHING,           rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [4] = { id = xi.ki.WAY_OF_THE_WEAVER,   rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [5] = -- Leathercraft
+    {
+        [0] = { id = xi.ki.LEATHER_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.LEATHER_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.TANNING,               rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.WAY_OF_THE_TANNER,     rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [6] = -- Bonecraft
+    {
+        [0] = { id = xi.ki.BONE_PURIFICATION,     rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [1] = { id = xi.ki.BONE_ENSORCELLMENT,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.FILING,                rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [3] = { id = xi.ki.WAY_OF_THE_BONEWORKER, rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [7] = -- Alchemy
+    {
+        [0] = { id = xi.ki.ANIMA_SYNTHESIS,        rank = xi.crafting.rank.NOVICE,  cost = 20000 },
+        [1] = { id = xi.ki.ALCHEMIC_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [2] = { id = xi.ki.ALCHEMIC_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
+        [3] = { id = xi.ki.TRITURATION,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [4] = { id = xi.ki.CONCOCTION,             rank = xi.crafting.rank.NOVICE,  cost = 20000 },
+        [5] = { id = xi.ki.IATROCHEMISTRY,         rank = xi.crafting.rank.NOVICE,  cost = 10000 },
+        [6] = { id = xi.ki.WAY_OF_THE_ALCHEMIST,   rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+    [8] = -- Cooking
+    {
+        [0] = { id = xi.ki.RAW_FISH_HANDLING,     rank = xi.crafting.rank.NOVICE,  cost = 30000 },
+        [1] = { id = xi.ki.NOODLE_KNEADING,       rank = xi.crafting.rank.NOVICE,  cost = 30000 },
+        [2] = { id = xi.ki.PATISSIER,             rank = xi.crafting.rank.NOVICE,  cost =  8000 },
+        [3] = { id = xi.ki.STEWPOT_MASTERY,       rank = xi.crafting.rank.NOVICE,  cost = 30000 },
+        [4] = { id = xi.ki.WAY_OF_THE_CULINARIAN, rank = xi.crafting.rank.VETERAN, cost = 20000 },
+    },
+}
+
+local guildItemTable =
+{
+    [0] = -- Fishing
+    {
+        [0] = { id = xi.items.ROBBER_RIG,           rank = xi.crafting.rank.NOVICE,     cost =   1500 },
+        [1] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [2] = { id = xi.items.WADERS,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [3] = { id = xi.items.FISHERMANS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [4] = { id = xi.items.FISHING_HOLE_MAP,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [5] = { id = xi.items.FISHERMANS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [6] = { id = xi.items.NET_AND_LURE,         rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.FISHERMENS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [1] = -- Woodworking
+    {
+        [0] = { id = xi.items.CARPENTERS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.CARPENTERS_GLOVES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.CARPENTERS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.DRAWING_DESK,         rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.CARPENTERS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.CARPENTERS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.CARPENTERS_KIT,       rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.CARPENTERS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [2] = -- Smithing
+    {
+        [0] = { id = xi.items.BLACKSMITHS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.SMITHYS_MITTS,         rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.BLACKSMITHS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.MASTERSMITH_ANVIL,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.BLACKSMITHS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.SMITHS_RING,           rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.STONE_HEARTH,          rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.BLACKSMITHS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [3] = -- Goldsmithing
+    {
+        [0] = { id = xi.items.GOLDSMITHS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.SHADED_SPECTACLES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.GOLDSMITHS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.STACK_OF_FOOLS_GOLD,  rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.GOLDSMITHS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.GOLDSMITHS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.GEMSCOPE,             rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.GOLDSMITHS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [4] = -- Clothcraft
+    {
+        [0] = { id = xi.items.WEAVERS_BELT,          rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.MAGNIFYING_SPECTACLES, rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.WEAVERS_APRON,         rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.GILT_TAPESTRY,         rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.WEAVERS_SIGNBOARD,     rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.TAILORS_RING,          rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.SPINNING_WHEEL,        rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.WEAVERS_EMBLEM,        rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [5] = -- Leathercraft
+    {
+        [0] = { id = xi.items.TANNERS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.TANNERS_GLOVES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.TANNERS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.GOLDEN_FLEECE,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.TANNERS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.TANNERS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.HIDE_STRETCHER,    rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.TANNERS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [6] = -- Bonecraft
+    {
+        [0] = { id = xi.items.BONEWORKERS_BELT,          rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.PROTECTIVE_SPECTACLES,     rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.BONEWORKERS_APRON,         rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.DROGAROGAS_FANG,           rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.BONEWORKERS_SIGNBOARD,     rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.BONECRAFTERS_RING,         rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.SET_OF_BONECRAFTING_TOOLS, rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.BONEWORKERS_EMBLEM,        rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [7] = -- Alchemy
+    {
+        [0] = { id = xi.items.ALCHEMISTS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.CADUCEUS,             rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.ALCHEMISTS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.COPY_OF_EMERALDA,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.ALCHEMISTS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.ALCHEMISTS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.ALEMBIC,              rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.ALCHEMISTS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
+    [8] = -- Cooking
+    {
+        [0] = { id = xi.items.CULINARIANS_BELT,        rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.CHEFS_HAT,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
+        [2] = { id = xi.items.CULINARIANS_APRON,       rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
+        [3] = { id = xi.items.CORDON_BLEU_COOKING_SET, rank = xi.crafting.rank.VETERAN,    cost = 150000 },
+        [4] = { id = xi.items.CULINARIANS_SIGNBOARD,   rank = xi.crafting.rank.VETERAN,    cost = 200000 },
+        [5] = { id = xi.items.CHEFS_RING,              rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
+        [6] = { id = xi.items.BRASS_CROCK,             rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
+        [7] = { id = xi.items.CULINARIANS_EMBLEM,      rank = xi.crafting.rank.VETERAN,    cost =  15000 },
+    },
 }
 
 xi.crafting.hasJoinedGuild = function(player, guildId)
@@ -244,11 +445,13 @@ xi.crafting.guildPointNPConTrade = function(player, npc, trade, csid, guildID)
     end
 end
 
-xi.crafting.guildPointNPConTrigger = function(player, guildId, csid, currency, keyitems)
+xi.crafting.guildPointNPConTrigger = function(player, guildId, csid)
     local gpItem, remainingPoints = player:getCurrentGPItem(guildId)
-    local rank                    = player:getSkillRank(guildId + 48)
+    local rank                    = player:getSkillRank(guildTable[guildId][1])
     local cap                     = (rank + 1) * 10
     local kibits                  = 0
+    local currency                = guildTable[guildId][2]
+    local keyitems                = guildKeyItemTable[guildId]
 
     for kbit, ki in pairs(keyitems) do
         if rank >= ki.rank then
@@ -261,10 +464,13 @@ xi.crafting.guildPointNPConTrigger = function(player, guildId, csid, currency, k
     player:startEvent(csid, player:getCurrency(currency), player:getCharVar('[GUILD]currentGuild') - 1, gpItem, remainingPoints, cap, 0, kibits)
 end
 
-xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildID, currency, keyitems, items)
-    local rank     = player:getSkillRank(guildID + 48)
+xi.crafting.guildPointNPConEventFinish = function(player, option, target, guildID)
+    local rank     = player:getSkillRank(guildTable[guildID][1])
     local category = bit.band(bit.rshift(option, 2), 3)
     local ID       = zones[player:getZoneID()]
+    local currency = guildTable[guildID][2]
+    local keyitems = guildKeyItemTable[guildID]
+    local items    = guildItemTable[guildID]
 
     -- Contract Dialog.
     if bit.tobit(option) == -1 and rank >= 3 then

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -183,7 +183,7 @@ local guildItemTable =
     [0] = -- Fishing
     {
         [0] = { id = xi.items.ROBBER_RIG,           rank = xi.crafting.rank.NOVICE,     cost =   1500 },
-        [1] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
+        [1] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.APPRENTICE, cost =  10000 },
         [2] = { id = xi.items.WADERS,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
         [3] = { id = xi.items.FISHERMANS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
         [4] = { id = xi.items.FISHING_HOLE_MAP,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -4,51 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos -214.355 -7.814 -63.809 235
 -----------------------------------
+local ID = require('scripts/zones/Bastok_Markets/IDs')
 require('scripts/globals/crafting')
 -----------------------------------
-local ID = require('scripts/zones/Bastok_Markets/IDs')
------------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.GOLD_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.GOLD_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.CHAINWORK,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.SHEETING,             rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.CLOCKMAKING,          rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [5] = { id = xi.ki.WAY_OF_THE_GOLDSMITH, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.GOLDSMITHS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.SHADED_SPECTACLES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.GOLDSMITHS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.STACK_OF_FOOLS_GOLD,  rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.GOLDSMITHS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.GOLDSMITHS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.GEMSCOPE,             rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.GOLDSMITHS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTradeplayer, npc, trade, 341, 3)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 3, 340, "guild_goldsmithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 3, 340)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3)
     elseif csid == 341 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -10,22 +10,22 @@ require('scripts/globals/crafting')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 341, 3)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 341, 3)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 340, 3)
+    xi.crafting.guildPointOnTrigger(player, 340, 3)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 3)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 3)
     elseif csid == 341 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 3, 340)
+    xi.crafting.guildPointNPConTrigger(player, 340, 3)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -10,7 +10,7 @@ require('scripts/globals/crafting')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTradeplayer, npc, trade, 341, 3)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 341, 3)
 end
 
 entity.onTrigger = function(player, npc)

--- a/scripts/zones/Bastok_Markets/npcs/Ellard.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ellard.lua
@@ -33,22 +33,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 341, 3)
+    xi.crafting.guildPointNPConTradeplayer, npc, trade, 341, 3)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 3, 340, "guild_goldsmithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 3, 340, "guild_goldsmithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 340 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 3, "guild_goldsmithing", keyitems, items)
     elseif csid == 341 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
@@ -4,52 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos 117.970 1.017 -10.438 234
 -----------------------------------
+local ID = require('scripts/zones/Bastok_Mines/IDs')
 require('scripts/globals/crafting')
 -----------------------------------
-local ID = require('scripts/zones/Bastok_Mines/IDs')
------------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.ANIMA_SYNTHESIS,        rank = xi.crafting.rank.NOVICE,  cost = 20000 },
-    [1] = { id = xi.ki.ALCHEMIC_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.ALCHEMIC_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [3] = { id = xi.ki.TRITURATION,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.CONCOCTION,             rank = xi.crafting.rank.NOVICE,  cost = 20000 },
-    [5] = { id = xi.ki.IATROCHEMISTRY,         rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [6] = { id = xi.ki.WAY_OF_THE_ALCHEMIST,   rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.ALCHEMISTS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.CADUCEUS,             rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.ALCHEMISTS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.COPY_OF_EMERALDA,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.ALCHEMISTS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.ALCHEMISTS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.ALEMBIC,              rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.ALCHEMISTS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 207, 7)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 7, 206, "guild_alchemy", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 7, 206)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7)
     elseif csid == 207 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
@@ -34,22 +34,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 207, 7)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 207, 7)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 7, 206, "guild_alchemy", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 7, 206, "guild_alchemy", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7, "guild_alchemy", keyitems, items)
     elseif csid == 207 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
@@ -10,22 +10,22 @@ require('scripts/globals/crafting')
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 207, 7)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 207, 7)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 206, 7)
+    xi.crafting.guildPointOnTrigger(player, 206, 7)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 7)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 206 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 7)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 7)
     elseif csid == 207 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Hemewmew.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 7, 206)
+    xi.crafting.guildPointNPConTrigger(player, 206, 7)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -9,44 +9,23 @@ require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
 
-local keyitems =
-{
-    [0] = { id = xi.ki.METAL_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.METAL_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.CHAINWORK,             rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.SHEETING,              rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.WAY_OF_THE_BLACKSMITH, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.BLACKSMITHS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.SMITHYS_MITTS,         rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.BLACKSMITHS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.MASTERSMITH_ANVIL,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.BLACKSMITHS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.SMITHS_RING,           rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.STONE_HEARTH,          rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.BLACKSMITHS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
-
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 801, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 2, 800, "guild_smithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 2, 800)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
     elseif csid == 801 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 2, 800)
+    xi.crafting.guildPointNPConTrigger(player, 800, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -31,22 +31,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 801, 2)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 801, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 2, 800, "guild_smithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 2, 800, "guild_smithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
     elseif csid == 801 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Metalworks/npcs/Lorena.lua
+++ b/scripts/zones/Metalworks/npcs/Lorena.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 801, 2)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 801, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 800, 2)
+    xi.crafting.guildPointOnTrigger(player, 800, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 2)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 800 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 2)
     elseif csid == 801 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -4,49 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos -189.282 10.999 262.626 231
 -----------------------------------
-require("scripts/globals/crafting")
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.WOOD_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.WOOD_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.LUMBERJACK,           rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.BOLTMAKER,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.WAY_OF_THE_CARPENTER, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.CARPENTERS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.CARPENTERS_GLOVES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.CARPENTERS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.DRAWING_DESK,         rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.CARPENTERS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.CARPENTERS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.CARPENTERS_KIT,       rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.CARPENTERS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 732, 1)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 1, 731, "guild_woodworking", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 1, 731)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1)
     elseif csid == 732 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 732, 1)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 732, 1)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 731, 1)
+    xi.crafting.guildPointOnTrigger(player, 731, 1)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 1)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 1)
     elseif csid == 732 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -31,22 +31,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 732, 1)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 732, 1)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 1, 731, "guild_woodworking", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 1, 731, "guild_woodworking", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 731 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 1, "guild_woodworking", keyitems, items)
     elseif csid == 732 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Andreas.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 1, 731)
+    xi.crafting.guildPointNPConTrigger(player, 731, 1)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 2, 729)
+    xi.crafting.guildPointNPConTrigger(player, 729, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -4,49 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos -191.738 11.001 138.656 231
 -----------------------------------
-require("scripts/globals/crafting")
 local ID = require("scripts/zones/Northern_San_dOria/IDs")
+require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.METAL_PURIFICATION,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.METAL_ENSORCELLMENT,   rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.CHAINWORK,             rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.SHEETING,              rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.WAY_OF_THE_BLACKSMITH, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.BLACKSMITHS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.SMITHYS_MITTS,         rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.BLACKSMITHS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.MASTERSMITH_ANVIL,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.BLACKSMITHS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.SMITHS_RING,           rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.STONE_HEARTH,          rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.BLACKSMITHS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 730, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 2, 729, "guild_smithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 2, 729)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
     elseif csid == 730 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -31,22 +31,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 730, 2)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 730, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 2, 729, "guild_smithing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 2, 729, "guild_smithing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2, "guild_smithing", keyitems, items)
     elseif csid == 730 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Macuillie.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 730, 2)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 730, 2)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 729, 2)
+    xi.crafting.guildPointOnTrigger(player, 729, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 2)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 729 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 2)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 2)
     elseif csid == 730 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Port_Windurst/npcs/Fennella.lua
+++ b/scripts/zones/Port_Windurst/npcs/Fennella.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 10021, 0)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 10021, 0)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 10020, 0)
+    xi.crafting.guildPointOnTrigger(player, 10020, 0)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 0)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 0)
     elseif csid == 10021 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Port_Windurst/npcs/Fennella.lua
+++ b/scripts/zones/Port_Windurst/npcs/Fennella.lua
@@ -4,48 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos -177.811 -2.835 65.639 240
 -----------------------------------
-require("scripts/globals/crafting")
 local ID = require("scripts/zones/Port_Windurst/IDs")
+require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.FROG_FISHING,    rank = xi.crafting.rank.NOVICE,  cost =  30000 },
-    [1] = { id = xi.ki.SERPENT_RUMORS,  rank = xi.crafting.rank.ADEPT,   cost =  95000 },
-    [2] = { id = xi.ki.MOOCHING,        rank = xi.crafting.rank.VETERAN, cost = 115000 },
-    [3] = { id = xi.ki.ANGLERS_ALMANAC, rank = xi.crafting.rank.VETERAN, cost =  20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.ROBBER_RIG,           rank = xi.crafting.rank.NOVICE,     cost =   1500 },
-    [1] = { id = xi.items.FISHERMANS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [2] = { id = xi.items.WADERS,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [3] = { id = xi.items.FISHERMANS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [4] = { id = xi.items.FISHING_HOLE_MAP,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [5] = { id = xi.items.FISHERMANS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [6] = { id = xi.items.NET_AND_LURE,         rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.FISHERMENS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 10021, 0)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 0, 10020, "guild_fishing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 0, 10020)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0)
     elseif csid == 10021 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Port_Windurst/npcs/Fennella.lua
+++ b/scripts/zones/Port_Windurst/npcs/Fennella.lua
@@ -30,22 +30,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10021, 0)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 10021, 0)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 0, 10020, "guild_fishing", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 0, 10020, "guild_fishing", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10020 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 0, "guild_Fishing", keyitems, items)
     elseif csid == 10021 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Port_Windurst/npcs/Fennella.lua
+++ b/scripts/zones/Port_Windurst/npcs/Fennella.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 0, 10020)
+    xi.crafting.guildPointNPConTrigger(player, 10020, 0)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 5, 690)
+    xi.crafting.guildPointNPConTrigger(player, 690, 5)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -9,43 +9,23 @@ require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
 
-local keyitems =
-{
-    [0] = { id = xi.ki.LEATHER_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.LEATHER_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.TANNING,               rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.WAY_OF_THE_TANNER,     rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.TANNERS_BELT,      rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.TANNERS_GLOVES,    rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.TANNERS_APRON,     rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.GOLDEN_FLEECE,     rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.TANNERS_SIGNBOARD, rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.TANNERS_RING,      rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.HIDE_STRETCHER,    rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.TANNERS_EMBLEM,    rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
-
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 691, 5)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 5, 690, "guild_leathercraft", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 5, 690)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5)
     elseif csid == 691 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 691, 5)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 691, 5)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 690, 5)
+    xi.crafting.guildPointOnTrigger(player, 690, 5)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 5)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 5)
     elseif csid == 691 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alivatand.lua
@@ -30,22 +30,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 691, 5)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 691, 5)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 5, 690, "guild_leathercraft", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 5, 690, "guild_leathercraft", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 690 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 5, "guild_leathercraft", keyitems, items)
     elseif csid == 691 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 8)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 10025, 8)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 10024, 8)
+    xi.crafting.guildPointOnTrigger(player, 10024, 8)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 8)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 8)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
@@ -4,49 +4,28 @@
 -- Type: Guildworker's Union Representative
 -- !pos -112.561 -2 55.205 238
 -----------------------------------
-require("scripts/globals/crafting")
 local ID = require("scripts/zones/Windurst_Waters/IDs")
+require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
-
-local keyitems =
-{
-    [0] = { id = xi.ki.RAW_FISH_HANDLING,     rank = xi.crafting.rank.NOVICE,  cost = 30000 },
-    [1] = { id = xi.ki.NOODLE_KNEADING,       rank = xi.crafting.rank.NOVICE,  cost = 30000 },
-    [2] = { id = xi.ki.PATISSIER,             rank = xi.crafting.rank.NOVICE,  cost =  8000 },
-    [3] = { id = xi.ki.STEWPOT_MASTERY,       rank = xi.crafting.rank.NOVICE,  cost = 30000 },
-    [4] = { id = xi.ki.WAY_OF_THE_CULINARIAN, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.CULINARIANS_BELT,        rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.CHEFS_HAT,               rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.CULINARIANS_APRON,       rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.CORDON_BLEU_COOKING_SET, rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.CULINARIANS_SIGNBOARD,   rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.CHEFS_RING,              rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.BRASS_CROCK,             rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.CULINARIANS_EMBLEM,      rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
 
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 8)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 8, 10024, "guild_cooking", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 8, 10024)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
@@ -31,22 +31,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10025, 8)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 8)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 8, 10024, "guild_cooking", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 8, 10024, "guild_cooking", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 8, "guild_cooking", keyitems, items)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Qhum_Knaidjn.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 8, 10024)
+    xi.crafting.guildPointNPConTrigger(player, 10024, 8)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
@@ -31,22 +31,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10025, 4)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 4)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 4, 10024, "guild_weaving", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 4, 10024, "guild_weaving", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
@@ -9,44 +9,23 @@ require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
 
-local keyitems =
-{
-    [0] = { id = xi.ki.CLOTH_PURIFICATION,  rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.CLOTH_ENSORCELLMENT, rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.SPINNING,            rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.FLETCHING,           rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [4] = { id = xi.ki.WAY_OF_THE_WEAVER,   rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.WEAVERS_BELT,          rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.MAGNIFYING_SPECTACLES, rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.WEAVERS_APRON,         rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.GILT_TAPESTRY,         rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.WEAVERS_SIGNBOARD,     rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.TAILORS_RING,          rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.SPINNING_WHEEL,        rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.WEAVERS_EMBLEM,        rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
-
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 4)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 4, 10024, "guild_weaving", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 4, 10024)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4, "guild_weaving", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 10025, 4)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 10025, 4)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 10024, 4)
+    xi.crafting.guildPointOnTrigger(player, 10024, 4)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 4)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10024 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 4)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 4)
     elseif csid == 10025 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Hauh_Colphioh.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 4, 10024)
+    xi.crafting.guildPointNPConTrigger(player, 10024, 4)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
@@ -10,22 +10,22 @@ require("scripts/globals/crafting")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.guildPointNPConTrade(player, npc, trade, 10023, 6)
+    xi.crafting.guildPointOnTrade(player, npc, trade, 10023, 6)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 10022, 6)
+    xi.crafting.guildPointOnTrigger(player, 10022, 6)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 6)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6)
+        xi.crafting.guildPointOnEventFinish(player, option, npc, 6)
     elseif csid == 10023 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
@@ -14,7 +14,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 6, 10022)
+    xi.crafting.guildPointNPConTrigger(player, 10022, 6)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
@@ -9,43 +9,23 @@ require("scripts/globals/crafting")
 -----------------------------------
 local entity = {}
 
-local keyitems =
-{
-    [0] = { id = xi.ki.BONE_PURIFICATION,     rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [1] = { id = xi.ki.BONE_ENSORCELLMENT,    rank = xi.crafting.rank.NOVICE,  cost = 40000 },
-    [2] = { id = xi.ki.FILING,                rank = xi.crafting.rank.NOVICE,  cost = 10000 },
-    [3] = { id = xi.ki.WAY_OF_THE_BONEWORKER, rank = xi.crafting.rank.VETERAN, cost = 20000 },
-}
-
-local items =
-{
-    [0] = { id = xi.items.BONEWORKERS_BELT,          rank = xi.crafting.rank.NOVICE,     cost =  10000 },
-    [1] = { id = xi.items.PROTECTIVE_SPECTACLES,     rank = xi.crafting.rank.JOURNEYMAN, cost =  70000 },
-    [2] = { id = xi.items.BONEWORKERS_APRON,         rank = xi.crafting.rank.ARTISAN,    cost = 100000 },
-    [3] = { id = xi.items.DROGAROGAS_FANG,           rank = xi.crafting.rank.VETERAN,    cost = 150000 },
-    [4] = { id = xi.items.BONEWORKERS_SIGNBOARD,     rank = xi.crafting.rank.VETERAN,    cost = 200000 },
-    [5] = { id = xi.items.BONECRAFTERS_RING,         rank = xi.crafting.rank.CRAFTSMAN,  cost =  80000 },
-    [6] = { id = xi.items.SET_OF_BONECRAFTING_TOOLS, rank = xi.crafting.rank.ARTISAN,    cost =  50000 },
-    [7] = { id = xi.items.BONEWORKERS_EMBLEM,        rank = xi.crafting.rank.VETERAN,    cost =  15000 },
-}
-
 entity.onTrade = function(player, npc, trade)
     xi.crafting.guildPointNPConTrade(player, npc, trade, 10023, 6)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.guildPointNPConTrigger(player, 6, 10022, "guild_bonecraft", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 6, 10022)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6)
     elseif csid == 10023 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end

--- a/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Samigo-Pormigo.lua
@@ -30,22 +30,22 @@ local items =
 }
 
 entity.onTrade = function(player, npc, trade)
-    xi.crafting.unionRepresentativeTrade(player, npc, trade, 10023, 6)
+    xi.crafting.guildPointNPConTrade(player, npc, trade, 10023, 6)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.crafting.unionRepresentativeTrigger(player, 6, 10022, "guild_bonecraft", keyitems)
+    xi.crafting.guildPointNPConTrigger(player, 6, 10022, "guild_bonecraft", keyitems)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
     end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10022 then
-        xi.crafting.unionRepresentativeTriggerFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
+        xi.crafting.guildPointNPConEventFinish(player, option, npc, 6, "guild_bonecraft", keyitems, items)
     elseif csid == 10023 then
         player:messageSpecial(ID.text.GP_OBTAINED, option)
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cleans union representative NPCs via the following changes:
- Renames their functions
- Moves their inventories to crafting.lua
- Renames the variables used in their functions.

Additionally, this also has the following changes in the fishing guild:
- Minor correction in the required rank for an item.
- Fixes items selected not matching items given.

A note on Guild IDs: We use 2 different guild id systems. This NPCs use the correct order used by retail. However, the order we have defined doesn't match it and I don't see why this order was chosen, since it also doesn't follow the skill ID order.

Once I get to cleaning guild masters, I will clean those up, but, for the time being, that's out of the scope of this PR.
BUT it WILL get done.

## Steps to test these changes

Review by commit for clarity (maybe)
It should be functionally the same. Except for the fishing guild, which should work properly now.
