### PR TITLE
[Magic] Add setting for immunobreak & Resist rank multiplier re-scaling

### DIFF
--- a/scripts/globals/combat/magic_hit_rate.lua
+++ b/scripts/globals/combat/magic_hit_rate.lua
@@ -312,6 +312,25 @@ end
 ---------------------------------------------------------------------------
 -- Calculate Target Magic Evasion
 ---------------------------------------------------------------------------
+local resistRankMultiplier =
+{
+-- [Rank] = Magic Evasion multiplier.
+    [-3] = 0.95,
+    [-2] = 0.96019,
+    [-1] = 0.98,
+    [ 0] = 1,
+    [ 1] = 1.023,
+    [ 2] = 1.049,
+    [ 3] = 1.0905,
+    [ 4] = 1.126,
+    [ 5] = 1.2075,
+    [ 6] = 1.3475,
+    [ 7] = 1.70065,
+    [ 8] = 2.141,
+    [ 9] = 2.2,
+    [10] = 2.275, -- Impossible to test since "Magic Hit Rate" is floored to 5% at this point.
+    [11] = 2.35,  -- Impossible to test since "Magic Hit Rate" is floored to 5% at this point.
+}
 
 xi.combat.magicHitRate.calculateTargetMagicEvasion = function(actor, target, spellElement, isEnfeeble, mEvaMod, rankModifier)
     local magicEva   = target:getMod(xi.mod.MEVA) -- Base MACC.
@@ -323,14 +342,13 @@ xi.combat.magicHitRate.calculateTargetMagicEvasion = function(actor, target, spe
     if spellElement ~= xi.magic.ele.NONE then
         -- Mod set in database for mobs. Base 0 means not resistant nor weak. Bar-element spells included here.
         resMod     = target:getMod(xi.combat.element.elementalMagicEva[spellElement])
-        resistRank = target:getMod(xi.combat.element.resistRankMod[spellElement])
+        resistRank = utils.clamp(target:getMod(xi.combat.element.resistRankMod[spellElement]), -3, 11)
 
         if resistRank > 4 then
             resistRank = utils.clamp(resistRank - rankModifier, 4, 11)
         end
 
-        magicEva = magicEva * (1 + (resistRank * 0.075))
-        magicEva = magicEva + resMod
+        magicEva = math.floor(magicEva * resistRankMultiplier[resistRank]) + resMod
     end
 
     -- Magic evasion against specific status effects.

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -414,9 +414,9 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
         end
 
         if
+            xi.settings.main.ENABLE_IMMUNOBREAK and
             caster:isPC() and
             target:isMob() and
-            xi.settings.main.ENABLE_IMMUNOBREAK and
             immunobreakTable[spellEffect] and          -- Only certain effects can be immunobroken.
             skillType == xi.skill.ENFEEBLING_MAGIC and -- Only Enfeebling magic can immunobreak.
             resistRank > 4                             -- Only mobs with a resistace rank of 5+ (50% EEM) can be immunobroken.

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -416,6 +416,7 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
         if
             caster:isPC() and
             target:isMob() and
+            xi.settings.main.ENABLE_IMMUNOBREAK and
             immunobreakTable[spellEffect] and          -- Only certain effects can be immunobroken.
             skillType == xi.skill.ENFEEBLING_MAGIC and -- Only Enfeebling magic can immunobreak.
             resistRank > 4                             -- Only mobs with a resistace rank of 5+ (50% EEM) can be immunobroken.

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -119,8 +119,9 @@ xi.settings.main =
     ITEM_POWER      = 1.000, -- Multiplies the effect of items such as Potions and Ethers.
     WEAPON_SKILL_POWER  = 1.000, -- Multiplies damage dealt by Weapon Skills.
 
-    USE_ADOULIN_WEAPON_SKILL_CHANGES = true, -- true/false. Change to toggle new Adoulin weapon skill damage calculations
+    USE_ADOULIN_WEAPON_SKILL_CHANGES = true,  -- true/false. Change to toggle new Adoulin weapon skill damage calculations
     DISABLE_PARTY_EXP_PENALTY        = false, -- true/false.
+    ENABLE_IMMUNOBREAK               = true,  -- true/false. Allow/Disallow immunobreaks to happen.
 
     -- TRUSTS
     ENABLE_TRUST_CASTING           = 1,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds setting to enable or dissable Immunobreaks.
- Re-scales resistance rank multiplier on magic evasion, according to Jimmayus' documentation.

## Steps to test these changes

- Change setting to false to dissable immunobreaks.
- The way the re-scaling goes, mobs will be less weak at negative ranks, but also weaker at low (possitive) ranks and more resistant at higher ones.
