### PR TITLE
[ci] Add hasSpell to magic number check and use xi.magic.spell enum

### DIFF
--- a/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
+++ b/scripts/missions/bastok/2_3_1_The_Emissary_Sandoria.lua
@@ -36,7 +36,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsHalverTrust = (not player:hasSpell(972) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(501, { [7] = needsHalverTrust })
                     elseif missionStatus > 3 then
@@ -51,7 +51,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 4)
 
                     if
-                        not player:hasSpell(972) and
+                        not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_HALVERS_ALTER_EGO)

--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -71,7 +71,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsSemihTrust = (not player:hasSpell(940) and not player:hasItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:hasItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
                         local hasTrustQuest =
                         (
                             player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) or
@@ -117,7 +117,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.SWORD_OFFERING)
 
                     if
-                        not player:hasSpell(940) and
+                        not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:hasItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)

--- a/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
+++ b/scripts/missions/bastok/2_3_3_The_Emissary_Sandoria2.lua
@@ -36,7 +36,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 8 then
-                        local needsHalverTrust = (not player:hasSpell(972) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(503, { [7] = needsHalverTrust })
                     elseif missionStatus <= 10 then
@@ -51,7 +51,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 9)
 
                     if
-                        not player:hasSpell(972) and
+                        not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_HALVERS_ALTER_EGO)

--- a/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
+++ b/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
@@ -117,7 +117,7 @@ mission.sections =
                     if missionStatus == 11 then
                         return mission:progressEvent(507)
                     elseif missionStatus == 0 then
-                        local needsHalverTrust = (not player:hasSpell(972) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(505, { [7] = needsHalverTrust })
                     else
@@ -133,7 +133,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_THE_CONSULS_SANDORIA)
 
                     if
-                        not player:hasSpell(972) and
+                        not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_HALVERS_ALTER_EGO)

--- a/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
+++ b/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
@@ -55,7 +55,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 4 then
-                        local needsSemihTrust = (not player:hasSpell(940) and not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(238, 1, 1, 1, 1, xi.nation.SANDORIA, 0, 0, needsSemihTrust)
                     elseif missionStatus == 5 then
@@ -95,7 +95,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.SHIELD_OFFERING)
 
                     if
-                        not player:hasSpell(940) and
+                        not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)

--- a/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
+++ b/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
@@ -111,7 +111,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        local needsSemihTrust = (not player:hasSpell(940) and not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
+                        local needsSemihTrust = (not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(95, 0, 0, 0, xi.ki.LETTER_TO_THE_CONSULS_WINDURST, 0, 0, 0, needsSemihTrust)
                     elseif missionStatus == 11 then
@@ -129,7 +129,7 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
 
                     if
-                        not player:hasSpell(940) and
+                        not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                         not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_SEMIHS_ALTER_EGO)

--- a/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
+++ b/scripts/missions/windurst/2_3_1_The_Three_Kingdoms_Sandoria.lua
@@ -36,7 +36,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 3 then
-                        local needsHalverTrust = (not player:hasSpell(972) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(502, { [7] = needsHalverTrust })
                     else
@@ -51,7 +51,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 4)
 
                     if
-                        not player:hasSpell(972) and
+                        not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_HALVERS_ALTER_EGO)

--- a/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
+++ b/scripts/missions/windurst/2_3_3_The_Three_Kingdoms_Sandoria2.lua
@@ -35,7 +35,7 @@ mission.sections =
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 8 then
-                        local needsHalverTrust = (not player:hasSpell(972) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
+                        local needsHalverTrust = (not player:hasSpell(xi.magic.spell.HALVER) and not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)) and 1 or 0
 
                         return mission:progressEvent(504, { [7] = needsHalverTrust })
                     else
@@ -50,7 +50,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 9)
 
                     if
