### PR TITLE
Rename functions that load mods from sql tables

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -251,7 +251,7 @@ int32 do_init(int32 argc, char** argv)
     battleutils::LoadSkillChainDamageModifiers();
     petutils::LoadPetList();
     trustutils::LoadTrustList();
-    mobutils::LoadCustomMods();
+    mobutils::LoadSqlModifiers();
     jobpointutils::LoadGifts();
     daily::LoadDailyItems();
     roeutils::UpdateUnityRankings();

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -878,7 +878,7 @@ namespace mobutils
 
     void SetupEventMob(CMobEntity* PMob)
     {
-        // event mob types will always have custom roaming
+        // event mob types will always have scripted roaming (any mob can have it scripted, but these ALWAYS do)
         PMob->m_roamFlags |= ROAMFLAG_SCRIPTED;
         PMob->setMobMod(MOBMOD_ROAM_RESET_FACING, 1);
         PMob->m_maxRoamDistance = 0.5f; // always go back to spawn
@@ -1032,16 +1032,15 @@ namespace mobutils
     }
 
     /*
-Loads up custom mob mods from mob_pool_mods and mob_family_mods table. This will allow you to customize
-a mobs regen rate, magic defense, triple attack rate from a table instead of hardcoding it.
+    Loads up mob mods from mob_pool_mods and mob_family_mods table. This will allow you to change
+    a mobs regen rate, magic defense, triple attack rate from a table instead of hardcoding it.
 
-Usage:
+    Usage:
 
-    Evil weapons have a magic defense boost. So pop that into mob_family_mods table.
-    Goblin Diggers have a vermin killer trait, so find its poolid and put it in mod_pool_mods table.
-
-*/
-    void LoadCustomMods()
+        Evil weapons have a magic defense boost. So pop that into mob_family_mods table.
+        Goblin Diggers have a vermin killer trait, so find its poolid and put it in mod_pool_mods table.
+    */
+    void LoadSqlModifiers()
     {
         // load family mods
         const char QueryFamilyMods[] = "SELECT familyid, modid, value, is_mob_mod FROM mob_family_mods;";
@@ -1188,9 +1187,9 @@ Usage:
         return nullptr;
     }
 
-    void AddCustomMods(CMobEntity* PMob)
+    void AddSqlModifiers(CMobEntity* PMob)
     {
-        // find my families custom mods
+        // find my families mods
         ModsList_t* PFamilyMods = GetMobFamilyMods(PMob->m_Family);
 
         if (PFamilyMods != nullptr)
@@ -1207,7 +1206,7 @@ Usage:
             }
         }
 
-        // find my pools custom mods
+        // find my pools mods
         ModsList_t* PPoolMods = GetMobPoolMods(PMob->m_Pool);
 
         if (PPoolMods != nullptr)
@@ -1224,7 +1223,7 @@ Usage:
             }
         }
 
-        // find my pools custom mods
+        // find my IDs mods
         ModsList_t* PSpawnMods = GetMobSpawnMods(PMob->id);
 
         if (PSpawnMods != nullptr)
@@ -1525,7 +1524,7 @@ Usage:
                 PMob->setMobMod(MOBMOD_DETECTION, sql->GetUIntData(70));
 
                 mobutils::InitializeMob(PMob);
-                mobutils::AddCustomMods(PMob);
+                mobutils::AddSqlModifiers(PMob);
             }
         }
         return PMob;

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -71,14 +71,14 @@ namespace mobutils
     uint16 GetBaseToRank(uint8 rank, uint16 level);
     void   GetAvailableSpells(CMobEntity* PMob);
     void   InitializeMob(CMobEntity* PMob);
-    void   LoadCustomMods();
+    void   LoadSqlModifiers();
 
     // get modifiers for pool / family / spawn
     ModsList_t* GetMobFamilyMods(uint16 familyId, bool create = false);
     ModsList_t* GetMobPoolMods(uint32 poolId, bool create = false);
     ModsList_t* GetMobSpawnMods(uint32 mobId, bool create = false);
 
-    void AddCustomMods(CMobEntity* PMob);
+    void AddSqlModifiers(CMobEntity* PMob);
 
     void        SetSpellList(CMobEntity*, uint16);
     CMobEntity* InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* = nullptr);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -479,7 +479,7 @@ namespace trustutils
         }
 
         // add mob pool mods ahead of applying stats
-        mobutils::AddCustomMods(PTrust);
+        mobutils::AddSqlModifiers(PTrust);
 
         JOBTYPE mJob = PTrust->GetMJob();
         JOBTYPE sJob = PTrust->GetSJob();

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -651,7 +651,7 @@ namespace zoneutils
 
             PZone->ForEachMob([](CMobEntity* PMob)
             {
-                mobutils::AddCustomMods(PMob);
+                mobutils::AddSqlModifiers(PMob);
 
                 luautils::OnMobInitialize(PMob);
                 luautils::ApplyMixins(PMob);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Renames 2 functions. Obliterate the word "custom" from something that demands retail game accuracy.

## Steps to test these changes
Confirm monsters still get mods and mobmods as normal. pretty simple to just check one of the sql table rows and confirm mob spawns with it.
