### PR TITLE
[fix] Remove charid write-back to extra packet in message server

### DIFF
--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -149,9 +149,8 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
                                 "WHERE IF (allianceid <> 0, allianceid = (SELECT MAX(allianceid) FROM accounts_parties WHERE partyid = %d), "
                                 "partyid = %d) GROUP BY server_addr, server_port;";
 
-            uint32 partyid                        = ref<uint32>((uint8*)extra->data(), 0);
-            ref<uint32>((uint8*)extra->data(), 0) = sql->GetUIntData(2);
-            ret                                   = sql->Query(query, partyid, partyid);
+            uint32 partyid = ref<uint32>((uint8*)extra->data(), 0);
+            ret            = sql->Query(query, partyid, partyid);
             break;
         }
         case MSG_CHAT_LINKSHELL:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This bug came in during:
https://github.com/LandSandBoat/server/commit/efa188386304e87c09cc50635db0afdf74e5685e
https://github.com/LandSandBoat/server/commit/6a2950c4482f2645394185c3eda3015496c49871
https://github.com/LandSandBoat/server/commit/7e5a982eb88aae8de8dcfbb3e392b8b16e1ec461

I've been looking at it, and I can't see what the write back to `extra` is doing, since `extra` is only forwareded out of the message server after this. There aren't any changes to the party system, so I suspect its just an accidental change? Kore will correct me if this breaks something, but I'm prioritising stability for now.

Fixes https://github.com/LandSandBoat/server/issues/4135

## Steps to test these changes

Start up, join a party, let updates happen, no errors