-                        not player:hasSpell(972) and
+                        not player:hasSpell(xi.magic.spell.HALVER) and
                         not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO)
                     then
                         npcUtil.giveItem(player, xi.items.CIPHER_OF_HALVERS_ALTER_EGO)

--- a/scripts/quests/hiddenQuests/Trust_Abquhbah.lua
+++ b/scripts/quests/hiddenQuests/Trust_Abquhbah.lua
@@ -13,7 +13,7 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(982) and
+            return not player:hasSpell(xi.magic.spell.ABQUHBAH) and
                 not player:findItem(xi.items.CIPHER_OF_ABQUHBAHS_ALTER_EGO) and
                 player:hasCompletedMission(xi.mission.log_id.TOAU, xi.mission.id.toau.IMMORTAL_SENTRIES) and
                 player:getCurrentMission(xi.mission.log_id.ROV) >= xi.mission.id.rov.EVER_FORWARD

--- a/scripts/quests/hiddenQuests/Trust_Halver.lua
+++ b/scripts/quests/hiddenQuests/Trust_Halver.lua
@@ -12,7 +12,7 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(972) and
+            return not player:hasSpell(xi.magic.spell.HALVER) and
                 not player:findItem(xi.items.CIPHER_OF_HALVERS_ALTER_EGO) and
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.THE_PATH_UNTRAVELED)
         end,

--- a/scripts/quests/hiddenQuests/Trust_Semih.lua
+++ b/scripts/quests/hiddenQuests/Trust_Semih.lua
@@ -12,7 +12,7 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(940) and
+            return not player:hasSpell(xi.magic.spell.SEMIH_LAFIHNA) and
                 not player:findItem(xi.items.CIPHER_OF_SEMIHS_ALTER_EGO) and
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.THE_PATH_UNTRAVELED)
         end,

--- a/scripts/quests/hiddenQuests/Trust_Zeid_II.lua
+++ b/scripts/quests/hiddenQuests/Trust_Zeid_II.lua
@@ -12,7 +12,7 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return not player:hasSpell(1010) and
+            return not player:hasSpell(xi.magic.spell.ZEID_II) and
                 not player:findItem(xi.items.CIPHER_OF_ZEIDS_ALTER_EGO_II) and
                 player:hasCompletedMission(xi.mission.log_id.ROV, xi.mission.id.rov.VOLTO_OSCURO)
         end,

--- a/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/_6h0.lua
@@ -62,7 +62,7 @@ entity.onTrigger = function(player, npc)
     elseif
         player:getRank(player:getNation()) >= 6 and
         player:hasKeyItem(xi.ki.SAN_DORIA_TRUST_PERMIT) and
-        not player:hasSpell(905)
+        not player:hasSpell(xi.magic.spell.TRION)
     then
         player:startEvent(574, 0, 0, 0, TrustMemory(player))
 
@@ -113,7 +113,7 @@ entity.onEventFinish = function(player, csid, option)
             player:completeQuest(xi.quest.log_id.SANDORIA, xi.quest.id.sandoria.UNDER_OATH)
         end
     elseif csid == 574 and option == 2 then
-        player:addSpell(905, false, true)
+        player:addSpell(xi.magic.spell.TRION, false, true)
         player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 905)
     end
 end

--- a/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(298) then
-            player:addSpell(298)
+        if not player:hasSpell(xi.magic.spell.IFRIT) then
+            player:addSpell(xi.magic.spell.IFRIT)
             player:messageSpecial(ID.text.IFRIT_UNLOCKED, 0, 0, 0)
         end
 

--- a/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(302) then
-            player:addSpell(302)
+        if not player:hasSpell(xi.magic.spell.SHIVA) then
+            player:addSpell(xi.magic.spell.SHIVA)
             player:messageSpecial(ID.text.SHIVA_UNLOCKED, 0, 0, 4)
         end
 

