### PR TITLE
Fix typo in Adventurer's Coupon enum in Jack_of_Spades.lua

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Jack_of_Spades.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Jack_of_Spades.lua
@@ -8,7 +8,7 @@ require("scripts/globals/npc_util")
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.items.ADVENTURERS_COUPON) then -- adventurer coupon
+    if npcUtil.tradeHas(trade, xi.items.ADVENTURER_COUPON) then -- adventurer coupon
         player:startEvent(10010, xi.settings.main.GIL_RATE * 50)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Turn in of the Adventurer coupon is broken because the enum is incorrect

## Steps to test these changes

Trade Jack of Spades an Adventurer's coupon.
