### PR TITLE
Adds missing date check to HELM Egg Hunt

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1534,6 +1534,7 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
                 xi.events and
                 xi.events.eggHunt and
                 xi.events.eggHunt.enabledCheck and
+                xi.events.eggHunt.enabledCheck() and
                 player:getCharVar("[EGG_HUNT]DAILY_HELM") < VanadielUniqueDay()
             then
                 player:timer(3000, function(playerArg)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

HELM isn't calling `enabledCheck()` to test for Egg Hunt event, before adding eggs.

## Steps to test these changes

Once per day during event, players can get a random lettered egg from HELM. They shouldn't be able to outside of event.