### PR TITLE
Fix Chainbound duration/delay to match retail (values pulled from skillchains addon)

### DIFF
--- a/scripts/globals/abilities/konzen-ittai.lua
+++ b/scripts/globals/abilities/konzen-ittai.lua
@@ -23,7 +23,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
         not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
         not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
     then
-        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 2, 0, 5, 0, 1)
+        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 2, 0, 10, 0, 1)
     else
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
     end

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -426,7 +426,7 @@ xi.job_utils.dancer.useWildFlourishAbility = function(player, target, ability, a
         not target:hasStatusEffect(xi.effect.CHAINBOUND, 0) and
         not target:hasStatusEffect(xi.effect.SKILLCHAIN, 0)
     then
-        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 1, 0, 5, 0, 1)
+        target:addStatusEffectEx(xi.effect.CHAINBOUND, 0, 1, 0, 10, 0, 1)
     else
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT)
     end

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3775,7 +3775,7 @@ namespace battleutils
             // Chainbound active on target
             if (PCBEffect)
             {
-                if (PCBEffect->GetStartTime() + 3s < server_clock::now())
+                if (PCBEffect->GetStartTime() + 2s < server_clock::now())
                 {
                     // Konzen-Ittai
                     if (PCBEffect->GetPower() > 1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Chainbound status effect from Konzen-ittai and Wild Flourish were not functioning as they should. The window to use a weaponskill was incredibly short at ~2 seconds. Add latency on top of that and it was extremely difficulty to hit the skillchain reliably. I dug into the skillchains addon and copied the timings from there since I know they are accurate for retail from testing and experience.

Total Duration increased to 10 seconds. Initial Delay reduced to 2 seconds. This gives ~7 second window to skillchain after applying Chainbound.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Use Konzen-ittai or Wild Flourish followed by a weaponskill after ~2 seconds and observe a skillchain happens. Skillchain window should fall off after ~10 seconds total. Can test while using skillchains addon to have a visual guide for timings.
