### PR TITLE
Enable Magical BPs to receive TP bonus

### DIFF
--- a/scripts/globals/abilities/pets/aerial_blast.lua
+++ b/scripts/globals/abilities/pets/aerial_blast.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 

--- a/scripts/globals/abilities/pets/clarsach_call.lua
+++ b/scripts/globals/abilities/pets/clarsach_call.lua
@@ -20,7 +20,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, master)
     xi.job_utils.summoner.onUseBloodPact(master, pet, target, petskill)
 
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/diamond_dust.lua
+++ b/scripts/globals/abilities/pets/diamond_dust.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 

--- a/scripts/globals/abilities/pets/earthen_fury.lua
+++ b/scripts/globals/abilities/pets/earthen_fury.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.ICE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.ICE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.ICE, 1)
 

--- a/scripts/globals/abilities/pets/howling_moon.lua
+++ b/scripts/globals/abilities/pets/howling_moon.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 

--- a/scripts/globals/abilities/pets/inferno.lua
+++ b/scripts/globals/abilities/pets/inferno.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 

--- a/scripts/globals/abilities/pets/judgment_bolt.lua
+++ b/scripts/globals/abilities/pets/judgment_bolt.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.FIRE, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.FIRE)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, 1)
 

--- a/scripts/globals/abilities/pets/nether_blast.lua
+++ b/scripts/globals/abilities/pets/nether_blast.lua
@@ -13,7 +13,7 @@ end
 abilityObject.onPetAbility = function(target, pet, skill)
     local level = pet:getMainLvl()
     local damage = 5 * level + 10
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.DARK)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
 

--- a/scripts/globals/abilities/pets/searing_light.lua
+++ b/scripts/globals/abilities/pets/searing_light.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 26 + (level * 6)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHT, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHT)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHT, 1)
 

--- a/scripts/globals/abilities/pets/sonic_buffet.lua
+++ b/scripts/globals/abilities/pets/sonic_buffet.lua
@@ -21,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, petskill)
     -- TODO: upon smn BP damage rewrite, the base damage & mods etc need to be re-evaluated. These are eyeballed and guesstimated to fit what damage looks like on retail.
     local damage = math.floor(37.5 * (2.0 + 0.1 * tp / 150)) -- fTP starts at 2.0 and scales every 150 tp by .1 for a range of 2.0 to 4.0. Base value ballparked from retail.
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local damage = math.floor(325 + 0.025 * tp)
 
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.EARTH, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.EARTH)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, 1)
 

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(325 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -28,7 +28,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.LIGHTNING, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.LIGHTNING)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.LIGHTNING, 1)
 

--- a/scripts/globals/abilities/pets/tidal_wave.lua
+++ b/scripts/globals/abilities/pets/tidal_wave.lua
@@ -22,7 +22,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
     local level = pet:getMainLvl()
     local damage = 48 + (level * 8)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 

--- a/scripts/globals/abilities/pets/tornado_ii.lua
+++ b/scripts/globals/abilities/pets/tornado_ii.lua
@@ -26,7 +26,7 @@ abilityObject.onPetAbility = function(target, pet, petskill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, petskill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, petskill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
 
     local damage = math.floor(45 + 0.025 * tp)
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -16,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     local damage = math.floor(325 + 0.025 * tp)
 
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WATER, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WATER)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WATER, 1)
 

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -27,7 +27,7 @@ abilityObject.onPetAbility = function(target, pet, skill)
     --note: this formula is only accurate for level 75 - 76+ may have a different intercept and/or slope
     local damage = math.floor(512 + 1.72 * (tp + 1))
     damage = damage + (dINT * 1.5)
-    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+    damage = xi.mobskills.mobMagicalMove(pet, target, skill, damage, xi.magic.ele.WIND, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
     damage = xi.mobskills.mobAddBonuses(pet, target, damage.dmg, xi.magic.ele.WIND)
     damage = xi.summon.avatarFinalAdjustments(damage, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, 1)
 

--- a/scripts/globals/abilities/pets/zantetsuken.lua
+++ b/scripts/globals/abilities/pets/zantetsuken.lua
@@ -21,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master)
             dmg = 9999
         end
 
-        dmg = xi.mobskills.mobMagicalMove(pet, target, skill, dmg, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.NO_EFFECT, 0)
+        dmg = xi.mobskills.mobMagicalMove(pet, target, skill, dmg, xi.magic.ele.DARK, 1, xi.mobskills.magicalTpBonus.DMG_BONUS, 0)
         dmg = xi.mobskills.mobAddBonuses(pet, target, dmg.dmg, xi.magic.ele.DARK)
         dmg = xi.summon.avatarFinalAdjustments(dmg, pet, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, 1)
         target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.DARK)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Magical Blood Pacts should be affected by TP and currently they are not. This is also causing the Summoner ability 'Mana Cede' not to do essentially nothing.

## Steps to test these changes
Make a mob immortal, use a magical blood pact without pet TP. Note the damage.
Now let the mob gain some TP and use the BP again, note the increased damage.
