### PR TITLE
Move conquest system to world server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -121,5 +121,14 @@
             "MIMode": "lldb",
             "targetArchitecture": "x64",
         },
+        {
+          "name": "(OSX) xi_world",
+          "type": "cppdbg",
+          "request": "launch",
+          "program": "${workspaceFolder}/xi_world",
+          "cwd": "${workspaceFolder}",
+          "MIMode": "lldb",
+          "targetArchitecture": "x64"
+        }
     ],
 }

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -146,6 +146,10 @@ enum MSGSERVTYPE : uint8
     MSG_LUA_FUNCTION,
     MSG_CHARVAR_UPDATE,
 
+    // conquest, besieged, campaign..
+    MSG_WORLD2MAP_REGIONAL_EVENT,
+    MSG_MAP2WORLD_REGIONAL_EVENT,
+
     // gm commands
     MSG_SEND_TO_ZONE,
     MSG_SEND_TO_ENTITY,
@@ -153,6 +157,41 @@ enum MSGSERVTYPE : uint8
     // rpc
     MSG_RPC_SEND, // sent by sender -> reciever
     MSG_RPC_RECV, // sent by reciever -> sender
+};
+
+enum REGIONALMSGTYPE : uint8
+{
+    REGIONAL_EVT_MSG_CONQUEST,
+    REGIONAL_EVT_MSG_BESIEGED,
+    REGIONAL_EVT_MSG_CAMPAIGN,
+};
+
+enum CONQUESTMSGTYPE : uint8
+{
+    // WORLD --------> MAP
+
+    // World map broadcasts weekly update started to all zones
+    CONQUEST_WORLD2MAP_WEEKLY_UPDATE_START,
+    // World map broadcasts that update is done, with the respective tally
+    CONQUEST_WORLD2MAP_WEEKLY_UPDATE_END,
+    // World map broadcasts influence point updates to all zones.
+    // Used for periodic updates or initialization.
+    CONQUEST_WORLD2MAP_INFLUENCE_POINTS,
+    // World map broadcasts region control data to all zones.
+    // Used for initialization.
+    CONQUEST_WORLD2MAP_REGION_CONTROL,
+
+    // MAP ----------> WORLD
+
+    // A GM Triggers a weekly update. From one zone to world.
+    // World should send CONQUEST_WORLD2MAP_WEEKLY_UPDATE_START and
+    // CONQUEST_WORLD2MAP_WEEKLY_UPDATE_END when done
+    CONQUEST_MAP2WORLD_GM_WEEKLY_UPDATE,
+    // A GM requests houry conquest data (just influence points).
+    // World server should respond with CONQUEST_WORLD2MAP_INFLUENCE_POINTS triggering a zone update
+    CONQUEST_MAP2WORLD_GM_CONQUEST_UPDATE,
+    // Influence point update from any zone to world.
+    CONQUEST_MAP2WORLD_ADD_INFLUENCE_POINTS,
 };
 
 constexpr auto msgTypeToStr = [](uint8 msgtype)
@@ -199,6 +238,8 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_RPC_SEND";
         case MSG_RPC_RECV:
             return "MSG_RPC_RECV";
+        case MSG_WORLD2MAP_REGIONAL_EVENT:
+            return "MSG_WORLD2MAP_REGIONAL_EVENT";
         default:
             return "Unknown";
     };

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -583,7 +583,6 @@ void DecodeStringLinkshell(const std::string& signature, char* target)
 std::string EncodeStringSignature(const std::string& signature, char* target)
 {
     uint8 encodedSignature[SignatureStringLength] = {};
-    uint8 chars                                   = 0;
     auto  length                                  = std::min<size_t>(15u, signature.size());
 
     for (std::size_t currChar = 0; currChar < length; ++currChar)
@@ -602,7 +601,6 @@ std::string EncodeStringSignature(const std::string& signature, char* target)
             tempChar = signature[currChar] - 'a' + 37;
         }
         packBitsLE(encodedSignature, tempChar, static_cast<uint32>(6 * currChar), 6);
-        chars++;
     }
 
     return strncpy(target, reinterpret_cast<const char*>(encodedSignature), SignatureStringLength);

--- a/src/common/vana_time.cpp
+++ b/src/common/vana_time.cpp
@@ -19,7 +19,7 @@
 ===========================================================================
 */
 
-#include "common/logging.h"
+#include "logging.h"
 
 #include <ctime>
 

--- a/src/common/vana_time.h
+++ b/src/common/vana_time.h
@@ -35,7 +35,7 @@
 
 #define JST_OFFSET 32400 // JST +offset from UTC
 
