### PR TITLE
Fixes issue trading crystals to conquest overseers

### DIFF
--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -761,6 +761,11 @@ xi.garrison.onTrade = function(player, npc, trade, guardNation)
     local nationID = GetRegionOwner(zone:getRegionID())
     local zoneData = xi.garrison.zoneData[zoneID]
 
+    -- If called outside of Garrison areas
+    if zoneData == nil then
+        return
+    end
+
     -- If info is missing, a debug message will be logged and Garrison will not begin
     if xi.garrison.getAllyInfo(zoneID, zoneData, nationID) == nil then
         player:PrintToPlayer('Garrison is currently unavailable for this region.', xi.msg.channel.SYSTEM_3)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
`xi.conquest.overseerOnTrade` can be called outside the context of Garrison areas (eg. when trading crystals to a "gate guard") and the nil result is not handled inside `garrison.lua`. This change handles the nil result.

## Steps to test these changes
Should be able to trade to conquest overseers and start Garrison. Both conditions tested in game.