### PR TITLE
[gear sets] Account for items that belong to multiple sets

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2541,19 +2541,13 @@ xi.gear_sets.createItemToSetId = function()
 
     for setId, setData in pairs(gearSets) do
         for _, itemId in ipairs(setData.items) do
-            if itemTable[itemId] ~= nil then -- Handle items that belong to multiple sets such as Virtue Stone
-                if type(itemTable[itemId]) == 'table' then
-                    table.insert(itemTable[itemId], setId)
-                else
-                    local setIdTable = {}
+            if itemTable[itemId] == nil then
+                local setIdTable = {}
 
-                    setIdTable[1] = itemTable[itemId]
-                    setIdTable[2] = setId
-                    itemTable[itemId] = setIdTable
-                end
-            else
-                itemTable[itemId] = setId
+                itemTable[itemId] = setIdTable
             end
+
+            table.insert(itemTable[itemId], setId)
         end
     end
 
@@ -2574,12 +2568,8 @@ xi.gear_sets.checkForGearSet = function(player)
         local setId   = xi.gear_sets.itemToSetId[equipId]
 
         if setId then
-            if type(setId) == 'table' then
-                for _, v in ipairs(setId) do
-                    equippedSets[v] = equippedSets[v] and (equippedSets[v] + 1) or 1
-                end
-            else
-                equippedSets[setId] = equippedSets[setId] and (equippedSets[setId] + 1) or 1
+            for _, v in ipairs(setId) do
+                equippedSets[v] = equippedSets[v] and (equippedSets[v] + 1) or 1
             end
         end
     end

--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -2541,7 +2541,19 @@ xi.gear_sets.createItemToSetId = function()
 
     for setId, setData in pairs(gearSets) do
         for _, itemId in ipairs(setData.items) do
-            itemTable[itemId] = setId
+            if itemTable[itemId] ~= nil then -- Handle items that belong to multiple sets such as Virtue Stone
+                if type(itemTable[itemId]) == 'table' then
+                    table.insert(itemTable[itemId], setId)
+                else
+                    local setIdTable = {}
+
+                    setIdTable[1] = itemTable[itemId]
+                    setIdTable[2] = setId
+                    itemTable[itemId] = setIdTable
+                end
+            else
+                itemTable[itemId] = setId
+            end
         end
     end
 
@@ -2562,7 +2574,13 @@ xi.gear_sets.checkForGearSet = function(player)
         local setId   = xi.gear_sets.itemToSetId[equipId]
 
         if setId then
-            equippedSets[setId] = equippedSets[setId] and (equippedSets[setId] + 1) or 1
+            if type(setId) == 'table' then
+                for _, v in ipairs(setId) do
+                    equippedSets[v] = equippedSets[v] and (equippedSets[v] + 1) or 1
+                end
+            else
+                equippedSets[setId] = equippedSets[setId] and (equippedSets[setId] + 1) or 1
+            end
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Before this commit, items such as Virtue Stone only activates one of the sets it belongs to (which happens to be the Hope Staff) because its entry in the xi.gear_sets.itemToSetId table only holds one setId, fix this by turning the entry into an array containing all the setIds the item belongs to.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !changejob rdm 99
2. !additem 17710
3. !additem 18244
4. Equip both items, observe how !getmod AMMO_SWING returns 0
5. Apply this patch
6. !getmod AMMO_SWING should now returns 50
<!-- Clear and detailed steps to test your changes here -->
