### PR TITLE
Fixes level cap info for Snoll Tzar fight

### DIFF
--- a/sql/bcnm_info.sql
+++ b/sql/bcnm_info.sql
@@ -202,7 +202,7 @@ INSERT INTO `bcnm_info` VALUES (608,211,'trial_by_water','nobody',0,1800,1800,0,
 INSERT INTO `bcnm_info` VALUES (609,211,'trial-size_trial_by_water','nobody',0,900,900,20,1,0,5,0);
 INSERT INTO `bcnm_info` VALUES (610,211,'waking_the_beast','nobody',0,1800,1800,0,18,0,5,0);
 INSERT INTO `bcnm_info` VALUES (611,211,'sugar-coated_directive','nobody',0,1800,1800,99,6,0,5,0);
-INSERT INTO `bcnm_info` VALUES (640,6,'flames_for_the_dead','nobody',0,1800,1800,99,6,0,5,0);
+INSERT INTO `bcnm_info` VALUES (640,6,'flames_for_the_dead','nobody',0,1800,1800,60,6,0,5,0);
 INSERT INTO `bcnm_info` VALUES (641,6,'follow_the_white_rabbit','nobody',0,1800,1800,75,18,641,15,0);
 INSERT INTO `bcnm_info` VALUES (642,6,'when_hell_freezes_over','nobody',0,900,900,75,18,642,15,0);
 INSERT INTO `bcnm_info` VALUES (643,6,'brothers','nobody',0,1800,1800,75,18,643,15,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Flames for the Dead (Snoll Tzar) doesn't have the correct level cap information (60), which means it isn't applied when `map.LV_CAP_MISSION_BCNM` is turned on. For example, the Promyvion battlefields have this value set to 30:
```
INSERT INTO `bcnm_info` VALUES (768,17,'ancient_flames_beckon','nobody',0,1800,1800,30,6,0,5,1);
```
With `map.LV_CAP_MISSION_BCNM` off, they will all be uncapped regardless.

https://ffxiclopedia.fandom.com/wiki/Where_Messengers_Gather_(Ulmia%27s_Path)?oldid=179202#Bearclaw_Pinnacle_-_Level_60_Cap_BCNM

## Steps to test these changes

Update with DB tool and enter the battlefield.
`!pos -717 9 -442 6`
