### PR TITLE
Remove unused parameter from calculatePerformanceBoost

### DIFF
--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -197,7 +197,7 @@ end
 
 -- Due to load order, we can't expect to determine Optic Fiber enhancements on change.
 -- For maneuvers, calculate this based on the number of light maneuvers that are active.
-local function calculatePerformanceBoost(pet, numManeuvers)
+local function calculatePerformanceBoost(pet)
     local master = pet:getMaster()
     local performanceBoost = 0
 
@@ -264,7 +264,7 @@ xi.automaton.updateAttachmentModifier = function(pet, attachment, maneuvers)
 
         -- Apply Automaton Performance Boost if applicable.
         if modList[3] then
-            modValue = math.floor(modValue * (1 + calculatePerformanceBoost(pet, maneuvers) / 100))
+            modValue = math.floor(modValue * (1 + calculatePerformanceBoost(pet) / 100))
         end
 
         if modValue ~= previousMod then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Missed this when removing a _lot_ of debugging steps.  calculatePerformanceBoost for automatons only requires the pet parameter, and this removes the maneuver parameter.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
