### PR TITLE
Silently add Old Toolbox KI in Eleventh's Hour

### DIFF
--- a/scripts/quests/bastok/The_Elevenths_Hour.lua
+++ b/scripts/quests/bastok/The_Elevenths_Hour.lua
@@ -111,7 +111,7 @@ quest.sections =
             {
                 [23] = function(player, csid, option, npc)
                     if option == 0 then
-                        npcUtil.giveKeyItem(player, xi.ki.OLD_TOOLBOX)
+                        player:addKeyItem(xi.ki.OLD_TOOLBOX)
                     end
                 end
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #4217 

Event 23 has its own KI reward message, and was duplicated with npcUtil.giveKeyItem().  Changes to addKeyItem to remove duplicate message
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Interact with NPC for event 23, and obtain the KI
<!-- Clear and detailed steps to test your changes here -->
