### PR TITLE
Fix Model ID for dart and hawkeye

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -7030,11 +7030,11 @@ INSERT INTO `item_equipment` VALUES (17303,'manji_shuriken',48,0,4096,30,0,0,8,4
 INSERT INTO `item_equipment` VALUES (17304,'fuma_shuriken',60,0,4096,89,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17305,'cluster_arm',5,0,2101409,29,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17306,'snoll_arm',5,0,2101409,29,0,0,8,4,0);
-INSERT INTO `item_equipment` VALUES (17307,'dart',7,0,2166961,16,0,0,8,4,0);
-INSERT INTO `item_equipment` VALUES (17308,'hawkeye',14,0,2166961,0,0,0,8,4,0);
+INSERT INTO `item_equipment` VALUES (17307,'dart',7,0,2166961,22,0,0,8,4,0);
+INSERT INTO `item_equipment` VALUES (17308,'hawkeye',14,0,2166961,22,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17309,'pinwheel',24,0,2166961,22,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17310,'hyo',36,0,2166961,16,0,0,8,4,0);
-INSERT INTO `item_equipment` VALUES (17311,'dart_+1',58,0,2166961,16,0,0,8,4,0);
+INSERT INTO `item_equipment` VALUES (17311,'dart_+1',58,0,2166961,22,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17312,'iron_bullet',50,0,70688,0,0,0,8,0,0);
 INSERT INTO `item_equipment` VALUES (17313,'grenade',19,0,2101409,29,0,0,8,4,0);
 INSERT INTO `item_equipment` VALUES (17314,'quake_grenade',32,0,2101409,29,0,0,8,4,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #26

Corrects the model ID for dart, dart+1, and hawkeye.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Throw dart, and do not see singing animation
<!-- Clear and detailed steps to test your changes here -->
