### PR TITLE
[core] Deprecate XI_DEBUG_BREAK_IF

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -34,11 +34,8 @@
 #endif
 
 // define a break macro for debugging
-#define XI_DEBUG_BREAK_IF(_CONDITION_)                               \
-    if (_CONDITION_)                                                 \
-    {                                                                \
-        ShowCritical("HIT DEBUG BREAK CONDITION: %s", #_CONDITION_); \
-    }
+#define XI_DEBUG_BREAK_IF(_CONDITION_) \
+    static_assert(false, "Use of XI_DEBUG_BREAK_IF is deprecated. Check your conditions and log appropriately instead.")
 
 // typedef/using
 using int8  = std::int8_t;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We've killed all uses of XI_DEBUG_BREAK_IF, but there are downstream repos who still have code that's littered with it.

```cpp
        CItemWeapon* PBait = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
        XI_DEBUG_BREAK_IF(PBait == nullptr);
        XI_DEBUG_BREAK_IF(PBait->isType(ITEM_WEAPON) == false);             <--- CRASHING HERE
        XI_DEBUG_BREAK_IF(PBait->getSkillType() != SKILL_FISHING);
```

With the current debug break, the code will log and make it to the second condition, where it's executed and then it crashes, rather than actually asserting. I think it's best that we disallow this code so that people can't copy/paste blindly without ripping these things out.
