### PR TITLE
Fixes Incorrect Bean Daifuku and +1

### DIFF
--- a/scripts/globals/items/bean_daifuku.lua
+++ b/scripts/globals/items/bean_daifuku.lua
@@ -4,14 +4,15 @@
 -- Food Effect: 30 Min, All Races
 -----------------------------------
 -- HP +20
--- VIT +3
--- Accuracy +10% (cap 50)
--- Ranged Accuracy +10% (cap 50)
+-- VIT +5
+-- Accuracy +10% (cap 80)
+-- Ranged Accuracy +10% (cap 80)
 -- Pet:
 -- HP +20
--- VIT +3
--- Accuracy +10% (cap 75)
--- Ranged Accuracy +10% (cap 75)
+-- VIT +5
+-- Accuracy +10% (cap 105)
+-- Ranged Accuracy +10% (cap 105)
+-- Defense +10% (cap 100)
 -- Haste +3%
 -----------------------------------
 local itemObject = {}
@@ -31,33 +32,37 @@ end
 
 itemObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.HP, 20)
-    target:addMod(xi.mod.VIT, 3)
+    target:addMod(xi.mod.VIT, 5)
     target:addMod(xi.mod.FOOD_ACCP, 10)
-    target:addMod(xi.mod.FOOD_ACC_CAP, 50)
+    target:addMod(xi.mod.FOOD_ACC_CAP, 80)
     target:addMod(xi.mod.FOOD_RACCP, 10)
-    target:addMod(xi.mod.FOOD_RACC_CAP, 50)
+    target:addMod(xi.mod.FOOD_RACC_CAP, 80)
     target:addPetMod(xi.mod.HP, 20)
-    target:addPetMod(xi.mod.VIT, 3)
+    target:addPetMod(xi.mod.VIT, 5)
     target:addPetMod(xi.mod.FOOD_ACCP, 10)
-    target:addPetMod(xi.mod.FOOD_ACC_CAP, 75)
+    target:addPetMod(xi.mod.FOOD_ACC_CAP, 105)
     target:addPetMod(xi.mod.FOOD_RACCP, 10)
-    target:addPetMod(xi.mod.FOOD_RACC_CAP, 75)
+    target:addPetMod(xi.mod.FOOD_RACC_CAP, 105)
+    target:addPetMod(xi.mod.FOOD_DEFP, 10)
+    target:addPetMod(xi.mod.FOOD_DEF_CAP, 100)
     target:addPetMod(xi.mod.HASTE_GEAR, 300)
 end
 
 itemObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.HP, 20)
-    target:delMod(xi.mod.VIT, 3)
+    target:delMod(xi.mod.VIT, 5)
     target:delMod(xi.mod.FOOD_ACCP, 10)
-    target:delMod(xi.mod.FOOD_ACC_CAP, 50)
+    target:delMod(xi.mod.FOOD_ACC_CAP, 80)
     target:delMod(xi.mod.FOOD_RACCP, 10)
-    target:delMod(xi.mod.FOOD_RACC_CAP, 50)
+    target:delMod(xi.mod.FOOD_RACC_CAP, 80)
     target:delPetMod(xi.mod.HP, 20)
-    target:delPetMod(xi.mod.VIT, 3)
+    target:delPetMod(xi.mod.VIT, 5)
     target:delPetMod(xi.mod.FOOD_ACCP, 10)
-    target:delPetMod(xi.mod.FOOD_ACC_CAP, 75)
+    target:delPetMod(xi.mod.FOOD_ACC_CAP, 105)
     target:delPetMod(xi.mod.FOOD_RACCP, 10)
-    target:delPetMod(xi.mod.FOOD_RACC_CAP, 75)
+    target:delPetMod(xi.mod.FOOD_RACC_CAP, 105)
+    target:delPetMod(xi.mod.FOOD_DEFP, 10)
+    target:delPetMod(xi.mod.FOOD_DEF_CAP, 100)
     target:delPetMod(xi.mod.HASTE_GEAR, 300)
 end
 

--- a/scripts/globals/items/bean_daifuku_+1.lua
+++ b/scripts/globals/items/bean_daifuku_+1.lua
@@ -4,14 +4,15 @@
 -- Food Effect: 60 Min, All Races
 -----------------------------------
 -- HP +30
--- VIT +4
--- Accuracy +11% (cap 54)
--- Ranged Accuracy +11% (cap 54)
+-- VIT +7
+-- Accuracy +11% (cap 85)
+-- Ranged Accuracy +11% (cap 85)
 -- Pet:
 -- HP +30
