### PR TITLE
Fix 100% accuracy on physical weaponskills, always apply accuracy floor to weaponskills.

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -349,10 +349,10 @@ local function getRangedHitRate(attacker, target, capHitRate, bonus)
         if hitrate > 0.95 then
             hitrate = 0.95
         end
+    end
 
-        if hitrate < 0.2 then
-            hitrate = 0.2
-        end
+    if hitrate < 0.2 then
+        hitrate = 0.2
     end
 
     return hitrate
@@ -1091,10 +1091,10 @@ function getHitRate(attacker, target, capHitRate, bonus)
         if hitrate > 0.95 then
             hitrate = 0.95
         end
+    end
 
-        if hitrate < 0.2 then
-            hitrate = 0.2
-        end
+    if hitrate < 0.2 then
+        hitrate = 0.2
     end
 
     return hitrate

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -368,8 +368,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
 
     if
         (missChance <= calcParams.hitRate or -- See if we hit the target
-        calcParams.guaranteedHit or
-        calcParams.melee) and
+        calcParams.guaranteedHit) and
         not calcParams.mustMiss
     then
         if not shadowAbsorb(target) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin -- WS were always hitting due to a bug I accidentally introduced.
I also noticed at the same time accuracy floor wasn't being honored -- so is accuracy cap but that needs a larger PR to do properly.

## Steps to test these changes

Use weaponskills as a lvl 1 vs a lvl 99, hit 20% of the time instead of 100% or 0%.
