### PR TITLE
Changing Ternary to Tertiary in zoneutils.cpp (#4045)

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -184,7 +184,7 @@ namespace zoneutils
     {
         CCharEntity* PPrimary   = nullptr;
         CCharEntity* PSecondary = nullptr;
-        CCharEntity* PTertiary   = nullptr;
+        CCharEntity* PTertiary  = nullptr;
 
         for (auto PZone : g_PZoneList)
         {

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -180,16 +180,16 @@ namespace zoneutils
         return nullptr;
     }
 
-    CCharEntity* GetCharToUpdate(uint32 primary, uint32 ternary)
+    CCharEntity* GetCharToUpdate(uint32 primary, uint32 tertiary)
     {
         CCharEntity* PPrimary   = nullptr;
         CCharEntity* PSecondary = nullptr;
-        CCharEntity* PTernary   = nullptr;
+        CCharEntity* PTertiary   = nullptr;
 
         for (auto PZone : g_PZoneList)
         {
             // clang-format off
-            PZone.second->ForEachChar([primary, ternary, &PPrimary, &PSecondary, &PTernary](CCharEntity* PChar)
+            PZone.second->ForEachChar([primary, tertiary, &PPrimary, &PSecondary, &PTertiary](CCharEntity* PChar)
             {
                 if (!PPrimary)
                 {
@@ -201,9 +201,9 @@ namespace zoneutils
                     {
                         PSecondary = PChar;
                     }
-                    else if (PChar->id == ternary)
+                    else if (PChar->id == tertiary)
                     {
-                        PTernary = PChar;
+                        PTertiary = PChar;
                     }
                 }
             });
@@ -219,7 +219,7 @@ namespace zoneutils
             return PSecondary;
         }
 
-        return PTernary;
+        return PTertiary;
     }
 
     std::vector<uint16> GetZonesOnThisProcess()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Issue #4045 via replacing Ternary with Tertiary in zoneutils.cpp, where it is grammatically appropriate to do so.

As stated in the issue, this does not change Ternary Flourish anywhere in the code, as that is fine.

## Steps to test these changes

Launched xi_map.exe, it didn't break. Launched the client, nothing in the map is broken.
