### PR TITLE
Fix Scroll of Burst II being unusable

### DIFF
--- a/scripts/globals/items/scroll_of_burst_ii.lua
+++ b/scripts/globals/items/scroll_of_burst_ii.lua
@@ -6,11 +6,11 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
-    return target:canLearnSpell(xi.magic.spell.xi.magic.spell.BURST_II)
+    return target:canLearnSpell(xi.magic.spell.BURST_II)
 end
 
 itemObject.onItemUse = function(target)
-    target:addSpell(xi.magic.spell.xi.magic.spell.BURST_II)
+    target:addSpell(xi.magic.spell.BURST_II)
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Remove the extra "xi.magic.spell"
This was broken in ea9df8c67896efbb37ce35929f01bb0d717447d0.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !changejob blm 75
2. !additem burst_ii
3. Try to use the scroll and observe how it doesn't work
4. Apply this patch
5. Observe how it now works
<!-- Clear and detailed steps to test your changes here -->
