### PR TITLE
[Fix] Elemental mobs physical resistances and detection in Central Temenos 2F and Eastern tower

### DIFF
--- a/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
+++ b/scripts/battlefields/Temenos/central_temenos_2nd_floor.lua
@@ -76,11 +76,14 @@ content.groups =
             "Light_Elemental",
         },
 
-        -- NOTE: Elementals take double physical damage because their family resistance is 25% so it totals to 50% resistance
+        -- NOTE: Elementals in here take 50% physical damage instead of the usual 25%
+        -- TODO: Verify if the Elementals here should detect sound
         mods =
         {
-            [xi.mod.UDMGPHYS    ] = -10000,
-            [xi.mod.UDMGMAGIC   ] = 5000,
+            [xi.mod.SLASH_SDT   ] = 500,
+            [xi.mod.PIERCE_SDT  ] = 500,
+            [xi.mod.IMPACT_SDT  ] = 500,
+            [xi.mod.HTH_SDT     ] = 500,
             [xi.mobMod.DETECTION] = xi.detects.HEARING,
         },
     },

--- a/scripts/battlefields/Temenos/temenos_eastern_tower.lua
+++ b/scripts/battlefields/Temenos/temenos_eastern_tower.lua
@@ -279,12 +279,16 @@ content.groups =
             "Dark_Elemental_E",
         },
 
-        -- NOTE: Elementals take double physical damage because their family resistance is 25% so it totals to 50% resistance
+        -- NOTE: Elementals in here take 50% physical damage instead of the usual 25%
+        -- TODO: Verify if the Elementals here should detect sound
         mods =
         {
-            [xi.mod.UDMGPHYS ] = 10000,
-            [xi.mod.UDMGMAGIC] = -5000,
-            [xi.mod.FASTCAST ] = 20,
+            [xi.mod.SLASH_SDT   ] = 500,
+            [xi.mod.PIERCE_SDT  ] = 500,
+            [xi.mod.IMPACT_SDT  ] = 500,
+            [xi.mod.HTH_SDT     ] = 500,
+            [xi.mobMod.DETECTION] = xi.detects.HEARING,
+            [xi.mod.FASTCAST    ] = 20,
         },
 
         mobMods =


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Before this commit, the Elementals in Central Temenos - 2nd Floor take 0 physical damage because of how they were set up, fix this by flipping the sign of xi.mod.UDMGPHYS and xi.mod.UDMGMAGIC to match scripts/battlefields/Temenos/temenos_eastern_tower.lua and update the comment in there.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. !pos 580.000 -2.375 104.000 37
2. !addkeyitem white_card
3. !addkeyitem cosmo_cleanse
4. Enter Central Temenos - 2nd Floor, observe how the elementals take no physical damage
5. Apply this patch
6. Observe how they now take physical damage

<!-- Clear and detailed steps to test your changes here -->