--- a/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(301) then
-            player:addSpell(301)
+        if not player:hasSpell(xi.magic.spell.GARUDA) then
+            player:addSpell(xi.magic.spell.GARUDA)
             player:messageSpecial(ID.text.GARUDA_UNLOCKED, 0, 0, 3)
         end
 

--- a/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(303) then
-            player:addSpell(303)
+        if not player:hasSpell(xi.magic.spell.RAMUH) then
+            player:addSpell(xi.magic.spell.RAMUH)
             player:messageSpecial(ID.text.RAMUH_UNLOCKED, 0, 0, 5)
         end
 

--- a/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(300) then
-            player:addSpell(300)
+        if not player:hasSpell(xi.magic.spell.LEVIATHAN) then
+            player:addSpell(xi.magic.spell.LEVIATHAN)
             player:messageSpecial(ID.text.LEVIATHAN_UNLOCKED, 0, 0, 2)
         end
 

--- a/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
@@ -33,8 +33,8 @@ end
 
 battlefieldObject.onEventFinish = function(player, csid, option)
     if csid == 32001 then
-        if not player:hasSpell(299) then
-            player:addSpell(299)
+        if not player:hasSpell(xi.magic.spell.TITAN) then
+            player:addSpell(xi.magic.spell.TITAN)
             player:messageSpecial(ID.text.TITAN_UNLOCKED, 0, 0, 1)
         end
 

--- a/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
@@ -59,7 +59,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(437)
     elseif
         trustWindurst == QUEST_COMPLETED and
-        not player:hasSpell(901) and
+        not player:hasSpell(xi.magic.spell.NANAA_MIHGO) and
         kupipiTrustChatFlag == 0
     then
         player:startEvent(438)

--- a/scripts/zones/Kazham/npcs/Ronta-Onta.lua
+++ b/scripts/zones/Kazham/npcs/Ronta-Onta.lua
@@ -49,7 +49,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end
 
-        if player:hasSpell(298) then
+        if player:hasSpell(xi.magic.spell.IFRIT) then
             numitem = numitem + 32
         end  -- Ability to summon Ifrit
 
@@ -89,7 +89,7 @@ entity.onEventFinish = function(player, csid, option)
             if option == 5 then
                 npcUtil.giveCurrency(player, 'gil', 10000)
             elseif option == 6 then
-                player:addSpell(298) -- Ifrit Spell
+                player:addSpell(xi.magic.spell.IFRIT) -- Ifrit Spell
                 player:messageSpecial(ID.text.IFRIT_UNLOCKED, 0, 0, 0)
             else
                 player:addItem(item)

--- a/scripts/zones/Mhaura/npcs/Ripapa.lua
+++ b/scripts/zones/Mhaura/npcs/Ripapa.lua
@@ -64,7 +64,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end
 
-        if player:hasSpell(303) then
+        if player:hasSpell(xi.magic.spell.RAMUH) then
             numitem = numitem + 32
         end  -- Ability to summon Ramuh
 

--- a/scripts/zones/Norg/npcs/Edal-Tahdal.lua
+++ b/scripts/zones/Norg/npcs/Edal-Tahdal.lua
@@ -50,7 +50,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end
 
-        if player:hasSpell(300) then
+        if player:hasSpell(xi.magic.spell.LEVIATHAN) then
             numitem = numitem + 32
         end  -- Ability to summon Leviathan
 
@@ -94,7 +94,7 @@ entity.onEventFinish = function(player, csid, option)
             if option == 5 then
                 npcUtil.giveCurrency(player, 'gil', 10000)
             elseif option == 6 then
-                player:addSpell(300) -- Avatar
+                player:addSpell(xi.magic.spell.LEVIATHAN) -- Avatar
                 player:messageSpecial(ID.text.AVATAR_UNLOCKED, 0, 0, 2)
             else
                 player:addItem(item)

--- a/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Excenmille.lua
@@ -60,7 +60,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(895)
     elseif
         trustSandoria == QUEST_COMPLETED and
