### PR TITLE
[dbtool] Make connect() less noisy if it fails

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -476,7 +476,7 @@ def connect():
             print_red(
                 "Incorrect mysql_login or mysql_password, update settings/network.lua."
             )
-            close()
+            quit()
         elif err.errno == mariadb.constants.ERR.ER_BAD_DB_ERROR:
             print_red("Database " + database + " does not exist.")
             if (
@@ -504,7 +504,8 @@ def connect():
             else:
                 quit()
         else:
-            print_red(err)
+            print_red(str(err))
+            quit()
         return False
     return True
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If your MariaDB service isn't running, you'll get errors when you start dbtool:

![image](https://github.com/LandSandBoat/server/assets/1389729/28a2a96c-e62e-4ba2-9882-1b7fb2978f5a)

They're very noisy, I've wrapped the errors and quit out immediately if db connection fails, that cleans everything up:

<img width="314" alt="image" src="https://github.com/LandSandBoat/server/assets/1389729/a1af6212-5b0e-4e41-b6a3-912b5f904aae">
