### PR TITLE
[Interaction] Fix impossible option in "Faded Promises" quest

### DIFF
--- a/scripts/quests/bastok/Faded_Promises.lua
+++ b/scripts/quests/bastok/Faded_Promises.lua
@@ -77,7 +77,8 @@ quest.sections =
             onEventFinish =
             {
                 [803] = function(player, csid, option, npc)
-                    if option == 1 then
+                    -- This event uses a very big number for cancelation, making the capture suite wrongly return 0.
+                    if option == 0 then
                         quest:setVar(player, 'Prog', 1)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes incorrect option being checked.

Event 803 "always returns option 0" in retail. (This is seemingly untrue, though. Just an issue with the capture suite)
![imagen](https://github.com/LandSandBoat/server/assets/60053999/cb68c35e-58d8-4003-b2b3-e9552f868dae)

First option return in screenshot is for second (the wrong) option.
Second option return in screenshot is for the first (the correct) option.

UPDATE: This seems to be an issue with the capture suite.

## Steps to test these changes

- Start quest.
- Talk to ayame.
- See the quest advance when selecting the correct option.