### PR TITLE
[chocobo] Add raising events debug scenario & improve playout

### DIFF
--- a/scripts/commands/chocoboraising.lua
+++ b/scripts/commands/chocoboraising.lua
@@ -69,6 +69,23 @@ function onTrigger(player)
         })
 
         table.insert(menu.options, {
+            "Debug #1",
+            function(playerArg)
+                playerArg:deleteRaisedChocobo()
+
+                local egg = {}
+                local newChoco = xi.chocoboRaising.newChocobo(playerArg, egg)
+                player:setChocoboRaisingInfo(newChoco)
+
+                local info = playerArg:getChocoboRaisingInfo()
+                info["created"] = info["created"] - (epochDay * 10)
+                playerArg:setChocoboRaisingInfo(info)
+
+                playerArg:PrintToPlayer("Setting up debug scenario 1 (10d update)", xi.msg.channel.SYSTEM_3, "")
+            end,
+        })
+
+        table.insert(menu.options, {
             "Change sex",
             function(playerArg)
                 local info = playerArg:getChocoboRaisingInfo()
@@ -113,6 +130,23 @@ function onTrigger(player)
             "Give Egg",
             function(playerArg)
                 npcUtil.giveItem(playerArg, xi.items.CHOCOBO_EGG_SLIGHTLY_WARM)
+            end,
+        })
+
+        table.insert(menu.options, {
+            "Debug #1",
+            function(playerArg)
+                playerArg:deleteRaisedChocobo()
+
+                local egg = {}
+                local newChoco = xi.chocoboRaising.newChocobo(playerArg, egg)
+                player:setChocoboRaisingInfo(newChoco)
+
+                local info = playerArg:getChocoboRaisingInfo()
+                info["created"] = info["created"] - (epochDay * 10)
+                playerArg:setChocoboRaisingInfo(info)
+
+                playerArg:PrintToPlayer("Setting up debug scenario 1 (10d update)", xi.msg.channel.SYSTEM_3, "")
             end,
         })
     end

--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -443,7 +443,7 @@ local cutscenes =
     -- 40: Player gives the chocobo x
     -- 48: Happy to see you
     -- 51: Hangs its head in shame
-    -- 53: Haven't seen you around, chocobo is sleeping (dispose of white handkerchief)
+    HAVENT_SEEN_YOU = 53, -- Haven't seen you around, chocobo is sleeping (dispose of white handkerchief)
     -- 54: Accept white handkerchief
     CRYING_AT_NIGHT = 69, -- White handkerchief
     -- 70: Chocobo full of energy!
@@ -572,6 +572,16 @@ local compareTables = function(t1, t2)
     return true
 end
 
+-- NOTE: This is playable, but not quite right.
+-- Day1-4 should be condensed together, with the
+-- hatching CS playing at the end.
+-- Currently this outputs:
+-- Day1-4: Basic care
+-- Day 4: Hatching CS
+-- Day 5-onwards: As normal
+-- It should output:
+-- Day1-4: Basic care, then hatching CS
+-- Day5-onwards: As normal
 local condenseEvents = function(player, chocoState, events)
     local cutEvent = function(t, eStart, eEnd, csList)
         table.insert(t, { eStart, eEnd, csList })
@@ -584,7 +594,7 @@ local condenseEvents = function(player, chocoState, events)
 
     -- Each event is a table of cs's
     debug(player, "Raw Events")
-    for idx, entry in pairs(events) do
+    for _, entry in pairs(events) do
         debug(player, "Day", entry[1], ":", entry[2][1])
         -- Only condense days with the same table contents
         if compareTables(entry[2], currentEventCSTable) then
@@ -598,8 +608,8 @@ local condenseEvents = function(player, chocoState, events)
 
             -- Start a new span
             currentEventCSTable = entry[2]
-            currentStartDay = chocoState.report.day_start + idx - 1
-            currentEndDay = chocoState.report.day_start + idx - 1
+            currentStartDay = entry[1]
+            currentEndDay = entry[1]
         end
     end
 
@@ -612,6 +622,37 @@ local condenseEvents = function(player, chocoState, events)
     end
 
     return condensedEvents
