### PR TITLE
[core] Update TP reduction with more statuses, larger comment

### DIFF
--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -158,7 +158,10 @@ void CMobSkillState::Cleanup(time_point tick)
         // But lose 25% at < 2900 TP.
         // Testing was done via charm on a steelshell, methodology was the following on BST/DRK with a scythe
         // charm -> build tp -> leave -> stun -> interrupt TP move with weapon bash -> charm and check TP. Note that weapon bash incurs damage and thus adds TP.
-        if (m_PEntity->StatusEffectContainer && m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT::EFFECT_STUN))
+        // Note: this is very incomplete. Further testing shows that other statuses also reduce TP but in addition it seems that specific mobskills may reduce TP more or less than these numbers
+        // Thus while incomplete, is better than nothing.
+        if (m_PEntity->StatusEffectContainer &&
+            m_PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT::EFFECT_STUN, EFFECT::EFFECT_TERROR, EFFECT::EFFECT_PETRIFICATION, EFFECT::EFFECT_SLEEP, EFFECT::EFFECT_SLEEP_II, EFFECT::EFFECT_LULLABY }))
         {
             int16 tp = m_spentTP;
             if (tp >= 2900)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Update TP reduction mechanic on mob TP move stunning with more statuses such as petrify, terror, sleeps, etc

## Steps to test these changes

Terror/Petrify/Sleep/Lullaby mob during a TP move and have it also reduce tp.