### PR TITLE
Add ability to track one-time (unique) events for a player

### DIFF
--- a/scripts/enum/unique_event.lua
+++ b/scripts/enum/unique_event.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Unique Events
+-----------------------------------
+xi = xi or {}
+
+-- NOTE: This enum, and unique events are ONLY ever to be used if there is no
+-- other method to track having completed something.  This field is currently
+-- 160 bits wide (0..159).  Core changes will be required if this number is
+-- exceeded.
+--
+-- DO NOT USE THIS FOR CUSTOM THINGS, IT WILL GET CLOBBERED BY UPSTREAM DEVS.
+
+xi.uniqueEvent =
+{
+    EKOKOKO_INTRODUCTION = 0,
+}

--- a/scripts/zones/Mhaura/npcs/Ekokoko.lua
+++ b/scripts/zones/Mhaura/npcs/Ekokoko.lua
@@ -11,9 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    -- TODO: This is not a random sequence, but 51 is displayed on first interaction ever,
-    -- 52 is displayed all subsequent times (tested against zone and logout).
-    if math.random() > 0.5 then
+    if not player:hasCompletedUniqueEvent(xi.uniqueEvent.EKOKOKO_INTRODUCTION) then
         player:startEvent(51)
     else
         player:startEvent(52)
@@ -24,6 +22,9 @@ entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 51 then
+        player:setUniqueEvent(xi.uniqueEvent.EKOKOKO_INTRODUCTION)
+    end
 end
 
 return entity

