### PR TITLE
[core] [lua] Add setting to despawn jugpets that sync below level req

### DIFF
--- a/scripts/globals/effects/level_restriction.lua
+++ b/scripts/globals/effects/level_restriction.lua
@@ -10,6 +10,20 @@ effectObject.onEffectGain = function(target, effect)
         target:levelRestriction(effect:getPower())
         target:messageBasic(xi.msg.basic.LEVEL_IS_RESTRICTED, effect:getPower()) -- <target>'s level is restricted to <param>
         target:clearTrusts()
+
+        if xi.settings.map.DESPAWN_JUGPETS_BELOW_MINIMUM_LEVEL then
+            local pet = target:getPet()
+            local masterLevel = target:getMainLvl()
+
+            if
+                pet and
+                pet:getObjType() == xi.objType.PET and
+                target:isJugPet() and -- isJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
+                masterLevel < pet:getMinimumPetLevel()
+            then
+                target:despawnPet()
+            end
+        end
     end
 end
 

--- a/scripts/globals/effects/level_sync.lua
+++ b/scripts/globals/effects/level_sync.lua
@@ -8,6 +8,20 @@ effectObject.onEffectGain = function(target, effect)
 
     if target:getObjType() == xi.objType.PC then
         target:clearTrusts()
+
+        if xi.settings.map.DESPAWN_JUGPETS_BELOW_MINIMUM_LEVEL then
+            local pet = target:getPet()
+            local masterLevel = target:getMainLvl()
+
+            if
+                pet and
+                pet:getObjType() == xi.objType.PET and
+                target:isJugPet() and -- isJugPet checks m_PBaseEntity->PPet's check type, not the target's pet type.
+                masterLevel < pet:getMinimumPetLevel()
+            then
+                target:despawnPet()
+            end
+        end
     end
 end
 

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -256,6 +256,11 @@ xi.settings.map =
     -- Enable/disable keeping jug pets through zoning
     KEEP_JUGPET_THROUGH_ZONING = false,
 
+    -- Despawn jug pets that have a minimum level below level sync or zone level restriction.
+    -- Such as despawning Courier Carrie in a level 20 cap when their minimum level to summon is 23.
+    -- While the default value of false is retail accurate, there are some balance concerns such as using 1000 needles at low levels from the cactuar pet.
+    DESPAWN_JUGPETS_BELOW_MINIMUM_LEVEL = false,
+
     -- Send stack traces to the client after caught Lua errors if
     -- their GM level is the same or higher than this number.
     -- The max GM level is 5, so setting this to 6 disables it

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13931,6 +13931,27 @@ void CLuaBaseEntity::setPet(sol::object const& petObj)
     return;
 }
 
