### PR TITLE
Add xi.dynamis.eye to enums

### DIFF
--- a/scripts/enum/dynamis.lua
+++ b/scripts/enum/dynamis.lua
@@ -1,0 +1,10 @@
+xi = xi or {}
+xi.dynamis = xi.dynamis or {}
+
+xi.dynamis.eye =
+{
+    NONE    = 0,
+    RED     = 1,
+    BLUE    = 2,
+    GREEN   = 3,
+}

--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -309,15 +309,6 @@ end
 -----------------------------------
 -- global functions
 -----------------------------------
-
-xi.dynamis.eye =
-{
-    NONE    = 0,
-    RED     = 1,
-    BLUE    = 2,
-    GREEN   = 3,
-}
-
 xi.dynamis.entryNpcOnTrigger = function(player, npc)
     local zoneId        = player:getZoneID()
     local info          = entryInfo[zoneId]


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes the dependency for the dynamis global from Dynamis zone IDs.lua by moving xi.dynamis.eye to enum.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
