### PR TITLE
[core] Fix Custom Menus Not Working With Japanese Client

### DIFF
--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -345,7 +345,7 @@ namespace luautils
 
     auto SetCustomMenuContext(CCharEntity* PChar, sol::table table) -> std::string;
     bool HasCustomMenuContext(CCharEntity* PChar);
-    void HandleCustomMenu(CCharEntity* PChar, std::string selection);
+    void HandleCustomMenu(CCharEntity* PChar, const std::string& selection);
 
     // Retrive the first itemId that matches a name
     uint16 GetItemIDByName(std::string const& name);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request resolves an outstanding issue/bug and adds additional functionality to the custom menu system.

  - Closes #3570 
  - Fixes custom menus not working properly with Japanese clients.
  - Outlines future expansion into supporting French and German clients if needed/wanted.
  - Adds support for supporting all of the potential messages that a client can send for both NA/JP in regards to GM tells.
  - Adds detection for when the GM tell window is closed due to the client being in an event. 
  - Adds a second parameter to the `onCancelled` callback, `is_event` to inform the invoker the menu was cancelled due to the client being in an event.

## Steps to test these changes

I've made a simple test addon to demonstrate the changes are working:

**testmenu.lua**
```lua
-----------------------------------
-- func: testmenu
-- desc: Creates a custom menu for testing purposes.
-----------------------------------

cmdprops =
{
    permission = 0,
    parameters = ""
}

function onTrigger(player)

    local options = {};
    table.insert(options, { '1', function (parg) parg:PrintToPlayer("Option 1 Selected", xi.msg.channel.NS_SAY); end });
    table.insert(options, { '2', function (parg) parg:PrintToPlayer("Option 2 Selected", xi.msg.channel.NS_SAY); end });
    table.insert(options, { '3', function (parg) parg:PrintToPlayer("Option 3 Selected", xi.msg.channel.NS_SAY); end });

    local menu = 
    {
        options = options,
        title = 'Menu Test',
        onCancelled = function (parg, is_event)
            parg:PrintToPlayer("Menu was cancelled. Event Status: " .. tostring(is_event), xi.msg.channel.NS_SAY);
        end,
        onEnd = function (parg)
            parg:PrintToPlayer("Menu end.", xi.msg.channel.NS_SAY);
        end,
        onStart = function (parg)
            parg:PrintToPlayer("Menu start.", xi.msg.channel.NS_SAY);
        end,
    };
    
    player:customMenu(menu);

end
```