### PR TITLE
[core] Allow DEs to define unique internal lookups

### DIFF
--- a/modules/custom/lua/test_npcs_in_gm_home.lua
+++ b/modules/custom/lua/test_npcs_in_gm_home.lua
@@ -24,6 +24,10 @@ m:addOverride("xi.zones.GM_Home.Zone.onInitialize", function(zone)
         -- NOTE: This name CAN include spaces and underscores.
         name = "Horro",
 
+        -- Optional: Define a different name that is visible to players.
+        -- "Horro" (DE_Horro) will still be used internally for lookups.
+        -- packetName = "New Horro",
+
         -- You can use regular model ids (See documentation/model_ids.txt, or play around with !costume)
         look = 2430,
 

--- a/scripts/commands/fafnir.lua
+++ b/scripts/commands/fafnir.lua
@@ -24,6 +24,10 @@ function onTrigger(player)
         -- NOTE: This name CAN include spaces and underscores.
         name = "Fafnir",
 
+        -- Optional: Define a different name that is visible to players.
+        -- "Fafnir" (DE_Fafnir) will still be used internally for lookups.
+        -- packetName = "Fake Fafnir",
+
         -- Set the position using in-game x, y and z
         x = player:getXPos(),
         y = player:getYPos(),

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -258,11 +258,10 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         name = PEntity->name;
     }
 
-    auto defaultLookupName = "DE_" + name;
-    auto lookupName        = table.get_or<std::string>("lookupName", defaultLookupName);
+    auto lookupName = "DE_" + name;
 
     PEntity->name       = lookupName;
-    PEntity->packetName = name;
+    PEntity->packetName = table.get_or<std::string>("packetName", name);
 
     PEntity->isRenamed = true;
 

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -258,7 +258,8 @@ std::optional<CLuaBaseEntity> CLuaZone::insertDynamicEntity(sol::table table)
         name = PEntity->name;
     }
 
-    auto lookupName = "DE_" + name;
+    auto defaultLookupName = "DE_" + name;
+    auto lookupName        = table.get_or<std::string>("lookupName", defaultLookupName);
 
     PEntity->name       = lookupName;
     PEntity->packetName = name;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
__Issue__
Currently, dynamic entities are restricted to using packet name as the internal lookup name. In the case of duplicate names, they use the same table, and cannot have unique callbacks, etc. `onTrigger`, `onTrade` etc.

__Example__
This limitation creates a barrier on using DEs for certain tasks, for example multiple event Moogles in one zone may all be called `Moogle` but need to perform different functionality. I've repeatedly hit this issue handling multiple mobs with the same name, and had to use convoluted workarounds like giving them slightly different names or checking positions, which was not ideal.

__Solution__
I've added an additional parameter `lookupName`, which when defined, will be used internally instead. The packet name (What is visible to players) remains the same. If `lookupName` is not defined, the dynamic entity will simply use `name`, which is the existing behavior.

## Steps to test these changes

```lua
zone:insertDynamicEntity({
    objtype    = xi.objType.NPC,
    name       = "Moogle",
    packetName = "Egg_Hunt_Moogle",
    look       = 82,
    x          = 1,
    y          = 1,
    z          = 1,
    onTrigger  = function(player, npc)
        player:PrintToPlayer("Moogle : I'm just a Moogle.", xi.msg.channel.NS_SAY)
    end,
})

zone:insertDynamicEntity({
    objtype    = xi.objType.NPC,
    name       = "Moogle",
    packetName = "Other_Moogle",
    look       = 82,
    x          = 3,
    y          = 3,
    z          = 3,
    onTrigger  = function(player, npc)
        player:PrintToPlayer("Moogle : I'm different.", xi.msg.channel.NS_SAY)
    end,
})
```
