### PR TITLE
[module] Use packet name for claimshield alerts

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -116,9 +116,9 @@ local timerFunc = function(mob)
         -- Message winner and their party/alliance that they've won
         local alliance = claimWinner:getAlliance()
         for _, member in pairs(alliance) do
-            local str = string.format("Your group has won the lottery for %s! (out of %i players)", mob:getName(), numEntries)
+            local str = string.format("Your group has won the lottery for %s! (out of %i players)", mob:getPacketName(), numEntries)
             if #alliance == 1 then
-                str = string.format("You have won the lottery for %s! (out of %i players)", mob:getName(), numEntries)
+                str = string.format("You have won the lottery for %s! (out of %i players)", mob:getPacketName(), numEntries)
             end
             member:PrintToPlayer(str, xi.msg.channel.SYSTEM_3, "")
 
@@ -132,9 +132,9 @@ local timerFunc = function(mob)
         -- Everyone left in the entries table isn't part of the winning group, message them and
         -- clear them from the enmity list
         for _, member in pairs(entries) do
-            local str = string.format("Your group was not successful in the lottery for %s. (out of %i players)", mob:getName(), numEntries)
+            local str = string.format("Your group was not successful in the lottery for %s. (out of %i players)", mob:getPacketName(), numEntries)
             if #alliance == 1 then
-                str = string.format("Your were not successful in the lottery for %s. (out of %i players)", mob:getName(), numEntries)
+                str = string.format("Your were not successful in the lottery for %s. (out of %i players)", mob:getPacketName(), numEntries)
             end
             member:PrintToPlayer(str, xi.msg.channel.SYSTEM_3, "")
             mob:clearEnmityForEntity(member)
@@ -144,7 +144,7 @@ end
 
 -- Called on entity onMobSpawn, sets up timerFunc
 local listenerFunc = function(mob)
-    print(string.format("Applying Claimshield to %s for %ims", mob:getName(), claimshieldTime))
+    print(string.format("Applying Claimshield to %s for %ims", mob:getPacketName(), claimshieldTime))
 
     mob:setClaimable(false)
     mob:setUnkillable(true)
@@ -156,7 +156,7 @@ end
 
 -- Main entrypoint of each override
 local overrideFunc = function(mob)
-    mob:addListener("SPAWN", mob:getName() .. "_CS_SPAWN", listenerFunc)
+    mob:addListener("SPAWN", mob:getPacketName() .. "_CS_SPAWN", listenerFunc)
 
     -- Call original onMobInitialize
     super(mob)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Will print "King Arthro" or "Fafnir" instead of "King_Arthro" or "DE_Fafnir" when using claimshield.

## Steps to test these changes

Use Claimshield
