### PR TITLE
Add safety to ConquestData::getRegionOwner

### DIFF
--- a/src/map/conquest_data.cpp
+++ b/src/map/conquest_data.cpp
@@ -86,7 +86,15 @@ int32 ConquestData::getInfluence(REGION_TYPE region, NATION_TYPE nation) const
 
 uint8 ConquestData::getRegionOwner(REGION_TYPE region) const
 {
-    return regionControls[(uint8)region].current;
+    uint8 regionNum = static_cast<uint8>(region);
+
+    if (regionNum < regionControls.size())
+    {
+        return regionControls[regionNum].current;
+    }
+
+    ShowError(fmt::format("Invalid conquest region passed to function ({})", regionNum));
+    return 0;
 }
 
 uint8 ConquestData::getRegionControlCount(NATION_TYPE nation) const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds additional safety and logging to ConquestData::getRegionOwner
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Kill a mob in Abyssea, see error in logs but no crash
<!-- Clear and detailed steps to test your changes here -->
