### PR TITLE
Change getCurrentTimeMs to function the same on all platforms

### DIFF
--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -146,13 +146,5 @@ time_point get_server_start_time()
 
 uint32 getCurrentTimeMs()
 {
-#ifdef WIN32
-    SYSTEMTIME oSystemTime;
-    GetSystemTime(&oSystemTime);
-    return oSystemTime.wMilliseconds;
-#else
-    timeval tv;
-    gettimeofday(&tv, 0);
-    return tv.tv_usec;
-#endif
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() % 1000;
 }


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

GetSystemTime in Windows was returning time since epoch in ms % 1000 The unix call to gettimeofday was not operated on the same way (returning a raw value without modulo), and used microseconds and not milliseconds.

This commit uses portable code to function the same on all platforms.
## Steps to test these changes

Nothing, since this function isn't used. Downstream is using it from here https://github.com/LandSandBoat/server/pull/2168