### PR TITLE
[core] Search.cpp - Changed any Russian comments to English

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -617,7 +617,7 @@ void HandleAuctionHouseRequest(CTCPRequestPacket& PTCPRequest)
     // 9 - name
     std::string OrderByString = "ORDER BY";
     uint8       paramCount    = ref<uint8>(data, 0x12);
-    for (uint8 i = 0; i < paramCount; ++i) // параметры сортировки предметов
+    for (uint8 i = 0; i < paramCount; ++i) // Item sort options
     {
         uint8 param = ref<uint32>(data, 0x18 + 8 * i);
         ShowInfo(" Param%u: %u", i, param);
@@ -684,7 +684,7 @@ void HandleAuctionHouseHistory(CTCPRequestPacket& PTCPRequest)
 
 search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
 {
-    // This function constructs a `search_req` based on which query should be send to the database.
+    // This function constructs a `search_req` based on which query should be sent to the database.
     // The results from the database will eventually be sent to the client.
 
     uint32 bitOffset = 0;
@@ -730,7 +730,7 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
 
         if ((EntryType != SEARCH_FRIEND) && (EntryType != SEARCH_LINKSHELL) && (EntryType != SEARCH_COMMENT) && (EntryType != SEARCH_FLAGS2))
         {
-            if ((bitOffset + 3) >= workloadBits) // so 0000000 at the end does not get interpret as name entry
+            if ((bitOffset + 3) >= workloadBits) // so 0000000 at the end does not get interpreted as name entry
             {
                 bitOffset = workloadBits;
                 break;
@@ -920,7 +920,7 @@ search_req _HandleSearchRequest(CTCPRequestPacket& PTCPRequest)
     }
 
     return sr;
-    // не обрабатываем последние биты, что мешает в одну кучу
+    // Do not process the last bits, which can interfere with other operations
     // For example: "/blacklist delete Name" and "/sea all Name"
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Within Search.cpp, changed any Russian comments to English.
- No other modifications, just a language change of comments.
- Also corrected a couple instances of incorrect tense of word used in a couple comments.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

No testing necessary, no code was changed, only comments.