### PR TITLE
[login] Add more robust login error handling

### DIFF
--- a/src/login/connect_server.cpp
+++ b/src/login/connect_server.cpp
@@ -86,12 +86,30 @@ ConnectServer::ConnectServer(int argc, char** argv)
         // if io_context finishes!
         ShowInfo("starting io_context");
 
-        io_context.run();
+        // This busy loop looks nasty, however --
+        // https://think-async.com/Asio/asio-1.24.0/doc/asio/reference/io_service.html
+        /* If an exception is thrown from a handler, the exception is allowed to propagate through the throwing thread's invocation of
+            run(), run_one(), run_for(), run_until(), poll() or poll_one(). No other threads that are calling any of these functions are affected.
+            It is then the responsibility of the application to catch the exception.
+        */
+
+        while (Application::IsRunning())
+        {
+            try
+            {
+                io_context.run();
+                break;
+            }
+            catch (std::exception& e)
+            {
+                // TODO: make a list of "allowed exceptions", the rest can/should cause shutdown.
+                ShowError(fmt::format("Inner fatal: {}", e.what()));
+            }
+        }
     }
     catch (std::exception& e)
     {
-        ShowError(fmt::format("Fatal: {}", e.what()));
-        io_context.stop();
+        ShowError(fmt::format("Outer fatal: {}", e.what()));
     }
 }
 


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sometimes, a handler can throw an exception that will stop the io_context from continuing work. This commit will allow the handlers to work after an exception of that type. Usually these are socket errors such as Windows giving us an invalid handle or some other OS level issues that we can't deal with.

However, even truly fatal exceptions are ignored and we will want a list in the future of "acceptable" exceptions to ignore for socket exception reasons.

## Steps to test these changes

Login as usual. No known way to directly trigger this code.
