### PR TITLE
[lua] Fix typo in Sentinel Column

### DIFF
--- a/scripts/zones/Apollyon/npcs/Sentinel_Column.lua
+++ b/scripts/zones/Apollyon/npcs/Sentinel_Column.lua
@@ -20,7 +20,7 @@ end
 entity.onEventUpdate = function(player, csid, option)
     player:updateEvent(
         0,
-        GetServerVariable("[SE_APOLLYON]Time"),      -- SW Apollyon
+        GetServerVariable("[SW_APOLLYON]Time"),      -- SW Apollyon
         GetServerVariable("[NW_APOLLYON]Time"),      -- NW Apollyon
         GetServerVariable("[SE_APOLLYON]Time"),      -- SE Apollyon
         GetServerVariable("[NE_APOLLYON]Time"),      -- NE Apollyon


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fix typo in Sentinel Column

## Steps to test these changes

Southwest Apollyon should not show time remaining of SE apollyon