### PR TITLE
[core] Add TP retention of interrupted mobskills for stunned mobskills only

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -153,5 +153,22 @@ void CMobSkillState::Cleanup(time_point tick)
         actionTarget.reaction        = REACTION::HIT;
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+
+        // On retail testing, mobs lose 33% of their TP at 2900 or higher TP
+        // But lose 25% at < 2900 TP.
+        // Testing was done via charm on a steelshell, methodology was the following on BST/DRK with a scythe
+        // charm -> build tp -> leave -> stun -> interrupt TP move with weapon bash -> charm and check TP. Note that weapon bash incurs damage and thus adds TP.
+        if (m_PEntity->StatusEffectContainer && m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT::EFFECT_STUN))
+        {
+            int16 tp = m_spentTP;
+            if (tp >= 2900)
+            {
+                m_PEntity->health.tp = std::floor(std::round(0.333333f * tp));
+            }
+            else
+            {
+                m_PEntity->health.tp = std::floor(0.25f * tp);
+            }
+        }
     }
 }

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -524,6 +524,8 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
 
         m_StatusEffectSet.insert(PStatusEffect);
 
+        ApplyStateAlteringEffects(PStatusEffect);
+
         luautils::OnEffectGain(m_POwner, PStatusEffect);
         m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", CLuaBaseEntity(m_POwner), CLuaStatusEffect(PStatusEffect));
 
@@ -742,6 +744,40 @@ void CStatusEffectContainer::KillAllStatusEffect()
     m_POwner->UpdateHealth();
 }
 
+// Apply any state alterations for the effect if applicable.
+void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffect)
+{
+    EFFECT effect = StatusEffect->GetStatusID();
+
+    if (m_POwner->isAlive())
+    {
+        // this should actually go into a char charm AI
+        if (m_POwner->objtype == TYPE_PC)
+        {
+            if (effect == EFFECT_CHARM || effect == EFFECT_CHARM_II)
+            {
+                if (m_POwner->PPet != nullptr)
+                {
+                    petutils::DespawnPet(m_POwner);
+                }
+            }
+        }
+
+        if (effect == EFFECT_SLEEP || effect == EFFECT_SLEEP_II || effect == EFFECT_STUN || effect == EFFECT_PETRIFICATION || effect == EFFECT_TERROR ||
+            effect == EFFECT_LULLABY || effect == EFFECT_PENALTY)
+        {
+            // change icon of sleep II and lullaby. Apparently they don't stop player movement.
+            if (effect == EFFECT_SLEEP_II || effect == EFFECT_LULLABY)
+            {
+                StatusEffect->SetIcon(EFFECT_SLEEP);
+            }
+            if (!m_POwner->PAI->IsCurrentState<CInactiveState>())
+            {
+                m_POwner->PAI->Inactive(0ms, false);
+            }
+        }
+    }
+}
 /************************************************************************
  *                                                                       *
  *  Удаляем все эффекты с указанными иконками                            *
@@ -1517,36 +1553,6 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     StatusEffect->SetName(name);
     StatusEffect->SetFlag(effects::EffectsParams[effect].Flag);
     StatusEffect->SetType(effects::EffectsParams[effect].Type);
-
-    // todo: find a better place to put this?
-    if (m_POwner->isAlive())
-    {
-        // this should actually go into a char charm AI
-        if (m_POwner->objtype == TYPE_PC)
-        {
-            if (effect == EFFECT_CHARM || effect == EFFECT_CHARM_II)
-            {
-                if (m_POwner->PPet != nullptr)
-                {
-                    petutils::DespawnPet(m_POwner);
-                }
-            }
-        }
-
-        if (effect == EFFECT_SLEEP || effect == EFFECT_SLEEP_II || effect == EFFECT_STUN || effect == EFFECT_PETRIFICATION || effect == EFFECT_TERROR ||
-            effect == EFFECT_LULLABY || effect == EFFECT_PENALTY)
-        {
-            // change icon of sleep II and lullaby. Apparently they don't stop player movement.
-            if (effect == EFFECT_SLEEP_II || effect == EFFECT_LULLABY)
-            {
-                StatusEffect->SetIcon(EFFECT_SLEEP);
-            }
-            if (!m_POwner->PAI->IsCurrentState<CInactiveState>())
-            {
-                m_POwner->PAI->Inactive(0ms, false);
-            }
-        }
-    }
 }
 
 /************************************************************************

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -54,6 +54,7 @@ public:
     void DelStatusEffectsByType(uint16 Type);
     bool DelStatusEffectByTier(EFFECT StatusID, uint16 power);
     void KillAllStatusEffect();
+    void ApplyStateAlteringEffects(CStatusEffect* StatusEffect);
 
     bool HasStatusEffect(EFFECT StatusID);               // проверяем наличие эффекта
     bool HasStatusEffect(EFFECT StatusID, uint16 SubID); // проверяем наличие эффекта с уникальным subid


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin, ad TP retention of interrupted mobskills that were stunned. These values were taken from retail testing.

Methodology was 
Charm steelshell, have it gain some TP, leave, stun, weapon bash to stun a TP move, recharm, record TP.
Weapon bash adds 98 TP.

starting TP of 1183 -> 640 TP after the test

Some samples I recorded:
(2064 + 98) * .25 = 540.5
(1183 + 98) * .25  = 640.5

25% held true except at/above 2900 TP where it was 33%. 3000 ->1000.

## Steps to test these changes

Stun a TP move at 3k tp, the mob should have 1k left. Stun a TP move at 1k, the mob should have 250 TP left.
