### PR TITLE
Add template note to not resolve your own comment threads

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 <!-- (it should look like this: - [x] I have ...) -->
 **_I affirm:_**
 - [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
+- [ ] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
 - [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
 - [ ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -43,10 +43,10 @@ jobs:
 
             // Count the filled in checkboxes:
             // 1x pre-filled
-            // 2x to be filled
-            // Minimum total: 3
+            // 3x to be filled
+            // Minimum total: 4
             const checkbox_count = count_instances(body_text, "[x]")
-            if (checkbox_count < 3)
+            if (checkbox_count < 4)
             {
                 console.log(`Found ${checkbox_count} completed checkboxes. Leaving a reminder comment.`)
                 const result = await github.rest.issues.createComment({


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Github is ignoring [the problem](https://github.com/orgs/community/discussions/18458), and people keep doing this and its irritating especially if they just disagreed with a requested change and then "close" the conversation. Hopefully this note reduces people closing them before we're ready.

## Steps to test these changes
None.