### PR TITLE
Correct duration on Drain II effect

### DIFF
--- a/scripts/globals/spells/black/drain_ii.lua
+++ b/scripts/globals/spells/black/drain_ii.lua
@@ -53,7 +53,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local leftOver = (caster:getHP() + dmg) - caster:getMaxHP()
 
     if leftOver > 0 then
-        caster:addStatusEffect(xi.effect.MAX_HP_BOOST, (leftOver / caster:getMaxHP()) * 100, 0, 60)
+        caster:addStatusEffect(xi.effect.MAX_HP_BOOST, (leftOver / caster:getMaxHP()) * 100, 0, 180)
     end
 
     caster:addHP(dmg)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Drain II's effect duration is incorrectly set to 60 seconds and should be 180 according to BGWiki
https://www.bg-wiki.com/ffxi/Drain_II

and according to ffxiclopedia:
https://ffxiclopedia.fandom.com/wiki/Drain_II

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
