### PR TITLE
Remove unimplemented global exception for clearVarFromAll

### DIFF
--- a/scripts/globals/harvest_festivals.lua
+++ b/scripts/globals/harvest_festivals.lua
@@ -144,6 +144,9 @@ xi.events.harvestFestival.onHalloweenTrade = function(player, trade, npc)
         for itemInList = 1, #treatsTable do
             if item == treatsTable[itemInList] then
                 local itemReward = halloweenItemsCheck(player)
+
+                -- TODO: These varName values below need to be cleared onGameDay
+
                 local varName = "harvestFestTreats"
                 local harvestFestTreats
                 if itemInList < 32 then -- The size of the list is too big for int 32 used that stores the bit mask, as such there are two lists

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -27,11 +27,6 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onGameDay = function()
-    -- Removes daily the bit mask that tracks the treats traded for Harvest Festival.
-    if xi.events.harvestFestival.isHalloweenEnabled() ~= 0 then
-        clearVarFromAll("harvestFestTreats")
-        clearVarFromAll("harvestFestTreats2")
-    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -45,7 +45,6 @@ global_objects=(
     set
     printf
     switch
-    clearVarFromAll
     getVanaMidnight
     getMidnight
     getConquestTally


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Removes the single zone (of many) that references clearVarFromAll from harvest festival event, and removes the CI exception for global
* Adds a TODO to handle this when refactoring this script
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed, outside of not seeing an error when this is no longer called
<!-- Clear and detailed steps to test your changes here -->
