### PR TITLE
[ci] Add rule to not allow code after `then` in conditional

### DIFF
--- a/scripts/actions/mobskills/astral_flow_pet.lua
+++ b/scripts/actions/mobskills/astral_flow_pet.lua
@@ -30,6 +30,19 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
     return 0
 end
 
+-- [mobskillId] = { petFamily1, petFamily2, ... }
+local petAstralFlowAbility =
+{
+    [839] = { 36, 381 }, -- Fenrir (Howling Moon)
+    [913] = { 38, 383 }, -- Ifrit (Inferno)
+    [914] = { 45, 388 }, -- Titan (Earthen Fury)
+    [915] = { 40, 384 }, -- Leviathan (Tidal Wave)
+    [916] = { 37, 382 }, -- Garuda (Aerial Blast)
+    [917] = { 44, 387 }, -- Shiva (Diamond Dust)
+    [918] = { 43, 386 }, -- Ramuh (Judgment Bolt)
+    [919] = { 34, 379 }, -- Carbuncle (Searing Light)
+}
+
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local pet = mob:getPet()
 
@@ -42,18 +55,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     -- Find proper pet skill
     local petFamily = pet:getFamily()
-    local skillId = 919
+    local skillId   = 919 -- Default to Searing Light if not found below
 
-    if     petFamily == 34 or petFamily == 379 then skillId = 919 -- carbuncle searing light
-    elseif petFamily == 36 or petFamily == 381 then skillId = 839 -- fenrir    howling moon
-    elseif petFamily == 37 or petFamily == 382 then skillId = 916 -- garuda    aerial blast
-    elseif petFamily == 38 or petFamily == 383 then skillId = 913 -- ifrit     inferno
-    elseif petFamily == 40 or petFamily == 384 then skillId = 915 -- leviathan tidal wave
-    elseif petFamily == 43 or petFamily == 386 then skillId = 918 -- ramuh     judgment bolt
-    elseif petFamily == 44 or petFamily == 387 then skillId = 917 -- shiva     diamond dust
-    elseif petFamily == 45 or petFamily == 388 then skillId = 914 -- titan     earthen fury
-    else
-        printf("[astral_flow_pet] received unexpected pet family %i. Defaulted skill to Searing Light.", petFamily)
+    for mobSkillId, petFamilyList in pairs(petAstralFlowAbility) do
+        if utils.contains(petFamily, petFamilyList) then
+            skillId = mobSkillId
+            break
+        end
     end
 
     pet:useMobAbility(skillId)

--- a/scripts/actions/spells/black/bio.lua
+++ b/scripts/actions/spells/black/bio.lua
@@ -43,10 +43,11 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     -- Calculate DoT effect
     -- http://wiki.ffo.jp/html/1954.html
-    local dotdmg = 0
-    if     skillLvl > 80 then dotdmg = 3
-    elseif skillLvl > 40 then dotdmg = 2
-    else                      dotdmg = 1
+    local dotdmg = 1
+    if skillLvl > 80 then
+        dotdmg = 3
+    elseif skillLvl > 40 then
+        dotdmg = 2
     end
 
     -- Do it!

--- a/scripts/actions/spells/black/bio_iii.lua
+++ b/scripts/actions/spells/black/bio_iii.lua
@@ -45,20 +45,31 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- http://wiki.ffo.jp/html/1954.html
     -- this is a tiered calculation that has at least three tiers,
     -- so I'll use breakpoints for human readability
-    local dotdmg = 0
-    if     skillLvl > 400 then dotdmg = 17
-    elseif skillLvl > 373 then dotdmg = 16
-    elseif skillLvl > 346 then dotdmg = 15
-    elseif skillLvl > 319 then dotdmg = 14
-    elseif skillLvl > 291 then dotdmg = 13
-    elseif skillLvl > 280 then dotdmg = 12
-    elseif skillLvl > 269 then dotdmg = 11
-    elseif skillLvl > 258 then dotdmg = 10
-    elseif skillLvl > 246 then dotdmg =  9
-    elseif skillLvl > 211 then dotdmg =  8
-    elseif skillLvl > 171 then dotdmg =  7
-    elseif skillLvl > 131 then dotdmg =  6
-    else                       dotdmg =  5
+    local dotdmg = 5
+    if skillLvl > 400 then
+        dotdmg = 17
+    elseif skillLvl > 373 then
+        dotdmg = 16
+    elseif skillLvl > 346 then
+        dotdmg = 15
+    elseif skillLvl > 319 then
+        dotdmg = 14
+    elseif skillLvl > 291 then
+        dotdmg = 13
+    elseif skillLvl > 280 then
+        dotdmg = 12
+    elseif skillLvl > 269 then
+        dotdmg = 11
+    elseif skillLvl > 258 then
+        dotdmg = 10
+    elseif skillLvl > 246 then
+        dotdmg = 9
+    elseif skillLvl > 211 then
+        dotdmg = 8
+    elseif skillLvl > 171 then
+        dotdmg = 7
+    elseif skillLvl > 131 then
+        dotdmg = 6
     end
 
     -- Do it!

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -678,28 +678,30 @@ local function rankPointMath(rank)
     return 0.372 * rank^2 - 1.62 * rank + 6.2
 end
 
