### PR TITLE
[Fix] Incorrect shell effect power values in mobskill scripts

### DIFF
--- a/scripts/globals/mobskills/bubble_armor.lua
+++ b/scripts/globals/mobskills/bubble_armor.lua
@@ -17,7 +17,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.SHELL
-    local power = 50
+    local power      = 5000
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 

--- a/scripts/globals/mobskills/bubble_curtain.lua
+++ b/scripts/globals/mobskills/bubble_curtain.lua
@@ -17,7 +17,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.SHELL
-    local power = 50
+    local power      = 5000
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 

--- a/scripts/globals/mobskills/crystaline_cocoon.lua
+++ b/scripts/globals/mobskills/crystaline_cocoon.lua
@@ -17,9 +17,9 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect1 = xi.effect.PROTECT
     local typeEffect2 = xi.effect.SHELL
-    local power1 = 50
-    local power2 = 20
-    local duration = 300
+    local power1      = 50
+    local power2      = 2000
+    local duration    = 300
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect1, power1, 0, duration))
     xi.mobskills.mobBuffMove(mob, typeEffect2, power2, 0, duration)

--- a/scripts/globals/mobskills/unblessed_armor.lua
+++ b/scripts/globals/mobskills/unblessed_armor.lua
@@ -17,7 +17,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.SHELL
-    local power = 50
+    local power      = 5000
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes wrong power values in mobskills that grant shell.
Missed when the modifier was converted to its new scale.

## Steps to test these changes

Fight a crab. Wait for it to use bubble courtain. !getmod DMGMAGIC

Same for the other 3 mobskills, but with other mobs