+// Returns the minimum level of the pet, such as level 23 for Courier Carrie or 0 if non applicable.
+uint8 CLuaBaseEntity::getMinimumPetLevel()
+{
+    CPetEntity* PPet = dynamic_cast<CPetEntity*>(m_PBaseEntity);
+
+    if (PPet)
+    {
+        Pet_t* petInfo = petutils::GetPetInfo(PPet->m_PetID);
+        if (petInfo)
+        {
+            return petInfo->minLevel;
+        }
+    }
+    else
+    {
+        ShowWarning("Non-CPetEntity called this function");
+    }
+
+    return 0;
+}
+
 /************************************************************************
  *  Function: getMaster()
  *  Purpose : Returns the Entity object for a pet's master
@@ -17206,6 +17227,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("isAvatar", CLuaBaseEntity::isAvatar);
     SOL_REGISTER("getPetElement", CLuaBaseEntity::getPetElement);
     SOL_REGISTER("setPet", CLuaBaseEntity::setPet);
+    SOL_REGISTER("getMinimumPetLevel", CLuaBaseEntity::getMinimumPetLevel);
     SOL_REGISTER("getMaster", CLuaBaseEntity::getMaster);
 
     SOL_REGISTER("getPetName", CLuaBaseEntity::getPetName);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -716,6 +716,7 @@ public:
     auto   getMaster() -> std::optional<CLuaBaseEntity>;
     uint8  getPetElement();
     void   setPet(sol::object const& petObj);
+    uint8  getMinimumPetLevel(); // Returns the minimum level of the pet, such as level 23 for Courier Carrie or 0 if non applicable.
 
     auto getPetName() -> const std::string;
     void setPetName(uint8 pType, uint16 value, sol::object const& arg2);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -58,136 +58,6 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "../packets/message_standard.h"
 #include "../packets/pet_sync.h"
 
-struct Pet_t
-{
-    uint16      PetID;     // ID in pet_list.sql
-    look_t      look;      // внешний вид
-    std::string name;      // имя
-    ECOSYSTEM   EcoSystem; // эко-система
-
-    uint8 minLevel; // минимально-возможный  уровень
-    uint8 maxLevel; // максимально-возможный уровень
-
-    uint8  name_prefix;
-    uint8  radius; // Model Radius - affects melee range etc.
-    uint16 m_Family;
-    uint32 time; // время существования (будет использоваться для задания длительности статус эффекта)
-
-    uint8 mJob;
-    uint8 sJob;
-    uint8 m_Element;
-    float HPscale; // HP boost percentage
-    float MPscale; // MP boost percentage
-
-    uint16 cmbDelay;
-    uint8  speed;
-    // stat ranks
-    uint8 strRank;
-    uint8 dexRank;
-    uint8 vitRank;
-    uint8 agiRank;
-    uint8 intRank;
-    uint8 mndRank;
-    uint8 chrRank;
-    uint8 attRank;
-    uint8 defRank;
-    uint8 evaRank;
-    uint8 accRank;
-
-    uint16 m_MobSkillList;
-
-    // magic stuff
-    bool   hasSpellScript;
-    uint16 spellList;
-
-    // resists
-    int16 slash_sdt;
-    int16 pierce_sdt;
-    int16 hth_sdt;
-    int16 impact_sdt;
-
-    int16 fire_sdt;
-    int16 ice_sdt;
-    int16 wind_sdt;
-    int16 earth_sdt;
-    int16 thunder_sdt;
-    int16 water_sdt;
-    int16 light_sdt;
-    int16 dark_sdt;
-
-    int8 fire_res_rank;
-    int8 ice_res_rank;
-    int8 wind_res_rank;
-    int8 earth_res_rank;
-    int8 thunder_res_rank;
-    int8 water_res_rank;
-    int8 light_res_rank;
-    int8 dark_res_rank;
-
-    Pet_t()
-    : EcoSystem(ECOSYSTEM::ECO_ERROR)
-    {
-        PetID = 0;
-
-        minLevel = -1;
-        maxLevel = 99;
-
-        name_prefix = 0;
-        radius      = 0;
-        m_Family    = 0;
-        time        = 0;
-
-        mJob      = 0;
-        sJob      = 0;
-        m_Element = 0;
-        HPscale   = 0.f;
-        MPscale   = 0.f;
-
-        cmbDelay = 0;
-        speed    = 0;
-
-        strRank = 0;
-        dexRank = 0;
-        vitRank = 0;
-        agiRank = 0;
-        intRank = 0;
-        mndRank = 0;
-        chrRank = 0;
-        attRank = 0;
-        defRank = 0;
-        evaRank = 0;
-        accRank = 0;
-
-        m_MobSkillList = 0;
-
-        hasSpellScript = false;
-        spellList      = 0;
-
-        slash_sdt  = 0;
-        pierce_sdt = 0;
-        hth_sdt    = 0;
-        impact_sdt = 0;
-
-        fire_sdt    = 0;
-        ice_sdt     = 0;
-        wind_sdt    = 0;
-        earth_sdt   = 0;
-        thunder_sdt = 0;
-        water_sdt   = 0;
-        light_sdt   = 0;
-        dark_sdt    = 0;
-
-        fire_res_rank    = 0;
-        ice_res_rank     = 0;
-        wind_res_rank    = 0;
-        earth_res_rank   = 0;
-        thunder_res_rank = 0;
-        water_res_rank   = 0;
-        light_res_rank   = 0;
-        dark_res_rank    = 0;
-    }
-};
-
 std::vector<Pet_t*> g_PPetList;
 
 namespace petutils
@@ -1828,6 +1698,19 @@ namespace petutils
             petType = PET_TYPE::LUOPAN;
         }
 
+        if (settings::get<bool>("map.DESPAWN_JUGPETS_BELOW_MINIMUM_LEVEL"))
+        {
+            // Don't spawn jugpet if min level is above master's level
+            if (petType == PET_TYPE::JUG_PET && PMaster->loc.zone)
+            {
+                uint8 levelRestriction = PMaster->loc.zone->getLevelRestriction();
+                if (levelRestriction != 0 && (PMaster->loc.zone->getLevelRestriction() < PPetData->minLevel))
+                {
+                    return;
+                }
+            }
+        }
+
         CPetEntity* PPet = nullptr;
         if (petType == PET_TYPE::AUTOMATON && PMaster->objtype == TYPE_PC)
         {
@@ -1938,4 +1821,16 @@ namespace petutils
         }
         return false;
     }
+
+    Pet_t* GetPetInfo(uint32 PetID)
+    {
+        for (Pet_t* info : g_PPetList)
+        {
+            if (info->PetID == PetID)
+                return info;
+        }
+
+        return nullptr;
+    }
+
 }; // namespace petutils

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -61,6 +61,136 @@ enum PETID
     MAX_PETID                = 77,
 };
 
+struct Pet_t
+{
+    uint16      PetID; // ID in pet_list.sql
+    look_t      look;
+    std::string name;
+    ECOSYSTEM   EcoSystem;
+
+    uint8 minLevel;
+    uint8 maxLevel;
+
+    uint8  name_prefix;
+    uint8  radius; // Model Radius - affects melee range etc.
+    uint16 m_Family;
+    uint32 time; // Duration of pet's "life span" before despawning
+
+    uint8 mJob;
+    uint8 sJob;
+    uint8 m_Element;
+    float HPscale; // HP boost percentage
+    float MPscale; // MP boost percentage
+
+    uint16 cmbDelay;
+    uint8  speed;
+    // stat ranks
+    uint8 strRank;
+    uint8 dexRank;
+    uint8 vitRank;
+    uint8 agiRank;
+    uint8 intRank;
+    uint8 mndRank;
+    uint8 chrRank;
+    uint8 attRank;
+    uint8 defRank;
+    uint8 evaRank;
+    uint8 accRank;
+
+    uint16 m_MobSkillList;
+
+    // magic stuff
+    bool   hasSpellScript;
+    uint16 spellList;
+
+    // resists
+    int16 slash_sdt;
+    int16 pierce_sdt;
+    int16 hth_sdt;
+    int16 impact_sdt;
+
+    int16 fire_sdt;
+    int16 ice_sdt;
+    int16 wind_sdt;
+    int16 earth_sdt;
+    int16 thunder_sdt;
+    int16 water_sdt;
+    int16 light_sdt;
+    int16 dark_sdt;
+
+    int8 fire_res_rank;
+    int8 ice_res_rank;
+    int8 wind_res_rank;
+    int8 earth_res_rank;
+    int8 thunder_res_rank;
+    int8 water_res_rank;
+    int8 light_res_rank;
+    int8 dark_res_rank;
+
+    Pet_t()
+    : EcoSystem(ECOSYSTEM::ECO_ERROR)
+    {
+        PetID = 0;
+
+        minLevel = -1;
+        maxLevel = 99;
+
+        name_prefix = 0;
+        radius      = 0;
+        m_Family    = 0;
+        time        = 0;
+
+        mJob      = 0;
+        sJob      = 0;
+        m_Element = 0;
+        HPscale   = 0.f;
+        MPscale   = 0.f;
+
+        cmbDelay = 0;
+        speed    = 0;
+
+        strRank = 0;
+        dexRank = 0;
+        vitRank = 0;
+        agiRank = 0;
+        intRank = 0;
+        mndRank = 0;
+        chrRank = 0;
+        attRank = 0;
+        defRank = 0;
+        evaRank = 0;
+        accRank = 0;
+
+        m_MobSkillList = 0;
+
+        hasSpellScript = false;
+        spellList      = 0;
+
+        slash_sdt  = 0;
+        pierce_sdt = 0;
+        hth_sdt    = 0;
+        impact_sdt = 0;
+
+        fire_sdt    = 0;
+        ice_sdt     = 0;
+        wind_sdt    = 0;
+        earth_sdt   = 0;
+        thunder_sdt = 0;
+        water_sdt   = 0;
+        light_sdt   = 0;
+        dark_sdt    = 0;
+
+        fire_res_rank    = 0;
+        ice_res_rank     = 0;
+        wind_res_rank    = 0;
+        earth_res_rank   = 0;
+        thunder_res_rank = 0;
+        water_res_rank   = 0;
+        light_res_rank   = 0;
+        dark_res_rank    = 0;
+    }
+};
+
 class CBattleEntity;
 class CPetEntity;
 
@@ -89,6 +219,8 @@ namespace petutils
     void SetupPetWithMaster(CBattleEntity* PMaster, CPetEntity* PPet);
 
     bool CheckPetModType(CBattleEntity* PPet, PetModType petmod);
+
+    Pet_t* GetPetInfo(uint32 PetID);
 }; // namespace petutils
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add setting to despawn jugpets that sync below level requirements. As the comments indicate, this is a balance setting. Retail's default behavior is to allow level syncs of any kind for whatever reason, despite allowing for some serious cheese with overpowered jugs.

## Steps to test these changes

enable setting, summon Courier Carrie,
`!addeffect level_sync 23` and `!addeffect level_restriction 23` and do not see Courier Carrie despawn.
`!addeffect level_sync 22` and `!addeffect level_restriction 22` and do see Courier Carrie despawn.
Enable a level restriction for a zone in sql and zone in with a pet that would not be able to be summoned due to the cap and it will not load. You can enable it with ```UPDATE `zone_settings` SET restriction = 50 WHERE `name` = "Sacrarium";```