### PR TITLE
[Quest] Curses, Foiled A-Golem!? Additional Title

### DIFF
--- a/scripts/quests/windurst/Curses_Foiled_A_Golem.lua
+++ b/scripts/quests/windurst/Curses_Foiled_A_Golem.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Curses, Foiled A-Golem!?
 -----------------------------------
--- !addquest 2 34
+-- !addquest 2 63
 -- Shantotto       : !pos 122 -2 112 239
 -- Torino-Samarino : !pos 105 -20 140 111
 -- Cermet Door     : !pos -183 0 190 204
@@ -185,6 +185,9 @@ quest.sections =
             onEventFinish =
             {
                 [342] = function(player, csid, option, npc)
+                    -- Per FFXIclopedia: You can still get [Total Loser] at the
+                    -- title-changing NPC after the quest has been completed.
+                    player:addTitle(xi.title.TOTAL_LOSER)
                     quest:complete(player)
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add the title "Total Loser" to the quest completion for Curses, Foiled A-Golem!? quest. The title should be added to available titles at a title-changing NPC, but the title "Doctor Shantotto's Flavor of the Month" should be the one that is set upon quest completion.

## Steps to test these changes

!pos 122 -2 112 239 (Shantotto)
!addquest 2 63
!exec player:startEvent(342)
Check title is "Doctor Shantotto's Flavor of the Month"
!pos 0.080 -10.765 5.394 239 (Burute-Sorute)
Purchase "Total Loser" title for 400 gil
Check title is "Total Loser"