### PR TITLE
[Fix] Add safety for nil values to immunobreak

### DIFF
--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -376,8 +376,12 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     local resistStages = pTable[spellId][8]
     local message      = pTable[spellId][9]
     local bonusMacc    = pTable[spellId][12]
-    local resistRank   = target:getMod(xi.combat.element.resistRankMod[spellElement]) or 0
-    local rankModifier = target:getMod(immunobreakTable[spellEffect][1]) or 0
+    local rankModifier = 0
+
+    -- Fetch immunobreak modifier to resistance rank if aplicable.
+    if immunobreakTable[spellEffect] then
+        rankModifier = target:getMod(immunobreakTable[spellEffect][1])
+    end
 
     -- Magic Hit Rate calculations.
     local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, spellGroup, skillType, spellElement, statUsed, bonusMacc)
@@ -404,7 +408,13 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
 
     -- The effect will get resisted.
     if resistRate <= 1 / (2 ^ resistStages) then
-        -- Attempt immunobreak.
+        -- Attempt immunobreak. Fetch resistance rank modifier.
+        local resistRank = 0
+
+        if spellElement ~= xi.magic.ele.NONE then
+            resistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+        end
+
         if
             caster:isPC() and
             target:isMob() and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix oversight when coding immunobreak, when using non immunobreakable status effects.

## Steps to test these changes

Cast enfeebling spells (Notably Drown, Burn and other elemental DoTs) without errors.
