### PR TITLE
[ci] Add potentially invalid enum check

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -41,6 +41,11 @@ deprecated_requires = [
     "IDs",
 ]
 
+invalid_enums = [
+    "xi.items.",
+    "xi.effects.",
+]
+
 # 'functionName' : [ noNumberInParamX, noNumberInParamY, ... ],
 # Parameters are 0-indexed
 disallowed_numeric_parameters = {
@@ -305,6 +310,11 @@ class LuaStyleCheck:
                     else:
                         self.error(f"Use of deprecated/unnecessary require: {deprecated_str}. This should be removed")
 
+    def check_invalid_enum(self, line):
+            for invalid_enum in invalid_enums:
+                if invalid_enum in line:
+                    self.error(f"Potential invalid enum reference used: {invalid_enum}.  Did you mean the one without an s?")
+
     def check_function_parameters(self, line):
         # Iterate through all entries in the disallowed table
         for fn_name, param_locations in disallowed_numeric_parameters.items():
@@ -364,6 +374,7 @@ class LuaStyleCheck:
                 self.check_no_newline_before_end(code_line)
                 self.check_no_function_decl_padding(code_line)
                 self.check_deprecated_require(code_line)
+                self.check_invalid_enum(code_line)
 
                 # Keep track of ID variable assignments and if they are referenced.
                 # TODO: Track each unique variable, and expand this to potentially something
@@ -454,7 +465,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 47
+    expected_errors = 49
 else:
     total_errors = LuaStyleCheck(target).errcount
 

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -182,3 +182,9 @@ end
 ('a', b)  -- PASS
 (',', b)  -- PASS
 (',',b)   -- FAIL
+
+xi.items.SOMETHING -- FAIL
+xi.item.SOMETHING  -- PASS
+
+xi.effects.SOMETHING -- FAIL
+xi.effect.SOMETHING  -- PASS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds CI test for potential invalid enum usage.  This is limited to xi.items and xi.effects which are item cache tables instead of enums at this time.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should fail if someone references those, and pass if they don't occur
<!-- Clear and detailed steps to test your changes here -->
