### PR TITLE
Fix for SOB6 Wild Card quest incorrect vars

### DIFF
--- a/scripts/quests/windurst/SOB6_Wild_Card.lua
+++ b/scripts/quests/windurst/SOB6_Wild_Card.lua
@@ -78,7 +78,7 @@ quest.sections =
             ['_6n2'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 2 then -- First meeting at house of hero.
+                    if quest:getVar(player, 'Prog') == 1 then -- First meeting at house of hero.
                         if player:getRank(xi.nation.WINDURST) < 9 then
                             return quest:progressEvent(386) -- Meet Joker.
                         else
@@ -97,23 +97,23 @@ quest.sections =
             onEventFinish =
             {
                 [386] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 3) -- 3 = Met Joker. Sets 2nd CS in Windurst Walls with either Joker or Apururu.
+                    quest:setVar(player, 'Prog', 2) -- 2 = Met Joker. Sets 2nd CS in Windurst Walls with either Joker or Apururu.
                 end,
 
                 [387] = function(player, csid, option, npc)
                     player:delKeyItem(xi.ki.JOKER_CARD)
                     npcUtil.giveCurrency(player, 'gil', 8000)
-                    quest:setVar(player, 'Prog', 5)
+                    quest:setVar(player, 'Prog', 4)
                 end,
 
                 [388] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 4) -- 4 = Met Apururu. Sets 2nd CS in Windurst Woods with Apururu.
+                    quest:setVar(player, 'Prog', 3) -- 3 = Met Apururu. Sets 2nd CS in Windurst Woods with Apururu.
                 end,
 
                 [389] = function(player, csid, option, npc)
                     player:delKeyItem(xi.ki.JOKER_CARD)
                     npcUtil.giveCurrency(player, 'gil', 8000)
-                    quest:setVar(player, 'Prog', 5)
+                    quest:setVar(player, 'Prog', 4)
                 end,
             },
         },
@@ -123,7 +123,7 @@ quest.sections =
             ['Honoi-Gomoi'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 5 then
+                    if quest:getVar(player, 'Prog') == 4 then
                         return quest:progressEvent(782) -- Quest Complete.
                     else
                         return quest:event(781) -- Reminder text.
@@ -146,7 +146,7 @@ quest.sections =
             ['Apururu'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 4 then
+                    if quest:getVar(player, 'Prog') == 3 then
                         return quest:progressEvent(600) -- 2nd meeting with Apururu after meeting him in Hero's hause.
                     end
                 end,
@@ -157,7 +157,7 @@ quest.sections =
                 [600] = function(player, csid, option, npc)
                     player:delKeyItem(xi.ki.JOKER_CARD)
                     npcUtil.giveCurrency(player, 'gil', 8000)
-                    quest:setVar(player, 'Prog', 5)
+                    quest:setVar(player, 'Prog', 4)
                 end,
             },
         },


### PR DESCRIPTION
Fixes the unobtainable var 2 portion of the quest.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fix fixes the unobtainable var 2 that you get from talking to the 2nd NPC. Vars 2, 3, 4, 5, have been adjusted to complete the quest which you couldn't complete prior.
 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

You can now continue onwards to complete the quest once you obtain it. 

<!-- Clear and detailed steps to test your changes here -->
