### PR TITLE
[Shops] Audited Royal Armoury

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
@@ -14,21 +14,21 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        17024,    72, 3,    -- Ash Club
-		17049,    52, 3,    -- Maple Wand
-		17050,   370, 3,    -- Willow Wand
-		17051,  1566, 1,    -- Yew Wand
-		17088,    64, 3,    -- Ash Staff
-		17089,   635, 3,    -- Holly Staff
+        17024,    74, 3,    -- Ash Club
+        17049,    54, 3,    -- Maple Wand
+        17050,   384, 3,    -- Willow Wand
+        17051,  1566, 1,    -- Yew Wand
+        17088,    66, 3,    -- Ash Staff
+        17089,   660, 3,    -- Holly Staff
         17090,  3606, 1,    -- Elm Staff
-		17095,   420, 3,    -- Ash Pole
-		17096,  5076, 2,    -- Holly Pole
+        17095,   436, 3,    -- Ash Pole
+        17096,  5076, 2,    -- Holly Pole
         17097, 18240, 1,    -- Elm Pole
-		16385,   144, 3,    -- Cesti
-		16391,   900, 3,    -- Brass Knuckles
-		16407,  1690, 3,    -- Brass Baghnakhs
-		16768,   344, 3,    -- Bronze Zaghnal
-		16769,  2825, 3,    -- Brass Zaghnal
+        16385,   149, 3,    -- Cesti
+        16391,   936, 3,    -- Brass Knuckles
+        16407,  1757, 3,    -- Brass Baghnakhs
+        16768,   357, 3,    -- Bronze Zaghnal
+        16769,  2938, 3,    -- Brass Zaghnal
         16770, 12540, 1,    -- Zaghnal
     }
 

--- a/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
@@ -14,22 +14,22 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        17051,  1409, 1,    -- Yew Wand
-        17090,  3245, 1,    -- Elm Staff
-        17097, 16416, 1,    -- Elm Pole
-        16770, 11286, 1,    -- Zaghnal
-        17096,  4568, 2,    -- Holly Pole
-        17024,    66, 3,    -- Ash Club
-        17049,    46, 3,    -- Maple Wand
-        17050,   333, 3,    -- Willow Wand
-        17088,    57, 3,    -- Ash Staff
-        17089,   571, 3,    -- Holly Staff
-        17095,   386, 3,    -- Ash Pole
-        16385,   132, 3,    -- Cesti
-        16391,   828, 3,    -- Brass Knuckles
-        16407,  1554, 3,    -- Brass Baghnakhs
-        16768,   309, 3,    -- Bronze Zaghnal
-        16769,  2542, 2,    -- Brass Zaghnal
+        17024,    72, 3,    -- Ash Club
+		17049,    52, 3,    -- Maple Wand
+		17050,   370, 3,    -- Willow Wand
+		17051,  1566, 1,    -- Yew Wand
+		17088,    64, 3,    -- Ash Staff
+		17089,   635, 3,    -- Holly Staff
+        17090,  3606, 1,    -- Elm Staff
+		17095,   420, 3,    -- Ash Pole
+		17096,  5076, 2,    -- Holly Pole
+        17097, 18240, 1,    -- Elm Pole
+		16385,   144, 3,    -- Cesti
+		16391,   900, 3,    -- Brass Knuckles
+		16407,  1690, 3,    -- Brass Baghnakhs
+		16768,   344, 3,    -- Bronze Zaghnal
+		16769,  2825, 3,    -- Brass Zaghnal
+        16770, 12540, 1,    -- Zaghnal
     }
 
     player:showText(npc, ID.text.ARLENNE_SHOP_DIALOG)

--- a/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
@@ -17,19 +17,19 @@ entity.onTrigger = function(player, npc)
         17024,    74, 3,    -- Ash Club
         17049,    54, 3,    -- Maple Wand
         17050,   384, 3,    -- Willow Wand
-        17051,  1566, 1,    -- Yew Wand
+        17051,  1628, 1,    -- Yew Wand
         17088,    66, 3,    -- Ash Staff
         17089,   660, 3,    -- Holly Staff
-        17090,  3606, 1,    -- Elm Staff
+        17090,  3750, 1,    -- Elm Staff
         17095,   436, 3,    -- Ash Pole
-        17096,  5076, 2,    -- Holly Pole
-        17097, 18240, 1,    -- Elm Pole
+        17096,  5279, 2,    -- Holly Pole
+        17097, 18969, 1,    -- Elm Pole
         16385,   149, 3,    -- Cesti
         16391,   936, 3,    -- Brass Knuckles
         16407,  1757, 3,    -- Brass Baghnakhs
         16768,   357, 3,    -- Bronze Zaghnal
         16769,  2938, 3,    -- Brass Zaghnal
-        16770, 12540, 1,    -- Zaghnal
+        16770, 13041, 1,    -- Zaghnal
     }
 
     player:showText(npc, ID.text.ARLENNE_SHOP_DIALOG)

