### PR TITLE
[lua] Add conditional logger factory

### DIFF
--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -35,13 +35,7 @@ xi = xi or {}
 xi.chocoboRaising = xi.chocoboRaising or {}
 xi.chocoboRaising.chocoState = xi.chocoboRaising.chocoState or {}
 
-local debug = function(player, ...)
-    if xi.settings.main.DEBUG_CHOCOBO_RAISING then
-        local t = { ... }
-        print(unpack(t))
-        player:PrintToPlayer(table.concat(t, " "), xi.msg.channel.SYSTEM_3, "")
-    end
-end
+local debug = utils.getDebugPlayerPrinter(xi.settings.main.DEBUG_CHOCOBO_RAISING)
 
 -----------------------------------
 -- Settings
@@ -625,9 +619,9 @@ local condenseEvents = function(player, chocoState, events)
     local currentEventCSTable = nil
 
     -- Each event is a table of cs's
-    debug(player, "Raw Events")
+    debug("Raw Events")
     for _, entry in pairs(events) do
-        debug(player, "Day", entry[1], ":", entry[2][1])
+        debug("Day", entry[1], ":", entry[2][1])
         -- Only condense days with the same table contents
         if compareTables(entry[2], currentEventCSTable) then
             -- Increase the span
@@ -648,9 +642,9 @@ local condenseEvents = function(player, chocoState, events)
     -- Final "cut"
     cutEvent(condensedEvents, currentStartDay, currentEndDay, currentEventCSTable)
 
-    debug(player, "Condensed Events & Spans")
+    debug("Condensed Events & Spans")
     for _, entry in pairs(condensedEvents) do
-        debug(player, "Days", entry[1], "to", entry[2], ":", entry[3][1])
+        debug("Days", entry[1], "to", entry[2], ":", entry[3][1])
     end
 
     return condensedEvents
@@ -693,7 +687,7 @@ local handleCSUpdate = function(player, chocoState, doEventUpdate)
     local locationOffset = raisingLocation[player:getZoneID()] * 256
     local csToPlay = locationOffset + csOffset
 
-    debug(player, "Playing CS: " .. csToPlay .. " (" .. csOffset .. ")")
+    debug("Playing CS: " .. csToPlay .. " (" .. csOffset .. ")")
     table.remove(chocoState.csList, 1)
 
     local currentAgeOfChocoboDuringCutscene = 0
@@ -730,7 +724,7 @@ local updateChocoState = function(player, chocoState)
     chocoState.age = math.floor((os.time() - chocoState.created) / xi.chocoboRaising.dayLength) + 1
     chocoState.last_update_age = chocoState.age
 
-    debug(player, "Writing chocoState.age & last_update_age:", chocoState.last_update_age)
+    debug("Writing chocoState.age & last_update_age:", chocoState.last_update_age)
 
     -- Write to cache
     xi.chocoboRaising.chocoState[player:getID()] = chocoState
@@ -757,8 +751,8 @@ xi.chocoboRaising.initChocoboData = function(player)
 
     chocoState.age = math.floor((os.time() - chocoState.created) / xi.chocoboRaising.dayLength) + 1
 
-    debug(player, "chocoState.age = " .. chocoState.age)
-    debug(player, "chocoState.last_update_age = " .. chocoState.last_update_age)
+    debug("chocoState.age = " .. chocoState.age)
+    debug("chocoState.last_update_age = " .. chocoState.last_update_age)
 
     chocoState.affectionRank = affectionRank.LIKES
 
@@ -780,7 +774,7 @@ xi.chocoboRaising.initChocoboData = function(player)
     chocoState.report.day_end   = chocoState.age
     local reportLength = chocoState.report.day_end - chocoState.report.day_start
 
-    debug(player, "reportLength", reportLength)
+    debug("reportLength", reportLength)
 
     chocoState.last_update_age = chocoState.age
 
@@ -1007,7 +1001,7 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
             return
         end
 
