### PR TITLE
Convert roe records to local returned table

### DIFF
--- a/scripts/globals/roe.lua
+++ b/scripts/globals/roe.lua
@@ -3,7 +3,8 @@
 -----------------------------------
 require('scripts/globals/npc_util')
 require('scripts/globals/quests')
-require('scripts/globals/roe_records')
+-----------------------------------
+local recordList = require('scripts/globals/roe_records')
 -----------------------------------
 xi = xi or {}
 xi.roe = xi.roe or {}
@@ -141,13 +142,13 @@ local defaults =
 }
 
 -- Apply defaults for records
-for _, v in pairs(xi.roe.records) do
+for _, v in pairs(recordList) do
     setmetatable(v, { __index = defaults })
 end
 
 -- Build global map of implemented records.
 -- This is used to deny taking records which aren't implemented in the above table.
-RoeParseRecords(xi.roe.records)
+RoeParseRecords(recordList)
 
 --[[ --------------------------------------------------------------------------
     Complete a record of eminence. This is for internal roe use only.
@@ -168,7 +169,7 @@ RoeParseRecords(xi.roe.records)
     })
 --------------------------------------------------------------------------- --]]
 local function completeRecord(player, record)
-    local recordEntry = xi.roe.records[record]
+    local recordEntry = recordList[record]
     local recordFlags = recordEntry.flags
     local rewards = recordEntry.reward
 
@@ -251,7 +252,7 @@ function xi.roe.onRecordTrigger(player, recordID, params)
     params = params or {}
     params.progress = params.progress or player:getEminenceProgress(recordID)
 
-    local entry = xi.roe.records[recordID]
+    local entry = recordList[recordID]
     local isClaiming = params.claim
 
     if entry and params.progress then

--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5,10 +5,8 @@ require("scripts/globals/expansion_areas")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 -----------------------------------
-xi = xi or {}
-xi.roe = xi.roe or {}
 
-xi.roe.records =
+local recordList =
 {
     -----------------------------------
     -- Tutorial -> Basics
@@ -9629,3 +9627,5 @@ xi.roe.records =
         flags = set { "hidden" },
     },
 }
+
+return recordList


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #4352 

Interesting note, when requiring a global table, if actions take place during load (outside of a function call later), it is not guaranteed to exist.  This changes roe_records to a local variable require that is returned, since it is only used in roe.lua to guaranteed its accessibility.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Accept any early RoE quest (tested with FoV), and see no errors
<!-- Clear and detailed steps to test your changes here -->
