### PR TITLE
Retail accurate AH listings

### DIFF
--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -11,7 +11,7 @@ xi.settings = xi.settings or {}
 
 xi.settings.search =
 {
-    -- Omit items with no buy history from auction house results
+    -- Omit items with no listing history from auction house results
     OMIT_NO_HISTORY = false,
 
     -- After EXPIRE_DAYS, will listed auctions expire?

--- a/sql/auction_house_items.sql
+++ b/sql/auction_house_items.sql
@@ -1,0 +1,9 @@
+--
+-- Table structure for table `auction_house_items`
+--
+
+DROP TABLE IF EXISTS `auction_house_items`;
+CREATE TABLE `auction_house_items` (
+  `itemid` smallint(5) unsigned NOT NULL,
+  PRIMARY KEY `itemid` (`itemid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -10,6 +10,14 @@ BEGIN
     IF OLD.seller != 0 AND NEW.sale != 0 THEN INSERT INTO delivery_box VALUES (NEW.seller, NEW.seller_name, 1, 0, 0xFFFF, NEW.itemid, NEW.sale, NULL, 0, 'AH-Jeuno', 0, 0); END IF;
 END $$
 
+DROP TRIGGER IF EXISTS auction_house_list $$
+CREATE TRIGGER auction_house_list
+    BEFORE INSERT ON auction_house
+    FOR EACH ROW
+BEGIN
+    INSERT IGNORE INTO `auction_house_items` SET `itemid` = NEW.itemid;
+END $$
+
 DROP TRIGGER IF EXISTS delivery_box_insert $$
 CREATE TRIGGER delivery_box_insert
     BEFORE INSERT ON delivery_box

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -87,18 +87,26 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
     ShowDebug("try find category %u", AHCategoryID);
 
     std::vector<ahItem*> ItemList;
+    const char*          selectFrom = "item_basic";
+    if (settings::get<bool>("search.OMIT_NO_HISTORY"))
+    {
+        // Get all items that have sold before or are currently listed
+        selectFrom = "(SELECT item_basic.aH, item_basic.itemId, item_basic.stackSize "
+                     "FROM item_basic "
+                     "INNER JOIN auction_house ON item_basic.itemId = auction_house.itemid GROUP BY auction_house.itemid"
+                     ") AS item_basic";
+    }
 
     const char* fmtQuery = "SELECT item_basic.itemid, item_basic.stackSize, COUNT(*)-SUM(stack), SUM(stack) "
-                           "FROM item_basic "
+                           "FROM %s "
                            "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
                            "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
                            "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
-                           "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
+                           "WHERE aH = %u "
                            "GROUP BY item_basic.itemid "
                            "%s";
 
-    int32 ret = sql->Query(fmtQuery, AHCategoryID, OrderByString);
-
+    int32 ret = sql->Query(fmtQuery, selectFrom, AHCategoryID, OrderByString);
     if (ret != SQL_ERROR && sql->NumRows() != 0)
     {
         while (sql->NextRow() == SQL_SUCCESS)
@@ -117,49 +125,6 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
             }
 
             ItemList.emplace_back(PAHItem);
-        }
-    }
-
-    if (settings::get<bool>("search.OMIT_NO_HISTORY"))
-    {
-        const char* noQtyQuery = "SELECT item_basic.itemid, item_basic.stackSize "
-                                 "FROM item_basic "
-                                 "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid "
-                                 "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
-                                 "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
-                                 "WHERE aH = %u AND auction_house.itemid IS NOT NULL "
-                                 "GROUP BY item_basic.itemid "
-                                 "%s";
-
-        int32 noQtyRet = sql->Query(noQtyQuery, AHCategoryID, OrderByString);
-        if (noQtyRet != SQL_ERROR && sql->NumRows() != 0)
-        {
-            while (sql->NextRow() == SQL_SUCCESS)
-            {
-                uint16 CurrItemID = sql->GetUIntData(0);
-                bool   itemFound  = false;
-                for (ahItem* PAHItem : ItemList)
-                {
-                    if (PAHItem->ItemID == CurrItemID)
-                    {
-                        itemFound = true;
-                        break;
-                    }
-                }
-
-                if (!itemFound)
-                {
-                    ahItem* PAHItem       = new ahItem;
-                    PAHItem->ItemID       = CurrItemID;
-                    PAHItem->SingleAmount = 0;
-                    PAHItem->StackAmount  = 0;
-                    if (sql->GetIntData(1) == 1)
-                    {
-                        PAHItem->StackAmount = -1;
-                    }
-                    ItemList.emplace_back(PAHItem);
-                }
-            }
         }
     }
 

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -90,10 +90,10 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 AHCategoryID, int8*
     const char*          selectFrom = "item_basic";
     if (settings::get<bool>("search.OMIT_NO_HISTORY"))
     {
-        // Get all items that have sold before or are currently listed
-        selectFrom = "(SELECT item_basic.aH, item_basic.itemId, item_basic.stackSize "
+        // Get items that have been listed before
+        selectFrom = "(SELECT item_basic.aH, item_basic.itemid, item_basic.stackSize "
                      "FROM item_basic "
-                     "INNER JOIN auction_house ON item_basic.itemId = auction_house.itemid GROUP BY auction_house.itemid"
+                     "INNER JOIN auction_house_items ON item_basic.itemid = auction_house_items.itemid"
                      ") AS item_basic";
     }
 

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -180,6 +180,7 @@ settings, default_settings = populate_settings()
 player_data = [
     "accounts.sql",
     "accounts_banned.sql",
+    "auction_house_items.sql",
     "auction_house.sql",
     "char_blacklist.sql",
     "char_chocobos.sql",


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Track which items have been listed on the AH using a new protected table
and trigger. Only show these items in the AH by default. This is controlled
by the `search.OMIT_NO_HISTORY` setting and is now on by default.

Run the following query to populate the new table using your existing
auction house history:
```
INSERT IGNORE INTO auction_house_items(itemid)
SELECT itemid FROM auction_house
GROUP BY itemid;
```

Fixes #3856

## Steps to test these changes

With empty auction_house and auction_house_items tables:
Make sure OMIT_NO_HISTORY is true in your search.lua settings file.
Search any category on AH, should all be empty.
List something on AH, it now appears in searches.
Remove listing, item still shows in searches.
Change OMIT_NO_HISTORY to false.
Search any category on AH, should all be fully populated.

