### PR TITLE
[ci] Replace lua strings with placeholder prior to checks

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -142,11 +142,7 @@ class LuaStyleCheck:
         """
         # ,[^ \n] : Any comma that does not have space or newline following
 
-        # Replace quoted strings with a placeholder
-        removed_string_line = re.sub('\"([^\"]*?)\"', "strVal", line)
-        removed_string_line = re.sub("\'([^\"]*?)\'", "strVal", removed_string_line)
-
-        for _ in re.finditer(",[^ \n]", removed_string_line):
+        for _ in re.finditer(",[^ \n]", line):
             self.error("Multiple parameters used without an appropriate following space or newline")
 
     def check_semicolon(self, line):
@@ -358,6 +354,10 @@ class LuaStyleCheck:
 
                 # Remove in-line comments
                 code_line = re.sub("(?=--)(.*?)(?=\r\n|\n)", "", line)
+
+                # Replace quoted strings with a placeholder
+                code_line = re.sub('\"([^\"]*?)\"', "strVal", code_line)
+                code_line = re.sub("\'([^\"]*?)\'", "strVal", code_line)
 
                 # Checks that apply to all lines
                 self.check_table_formatting(code_line)

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -191,3 +191,11 @@ xi.effect.SOMETHING  -- PASS
 
 if x == 1 then y = 2 -- FAIL
 elseif x == 2 then y = 3 -- FAIL
+
+"if x then y" -- PASS
+"( x-y == 0 )" -- PASS
+"if x then y end" -- PASS
+
+'if x then y' -- PASS
+'( x-y == 0 )' -- PASS
+'if x then y end' -- PASS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces lua strings with placeholder immediately after stripping comments to prevent accidentally triggering on string contents
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Additional tests added to CI, and should pass
<!-- Clear and detailed steps to test your changes here -->