-#include "../common/cbasetypes.h"
+#include "cbasetypes.h"
 
 enum DAYTYPE : uint8
 {

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -45,8 +45,11 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/char_recast_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/command_handler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/command_handler.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/conquest_data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/conquest_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/conquest_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/conquest_system.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/conquest_zmq.h
     ${CMAKE_CURRENT_SOURCE_DIR}/daily_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/daily_system.h
     ${CMAKE_CURRENT_SOURCE_DIR}/enmity_container.cpp

--- a/src/map/conquest_data.cpp
+++ b/src/map/conquest_data.cpp
@@ -1,0 +1,146 @@
+#include "conquest_data.h"
+
+#include "common/logging.h"
+#include "common/sql.h"
+#include "conquest_system.h"
+
+ConquestData::ConquestData(std::unique_ptr<SqlConnection>& sql)
+: regionControls(std::vector<region_control_t>(256))
+, influences(std::vector<influence_t>(256))
+{
+    load(sql);
+}
+
+void ConquestData::load(std::unique_ptr<SqlConnection>& sql)
+{
+    const char* Query = "SELECT region_control, region_control_prev, sandoria_influence, bastok_influence, windurst_influence, beastmen_influence \
+                             FROM conquest_system;";
+
+    int32 ret = sql->Query(Query);
+
+    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    {
+        uint8 regionId = 0;
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            region_control_t regionControl;
+            regionControl.current    = sql->GetIntData(0);
+            regionControl.prev       = sql->GetIntData(1);
+            regionControls[regionId] = regionControl;
+
+            influence_t influence;
+            influence.sandoria_influence = sql->GetIntData(2);
+            influence.bastok_influence   = sql->GetIntData(3);
+            influence.windurst_influence = sql->GetIntData(4);
+            influence.beastmen_influence = sql->GetIntData(5);
+            influences[regionId]         = influence;
+
+            regionId++;
+        }
+    }
+}
+
+int32 ConquestData::getInfluence(REGION_TYPE region, NATION_TYPE nation) const
+{
+    switch (nation)
+    {
+        case NATION_SANDORIA:
+            return influences[(uint8)region].sandoria_influence;
+        case NATION_BASTOK:
+            return influences[(uint8)region].bastok_influence;
+        case NATION_WINDURST:
+            return influences[(uint8)region].windurst_influence;
+        case NATION_BEASTMEN:
+            return influences[(uint8)region].beastmen_influence;
+        default:
+            ShowWarning("Influence not known for nation: %d", nation);
+            return 0;
+    }
+}
+
+uint8 ConquestData::getRegionOwner(REGION_TYPE region) const
+{
+    return regionControls[(uint8)region].current;
+}
+
+uint8 ConquestData::getRegionControlCount(NATION_TYPE nation) const
+{
+    uint8 count = 0;
+    for (const auto& regionControl : regionControls)
+    {
+        if (regionControl.current == nation)
+        {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+uint8 ConquestData::getPrevRegionControlCount(NATION_TYPE nation) const
+{
+    uint8 count = 0;
+    for (const auto& regionControl : regionControls)
+    {
+        if (regionControl.prev == nation)
+        {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+auto ConquestData::getRegionControls() -> std::vector<region_control_t> const
+{
+    return regionControls;
+}
+
+void ConquestData::addInfluencePoints(int points, NATION_TYPE nation, REGION_TYPE region)
+{
+    switch (nation)
+    {
+        case NATION_SANDORIA:
+        {
+            influences[(uint8)region].sandoria_influence += points;
+            break;
+        }
+        case NATION_BASTOK:
+        {
+            influences[(uint8)region].bastok_influence += points;
+            break;
+        }
+        case NATION_WINDURST:
+        {
+            influences[(uint8)region].windurst_influence += points;
+            break;
+        }
+        case NATION_BEASTMEN:
+        {
+            influences[(uint8)region].beastmen_influence += points;
+            break;
+        }
+        default:
+        {
+            ShowWarning("Influence not known for nation: %d", nation);
+        }
+    }
+}
+
+void ConquestData::updateInfluencePoints(std::vector<influence_t> const& influencePoints)
+{
+    influences.clear();
+    for (const auto& influence : influencePoints)
+    {
+        influences.push_back(influence);
+    }
+}
+
+void ConquestData::updateRegionControls(std::vector<region_control_t> const& updatedRegionControls)
+{
+    regionControls.clear();
+    for (const auto& regionControl : updatedRegionControls)
+    {
+        regionControls.push_back(regionControl);
+    }
+}

--- a/src/map/conquest_data.h
+++ b/src/map/conquest_data.h
@@ -1,0 +1,73 @@
+#ifndef SERVER_CONQUEST_DATA_H
+#define SERVER_CONQUEST_DATA_H
+
+#include <string>
+
+#include "common/cbasetypes.h"
+#include "conquest_zmq.h"
+#include "zone.h"
+
+/**
+ * Conquest Data that is cached by the map server. This data is used to avoid redundant DB reads.
+ * Conquest data should be update periodically, as a result of influence / regional control updates
+ * received by the world server's conquest system.
+ */
+class ConquestData
+{
+public:
+    ConquestData(std::unique_ptr<SqlConnection>& sql);
+
+    /**
+     * Gets the influence points for a given nation in a given region.
+     */
+    int32 getInfluence(REGION_TYPE region, NATION_TYPE nation) const;
+
+    /**
+     * Gets the owner of a given region. That is, the one controlling this region since last tally.
+     */
+    uint8 getRegionOwner(REGION_TYPE region) const;
+
+    /**
+     * Gets the number of regions controlled by a given nation.
+     */
+    uint8 getRegionControlCount(NATION_TYPE nation) const;
+
+    /**
+     * Gets the number of regions controlled by a given nation in the
+     * previous tally.
+     */
+    uint8 getPrevRegionControlCount(NATION_TYPE nation) const;
+
+    /**
+     * Gets the array of region controls, indexed by regionId.
+     */
+    auto getRegionControls() -> std::vector<region_control_t> const;
+
+    /**
+     * Adds the given influence points to the given nation for the given
+     * region.
+     */
+    void addInfluencePoints(int points, NATION_TYPE nation, REGION_TYPE region);
+    /**
+     * Updates the influence points to match those given.
+     */
+    void updateInfluencePoints(std::vector<influence_t> const& influencePoints);
+
+    /**
+     * Updates region controls to match those given.
+     */
+    void updateRegionControls(std::vector<region_control_t> const& regionControls);
+
+private:
+    std::vector<region_control_t> regionControls;
+    std::vector<influence_t>      influences;
+
+    /**
+     * Loads the latest conquest data from DB.
+     * Should only ever be done on map initialization.
+     * World server should be updating conquest data periodically.
+     */
+    void load(std::unique_ptr<SqlConnection>& sql);
+};
+
+#endif // SERVER_CONQUEST_DATA_H

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -21,9 +21,10 @@
 
 #include "conquest_system.h"
 
+#include "common/mmo.h"
 #include "common/vana_time.h"
-
 #include "entities/charentity.h"
+#include "message.h"
 #include "utils/charutils.h"
 #include "utils/zoneutils.h"
 
@@ -32,92 +33,39 @@
 #include "latent_effect_container.h"
 #include "lua/luautils.h"
 
-/************************************************************************
- *                                                                       *
- *  Реализация namespace conquest                                       *
- *                                                                       *
- ************************************************************************/
-
 namespace conquest
 {
-    /************************************************************************
-     *                                                                       *
-     *  UpdateConquestSystem                                                *
-     *                                                                       *
-     ************************************************************************/
-
-    void UpdateConquestSystem()
+    std::shared_ptr<ConquestData> conquestData;
+    std::shared_ptr<ConquestData> GetConquestData()
     {
-        TracyZoneScoped;
-
-        uint8 ranking            = conquest::GetBalance();
-        bool  isConquestAlliance = conquest::IsAlliance();
-        // clang-format off
-        zoneutils::ForEachZone([ranking, isConquestAlliance](CZone* PZone)
+        if (conquestData == nullptr)
         {
-            // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
-            {
-                uint8 influence = conquest::GetInfluenceGraphics(PZone->GetRegionID());
-                uint8 owner     = conquest::GetRegionOwner(PZone->GetRegionID());
+            conquestData = std::make_shared<ConquestData>(sql);
+        }
 
-                luautils::OnConquestUpdate(PZone, Conquest_Update, influence, owner, ranking, isConquestAlliance);
-                PZone->ForEachChar([](CCharEntity* PChar)
-                {
-                    PChar->PLatentEffectContainer->CheckLatentsZone();
-                });
-            }
-        });
-        // clang-format on
+        return conquestData;
     }
 
-    void UpdateInfluencePoints(int points, unsigned int nation, REGION_TYPE region)
+    void AddInfluencePoints(int points, unsigned int nation, REGION_TYPE region)
     {
-        if (region == REGION_TYPE::UNKNOWN)
-        {
-            return;
-        }
+        // Send update message to world server
+        // Note that we do not update local cache, as it would potentially become out of sync from
+        // world server due to other map updates anyway. We wait for eventual consistency.
+        const std::size_t headerLength = 2 * sizeof(uint8);
+        const std::size_t dataLength   = headerLength + sizeof(int32) + sizeof(uint32) + sizeof(uint8);
+        uint8             data[dataLength]{};
 
-        std::string Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d;";
+        // Regional event type + conquest msg type
+        ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+        ref<uint8>((uint8*)data, 1) = CONQUEST_MAP2WORLD_ADD_INFLUENCE_POINTS;
 
-        int ret = sql->Query(Query.c_str(), static_cast<uint8>(region));
+        // Payload
+        ref<int32>(data, 2)  = points;
+        ref<uint32>(data, 6) = nation;
+        ref<uint8>(data, 10) = (uint8)region;
 
-        if (ret == SQL_ERROR || sql->NextRow() != SQL_SUCCESS)
-        {
-            return;
-        }
-
-        int influences[4] = {
-            sql->GetIntData(0),
-            sql->GetIntData(1),
-            sql->GetIntData(2),
-            sql->GetIntData(3),
-        };
-
-        if (influences[nation] == 5000)
-        {
-            return;
-        }
-
-        auto lost = 0;
-        for (auto i = 0u; i < 4; ++i)
-        {
-            if (i == nation)
-            {
-                continue;
-            }
-
-            auto loss = std::min<int>(points * influences[i] / (5000 - influences[nation]), influences[i]);
-            influences[i] -= loss;
-            lost += loss;
-        }
-
-        influences[nation] += lost;
-
-        sql->Query(
-            "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-            "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u;",
-            influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region));
+        // Do send the message
+        message::send(MSG_MAP2WORLD_REGIONAL_EVENT, data, dataLength);
     }
 
     /************************************************************************
@@ -129,7 +77,7 @@ namespace conquest
     void GainInfluencePoints(CCharEntity* PChar, uint32 points)
     {
         points += (uint32)(PChar->getMod(Mod::CONQUEST_REGION_BONUS) / 100.0);
-        conquest::UpdateInfluencePoints(points, PChar->profile.nation, PChar->loc.zone->GetRegionID());
+        conquest::AddInfluencePoints(points, PChar->profile.nation, PChar->loc.zone->GetRegionID());
     }
 
     /************************************************************************
@@ -196,7 +144,7 @@ namespace conquest
             }
         }
 
-        conquest::UpdateInfluencePoints(points, NATION_BEASTMEN, region);
+        conquest::AddInfluencePoints(points, NATION_BEASTMEN, region);
     }
 
     /************************************************************************
@@ -285,24 +233,13 @@ namespace conquest
         }
     }
 
-    uint8 GetInfluenceGraphics(REGION_TYPE regionid)
+    uint8 GetInfluenceGraphics(REGION_TYPE region)
     {
-        int32       sandoria = 0;
-        int32       bastok   = 0;
-        int32       windurst = 0;
-        int32       beastmen = 0;
-        const char* Query    = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence \
-                             FROM conquest_system WHERE region_id = %d;";
+        int32 sandoria = GetConquestData()->getInfluence(region, NATION_SANDORIA);
+        int32 bastok   = GetConquestData()->getInfluence(region, NATION_BASTOK);
+        int32 windurst = GetConquestData()->getInfluence(region, NATION_WINDURST);
+        int32 beastmen = GetConquestData()->getInfluence(region, NATION_BEASTMEN);
 
-        int32 ret = sql->Query(Query, static_cast<uint8>(regionid));
-
-        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
-        {
-            sandoria = sql->GetIntData(0);
-            bastok   = sql->GetIntData(1);
-            windurst = sql->GetIntData(2);
-            beastmen = sql->GetIntData(3);
-        }
         return GetInfluenceGraphics(sandoria, bastok, windurst, beastmen);
     }
 
@@ -356,27 +293,49 @@ namespace conquest
 
     void UpdateConquestGM(ConquestUpdate type)
     {
-        if (type == Conquest_Tally_Start || type == Conquest_Tally_End)
+        if (type == Conquest_Tally_Start)
         {
-            UpdateWeekConquest();
+            // Notify world server that we want to force a weekly update
+            const std::size_t dataLen = 2 * sizeof(uint8);
+            uint8             data[dataLen]{};
+
+            // Create ZMQ message with header and no other payload
+            ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+            ref<uint8>((uint8*)data, 1) = CONQUEST_MAP2WORLD_GM_WEEKLY_UPDATE;
+
+            // Send to world
+            message::send(MSG_MAP2WORLD_REGIONAL_EVENT, data, dataLen);
         }
-        else
+        else if (type == Conquest_Update)
         {
-            UpdateConquestSystem();
+            // Fetch most recent data from world server
+            const std::size_t dataLen = 2 * sizeof(uint8);
+            uint8             data[dataLen]{};
+
+            // Create ZMQ message with header and no payload
+            ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+            ref<uint8>((uint8*)data, 1) = CONQUEST_MAP2WORLD_GM_CONQUEST_UPDATE;
+
+            // Send to world
+            message::send(MSG_MAP2WORLD_REGIONAL_EVENT, data, dataLen);
+        }
+        else if (type == Conquest_Tally_End)
+        {
+            // Call conquest callbacks with cached data
+            conquest::HandleWeeklyTallyEnd(GetConquestData()->getRegionControls());
         }
     }
 
     /************************************************************************
-     *   UpdateWeekConquest                                                  *
-     *  Update region control                                               *
-     *   update 1 time per week                                             *
+     *   HandleWeekConquestUpdateStart                                      *
+     *   Calls map handlers for when conquest update starts                 *
+     *   called 1 time per week                                             *
+     *   This does NOT update the DB. World server is responsible for that. *
      ************************************************************************/
 
-    void UpdateWeekConquest()
+    void HandleWeeklyTallyStart()
     {
         TracyZoneScoped;
-        // TODO: move to lobby server
-        // launch conquest message in all zone (monday server midnight)
 
         uint8 ranking            = conquest::GetBalance();
         bool  isConquestAlliance = conquest::IsAlliance();
@@ -393,25 +352,30 @@ namespace conquest
             }
         });
         // clang-format on
+    }
 
-        const char* Query = "UPDATE conquest_system SET region_control = \
-                            IF(sandoria_influence > bastok_influence AND sandoria_influence > windurst_influence AND \
-                            sandoria_influence > beastmen_influence, 0, \
-                            IF(bastok_influence > sandoria_influence AND bastok_influence > windurst_influence AND \
-                            bastok_influence > beastmen_influence, 1, \
-                            IF(windurst_influence > bastok_influence AND windurst_influence > sandoria_influence AND \
-                            windurst_influence > beastmen_influence, 2, 3)));";
+    /************************************************************************
+     *   HandleWeekConquestUpdateEnd                                        *
+     *   Calls map handlers for when conquest update ends                   *
+     *   Called in response to world msg after actual db is updated         *
+     *   This does NOT update the DB. World server is responsible for that. *
+     ************************************************************************/
+    void HandleWeeklyTallyEnd(std::vector<region_control_t> const& regionControls)
+    {
+        TracyZoneScoped;
 
-        sql->Query(Query);
+        // 1-  Update local cache
+        GetConquestData()->updateRegionControls(regionControls);
 
+        // 2- Update zones based on the new data
         // update conquest overseers
         for (uint8 i = 0; i <= 18; i++)
         {
             luautils::SetRegionalConquestOverseers(i);
         }
 
-        ranking            = conquest::GetBalance();
-        isConquestAlliance = conquest::IsAlliance();
+        uint8 ranking            = conquest::GetBalance();
+        bool  isConquestAlliance = conquest::IsAlliance();
 
         // clang-format off
         zoneutils::ForEachZone([ranking, isConquestAlliance](CZone* PZone)
@@ -425,6 +389,8 @@ namespace conquest
                 luautils::OnConquestUpdate(PZone, Conquest_Tally_End, influence, owner, ranking, isConquestAlliance);
                 PZone->ForEachChar([](CCharEntity* PChar)
                 {
+                    // TODO: Use region controls cache here.
+                    // Right now, CConquestPacket queries from DB
                     PChar->pushPacket(new CConquestPacket(PChar));
                     PChar->PLatentEffectContainer->CheckLatentsZone();
                 });
@@ -433,6 +399,44 @@ namespace conquest
         // clang-format on
 
         ShowDebug("Conquest Weekly Update is finished");
+    }
+
+    /************************************************************************
+     *                                                                       *
+     *  HandleInfluenceUpdate                                                *
+     *  Called when influence updates are received from the world server.    *
+     *                                                                       *
+     ************************************************************************/
+
+    void HandleInfluenceUpdate(std::vector<influence_t> const& influences, bool shouldUpdateZones)
+    {
+        TracyZoneScoped;
+
+        GetConquestData()->updateInfluencePoints(influences);
+
+        if (shouldUpdateZones)
+        {
+            uint8 ranking            = conquest::GetBalance();
+            bool  isConquestAlliance = conquest::IsAlliance();
+
+            // clang-format off
+            zoneutils::ForEachZone([ranking, isConquestAlliance](CZone* PZone)
+            {
+                // only find chars for zones that have had conquest updated
+                if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
+                {
+                    uint8 influence = conquest::GetInfluenceGraphics(PZone->GetRegionID());
+                    uint8 owner     = conquest::GetRegionOwner(PZone->GetRegionID());
+
+                    luautils::OnConquestUpdate(PZone, Conquest_Update, influence, owner, ranking, isConquestAlliance);
+                    PZone->ForEachChar([](CCharEntity* PChar)
+                    {
+                        PChar->PLatentEffectContainer->CheckLatentsZone();
+                    });
+                }
+            });
+            // clang-format on
+        }
     }
 
     /************************************************************************
@@ -502,58 +506,14 @@ namespace conquest
 
     uint8 GetBalance()
     {
-        uint8       sandoria = 0;
-        uint8       bastok   = 0;
-        uint8       windurst = 0;
-        const char* Query    = "SELECT region_control, COUNT(*) FROM conquest_system WHERE region_control < 3 GROUP BY region_control;";
+        uint8 sandoria = GetConquestData()->getRegionControlCount(NATION_SANDORIA);
+        uint8 bastok   = GetConquestData()->getRegionControlCount(NATION_BASTOK);
+        uint8 windurst = GetConquestData()->getRegionControlCount(NATION_WINDURST);
 
-        int32 ret = sql->Query(Query);
+        uint8 sandoria_prev = GetConquestData()->getPrevRegionControlCount(NATION_SANDORIA);
+        uint8 bastok_prev   = GetConquestData()->getPrevRegionControlCount(NATION_BASTOK);
+        uint8 windurst_prev = GetConquestData()->getPrevRegionControlCount(NATION_WINDURST);
 
-        if (ret != SQL_ERROR && sql->NumRows() != 0)
-        {
-            while (sql->NextRow() == SQL_SUCCESS)
-            {
-                if (sql->GetIntData(0) == 0)
-                {
-                    sandoria = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 1)
-                {
-                    bastok = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 2)
-                {
-                    windurst = sql->GetIntData(1);
-                }
-            }
-        }
-
-        uint8 sandoria_prev = 0;
-        uint8 bastok_prev   = 0;
-        uint8 windurst_prev = 0;
-
-        Query = "SELECT region_control_prev, COUNT(*) FROM conquest_system WHERE region_control_prev < 3 GROUP BY region_control_prev;";
-
-        ret = sql->Query(Query);
-
-        if (ret != SQL_ERROR && sql->NumRows() != 0)
-        {
-            while (sql->NextRow() == SQL_SUCCESS)
-            {
-                if (sql->GetIntData(0) == 0)
-                {
-                    sandoria_prev = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 1)
-                {
-                    bastok_prev = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 2)
-                {
-                    windurst_prev = sql->GetIntData(1);
-                }
-            }
-        }
         return GetBalance(sandoria, bastok, windurst, sandoria_prev, bastok_prev, windurst_prev);
     }
 
@@ -599,65 +559,20 @@ namespace conquest
 
     bool IsAlliance()
     {
-        uint8       sandoria = 0;
-        uint8       bastok   = 0;
-        uint8       windurst = 0;
-        const char* Query    = "SELECT region_control, COUNT(*) FROM conquest_system WHERE region_control < 3 GROUP BY region_control;";
+        uint8 sandoria = GetConquestData()->getRegionControlCount(NATION_SANDORIA);
+        uint8 bastok   = GetConquestData()->getRegionControlCount(NATION_BASTOK);
+        uint8 windurst = GetConquestData()->getRegionControlCount(NATION_WINDURST);
 
-        int32 ret = sql->Query(Query);
-
-        if (ret != SQL_ERROR && sql->NumRows() != 0)
-        {
-            while (sql->NextRow() == SQL_SUCCESS)
-            {
-                if (sql->GetIntData(0) == 0)
-                {
-                    sandoria = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 1)
-                {
-                    bastok = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 2)
-                {
-                    windurst = sql->GetIntData(1);
-                }
-            }
-        }
-
-        uint8 sandoria_prev = 0;
-        uint8 bastok_prev   = 0;
-        uint8 windurst_prev = 0;
-
-        Query = "SELECT region_control_prev, COUNT(*) FROM conquest_system WHERE region_control_prev < 3 GROUP BY region_control_prev;";
-
-        ret = sql->Query(Query);
-
-        if (ret != SQL_ERROR && sql->NumRows() != 0)
-        {
-            while (sql->NextRow() == SQL_SUCCESS)
-            {
-                if (sql->GetIntData(0) == 0)
-                {
-                    sandoria_prev = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 1)
-                {
-                    bastok_prev = sql->GetIntData(1);
-                }
-                else if (sql->GetIntData(0) == 2)
-                {
-                    windurst_prev = sql->GetIntData(1);
-                }
-            }
-        }
+        uint8 sandoria_prev = GetConquestData()->getPrevRegionControlCount(NATION_SANDORIA);
+        uint8 bastok_prev   = GetConquestData()->getPrevRegionControlCount(NATION_BASTOK);
+        uint8 windurst_prev = GetConquestData()->getPrevRegionControlCount(NATION_WINDURST);
 
         return GetAlliance(sandoria, bastok, windurst, sandoria_prev, bastok_prev, windurst_prev) == 1;
     }
 
     /************************************************************************
      *                                                                       *
-     *  Оставшееся количество дней до подсчета conquest                      *
+     *  Gets the number of Vanadiel days left for tally                      *
      *                                                                       *
      ************************************************************************/
 
@@ -671,35 +586,28 @@ namespace conquest
 
     /************************************************************************
      *                                                                       *
-     *  Узнаем страну, владеющую данной зоной                                *
+     *  Get the nation that owns the given ration                            *
      *                                                                       *
      ************************************************************************/
 
-    uint8 GetRegionOwner(REGION_TYPE RegionID)
+    uint8 GetRegionOwner(REGION_TYPE region)
     {
-        const char* Query = "SELECT region_control FROM conquest_system WHERE region_id = %d";
-
-        int32 ret = sql->Query(Query, static_cast<uint8>(RegionID));
-
-        if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
-        {
-            return sql->GetIntData(0);
-        }
-        return NATION_NEUTRAL;
+        return GetConquestData()->getRegionOwner(region);
     }
 
     /************************************************************************
      *                                                                       *
-     *  Добавляем персонажу conquest points, основываясь на полученном опыте *
+     *  Adds conquest points to the character based on the exp gained.       *
+     *  Sends an update to world server with the influence change.           *
      *                                                                       *
      ************************************************************************/
 
-    // TODO: необходимо учитывать добавленные очки для еженедельного подсчета conquest
-
+    // TODO: Take into account the added points for the weekly tally
+    // NOTE: This todo was an old comment. Unsure if it's still valid
     uint32 AddConquestPoints(CCharEntity* PChar, uint32 exp)
     {
-        // ВНИМЕНИЕ: не нужно отправлять персонажу CConquestPacket,
-        // т.к. клиент сам запрашивает этот пакет через фиксированный промежуток времени
+        // NOTE: No need to send CConquestPacket,
+        // The client itself requests this packet after a fixed period of time
 
         REGION_TYPE region = PChar->loc.zone->GetRegionID();
 

--- a/src/map/conquest_system.h
+++ b/src/map/conquest_system.h
@@ -24,13 +24,9 @@
 
 #include "../common/cbasetypes.h"
 
+#include "conquest_data.h"
+#include "conquest_zmq.h"
 #include "zone.h"
-
-#define NATION_SANDORIA 0x00
-#define NATION_BASTOK   0x01
-#define NATION_WINDURST 0x02
-#define NATION_BEASTMEN 0x03
-#define NATION_NEUTRAL  0xFF
 
 enum ConquestUpdate : uint8
 {
@@ -39,19 +35,18 @@ enum ConquestUpdate : uint8
     Conquest_Update      = 2
 };
 
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/
-
 class CCharEntity;
 
+/**
+ * Conquest System operations for map server.
+ * These methods should never update DB. Instead, they should send a message to the world server and
+ * let the world server's conquest system perform DB updates.
+ */
 namespace conquest
 {
-    void UpdateConquestSystem(); // Update conquest information in the DB
+    std::shared_ptr<ConquestData> GetConquestData(); // Cached data with influences / region controls
 
-    void UpdateInfluencePoints(int points, unsigned int nation, unsigned int region);
+    void UpdateConquestGM(ConquestUpdate type);                  // Update conquest system by GM (modify in the DB and use @updateconquest)
     void GainInfluencePoints(CCharEntity* PChar, uint32 points); // Gain influence for player's nation (+1)
     void LoseInfluencePoints(CCharEntity* PChar);                // Lose influence for player's nation and gain for beastmen influence
 
@@ -60,8 +55,9 @@ namespace conquest
     uint8 GetInfluenceRanking(int32 san_inf, int32 bas_inf, int32 win_inf, int32 bst_inf);
     uint8 GetInfluenceRanking(int32 san_inf, int32 bas_inf, int32 win_inf);
 
-    void UpdateConquestGM(ConquestUpdate type); // Update conquest system by GM (modify in the DB and use @updateconquest)
-    void UpdateWeekConquest();                  // Update conquest system every sunday
+    void HandleInfluenceUpdate(std::vector<influence_t> const& influences, bool shouldUpdateZones); // Triggered periodically when world server sends updates of the latest influence data.
+    void HandleWeeklyTallyStart();                                                                  // Triggered on update conquest system every sunday (by world server msg)
+    void HandleWeeklyTallyEnd(std::vector<region_control_t> const& regionControls);                 // Triggered when conquest update ends (by world server msg)
 
     uint8 GetBalance(uint8 sandoria, uint8 bastok, uint8 windurst, // Ranking for 3 nations
                      uint8 sandoria_prev, uint8 bastok_prev, uint8 windurst_prev);

--- a/src/map/conquest_zmq.h
+++ b/src/map/conquest_zmq.h
@@ -1,0 +1,18 @@
+#ifndef SERVER_CONQUEST_ZMQ_H
+#define SERVER_CONQUEST_ZMQ_H
+
+struct region_control_t
+{
+    uint8 current;
+    uint8 prev;
+};
+
+struct influence_t
+{
+    uint16 sandoria_influence;
+    uint16 bastok_influence;
+    uint16 windurst_influence;
+    uint16 beastmen_influence;
+};
+
+#endif // SERVER_CONQUEST_ZMQ_H

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -63,6 +63,7 @@
 #include "alliance.h"
 #include "battlefield.h"
 #include "campaign_system.h"
+#include "common/vana_time.h"
 #include "conquest_system.h"
 #include "daily_system.h"
 #include "entities/automatonentity.h"

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -38,6 +38,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include <thread>
 
 #include "ability.h"
+#include "common/vana_time.h"
 #include "job_points.h"
 #include "linkshell.h"
 #include "message.h"

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -25,6 +25,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "message.h"
 
 #include "alliance.h"
+#include "conquest_system.h"
+#include "conquest_zmq.h"
 #include "linkshell.h"
 #include "party.h"
 #include "status_effect_container.h"
@@ -652,6 +654,97 @@ namespace message
                         ShowError("message::parse::MSG_RPC_RECV: %s", err.what());
                     }
                     replyMap.erase(slotKey);
+                }
+
+                break;
+            }
+            case MSG_WORLD2MAP_REGIONAL_EVENT:
+            {
+                // Extract data
+                uint8* data      = (uint8*)extra.data();
+                uint8  eventType = ref<uint8>(data, 0);
+                uint8  subtype   = ref<uint8>(data, 1);
+
+                // Handle each event type and subtype.
+                // Consider refactoring this as the types grow.
+                switch (eventType)
+                {
+                    case REGIONAL_EVT_MSG_CONQUEST:
+                    {
+                        if (subtype == CONQUEST_WORLD2MAP_WEEKLY_UPDATE_START)
+                        {
+                            conquest::HandleWeeklyTallyStart();
+                            return;
+                        }
+
+                        if (subtype == CONQUEST_WORLD2MAP_WEEKLY_UPDATE_END)
+                        {
+                            const std::size_t             headerLength   = 2 * sizeof(uint8);
+                            uint32                        size           = ref<uint32>(data, 2);
+                            std::vector<region_control_t> regionControls = std::vector<region_control_t>(size);
+                            for (int i = 0; i < size; i++)
+                            {
+                                const std::size_t start = headerLength + sizeof(size_t) + i * sizeof(region_control_t);
+
+                                region_control_t regionControl;
+                                regionControl.current = ref<uint8>(data, start);
+                                regionControl.prev    = ref<uint8>(data, start + 1);
+
+                                regionControls[i] = regionControl;
+                            }
+
+                            conquest::HandleWeeklyTallyEnd(regionControls);
+                            return;
+                        }
+
+                        if (subtype == CONQUEST_WORLD2MAP_INFLUENCE_POINTS)
+                        {
+                            const std::size_t        headerLength      = 2 * sizeof(uint8);
+                            bool                     shouldUpdateZones = ref<bool>(data, 2);
+                            uint32                   size              = ref<uint32>(data, 3);
+                            std::vector<influence_t> influencePoints   = std::vector<influence_t>(size);
+                            for (int i = 0; i < size; i++)
+                            {
+                                const std::size_t start = headerLength + sizeof(bool) + sizeof(size_t) + i * sizeof(influence_t);
+
+                                influence_t influence;
+                                influence.sandoria_influence = ref<uint16>(data, start);
+                                influence.bastok_influence   = ref<uint16>(data, start + 2);
+                                influence.windurst_influence = ref<uint16>(data, start + 4);
+                                influence.beastmen_influence = ref<uint16>(data, start + 6);
+
+                                influencePoints[i] = influence;
+                            }
+
+                            conquest::HandleInfluenceUpdate(influencePoints, shouldUpdateZones);
+                            return;
+                        }
+
+                        if (subtype == CONQUEST_WORLD2MAP_REGION_CONTROL)
+                        {
+                            const std::size_t             headerLength = 2 * sizeof(uint8);
+                            uint32                        size         = ref<uint32>(data, 2);
+                            std::vector<region_control_t> regionControls;
+                            for (int i = 0; i < size; i++)
+                            {
+                                const std::size_t start = headerLength + sizeof(size_t) + i * sizeof(region_control_t);
+
+                                region_control_t regionControl;
+                                regionControl.current = ref<uint8_t>(data, start);
+                                regionControl.prev    = ref<uint8_t>(data, start + 1);
+                                regionControls.push_back(regionControl);
+                            }
+
+                            conquest::GetConquestData()->updateRegionControls(regionControls);
+                            return;
+                        }
+
+                        break;
+                    }
+                    default:
+                    {
+                        ShowWarning("Message: unhandled regional event type %d", eventType);
+                    }
                 }
 
                 break;

--- a/src/map/packets/conquest_map.cpp
+++ b/src/map/packets/conquest_map.cpp
@@ -23,7 +23,9 @@
 
 #include <cstring>
 
+#include "../conquest_system.h"
 #include "besieged_system.h"
+#include "conquest_data.h"
 #include "conquest_system.h"
 #include "entities/charentity.h"
 
@@ -36,77 +38,38 @@ CConquestPacket::CConquestPacket(CCharEntity* PChar)
     this->setType(0x5E);
     this->setSize(0xB4);
 
-    // TODO: Periodically cache this information inside conquest_system so that it
-    //     : isn't so on-demand
-    const char* Query = "SELECT region_id, region_control, region_control_prev, \
-                         sandoria_influence, bastok_influence, windurst_influence, \
-                         beastmen_influence FROM conquest_system;";
+    auto  conquestData     = conquest::GetConquestData();
+    uint8 sandoria_regions = conquestData->getRegionControlCount(NATION_SANDORIA);
+    uint8 bastok_regions   = conquestData->getRegionControlCount(NATION_BASTOK);
+    uint8 windurst_regions = conquestData->getRegionControlCount(NATION_WINDURST);
+    uint8 sandoria_prev    = conquestData->getPrevRegionControlCount(NATION_SANDORIA);
+    uint8 bastok_prev      = conquestData->getPrevRegionControlCount(NATION_BASTOK);
+    uint8 windurst_prev    = conquestData->getPrevRegionControlCount(NATION_WINDURST);
 
-    int32 ret = sql->Query(Query);
-
-    uint8 sandoria_regions = 0;
-    uint8 bastok_regions   = 0;
-    uint8 windurst_regions = 0;
-    uint8 sandoria_prev    = 0;
-    uint8 bastok_prev      = 0;
-    uint8 windurst_prev    = 0;
-
-    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    for (uint8 regionId = (uint8)REGION_TYPE::RONFAURE; regionId != (uint8)REGION_TYPE::EAST_ULBUKA; regionId++)
     {
-        while (sql->NextRow() == SQL_SUCCESS)
+        uint8 region_owner              = conquestData->getRegionOwner((REGION_TYPE)regionId);
+        int32 san_inf                   = conquestData->getInfluence((REGION_TYPE)regionId, NATION_SANDORIA);
+        int32 bas_inf                   = conquestData->getInfluence((REGION_TYPE)regionId, NATION_BASTOK);
+        int32 win_inf                   = conquestData->getInfluence((REGION_TYPE)regionId, NATION_WINDURST);
+        int32 bst_inf                   = conquestData->getInfluence((REGION_TYPE)regionId, NATION_BEASTMEN);
+        ref<uint8>(0x1A + regionId * 4) = conquest::GetInfluenceRanking(san_inf, bas_inf, win_inf, bst_inf);
+        ref<uint8>(0x1B + regionId * 4) = conquest::GetInfluenceRanking(san_inf, bas_inf, win_inf);
+        ref<uint8>(0x1C + regionId * 4) = conquest::GetInfluenceGraphics(san_inf, bas_inf, win_inf, bst_inf);
+        ref<uint8>(0x1D + regionId * 4) = region_owner + 1;
+
+        int64 total         = san_inf + bas_inf + win_inf;
+        int64 totalBeastmen = total + bst_inf;
+
+        if (PChar->loc.zone->GetRegionID() == static_cast<REGION_TYPE>(regionId))
         {
-            int regionid            = sql->GetIntData(0);
-            int region_control      = sql->GetIntData(1);
-            int region_control_prev = sql->GetIntData(2);
-
-            if (region_control == 0)
-            {
-                sandoria_regions++;
-            }
-            else if (region_control == 1)
-            {
-                bastok_regions++;
-            }
-            else if (region_control == 2)
-            {
-                windurst_regions++;
-            }
-
-            if (region_control_prev == 0)
-            {
-                sandoria_prev++;
-            }
-            else if (region_control_prev == 1)
-            {
-                bastok_prev++;
-            }
-            else if (region_control_prev == 2)
-            {
-                windurst_prev++;
-            }
-
-            int32 san_inf                   = sql->GetIntData(3);
-            int32 bas_inf                   = sql->GetIntData(4);
-            int32 win_inf                   = sql->GetIntData(5);
-            int32 bst_inf                   = sql->GetIntData(6);
-            ref<uint8>(0x1A + regionid * 4) = conquest::GetInfluenceRanking(san_inf, bas_inf, win_inf, bst_inf);
-            ref<uint8>(0x1B + regionid * 4) = conquest::GetInfluenceRanking(san_inf, bas_inf, win_inf);
-            ref<uint8>(0x1C + regionid * 4) = conquest::GetInfluenceGraphics(san_inf, bas_inf, win_inf, bst_inf);
-            ref<uint8>(0x1D + regionid * 4) = region_control + 1;
-
-            int64 total         = san_inf + bas_inf + win_inf;
-            int64 totalBeastmen = total + bst_inf;
-
-            if (PChar->loc.zone->GetRegionID() == static_cast<REGION_TYPE>(regionid))
-            {
-                ref<uint8>(0x86) = (uint8)((san_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
-                ref<uint8>(0x87) = (uint8)((bas_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
-                ref<uint8>(0x88) = (uint8)((win_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
-                ref<uint8>(0x89) = (uint8)((san_inf * 100) / (total == 0 ? 1 : total));
-                ref<uint8>(0x8A) = (uint8)((bas_inf * 100) / (total == 0 ? 1 : total));
-                ref<uint8>(0x8B) = (uint8)((win_inf * 100) / (total == 0 ? 1 : total));
-                ref<uint8>(0x94) = (uint8)((bst_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
-            }
+            ref<uint8>(0x86) = (uint8)((san_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
+            ref<uint8>(0x87) = (uint8)((bas_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
+            ref<uint8>(0x88) = (uint8)((win_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
+            ref<uint8>(0x89) = (uint8)((san_inf * 100) / (total == 0 ? 1 : total));
+            ref<uint8>(0x8A) = (uint8)((bas_inf * 100) / (total == 0 ? 1 : total));
+            ref<uint8>(0x8B) = (uint8)((win_inf * 100) / (total == 0 ? 1 : total));
+            ref<uint8>(0x94) = (uint8)((bst_inf * 100) / (totalBeastmen == 0 ? 1 : totalBeastmen));
         }
     }
 

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -25,6 +25,7 @@
 
 #include <ctime>
 
+#include "common/vana_time.h"
 #include "lua/luautils.h"
 #include "packets/chat_message.h"
 #include "utils/charutils.h"

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -24,7 +24,7 @@
 #include "common/logging.h"
 #include "common/vana_time.h"
 
-#include "conquest_system.h"
+#include "common/vana_time.h"
 #include "daily_system.h"
 #include "entities/charentity.h"
 #include "latent_effect_container.h"
@@ -50,7 +50,6 @@ int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
     {
         if (tick > (lastConquestTally + 1h))
         {
-            conquest::UpdateWeekConquest();
             roeutils::CycleWeeklyRecords();
             roeutils::CycleUnityRankings();
             lastConquestTally = tick;
@@ -61,7 +60,6 @@ int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
     {
         if (tick > (lastConquestUpdate + 1h))
         {
-            conquest::UpdateConquestSystem();
             roeutils::UpdateUnityRankings();
             lastConquestUpdate = tick;
         }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -301,7 +301,7 @@ namespace battleutils
 
         if (ret != SQL_ERROR && sql->NumRows() != 0)
         {
-            for (uint32 x = 0; sql->NextRow() == SQL_SUCCESS; ++x)
+            while (sql->NextRow() == SQL_SUCCESS)
             {
                 uint16 level                              = (uint16)sql->GetIntData(0);
                 uint16 count                              = (uint16)sql->GetIntData(1);

--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -55,6 +55,7 @@
 
 #include "battleutils.h"
 #include "charutils.h"
+#include "common/vana_time.h"
 #include "itemutils.h"
 #include "zoneutils.h"
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -34,6 +34,7 @@
 #include <cstring>
 
 #include "battlefield.h"
+#include "common/vana_time.h"
 #include "enmity_container.h"
 #include "latent_effect_container.h"
 #include "linkshell.h"

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -346,6 +346,15 @@ enum ZONEID : uint16
     MAX_ZONEID                          = 300,
 };
 
+enum NATION_TYPE : uint8
+{
+    NATION_SANDORIA = 0x00,
+    NATION_BASTOK   = 0x01,
+    NATION_WINDURST = 0x02,
+    NATION_BEASTMEN = 0x03,
+    NATION_NEUTRAL  = 0xFF,
+};
+
 enum class REGION_TYPE : uint8
 {
     RONFAURE         = 0,

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     http_server.cpp
     http_server.h
     main.cpp
+    message_handler.h
     message_server.cpp
     message_server.h
     world_server.cpp
@@ -47,5 +48,9 @@ target_include_directories(xi_world
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+if (APPLE)
+    disable_lto(xi_world)
+endif()
 
 set_target_output_directory(xi_world)

--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -20,3 +20,282 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 */
 
 #include "conquest_system.h"
+
+#include "message_server.h"
+
+ConquestSystem::ConquestSystem()
+: sql(std::make_unique<SqlConnection>())
+{
+}
+
+bool ConquestSystem::handleMessage(std::vector<uint8> payload,
+                                   in_addr            from_addr,
+                                   uint16             from_port)
+{
+    const uint8 conquestMsgType = payload[1];
+    if (conquestMsgType == CONQUESTMSGTYPE::CONQUEST_MAP2WORLD_GM_WEEKLY_UPDATE)
+    {
+        updateWeekConquest();
+        return true;
+    }
+
+    if (conquestMsgType == CONQUESTMSGTYPE::CONQUEST_MAP2WORLD_ADD_INFLUENCE_POINTS)
+    {
+        // const int32  points = ref<int32>(data, 2);
+        int32  points = 0;
+        uint32 nation = 0;
+        uint8  region = 0;
+        std::memcpy(&points, payload.data() + 2, sizeof(int32));
+        std::memcpy(&nation, payload.data() + 6, sizeof(uint32));
+        std::memcpy(&region, payload.data() + 10, sizeof(uint8));
+
+        // TODO: Buffer / flush influence point changes instead of immediately broadcasting to all map servers
+        if (updateInfluencePoints(points, nation, (REGION_TYPE)region))
+        {
+            sendInfluencesMsg(false);
+        }
+
+        return true;
+    }
+
+    if (conquestMsgType == CONQUESTMSGTYPE::CONQUEST_MAP2WORLD_GM_CONQUEST_UPDATE)
+    {
+        // Convert from_addr to ip + port
+        uint64 ipp = from_addr.s_addr;
+        ipp |= (((uint64)from_port) << 32);
+
+        // Send influence data to the requesting map server
+        sendInfluencesMsg(true, ipp);
+        return true;
+    }
+
+    ShowDebug(fmt::format("Message: unknown conquest type received: {} from {}:{}",
+                          static_cast<uint8>(conquestMsgType),
+                          from_addr.s_addr,
+                          from_port));
+    return false;
+}
+
+void ConquestSystem::sendTallyStartMsg()
+{
+    // 1- Send message to all zones. We are starting update.
+    const std::size_t dataLen = 2 * sizeof(uint8);
+    uint8             data[2 * sizeof(uint8) + sizeof(uint32)]{};
+
+    // Create ZMQ message with header and no other payload
+    ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+    ref<uint8>((uint8*)data, 1) = CONQUEST_WORLD2MAP_WEEKLY_UPDATE_START;
+
+    // Send to map
+    zmq::message_t dataMsg = zmq::message_t(dataLen);
+    memcpy(dataMsg.data(), data, dataLen);
+    queue_message_broadcast(MSG_WORLD2MAP_REGIONAL_EVENT, &dataMsg);
+}
+
+void ConquestSystem::sendInfluencesMsg(bool shouldUpdateZones, uint64 ipp)
+{
+    auto influences = getRegionalInfluences();
+
+    // Base length is the type + subtype + influence size
+    const std::size_t headerLength = 2 * sizeof(uint8);
+    const std::size_t dataLen      = headerLength + sizeof(bool) + sizeof(size_t) + sizeof(influence_t) * influences.size();
+    const uint8*      data         = new uint8[dataLen];
+
+    // Regional event type + conquest msg type
+    ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+    ref<uint8>((uint8*)data, 1) = CONQUEST_WORLD2MAP_INFLUENCE_POINTS;
+    ref<uint8>((uint8*)data, 2) = shouldUpdateZones;
+
+    // Influences controls array
+    ref<uint32>((uint8*)data, 3) = influences.size();
+    for (int i = 0; i < influences.size(); i++)
+    {
+        // Everything is offset by i*size of region control struct + headerLength
+        const std::size_t start              = headerLength + sizeof(bool) + sizeof(size_t) + i * sizeof(influence_t);
+        ref<uint16>((uint8*)data, start)     = influences[i].sandoria_influence;
+        ref<uint16>((uint8*)data, start + 2) = influences[i].bastok_influence;
+        ref<uint16>((uint8*)data, start + 4) = influences[i].windurst_influence;
+        ref<uint16>((uint8*)data, start + 6) = influences[i].beastmen_influence;
+    }
+
+    // 3- Create ZMQ Message and queue it
+    zmq::message_t dataMsg = zmq::message_t(dataLen);
+    memcpy(dataMsg.data(), data, dataLen);
+    if (ipp == 0xFFFF)
+    {
+        queue_message_broadcast(MSG_WORLD2MAP_REGIONAL_EVENT, &dataMsg);
+    }
+    else
+    {
+        queue_message(ipp, MSG_WORLD2MAP_REGIONAL_EVENT, &dataMsg);
+    }
+}
+
+void ConquestSystem::sendRegionControlsMsg(CONQUESTMSGTYPE msgType, uint64 ipp)
+{
+    // 2- Serialize regional controls with the following schema:
+    // - REGIONALMSGTYPE
+    // - CONQUESTMSGTYPE
+    // - region controls array size
+    // - For N elements we have:
+    //      - current control (uint8)
+    //      - prev control (uint8)
+    auto regionControls = getRegionControls();
+
+    // Base length is the type + subtype + region control size
+    const std::size_t headerLength = 2 * sizeof(uint8);
+    const std::size_t dataLen      = headerLength + sizeof(region_control_t) * regionControls.size();
+    const uint8*      data         = new uint8[dataLen];
+
+    // Regional event type + conquest msg type
+    ref<uint8>((uint8*)data, 0) = REGIONAL_EVT_MSG_CONQUEST;
+    ref<uint8>((uint8*)data, 1) = msgType;
+
+    // Region controls array
+    ref<uint32>((uint8*)data, 2) = regionControls.size();
+    for (int i = 0; i < regionControls.size(); i++)
+    {
+        // Everything is offset by i*size of region control struct + headerLength + size of size_t
+        const std::size_t offset             = headerLength + sizeof(size_t) + sizeof(region_control_t) * i;
+        ref<uint8>((uint8*)data, offset)     = regionControls[i].current;
+        ref<uint8>((uint8*)data, offset + 1) = regionControls[i].prev;
+    }
+
+    // 3- Create ZMQ Message and queue it
+    zmq::message_t dataMsg = zmq::message_t(dataLen);
+    memcpy(dataMsg.data(), data, dataLen);
+
+    if (ipp == 0xFFFF)
+    {
+        queue_message_broadcast(MSG_WORLD2MAP_REGIONAL_EVENT, &dataMsg);
+    }
+    else
+    {
+        queue_message(ipp, MSG_WORLD2MAP_REGIONAL_EVENT, &dataMsg);
+    }
+}
+
+bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGION_TYPE region)
+{
+    if (region == REGION_TYPE::UNKNOWN)
+    {
+        return false;
+    }
+
+    std::string Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d;";
+
+    int ret = sql->Query(Query.c_str(), static_cast<uint8>(region));
+
+    if (ret == SQL_ERROR || sql->NextRow() != SQL_SUCCESS)
+    {
+        return false;
+    }
+
+    int influences[4] = {
+        sql->GetIntData(0),
+        sql->GetIntData(1),
+        sql->GetIntData(2),
+        sql->GetIntData(3),
+    };
+
+    if (influences[nation] == 5000)
+    {
+        return false;
+    }
+
+    auto lost = 0;
+    for (auto i = 0u; i < 4; ++i)
+    {
+        if (i == nation)
+        {
+            continue;
+        }
+
+        auto loss = std::min<int>(points * influences[i] / (5000 - influences[nation]), influences[i]);
+        influences[i] -= loss;
+        lost += loss;
+    }
+
+    influences[nation] += lost;
+
+    ret = sql->Query("UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
+                     "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %u;",
+                     influences[0], influences[1], influences[2], influences[3], static_cast<uint8>(region));
+
+    return ret != SQL_ERROR;
+}
+
+void ConquestSystem::updateWeekConquest()
+{
+    TracyZoneScoped;
+
+    // 1- Notify all zones that tally started
+    sendTallyStartMsg();
+
+    // 2- Do the actual db update
+    const char* Query = "UPDATE conquest_system SET region_control = \
+                            IF(sandoria_influence > bastok_influence AND sandoria_influence > windurst_influence AND \
+                            sandoria_influence > beastmen_influence, 0, \
+                            IF(bastok_influence > sandoria_influence AND bastok_influence > windurst_influence AND \
+                            bastok_influence > beastmen_influence, 1, \
+                            IF(windurst_influence > bastok_influence AND windurst_influence > sandoria_influence AND \
+                            windurst_influence > beastmen_influence, 2, 3)));";
+
+    int ret = sql->Query(Query);
+    if (ret == SQL_ERROR)
+    {
+        ShowError("handleWeeklyUpdate() failed");
+    }
+
+    // 3- Send tally end Msg
+    sendRegionControlsMsg(CONQUEST_WORLD2MAP_WEEKLY_UPDATE_END);
+}
+
+void ConquestSystem::updateHourlyConquest()
+{
+    sendInfluencesMsg(true);
+}
+
+auto ConquestSystem::getRegionalInfluences() -> std::vector<influence_t> const
+{
+    const char* Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system;";
+
+    int32 ret = sql->Query(Query);
+
+    std::vector<influence_t> influences;
+    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    {
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            influence_t influence{};
+            influence.sandoria_influence = sql->GetIntData(0);
+            influence.bastok_influence   = sql->GetIntData(1);
+            influence.windurst_influence = sql->GetIntData(2);
+            influence.beastmen_influence = sql->GetIntData(3);
+            influences.push_back(influence);
+        }
+    }
+
+    return influences;
+}
+
+auto ConquestSystem::getRegionControls() -> std::vector<region_control_t> const
+{
+    const char* Query = "SELECT region_control, region_control_prev FROM conquest_system;";
+
+    int32 ret = sql->Query(Query);
+
+    std::vector<region_control_t> controllers;
+    if (ret != SQL_ERROR && sql->NumRows() != 0)
+    {
+        while (sql->NextRow() == SQL_SUCCESS)
+        {
+            region_control_t regionControl{};
+            regionControl.current = sql->GetIntData(0);
+            regionControl.prev    = sql->GetIntData(1);
+            controllers.push_back(regionControl);
+        }
+    }
+
+    return controllers;
+}

--- a/src/world/conquest_system.h
+++ b/src/world/conquest_system.h
@@ -18,11 +18,52 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 ===========================================================================
 */
+
 #pragma once
 
-class ConquestSystem
+#include "common/sql.h"
+#include "map/conquest_zmq.h"
+#include "map/zone.h"
+#include "message_handler.h"
+
+/**
+ * Conquest System on the world server.
+ * This class handles all the DB updates as a response to map server updates.
+ */
+class ConquestSystem : public IMessageHandler
 {
 public:
-    ConquestSystem()  = default;
-    ~ConquestSystem() = default;
+    ConquestSystem();
+    ~ConquestSystem() override = default;
+
+    /**
+     * IMessageHandler implementation. Used to handle messages from message_server.
+     */
+    bool handleMessage(std::vector<uint8> payload,
+                       in_addr            from_addr,
+                       uint16             from_port) override;
+
+    /**
+     * Called weekly, updates conquest data and sends regional control information
+     * to maps servers when done.
+     */
+    void updateWeekConquest();
+
+    /**
+     * Called hourly, updates influence data and sends an immediate influence update
+     * message to map servers.
+     */
+    void updateHourlyConquest();
+
+private:
+    std::unique_ptr<SqlConnection> sql;
+
+    bool updateInfluencePoints(int points, unsigned int nation, REGION_TYPE region);
+
+    auto getRegionalInfluences() -> std::vector<influence_t> const;
+    auto getRegionControls() -> std::vector<region_control_t> const;
+
+    void sendTallyStartMsg();
+    void sendInfluencesMsg(bool shouldUpdateZones, uint64 ipp = 0xFFFF);
+    void sendRegionControlsMsg(CONQUESTMSGTYPE msgType, uint64 ipp = 0xFFFF);
 };

--- a/src/world/message_handler.h
+++ b/src/world/message_handler.h
@@ -1,0 +1,18 @@
+#ifndef SERVER_MESSAGE_HANDLER_H
+#define SERVER_MESSAGE_HANDLER_H
+
+#include "common/mmo.h"
+#include <zmq.hpp>
+
+class IMessageHandler
+{
+public:
+    virtual ~IMessageHandler()
+    {
+    }
+    virtual bool handleMessage(std::vector<uint8> payload,
+                               in_addr            from_addr,
+                               uint16             from_port) = 0;
+};
+
+#endif // SERVER_MESSAGE_HANDLER_H

--- a/src/world/message_server.h
+++ b/src/world/message_server.h
@@ -23,12 +23,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "common/mmo.h"
 #include "common/socket.h"
 #include "common/sql.h"
+#include "conquest_system.h"
+#include "message_handler.h"
 
 #include <nonstd/jthread.hpp>
 #include <zmq.hpp>
 #include <zmq_addon.hpp>
 
-void queue_message(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet);
+void queue_message(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet = nullptr);
+void queue_message_broadcast(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet = nullptr);
 
 void message_server_init(const bool& requestExit);
 void message_server_close();

--- a/src/world/world_server.h
+++ b/src/world/world_server.h
@@ -39,12 +39,12 @@ public:
     void Tick() override;
 
 private:
-    std::unique_ptr<message_server_wrapper_t> messageServer;
+    std::shared_ptr<ConquestSystem> conquestSystem;
 
-    std::unique_ptr<ConquestSystem>     conquestSystem;
     std::unique_ptr<BesiegedSystem>     besiegedSystem;
     std::unique_ptr<CampaignSystem>     campaignSystem;
     std::unique_ptr<ColonizationSystem> colonizationSystem;
 
-    std::unique_ptr<HTTPServer> httpServer;
+    std::unique_ptr<HTTPServer>               httpServer;
+    std::unique_ptr<message_server_wrapper_t> messageServer;
 };


### PR DESCRIPTION
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Weekly tally / hourly updates now happen on world server
- World server communicates of map server updates via zmq
- Adds xi_world configuration and debug symbols for Mac OS
- Maps cache all data. Only world server uses DB.

## Steps to test these changes

Kill stuff as level 15+ outside. Check that influence points are changed in db. Check region map.
Run !updateconquest 0 for tally.
Run !updateconquest 2 for conquest update, after killing lots of mobs.
