### PR TITLE
Fix incorrect operand in Missionary Man Quest

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
@@ -18,9 +18,9 @@ entity.onTrigger = function(player, npc)
 
     if missionaryManVar == 2 then
         player:startEvent(698, 0, 1146) -- Start statue creation
-    elseif missionaryManVar == 3 and finishtime < os.time() then
+    elseif missionaryManVar == 3 and finishtime > os.time() then
         player:startEvent(699) -- During statue creation
-    elseif missionaryManVar == 3 and finishtime >= os.time() then
+    elseif missionaryManVar == 3 and finishtime <= os.time() then
         player:startEvent(700) -- End of statue creation
     elseif missionaryManVar == 4 then
         player:startEvent(701) -- During quest (after creation)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Missionary Man quest cannot progress in current state because operand is backwards

## Steps to test these changes

Add the quest, wait one minute, and you should be able to progress.
