### PR TITLE
Disable Eruca casting while asleep

### DIFF
--- a/scripts/mixins/families/eruca.lua
+++ b/scripts/mixins/families/eruca.lua
@@ -31,6 +31,7 @@ local function bedTime(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
     mob:setMobMod(xi.mobMod.NO_AGGRO, 1)
     mob:setMobMod(xi.mobMod.NO_LINK, 1)
+    mob:setMagicCastingEnabled(false)
     mob:setLocalVar("ResleepTime", 0)
 end
 
@@ -39,6 +40,7 @@ local function wakeUp(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
     mob:setMobMod(xi.mobMod.NO_AGGRO, 0)
     mob:setMobMod(xi.mobMod.NO_LINK, 0)
+    mob:setMagicCastingEnabled(true)
     mob:setLocalVar("ResleepTime", 0)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #44

* Adds mobMob to disable casting
* Adds/Removes NO_CAST mobMod to eruca mixin for day/night cycles

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Observe eruca during their sleep cycles, and they should not cast
<!-- Clear and detailed steps to test your changes here -->
