### PR TITLE
Brisingamen +1 Latent Correction

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -264,7 +264,7 @@ INSERT INTO `item_latents` VALUES (12742,369,-4,56,0);   -- Rune Bangles -4MP/ti
 INSERT INTO `item_latents` VALUES (12751,71,4,13,6);
 
 -- -------------------------------------------------------
--- Brisingamen / Brisingamen +1
+-- Brisingamen
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (13097,2,10,26,0);     -- Daytime: HP +10
 INSERT INTO `item_latents` VALUES (13097,5,10,26,1);     -- Nighttime: MP +10
@@ -310,16 +310,18 @@ INSERT INTO `item_latents` VALUES (13143,368,25,13,193);
 -- -------------------------------------------------------
 INSERT INTO `item_latents` VALUES (13145,28,8,4,51);     -- "Magic Atk. Bonus" while MP <51%
 
--- Brisingamen+1 stats need to be found on retail so they can be corrected
-INSERT INTO `item_latents` VALUES (13162,2,10,26,0);     -- Daytime: HP +10 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,5,10,26,1);     -- Nighttime: MP +10 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,8,5,28,0);      -- Firesday: STR +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,9,5,35,0);      -- Lightningsday: DEX +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,10,5,29,0);     -- Earthsday: VIT +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,11,5,31,0);     -- Windsday: AGI +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,12,5,34,0);     -- Iceday: INT +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,13,5,30,0);     -- Watersday: MND +5 (needs HQ stats)
-INSERT INTO `item_latents` VALUES (13162,14,5,36,0);     -- Lightsday: CHR +5 (needs HQ stats)
+----------------------------------------------------------
+-- Brisingamen+1
+----------------------------------------------------------
+INSERT INTO `item_latents` VALUES (13162,2,12,26,0);     -- Daytime: HP +12
+INSERT INTO `item_latents` VALUES (13162,5,12,26,1);     -- Nighttime: MP +12
+INSERT INTO `item_latents` VALUES (13162,8,7,28,0);      -- Firesday: STR +7
+INSERT INTO `item_latents` VALUES (13162,9,7,35,0);      -- Lightningsday: DEX +7
+INSERT INTO `item_latents` VALUES (13162,10,7,29,0);     -- Earthsday: VIT +7
+INSERT INTO `item_latents` VALUES (13162,11,7,31,0);     -- Windsday: AGI +7
+INSERT INTO `item_latents` VALUES (13162,12,7,34,0);     -- Iceday: INT +7
+INSERT INTO `item_latents` VALUES (13162,13,7,30,0);     -- Watersday: MND +7
+INSERT INTO `item_latents` VALUES (13162,14,7,36,0);     -- Lightsday: CHR +7
 
 -- -------------------------------------------------------
 -- Auditory Torque


### PR DESCRIPTION
Corrects the plus 1 version of Brisingamen.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This corrects the Brisingamen +1 from the NQ stats. 

Day : HP +12
Night : MP +12
Tuesday : STR +7
Saturday : VIT +7
Wednesday : MND +7
Wind day : AGI +7
Ice Day : INT +7
Thunder days : DEX +7
Lightday : CHR +7
Darkday : No change

Sources: 
JP wiki -> https://wiki.ffo.jp/html/2512.html
BGwiki -> https://www.bg-wiki.com/ffxi/Brisingamen_%2B1

I did have someone on retail verify the stats but I did not get a SS/video of it. I will inquire to get one since hearsay isn't exactly good for verification.  

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

Equip the HQ item and enjoy the slightly elevated stats.

<!-- Clear and detailed steps to test your changes here -->
