### PR TITLE
Correct Dweomershell droplist

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -14704,7 +14704,6 @@ INSERT INTO `mob_droplist` VALUES (1816,0,0,1000,4400,@UNCOMMON); -- Slice Of La
 INSERT INTO `mob_droplist` VALUES (1816,0,0,1000,881,@VRARE);     -- Crab Shell (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1816,2,0,1000,936,0);          -- Chunk Of Rock Salt (Steal)
 
--- ZoneID:  54 - Dweomershell
 -- ZoneID:  74 - Nipper
 INSERT INTO `mob_droplist` VALUES (1817,0,0,1000,5377,@UNCOMMON); -- Fractus Cell (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (1817,0,0,1000,5378,@UNCOMMON); -- Congestus Cell (Uncommon, 10%)
@@ -17816,6 +17815,8 @@ INSERT INTO `mob_droplist` VALUES (2243,2,0,1000,4374,0);         -- Sleepshroom
 INSERT INTO `mob_droplist` VALUES (2244,0,0,1000,4374,180); -- Sleepshroom (18.0%)
 INSERT INTO `mob_droplist` VALUES (2244,0,0,1000,4375,130); -- Danceshroom (13.0%)
 INSERT INTO `mob_droplist` VALUES (2244,2,0,1000,4374,0);   -- Sleepshroom (Steal)
+
+-- ZoneID:  54 - Dweomershell
 
 -- ZoneID:  61 - Sicklemoon Crab
 INSERT INTO `mob_droplist` VALUES (2245,0,0,1000,4400,@UNCOMMON); -- Slice Of Land Crab Meat (Uncommon, 10%)
@@ -21907,6 +21908,7 @@ INSERT INTO `mob_droplist` VALUES (2667,2,0,1000,1449,0);        -- Tukuku White
 INSERT INTO `mob_droplist` VALUES (2667,2,0,1000,1452,0);        -- Ordelle Bronzepiece (Steal)
 INSERT INTO `mob_droplist` VALUES (2667,2,0,1000,1455,0);        -- One Byne Bill (Steal)
 
+-- ZoneID:  54 - Dweomershell
 -- ZoneID:  61 - Wootzshell
 -- ZoneID:  61 - Orichalcumshell
 INSERT INTO `mob_droplist` VALUES (2668,0,0,1000,4400,160);   -- Slice Of Land Crab Meat (16.0%)

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -17816,8 +17816,6 @@ INSERT INTO `mob_droplist` VALUES (2244,0,0,1000,4374,180); -- Sleepshroom (18.0
 INSERT INTO `mob_droplist` VALUES (2244,0,0,1000,4375,130); -- Danceshroom (13.0%)
 INSERT INTO `mob_droplist` VALUES (2244,2,0,1000,4374,0);   -- Sleepshroom (Steal)
 
--- ZoneID:  54 - Dweomershell
-
 -- ZoneID:  61 - Sicklemoon Crab
 INSERT INTO `mob_droplist` VALUES (2245,0,0,1000,4400,@UNCOMMON); -- Slice Of Land Crab Meat (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2245,0,0,1000,1889,60);        -- Sack Of White Sand (6.0%)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -2753,7 +2753,7 @@ INSERT INTO `mob_groups` VALUES (61,2894,54,'Nix_Songstress',960,0,1657,0,0,81,8
 INSERT INTO `mob_groups` VALUES (62,913,54,'Dark_Elemental',960,4,568,0,0,80,80,0);
 INSERT INTO `mob_groups` VALUES (63,2367,54,'Lamie_No9',259200,0,0,0,0,80,85,0);
 INSERT INTO `mob_groups` VALUES (64,2358,54,'Lamias_Avatar',0,128,0,0,0,72,76,0);
-INSERT INTO `mob_groups` VALUES (65,5329,54,'Dweomershell',330,0,1817,0,0,88,90,0);
+INSERT INTO `mob_groups` VALUES (65,5329,54,'Dweomershell',330,0,2668,0,0,88,90,0);
 INSERT INTO `mob_groups` VALUES (66,2896,54,'Nix_Wavedancer',960,0,1657,0,0,81,83,0);
 INSERT INTO `mob_groups` VALUES (67,2893,54,'Nix_Bladedancer',960,0,1820,0,0,81,83,0);
 INSERT INTO `mob_groups` VALUES (68,2895,54,'Nix_Typhoondancer',960,0,1657,0,0,81,83,0);


### PR DESCRIPTION
Added dweomershell to the correct droplist. Was dropping cells from Promy zones.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

This PR corrects the Dweomershell drops to it's correct drops and droprate. Before, it was dropping cells it doesn't normally drop.

## Steps to test these changes

Fight the dweomershell and finally get it's crabby drops
