### PR TITLE
[Magic] Implement Immunobreak

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -243,6 +243,8 @@ xi.mod =
     HUMANOID_KILLER                 = 236,
     LUMINIAN_KILLER                 = 237,
     LUMINION_KILLER                 = 238,
+
+    -- Status effect Job trait resistance modifiers.
     SLEEPRES                        = 240,
     POISONRES                       = 241,
     PARALYZERES                     = 242,
@@ -260,6 +262,8 @@ xi.mod =
     LULLABYRES                      = 254,
     DEATHRES                        = 255,
     STATUSRES                       = 958, -- "Resistance to All Status Ailments"
+
+    -- Status effect Magic Evasion modifiers.
     SLEEP_MEVA                      = 200,
     POISON_MEVA                     = 201,
     PARALYZE_MEVA                   = 202,
@@ -277,6 +281,19 @@ xi.mod =
     LULLABY_MEVA                    = 214,
     DEATH_MEVA                      = 215,
     STATUS_MEVA                     = 216,
+
+    -- Status effect magic Evasion modifiers.
+    SLEEP_IMMUNOBREAK               = 261,
+    POISON_IMMUNOBREAK              = 262,
+    PARALYZE_IMMUNOBREAK            = 263,
+    BLIND_IMMUNOBREAK               = 264,
+    SILENCE_IMMUNOBREAK             = 265,
+    PETRIFY_IMMUNOBREAK             = 266,
+    BIND_IMMUNOBREAK                = 267,
+    GRAVITY_IMMUNOBREAK             = 268,
+    SLOW_IMMUNOBREAK                = 269,
+    ADDLE_IMMUNOBREAK               = 270,
+
     AFTERMATH                       = 256,
     PARALYZE                        = 257,
     MIJIN_RERAISE                   = 258,

--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -9,7 +9,7 @@ xi.combat.magicHitRate = xi.combat.magicHitRate or {}
 -----------------------------------
 
 -- Modifier table per element.
-local elementTable =
+xi.combat.magicHitRate.elementTable =
 {
     [xi.magic.element.FIRE   ] = { xi.mod.FIREACC,    xi.mod.FIRE_AFFINITY_ACC,    xi.mod.FIRE_MEVA,    xi.mod.FIRE_RES_RANK,    xi.merit.FIRE_MAGIC_ACCURACY      },
     [xi.magic.element.ICE    ] = { xi.mod.ICEACC,     xi.mod.ICE_AFFINITY_ACC,     xi.mod.ICE_MEVA,     xi.mod.ICE_RES_RANK,     xi.merit.ICE_MAGIC_ACCURACY       },
@@ -41,8 +41,8 @@ xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spe
 
     -- Add acc for elemental affinity accuracy and element specific accuracy
     if spellElement ~= xi.magic.ele.NONE then
-        local elementBonus  = actor:getMod(elementTable[spellElement][1])
-        local affinityBonus = actor:getMod(elementTable[spellElement][2]) * 10
+        local elementBonus  = actor:getMod(xi.combat.magicHitRate.elementTable[spellElement][1])
+        local affinityBonus = actor:getMod(xi.combat.magicHitRate.elementTable[spellElement][2]) * 10
 
         magicAcc = magicAcc + elementBonus + affinityBonus
     end
@@ -181,7 +181,7 @@ xi.combat.magicHitRate.calculateActorMagicAccuracy = function(actor, target, spe
                 spellElement >= xi.magic.element.FIRE and
                 spellElement <= xi.magic.element.WATER
             then
-                magicAcc = magicAcc + actor:getMerit(elementTable[spellElement][5])
+                magicAcc = magicAcc + actor:getMerit(xi.combat.magicHitRate.elementTable[spellElement][5])
             end
 
             -- Category 2
@@ -229,8 +229,8 @@ xi.combat.magicHitRate.calculateTargetMagicEvasion = function(actor, target, spe
     -- Elemental magic evasion.
     if spellElement ~= xi.magic.ele.NONE then
         -- Mod set in database for mobs. Base 0 means not resistant nor weak. Bar-element spells included here.
-        resMod     = target:getMod(elementTable[spellElement][3])
-        resistRank = target:getMod(elementTable[spellElement][4])
+        resMod     = target:getMod(xi.combat.magicHitRate.elementTable[spellElement][3])
+        resistRank = target:getMod(xi.combat.magicHitRate.elementTable[spellElement][4])
 
         if resistRank > 4 then
             resistRank = utils.clamp(resistRank - rankModifier, 4, 11)
@@ -272,7 +272,7 @@ end
 
 xi.combat.magicHitRate.calculateResistRate = function(actor, target, skillType, spellElement, magicHitRate, rankModifier)
     local targetResistRate = 0 -- The variable we return.
-    local targetResistRank = target:getMod(elementTable[spellElement][4])
+    local targetResistRank = target:getMod(xi.combat.magicHitRate.elementTable[spellElement][4])
 
     ----------------------------------------
     -- Handle "Magic Shield" status effect.

--- a/scripts/globals/effects/addle.lua
+++ b/scripts/globals/effects/addle.lua
@@ -6,6 +6,9 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.FASTCAST, -effect:getPower()) -- Yes we are subtracting in addMod()
     target:addMod(xi.mod.MACC, -effect:getSubPower()) -- This is intentional
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.ADDLE_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/bind.lua
+++ b/scripts/globals/effects/bind.lua
@@ -6,6 +6,9 @@ local effectObject = {}
 effectObject.onEffectGain = function(target, effect)
     effect:setPower(target:getSpeed())
     target:setSpeed(0)
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.BIND_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/blindness.lua
+++ b/scripts/globals/effects/blindness.lua
@@ -5,6 +5,10 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ACC, -effect:getPower())
+    target:addMod(xi.mod.RACC, -effect:getPower())
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.BLIND_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -12,6 +16,7 @@ end
 
 effectObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ACC, -effect:getPower())
