### PR TITLE
Updated IDs from mog garden to fished items

### DIFF
--- a/sql/guild_item_points.sql
+++ b/sql/guild_item_points.sql
@@ -48,18 +48,18 @@ INSERT INTO `guild_item_points` VALUES (0, 4290, 2, 156, 6960, 6); -- Elshimo Fr
 INSERT INTO `guild_item_points` VALUES (0, 4483, 2, 156, 6960, 7); -- Tiger Cod (156 / 6960)
 
 -- Fishing / Novice
-INSERT INTO `guild_item_points` VALUES (0, 5791, 3, 78, 6720, 0); -- Shining Trout (78 / 6720)
+INSERT INTO `guild_item_points` VALUES (0, 4354, 3, 78, 6720, 0); -- Shining Trout (78 / 6720)
 INSERT INTO `guild_item_points` VALUES (0, 4528, 3, 375, 9840, 1); -- Crystal Bass (375 / 9840)
-INSERT INTO `guild_item_points` VALUES (0, 5796, 3, 240, 8640, 2); -- Nosteau Herring (240 / 8640)
-INSERT INTO `guild_item_points` VALUES (0, 5804, 3, 1350, 15120, 3); -- Veydal Wrasse (1350 / 15120)
-INSERT INTO `guild_item_points` VALUES (0, 5805, 3, 300, 9120, 4); -- Gugru Tuna (300 / 9120)
+INSERT INTO `guild_item_points` VALUES (0, 4482, 3, 240, 8640, 2); -- Nosteau Herring (240 / 8640)
+INSERT INTO `guild_item_points` VALUES (0, 5141, 3, 1350, 15120, 3); -- Veydal Wrasse (1350 / 15120)
+INSERT INTO `guild_item_points` VALUES (0, 4480, 3, 300, 9120, 4); -- Gugru Tuna (300 / 9120)
 INSERT INTO `guild_item_points` VALUES (0, 4580, 3, 375, 9840, 5); -- Coral Butterfly (375 / 9840)
-INSERT INTO `guild_item_points` VALUES (0, 5791, 3, 78, 6720, 6); -- Shining Trout (78 / 6720)
-INSERT INTO `guild_item_points` VALUES (0, 5795, 3, 96, 6960, 7); -- Ogre Eel (96 / 6960)
+INSERT INTO `guild_item_points` VALUES (0, 4354, 3, 78, 6720, 6); -- Shining Trout (78 / 6720)
+INSERT INTO `guild_item_points` VALUES (0, 4481, 3, 96, 6960, 7); -- Ogre Eel (96 / 6960)
 
 -- Fishing / Apprentice
-INSERT INTO `guild_item_points` VALUES (0, 5801, 4, 900, 13440, 0); -- Monke-Onke (900 / 13440)
-INSERT INTO `guild_item_points` VALUES (0, 5800, 4, 576, 11760, 1); -- Giant Donko (576 / 11760)
+INSERT INTO `guild_item_points` VALUES (0, 4462, 4, 900, 13440, 0); -- Monke-Onke (900 / 13440)
+INSERT INTO `guild_item_points` VALUES (0, 4306, 4, 576, 11760, 1); -- Giant Donko (576 / 11760)
 INSERT INTO `guild_item_points` VALUES (0, 4383, 4, 576, 11760, 2); -- Gold Lobster (576 / 11760)
 INSERT INTO `guild_item_points` VALUES (0, 4470, 4, 459, 10800, 3); -- Icefish (459 / 10800)
 INSERT INTO `guild_item_points` VALUES (0, 4385, 4, 93, 7440, 4); -- Zafmlug Bass (93 / 7440)
@@ -70,12 +70,12 @@ INSERT INTO `guild_item_points` VALUES (0, 4385, 4, 93, 7440, 7); -- Zafmlug Bas
 -- Fishing / Journeyman
 INSERT INTO `guild_item_points` VALUES (0, 4427, 5, 900, 13680, 0); -- Gold Carp (900 / 13680)
 INSERT INTO `guild_item_points` VALUES (0, 4579, 5, 525, 11760, 1); -- Elshimo Newt (525 / 11760)
-INSERT INTO `guild_item_points` VALUES (0, 5806, 5, 900, 13680, 2); -- Bhefhel Marlin (900 / 13680)
+INSERT INTO `guild_item_points` VALUES (0, 4479, 5, 900, 13680, 2); -- Bhefhel Marlin (900 / 13680)
 INSERT INTO `guild_item_points` VALUES (0, 4402, 5, 900, 13680, 3); -- Red Terrapin (900 / 13680)
-INSERT INTO `guild_item_points` VALUES (0, 5798, 5, 900, 13680, 4); -- Bluetail (900 / 13680)
-INSERT INTO `guild_item_points` VALUES (0, 5806, 5, 900, 13680, 5); -- Bhefhel Marlin (900 / 13680)
+INSERT INTO `guild_item_points` VALUES (0, 4399, 5, 900, 13680, 4); -- Bluetail (900 / 13680)
+INSERT INTO `guild_item_points` VALUES (0, 4479, 5, 900, 13680, 5); -- Bhefhel Marlin (900 / 13680)
 INSERT INTO `guild_item_points` VALUES (0, 4317, 5, 120, 8400, 6); -- Trilobite (120 / 8400)
-INSERT INTO `guild_item_points` VALUES (0, 5798, 5, 900, 13680, 7); -- Bluetail (900 / 13680)
+INSERT INTO `guild_item_points` VALUES (0, 4399, 5, 900, 13680, 7); -- Bluetail (900 / 13680)
 
 -- Fishing / Craftsman
 INSERT INTO `guild_item_points` VALUES (0, 4473, 6, 1320, 15360, 0); -- Crescent Fish (1320 / 15360)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes Issue #3610, update fishIDs for guildpoint items that were using mog garden versions:

bhefhel_marlin	5806    ->	4479
bluetail	    5798    ->	4399
giant_donko	    5800    ->	4306
gugru_tuna	    5805    ->	4480
monke-onke	    5801    ->	4462
nosteau_herring	5796    ->	4482
ogre_eel	    5795    ->	4481
shining_trout	5791    ->	4354
veydal_wrasse	5804    ->	5141

## Steps to test these changes

Update guild_item_points.sql, or table with requisite IDs, and waited for Fennella to request fish in question.
