### PR TITLE
[core] Adds AddCustomMods() back to Dynamic Entities

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1525,6 +1525,7 @@ Usage:
                 PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(70));
 
                 mobutils::InitializeMob(PMob);
+                mobutils::AddCustomMods(PMob);
             }
         }
         return PMob;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This seems like a minor oversight because without this being called Dynamic mobs do not get the correct mods/hp/mp values.

This was accidently removed in this PR https://github.com/LandSandBoat/server/pull/3530

Putting this back in yields the correct MP/stats.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
By using the command `!fafnir` made for dynamic entities you can change the `groupId` and `groupZoneId` to any mob that has a sethp/mp pool.

Doing this prior to the change you will see the values are incorrect when spawning.

After the fix the values will be accurate again.
<!-- Clear and detailed steps to test your changes here -->
