### PR TITLE
Move roe records back to global table, add init function

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5,8 +5,14 @@ require("scripts/globals/expansion_areas")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 -----------------------------------
+xi = xi or {}
+xi.roe = xi.roe or {}
 
-local recordList =
+-- NOTE: This file calls the roe global init function at the end to populate default
+-- values that may be missing.  This same behavior happens in the roe global as well
+-- to ensure that whichever is loaded last will always have accurate information.
+
+xi.roe.records =
 {
     -----------------------------------
     -- Tutorial -> Basics
@@ -9628,4 +9634,6 @@ local recordList =
     },
 }
 
-return recordList
+if xi.roe.initialize then
+    xi.roe.initialize()
+end

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -215,6 +215,8 @@ namespace luautils
         lua.set_function("GetCachedInstanceScript", &luautils::GetCachedInstanceScript);
         lua.set_function("GetItemIDByName", &luautils::GetItemIDByName);
         lua.set_function("SendLuaFuncStringToZone", &luautils::SendLuaFuncStringToZone);
+        lua.set_function("RoeParseRecords", &roeutils::ParseRecords);
+        lua.set_function("RoeParseTimed", &roeutils::ParseTimedSchedule);
 
         // This binding specifically exists to forcefully crash the server.
         // clang-format off
@@ -250,7 +252,6 @@ namespace luautils
         // Load globals
         // Truly global files first
         lua.safe_script_file("./scripts/globals/common.lua");
-        roeutils::init(); // TODO: Get rid of the need to do this
 
         // Load global enums
         for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/enum"))

--- a/src/map/roe.cpp
+++ b/src/map/roe.cpp
@@ -97,14 +97,6 @@ void call_onRecordTrigger(CCharEntity* PChar, uint16 recordID, const RoeDatagram
 
 namespace roeutils
 {
-    void init()
-    {
-        TracyZoneScoped;
-        lua["RoeParseRecords"] = &roeutils::ParseRecords;
-        lua["RoeParseTimed"]   = &roeutils::ParseTimedSchedule;
-        RoeHandlers.fill(RoeCheckHandler());
-    }
-
     void ParseRecords(sol::table const& records_table)
     {
         TracyZoneScoped;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Restores roe records to `xi.roe.records` and updates caching of records to apply appropriate defaults in all cases
* Removes `roeutils::init()` and sets function bindings in luautils

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Start Server and do not hot reload any file
2. Successfully trigger Timed objective
3. Successfully trigger non-Timed objective

<!-- Clear and detailed steps to test your changes here -->
