### PR TITLE
add checkbox_total variable to github workflow

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -19,14 +19,16 @@ jobs:
                 return string.split(word).length - 1;
             }
 
-            const event_type = "${{ github.event_name }}"
-            var   body_text  = ""
-            var   type_name  = ""
+            const event_type     = "${{ github.event_name }}"
+            var   checkbox_total = 3
+            var   body_text      = ""
+            var   type_name      = ""
 
             if (event_type === "pull_request_target")
             {
-                body_text = context.payload.pull_request.body
-                type_name = "PR"
+                body_text      = context.payload.pull_request.body
+                type_name      = "PR"
+                checkbox_total = 4
             }
             else // issue
             {
@@ -41,12 +43,9 @@ jobs:
             console.log(`body_text: ${body_text}`)
             console.log(`type_name: ${type_name}`)
 
-            // Count the filled in checkboxes:
-            // 1x pre-filled
-            // 3x to be filled
-            // Minimum total: 4
+            // Count the filled in checkboxes, comparing checkbox_count to checkbox_total
             const checkbox_count = count_instances(body_text, "[x]")
-            if (checkbox_count < 4)
+            if (checkbox_count < checkbox_total)
             {
                 console.log(`Found ${checkbox_count} completed checkboxes. Leaving a reminder comment.`)
                 const result = await github.rest.issues.createComment({


### PR DESCRIPTION
we needed to have a variable because this check happens on both issues and PRs, but they use a different number of checkboxes

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
we needed to have a variable because this check happens on both issues and PRs, but they use a different number of checkboxes

## Steps to test these changes

~~The variable syntax isn't clear to me what we have doesn't look like GitHub's documentation, so this is not yet tested. I've never seen variables in yaml specify a datatype before, but the existing ones do . "why are these intergers const?"~~

_its frakkin javascipt_