+end
+
+local onRaisingEventPlayout = function(player, csOffset, chocoState)
+    switch (csOffset): caseof
+    {
+        [cutscenes.REPORT_BASIC_CARE] = function()
+            -- TODO: Take in a multiplier to account for merged time ranges
+            -- TODO: Add settings multipliers
+            -- TODO Make sure these are clamped!
+            chocoState.strength    = chocoState.strength + 1
+            chocoState.endurance   = chocoState.endurance + 1
+            chocoState.discernment = chocoState.discernment + 1
+            chocoState.receptivity = chocoState.receptivity + 1
+
+            chocoState.affection = chocoState.affection - 1
+            chocoState.energy    = chocoState.energy - 1
+        end,
+
+        [cutscenes.CRYING_AT_NIGHT] = function()
+            -- NOTE: The messaging is handled in the CS
+            player:addKeyItem(xi.ki.WHITE_HANDKERCHIEF)
+            player:setCharVar("[choco]WH_TIME", os.time() * utils.days(1))
+        end,
+
+        [cutscenes.HAVENT_SEEN_YOU] = function()
+            player:delKeyItem(xi.ki.WHITE_HANDKERCHIEF)
+            player:setCharVar("[choco]WH_TIME", 0)
+        end,
+    }
+
+    return chocoState
 end
 
 xi.chocoboRaising.initChocoboData = function(player)
@@ -709,16 +750,30 @@ xi.chocoboRaising.initChocoboData = function(player)
             end
         end
 
+        -- Start White Handkerchief quest
+        local whiteHandkerchiefStarted = false
+        if
+            -- TODO: Should this be a charvar to track this?
+            not player:hasKeyItem(xi.ki.WHITE_HANDKERCHIEF) and
+            age == 7
+        then
+            table.insert(events, { age, { cutscenes.CRYING_AT_NIGHT } })
+            whiteHandkerchiefStarted = true
+        end
+
+        -- Cancel White Handkerchief quest
+        if
+            whiteHandkerchiefStarted and
+            age == 15 and
+            reportLength >= 7
+        then
+            table.insert(events, { age, { cutscenes.HAVENT_SEEN_YOU } })
+        end
+
         -- TODO: Remove used days from care plan and write back to chocoState + db
     end
 
-    -- TODO: This is not quite right. Day1-4 should be condensed together, with the
-    -- hatching CS playing at the end. Then Day5 as it's own entry afterwards.
-
     -- Step 3: Condense that table down
-    -- Example: In the above example, if days 1, 2, and 3 are the same
-    -- thing, they will be condensed down to a single Day1-Day3 update.
-
     -- Step 4: Assign this report to the cache
     chocoState.report.events = condenseEvents(player, chocoState, events)
 
@@ -733,6 +788,10 @@ xi.chocoboRaising.startCutscene = function(player, npc, trade)
     local rejectionCsid = csidTable[player:getZoneID()][4]
 
     local chocoState = xi.chocoboRaising.initChocoboData(player)
+    if chocoState == nil then
+        print("ERROR! startCutscene 'chocoState' is nil!")
+        return
+    end
 
     if trade ~= nil then -- Trade
         if
@@ -1545,6 +1604,8 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option)
                     chocoState.stage = stage.ADULT_4
                 end
 
+                chocoState = onRaisingEventPlayout(player, csOffset, chocoState)
+
                 player:updateEventString(chocoState.first_name, chocoState.last_name, chocoState.first_name, chocoState.first_name,
                     0, 0, 0, 0, 0, 0, 0, 0)
                 player:updateEvent(#chocoState.csList, csToPlay, 0, chocoState.colour,
@@ -1556,6 +1617,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option)
             end,
 
             [504] = function() -- Skip report
+                debug(player, "Skip report (Currently doesn't work!)")
                 -- TODO: Do empty playout of report so that age and state are up-to-date
                 chocoState.last_update_age = chocoState.age
                 xi.chocoboRaising.chocoState[player:getID()] = chocoState

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -97,8 +97,19 @@ function utils.join(input1, input2)
     return result
 end
 
+-- For use alongside os.time()
 function utils.minutes(minutes)
     return minutes * 60
+end
+
+-- For use alongside os.time()
+function utils.hours(hours)
+    return hours * 60 * 60
+end
+
+-- For use alongside os.time()
+function utils.days(days)
+    return days * 60 * 60 * 24
 end
 
 -- Generates a random permutation of integers >= min_val and <= max_val


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves some things around in the chocobo raising state machine thing, to try and fix event condensing and playout. This is the thing that's been blocking me from releasing a test version of chocobo raising.

## Steps to test these changes

- Enable it the feature and debugging by changing the settings at the top of `chocobo_raising.lua`
- `!chocoboraising`
- There is an option to set up the `Debug #1` scenario
- Talk to one of the chocobo raising NPCs
- See the output I'm trying to fix:
![image](https://github.com/LandSandBoat/server/assets/1389729/a3d91070-cdf2-4e8a-bfdf-c5c95b30739a)
I eventually want it to be:
```
1-4: 0
4-4: 33
5-10: 0
```

If you want to take a crack at fixing it, all the logic is inside `condenseEvents()`