### PR TITLE
[Quests] Add module for missable quest "Mom, the adventurer?"

### DIFF
--- a/modules/era/lua/missable_mom_the_adventurer.lua
+++ b/modules/era/lua/missable_mom_the_adventurer.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Module to make "Mom the Adventurer?" quest missable.
+-----------------------------------
+require("modules/module_utils")
+-----------------------------------
+local m = Module:new("missable_mom_the_adventurer")
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/Mom_the_Adventurer', function(quest)
+        quest.sections[1].check = function(player, status, vars)
+            return status ~= QUEST_ACCEPTED and
+                player:getFameLevel(xi.quest.fame_area.BASTOK) < 2 and
+                vars.Prog == 0
+        end
+    end)
+end)
+
+return m

--- a/scripts/quests/bastok/Mom_the_Adventurer.lua
+++ b/scripts/quests/bastok/Mom_the_Adventurer.lua
@@ -37,7 +37,6 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status ~= QUEST_ACCEPTED and
-                player:getFameLevel(xi.quest.fame_area.BASTOK) < 2 and
                 vars.Prog == 0
         end,
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It sometimes happens that quests are missable in retail.
I don't know of any other case other than "Mom, the adventurer?", but it happens.
This PR does:
- Makes "Mom, the adventurer?" unmissable by default, as discussed.
- Adds a module to restore it's missability.

## Steps to test these changes

Get fame lvl 3+ in bastok, enable the setting and be able to activate this quest.
Activate module and be able to miss it.