+    target:delMod(xi.mod.RACC, -effect:getPower())
 end
 
 return effectObject

--- a/scripts/globals/effects/paralysis.lua
+++ b/scripts/globals/effects/paralysis.lua
@@ -5,6 +5,9 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.PARALYZE, effect:getPower())
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.PARALYZE_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/petrification.lua
+++ b/scripts/globals/effects/petrification.lua
@@ -4,6 +4,8 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- Immunobreak reset.
+    target:setMod(xi.mod.PETRIFY_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/poison.lua
+++ b/scripts/globals/effects/poison.lua
@@ -5,6 +5,9 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.REGEN_DOWN, effect:getPower())
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.POISON_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/silence.lua
+++ b/scripts/globals/effects/silence.lua
@@ -4,6 +4,8 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- Immunobreak reset.
+    target:setMod(xi.mod.SILENCE_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/sleep.lua
+++ b/scripts/globals/effects/sleep.lua
@@ -4,6 +4,8 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    -- Immunobreak reset.
+    target:setMod(xi.mod.SLEEP_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/slow.lua
+++ b/scripts/globals/effects/slow.lua
@@ -5,6 +5,9 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.HASTE_MAGIC, -effect:getPower())
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.SLOW_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/effects/weight.lua
+++ b/scripts/globals/effects/weight.lua
@@ -5,6 +5,9 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.MOVE, -effect:getPower())
+
+    -- Immunobreak reset.
+    target:setMod(xi.mod.GRAVITY_IMMUNOBREAK, 0)
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -385,13 +385,13 @@ xi.spells.damage.calculateResist = function(caster, target, spellGroup, skillTyp
     local magicAcc = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
 
     -- Get Target Magic Evasion.
-    local magicEva = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, false, 0) -- false = not an enfeeble. 0 = No meva modifier.
+    local magicEva = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, false, 0, 0) -- false = not an enfeeble.
 
     -- Calculate Magic Hit Rate with the previous 2 values.
     local magicHitRate = xi.combat.magicHitRate.calculateMagicHitRate(magicAcc, magicEva)
 
     -- Calculate Resist Rate.
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, skillType, spellElement, magicHitRate)
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, skillType, spellElement, magicHitRate, 0)
 
     return resist
 end

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -14,76 +14,76 @@ xi.spells = xi.spells or {}
 xi.spells.enfeebling = xi.spells.enfeebling or {}
 -----------------------------------
 local pTable =
