### PR TITLE
[core] Additions to Packet Guard

### DIFF
--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -568,6 +568,7 @@ public:
     std::vector<AuctionHistory_t> m_ah_history;  // AH history list (in the future consider using UContainer)
 
     std::unordered_map<uint16, uint32> m_PacketRecievedTimestamps;
+    uint16                             m_LastPacketType{};
 
     void   SetPlayTime(uint32 playTime);        // Set playtime
     uint32 GetPlayTime(bool needUpdate = true); // Get playtime

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -124,12 +124,6 @@ namespace
     uint32 TotalPacketsDelayedPerTick = 0U;
 } // namespace
 
-/************************************************************************
- *                                                                       *
- *  mapsession_getbyipp                                                  *
- *                                                                       *
- ************************************************************************/
-
 map_session_data_t* mapsession_getbyipp(uint64 ipp)
 {
     TracyZoneScoped;
@@ -145,11 +139,20 @@ map_session_data_t* mapsession_getbyipp(uint64 ipp)
     return nullptr;
 }
 
-/************************************************************************
- *                                                                       *
- *  mapsession_createsession                                             *
- *                                                                       *
- ************************************************************************/
+map_session_data_t* mapsession_getbychar(CCharEntity* PChar)
+{
+    TracyZoneScoped;
+
+    for (const auto& [_, session] : map_session_list)
+    {
+        if (PChar && session->PChar->id == PChar->id)
+        {
+            return session;
+        }
+    }
+
+    return nullptr;
+}
 
 map_session_data_t* mapsession_createsession(uint32 ip, uint16 port)
 {
@@ -941,6 +944,13 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
             {
                 ShowWarning("[PacketGuard] Caught mismatch between player substate and recieved packet: Player: %s - Packet: %03hX",
                             PChar->getName(), SmallPD_Type);
+                // TODO: Plug in optional jailutils usage
+                continue; // skip this packet
+            }
+
+            if (settings::get<bool>("map.PACKETGUARD_ENABLED") && !PacketGuard::PacketsArrivingInCorrectOrder(PChar, SmallPD_Type))
+            {
+                ShowWarning("[PacketGuard] Caught out-of-order packet: Player: %s - Packet: %03hX", PChar->getName(), SmallPD_Type);
                 // TODO: Plug in optional jailutils usage
                 continue; // skip this packet
             }

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -111,6 +111,7 @@ extern in_addr map_ip;
 extern uint16  map_port;
 
 extern inline map_session_data_t* mapsession_getbyipp(uint64 ipp);
+extern inline map_session_data_t* mapsession_getbychar(CCharEntity* PChar);
 extern inline map_session_data_t* mapsession_createsession(uint32 ip, uint16 port);
 
 extern std::unique_ptr<SqlConnection> _sql;

--- a/src/map/packet_guard.cpp
+++ b/src/map/packet_guard.cpp
@@ -15,7 +15,9 @@ namespace PacketGuard
 #endif
 
     std::unordered_map<CHAR_SUBSTATE, std::unordered_map<uint16, bool>> allowList;
-    std::unordered_map<uint16, uint32>                                  ratelimitList; // Default will be 0 - No Limit
+
+    // Time in seconds (double)
+    std::unordered_map<uint16, double> ratelimitList; // Default will be 0 - No Limit
 
     void Init()
     {
@@ -55,11 +57,15 @@ namespace PacketGuard
 
         // Rate limiting
         // NOTE: You should rate limit any packet that a player can
-        //       send at will that results in an immediate database hit
-        // ratelimitList[0x03B] = 1; // Mannequin Equip
-        ratelimitList[0x05D] = 2000; // Emotes
-        ratelimitList[0x11B] = 2000; // Set Job Master Display
-        ratelimitList[0x11D] = 2000; // Jump
+        //     : send at will that results in an immediate database hit
+        //     : or generates logs or results in file or network io.
+        ratelimitList[0x017] = 1.0; // Invalid NPC Information Response
+        ratelimitList[0x03B] = 1.0; // Mannequin Equip
+        ratelimitList[0x05D] = 2.0; // Emotes
+        ratelimitList[0x0F4] = 1.0; // Wide Scan
+        ratelimitList[0x0F5] = 1.0; // Wide Scan Track
+        ratelimitList[0x11B] = 2.0; // Set Job Master Display
+        ratelimitList[0x11D] = 2.0; // Jump
     }
 
     bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type)
@@ -86,18 +92,38 @@ namespace PacketGuard
     {
         TracyZoneScoped;
         using namespace std::chrono;
-        uint32 lastPacketRecievedTime = PChar->m_PacketRecievedTimestamps[SmallPD_Type];
-        uint32 timeNowMilliseconds    = static_cast<uint32>(time_point_cast<milliseconds>(server_clock::now()).time_since_epoch().count());
-        uint32 ratelimitTime          = ratelimitList[SmallPD_Type];
 
-        PChar->m_PacketRecievedTimestamps[SmallPD_Type] = timeNowMilliseconds;
+        double lastPacketRecievedTime = static_cast<double>(PChar->m_PacketRecievedTimestamps[SmallPD_Type]);
+        double timeNowSeconds         = static_cast<double>(time_point_cast<seconds>(server_clock::now()).time_since_epoch().count());
+        double ratelimitTime          = ratelimitList[SmallPD_Type];
+
+        PChar->m_PacketRecievedTimestamps[SmallPD_Type] = timeNowSeconds;
 
         if (lastPacketRecievedTime == 0 || ratelimitTime == 0)
         {
             return false;
         }
 
-        return timeNowMilliseconds - lastPacketRecievedTime < ratelimitList[SmallPD_Type];
+        return timeNowSeconds - lastPacketRecievedTime < ratelimitList[SmallPD_Type];
+    }
+
+    bool PacketsArrivingInCorrectOrder(CCharEntity* PChar, uint16 SmallPD_Type)
+    {
+        TracyZoneScoped;
+
+        const auto currentPacketId  = SmallPD_Type;
+        const auto previousPacketId = PChar->m_LastPacketType;
+
+        // Update the last packet type now that we've cached it
+        PChar->m_LastPacketType = currentPacketId;
+
+        // 0x084 (vendor appraise) should always lead into 0x085 (vendor sell)
+        if (currentPacketId == 0x085 && previousPacketId != 0x084)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     void PrintPacketList(CCharEntity* PChar)

--- a/src/map/packet_guard.h
+++ b/src/map/packet_guard.h
@@ -12,6 +12,7 @@ namespace PacketGuard
     void Init();
     bool PacketIsValidForPlayerState(CCharEntity* PChar, uint16 SmallPD_Type);
     bool IsRateLimitedPacket(CCharEntity* PChar, uint16 SmallPD_Type);
+    bool PacketsArrivingInCorrectOrder(CCharEntity* PChar, uint16 SmallPD_Type);
     void PrintPacketList(CCharEntity* PChar);
 
     auto GetPacketAllowList() -> std::unordered_map<CHAR_SUBSTATE, std::unordered_map<uint16, bool>>&;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Changes the internal timing inside packet guard to use second doubles instead of milliseconds uint32
- Adds some more rate limited packets
- Track m_LastPacketType, and add PacketsArrivingInCorrectOrder

