### PR TITLE
Remove calculateDurationForLvl, replace single usage

### DIFF
--- a/scripts/actions/spells/white/stoneskin.lua
+++ b/scripts/actions/spells/white/stoneskin.lua
@@ -28,7 +28,12 @@ spellObject.onSpellCast = function(caster, target, spell)
     pAbs = utils.clamp(pAbs, 1, xi.settings.main.STONESKIN_CAP)
 
     local duration = calculateDuration(300, spell:getSkillType(), spell:getSpellGroup(), caster, target)
-    duration = calculateDurationForLvl(duration, 28, target:getMainLvl())
+
+    -- Reduce duration if the target is below Stoneskin's level (formerly calculateDurationForLvl)
+    local targetLvl = target:getMainLvl()
+    if targetLvl < 28 then
+        duration = duration * targetLvl / 28
+    end
 
     local final = pAbs + pEquipMods
     if target:addStatusEffect(xi.effect.STONESKIN, final, 0, duration, 0, 0, 4) then

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1091,14 +1091,6 @@ function canOverwrite(target, effect, power, mod)
     return true
 end
 
-function calculateDurationForLvl(duration, spellLvl, targetLvl)
-    if targetLvl < spellLvl then
-        return duration * targetLvl / spellLvl
-    end
-
-    return duration
-end
-
 function calculateDuration(duration, magicSkill, spellGroup, caster, target, useComposure)
     local casterJob = caster:getMainJob()
 

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -93,7 +93,6 @@ global_objects=(
     applyResistanceEffect
     adjustForTarget
     calculateDuration
-    calculateDurationForLvl
     calculateMagicDamage
     calculatePotency
     canOverwrite


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Global function `calculateDurationForLvl` was used in only one place (Stoneskin).  This removes that function, the CI exception, and applies the same logic to that location
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