-        not player:hasSpell(902) and
+        not player:hasSpell(xi.magic.spell.CURILLA) and
         excenmilleTrustChatFlag == 0
     then
         player:startEvent(896, 0, 0, 0, 0, 0, 0, 0, rank3)

--- a/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
@@ -68,7 +68,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end   -- Rust 'B' Gone
 
-        if player:hasSpell(302) then
+        if player:hasSpell(xi.magic.spell.SHIVA) then
             numitem = numitem + 32
         end  -- Ability to summon Shiva
 
@@ -113,7 +113,7 @@ entity.onEventFinish = function(player, csid, option)
             if option == 5 then
                 npcUtil.giveCurrency(player, 'gil', 10000)
             elseif option == 6 then
-                player:addSpell(302) -- Avatar
+                player:addSpell(xi.magic.spell.SHIVA) -- Avatar
                 player:messageSpecial(ID.text.SHIVA_UNLOCKED, 0, 0, 4)
             else
                 player:addItem(item)

--- a/scripts/zones/Port_Bastok/npcs/Juroro.lua
+++ b/scripts/zones/Port_Bastok/npcs/Juroro.lua
@@ -48,7 +48,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end   -- Desert Light
 
-        if player:hasSpell(299) then
+        if player:hasSpell(xi.magic.spell.TITAN) then
             numitem = numitem + 32
         end  -- Ability to summon Titan
 
@@ -90,7 +90,7 @@ entity.onEventFinish = function(player, csid, option)
             if option == 5 then
                 npcUtil.giveCurrency(player, 'gil', 10000)
             elseif option == 6 then
-                player:addSpell(299) -- Avatar Titan Spell
+                player:addSpell(xi.magic.spell.TITAN) -- Avatar Titan Spell
                 player:messageSpecial(ID.text.TITAN_UNLOCKED, 0, 0, 1)
             else
                 player:addItem(item)

--- a/scripts/zones/Rabao/npcs/Agado-Pugado.lua
+++ b/scripts/zones/Rabao/npcs/Agado-Pugado.lua
@@ -72,7 +72,7 @@ entity.onTrigger = function(player, npc)
             numitem = numitem + 8
         end   -- Bubbly Water
 
-        if player:hasSpell(301) then
+        if player:hasSpell(xi.magic.spell.GARUDA) then
             numitem = numitem + 32
         end  -- Ability to summon Garuda
 
@@ -116,7 +116,7 @@ entity.onEventFinish = function(player, csid, option)
             if option == 5 then
                 npcUtil.giveCurrency(player, 'gil', 10000)
             elseif option == 6 then
-                player:addSpell(301) -- Garuda Spell
+                player:addSpell(xi.magic.spell.GARUDA) -- Garuda Spell
                 player:messageSpecial(ID.text.GARUDA_UNLOCKED, 0, 0, 3)
             else
                 player:addItem(item)

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/npcs/Erlene.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
         aLittleKnowledge == QUEST_COMPLETED and
         mJob == xi.job.SCH and
         mLvl >= 5 and
-        not (player:hasSpell(478) and player:hasSpell(502))
+        not (player:hasSpell(xi.magic.spell.EMBRAVA) and player:hasSpell(xi.magic.spell.KAUSTRA))
     then
         player:startEvent(47)
     elseif
@@ -66,9 +66,12 @@ end
 
 entity.onEventFinish = function(player, csid, option)
     if csid == 47 then
-        if player:canLearnSpell(478) and player:canLearnSpell(502) then
-            player:addSpell(478, true)
-            player:addSpell(502, true)
+        if
+            player:canLearnSpell(xi.magic.spell.EMBRAVA) and
+            player:canLearnSpell(xi.magic.spell.KAUSTRA)
+        then
+            player:addSpell(xi.magic.spell.EMBRAVA, true)
+            player:addSpell(xi.magic.spell.KAUSTRA, true)
             player:messageSpecial(ID.text.YOU_LEARN_EMBRAVA_AND_KAUSTRA)
         end
     elseif csid == 18 then