-{   --                                 1                             2               3                   4                    5      6    7         8       9    10        11         12       13
-    --                 [Spell ID ] = { Effect,                       Stat-Used,      Resist-Mod,         MEVA-Mod,            pBase, DoT, Duration, Resist, msg, immunity, pSaboteur, pResist, mAcc },
+{   --                                 1                             2           3                   4                    5      6    7         8       9    10        11         12
+    --                 [Spell ID ] = { Effect,                       Stat-Used,  Resist-Mod,         MEVA-Mod,            pBase, DoT, Duration, Resist, msg, immunity, pSaboteur, mAcc },
 
     -- Black Magic
-    [xi.magic.spell.BIND         ] = { xi.effect.BIND,               xi.mod.INT,     xi.mod.BINDRES,     xi.mod.BIND_MEVA,        0,   0,       60,      2,   0,        4, false,     false,     0 },
-    [xi.magic.spell.BINDGA       ] = { xi.effect.BIND,               xi.mod.INT,     xi.mod.BINDRES,     xi.mod.BIND_MEVA,        0,   0,       60,      2,   0,        4, false,     false,     0 },
-    [xi.magic.spell.BLIND        ] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,      false,     0 },
-    [xi.magic.spell.BLIND_II     ] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,      false,     0 },
-    [xi.magic.spell.BLINDGA      ] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,      false,     0 },
-    [xi.magic.spell.BREAK        ] = { xi.effect.PETRIFICATION,      xi.mod.INT,     xi.mod.PETRIFYRES,  xi.mod.PETRIFY_MEVA,     1,   0,       30,      2,   0,        0, false,     false,     0 },
-    [xi.magic.spell.BREAKGA      ] = { xi.effect.PETRIFICATION,      xi.mod.INT,     xi.mod.PETRIFYRES,  xi.mod.PETRIFY_MEVA,     1,   0,       30,      2,   0,        0, false,     false,     0 },
-    [xi.magic.spell.BURN         ] = { xi.effect.BURN,               xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.CHOKE        ] = { xi.effect.CHOKE,              xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.CURSE        ] = { xi.effect.CURSE_I,            xi.mod.INT,     xi.mod.CURSERES,    xi.mod.CURSE_MEVA,      50,   0,      300,      2,   0,        0, false,     false,     0 },
-    [xi.magic.spell.DISPEL       ] = { xi.effect.NONE,               xi.mod.INT,     0,                  0,                       0,   0,        0,      4,   0,        0, false,     false,   175 },
-    [xi.magic.spell.DISPELGA     ] = { xi.effect.NONE,               xi.mod.INT,     0,                  0,                       0,   0,        0,      4,   0,        0, false,     false,     0 },
-    [xi.magic.spell.DISTRACT     ] = { xi.effect.EVASION_DOWN,       xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.DISTRACT_II  ] = { xi.effect.EVASION_DOWN,       xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.DISTRACT_III ] = { xi.effect.EVASION_DOWN,       xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.DROWN        ] = { xi.effect.DROWN,              xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.FRAZZLE      ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.FRAZZLE_II   ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.FRAZZLE_III  ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND,     0,                  0,                       0,   0,      120,      2,   0,        0, true,      true ,   150 },
-    [xi.magic.spell.FROST        ] = { xi.effect.FROST,              xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.GRAVITY      ] = { xi.effect.WEIGHT,             xi.mod.INT,     xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    26,   0,      120,      2,   0,        2, true,      false,     0 },
-    [xi.magic.spell.GRAVITY_II   ] = { xi.effect.WEIGHT,             xi.mod.INT,     xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    32,   0,      180,      2,   0,        2, true,      false,     0 },
-    [xi.magic.spell.GRAVIGA      ] = { xi.effect.WEIGHT,             xi.mod.INT,     xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    50,   0,      120,      2,   0,        2, true,      false,     0 },
-    [xi.magic.spell.POISON       ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,       90,      2,   0,      256, true,      false,     0 },
-    [xi.magic.spell.POISON_II    ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      120,      2,   0,      256, true,      false,    30 },
-    [xi.magic.spell.POISON_III   ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      150,      2,   0,      256, true,      false,     0 },
-    [xi.magic.spell.POISONGA     ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,       90,      2,   0,      256, true,      false,     0 },
-    [xi.magic.spell.POISONGA_II  ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      120,      2,   0,      256, true,      false,     0 },
-    [xi.magic.spell.POISONGA_III ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      150,      2,   0,      256, true,      false,     0 },
-    [xi.magic.spell.RASP         ] = { xi.effect.RASP,               xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.SHOCK        ] = { xi.effect.SHOCK,              xi.mod.INT,     0,                  0,                       0,   3,       90,      3,   1,        0, true,      false,     0 },
-    [xi.magic.spell.SLEEP        ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.SLEEP_II     ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.SLEEPGA      ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.SLEEPGA_II   ] = { xi.effect.SLEEP_I,            xi.mod.INT,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,     false,     0 },
-    [xi.magic.spell.STUN         ] = { xi.effect.STUN,               xi.mod.INT,     xi.mod.STUNRES,     xi.mod.STUN_MEVA,        1,   0,        5,      4,   0,        8, false,     false,   200 },
-    [xi.magic.spell.VIRUS        ] = { xi.effect.PLAGUE,             xi.mod.INT,     xi.mod.VIRUSRES,    xi.mod.VIRUS_MEVA,       5,   3,       60,      2,   0,        0, false,     false,     0 },
+    [xi.magic.spell.BIND         ] = { xi.effect.BIND,               xi.mod.INT, xi.mod.BINDRES,     xi.mod.BIND_MEVA,        0,   0,       60,      2,   0,        4, false,       0 },
+    [xi.magic.spell.BINDGA       ] = { xi.effect.BIND,               xi.mod.INT, xi.mod.BINDRES,     xi.mod.BIND_MEVA,        0,   0,       60,      2,   0,        4, false,       0 },
+    [xi.magic.spell.BLIND        ] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,        0 },
+    [xi.magic.spell.BLIND_II     ] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,        0 },
+    [xi.magic.spell.BLINDGA      ] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,       0,   0,      180,      2,   0,       64, true,        0 },
+    [xi.magic.spell.BREAK        ] = { xi.effect.PETRIFICATION,      xi.mod.INT, xi.mod.PETRIFYRES,  xi.mod.PETRIFY_MEVA,     1,   0,       30,      2,   0,        0, false,       0 },
+    [xi.magic.spell.BREAKGA      ] = { xi.effect.PETRIFICATION,      xi.mod.INT, xi.mod.PETRIFYRES,  xi.mod.PETRIFY_MEVA,     1,   0,       30,      2,   0,        0, false,       0 },
+    [xi.magic.spell.BURN         ] = { xi.effect.BURN,               xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.CHOKE        ] = { xi.effect.CHOKE,              xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.CURSE        ] = { xi.effect.CURSE_I,            xi.mod.INT, xi.mod.CURSERES,    xi.mod.CURSE_MEVA,      50,   0,      300,      2,   0,        0, false,       0 },
+    [xi.magic.spell.DISPEL       ] = { xi.effect.NONE,               xi.mod.INT, 0,                  0,                       0,   0,        0,      4,   0,        0, false,     175 },
+    [xi.magic.spell.DISPELGA     ] = { xi.effect.NONE,               xi.mod.INT, 0,                  0,                       0,   0,        0,      4,   0,        0, false,       0 },
+    [xi.magic.spell.DISTRACT     ] = { xi.effect.EVASION_DOWN,       xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.DISTRACT_II  ] = { xi.effect.EVASION_DOWN,       xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.DISTRACT_III ] = { xi.effect.EVASION_DOWN,       xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.DROWN        ] = { xi.effect.DROWN,              xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.FRAZZLE      ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.FRAZZLE_II   ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.FRAZZLE_III  ] = { xi.effect.MAGIC_EVASION_DOWN, xi.mod.MND, 0,                  0,                       0,   0,      120,      2,   0,        0, true,      150 },
+    [xi.magic.spell.FROST        ] = { xi.effect.FROST,              xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.GRAVITY      ] = { xi.effect.WEIGHT,             xi.mod.INT, xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    26,   0,      120,      2,   0,        2, true,        0 },
+    [xi.magic.spell.GRAVITY_II   ] = { xi.effect.WEIGHT,             xi.mod.INT, xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    32,   0,      180,      2,   0,        2, true,        0 },
+    [xi.magic.spell.GRAVIGA      ] = { xi.effect.WEIGHT,             xi.mod.INT, xi.mod.GRAVITYRES,  xi.mod.GRAVITY_MEVA,    50,   0,      120,      2,   0,        2, true,        0 },
+    [xi.magic.spell.POISON       ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,       90,      2,   0,      256, true,        0 },
+    [xi.magic.spell.POISON_II    ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      120,      2,   0,      256, true,       30 },
+    [xi.magic.spell.POISON_III   ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      150,      2,   0,      256, true,        0 },
+    [xi.magic.spell.POISONGA     ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,       90,      2,   0,      256, true,        0 },
+    [xi.magic.spell.POISONGA_II  ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      120,      2,   0,      256, true,        0 },
+    [xi.magic.spell.POISONGA_III ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      0,   3,      150,      2,   0,      256, true,        0 },
+    [xi.magic.spell.RASP         ] = { xi.effect.RASP,               xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.SHOCK        ] = { xi.effect.SHOCK,              xi.mod.INT, 0,                  0,                       0,   3,       90,      3,   1,        0, true,        0 },
+    [xi.magic.spell.SLEEP        ] = { xi.effect.SLEEP_I,            xi.mod.INT, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,       0 },
+    [xi.magic.spell.SLEEP_II     ] = { xi.effect.SLEEP_I,            xi.mod.INT, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,       0 },
+    [xi.magic.spell.SLEEPGA      ] = { xi.effect.SLEEP_I,            xi.mod.INT, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       1,   0,       60,      2,   0,        1, false,       0 },
+    [xi.magic.spell.SLEEPGA_II   ] = { xi.effect.SLEEP_I,            xi.mod.INT, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   0,        1, false,       0 },
+    [xi.magic.spell.STUN         ] = { xi.effect.STUN,               xi.mod.INT, xi.mod.STUNRES,     xi.mod.STUN_MEVA,        1,   0,        5,      4,   0,        8, false,     200 },
+    [xi.magic.spell.VIRUS        ] = { xi.effect.PLAGUE,             xi.mod.INT, xi.mod.VIRUSRES,    xi.mod.VIRUS_MEVA,       5,   3,       60,      2,   0,        0, false,       0 },
 
     -- White Magic
