### PR TITLE
Set ConquestData vector size, use region_id as key

### DIFF
--- a/src/map/conquest_data.cpp
+++ b/src/map/conquest_data.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2023 LandSandBoat Dev Teams
@@ -26,37 +26,36 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "conquest_system.h"
 
 ConquestData::ConquestData(std::unique_ptr<SqlConnection>& sql)
-: regionControls(std::vector<region_control_t>(256))
-, influences(std::vector<influence_t>(256))
+: regionControls(std::vector<region_control_t>(19))
+, influences(std::vector<influence_t>(19))
 {
     load(sql);
 }
 
 void ConquestData::load(std::unique_ptr<SqlConnection>& sql)
 {
-    const char* Query = "SELECT region_control, region_control_prev, sandoria_influence, bastok_influence, windurst_influence, beastmen_influence \
+    const char* Query = "SELECT region_id, region_control, region_control_prev, sandoria_influence, bastok_influence, windurst_influence, beastmen_influence \
                              FROM conquest_system;";
 
     int32 ret = sql->Query(Query);
 
     if (ret != SQL_ERROR && sql->NumRows() != 0)
     {
-        uint8 regionId = 0;
         while (sql->NextRow() == SQL_SUCCESS)
         {
+            uint8 regionId = sql->GetUIntData(0);
+
             region_control_t regionControl{};
-            regionControl.current    = sql->GetIntData(0);
-            regionControl.prev       = sql->GetIntData(1);
+            regionControl.current    = sql->GetIntData(1);
+            regionControl.prev       = sql->GetIntData(2);
             regionControls[regionId] = regionControl;
 
             influence_t influence{};
-            influence.sandoria_influence = sql->GetIntData(2);
-            influence.bastok_influence   = sql->GetIntData(3);
-            influence.windurst_influence = sql->GetIntData(4);
-            influence.beastmen_influence = sql->GetIntData(5);
+            influence.sandoria_influence = sql->GetIntData(3);
+            influence.bastok_influence   = sql->GetIntData(4);
+            influence.windurst_influence = sql->GetIntData(5);
+            influence.beastmen_influence = sql->GetIntData(6);
             influences[regionId]         = influence;
-
-            regionId++;
         }
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Removes counter and uses region_id from sql as key for data
* Reduces constructed vector size of 256 to 19 (number of actual regions)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Based on the conquest_system table, conquest rankings should be accurately displayed
<!-- Clear and detailed steps to test your changes here -->
