### PR TITLE
[CI] Ignore string contents in parameter padding check

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -123,7 +123,11 @@ class LuaStyleCheck:
         """
         # ,[^ \n] : Any comma that does not have space or newline following
 
-        for _ in re.finditer(",[^ \n]", line):
+        # Replace quoted strings with a placeholder
+        removed_string_line = re.sub('\"([^\"]*?)\"', "strVal", line)
+        removed_string_line = re.sub("\'([^\"]*?)\'", "strVal", removed_string_line)
+
+        for _ in re.finditer(",[^ \n]", removed_string_line):
             self.error("Multiple parameters used without an appropriate following space or newline")
 
     def check_semicolon(self, line):
@@ -421,7 +425,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 41
+    expected_errors = 47
 else:
     total_errors = LuaStyleCheck(target).errcount
 

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -171,3 +171,14 @@ local reallyLongVariableNameTwo = 2
 
 if reallyLongVariableNameOne == reallyLongVariableNameTwo and reallyLongVariableNameTwo - reallyLongVariableNameOne == 0 then -- FAIL
 end
+
+-- String values in parameters
+(a,"b",c) -- FAIL x2
+("a", b)  -- PASS
+(",", b)  -- PASS
+(",",b)   -- FAIL
+
+(a,'b',c) -- FAIL x2
+('a', b)  -- PASS
+(',', b)  -- PASS
+(',',b)   -- FAIL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Replaces string literals with a fixed value prior to parameter padding checks
* Updates stylecheck tests to cover the above changes

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should pass its selftest
<!-- Clear and detailed steps to test your changes here -->