-    [xi.magic.spell.FLASH        ] = { xi.effect.FLASH,              xi.mod.MND,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,     300,   0,       12,      4,   0,        0, true,      false,   200 },
-    [xi.magic.spell.INUNDATION   ] = { xi.effect.INUNDATION,         xi.mod.MND,     0,                  0,                       1,   0,      300,      5,   0,        0, false,     false,     0 },
-    [xi.magic.spell.PARALYZE     ] = { xi.effect.PARALYSIS,          xi.mod.MND,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,      true ,   -10 },
-    [xi.magic.spell.PARALYZE_II  ] = { xi.effect.PARALYSIS,          xi.mod.MND,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,      true ,     0 },
-    [xi.magic.spell.PARALYGA     ] = { xi.effect.PARALYSIS,          xi.mod.MND,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,      true ,     0 },
-    [xi.magic.spell.REPOSE       ] = { xi.effect.SLEEP_II,           xi.mod.MND,     xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   1,        1, false,     false,     0 },
-    [xi.magic.spell.SILENCE      ] = { xi.effect.SILENCE,            xi.mod.MND,     xi.mod.SILENCERES,  xi.mod.SILENCE_MEVA,     1,   0,      120,      2,   0,       16, false,     false,     0 },
-    [xi.magic.spell.SILENCEGA    ] = { xi.effect.SILENCE,            xi.mod.MND,     xi.mod.SILENCERES,  xi.mod.SILENCE_MEVA,     1,   0,      120,      2,   0,       16, false,     false,     0 },
-    [xi.magic.spell.SLOW         ] = { xi.effect.SLOW,               xi.mod.MND,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,      true ,    10 },
-    [xi.magic.spell.SLOW_II      ] = { xi.effect.SLOW,               xi.mod.MND,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,      true ,    10 },
-    [xi.magic.spell.SLOWGA       ] = { xi.effect.SLOW,               xi.mod.MND,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,      true ,     0 },
+    [xi.magic.spell.FLASH        ] = { xi.effect.FLASH,              xi.mod.MND, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,     300,   0,       12,      4,   0,        0, true,      200 },
+    [xi.magic.spell.INUNDATION   ] = { xi.effect.INUNDATION,         xi.mod.MND, 0,                  0,                       1,   0,      300,      5,   0,        0, false,       0 },
+    [xi.magic.spell.PARALYZE     ] = { xi.effect.PARALYSIS,          xi.mod.MND, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,      -10 },
+    [xi.magic.spell.PARALYZE_II  ] = { xi.effect.PARALYSIS,          xi.mod.MND, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,        0 },
+    [xi.magic.spell.PARALYGA     ] = { xi.effect.PARALYSIS,          xi.mod.MND, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,    0,   0,      120,      2,   0,       32, true,        0 },
+    [xi.magic.spell.REPOSE       ] = { xi.effect.SLEEP_II,           xi.mod.MND, xi.mod.SLEEPRES,    xi.mod.SLEEP_MEVA,       2,   0,       90,      2,   1,        1, false,       0 },
+    [xi.magic.spell.SILENCE      ] = { xi.effect.SILENCE,            xi.mod.MND, xi.mod.SILENCERES,  xi.mod.SILENCE_MEVA,     1,   0,      120,      2,   0,       16, false,       0 },
+    [xi.magic.spell.SILENCEGA    ] = { xi.effect.SILENCE,            xi.mod.MND, xi.mod.SILENCERES,  xi.mod.SILENCE_MEVA,     1,   0,      120,      2,   0,       16, false,       0 },
+    [xi.magic.spell.SLOW         ] = { xi.effect.SLOW,               xi.mod.MND, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,       10 },
+    [xi.magic.spell.SLOW_II      ] = { xi.effect.SLOW,               xi.mod.MND, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,       10 },
+    [xi.magic.spell.SLOWGA       ] = { xi.effect.SLOW,               xi.mod.MND, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,        0,   0,      180,      2,   0,      128, true,        0 },
 
     -- Ninjutsu