--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -19,5 +19,6 @@ CREATE TABLE `char_unlocks` (
   `waypoints` blob DEFAULT NULL,
   `eschan_portals` blob DEFAULT NULL,
   `claimed_deeds` blob DEFAULT NULL,
+  `unique_event` blob DEFAULT NULL,
   PRIMARY KEY (`charid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -348,6 +348,7 @@ public:
     uint8  m_SetBlueSpells[20]{}; // The 0x200 offsetted blue magic spell IDs which the user has set. (1 byte per spell)
     uint32 m_FieldChocobo{};
     uint32 m_claimedDeeds[5]{};
+    uint32 m_uniqueEvents[5]{};
 
     UnlockedAttachments_t m_unlockedAttachments{}; // Unlocked Automaton Attachments (1 bit per attachment)
     CAutomatonEntity*     PAutomaton;              // Automaton statistics

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7657,7 +7657,7 @@ void CLuaBaseEntity::delUniqueEvent(uint16 uniqueEventId)
 }
 
 /************************************************************************
- *  Function: hasUniqueEvent()
+ *  Function: hasCompletedUniqueEvent()
  *  Purpose : Returns true if the player has seen his event before
  *  Example : if player:hasUniqueEvent(xi.uniqueEvent.TUCKER_INTRO_DIALOGUE) then
  *  NOTE    : This should never be used outside of debugging!

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7604,6 +7604,80 @@ void CLuaBaseEntity::resetClaimedDeeds()
 }
 
 /************************************************************************
+ *  Function: setUniqueEvent()
+ *  Purpose : Sets and saves unique event tracking value into database
+ *  Example : player:setUniqueEvent(xi.uniqueEvent.TUCKER_INTRO_DIALOGUE)
+ ************************************************************************/
+void CLuaBaseEntity::setUniqueEvent(uint16 uniqueEventId)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to set Unique Event mask for Non-PC.");
+        return;
+    }
+
+    auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
+    uint8 index  = uniqueEventId / 32;
+    uint8 setBit = uniqueEventId % 32;
+
+    PChar->m_uniqueEvents[index] |= (1 << setBit);
+
+    const char* query = "UPDATE char_unlocks SET unique_event = '%s' WHERE charid = %u;";
+    char        buf[sizeof(PChar->m_uniqueEvents) * 2 + 1];
+
+    sql->EscapeStringLen(buf, (const char*)&PChar->m_uniqueEvents, sizeof(PChar->m_uniqueEvents));
+    sql->Query(query, buf, PChar->id);
+}
+
+/************************************************************************
+ *  Function: delUniqueEvent()
+ *  Purpose : Removes and saves unique event tracking value into database
+ *  Example : player:delUniqueEvent(xi.uniqueEvent.TUCKER_INTRO_DIALOGUE)
+ *  NOTE    : This should never be used outside of debugging!
+ ************************************************************************/
+void CLuaBaseEntity::delUniqueEvent(uint16 uniqueEventId)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to del from Unique Event mask for Non-PC.");
+        return;
+    }
+
+    auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
+    uint8 index  = uniqueEventId / 32;
+    uint8 setBit = uniqueEventId % 32;
+
+    PChar->m_uniqueEvents[index] &= ~(1 << setBit);
+
+    const char* query = "UPDATE char_unlocks SET unique_event = '%s' WHERE charid = %u;";
+    char        buf[sizeof(PChar->m_uniqueEvents) * 2 + 1];
+
+    sql->EscapeStringLen(buf, (const char*)&PChar->m_uniqueEvents, sizeof(PChar->m_uniqueEvents));
+    sql->Query(query, buf, PChar->id);
+}
+
+/************************************************************************
+ *  Function: hasUniqueEvent()
+ *  Purpose : Returns true if the player has seen his event before
+ *  Example : if player:hasUniqueEvent(xi.uniqueEvent.TUCKER_INTRO_DIALOGUE) then
+ *  NOTE    : This should never be used outside of debugging!
+ ************************************************************************/
+bool CLuaBaseEntity::hasCompletedUniqueEvent(uint16 uniqueEventId)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Attempt to compare Unique Event mask for Non-PC.");
+        return false;
+    }
+
+    auto* PChar  = static_cast<CCharEntity*>(m_PBaseEntity);
+    uint8 index  = uniqueEventId / 32;
+    uint8 setBit = uniqueEventId % 32;
+
+    return PChar->m_uniqueEvents[index] & (1 << setBit);
+}
+
+/************************************************************************
  *  Function: addAssault()
  *  Purpose : Adds an assault mission to the player's log
  *  Example : player:addAssault(bit.rshift(option,4))
@@ -16974,6 +17048,10 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("toggleReceivedDeedRewards", CLuaBaseEntity::toggleReceivedDeedRewards);
     SOL_REGISTER("setClaimedDeed", CLuaBaseEntity::setClaimedDeed);
     SOL_REGISTER("resetClaimedDeeds", CLuaBaseEntity::resetClaimedDeeds);
+
+    SOL_REGISTER("setUniqueEvent", CLuaBaseEntity::setUniqueEvent);
+    SOL_REGISTER("delUniqueEvent", CLuaBaseEntity::delUniqueEvent);
+    SOL_REGISTER("hasCompletedUniqueEvent", CLuaBaseEntity::hasCompletedUniqueEvent);
 
     SOL_REGISTER("addAssault", CLuaBaseEntity::addAssault);
     SOL_REGISTER("delAssault", CLuaBaseEntity::delAssault);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -379,6 +379,10 @@ public:
     void   setClaimedDeed(uint16 deedBitNum);
     void   resetClaimedDeeds();
 
+    void setUniqueEvent(uint16 uniqueEventId);
+    void delUniqueEvent(uint16 uniqueEventId);
+    bool hasCompletedUniqueEvent(uint16 uniqueEventId);
+
     void  addAssault(uint8 missionID);          // Add Mission
     void  delAssault(uint8 missionID);          // Delete Mission from Mission Log
     uint8 getCurrentAssault();                  // Gets the current mission

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -776,7 +776,7 @@ namespace charutils
 
         fmtQuery = "SELECT outpost_sandy, outpost_bastok, outpost_windy, runic_portal, maw, "
                    "campaign_sandy, campaign_bastok, campaign_windy, homepoints, survivals, "
-                   "abyssea_conflux, waypoints, eschan_portals, claimed_deeds "
+                   "abyssea_conflux, waypoints, eschan_portals, claimed_deeds, unique_event "
                    "FROM char_unlocks "
                    "WHERE charid = %u;";
 
@@ -822,6 +822,11 @@ namespace charutils
             buf    = nullptr;
             sql->GetData(13, &buf, &length);
             memcpy(&PChar->m_claimedDeeds, buf, (length > sizeof(PChar->m_claimedDeeds) ? sizeof(PChar->m_claimedDeeds) : length));
+
+            length = 0;
+            buf    = nullptr;
+            sql->GetData(14, &buf, &length);
+            memcpy(&PChar->m_uniqueEvents, buf, (length > sizeof(PChar->m_claimedDeeds) ? sizeof(PChar->m_claimedDeeds) : length));
         }
 
         PChar->PMeritPoints = new CMeritPoints(PChar);

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -54,9 +54,11 @@ disallowed_numeric_parameters = {
     "delSpell"                : [ 0 ],
     "delStatusEffect"         : [ 0 ],
     "delStatusEffectEx"       : [ 0 ],
+    "delUniqueEvent"          : [ 0 ],
     "getEquipID"              : [ 0 ],
     "getEquippedItem"         : [ 0 ],
     "getItemQty"              : [ 0 ],
+    "hasCompletedUniqueEvent" : [ 0 ],
     "hasItem"                 : [ 0 ],
     "hasItemQty"              : [ 0 ],
     "hasSpell"                : [ 0 ],
@@ -68,6 +70,7 @@ disallowed_numeric_parameters = {
     "npcUtil.giveItem"        : [ 1 ],
     "npcUtil.tradeHas"        : [ 1 ],
     "npcUtil.tradeHasExactly" : [ 1 ],
+    "setUniqueEvent"          : [ 0 ],
     "showText"                : [ 0 ],
 }
 

--- a/tools/migrations/037_unique_events.py
+++ b/tools/migrations/037_unique_events.py
@@ -1,0 +1,26 @@
+import mariadb
+
+def migration_name():
+    return "Adding unique_event column to char_unlocks table"
+
+def check_preconditions(cur):
+    return
+
+def needs_to_run(cur):
+    # Ensure unique_event column exists in char_profile
+    cur.execute("SHOW COLUMNS FROM char_unlocks LIKE 'unique_event'")
+
+    if cur.fetchone():
+        return False
+
+    return True
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE `char_unlocks` \
+            ADD COLUMN `unique_event` BLOB DEFAULT NULL AFTER `claimed_deeds`;"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds a DB field in char_unlocks to track unique events (Things that we cannot track by any other means, that can only happen once)
* Adds set/del/hasCompletedUniqueEvent bindings
* Adds uniqueEvent enum in lua land to identify the above events
* Adds example usage for Ekokoko in Mhaura

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Talk to Ekokoko, see that the response is latched to event 52 after the first interaction
<!-- Clear and detailed steps to test your changes here -->
