### PR TITLE
[Fix] Tractor and Raise being usable when they shouldn't.

### DIFF
--- a/scripts/globals/spells/black/tractor.lua
+++ b/scripts/globals/spells/black/tractor.lua
@@ -7,7 +7,12 @@ require("scripts/globals/msg")
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    if target:isMob() then -- Because Prishe in CoP mission
+    if
+        target:isMob() or                             -- Because Prishe in CoP mission.
+        target:isAlive() or                           -- Can't cast on alive targets.
+        target:hasRaiseTractorMenu() or               -- Raise and tractor menus both block the casting.
+        target:hasStatusEffect(xi.effect.BATTLEFIELD) -- Cannot be cast on BCNMs.
+    then
         return xi.msg.basic.CANNOT_ON_THAT_TARG
     end
 

--- a/scripts/globals/spells/white/arise.lua
+++ b/scripts/globals/spells/white/arise.lua
@@ -6,6 +6,13 @@ require("scripts/globals/msg")
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
+    if
+        target:isAlive() or          -- Can't cast on alive targets.
+        target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
+    then
+        return xi.msg.basic.CANNOT_ON_THAT_TARG
+    end
+
     return 0
 end
 

--- a/scripts/globals/spells/white/raise.lua
+++ b/scripts/globals/spells/white/raise.lua
@@ -6,6 +6,13 @@ require("scripts/globals/msg")
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
+    if
+        target:isAlive() or          -- Can't cast on alive targets.
+        target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
+    then
+        return xi.msg.basic.CANNOT_ON_THAT_TARG
+    end
+
     return 0
 end
 

--- a/scripts/globals/spells/white/raise_ii.lua
+++ b/scripts/globals/spells/white/raise_ii.lua
@@ -6,6 +6,13 @@ require("scripts/globals/msg")
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
+    if
+        target:isAlive() or          -- Can't cast on alive targets.
+        target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
+    then
+        return xi.msg.basic.CANNOT_ON_THAT_TARG
+    end
+
     return 0
 end
 

--- a/scripts/globals/spells/white/raise_iii.lua
+++ b/scripts/globals/spells/white/raise_iii.lua
@@ -6,6 +6,13 @@ require("scripts/globals/msg")
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
+    if
+        target:isAlive() or          -- Can't cast on alive targets.
+        target:hasRaiseTractorMenu() -- Raise and tractor menus both block the casting.
+    then
+        return xi.msg.basic.CANNOT_ON_THAT_TARG
+    end
+
     return 0
 end
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10674,6 +10674,26 @@ bool CLuaBaseEntity::isDead()
 }
 
 /************************************************************************
+ *  Function: hasRaiseTractorMenu()
+ *  Purpose : Returns true if player has Raise or Tractor menu. Used to block casting on players with menu.
+ *  Example : if target:hasRaiseTractorMenu() then
+ ************************************************************************/
+bool CLuaBaseEntity::hasRaiseTractorMenu()
+{
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+
+        if (PChar->m_hasTractor == 0 && PChar->m_hasRaise == 0)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/************************************************************************
  *  Function: sendRaise()
  *  Purpose : Updates the m_hasRaise private member with the Raise Level
  *  Example : target:sendRaise(1) -- 2, 3 or 4 for R2, R3, Arise
@@ -17066,6 +17086,7 @@ void CLuaBaseEntity::Register()
     // Battle Utilities
     SOL_REGISTER("isAlive", CLuaBaseEntity::isAlive);
     SOL_REGISTER("isDead", CLuaBaseEntity::isDead);
+    SOL_REGISTER("hasRaiseTractorMenu", CLuaBaseEntity::hasRaiseTractorMenu);
 
     SOL_REGISTER("sendRaise", CLuaBaseEntity::sendRaise);
     SOL_REGISTER("sendReraise", CLuaBaseEntity::sendReraise);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -544,6 +544,8 @@ public:
     // Battle Utilities
     bool isAlive();
     bool isDead();
+
+    bool hasRaiseTractorMenu();
     void sendRaise(uint8 raiseLevel);
     void sendReraise(uint8 raiseLevel);
     void sendTractor(float xPos, float yPos, float zPos, uint8 rotation);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Tractor and Raise can't be casted on a player that is dead but has the raise or the tractor menu active.
Confirmed this logic in retail with the use of 2 characters.

This PR fixes this issue/replicates this behavior.
Tested and working.

## Steps to test these changes

Step 1: Char A -> Die
Step 2: Char B -> Cast Tractor or any raise spell on Char A. Char A: Do nothing.
Step 3: Char B -> Attempt to cast tractor or Raise on Char A. Be blocked. Char A: Negate the raise or warp.
Step 4:  Char B -> Cast Tractor or any raise spell on Char A. Now you are able to.
