### PR TITLE
[Magic] Clean and add resistance rank logic to resist tiers.

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -32,12 +32,15 @@ xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spe
         magicAcc = magicAcc + utils.getSkillLvl(1, actor:getMainLvl())
     end
 
+    -- Add action bonus magic accuracy.
+    magicAcc = magicAcc + bonusMacc
+
     -- Add acc for elemental affinity accuracy and element specific accuracy
     if spellElement ~= xi.magic.ele.NONE then
         local elementBonus  = actor:getMod(elementTable[spellElement][1])
         local affinityBonus = actor:getMod(elementTable[spellElement][2]) * 10
 
-        magicAcc            = magicAcc + elementBonus + affinityBonus
+        magicAcc = magicAcc + elementBonus + affinityBonus
     end
 
     -- Get dStat Magic Accuracy.

--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -237,8 +237,12 @@ xi.combat.magicHitRate.calculateTargetMagicEvasion = function(actor, target, spe
         magicEva = magicEva + target:getMod(mEvaMod) + target:getMod(xi.mod.STATUS_MEVA)
     end
 
-    -- Level correction. Target gets a bonus when higher level. Never a penalty.
-    if levelDiff > 0 then
+    -- Level correction. Target gets a bonus the higher the level if it's a mob. Never a penalty.
+    if
+        levelDiff > 0 and
+        xi.combat.levelCorrection.isLevelCorrectedZone(actor) and
+        not target:isPC()
+    then
         magicEva = magicEva + levelDiff * 4
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a limit of 1 to resist tiers when target is very weak to the action element (makink a 1/2 the max resist that will happen)
- Applies level corrected zones to lvl correction logic and makes only mobs gain a boost from lvl correction.
- Applies action bonus macc to base macc.
- Cleans and reorganices `calculateResistRate` function, to make it streamlined and clear.

Pretty much what draft PR #3936 is doing, but cleaner and finished.
Still a great job from Frank.

## Steps to test these changes

No real changes will be notizable at first glanze. Or shouldnt. Cast enfeebling or nuke spells with no errors in log.