--- VIT +4
--- Accuracy +11% (cap 81)
--- Ranged Accuracy +11% (cap 81)
+-- VIT +7
+-- Accuracy +11% (cap 110)
+-- Ranged Accuracy +11% (cap 110)
+-- Defense +11% (cap 105)
 -- Haste +4%
 -----------------------------------
 local itemObject = {}
@@ -31,33 +32,37 @@ end
 
 itemObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.HP, 30)
-    target:addMod(xi.mod.VIT, 4)
+    target:addMod(xi.mod.VIT, 7)
     target:addMod(xi.mod.FOOD_ACCP, 11)
-    target:addMod(xi.mod.FOOD_ACC_CAP, 54)
+    target:addMod(xi.mod.FOOD_ACC_CAP, 85)
     target:addMod(xi.mod.FOOD_RACCP, 11)
-    target:addMod(xi.mod.FOOD_RACC_CAP, 54)
+    target:addMod(xi.mod.FOOD_RACC_CAP, 85)
     target:addPetMod(xi.mod.HP, 30)
-    target:addPetMod(xi.mod.VIT, 4)
+    target:addPetMod(xi.mod.VIT, 7)
     target:addPetMod(xi.mod.FOOD_ACCP, 11)
-    target:addPetMod(xi.mod.FOOD_ACC_CAP, 81)
+    target:addPetMod(xi.mod.FOOD_ACC_CAP, 110)
     target:addPetMod(xi.mod.FOOD_RACCP, 11)
-    target:addPetMod(xi.mod.FOOD_RACC_CAP, 81)
+    target:addPetMod(xi.mod.FOOD_RACC_CAP, 110)
+    target:addPetMod(xi.mod.FOOD_DEFP, 11)
+    target:addPetMod(xi.mod.FOOD_DEF_CAP, 105)
     target:addPetMod(xi.mod.HASTE_GEAR, 400)
 end
 
 itemObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.HP, 30)
-    target:delMod(xi.mod.VIT, 4)
+    target:delMod(xi.mod.VIT, 7)
     target:delMod(xi.mod.FOOD_ACCP, 11)
-    target:delMod(xi.mod.FOOD_ACC_CAP, 54)
+    target:delMod(xi.mod.FOOD_ACC_CAP, 85)
     target:delMod(xi.mod.FOOD_RACCP, 11)
-    target:delMod(xi.mod.FOOD_RACC_CAP, 54)
+    target:delMod(xi.mod.FOOD_RACC_CAP, 85)
     target:delPetMod(xi.mod.HP, 30)
-    target:delPetMod(xi.mod.VIT, 4)
+    target:delPetMod(xi.mod.VIT, 7)
     target:delPetMod(xi.mod.FOOD_ACCP, 11)
-    target:delPetMod(xi.mod.FOOD_ACC_CAP, 81)
+    target:delPetMod(xi.mod.FOOD_ACC_CAP, 110)
     target:delPetMod(xi.mod.FOOD_RACCP, 11)
-    target:delPetMod(xi.mod.FOOD_RACC_CAP, 81)
+    target:delPetMod(xi.mod.FOOD_RACC_CAP, 110)
+    target:delPetMod(xi.mod.FOOD_DEFP, 11)
+    target:delPetMod(xi.mod.FOOD_DEF_CAP, 105)
     target:delPetMod(xi.mod.HASTE_GEAR, 400)
 end
 


### PR DESCRIPTION
Corrects all the stat caps.
Corrects Vit gain
Adds Defense stat and cap
Also adjusted +1 version.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Bean Daifuku and it's +1 has a lot of incorrect data on it. [Source for Bean Daifuku](https://www.bg-wiki.com/images/e/e6/Bean_Daifuku_description.png) and [Bean Daifuku +1](https://www.bg-wiki.com/ffxi/Bean_Daifuku_%2B1)

Adjs are: 

Changes player Accuracy and Ranged Accuracy Cap from 50 to 80
Changes player and pet Vit from 3 to 5. 
Changes pet accuracy and ranged accuracy cap from 75 to 105
Adds Defense 10% with 100 cap to pet.

For the +1

Changes player Accuracy and Ranged Accuracy Cap from 54 to 85
Changes player and pet Vit from 4 to 7. 
Changes pet accuracy and ranged accuracy cap from 80 to 110
Adds Defense 11% with 105 cap to pet.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Eat a Bean Daifuku or it's +1 variant and bask in the new correct stats. 

<!-- Clear and detailed steps to test your changes here -->
