### PR TITLE
Fixes print message for !pos command

### DIFF
--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -21,6 +21,12 @@ function onTrigger(player, arg)
     local y
     local z
     local targ
+
+    if arg == nil then
+        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f  Rot %i  (Zone: %i)", player:getName(), player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID()), xi.msg.channel.SYSTEM_3)
+        return
+    end
+
     local args = utils.splitArg(arg)
 
     -- shift arguments depending on number passed


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes print functionality broken by #4097

Print and return early if arg is nil

## Steps to test these changes

`!pos` to see your current position
