### PR TITLE
Improves !additem command with item name handling

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5499,8 +5499,8 @@ namespace luautils
     uint16 GetItemIDByName(std::string const& name)
     {
         uint16      id    = 0;
-        const char* Query = "SELECT itemid FROM item_basic WHERE name LIKE '%s';";
-        int32       ret   = sql->Query(Query, name);
+        const char* Query = "SELECT itemid FROM item_basic WHERE name LIKE '%s' OR sortname LIKE '%s';";
+        int32       ret   = sql->Query(Query, name, name);
 
         if (ret != SQL_ERROR && sql->NumRows() == 1) // Found a single result
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Improves `!additem` command (and `GetItemIDByName`) by adding support for `sortname` match. This often means shorter and more familiar names that don't require memorising the prefix. The item ID and augment functions of `!additem` remain unchanged.

Before:
`!additem chunk_of_rock_salt`

After:
`!additem rock_salt`
`!additem chunk_of_rock_salt`

## Steps to test these changes

`!additem (name)`
`!additem (sortname)`