--- a/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
@@ -18,12 +18,12 @@ entity.onTrigger = function(player, npc)
         16466,  2522, 3,    -- Knife
         17059,   104, 3,    -- Bronze Rod
         17081,   717, 3,    -- Brass Rod
-        17060,  2652, 1,    -- Rod
+        17060,  2758, 1,    -- Rod
         17034,   195, 3,    -- Bronze Mace
-        17035,  4848, 2,    -- Mace
+        17035,  5041, 2,    -- Mace
         16640,   328, 3,    -- Bronze Axe
         16583,  2828, 3,    -- Claymore
-        16584, 42000, 1,    -- Mythril Claymore
+        16584, 43680, 1,    -- Mythril Claymore
         16833,   915, 3,    -- Bronze Spear
         16834,  5408, 3,    -- Brass Spear
         16835, 18345, 3,    -- Spear

--- a/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
@@ -14,17 +14,20 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        16584, 37800, 1,    -- Mythril Claymore
-        16466,  2182, 1,    -- Knife
-        17060,  2386, 1,    -- Rod
-        16640,   284, 2,    -- Bronze Axe
-        16465,   147, 2,    -- Bronze Knife
-        17081,   621, 2,    -- Brass Rod
-        16583,  2448, 2,    -- Claymore
-        17035,  4363, 2,    -- Mace
-        17059,    90, 3,    -- Bronze Rod
-        17034,   169, 3,    -- Bronze Mace
-        16845, 16578, 3,    -- Lance
+        16465,   164, 3,    -- Bronze Knife
+		16466,  2425, 3,    -- Knife
+		17059,   100, 3,    -- Bronze Rod
+		17081,   690, 3,    -- Brass Rod
+        17060,  2652, 1,    -- Rod
+		17034,   188, 3,    -- Bronze Mace
+        17035,  4848, 2,    -- Mace
+        16640,   316, 3,    -- Bronze Axe
+        16583,  2720, 3,    -- Claymore
+		16584, 42000, 1,    -- Mythril Claymore
+		16833,   880, 3,    -- Bronze Spear
+		16834,  5200, 3,    -- Brass Spear
+		16835, 17640, 3,    -- Spear
+		16845, 18420, 3,    -- Lance
     }
 
     player:showText(npc, ID.text.TAVOURINE_SHOP_DIALOG)

--- a/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
@@ -14,20 +14,20 @@ end
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        16465,   164, 3,    -- Bronze Knife
-		16466,  2425, 3,    -- Knife
-		17059,   100, 3,    -- Bronze Rod
-		17081,   690, 3,    -- Brass Rod
+        16465,   170, 3,    -- Bronze Knife
+        16466,  2522, 3,    -- Knife
+        17059,   104, 3,    -- Bronze Rod
+        17081,   717, 3,    -- Brass Rod
         17060,  2652, 1,    -- Rod
-		17034,   188, 3,    -- Bronze Mace
+        17034,   195, 3,    -- Bronze Mace
         17035,  4848, 2,    -- Mace
-        16640,   316, 3,    -- Bronze Axe
-        16583,  2720, 3,    -- Claymore
-		16584, 42000, 1,    -- Mythril Claymore
-		16833,   880, 3,    -- Bronze Spear
-		16834,  5200, 3,    -- Brass Spear
-		16835, 17640, 3,    -- Spear
-		16845, 18420, 3,    -- Lance
+        16640,   328, 3,    -- Bronze Axe
+        16583,  2828, 3,    -- Claymore
+        16584, 42000, 1,    -- Mythril Claymore
+        16833,   915, 3,    -- Bronze Spear
+        16834,  5408, 3,    -- Brass Spear
+        16835, 18345, 3,    -- Spear
+        16845, 19156, 3,    -- Lance
     }
 
     player:showText(npc, ID.text.TAVOURINE_SHOP_DIALOG)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Audited the 2 shop NPCs in Northern Sandy. Arlenne & Tavourine of Royal Armoury.

- Fixed prices
- Fixed nation conquest requirements
- Fixed order of items
- Added missing weapons (Bronze Spear, Brass Spear, Spear)

I compared BGwiki to JPwiki and noticed that JPwiki has the updated list of the July 2011 patch. (They even list the changes on their shop page.) 
Also the JP list has a note that their prices are the base prices untouched by fame etc. (The numbers also make alot more sense.)
I also ordered the items according to the JPwiki because they usually use the retail list instead of the LSB ordering by conquest/ID.) Not gonna touch the formatting otherwise.

Sources:
- https://www.bg-wiki.com/ffxi/Tavourine
- https://wiki-ffo-jp.translate.goog/html/9245.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US
- https://www.bg-wiki.com/ffxi/Version_Update_(07/11/2011)

## Steps to test these changes

Check out the shops.
