### PR TITLE
Improve functionality of !pos and !reset

### DIFF
--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -68,7 +68,7 @@ function onTrigger(player, arg1, arg2, arg3, arg4, arg5)
 
     -- report or move position
     if x == nil or y == nil or z == nil then
-        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos()))
+        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f  Rot %i", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos()))
     else
         if zoneId == nil then
             zoneId = targ:getZoneID()

--- a/scripts/commands/reset.lua
+++ b/scripts/commands/reset.lua
@@ -53,6 +53,7 @@ function onTrigger(player, target)
         xi.effect.CHARM_I,
         xi.effect.CHARM_II,
         xi.effect.POISON,
+        xi.effect.PETRIFICATION,
     }
 
     for _, v in pairs(effects) do


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Modifies !reset to remove petrification.
Modifies !pos to include player's current rotation

## Steps to test these changes

Use each command