### PR TITLE
Dragoon Spirit Link Fix

### DIFF
--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -325,7 +325,7 @@ local function checkForRemovableEffectsOnSpiritLink(player, wyvern)
         for _, effect in pairs(effects) do
             local id = effect:getEffectType()
             if
-                bit.band(effect:getFlag(), xi.effectFlag.ERASABLE) == xi.effectFlag.ERASABLE or
+                bit.band(effect:getEffectFlags(), xi.effectFlag.ERASABLE) == xi.effectFlag.ERASABLE or
                 additionalRemovableEffects[id] ~= nil
             then
                 table.insert(validEffects, id)
@@ -367,7 +367,7 @@ xi.job_utils.dragoon.useSpiritLink = function(player, target, ability)
         local copyi = 0
 
         for _, effect in pairs(effects) do
-            if bit.band(effect:getFlag(), xi.effectFlag.EMPATHY) == xi.effectFlag.EMPATHY then
+            if bit.band(effect:getEffectFlags(), xi.effectFlag.EMPATHY) == xi.effectFlag.EMPATHY then
                 validEffects[i + 1] = effect
                 i = i + 1
             end


### PR DESCRIPTION
A replacement function name change a while ago was missed which made this ability break. Now fixed.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the missed function name replacement within the Spirit Link ability portion so Dragoons who have Empathy merited can now use the ability.

Fixes Issue [#4371](https://github.com/LandSandBoat/server/issues/4371)

## Steps to test these changes

Put merits in Empathy on Dragoon, use Spirit Link when Wyvern is damaged. 
