### PR TITLE
[Cleanup] Apply some style to summon.lua and replace redundant functions.

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -2,6 +2,7 @@
 -- Avatar Global Functions
 -----------------------------------
 require("scripts/globals/combat/level_correction")
+require("scripts/globals/combat/physical_utilities")
 require("scripts/globals/msg")
 -----------------------------------
 xi = xi or {}
@@ -91,33 +92,6 @@ local function avatarFTP(tp, ftp1, ftp2, ftp3)
     end
 
     return 1 -- no ftp mod
-end
-
-local function getAvatarFSTR(weaponDmg, avatarStr, targetVit)
-    -- https://www.bluegartr.com/threads/114636-Monster-Avatar-Pet-damage
-    -- fSTR for avatars has no cap and a lower bound of floor(weaponDmg/9)
-    local dSTR = avatarStr - targetVit
-    local fSTR = dSTR
-    if dSTR >= 12 then
-        fSTR = (dSTR + 4) / 4
-    elseif dSTR >= 6 then
-        fSTR = (dSTR + 6) / 4
-    elseif dSTR >= 1 then
-        fSTR = (dSTR + 7) / 4
-    elseif dSTR >= -2 then
-        fSTR = (dSTR + 8) / 4
-    elseif dSTR >= -7 then
-        fSTR = (dSTR + 9) / 4
-    elseif dSTR >= -15 then
-        fSTR = (dSTR + 10) / 4
-    elseif dSTR >= -21 then
-        fSTR = (dSTR + 12) / 4
-    else
-        fSTR = (dSTR + 13) / 4
-    end
-
-    local min = math.floor(weaponDmg / 9)
-    return math.max(-min, fSTR)
 end
 
 local function avatarHitDmg(weaponDmg, fSTR, pDif)
@@ -224,7 +198,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
 
         local weaponDmg = avatar:getWeaponDmg()
 
-        local fSTR = getAvatarFSTR(weaponDmg, avatar:getStat(xi.mod.STR), target:getStat(xi.mod.VIT))
+        local fSTR = xi.combat.physical.calculateMeleeStatFactor(avatar, target)
 
         -- https://www.bg-wiki.com/bg/PDIF
         -- https://www.bluegartr.com/threads/127523-pDIF-Changes-(Feb.-10th-2016)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Avatar Global Functions
 -----------------------------------
+require("scripts/globals/combat/level_correction")
 require("scripts/globals/msg")
 -----------------------------------
 xi = xi or {}
@@ -142,11 +143,7 @@ xi.summon.avatarPhysicalMove = function(avatar, target, skill, numberofhits, acc
     local acc = avatar:getACC() + xi.summon.getSummoningSkillOverCap(avatar)
     local eva = target:getEVA()
 
-    -- Level correction does not happen in Adoulin zones, Legion, or zones in Escha/Reisenjima
-    -- https://www.bg-wiki.com/bg/PDIF#Level_Correction_Function_.28cRatio.29
-    local zoneId = avatar:getZone():getID()
-
-    local shouldApplyLevelCorrection = (zoneId < 256) and zoneId ~= 183
+    local shouldApplyLevelCorrection = xi.combat.levelCorrection.isLevelCorrectedZone(avatar)
 
     -- https://forum.square-enix.com/ffxi/threads/45365?p=534537#post534537
     -- https://www.bg-wiki.com/bg/Hit_Rate


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Makes summon.lua use our existing "level correction zone check" function
- Makes summon.lua use our existing "fSTR" function
- Cleans and applies some styling to summon.lua, so our eyes bleed a little less.

## Steps to test these changes

Use blood pacts.
- See if lvl correction is applied correctly acording to settings.
- See them still do massive ammounts of damage
- Get no errors in console