-    [xi.magic.spell.AISHA_ICHI   ] = { xi.effect.ATTACK_DOWN,        xi.mod.INT,     0,                  0,                      15,   0,      120,      4,   1,        0, false,     false,     0 },
-    [xi.magic.spell.DOKUMORI_ICHI] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,      3,   3,       60,      2,   0,      256, false,     false,     0 },
-    [xi.magic.spell.DOKUMORI_NI  ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,     10,   3,      120,      2,   0,      256, false,     false,     0 },
-    [xi.magic.spell.DOKUMORI_SAN ] = { xi.effect.POISON,             xi.mod.INT,     xi.mod.POISONRES,   xi.mod.POISON_MEVA,     20,   3,      360,      2,   0,      256, false,     false,     0 },
-    [xi.magic.spell.HOJO_ICHI    ] = { xi.effect.SLOW,               xi.mod.INT,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     1465,   0,      180,      2,   0,      128, false,     false,     0 },
-    [xi.magic.spell.HOJO_NI      ] = { xi.effect.SLOW,               xi.mod.INT,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     1953,   0,      300,      2,   0,      128, false,     false,     0 },
-    [xi.magic.spell.HOJO_SAN     ] = { xi.effect.SLOW,               xi.mod.INT,     xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     2930,   0,      420,      2,   0,      128, false,     false,     0 },
-    [xi.magic.spell.JUBAKU_ICHI  ] = { xi.effect.PARALYSIS,          xi.mod.INT,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   20,   0,      180,      2,   1,       32, false,     false,     0 },
-    [xi.magic.spell.JUBAKU_NI    ] = { xi.effect.PARALYSIS,          xi.mod.INT,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   30,   0,      300,      2,   1,       32, false,     false,     0 },
-    [xi.magic.spell.JUBAKU_SAN   ] = { xi.effect.PARALYSIS,          xi.mod.INT,     xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   35,   0,      420,      2,   1,       32, false,     false,     0 },
-    [xi.magic.spell.KURAYAMI_ICHI] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      20,   0,      180,      2,   0,       64, false,     false,     0 },
-    [xi.magic.spell.KURAYAMI_NI  ] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      30,   0,      300,      2,   0,       64, false,     false,     0 },
-    [xi.magic.spell.KURAYAMI_SAN ] = { xi.effect.BLINDNESS,          xi.mod.INT,     xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      40,   0,      420,      2,   0,       64, false,     false,     0 },
-    [xi.magic.spell.YURIN_ICHI   ] = { xi.effect.INHIBIT_TP,         xi.mod.INT,     0,                  0,                      10,   0,      180,      3,   1,        0, false,     false,     0 },
+    [xi.magic.spell.AISHA_ICHI   ] = { xi.effect.ATTACK_DOWN,        xi.mod.INT, 0,                  0,                      15,   0,      120,      4,   1,        0, false,       0 },
+    [xi.magic.spell.DOKUMORI_ICHI] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,      3,   3,       60,      2,   0,      256, false,       0 },
+    [xi.magic.spell.DOKUMORI_NI  ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,     10,   3,      120,      2,   0,      256, false,       0 },
+    [xi.magic.spell.DOKUMORI_SAN ] = { xi.effect.POISON,             xi.mod.INT, xi.mod.POISONRES,   xi.mod.POISON_MEVA,     20,   3,      360,      2,   0,      256, false,       0 },
+    [xi.magic.spell.HOJO_ICHI    ] = { xi.effect.SLOW,               xi.mod.INT, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     1465,   0,      180,      2,   0,      128, false,       0 },
+    [xi.magic.spell.HOJO_NI      ] = { xi.effect.SLOW,               xi.mod.INT, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     1953,   0,      300,      2,   0,      128, false,       0 },
+    [xi.magic.spell.HOJO_SAN     ] = { xi.effect.SLOW,               xi.mod.INT, xi.mod.SLOWRES,     xi.mod.SLOW_MEVA,     2930,   0,      420,      2,   0,      128, false,       0 },
+    [xi.magic.spell.JUBAKU_ICHI  ] = { xi.effect.PARALYSIS,          xi.mod.INT, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   20,   0,      180,      2,   1,       32, false,       0 },
+    [xi.magic.spell.JUBAKU_NI    ] = { xi.effect.PARALYSIS,          xi.mod.INT, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   30,   0,      300,      2,   1,       32, false,       0 },
+    [xi.magic.spell.JUBAKU_SAN   ] = { xi.effect.PARALYSIS,          xi.mod.INT, xi.mod.PARALYZERES, xi.mod.PARALYZE_MEVA,   35,   0,      420,      2,   1,       32, false,       0 },
+    [xi.magic.spell.KURAYAMI_ICHI] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      20,   0,      180,      2,   0,       64, false,       0 },
+    [xi.magic.spell.KURAYAMI_NI  ] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      30,   0,      300,      2,   0,       64, false,       0 },
+    [xi.magic.spell.KURAYAMI_SAN ] = { xi.effect.BLINDNESS,          xi.mod.INT, xi.mod.BLINDRES,    xi.mod.BLIND_MEVA,      40,   0,      420,      2,   0,       64, false,       0 },
+    [xi.magic.spell.YURIN_ICHI   ] = { xi.effect.INHIBIT_TP,         xi.mod.INT, 0,                  0,                      10,   0,      180,      3,   1,        0, false,       0 },
 }
 
 local elementalDebuffTable =