+-- Number of crystal trades required for specific missions in each nation.
+-- TODO: This needs to be audited for modern retail.
+local crystalRequirements =
+{
+    [ 3] = 9,
+    [ 4] = 17,
+    [ 5] = 42,
+    [10] = 12,  -- 1 stack needed to unlock
+    [11] = 30,  -- 2.5 stacks needed to unlock (2 stacks of crystals + 3.1 rank points corresponding to half a stack)
+    [12] = 48,  -- 4 stacks to unlock (3.5 stacks + 3.1 rank points corresponding to half a stack)
+    [13] = 36,
+    [15] = 44,  -- Mission unlocks at 50% rank bar ~= 44 crystals using the present formula.
+    [16] = 36,
+    [17] = 93,  -- 3 additional stacks to unlock + 3 original stacks + 21 from mission 6.1
+    [18] = 45,  -- 45 needed, from http://wiki.ffxiclopedia.org/wiki/The_Final_Image
+    [19] = 119, -- 4 additional stacks needed, plus mission reward of 26
+    [20] = 57,
+    [21] = 148, -- 5 additional stacks needed, plus mission reward of 31
+    [22] = 96,  -- 8 stacks needed (higher value chosen so final rank bar requirement is closer to 90%)
+    [23] = 228, -- Additional 8 stacks needed, plus mission reward of 36 (87% rank bar)
+}
+
 xi.mission.getMissionRankPoints = function(player, missionID)
-    local crystals = 0
-
-    if     missionID ==  3 then crystals = 9
-    elseif missionID ==  4 then crystals = 17
-    elseif missionID ==  5 then crystals = 42
-    elseif missionID == 10 then crystals = 12                    -- 1 stack needed to unlock
-    elseif missionID == 11 then crystals = 30                    -- 2.5 stacks needed to unlock (2 stacks of crystals + 3.1 rank points corresponding to half a stack)
-    elseif missionID == 12 then crystals = 48                    -- 4 stacks to unlock (3.5 stacks + 3.1 rank points corresponding to half a stack)
-    elseif missionID == 13 then crystals = 36                    -- 3 stacks to unlock
-    -- 5.1 starts directly after Magicite, no crystals needed
-    elseif missionID == 15 then crystals = 44                    -- Mission unlocks at 50% rank bar ~= 44 crystals using the present formula.
-    elseif missionID == 16 then crystals = 36                    -- 3 stacks to unlock
-    elseif missionID == 17 then crystals = 93                    -- 3 additional stacks to unlock + 3 original stacks + 21 from mission 6.1
-    elseif missionID == 18 then crystals = 45                    -- 45 needed, from http://wiki.ffxiclopedia.org/wiki/The_Final_Image
-    elseif missionID == 19 then crystals = 119                    -- 4 additional stacks needed, plus mission reward of 26
-    elseif missionID == 20 then crystals = 57                    -- 4 3/4 stacks needed
-    elseif missionID == 21 then crystals = 148                    -- 5 additional stacks needed, plus mission reward of 31,
-    elseif missionID == 22 then crystals = 96                    -- 8 stacks needed (higher value chosen so final rank bar requirement is closer to 90%)
-    elseif missionID == 23 then crystals = 228                    -- Additional 8 stacks needed, plus mission reward of 36 (87% rank bar)
-    end
-
+    local crystals     = crystalRequirements[missionID] or 0
     local pointsNeeded = 1024 * (crystals - 0.25) / (3 * rankPointMath(player:getRank(player:getNation())))
 
     if player:getRankPoints() >= pointsNeeded then

--- a/scripts/zones/Kazham/npcs/Ronta-Onta.lua
+++ b/scripts/zones/Kazham/npcs/Ronta-Onta.lua
@@ -75,10 +75,14 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED, xi.ki.TUNING_FORK_OF_FIRE)
     elseif csid == 273 then
         local item = 0
-        if option == 1 then item = xi.item.IFRITS_BLADE
-        elseif option == 2 then item = xi.item.FIRE_BELT
-        elseif option == 3 then item = xi.item.FIRE_RING
-        elseif option == 4 then item = xi.item.EGILS_TORCH
+        if option == 1 then
+            item = xi.item.IFRITS_BLADE
+        elseif option == 2 then
+            item = xi.item.FIRE_BELT
+        elseif option == 3 then
+            item = xi.item.FIRE_RING
+        elseif option == 4 then
+            item = xi.item.EGILS_TORCH
         end
 
         if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -399,6 +399,10 @@ class LuaStyleCheck:
                 if contains_word('if')(code_line) or contains_word('elseif')(code_line) or in_condition:
                     full_condition += code_line
 
+                    match = re.search(r"\bthen\b\s*(.*)", code_line)
+                    if match and match.group(1):
+                        self.error("Code after a condition ends should be on its own line.")
+
                     if contains_word('then')(code_line):
                         condition_str = full_condition.replace('elseif','').replace('if','').replace('then','').strip()
                         paren_regex = regex.compile("\((([^\)\(]+)|(?R))*+\)", re.S)
@@ -465,7 +469,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 49
+    expected_errors = 52
 else:
     total_errors = LuaStyleCheck(target).errcount
 

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -100,7 +100,7 @@ end
 local function badFunction3() return 1 end -- FAIL (x2)
 
 -- check_no_single_line_conditions()
-if a == b then a = 5 end -- FAIL
+if a == b then a = 5 end -- FAIL (x2)
 
 -- check_no_function_decl_padding()
 local function test (var1)
@@ -188,3 +188,6 @@ xi.item.SOMETHING  -- PASS
 
 xi.effects.SOMETHING -- FAIL
 xi.effect.SOMETHING  -- PASS
+
+if x == 1 then y = 2 -- FAIL
+elseif x == 2 then y = 3 -- FAIL


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds CI rule to check for any non-comment text after the word `then` in lua scripts and corrects all issues raised from it.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
