### PR TITLE
[luacheck] Fix error-prone negation in conditionals

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -364,7 +364,7 @@ end
 function npcUtil.giveCurrency(player, currency, amount)
     local ID = zones[player:getZoneID()]
 
-    if (not type(currency) == "string") or (not type(amount) == "number") then
+    if type(currency) ~= "string" or type(amount) ~= "number" then
         print(string.format("ERROR: invalid parameter given to npcUtil.giveCurrency in zone %s.", player:getZoneName()))
         return false
     end

--- a/scripts/quests/jeuno/LB09_2_Prelude_to_Puissance.lua
+++ b/scripts/quests/jeuno/LB09_2_Prelude_to_Puissance.lua
@@ -100,8 +100,8 @@ quest.sections =
                         if quest:complete(player) then
                             -- This options immediately start next quest. (All except 0 and 15).
                             if
-                                not option == 0 or
-                                not option == 15
+                                option ~= 0 and
+                                option ~= 15
                             then
                                 player:addQuest(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.BEYOND_INFINITY)
                             end

--- a/scripts/quests/windurst/Chasing_Tales.lua
+++ b/scripts/quests/windurst/Chasing_Tales.lua
@@ -44,7 +44,7 @@ quest.sections =
                     -- https://ffxiclopedia.fandom.com/wiki/Chasing_Tales
                     if
                         player:getNation() ~= xi.nation.WINDURST or
-                        not player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.THE_JESTER_WHOD_BE_KING
+                        player:getCurrentMission(xi.mission.log_id.WINDURST) ~= xi.mission.id.windurst.THE_JESTER_WHOD_BE_KING
                     then
                         return quest:progressEvent(403)
                     end

--- a/scripts/quests/windurst/Early_Bird_Catches_the_Bookworm.lua
+++ b/scripts/quests/windurst/Early_Bird_Catches_the_Bookworm.lua
@@ -42,8 +42,8 @@ quest.sections =
                     -- https://ffxiclopedia.fandom.com/wiki/Early_Bird_Catches_the_Bookworm
                     if
                         player:getNation() ~= xi.nation.WINDURST or
-                        (not player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.LOST_FOR_WORDS and
-                        not player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.THE_SIXTH_MINISTRY)
+                        (player:getCurrentMission(xi.mission.log_id.WINDURST) ~= xi.mission.id.windurst.LOST_FOR_WORDS and
+                        player:getCurrentMission(xi.mission.log_id.WINDURST) ~= xi.mission.id.windurst.THE_SIXTH_MINISTRY)
                     then
                         return quest:progressEvent(387)
                     end

--- a/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
@@ -6,8 +6,8 @@ local entity = {}
 
 entity.onMobRoam = function(mob)
     if
-        not mob:getWeather() == xi.weather.WIND and
-        not mob:getWeather() == xi.weather.GALES
+        mob:getWeather() ~= xi.weather.WIND and
+        mob:getWeather() ~= xi.weather.GALES
     then
         DespawnMob(mob:getID())
     end
@@ -31,8 +31,8 @@ end
 
 entity.onMobDisengage = function(mob, weather)
     if
-        not mob:getWeather() == xi.weather.WIND and
-        not mob:getWeather() == xi.weather.GALES
+        mob:getWeather() ~= xi.weather.WIND and
+        mob:getWeather() ~= xi.weather.GALES
     then
         DespawnMob(mob:getID())
     end

--- a/scripts/zones/Quicksand_Caves/npcs/qm5.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/qm5.lua
@@ -21,12 +21,11 @@ entity.onTrigger = function(player, npc)
     local hasAncientTablet = player:hasKeyItem(xi.ki.TABLET_OF_ANCIENT_MAGIC)
 
     -- Need to make sure the quest is flagged the player is no further along in the quest
-
     if
         theMissingPiece == QUEST_ACCEPTED and
         not hasAncientTablet and
         not hasAncientFragment and
-        not player:getTitle() == xi.title.ACQUIRER_OF_ANCIENT_ARCANUM
+        player:getTitle() ~= xi.title.ACQUIRER_OF_ANCIENT_ARCANUM
     then
         player:addKeyItem(xi.ki.ANCIENT_TABLET_FRAGMENT)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.ANCIENT_TABLET_FRAGMENT)

--- a/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Dem/bcnms/ancient_flames_beckon.lua
@@ -47,7 +47,7 @@ end
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
     if
         player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
+        player:getLocalVar('toLufaise') ~= 1
     then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)

--- a/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Holla/bcnms/ancient_flames_beckon.lua
@@ -47,7 +47,7 @@ end
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
     if
         player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
+        player:getLocalVar('toLufaise') ~= 1
     then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)

--- a/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
+++ b/scripts/zones/Spire_of_Mea/bcnms/ancient_flames_beckon.lua
@@ -47,7 +47,7 @@ end
 battlefieldObject.onEventFinish = function(player, csid, option, npc)
     if
         player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS and
-        not player:getLocalVar('toLufaise') == 1
+        player:getLocalVar('toLufaise') ~= 1
     then
         player:addExp(1500)
         xi.teleport.to(player, xi.teleport.id.EXITPROMDEM)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
After upgrading luacheck to 1.1.1, there were additional issues called out by it regarding error-prone negation (`if not x == y`).  This PR addresses those issues.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No impact should be observed, outside of fixing incorrect logic in LB9 (Part 2)
<!-- Clear and detailed steps to test your changes here -->
