### PR TITLE
Fix range and logic for `MAX_ZONE` in GM commands

### DIFF
--- a/scripts/commands/send.lua
+++ b/scripts/commands/send.lua
@@ -353,7 +353,7 @@ function onTrigger(player, bytes)
         if tonumber(dest) ~= nil then
             -- destination is a zone ID.
             zone = tonumber(dest)
-            if zone < 0 or zone >= xi.zone.MAX_ZONE then
+            if zone < 0 or zone > xi.zone.MAX_ZONE then
                 error(player, "Invalid zone ID.")
                 return
             end

--- a/scripts/commands/zone.lua
+++ b/scripts/commands/zone.lua
@@ -333,7 +333,7 @@ function onTrigger(player, bytes)
     else
         -- destination is a zone ID.
         zone = tonumber(bytes)
-        if zone == nil or zone < 0 or zone >= xi.zone.MAX_ZONE then
+        if zone == nil or zone < 0 or zone > xi.zone.MAX_ZONE then
             error(player, "Invalid zone ID.")
             return
         end

--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -394,7 +394,7 @@ xi.zone =
     GWORA_THRONE_ROOM               = 299,
 
     -- Increment this when adding new zones
-    MAX_ZONE                        = 300,
+    MAX_ZONE                        = 299,
 }
 
 xi.expansionRegion = xi.expansionRegion or {}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
GM commands allowed for an invalid zone (300) to be used for !send and !zone.  Reduces the lua definition of `MAX_ZONE` to 299, and applies correct conditional logic
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Try to zone or send player to zone 300 (fail)
Repeat procedure with zone 299 (success)
<!-- Clear and detailed steps to test your changes here -->
