### PR TITLE
[core] Attempt to prevent "undead" actions, see commit text

### DIFF
--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -170,5 +170,5 @@ bool CAttackState::CanAttack(CBattleEntity* PTarget)
 
 bool CAttackState::AttackReady()
 {
-    return m_attackTime < 0ms;
+    return m_attackTime < 0ms && m_PEntity->isAlive();
 }

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -101,7 +101,7 @@ void CMobSkillState::SpendCost()
 
 bool CMobSkillState::Update(time_point tick)
 {
-    if (tick > GetEntryTime() + m_castTime && !IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_castTime && !IsCompleted()))
     {
         action_t action;
         m_PEntity->OnMobSkillFinished(*this, action);
@@ -138,7 +138,7 @@ bool CMobSkillState::Update(time_point tick)
 
 void CMobSkillState::Cleanup(time_point tick)
 {
-    if (!IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && !IsCompleted())
     {
         action_t action;
         action.id         = m_PEntity->id;

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -93,7 +93,7 @@ void CPetSkillState::SpendCost()
 
 bool CPetSkillState::Update(time_point tick)
 {
-    if (tick > GetEntryTime() + m_castTime && !IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_castTime && !IsCompleted()))
     {
         action_t action;
         m_PEntity->OnPetSkillFinished(*this, action);
@@ -130,7 +130,7 @@ bool CPetSkillState::Update(time_point tick)
 
 void CPetSkillState::Cleanup(time_point tick)
 {
-    if (!IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && !IsCompleted())
     {
         action_t action;
         action.id         = m_PEntity->id;

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -99,7 +99,7 @@ bool CRangeState::CanChangeState()
 
 bool CRangeState::Update(time_point tick)
 {
-    if (tick > GetEntryTime() + m_aimTime && !IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_aimTime && !IsCompleted()))
     {
         auto* PTarget = m_PEntity->IsValidTarget(m_targid, TARGET_ENEMY, m_errorMsg);
 

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -108,7 +108,7 @@ void CWeaponSkillState::SpendCost()
 
 bool CWeaponSkillState::Update(time_point tick)
 {
-    if (!IsCompleted())
+    if (m_PEntity && m_PEntity->isAlive() && !IsCompleted())
     {
         CBattleEntity* PTarget = dynamic_cast<CBattleEntity*>(GetTarget());
         action_t       action;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1744,8 +1744,10 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
     /////////////////////////////////////////////////////////////////////////
     //  Start of the attack loop.
+    //  Make sure our target is alive on each iteration to not overkill;
+    //  And make sure we aren't dead in case we died to a counter.
     /////////////////////////////////////////////////////////////////////////
-    while (attackRound.GetAttackSwingCount() && !(PTarget->isDead()))
+    while (attackRound.GetAttackSwingCount() && PTarget->isAlive() && this->isAlive())
     {
         actionTarget_t& actionTarget = list.getNewActionTarget();
         // Reference to the current swing.


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This commit is attempting to prevent actions from occuring after a mob/player has died

If a counter kills you, you should not be able to continue your attack beyond that attack round If you are dead, you should not be able to auto attack, or finish a skill or ranged attack of any kind

TODO: verify if any interrupt packets on some of the harder cases to occur (such as weaponskill state) upon death

## Steps to test these changes

Kill mob/player in various states of readying TP moves, auto attacks, etc, don't see any "beyond the grave" attacks