@@ -373,21 +373,13 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local mEvaMod      = pTable[spellId][4]
     local resistStages = pTable[spellId][8]
     local message      = pTable[spellId][9]
-    local bonusMacc    = pTable[spellId][13]
+    local bonusMacc    = pTable[spellId][12]
 
     -- Magic Hit Rate calculations.
     local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
     local magicEva     = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, spellElement, true, mEvaMod)
     local magicHitRate = xi.combat.magicHitRate.calculateMagicHitRate(magicAcc, magicEva)
-
-    -- Calculate individualy resist rates for potency and duration.
-    local resistDuration = xi.combat.magicHitRate.calculateResistRate(caster, target, skillType, spellElement, magicHitRate)
-    local resistPotency  = 1
-
-    -- Check if potency is affected by resist rate.
-    if pTable[spellId][12] then
-        resistPotency  = xi.combat.magicHitRate.calculateResistRate(caster, target, skillType, spellElement, magicHitRate)
-    end
+    local resistRate   = xi.combat.magicHitRate.calculateResistRate(caster, target, skillType, spellElement, magicHitRate)
 
     ------------------------------
     -- STEP 3: Check if spell resists.
@@ -398,13 +390,11 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
             skillType == xi.skill.ENFEEBLING_MAGIC and
             caster:hasStatusEffect(xi.effect.STYMIE)
         then
