### PR TITLE
Add Influence cache and reorganize time server

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -682,7 +682,7 @@ namespace message
                             const std::size_t             headerLength   = 2 * sizeof(uint8);
                             uint32                        size           = ref<uint32>(data, 2);
                             std::vector<region_control_t> regionControls = std::vector<region_control_t>(size);
-                            for (int i = 0; i < size; i++)
+                            for (std::size_t i = 0; i < size; i++)
                             {
                                 const std::size_t start = headerLength + sizeof(size_t) + i * sizeof(region_control_t);
 
@@ -703,7 +703,7 @@ namespace message
                             bool                     shouldUpdateZones = ref<bool>(data, 2);
                             uint32                   size              = ref<uint32>(data, 3);
                             std::vector<influence_t> influencePoints   = std::vector<influence_t>(size);
-                            for (int i = 0; i < size; i++)
+                            for (std::size_t i = 0; i < size; i++)
                             {
                                 const std::size_t start = headerLength + sizeof(bool) + sizeof(size_t) + i * sizeof(influence_t);
 
@@ -725,7 +725,7 @@ namespace message
                             const std::size_t             headerLength = 2 * sizeof(uint8);
                             uint32                        size         = ref<uint32>(data, 2);
                             std::vector<region_control_t> regionControls;
-                            for (int i = 0; i < size; i++)
+                            for (std::size_t i = 0; i < size; i++)
                             {
                                 const std::size_t start = headerLength + sizeof(size_t) + i * sizeof(region_control_t);
 

--- a/src/world/CMakeLists.txt
+++ b/src/world/CMakeLists.txt
@@ -8,12 +8,16 @@ set(SOURCES
     colonization_system.h
     conquest_system.cpp
     conquest_system.h
+    gobbie_box.h
+    gobbie_box.cpp
     http_server.cpp
     http_server.h
     main.cpp
     message_handler.h
     message_server.cpp
     message_server.h
+    time_server.h
+    time_server.cpp
     world_server.cpp
     world_server.h)
 

--- a/src/world/conquest_system.h
+++ b/src/world/conquest_system.h
@@ -55,6 +55,12 @@ public:
      */
     void updateHourlyConquest();
 
+    /**
+     * Called every vana hour (every 2.4 min). Used to send updated influence data
+     * to all map servers. Does not request a zone update.
+     */
+    void updateVanaHourlyConquest();
+
 private:
     std::unique_ptr<SqlConnection> sql;
 

--- a/src/world/gobbie_box.cpp
+++ b/src/world/gobbie_box.cpp
@@ -1,0 +1,32 @@
+#include "gobbie_box.h"
+
+namespace gobbiebox
+{
+    void UpdateDailyTallyPoints(WorldServer* worldServer)
+    {
+        uint16 dailyTallyLimit  = settings::get<uint16>("main.DAILY_TALLY_LIMIT");
+        uint16 dailyTallyAmount = settings::get<uint16>("main.DAILY_TALLY_AMOUNT");
+
+        const char* fmtQuery = "UPDATE char_points \
+            SET char_points.daily_tally = LEAST(%u, char_points.daily_tally + %u) \
+            WHERE char_points.daily_tally > -1;";
+
+        int32 ret = worldServer->sql->Query(fmtQuery, dailyTallyLimit, dailyTallyAmount);
+
+        if (ret == SQL_ERROR)
+        {
+            ShowError("Failed to update daily tally points");
+        }
+        else
+        {
+            ShowDebug("Distributed daily tally points");
+        }
+
+        fmtQuery = "DELETE FROM char_vars WHERE varname = 'gobbieBoxUsed';";
+
+        if (worldServer->sql->Query(fmtQuery, dailyTallyAmount) == SQL_ERROR)
+        {
+            ShowError("Failed to delete daily tally char_vars entries");
+        }
+    }
+} // namespace gobbiebox

--- a/src/world/gobbie_box.h
+++ b/src/world/gobbie_box.h
@@ -1,0 +1,13 @@
+#ifndef SERVER_GOBLIN_BOX_DAILY_TALLY_H
+#define SERVER_GOBLIN_BOX_DAILY_TALLY_H
+
+#include "../common/sql.h"
+#include "world_server.h"
+#include <string>
+
+namespace gobbiebox
+{
+    void UpdateDailyTallyPoints(WorldServer* worldServer);
+}
+
+#endif // SERVER_GOBLIN_BOX_DAILY_TALLY_H

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -113,7 +113,7 @@ void message_server_send(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zm
 void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet, zmq::message_t* from)
 {
     int     ret = SQL_ERROR;
-    in_addr from_ip;
+    in_addr from_ip{};
     uint16  from_port = 0;
     bool    ipstring  = false;
     char    from_address[INET_ADDRSTRLEN];

--- a/src/world/time_server.cpp
+++ b/src/world/time_server.cpp
@@ -1,0 +1,88 @@
+#include "time_server.h"
+
+#include "../common/cbasetypes.h"
+#include "../common/taskmgr.h"
+#include "../common/tracy.h"
+#include "../common/vana_time.h"
+#include "gobbie_box.h"
+#include "world_server.h"
+
+int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
+{
+    TracyZoneScoped;
+    TIMETYPE     VanadielTOTD = CVanaTime::getInstance()->SyncTime();
+    WorldServer* worldServer  = std::any_cast<WorldServer*>(PTask->m_data);
+
+    // Weekly update for conquest (sunday at midnight)
+    static time_point lastConquestTally  = tick - 1h;
+    static time_point lastConquestUpdate = tick - 1h;
+    if (CVanaTime::getInstance()->getJstWeekDay() == 1 && CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastConquestTally + 1h))
+        {
+            worldServer->conquestSystem->updateWeekConquest();
+            lastConquestTally = tick;
+        }
+    }
+    // Hourly conquest update
+    else if (CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastConquestUpdate + 1h))
+        {
+            worldServer->conquestSystem->updateHourlyConquest();
+            lastConquestUpdate = tick;
+        }
+    }
+
+    // Vanadiel Hour
+    static time_point lastVHourlyUpdate = tick - 4800ms;
+    if (CVanaTime::getInstance()->getMinute() == 0)
+    {
+        if (tick > (lastVHourlyUpdate + 4800ms))
+        {
+            worldServer->conquestSystem->updateVanaHourlyConquest();
+            lastVHourlyUpdate = tick;
+        }
+    }
+
+    // JST Midnight
+    static time_point lastTickedJstMidnight = tick - 1h;
+    if (CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastTickedJstMidnight + 1h))
+        {
+            if (settings::get<bool>("main.ENABLE_DAILY_TALLY"))
+            {
+                gobbiebox::UpdateDailyTallyPoints(worldServer);
+            }
+
+            lastTickedJstMidnight = tick;
+        }
+    }
+
+    // 4-hour RoE Timed blocks
+    static time_point lastTickedRoeBlock = tick - 1h;
+    if (CVanaTime::getInstance()->getJstHour() % 4 == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
+    {
+        if (tick > (lastTickedRoeBlock + 1h))
+        {
+            lastTickedRoeBlock = tick;
+        }
+    }
+
+    // Vanadiel Day
+    static time_point lastVDailyUpdate = tick - 4800ms;
+    if (CVanaTime::getInstance()->getHour() == 0 && CVanaTime::getInstance()->getMinute() == 0)
+    {
+        if (tick > (lastVDailyUpdate + 4800ms))
+        {
+            lastVDailyUpdate = tick;
+        }
+    }
+
+    if (VanadielTOTD != TIME_NONE)
+    {
+    }
+
+    return 0;
+}

