### PR TITLE
Fixes Zaldon not taking traded fish

### DIFF
--- a/scripts/zones/Selbina/npcs/Zaldon.lua
+++ b/scripts/zones/Selbina/npcs/Zaldon.lua
@@ -520,13 +520,13 @@ local function tradeFish(player, fishId)
             --     : because the cutscene gives away whether or not the trade was successful
             --     : or not, and it's possible for players to cheese this trade by force-dc-ing.
             player:confirmTrade()
-
             player:startEvent(166, 0, rewards[i].itemId)
             break
         end
     end
 
     if not found then
+        player:confirmTrade()
         player:startEvent(167)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Zaldon should always take the traded fish, even if it doesn't contain an item (And the player just receives gil).

## Steps to test these changes

Meet the pre-requisites for [Inside the Belly](https://www.bg-wiki.com/ffxi/Inside_the_Belly), then trade Zaldon any fish from the table. The fish should be consumed on trade, regardless of whether you receive gil or an item.
