### PR TITLE
[Enum] Move loot file to enum folder

### DIFF
--- a/scripts/battlefields/Temenos/central_temenos_basement.lua
+++ b/scripts/battlefields/Temenos/central_temenos_basement.lua
@@ -59,7 +59,7 @@ content.groups =
                 mob:addListener("ITEM_DROPS", "ITEM_DROPS_AERN", function(mobArg, loot)
                     local quantity = math.min(3, mob:getLocalVar("AERN_RERAISES"))
 
-                    loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARANTEED, quantity)
+                    loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.drop_rate.GUARANTEED, quantity)
                 end)
             end
 

--- a/scripts/battlefields/Temenos/central_temenos_basement.lua
+++ b/scripts/battlefields/Temenos/central_temenos_basement.lua
@@ -9,7 +9,6 @@ local ID = require("scripts/zones/Temenos/IDs")
 require("scripts/globals/battlefield")
 require("scripts/globals/limbus")
 require("scripts/globals/items")
-require("scripts/globals/loot")
 -----------------------------------
 
 local content = Limbus:new({

--- a/scripts/enum/drop_rate.lua
+++ b/scripts/enum/drop_rate.lua
@@ -1,11 +1,9 @@
-xi = xi or {}
-xi.loot = xi.loot or {}
-
 ------------------------------------
 -- Drop Rarity Rates
 ------------------------------------
+xi = xi or {}
 
-xi.loot.rate =
+xi.drop_rate =
 {
     NEVER       = 0, --   0.00%
     ULTRA_RARE  = 1, --   0.10%

--- a/scripts/zones/Apollyon/mobs/Gunpod.lua
+++ b/scripts/zones/Apollyon/mobs/Gunpod.lua
@@ -61,12 +61,12 @@ entity.onMobInitialize = function(mob)
             }
         else
             -- Acient Beastcoins
-            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.GUARANTEED, 5)
-            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.loot.rate.COMMON)
+            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.drop_rate.GUARANTEED, 5)
+            loot:addItem(xi.items.ANCIENT_BEASTCOIN, xi.drop_rate.COMMON)
             return
         end
 
-        loot:addGroup(xi.loot.rate.GUARANTEED, group)
+        loot:addGroup(xi.drop_rate.GUARANTEED, group)
     end)
 end
 

--- a/scripts/zones/Apollyon/mobs/Gunpod.lua
+++ b/scripts/zones/Apollyon/mobs/Gunpod.lua
@@ -2,9 +2,6 @@
 -- Area: Apollyon Central
 --  Mob: Gunpod
 -----------------------------------
-require("scripts/globals/loot")
------------------------------------
-
 local entity = {}
 
 entity.onMobInitialize = function(mob)

--- a/scripts/zones/Gusgen_Mines/npcs/qm1.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm1.lua
@@ -4,7 +4,6 @@
 -- Spawns Aroma Fly - RSE Satchets
 -----------------------------------
 local ID = require("scripts/zones/Gusgen_Mines/IDs")
-require("scripts/globals/loot")
 require("scripts/globals/npc_util")
 -----------------------------------
 local entity = {}

--- a/scripts/zones/Gusgen_Mines/npcs/qm1.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/qm1.lua
@@ -29,7 +29,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_FLY):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -14,14 +14,14 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:addListener("ITEM_DROPS", "ITEM_DROPS_PADFOOD", function(mobArg, loot)
         if mob:getID() == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
-            loot:addGroup(xi.loot.rate.GUARANTEED,
+            loot:addGroup(xi.drop_rate.GUARANTEED,
             {
                 { item = xi.items.ASSAILANTS_RING, weight = 750 },
                 { item = xi.items.ASTRAL_EARRING, weight = 250 },
             })
         else
-            loot:addItem(xi.items.SHEEPSKIN, xi.loot.rate.VERY_COMMON)
-            loot:addItem(xi.items.LANOLIN_CUBE, xi.loot.rate.GUARANTEED)
+            loot:addItem(xi.items.SHEEPSKIN, xi.drop_rate.VERY_COMMON)
+            loot:addItem(xi.items.LANOLIN_CUBE, xi.drop_rate.GUARANTEED)
         end
     end)
 end

--- a/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_CRAWLER):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/scripts/zones/Ordelles_Caves/npcs/qm1.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/qm1.lua
@@ -28,7 +28,7 @@ entity.onTrigger = function(player, npc)
 
         local item = 18246 + playerRace - raceOffset
         GetMobByID(ID.mob.AROMA_LEECH):addListener("ITEM_DROPS", "ITEM_DROPS_RSE", function(mob, loot)
-            loot:addItemFixed(item, xi.loot.rate.UNCOMMON)
+            loot:addItemFixed(item, xi.drop_rate.UNCOMMON)
         end)
 
         local newSpawn = math.random(1, 3) -- determine new spawn point for ???

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -29,6 +29,7 @@ deprecated_functions = [
 
 deprecated_requires = [
     "scripts/globals/keyitems",
+    "scripts/globals/loot",
     "scripts/globals/status",
     "scripts/globals/settings",
     "scripts/enum",


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves loot file, containing the drop rate... rates, to enum folder.
- Renames `xi.loot.rate` to `xi.drop_rate`
- Removes unneeded requires
- Renames the 11 uses in the code and the file name.

## Steps to test these changes

No real changes made.
