### PR TITLE
Apply pathing to appropriate Magriffon only, update quest NPCs

### DIFF
--- a/scripts/zones/Kazham/IDs.lua
+++ b/scripts/zones/Kazham/IDs.lua
@@ -43,6 +43,7 @@ zones[xi.zone.KAZHAM] =
     },
     npc =
     {
+        MAGRIFFON = GetFirstID('Magriffon'),
     },
 }
 

--- a/scripts/zones/Kazham/npcs/Magriffon.lua
+++ b/scripts/zones/Kazham/npcs/Magriffon.lua
@@ -17,9 +17,12 @@ local pathNodes =
 }
 
 entity.onSpawn = function(npc)
-    npc:initNpcAi()
-    npc:setPos(xi.path.first(pathNodes))
-    npc:pathThrough(pathNodes, xi.path.flag.PATROL)
+    -- Ensure that the correct Magriffon is given pathing information.
+    if npc:getID() == ID.npc.MAGRIFFON then
+        npc:initNpcAi()
+        npc:setPos(xi.path.first(pathNodes))
+        npc:pathThrough(pathNodes, xi.path.flag.PATROL)
+    end
 end
 
 entity.onTrade = function(player, npc, trade)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3472

Magriffon has two different entries in Kazham.  Apply a lookup for the first entry in the zone on spawn to determine if he's the one that's visible to players and walking around.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Event 148 for Even More Gullible's Travels should properly execute, and Magriffon should be pathing in Kazham
<!-- Clear and detailed steps to test your changes here -->