--- a/src/world/time_server.h
+++ b/src/world/time_server.h
@@ -1,0 +1,9 @@
+#ifndef SERVER_TIME_SERVER_H
+#define SERVER_TIME_SERVER_H
+
+#include "../common/cbasetypes.h"
+#include "../common/taskmgr.h"
+
+int32 time_server(time_point tick, CTaskMgr::CTask* PTask);
+
+#endif // SERVER_TIME_SERVER_H

--- a/src/world/world_server.cpp
+++ b/src/world/world_server.cpp
@@ -22,132 +22,17 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 
 #include "common/application.h"
 #include "common/logging.h"
-#include "common/vana_time.h"
-
-namespace
-{
-    std::unique_ptr<SqlConnection>  sql;
-    std::shared_ptr<ConquestSystem> conquest;
-} // namespace
-
-void UpdateDailyTallyPoints()
-{
-    uint16 dailyTallyLimit  = settings::get<uint16>("main.DAILY_TALLY_LIMIT");
-    uint16 dailyTallyAmount = settings::get<uint16>("main.DAILY_TALLY_AMOUNT");
-
-    const char* fmtQuery = "UPDATE char_points \
-            SET char_points.daily_tally = LEAST(%u, char_points.daily_tally + %u) \
-            WHERE char_points.daily_tally > -1;";
-
-    int32 ret = sql->Query(fmtQuery, dailyTallyLimit, dailyTallyAmount);
-
-    if (ret == SQL_ERROR)
-    {
-        ShowError("Failed to update daily tally points");
-    }
-    else
-    {
-        ShowDebug("Distributed daily tally points");
-    }
-
-    fmtQuery = "DELETE FROM char_vars WHERE varname = 'gobbieBoxUsed';";
-
-    if (sql->Query(fmtQuery, dailyTallyAmount) == SQL_ERROR)
-    {
-        ShowError("Failed to delete daily tally char_vars entries");
-    }
-}
-
-int32 time_server(time_point tick, CTaskMgr::CTask* PTask)
-{
-    TracyZoneScoped;
-    TIMETYPE VanadielTOTD = CVanaTime::getInstance()->SyncTime();
-
-    // Weekly update for conquest (sunday at midnight)
-    static time_point lastConquestTally  = tick - 1h;
-    static time_point lastConquestUpdate = tick - 1h;
-    if (CVanaTime::getInstance()->getJstWeekDay() == 1 && CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
-    {
-        if (tick > (lastConquestTally + 1h))
-        {
-            conquest->updateWeekConquest();
-            lastConquestTally = tick;
-        }
-    }
-    // Hourly conquest update
-    else if (CVanaTime::getInstance()->getJstMinute() == 0)
-    {
-        if (tick > (lastConquestUpdate + 1h))
-        {
-            conquest->updateHourlyConquest();
-            lastConquestUpdate = tick;
-        }
-    }
-
-    // Vanadiel Hour
-    static time_point lastVHourlyUpdate = tick - 4800ms;
-    if (CVanaTime::getInstance()->getMinute() == 0)
-    {
-        if (tick > (lastVHourlyUpdate + 4800ms))
-        {
-            lastVHourlyUpdate = tick;
-        }
-    }
-
-    // JST Midnight
-    static time_point lastTickedJstMidnight = tick - 1h;
-    if (CVanaTime::getInstance()->getJstHour() == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
-    {
-        if (tick > (lastTickedJstMidnight + 1h))
-        {
-            if (settings::get<bool>("main.ENABLE_DAILY_TALLY"))
-            {
-                UpdateDailyTallyPoints();
-            }
-
-            lastTickedJstMidnight = tick;
-        }
-    }
-
-    // 4-hour RoE Timed blocks
-    static time_point lastTickedRoeBlock = tick - 1h;
-    if (CVanaTime::getInstance()->getJstHour() % 4 == 0 && CVanaTime::getInstance()->getJstMinute() == 0)
-    {
-        if (tick > (lastTickedRoeBlock + 1h))
-        {
-            lastTickedRoeBlock = tick;
-        }
-    }
-
-    // Vanadiel Day
-    static time_point lastVDailyUpdate = tick - 4800ms;
-    if (CVanaTime::getInstance()->getHour() == 0 && CVanaTime::getInstance()->getMinute() == 0)
-    {
-        if (tick > (lastVDailyUpdate + 4800ms))
-        {
-            lastVDailyUpdate = tick;
-        }
-    }
-
-    if (VanadielTOTD != TIME_NONE)
-    {
-    }
-
-    return 0;
-}
+#include "time_server.h"
 
 WorldServer::WorldServer(int argc, char** argv)
 : Application("world", argc, argv)
-, conquestSystem(std::make_shared<ConquestSystem>())
+, sql(std::make_unique<SqlConnection>())
+, conquestSystem(std::make_unique<ConquestSystem>())
 , httpServer(std::make_unique<HTTPServer>())
 , messageServer(std::make_unique<message_server_wrapper_t>(std::ref(m_RequestExit)))
 {
-    // Anonymous namespace preparation
-    sql      = std::make_unique<SqlConnection>();
-    conquest = conquestSystem;
-
     // Tasks
-    CTaskMgr::getInstance()->AddTask("time_server", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, time_server, 2400ms);
+    CTaskMgr::getInstance()->AddTask("time_server", server_clock::now(), this, CTaskMgr::TASK_INTERVAL, time_server, 2400ms);
 }
 
 WorldServer::~WorldServer() = default;

--- a/src/world/world_server.h
+++ b/src/world/world_server.h
@@ -38,9 +38,10 @@ public:
 
     void Tick() override;
 
-private:
-    std::shared_ptr<ConquestSystem> conquestSystem;
+    std::unique_ptr<SqlConnection>  sql;
+    std::unique_ptr<ConquestSystem> conquestSystem;
 
+private:
     std::unique_ptr<BesiegedSystem>     besiegedSystem;
     std::unique_ptr<CampaignSystem>     campaignSystem;
     std::unique_ptr<ColonizationSystem> colonizationSystem;


### PR DESCRIPTION
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- No longer sends influence updates every time a map server updates it upstream
- Send influence updates periodically via time server
- Move time server to a separate file
- Move gobbie box logic to a separate file

## Steps to test these changes

Stay online while vana hour, hour, week and jp midnight updates happen.
Kill shit and check that influence is updated in the region map after 2.4 minutes (1 vana hour)
