### PR TITLE
Fixes incorrect Moghancement for Birch Tree

### DIFF
--- a/sql/item_furnishing.sql
+++ b/sql/item_furnishing.sql
@@ -481,7 +481,7 @@ INSERT INTO `item_furnishing` VALUES (3712, 'bastokan_sill', 1, 514, 3, 1);
 INSERT INTO `item_furnishing` VALUES (3713, 'pot_of_wards', 1, 515, 4, 2);
 INSERT INTO `item_furnishing` VALUES (3714, 'pot_of_white_clematis', 1, 515, 4, 2);
 INSERT INTO `item_furnishing` VALUES (3715, 'pot_of_pink_clematis', 1, 515, 4, 2);
-INSERT INTO `item_furnishing` VALUES (3717, 'birch_tree', 1, 2854, 4, 5);
+INSERT INTO `item_furnishing` VALUES (3717, 'birch_tree', 1, 2853, 4, 5);
 INSERT INTO `item_furnishing` VALUES (3718, 'handful_of_adoulinian_tomatoes', 1, 2849, 6, 6);
 INSERT INTO `item_furnishing` VALUES (3719, 'prishe_statue_ii', 4, 512, 1, 3);
 INSERT INTO `item_furnishing` VALUES (3720, 'arciela_statue', 4, 513, 2, 3);


### PR DESCRIPTION
Changes Resist Virus to Resist Petrification

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Moghancement for the Birch Tree was Resist Virus which is incorrect according to [this BG-Wiki link](https://www.bg-wiki.com/ffxi/Birch_Tree) and was corrected to Resist Petrification.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Plant the tree in your moghouse. Find that you're resistant to Petrification instead of Virus.

<!-- Clear and detailed steps to test your changes here -->
