### PR TITLE
[core] Ranged Attack Adjustments for distance

### DIFF
--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -202,12 +202,6 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
         return false;
     }
 
-    if (!isEndOfAttack && distance(m_PEntity->loc.p, PTarget->loc.p) > 25)
-    {
-        m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY);
-        return false;
-    }
-
     if (!isEndOfAttack && !m_PEntity->CanSeeTarget(PTarget, false))
     {
         m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_CANNOT_PERFORM_ACTION);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1500,6 +1500,12 @@ namespace battleutils
         int acc     = 0;
         int hitrate = 75;
 
+        // Check to see if distance is greater than 25 and force hitrate to be 0
+        if (distance(PAttacker->loc.p, PDefender->loc.p) > 25)
+        {
+            return 0;
+        }
+
         if (PAttacker->objtype == TYPE_PC)
         {
             CCharEntity* PChar = (CCharEntity*)PAttacker;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR is from @sarca571ca with some minor adjustments.

- Ranged attacks are no longer stopped when mobs travel past max range.
- Ranged attacks now always miss when beyond max range.

Capture Discord: https://discord.com/channels/443544205206355968/443894311881408522/1142558127405940736
https://www.youtube.com/watch?v=7iBdomixR9U&ab_channel=sarca571ca
https://youtu.be/P8VtRWSvqDw
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use a ranged weapon(preferably with a long delay), target a mob near max range start a ranged attack as they are moving out of range. Observe that when the mob goes beyond the 25 yalm limit the ranged attack will still go off but *always* miss.
<!-- Clear and detailed steps to test your changes here -->