-            resistDuration = 1
-            resistPotency  = 1
+            resistRate = 1
 
         -- Fealty
         elseif target:hasStatusEffect(xi.effect.FEALTY) then
-            resistDuration = 0
-            resistPotency  = 0
+            resistRate = 1
         end
     end
 
@@ -419,11 +409,10 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     ------------------------------
     -- Calculate Duration.
     local duration = xi.spells.enfeebling.calculateDuration(caster, target, spellId, spellEffect, skillType)
-    duration       = math.floor(duration * resistDuration)
+    duration       = math.floor(duration * resistRate)
 
     -- Calculate potency.
     local potency = xi.spells.enfeebling.calculatePotency(caster, target, spellId, spellEffect, skillType, statUsed)
-    potency       = math.floor(potency * resistPotency)
 
     -- Set tick (Poison, etc...)
     local tick = pTable[spellId][6]

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -328,6 +328,18 @@ enum class Mod
     DEATH_MEVA    = 215,
     STATUS_MEVA   = 216,
 
+    // Status effect Immunobreak modifiers.
+    SLEEP_IMMUNOBREAK    = 261,
+    POISON_IMMUNOBREAK   = 262,
+    PARALYZE_IMMUNOBREAK = 263,
+    BLIND_IMMUNOBREAK    = 264,
+    SILENCE_IMMUNOBREAK  = 265,
+    PETRIFY_IMMUNOBREAK  = 266,
+    BIND_IMMUNOBREAK     = 267,
+    GRAVITY_IMMUNOBREAK  = 268,
+    SLOW_IMMUNOBREAK     = 269,
+    ADDLE_IMMUNOBREAK    = 270,
+
     PARALYZE      = 257, // Paralyze -- percent chance to proc
     MIJIN_RERAISE = 258, // Augments Mijin Gakure
     DUAL_WIELD    = 259, // Percent reduction in dual wield delay.
@@ -969,7 +981,7 @@ enum class Mod
     // 138 to 143
     // 156 to 159
     // 217 to 223
-    // 261 to 280
+    // 271 to 280
     //
     // SPARE = 1076 and onward
 };


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Implements Immunobreak system.
- Corrects blind not giving RACC penaly
- Removes potency from the resistance check.
- Converts magic-hit-rate elemental table from local to global, to easily check certain elemental modifiers with ease. (Consider moving this to somewhere else in a different PR.)

TY Spicy for all the info.

## Steps to test these changes
I heavily suggest to review by commit.

Cast enfeebling spells that can immunobreak on mobs that can resist you.

NOTE: The mob must have a resistance rank of 5 and avobe to be able to be immunobroken. This values can be artificialy set via !setmod GM command. Someday, we will have correct values in mob_resistances.sql.
