### PR TITLE
Fix lookups for pet script globals

### DIFF
--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -1,9 +1,11 @@
 -----------------------------------
 -- PET: Automaton
 -----------------------------------
-local entity = {}
+xi = xi or {}
+xi.pets = xi.pets or {}
+xi.pets.automaton = {}
 
-entity.onMobSpawn = function(mob)
+xi.pets.automaton.onMobSpawn = function(mob)
     mob:setLocalVar("MANEUVER_DURATION", 60)
     mob:addListener("EFFECTS_TICK", "MANEUVER_DURATION", function(automaton)
         if automaton:getTarget() then
@@ -13,8 +15,6 @@ entity.onMobSpawn = function(mob)
     end)
 end
 
-entity.onMobDeath = function(mob)
+xi.pets.automaton.onMobDeath = function(mob)
     mob:removeListener("MANEUVER_DURATION")
 end
-
-return entity

--- a/scripts/globals/pets/luopan.lua
+++ b/scripts/globals/pets/luopan.lua
@@ -1,16 +1,16 @@
 -----------------------------------
 -- PET: Luopan
 -----------------------------------
-local entity = {}
+xi = xi or {}
+xi.pets = xi.pets or {}
+xi.pets.luopan = {}
 
-entity.onMobSpawn = function(mob)
+xi.pets.luopan.onMobSpawn = function(mob)
     -- BGWIKI: "Regardless of perpetuation cost reduction, Luopans have a maximum duration of 10 minutes."
     mob:timer(600000, function(mobArg)
         mobArg:setHP(0)
     end)
 end
 
-entity.onMobDeath = function(mob)
+xi.pets.luopan.onMobDeath = function(mob)
 end
-
-return entity

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -4,7 +4,9 @@
 require("scripts/globals/ability")
 require("scripts/globals/job_utils/dragoon")
 -----------------------------------
-local entity = {}
+xi = xi or {}
+xi.pets = xi.pets or {}
+xi.pets.wyvern = {}
 
 local wyvernCapabilities =
 {
@@ -108,7 +110,7 @@ local function doStatusBreath(target, player)
     return false
 end
 
-entity.onMobSpawn = function(mob)
+xi.pets.wyvern.onMobSpawn = function(mob)
     local master = mob:getMaster()
 
     if master:getMod(xi.mod.WYVERN_SUBJOB_TRAITS) > 0 then
@@ -192,7 +194,7 @@ local function removeWyvernLevels(mob)
     end
 end
 
-entity.onMobDeath = function(mob, player)
+xi.pets.wyvern.onMobDeath = function(mob, player)
     removeWyvernLevels(mob)
 
     local master  = mob:getMaster()
@@ -203,10 +205,8 @@ entity.onMobDeath = function(mob, player)
     master:removeListener("PET_WYVERN_EXP")
 end
 
-entity.onPetLevelRestriction = function(pet)
+xi.pets.wyvern.onPetLevelRestriction = function(pet)
     removeWyvernLevels(pet)
     pet:setLocalVar("wyvern_exp", 0)
     pet:setLocalVar("level_Ups", 0)
 end
-
-return entity

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -456,7 +456,7 @@ namespace luautils
         {
             std::string mob_name = static_cast<CPetEntity*>(PEntity)->GetScriptName();
 
-            if (auto cached_func = lua["xi"]["globals"]["pets"][mob_name][funcName]; cached_func.valid())
+            if (auto cached_func = lua["xi"]["pets"][mob_name][funcName]; cached_func.valid())
             {
                 return cached_func;
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
With the moves to all globals being treated the same, 3 pet scripts needed to be attached to xi properly and the reference looked up changed.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1 !changejob drg 99
2. call wyvern
3. Poke something and watch the wyvern attack, super jumb and watch the wyvern climb
<!-- Clear and detailed steps to test your changes here -->
