### PR TITLE
[Interaction] Fix "Acting in good faith" quest not starting

### DIFF
--- a/scripts/quests/windurst/Acting_in_Good_Faith.lua
+++ b/scripts/quests/windurst/Acting_in_Good_Faith.lua
@@ -36,7 +36,7 @@ quest.sections =
             {
                 [10019] = function(player, csid, option, npc)
                     if option == 0 then
-                        npcUtil.giveKeyItem(xi.ki.SPIRIT_INCENSE)
+                        npcUtil.giveKeyItem(player, xi.ki.SPIRIT_INCENSE)
                         quest:begin(player)
                     end
                 end,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As pointed by Claywar, the KI npcUtil was missing the player argument, which made the script error and fail to give both the KI and the quest-

## Steps to test these changes

Have fame 4+ with windurst and lvl 10+. Speak with NPC and get the quest started, the quest recorded in your quest log and the KI in your temporal KI list.
