### PR TITLE
Fix status effect SetEffectParams flag setting

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1553,7 +1553,7 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     }
 
     StatusEffect->SetEffectName(name);
-    StatusEffect->HasEffectFlag(effects::EffectsParams[effect].Flag);
+    StatusEffect->AddEffectFlag(effects::EffectsParams[effect].Flag);
     StatusEffect->SetEffectType(effects::EffectsParams[effect].Type);
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
CodeQL caught this one since a bool function was not being assigned previously.  Uses `SetEffectFlags` instead of `hasEffectFlag` for setting parameters
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Flags should be set properly
<!-- Clear and detailed steps to test your changes here -->
