### PR TITLE
[core] Audit Party/Alliance messaging

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -140,6 +140,7 @@ enum MSGSERVTYPE : uint8
     MSG_PT_INV_RES,
     MSG_PT_RELOAD,
     MSG_PT_DISBAND,
+    MSG_ALLIANCE_DISSOLVE,
     MSG_DIRECT,
     MSG_LINKSHELL_RANK_CHANGE,
     MSG_LINKSHELL_REMOVE,
@@ -221,6 +222,8 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_PT_RELOAD";
         case MSG_PT_DISBAND:
             return "MSG_PT_DISBAND";
+        case MSG_ALLIANCE_DISSOLVE:
+            return "MSG_ALLIANCE_DISSOLVE";
         case MSG_DIRECT:
             return "MSG_DIRECT";
         case MSG_LINKSHELL_RANK_CHANGE:

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -72,10 +72,9 @@ void CAlliance::dissolveAlliance(bool playerInitiated)
     {
         // sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE allianceid = %u;", ALLIANCE_LEADER | PARTY_SECOND
         // | PARTY_THIRD, m_AllianceID);
-        uint8 data[8]{};
+        uint8 data[4]{};
         ref<uint32>(data, 0) = m_AllianceID;
-        ref<uint32>(data, 4) = m_AllianceID;
-        message::send(MSG_PT_DISBAND, data, sizeof data, nullptr);
+        message::send(MSG_ALLIANCE_DISSOLVE, data, sizeof data, nullptr);
     }
     else
     {
@@ -155,17 +154,21 @@ void CAlliance::removeParty(CParty* party)
         }
     }
 
+    uint32 mainPartyID = getMainParty()->GetPartyID();
+
     delParty(party);
 
     sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE partyid = %u;",
                ALLIANCE_LEADER | PARTY_SECOND | PARTY_THIRD, party->GetPartyID());
+
+    // notify alliance
     uint8 data[4]{};
-    ref<uint32>(data, 0) = m_AllianceID;
+    ref<uint32>(data, 0) = mainPartyID;
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 
-    uint8 data2[4]{};
-    ref<uint32>(data2, 0) = party->GetPartyID();
-    message::send(MSG_PT_RELOAD, data2, sizeof data2, nullptr);
+    // notify leaving party
+    ref<uint32>(data, 0) = party->GetPartyID();
+    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 
 void CAlliance::delParty(CParty* party)
@@ -258,8 +261,9 @@ void CAlliance::addParty(CParty* party)
                party->GetPartyID());
     party->SetPartyNumber(newparty);
 
+    // MSG_PT_RELOAD also reloads all the alliances parties if available
     uint8 data[4]{};
-    ref<uint32>(data, 0) = m_AllianceID;
+    ref<uint32>(data, 0) = party->GetPartyID();
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 
@@ -283,9 +287,8 @@ void CAlliance::addParty(uint32 partyid) const
         }
     }
     sql->Query("UPDATE accounts_parties SET allianceid = %u, partyflag = partyflag | %d WHERE partyid = %u;", m_AllianceID, newparty, partyid);
-    uint8 data[8]{};
-    ref<uint32>(data, 0) = m_AllianceID;
-    ref<uint32>(data, 4) = partyid;
+    uint8 data[4]{};
+    ref<uint32>(data, 0) = partyid;
     message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4462,9 +4462,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                             sql->AffectedRows())
                         {
                             ShowDebug("%s has removed %s from party", PChar->GetName(), data[0x0C]);
-                            uint8 removeData[8]{};
+                            uint8 removeData[4]{};
                             ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
-                            ref<uint32>(removeData, 4) = id;
                             message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
                         }
                     }
@@ -4551,9 +4550,8 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                                 sql->AffectedRows())
                             {
                                 ShowDebug("%s has removed %s party from alliance", PChar->GetName(), data[0x0C]);
-                                uint8 removeData[8]{};
+                                uint8 removeData[4]{};
                                 ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
-                                ref<uint32>(removeData, 4) = id;
                                 message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
                             }
                         }
@@ -4763,8 +4761,10 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
 
                 ShowDebug(fmt::format("(Alliance)Changing leader to {}", memberName));
                 PChar->PParty->m_PAlliance->assignAllianceLeader((const char*)data[0x04]);
+
+                // MSG_PT_RELOAD also reloads all the alliances parties if available
                 uint8 leaderData[4]{};
-                ref<uint32>(leaderData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+                ref<uint32>(leaderData, 0) = PChar->PParty->GetPartyID();
                 message::send(MSG_PT_RELOAD, leaderData, sizeof leaderData, nullptr);
             }
         }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -149,9 +149,8 @@ void CParty::DisbandParty(bool playerInitiated)
         // make sure chat server isn't notified of a disband if this came from the chat server already
         if (playerInitiated)
         {
-            uint8 data[8]{};
+            uint8 data[4]{};
             ref<uint32>(data, 0) = m_PartyID;
-            ref<uint32>(data, 4) = m_PartyID;
             message::send(MSG_PT_DISBAND, data, sizeof data, nullptr);
         }
     }
@@ -636,9 +635,8 @@ void CParty::AddMember(uint32 id)
         }
         sql->Query("INSERT INTO accounts_parties (charid, partyid, allianceid, partyflag) VALUES (%u, %u, %u, %u);", id, m_PartyID, allianceid,
                    Flags);
-        uint8 data[8]{};
+        uint8 data[4]{};
         ref<uint32>(data, 0) = m_PartyID;
-        ref<uint32>(data, 4) = id;
         message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
 
         /*if (PChar->nameflags.flags & FLAG_INVITE)

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -153,6 +153,16 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
             ret            = sql->Query(query, partyid, partyid);
             break;
         }
+        case MSG_ALLIANCE_DISSOLVE:
+        {
+            const char* query = "SELECT server_addr, server_port, MIN(charid) FROM accounts_sessions JOIN accounts_parties USING (charid) "
+                                "WHERE allianceid = %d "
+                                "GROUP BY server_addr, server_port;";
+
+            uint32 allianceid = ref<uint32>((uint8*)extra->data(), 0);
+            ret               = sql->Query(query, allianceid);
+            break;
+        }
         case MSG_CHAT_LINKSHELL:
         {
             const char* query = "SELECT server_addr, server_port FROM accounts_sessions "


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This should fix up little issues with invalid messages being sent that would never parse, such as your party/alliance never updating until you zone

## Steps to test these changes

Add party members to party, have them zone and see them zone out instead of stay in the same zone visually despite actually not being in the same zone. Same for alliance members.

Kick party/alliance members and have it work properly on the client.
Kick parties from the alliance and have it work properly on the client.
/acmd breakup and have it work properly on the client.