### PR TITLE
Remove unused parameters from Emela-ntouka setRespawnTime

### DIFF
--- a/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Emela-ntouka.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Emela-ntouka.lua
@@ -27,7 +27,7 @@ entity.onMobSpawn = function(mob)
         end
     end)
 
-    mob:setRespawnTime(0, true)
+    mob:setRespawnTime(0)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
@@ -38,7 +38,7 @@ entity.onMobDespawn = function(mob)
     mob:removeListener("DOUBLE_BLOCKHEAD")
 
     -- Do not respawn for 3-4 hours
-    mob:setRespawnTime(math.random(10800, 14400), true)
+    mob:setRespawnTime(math.random(10800, 14400))
     mob:resetLocalVars()
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Binding: `void CLuaBaseEntity::setRespawnTime(uint32 seconds)`

Removes second parameter from this script which provides no impact

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
