### PR TITLE
Fix invalid regions being passed to HandleWeeklyTallyEnd

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -454,7 +454,7 @@ namespace conquest
         zoneutils::ForEachZone([ranking, isConquestAlliance](CZone* PZone)
         {
             // only find chars for zones that have had conquest updated
-            if (PZone->GetRegionID() <= REGION_TYPE::DYNAMIS)
+            if (PZone->GetRegionID() <= REGION_TYPE::TAVNAZIA)
             {
                 uint8 influence = conquest::GetInfluenceGraphics(PZone->GetRegionID());
                 uint8 owner     = conquest::GetRegionOwner(PZone->GetRegionID());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Reduces range of regions iterated over in HandleWeeklyTallyEnd to match valid regions
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Weekly Tally should not crash
<!-- Clear and detailed steps to test your changes here -->
