### PR TITLE
[Magic] Correct Sleep effect and message from Lullabys and sleep/ga II

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -50,9 +50,9 @@ local pTable =
     [xi.magic.spell.RASP         ] = { xi.effect.RASP,               xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
     [xi.magic.spell.SHOCK        ] = { xi.effect.SHOCK,              xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
     [xi.magic.spell.SLEEP        ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.SLEEP_II     ] = { xi.effect.SLEEP_II,           xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
+    [xi.magic.spell.SLEEP_II     ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
     [xi.magic.spell.SLEEPGA      ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.SLEEPGA_II   ] = { xi.effect.SLEEP_II,           xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
+    [xi.magic.spell.SLEEPGA_II   ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
     [xi.magic.spell.STUN         ] = { xi.effect.STUN,               xi.mod.INT,     xi.mod.STUNRES,     xi.mod.STUN_MEVA,        1,   0,        5,      4,   0,        8, false,     false,   200 },
     [xi.magic.spell.VIRUS        ] = { xi.effect.PLAGUE,             xi.mod.INT,     xi.mod.VIRUSRES,    xi.mod.VIRUS_MEVA,       5,   3,       60,      2,   0,        0, false,     false,     0 },
 

--- a/scripts/globals/spells/songs/foe_lullaby.lua
+++ b/scripts/globals/spells/songs/foe_lullaby.lua
@@ -12,17 +12,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = 30
-    -- local pCHR = caster:getStat(xi.mod.CHR)
-    -- local mCHR = target:getStat(xi.mod.CHR)
-    -- local dCHR = pCHR - mCHR
-    local params = {}
-    params.diff = nil
+    local params     = {}
+    params.diff      = nil
     params.attribute = xi.mod.CHR
     params.skillType = xi.skill.SINGING
-    params.bonus = 0
-    params.effect = xi.effect.LULLABY
-    local resm = applyResistanceEffect(caster, target, spell, params)
+    params.bonus     = 0
+    params.effect    = xi.effect.SLEEP_I
+
+    local resm     = applyResistanceEffect(caster, target, spell, params)
+    local duration = 30
 
     if resm < 0.5 then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST) -- resist message
@@ -35,14 +33,14 @@ spellObject.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
-            spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+        if target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration) then
+            spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end
     end
 
-    return xi.effect.LULLABY
+    return xi.effect.SLEEP_I
 end
 
 return spellObject

--- a/scripts/globals/spells/songs/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/songs/foe_lullaby_ii.lua
@@ -12,17 +12,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = 60
-    -- local pCHR = caster:getStat(xi.mod.CHR)
-    -- local mCHR = target:getStat(xi.mod.CHR)
-    -- local dCHR = pCHR - mCHR
-    local params = {}
-    params.diff = nil
+    local params     = {}
+    params.diff      = nil
     params.attribute = xi.mod.CHR
     params.skillType = xi.skill.SINGING
-    params.bonus = 0
-    params.effect = xi.effect.LULLABY
-    local resm = applyResistanceEffect(caster, target, spell, params)
+    params.bonus     = 0
+    params.effect    = xi.effect.SLEEP_I
+
+    local resm     = applyResistanceEffect(caster, target, spell, params)
+    local duration = 60
 
     if resm < 0.5 then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST) -- resist message
@@ -35,14 +33,14 @@ spellObject.onSpellCast = function(caster, target, spell)
             duration = duration * 2
         end
 
-        if target:addStatusEffect(xi.effect.LULLABY, 1, 0, duration) then
-            spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
+        if target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration) then
+            spell:setMsg(xi.msg.basic.MAGIC_ENFEEB_IS)
         else
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         end
     end
 
-    return xi.effect.LULLABY
+    return xi.effect.SLEEP_I
 end
 
 return spellObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrects effect for Foe Lullaby, Foe Lullaby II, Sleep II and Sleepga II to all use xi.effect.SLEEP_I
- Corrects message displayed for Foe Lullaby and Foe Lullaby II to <target> is ...

## Steps to test these changes

Cast any of those 4 spells. You wont notice a difference with Sleep II nor Sleepga II though