--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -26,7 +26,7 @@ entity.onTrigger = function(player, npc)
             + (player:hasItem(xi.items.DIABOLOSS_EARRING) and 2 or 0) -- Diabolos's Earring
             + (player:hasItem(xi.items.DIABOLOSS_RING) and 4 or 0) -- Diabolos's Ring
             + (player:hasItem(xi.items.DIABOLOSS_TORQUE) and 8 or 0) -- Diabolos's Torque
-            + (player:hasSpell(304) and 32 or 16) -- Pact or gil
+            + (player:hasSpell(xi.magic.spell.DIABOLOS) and 32 or 16) -- Pact or gil
         player:startEvent(920, xi.items.DIABOLOSS_POLE, xi.items.DIABOLOSS_EARRING, xi.items.DIABOLOSS_RING, xi.items.DIABOLOSS_TORQUE, 0, 0, 0, availRewards)
     elseif
         not player:hasKeyItem(xi.ki.VIAL_OF_DREAM_INCENSE) and
@@ -65,8 +65,8 @@ entity.onEventFinish = function(player, csid, option)
             reward.item = xi.items.DIABOLOSS_TORQUE
         elseif option == 5 then
             reward.gil = 15000
-        elseif option == 6 and not player:hasSpell(304) then
-            player:addSpell(304)
+        elseif option == 6 and not player:hasSpell(xi.magic.spell.DIABOLOS) then
+            player:addSpell(xi.magic.spell.DIABOLOS)
             player:messageSpecial(ID.text.DIABOLOS_UNLOCKED, 0, 0, 0)
         end
 

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -55,7 +55,7 @@ local function getFenrirRewardMask(player)
         rewardMask = rewardMask + 16
     end -- Ancient's Key
 
-    if player:hasSpell(297) then
+    if player:hasSpell(xi.magic.spell.FENRIR) then
         rewardMask = rewardMask + 64
     end  -- Pact
 
@@ -189,7 +189,7 @@ entity.onEventFinish = function(player, csid, option)
         elseif option == 6 then
             npcUtil.giveCurrency(player, 'gil', 15000)
         elseif option == 7 then
-            player:addSpell(297) -- Pact
+            player:addSpell(xi.magic.spell.FENRIR) -- Pact
         elseif option == 8 then
             player:addKeyItem(xi.ki.FENRIR_WHISTLE)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.FENRIR_WHISTLE)

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -94,7 +94,7 @@ entity.onTrigger = function(player, npc)
         -- TRUST
     elseif
         player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT) and
-        not player:hasSpell(904)
+        not player:hasSpell(xi.magic.spell.AJIDO_MARUJIDO)
     then
         local rank6 = player:getRank(player:getNation()) >= 6 and 1 or 0
 
@@ -126,8 +126,8 @@ entity.onEventFinish = function(player, csid, option)
 
         -- TRUST
     elseif csid == 866 and option == 2 then
-        player:addSpell(904, true, true)
-        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, 904)
+        player:addSpell(xi.magic.spell.AJIDO_MARUJIDO, true, true)
+        player:messageSpecial(ID.text.YOU_LEARNED_TRUST, 0, xi.magic.spell.AJIDO_MARUJIDO)
     end
 end
 

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -54,6 +54,7 @@ disallowed_numeric_parameters = {
     "getItemQty"            : [ 0 ],
     "hasItem"               : [ 0 ],
     "hasItemQty"            : [ 0 ],
+    "hasSpell"              : [ 0 ],
     "messageBasic"          : [ 0 ],
     "messageName"           : [ 0 ],
     "messageSpecial"        : [ 0 ],


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces calls to hasSpell using magic numbers with enum values, and adds CI rule
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed, CI should pass
<!-- Clear and detailed steps to test your changes here -->