-        debug(player, string.format("CS Update: %i", option))
+        debug(string.format("CS Update: %i", option))
 
         -- Setting the name for a chocobo: when the name is
         -- applied from the menu the name offsets (from the menu)
@@ -1045,14 +1039,14 @@ xi.chocoboRaising.onEventUpdateVCSTrainer = function(player, csid, option, npc)
                 chocoState.first_name = fname
                 chocoState.last_name = lname
 
-                debug(player, string.format("%s updating chocobo name: %s", player:getName(), fullnamekey))
+                debug(string.format("%s updating chocobo name: %s", player:getName(), fullnamekey))
 
                 -- Write to cache
                 xi.chocoboRaising.chocoState[player:getID()] = chocoState
 
                 -- Set synthetic CS option for later CSs
                 option = 0xFF
-                debug(player, string.format("CS (Synthetic) Update: %i", option))
+                debug(string.format("CS (Synthetic) Update: %i", option))
             end
         end
 

--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -49,6 +49,9 @@ void lua_init()
     // Bind print(...) globally
     lua.set_function("print", &lua_print);
 
+    // Bind tostring(...) globally
+    lua.set_function("tostring", &lua_to_string);
+
     // Attempt to startup lldebugger
     auto result = lua["require"]("lldebugger");
     if (result.valid())
@@ -61,7 +64,7 @@ void lua_init()
 /**
  * @brief
  */
-std::string lua_to_string(sol::object const& obj, std::size_t depth)
+std::string lua_to_string_depth(sol::object const& obj, std::size_t depth)
 {
     switch (obj.get_type())
     {
@@ -128,11 +131,11 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
             {
                 if (keyObj.get_type() == sol::type::string)
                 {
-                    stringVec.emplace_back(fmt::format("{}{}: {}", indent, lua_to_string(keyObj), lua_to_string(valObj, depth + 1)));
+                    stringVec.emplace_back(fmt::format("{}{}: {}", indent, lua_to_string_depth(keyObj, 0), lua_to_string_depth(valObj, depth + 1)));
                 }
                 else
                 {
-                    stringVec.emplace_back(fmt::format("{}{}", indent, lua_to_string(valObj, depth + 1)));
+                    stringVec.emplace_back(fmt::format("{}{}", indent, lua_to_string_depth(valObj, depth + 1)));
                 }
             }
 
@@ -158,7 +161,7 @@ std::string lua_to_string(sol::object const& obj, std::size_t depth)
 /**
  * @brief
  */
-void lua_print(sol::variadic_args va)
+std::string lua_to_string(sol::variadic_args va)
 {
     TracyZoneScoped;
 
@@ -175,9 +178,19 @@ void lua_print(sol::variadic_args va)
         }
         else
         {
-            vec.emplace_back(lua_to_string(va[i]));
+            vec.emplace_back(lua_to_string_depth(va[i], 0));
         }
     }
 
-    ShowLua(fmt::format("{}", fmt::join(vec.begin(), vec.end(), " ")).c_str());
+    return fmt::format("{}", fmt::join(vec.begin(), vec.end(), " "));
+}
+
+/**
+ * @brief
+ */
+void lua_print(sol::variadic_args va)
+{
+    TracyZoneScoped;
+
+    ShowLua(lua_to_string(va).c_str());
 }

--- a/src/common/lua.h
+++ b/src/common/lua.h
@@ -28,7 +28,8 @@
 extern sol::state lua;
 
 void lua_init();
-auto lua_to_string(sol::object const& obj, std::size_t depth = 0) -> std::string;
+auto lua_to_string_depth(sol::object const& obj, std::size_t depth) -> std::string;
+auto lua_to_string(sol::variadic_args va) -> std::string;
 void lua_print(sol::variadic_args va);
 
 #endif // _LUA_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Uses some Lua black magic to allow us to automatically look up `player` in the context in which your logger was called, and print out the same message to that client.

Converted chocobo raising logging as an example

EDIT: Also refactors our cpp binding for Lua `print` and refactors things to make Lua's `tostring` use that internal logic. 