### PR TITLE
[core] Fix Lua tostring fallback

### DIFF
--- a/src/common/lua.cpp
+++ b/src/common/lua.cpp
@@ -49,6 +49,10 @@ void lua_init()
     // Bind print(...) globally
     lua.set_function("print", &lua_print);
 
+    // Copy the original tostring impl into _tostring, so we can use our own
+    // implementation for tostring, but then fall back to the original for usertypes.
+    lua.set_function("_tostring", lua.get<sol::function>("tostring"));
+
     // Bind tostring(...) globally
     lua.set_function("tostring", &lua_to_string);
 
@@ -103,7 +107,8 @@ std::string lua_to_string_depth(sol::object const& obj, std::size_t depth)
         }
         case sol::type::userdata:
         {
-            return lua["tostring"](obj);
+            // Fallback to original implementation of tostring that we stored in _tostring
+            return lua["_tostring"](obj);
         }
         case sol::type::lightuserdata:
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`!exec print(target)` and `!exec print(player)` were recursing and causing a stack overflow. This adds a base base to stop that happening - falling back to the original Lua tostring impl if we want to print a usertype.