### PR TITLE
[Nyzul] Simplify entity tables and mob logic

### DIFF
--- a/scripts/globals/nyzul.lua
+++ b/scripts/globals/nyzul.lua
@@ -64,17 +64,17 @@ xi.nyzul.penalty =
 
 xi.nyzul.FloorLayout =
 {
-    [0]  = {   -20, -0.5, -380 }, -- boss floors 20, 40, 60, 80
---  [?]  = {  -491, -4.0, -500 }, -- boss floor 20 confirmed
-    [1]  = {   380, -0.5, -500 },
-    [2]  = {   500, -0.5,  -20 },
-    [3]  = {   500, -0.5,   60 },
-    [4]  = {   500, -0.5, -100 },
-    [5]  = {   540, -0.5, -140 },
-    [6]  = {   460, -0.5, -219 },
-    [7]  = {   420, -0.5,  500 },
-    [8]  = {    60, -0.5, -335 },
-    [9]  = {    20, -0.5, -500 },
+    [ 0] = {   -20, -0.5, -380 }, -- boss floors 20, 40, 60, 80
+--  [ ?] = {  -491, -4.0, -500 }, -- boss floor 20 confirmed
+    [ 1] = {   380, -0.5, -500 },
+    [ 2] = {   500, -0.5,  -20 },
+    [ 3] = {   500, -0.5,   60 },
+    [ 4] = {   500, -0.5, -100 },
+    [ 5] = {   540, -0.5, -140 },
+    [ 6] = {   460, -0.5, -219 },
+    [ 7] = {   420, -0.5,  500 },
+    [ 8] = {    60, -0.5, -335 },
+    [ 9] = {    20, -0.5, -500 },
     [10] = {   -95, -0.5,   60 },
     [11] = {   100, -0.5,  100 },
     [12] = {  -460, -4.0, -180 },
@@ -94,15 +94,15 @@ xi.nyzul.FloorLayout =
 
 xi.nyzul.floorCost =
 {
-    [1]  = { level =  1, cost =    0 },
-    [2]  = { level =  6, cost =  500 },
-    [3]  = { level = 11, cost =  550 },
-    [4]  = { level = 16, cost =  600 },
-    [5]  = { level = 21, cost =  650 },
-    [6]  = { level = 26, cost =  700 },
-    [7]  = { level = 31, cost =  750 },
-    [8]  = { level = 36, cost =  800 },
-    [9]  = { level = 41, cost =  850 },
+    [ 1] = { level =  1, cost =    0 },
+    [ 2] = { level =  6, cost =  500 },
+    [ 3] = { level = 11, cost =  550 },
+    [ 4] = { level = 16, cost =  600 },
+    [ 5] = { level = 21, cost =  650 },
+    [ 6] = { level = 26, cost =  700 },
+    [ 7] = { level = 31, cost =  750 },
+    [ 8] = { level = 36, cost =  800 },
+    [ 9] = { level = 41, cost =  850 },
     [10] = { level = 46, cost =  900 },
     [11] = { level = 51, cost = 1000 },
     [12] = { level = 56, cost = 1100 },
@@ -116,246 +116,66 @@ xi.nyzul.floorCost =
     [20] = { level = 96, cost = 1900 },
 }
 
-xi.nyzul.pickMobs =
+xi.nyzul.enemyLeaders =
 {
-    [0] = -- 20th Floor bosses
-    {
-        [40] = -- 20 and 40 floor Bosses
-        {
-            ADAMANTOISE = ID.mob[51].ADAMANTOISE,
-            FAFNIR      = ID.mob[51].ADAMANTOISE + 2,
-        },
-        [100] = -- floors 60, 80 and 100 floor bosses
-        {
-            KHIMAIRA = ID.mob[51].ADAMANTOISE + 3,
-            CERBERUS = ID.mob[51].ADAMANTOISE + 5,
-        },
-    },
-
-    [1] = -- Enemy Leaders, can appear on all floors but %20 that are on objective
-    {
-        MOKKE               = ID.mob[51].MOKKE,
-        LONG_HORNED_CHARIOT = ID.mob[51].LONG_HORNED_CHARIOT,
-    },
-
-    [2] = -- Specified Enemies
-    {
-        [0] = -- Heraldic Imp x5
-        {
-            ID.mob[51].OFFSET_SPECIFIED,     ID.mob[51].OFFSET_SPECIFIED + 1, ID.mob[51].OFFSET_SPECIFIED + 2,
-            ID.mob[51].OFFSET_SPECIFIED + 3, ID.mob[51].OFFSET_SPECIFIED + 4
-        },
-        [1] = -- Psycheflayer x5
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 5, ID.mob[51].OFFSET_SPECIFIED + 6, ID.mob[51].OFFSET_SPECIFIED + 7,
-            ID.mob[51].OFFSET_SPECIFIED + 8, ID.mob[51].OFFSET_SPECIFIED + 9
-        },
-        [2] = -- Poroggo Gent x5
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 10, ID.mob[51].OFFSET_SPECIFIED + 11, ID.mob[51].OFFSET_SPECIFIED + 12,
-            ID.mob[51].OFFSET_SPECIFIED + 13, ID.mob[51].OFFSET_SPECIFIED + 14
-        },
-        [3] = -- Ebony Pudding x5
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 15, ID.mob[51].OFFSET_SPECIFIED + 16, ID.mob[51].OFFSET_SPECIFIED + 17,
-            ID.mob[51].OFFSET_SPECIFIED + 18, ID.mob[51].OFFSET_SPECIFIED + 19
-        },
-        [4] = -- Qiqirn_Treasure_Hunter x2
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 20, ID.mob[51].OFFSET_SPECIFIED + 21
-        },
-        [5] = -- Qiqirn_Archaeologist x3
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 22, ID.mob[51].OFFSET_SPECIFIED + 23, ID.mob[51].OFFSET_SPECIFIED + 24
-        },
-        [6] = -- Racing_Chariot x5
-        {
-            ID.mob[51].OFFSET_SPECIFIED + 25, ID.mob[51].OFFSET_SPECIFIED + 26, ID.mob[51].OFFSET_SPECIFIED + 27,
-            ID.mob[51].OFFSET_SPECIFIED + 28, ID.mob[51].OFFSET_SPECIFIED + 29
-        },
-    },
+    -- [Floor_Section] = { first_mob_id, last_mob_id },
+    [  1] = { ID.mob[51].MOKKE,           ID.mob[51].LONG_HORNED_CHARIOT }, -- Regular enemy leaders. Can appear on all floors, except floor-20 multiples.
+    [ 40] = { ID.mob[51].ADAMANTOISE,     ID.mob[51].ADAMANTOISE + 2     }, -- Floors 1 to 40 bosses. Original Land Kings.
+    [100] = { ID.mob[51].ADAMANTOISE + 3, ID.mob[51].ADAMANTOISE + 5     }, -- Floors 60 to 100 bosses. ToAU Land Kings.
 }
 
-xi.nyzul.randomNMs =
+xi.nyzul.specifiedMobs =
 {
-    evenFloor =
-    {
-        [1] = -- floor 1 to 19 NM's
-        {
-            ID.mob[51].OFFSET_NM,     ID.mob[51].OFFSET_NM + 1, ID.mob[51].OFFSET_NM + 2, ID.mob[51].OFFSET_NM + 3, ID.mob[51].OFFSET_NM + 4,
-            ID.mob[51].OFFSET_NM + 5, ID.mob[51].OFFSET_NM + 6, ID.mob[51].OFFSET_NM + 7, ID.mob[51].OFFSET_NM + 8,
-        },
-        [2] = -- floor 21 to 39 NM's
-        {
-            ID.mob[51].OFFSET_NM + 18, ID.mob[51].OFFSET_NM + 19, ID.mob[51].OFFSET_NM + 20, ID.mob[51].OFFSET_NM + 21, ID.mob[51].OFFSET_NM + 22,
-            ID.mob[51].OFFSET_NM + 23, ID.mob[51].OFFSET_NM + 24, ID.mob[51].OFFSET_NM + 25, ID.mob[51].OFFSET_NM + 26,
-        },
-        [3] = -- floor 41 to 59 NM's
-        {
-            ID.mob[51].OFFSET_NM + 36, ID.mob[51].OFFSET_NM + 37, ID.mob[51].OFFSET_NM + 38, ID.mob[51].OFFSET_NM + 39, ID.mob[51].OFFSET_NM + 40,
-            ID.mob[51].OFFSET_NM + 41, ID.mob[51].OFFSET_NM + 42, ID.mob[51].OFFSET_NM + 43, ID.mob[51].OFFSET_NM + 44,
-        },
-        [4] = -- floor 61 to 79 NM's
-        {
-            ID.mob[51].OFFSET_NM + 54, ID.mob[51].OFFSET_NM + 55, ID.mob[51].OFFSET_NM + 56, ID.mob[51].OFFSET_NM + 57, ID.mob[51].OFFSET_NM + 58,
-            ID.mob[51].OFFSET_NM + 59, ID.mob[51].OFFSET_NM + 60, ID.mob[51].OFFSET_NM + 61, ID.mob[51].OFFSET_NM + 62,
-        },
-        [5] = -- floor 81 to 99 NM's
-        {
-            ID.mob[51].OFFSET_NM + 72, ID.mob[51].OFFSET_NM + 73, ID.mob[51].OFFSET_NM + 74, ID.mob[51].OFFSET_NM + 75, ID.mob[51].OFFSET_NM + 76,
-            ID.mob[51].OFFSET_NM + 77, ID.mob[51].OFFSET_NM + 78, ID.mob[51].OFFSET_NM + 79, ID.mob[51].OFFSET_NM + 80,
-        },
-    },
-
-    oddFloor =
-    {
-        [1] = -- floor 1 to 19 NM's
-        {
-            ID.mob[51].OFFSET_NM + 9,  ID.mob[51].OFFSET_NM + 10, ID.mob[51].OFFSET_NM + 11, ID.mob[51].OFFSET_NM + 12, ID.mob[51].OFFSET_NM + 13,
-            ID.mob[51].OFFSET_NM + 14, ID.mob[51].OFFSET_NM + 15, ID.mob[51].OFFSET_NM + 16, ID.mob[51].OFFSET_NM + 17,
-        },
-        [2] = -- floor 21 to 39 NM's
-        {
-            ID.mob[51].OFFSET_NM + 27, ID.mob[51].OFFSET_NM + 28, ID.mob[51].OFFSET_NM + 29, ID.mob[51].OFFSET_NM + 30, ID.mob[51].OFFSET_NM + 31,
-            ID.mob[51].OFFSET_NM + 32, ID.mob[51].OFFSET_NM + 33, ID.mob[51].OFFSET_NM + 34, ID.mob[51].OFFSET_NM + 35,
-        },
-        [3] = -- floor 41 to 59 NM's
-        {
-            ID.mob[51].OFFSET_NM + 45, ID.mob[51].OFFSET_NM + 46, ID.mob[51].OFFSET_NM + 47, ID.mob[51].OFFSET_NM + 48, ID.mob[51].OFFSET_NM + 49,
-            ID.mob[51].OFFSET_NM + 50, ID.mob[51].OFFSET_NM + 51, ID.mob[51].OFFSET_NM + 52, ID.mob[51].OFFSET_NM + 53,
-        },
-        [4] = -- floor 61 to 79 NM's
-        {
-            ID.mob[51].OFFSET_NM + 63, ID.mob[51].OFFSET_NM + 64, ID.mob[51].OFFSET_NM + 65, ID.mob[51].OFFSET_NM + 66, ID.mob[51].OFFSET_NM + 67,
-            ID.mob[51].OFFSET_NM + 68, ID.mob[51].OFFSET_NM + 69, ID.mob[51].OFFSET_NM + 70, ID.mob[51].OFFSET_NM + 71,
-        },
-        [5] = -- floor 81 to 99 NM's
-        {
-            ID.mob[51].OFFSET_NM + 81, ID.mob[51].OFFSET_NM + 82, ID.mob[51].OFFSET_NM + 83, ID.mob[51].OFFSET_NM + 84, ID.mob[51].OFFSET_NM + 85,
-            ID.mob[51].OFFSET_NM + 86, ID.mob[51].OFFSET_NM + 87, ID.mob[51].OFFSET_NM + 88, ID.mob[51].OFFSET_NM + 89,
-        },
-    },
+    -- [Mob family] = { first_mob_id, last_mob_id },
+    [1] = { ID.mob[51].OFFSET_SPECIFIED,      ID.mob[51].OFFSET_SPECIFIED +  4 }, -- Heraldic Imp x5
+    [2] = { ID.mob[51].OFFSET_SPECIFIED +  5, ID.mob[51].OFFSET_SPECIFIED +  9 }, -- Psycheflayer x5
+    [3] = { ID.mob[51].OFFSET_SPECIFIED + 10, ID.mob[51].OFFSET_SPECIFIED + 14 }, -- Poroggo Gent x5
+    [4] = { ID.mob[51].OFFSET_SPECIFIED + 15, ID.mob[51].OFFSET_SPECIFIED + 19 }, -- Ebony Pudding x5
+    [5] = { ID.mob[51].OFFSET_SPECIFIED + 20, ID.mob[51].OFFSET_SPECIFIED + 21 }, -- Qiqirn_Treasure_Hunter x2
+    [6] = { ID.mob[51].OFFSET_SPECIFIED + 22, ID.mob[51].OFFSET_SPECIFIED + 24 }, -- Qiqirn_Archaeologist x3
+    [7] = { ID.mob[51].OFFSET_SPECIFIED + 25, ID.mob[51].OFFSET_SPECIFIED + 29 }, -- Racing_Chariot x5
 }
 
-xi.nyzul.floorEntities = -- regular mobs by layout
+xi.nyzul.evenFloorRandomNMs =
 {
-    [1] = -- Aquans
-    {
-        ID.mob[51].OFFSET_REGULAR,     ID.mob[51].OFFSET_REGULAR + 1, ID.mob[51].OFFSET_REGULAR + 2,  ID.mob[51].OFFSET_REGULAR + 3,
-        ID.mob[51].OFFSET_REGULAR + 4, ID.mob[51].OFFSET_REGULAR + 5, ID.mob[51].OFFSET_REGULAR + 6,  ID.mob[51].OFFSET_REGULAR + 7,
-        ID.mob[51].OFFSET_REGULAR + 8, ID.mob[51].OFFSET_REGULAR + 9, ID.mob[51].OFFSET_REGULAR + 10, ID.mob[51].OFFSET_REGULAR + 11
-    },
+    -- [Floor_Section] = { first_mob_id, last_mob_id },
+    [1] = { ID.mob[51].OFFSET_NM,      ID.mob[51].OFFSET_NM +  8 }, -- Floors 1 to 20.
+    [2] = { ID.mob[51].OFFSET_NM + 18, ID.mob[51].OFFSET_NM + 26 }, -- Floors 21 to 40.
+    [3] = { ID.mob[51].OFFSET_NM + 36, ID.mob[51].OFFSET_NM + 44 }, -- Floors 41 to 60.
+    [4] = { ID.mob[51].OFFSET_NM + 54, ID.mob[51].OFFSET_NM + 62 }, -- Floors 61 to 80.
+    [5] = { ID.mob[51].OFFSET_NM + 72, ID.mob[51].OFFSET_NM + 80 }, -- Floors 81 to 100.
+}
 
-    [2] = -- Amorphs
-    {
-        ID.mob[51].OFFSET_REGULAR + 12, ID.mob[51].OFFSET_REGULAR + 13, ID.mob[51].OFFSET_REGULAR + 14, ID.mob[51].OFFSET_REGULAR + 15,
-        ID.mob[51].OFFSET_REGULAR + 16, ID.mob[51].OFFSET_REGULAR + 17, ID.mob[51].OFFSET_REGULAR + 18, ID.mob[51].OFFSET_REGULAR + 19,
-        ID.mob[51].OFFSET_REGULAR + 20, ID.mob[51].OFFSET_REGULAR + 21, ID.mob[51].OFFSET_REGULAR + 22, ID.mob[51].OFFSET_REGULAR + 23
-    },
+xi.nyzul.oddFloorRandomNMs =
+{
+    -- [Floor_Section] = { first_mob_id, last_mob_id },
+    [1] = { ID.mob[51].OFFSET_NM +  9, ID.mob[51].OFFSET_NM + 17 }, -- Floors 1 to 20.
+    [2] = { ID.mob[51].OFFSET_NM + 27, ID.mob[51].OFFSET_NM + 35 }, -- Floors 21 to 40.
+    [3] = { ID.mob[51].OFFSET_NM + 45, ID.mob[51].OFFSET_NM + 53 }, -- Floors 41 to 60.
+    [4] = { ID.mob[51].OFFSET_NM + 63, ID.mob[51].OFFSET_NM + 71 }, -- Floors 61 to 80.
+    [5] = { ID.mob[51].OFFSET_NM + 81, ID.mob[51].OFFSET_NM + 89 }, -- Floors 81 to 100.
+}
 
-    [3] = -- Arcana
-    {
-        ID.mob[51].OFFSET_REGULAR + 24, ID.mob[51].OFFSET_REGULAR + 25, ID.mob[51].OFFSET_REGULAR + 26, ID.mob[51].OFFSET_REGULAR + 27,
-        ID.mob[51].OFFSET_REGULAR + 28, ID.mob[51].OFFSET_REGULAR + 29, ID.mob[51].OFFSET_REGULAR + 30, ID.mob[51].OFFSET_REGULAR + 31,
-        ID.mob[51].OFFSET_REGULAR + 32, ID.mob[51].OFFSET_REGULAR + 33, ID.mob[51].OFFSET_REGULAR + 34, ID.mob[51].OFFSET_REGULAR + 35
-    },
-
-    [4] = -- Undead
-    {
-        ID.mob[51].OFFSET_REGULAR + 36, ID.mob[51].OFFSET_REGULAR + 37, ID.mob[51].OFFSET_REGULAR + 38, ID.mob[51].OFFSET_REGULAR + 39,
-        ID.mob[51].OFFSET_REGULAR + 40, ID.mob[51].OFFSET_REGULAR + 41, ID.mob[51].OFFSET_REGULAR + 42, ID.mob[51].OFFSET_REGULAR + 43,
-        ID.mob[51].OFFSET_REGULAR + 44, ID.mob[51].OFFSET_REGULAR + 45, ID.mob[51].OFFSET_REGULAR + 46, ID.mob[51].OFFSET_REGULAR + 47
-    },
-
-    [5] = -- Vermin
-    {
-        ID.mob[51].OFFSET_REGULAR + 48, ID.mob[51].OFFSET_REGULAR + 49, ID.mob[51].OFFSET_REGULAR + 50, ID.mob[51].OFFSET_REGULAR + 51,
-        ID.mob[51].OFFSET_REGULAR + 52, ID.mob[51].OFFSET_REGULAR + 53, ID.mob[51].OFFSET_REGULAR + 54, ID.mob[51].OFFSET_REGULAR + 55,
-        ID.mob[51].OFFSET_REGULAR + 56, ID.mob[51].OFFSET_REGULAR + 57, ID.mob[51].OFFSET_REGULAR + 58, ID.mob[51].OFFSET_REGULAR + 59
-    },
-
-    [6] = -- Demons
-    {
-        ID.mob[51].OFFSET_REGULAR + 60, ID.mob[51].OFFSET_REGULAR + 61, ID.mob[51].OFFSET_REGULAR + 62, ID.mob[51].OFFSET_REGULAR + 63,
-        ID.mob[51].OFFSET_REGULAR + 64, ID.mob[51].OFFSET_REGULAR + 65, ID.mob[51].OFFSET_REGULAR + 66, ID.mob[51].OFFSET_REGULAR + 67,
-        ID.mob[51].OFFSET_REGULAR + 68, ID.mob[51].OFFSET_REGULAR + 69, ID.mob[51].OFFSET_REGULAR + 70, ID.mob[51].OFFSET_REGULAR + 71
-    },
-
-    [7] = -- Dragons
-    {
-        ID.mob[51].OFFSET_REGULAR + 72, ID.mob[51].OFFSET_REGULAR + 73, ID.mob[51].OFFSET_REGULAR + 74, ID.mob[51].OFFSET_REGULAR + 75,
-        ID.mob[51].OFFSET_REGULAR + 76, ID.mob[51].OFFSET_REGULAR + 77, ID.mob[51].OFFSET_REGULAR + 78, ID.mob[51].OFFSET_REGULAR + 79,
-        ID.mob[51].OFFSET_REGULAR + 80, ID.mob[51].OFFSET_REGULAR + 81, ID.mob[51].OFFSET_REGULAR + 82, ID.mob[51].OFFSET_REGULAR + 83
-    },
-
-    [8] = -- Birds
-    {
-        ID.mob[51].OFFSET_REGULAR + 84, ID.mob[51].OFFSET_REGULAR + 85, ID.mob[51].OFFSET_REGULAR + 86, ID.mob[51].OFFSET_REGULAR + 87,
-        ID.mob[51].OFFSET_REGULAR + 88, ID.mob[51].OFFSET_REGULAR + 89, ID.mob[51].OFFSET_REGULAR + 90, ID.mob[51].OFFSET_REGULAR + 91,
-        ID.mob[51].OFFSET_REGULAR + 92, ID.mob[51].OFFSET_REGULAR + 93, ID.mob[51].OFFSET_REGULAR + 94, ID.mob[51].OFFSET_REGULAR + 95
-    },
-
-    [9] = -- Beasts
-    {
-        ID.mob[51].OFFSET_REGULAR + 96,  ID.mob[51].OFFSET_REGULAR + 97,  ID.mob[51].OFFSET_REGULAR + 98,  ID.mob[51].OFFSET_REGULAR + 99,
-        ID.mob[51].OFFSET_REGULAR + 100, ID.mob[51].OFFSET_REGULAR + 101, ID.mob[51].OFFSET_REGULAR + 102, ID.mob[51].OFFSET_REGULAR + 103,
-        ID.mob[51].OFFSET_REGULAR + 104, ID.mob[51].OFFSET_REGULAR + 105, ID.mob[51].OFFSET_REGULAR + 106, ID.mob[51].OFFSET_REGULAR + 107
-    },
-
-    [10] = -- Plantoids
-    {
-        ID.mob[51].OFFSET_REGULAR + 108, ID.mob[51].OFFSET_REGULAR + 109, ID.mob[51].OFFSET_REGULAR + 110, ID.mob[51].OFFSET_REGULAR + 111,
-        ID.mob[51].OFFSET_REGULAR + 112, ID.mob[51].OFFSET_REGULAR + 113, ID.mob[51].OFFSET_REGULAR + 114, ID.mob[51].OFFSET_REGULAR + 115,
-        ID.mob[51].OFFSET_REGULAR + 116, ID.mob[51].OFFSET_REGULAR + 117, ID.mob[51].OFFSET_REGULAR + 118, ID.mob[51].OFFSET_REGULAR + 119
-    },
-
-    [11] =  -- Lizards
-    {
-        ID.mob[51].OFFSET_REGULAR + 120, ID.mob[51].OFFSET_REGULAR + 121, ID.mob[51].OFFSET_REGULAR + 122, ID.mob[51].OFFSET_REGULAR + 123,
-        ID.mob[51].OFFSET_REGULAR + 124, ID.mob[51].OFFSET_REGULAR + 125, ID.mob[51].OFFSET_REGULAR + 126, ID.mob[51].OFFSET_REGULAR + 127,
-        ID.mob[51].OFFSET_REGULAR + 128, ID.mob[51].OFFSET_REGULAR + 129, ID.mob[51].OFFSET_REGULAR + 130, ID.mob[51].OFFSET_REGULAR + 131
-    },
-
-    [12] = -- Amorphs
-    {
-        ID.mob[51].OFFSET_REGULAR + 132, ID.mob[51].OFFSET_REGULAR + 133, ID.mob[51].OFFSET_REGULAR + 134, ID.mob[51].OFFSET_REGULAR + 135,
-        ID.mob[51].OFFSET_REGULAR + 136, ID.mob[51].OFFSET_REGULAR + 137, ID.mob[51].OFFSET_REGULAR + 138, ID.mob[51].OFFSET_REGULAR + 139,
-        ID.mob[51].OFFSET_REGULAR + 140, ID.mob[51].OFFSET_REGULAR + 141, ID.mob[51].OFFSET_REGULAR + 142, ID.mob[51].OFFSET_REGULAR + 143
-    },
-
-    [13] = -- Mixed
-    {
-        ID.mob[51].OFFSET_REGULAR + 144, ID.mob[51].OFFSET_REGULAR + 145, ID.mob[51].OFFSET_REGULAR + 146, ID.mob[51].OFFSET_REGULAR + 147,
-        ID.mob[51].OFFSET_REGULAR + 148, ID.mob[51].OFFSET_REGULAR + 149, ID.mob[51].OFFSET_REGULAR + 150, ID.mob[51].OFFSET_REGULAR + 151,
-        ID.mob[51].OFFSET_REGULAR + 152, ID.mob[51].OFFSET_REGULAR + 153, ID.mob[51].OFFSET_REGULAR + 154, ID.mob[51].OFFSET_REGULAR + 155
-    },
-
-    [14] = -- Mixed
-    {
-        ID.mob[51].OFFSET_REGULAR + 156, ID.mob[51].OFFSET_REGULAR + 157, ID.mob[51].OFFSET_REGULAR + 158, ID.mob[51].OFFSET_REGULAR + 159,
-        ID.mob[51].OFFSET_REGULAR + 160, ID.mob[51].OFFSET_REGULAR + 161, ID.mob[51].OFFSET_REGULAR + 162, ID.mob[51].OFFSET_REGULAR + 163,
-        ID.mob[51].OFFSET_REGULAR + 164, ID.mob[51].OFFSET_REGULAR + 165, ID.mob[51].OFFSET_REGULAR + 166, ID.mob[51].OFFSET_REGULAR + 167
-    },
-
-    [15] = -- Amorphs
-    {
-        ID.mob[51].OFFSET_REGULAR + 168, ID.mob[51].OFFSET_REGULAR + 169, ID.mob[51].OFFSET_REGULAR + 170, ID.mob[51].OFFSET_REGULAR + 171,
-        ID.mob[51].OFFSET_REGULAR + 172, ID.mob[51].OFFSET_REGULAR + 173, ID.mob[51].OFFSET_REGULAR + 174, ID.mob[51].OFFSET_REGULAR + 175,
-        ID.mob[51].OFFSET_REGULAR + 176, ID.mob[51].OFFSET_REGULAR + 177, ID.mob[51].OFFSET_REGULAR + 178, ID.mob[51].OFFSET_REGULAR + 179
-    },
-
-    [16] = -- Arcana
-    {
-        ID.mob[51].OFFSET_REGULAR + 180, ID.mob[51].OFFSET_REGULAR + 181, ID.mob[51].OFFSET_REGULAR + 182, ID.mob[51].OFFSET_REGULAR + 183,
-        ID.mob[51].OFFSET_REGULAR + 184, ID.mob[51].OFFSET_REGULAR + 185, ID.mob[51].OFFSET_REGULAR + 186, ID.mob[51].OFFSET_REGULAR + 187,
-        ID.mob[51].OFFSET_REGULAR + 188, ID.mob[51].OFFSET_REGULAR + 189, ID.mob[51].OFFSET_REGULAR + 190, ID.mob[51].OFFSET_REGULAR + 191
-    },
-
-    [17] = -- Gears
-    {
-        start = ID.mob[51].OFFSET_GEARS,
-        stop  = ID.mob[51].OFFSET_GEARS + 5
-    },
+xi.nyzul.floorEntities =
+{
+    -- [Mob family] = { first_mob_id, last_mob_id },
+    [ 1] = { ID.mob[51].OFFSET_REGULAR,       ID.mob[51].OFFSET_REGULAR +  11 }, -- Aquans
+    [ 2] = { ID.mob[51].OFFSET_REGULAR +  12, ID.mob[51].OFFSET_REGULAR +  23 }, -- Amorphs
+    [ 3] = { ID.mob[51].OFFSET_REGULAR +  24, ID.mob[51].OFFSET_REGULAR +  35 }, -- Arcana
+    [ 4] = { ID.mob[51].OFFSET_REGULAR +  36, ID.mob[51].OFFSET_REGULAR +  47 }, -- Undead
+    [ 5] = { ID.mob[51].OFFSET_REGULAR +  48, ID.mob[51].OFFSET_REGULAR +  59 }, -- Vermin
+    [ 6] = { ID.mob[51].OFFSET_REGULAR +  60, ID.mob[51].OFFSET_REGULAR +  71 }, -- Demons
+    [ 7] = { ID.mob[51].OFFSET_REGULAR +  72, ID.mob[51].OFFSET_REGULAR +  83 }, -- Dragons
+    [ 8] = { ID.mob[51].OFFSET_REGULAR +  84, ID.mob[51].OFFSET_REGULAR +  95 }, -- Birds
+    [ 9] = { ID.mob[51].OFFSET_REGULAR +  96, ID.mob[51].OFFSET_REGULAR + 107 }, -- Beasts
+    [10] = { ID.mob[51].OFFSET_REGULAR + 108, ID.mob[51].OFFSET_REGULAR + 119 }, -- Plantoids
+    [11] = { ID.mob[51].OFFSET_REGULAR + 120, ID.mob[51].OFFSET_REGULAR + 131 }, -- Lizards
+    [12] = { ID.mob[51].OFFSET_REGULAR + 132, ID.mob[51].OFFSET_REGULAR + 143 }, -- Amorphs 2
+    [13] = { ID.mob[51].OFFSET_REGULAR + 144, ID.mob[51].OFFSET_REGULAR + 155 }, -- Mixed
+    [14] = { ID.mob[51].OFFSET_REGULAR + 156, ID.mob[51].OFFSET_REGULAR + 167 }, -- Mixed 2
+    [15] = { ID.mob[51].OFFSET_REGULAR + 168, ID.mob[51].OFFSET_REGULAR + 179 }, -- Amorphs 3
+    [16] = { ID.mob[51].OFFSET_REGULAR + 180, ID.mob[51].OFFSET_REGULAR + 191 }, -- Arcana 2
+    [17] = { ID.mob[51].OFFSET_GEARS,         ID.mob[51].OFFSET_GEARS   +   5 }, -- Gears
 }
 
 xi.nyzul.appraisalItems =

--- a/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
@@ -146,19 +146,15 @@ end
 
 local function pickMobs(instance)
     local currentFloor = instance:getLocalVar('Nyzul_Current_Floor')
-    local mobFamily    = math.random(1, 16)
-    local floorLayout  = instance:getLocalVar('Nyzul_Isle_FloorLayout')
-    local pointTable   = xi.nyzulPoint.SpawnPoint[floorLayout]
-    local spawnPoint   = {}
 
-    -- 20th floor bosses
+    -- 20th floor bosses.
     if currentFloor % 20 == 0 then
         local floorBoss = 0
 
-        if currentFloor == 20 or currentFloor == 40 then
-            floorBoss = math.random(xi.nyzul.pickMobs[0][40].ADAMANTOISE, xi.nyzul.pickMobs[0][40].FAFNIR)
-        elseif currentFloor == 60 or currentFloor == 80 or currentFloor == 100 then
-            floorBoss = math.random(xi.nyzul.pickMobs[0][100].KHIMAIRA, xi.nyzul.pickMobs[0][100].CERBERUS)
+        if currentFloor <= 40 then
+            floorBoss = math.random(xi.nyzul.enemyLeaders[40][1], xi.nyzul.enemyLeaders[40][2])
+        elseif currentFloor <= 100 then
+            floorBoss = math.random(xi.nyzul.enemyLeaders[100][1], xi.nyzul.enemyLeaders[100][2])
         end
 
         GetMobByID(ID.mob[51].ARCHAIC_RAMPART1, instance):setSpawn(-36, 0, -362, 0)
@@ -166,211 +162,222 @@ local function pickMobs(instance)
         SpawnMob(ID.mob[51].ARCHAIC_RAMPART1, instance)
         SpawnMob(floorBoss, instance)
 
-    -- All other floors
-    else
+    -- All other floors except free.
+    elseif instance:getStage() ~= xi.nyzul.objective.FREE_FLOOR then
+        -- Build dynamic table with all the possible spawn points.
+        local floorLayout      = instance:getLocalVar('Nyzul_Isle_FloorLayout')
+        local pointTable       = xi.nyzulPoint.SpawnPoint[floorLayout]
+        local sPoint           = 0
+        local sPointX          = 0
+        local sPointY          = 0
+        local sPointZ          = 0
+        local sPointRot        = 0
+        local dTableSpawnPoint = {}
+
         for i = 1, #pointTable do
-            table.insert(spawnPoint, i, pointTable[i])
+            table.insert(dTableSpawnPoint, i, pointTable[i])
         end
 
-        -- Not 'free floors'
-        if instance:getStage() ~= xi.nyzul.objective.FREE_FLOOR then
-            switch (instance:getStage()) : caseof
-            {
-                -- Enemy Leader Objective
-                [xi.nyzul.objective.ELIMINATE_ENEMY_LEADER] = function()
-                    local floorBoss = math.random(xi.nyzul.pickMobs[1].MOKKE, xi.nyzul.pickMobs[1].LONG_HORNED_CHARIOT)
+        -- Spawn objective-specific mobs.
+        switch (instance:getStage()) : caseof
+        {
+            -- Enemy Leader Objective
+            [xi.nyzul.objective.ELIMINATE_ENEMY_LEADER] = function()
+                local floorBoss = math.random(xi.nyzul.enemyLeaders[1][1], xi.nyzul.enemyLeaders[1][2])
+                sPoint          = math.random(1, #dTableSpawnPoint)
+                sPointX         = dTableSpawnPoint[sPoint][1]
+                sPointY         = dTableSpawnPoint[sPoint][2]
+                sPointZ         = dTableSpawnPoint[sPoint][3]
+                sPointRot       = dTableSpawnPoint[sPoint][4]
 
-                    if floorBoss == 17092962 then
-                        floorBoss = 17092961 + (math.random(0, 1) * 2)
-                    end
+                if floorBoss == ID.mob[51].MOKKE + 18 then
+                    floorBoss = ID.mob[51].MOKKE + 17 + (math.random(0, 1) * 2)
+                end
 
-                    local sPoint    = math.random(1, #spawnPoint)
-                    local sPointX   = spawnPoint[sPoint][1]
-                    local sPointY   = spawnPoint[sPoint][2]
-                    local sPointZ   = spawnPoint[sPoint][3]
-                    local sPointRot = spawnPoint[sPoint][4]
+                GetMobByID(floorBoss, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+                SpawnMob(floorBoss, instance)
+                table.remove(dTableSpawnPoint, sPoint)
+            end,
 
-                    GetMobByID(floorBoss, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                    SpawnMob(floorBoss, instance)
-                    table.remove(spawnPoint, sPoint)
-                end,
+            -- Specified Enemy Group Objective
+            [xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMIES] = function()
+                local specificGroup         = math.random(1, 7)
+                local specificEnemyGroup    = xi.nyzul.specifiedMobs[specificGroup]
+                local numberOfMobs          = specificEnemyGroup[2] - specificEnemyGroup[1] + 1
+                local groupAmount           = math.random(2, numberOfMobs)
+                local dTableSpecificEnemies = {}
 
-                -- Specified Enemy Group Objective
-                [xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMIES] = function()
-                    local specificEnemies    = {}
-                    local specificGroup      = math.random(0, 6)
-                    local groupAmount        = math.random(2, #xi.nyzul.pickMobs[2][specificGroup])
-                    local specificEnemyGroup = xi.nyzul.pickMobs[2][specificGroup]
+                for i = specificEnemyGroup[1], specificEnemyGroup[2] do
+                    table.insert(dTableSpecificEnemies, i)
+                end
 
-                    for i = 1, #specificEnemyGroup do
-                        table.insert(specificEnemies, specificEnemyGroup[i])
-                    end
+                while groupAmount > 0 do
+                    local randomEnemy = math.random(1, #dTableSpecificEnemies)
+                    local enemy       = dTableSpecificEnemies[randomEnemy]
+                    sPoint            = math.random(1, #dTableSpawnPoint)
+                    sPointX           = dTableSpawnPoint[sPoint][1]
+                    sPointY           = dTableSpawnPoint[sPoint][2]
+                    sPointZ           = dTableSpawnPoint[sPoint][3]
+                    sPointRot         = dTableSpawnPoint[sPoint][4]
 
-                    while groupAmount > 0 do
-                        local randomEnemy = math.random(1, #specificEnemies)
-                        local enemy       = specificEnemies[randomEnemy]
-                        local sPoint      = math.random(1, #spawnPoint)
-                        local sPointX     = spawnPoint[sPoint][1]
-                        local sPointY     = spawnPoint[sPoint][2]
-                        local sPointZ     = spawnPoint[sPoint][3]
-                        local sPointRot   = spawnPoint[sPoint][4]
+                    GetMobByID(enemy, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+                    SpawnMob(enemy, instance)
+                    table.remove(dTableSpawnPoint, sPoint)
+                    table.remove(dTableSpecificEnemies, randomEnemy)
+                    instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
 
-                        GetMobByID(enemy, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                        SpawnMob(enemy, instance)
-                        table.remove(spawnPoint, sPoint)
-                        table.remove(specificEnemies, randomEnemy)
-                        instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
+                    groupAmount = groupAmount - 1
+                end
+            end,
 
-                        groupAmount = groupAmount - 1
-                    end
-                end,
+            -- Eliminate All Objective
+            [xi.nyzul.objective.ELIMINATE_ALL_ENEMIES] = function()
+                if math.random(1, 100) <= 20 then -- 20% chance that Dahank will spawn.
+                    sPoint    = math.random(1, #dTableSpawnPoint)
+                    sPointX   = dTableSpawnPoint[sPoint][1]
+                    sPointY   = dTableSpawnPoint[sPoint][2]
+                    sPointZ   = dTableSpawnPoint[sPoint][3]
+                    sPointRot = dTableSpawnPoint[sPoint][4]
 
-                -- Eliminate All Objective
-                [xi.nyzul.objective.ELIMINATE_ALL_ENEMIES] = function()
-                    if math.random(0, 100) >= 80 then -- 20% chance that Dahank will spawn
-                        local sPoint    = math.random(1, #spawnPoint)
-                        local sPointX   = spawnPoint[sPoint][1]
-                        local sPointY   = spawnPoint[sPoint][2]
-                        local sPointZ   = spawnPoint[sPoint][3]
-                        local sPointRot = spawnPoint[sPoint][4]
-
-                        GetMobByID(ID.mob[51].DAHAK, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                        SpawnMob(ID.mob[51].DAHAK, instance)
-                        table.remove(spawnPoint, sPoint)
-                        instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
-                    end
-                end,
+                    GetMobByID(ID.mob[51].DAHAK, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+                    SpawnMob(ID.mob[51].DAHAK, instance)
+                    table.remove(dTableSpawnPoint, sPoint)
+                    instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
+                end
+            end,
 
             -- Activate Lamps Objective
-                [xi.nyzul.objective.ACTIVATE_ALL_LAMPS] = function()
-                    instance:setLocalVar('[Lamps]Objective', math.random(xi.nyzul.lampsObjective.REGISTER, xi.nyzul.lampsObjective.ORDER))
-                    lampsActivate(instance)
-                end,
-            }
+            [xi.nyzul.objective.ACTIVATE_ALL_LAMPS] = function()
+                instance:setLocalVar('[Lamps]Objective', math.random(xi.nyzul.lampsObjective.REGISTER, xi.nyzul.lampsObjective.ORDER))
+                lampsActivate(instance)
+            end,
+        }
 
-            -- 1st Rampart: 90% spawn rate
-            if math.random(0, 100) >= 90 then
-                local sPoint    = math.random(1, #spawnPoint)
-                local sPointX   = spawnPoint[sPoint][1]
-                local sPointY   = spawnPoint[sPoint][2]
-                local sPointZ   = spawnPoint[sPoint][3]
-                local sPointRot = spawnPoint[sPoint][4]
+        -- Spawn Rampart-Type mobs.
+        if math.random(1, 100) <= 90 then
+            sPoint    = math.random(1, #dTableSpawnPoint)
+            sPointX   = dTableSpawnPoint[sPoint][1]
+            sPointY   = dTableSpawnPoint[sPoint][2]
+            sPointZ   = dTableSpawnPoint[sPoint][3]
+            sPointRot = dTableSpawnPoint[sPoint][4]
 
-                GetMobByID(ID.mob[51].ARCHAIC_RAMPART1, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+            GetMobByID(ID.mob[51].ARCHAIC_RAMPART1, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
 
-                SpawnMob(ID.mob[51].ARCHAIC_RAMPART1, instance)
-                table.remove(spawnPoint, sPoint)
+            SpawnMob(ID.mob[51].ARCHAIC_RAMPART1, instance)
+            table.remove(dTableSpawnPoint, sPoint)
+
+            if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
+                instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
+            end
+        end
+
+        if math.random(1, 100) <= 20 then
+            sPoint    = math.random(1, #dTableSpawnPoint)
+            sPointX   = dTableSpawnPoint[sPoint][1]
+            sPointY   = dTableSpawnPoint[sPoint][2]
+            sPointZ   = dTableSpawnPoint[sPoint][3]
+            sPointRot = dTableSpawnPoint[sPoint][4]
+
+            GetMobByID(ID.mob[51].ARCHAIC_RAMPART2, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+            SpawnMob(ID.mob[51].ARCHAIC_RAMPART2, instance)
+            table.remove(dTableSpawnPoint, sPoint)
+
+            if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
+                instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
+            end
+        end
+
+        -- Spawn Gear-Type mobs.
+        if instance:getLocalVar('gearObjective') > 0 then
+            for i = xi.nyzul.floorEntities[17][1], xi.nyzul.floorEntities[17][2] do
+                sPoint    = math.random(1, #dTableSpawnPoint)
+                sPointX   = dTableSpawnPoint[sPoint][1]
+                sPointY   = dTableSpawnPoint[sPoint][2]
+                sPointZ   = dTableSpawnPoint[sPoint][3]
+                sPointRot = dTableSpawnPoint[sPoint][4]
+
+                instance:setLocalVar('gearPenalty', math.random(xi.nyzul.penalty.TIME, xi.nyzul.penalty.PATHOS))
+                GetMobByID(i, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+                SpawnMob(i, instance)
+                table.remove(dTableSpawnPoint, sPoint)
+            end
+        end
+
+        -- Spawn fodder NM's.
+        local spawnedNMs = math.random(0, 4)
+
+        if spawnedNMs > 0 then
+            local floorSection   = math.floor(currentFloor / 20) + 1
+            local mobGroup       = xi.nyzul.oddFloorRandomNMs[floorSection]
+            local dTableFloorNMs = {}
+
+            -- Even floors.
+            if currentFloor % 2 == 0 then
+                mobGroup = xi.nyzul.evenFloorRandomNMs[floorSection]
+            end
+
+            for i = mobGroup[1], mobGroup[2] do
+                table.insert(dTableFloorNMs, i)
+            end
+
+            while spawnedNMs > 2 do
+                local index = math.random(1, #dTableFloorNMs)
+                sPoint      = math.random(1, #dTableSpawnPoint)
+                sPointX     = dTableSpawnPoint[sPoint][1]
+                sPointY     = dTableSpawnPoint[sPoint][2]
+                sPointZ     = dTableSpawnPoint[sPoint][3]
+                sPointRot   = dTableSpawnPoint[sPoint][4]
+
+                GetMobByID(dTableFloorNMs[index], instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+                SpawnMob(dTableFloorNMs[index], instance)
+
+                table.remove(dTableFloorNMs, index)
+                table.remove(dTableSpawnPoint, sPoint)
+
+                spawnedNMs = spawnedNMs - 1
 
                 if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
                     instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
                 end
             end
+        end
 
-            -- 2nd Rampart: 20% spawn rate
-            if math.random(0, 100) >= 20 then
-                local sPoint    = math.random(1, #spawnPoint)
-                local sPointX   = spawnPoint[sPoint][1]
-                local sPointY   = spawnPoint[sPoint][2]
-                local sPointZ   = spawnPoint[sPoint][3]
-                local sPointRot = spawnPoint[sPoint][4]
+        -- Spawn fodder regular mobs.
+        local mobFamily     = math.random(1, 16)
+        local enemyAmount   = math.random(6, 12)
+        local dTableEnemies = {}
 
-                GetMobByID(ID.mob[51].ARCHAIC_RAMPART2, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                SpawnMob(ID.mob[51].ARCHAIC_RAMPART2, instance)
-                table.remove(spawnPoint, sPoint)
+        for i = xi.nyzul.floorEntities[mobFamily][1], xi.nyzul.floorEntities[mobFamily][2] do
+            table.insert(dTableEnemies, i)
+        end
 
-                if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
-                    instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
-                end
+        while enemyAmount > 0 do
+            local randomEnemy = math.random(1, #dTableEnemies)
+            local mobID       = dTableEnemies[randomEnemy]
+            sPoint            = math.random(1, #dTableSpawnPoint)
+            sPointX           = dTableSpawnPoint[sPoint][1]
+            sPointY           = dTableSpawnPoint[sPoint][2]
+            sPointZ           = dTableSpawnPoint[sPoint][3]
+            sPointRot         = dTableSpawnPoint[sPoint][4]
+
+            if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
+                instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
+            elseif
+                instance:getStage() == xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMY and
+                instance:getLocalVar('Nyzul_Specified_Enemy') == 0
+            then
+                instance:setLocalVar('Nyzul_Specified_Enemy', mobID)
             end
 
-            -- Spawn Gears
-            if instance:getLocalVar('gearObjective') > 0 then
-                for i = xi.nyzul.floorEntities[17].start, xi.nyzul.floorEntities[17].stop do
-                    local sPoint    = math.random(1, #spawnPoint)
-                    local sPointX   = spawnPoint[sPoint][1]
-                    local sPointY   = spawnPoint[sPoint][2]
-                    local sPointZ   = spawnPoint[sPoint][3]
-                    local sPointRot = spawnPoint[sPoint][4]
+            GetMobByID(mobID, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
+            SpawnMob(mobID, instance)
 
-                    instance:setLocalVar('gearPenalty', math.random(xi.nyzul.penalty.TIME, xi.nyzul.penalty.PATHOS))
-                    GetMobByID(i, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                    SpawnMob(i, instance)
-                    table.remove(spawnPoint, sPoint)
-                end
-            end
+            -- Remove used up entries from dynamic tables.
+            table.remove(dTableEnemies, randomEnemy)
+            table.remove(dTableSpawnPoint, sPoint)
 
-            -- Trash NM's of floor
-            local spawnedNMs = math.random(0, 4)
-
-            if spawnedNMs > 0 then
-                local floorSection = math.floor(currentFloor / 20) + 1
-                local floorNMs = {}
-
-                local mobGroup = xi.nyzul.randomNMs.oddFloor[floorSection]
-                if currentFloor % 2 == 0 then
-                    mobGroup = xi.nyzul.randomNMs.evenFloor[floorSection]
-                end
-
-                for i = 1, #mobGroup do
-                    table.insert(floorNMs, mobGroup[i])
-                end
-
-                while spawnedNMs > 2 do
-                    local sPoint    = math.random(1, #spawnPoint)
-                    local sPointX   = spawnPoint[sPoint][1]
-                    local sPointY   = spawnPoint[sPoint][2]
-                    local sPointZ   = spawnPoint[sPoint][3]
-                    local sPointRot = spawnPoint[sPoint][4]
-                    local index = math.random(1, #floorNMs)
-
-                    GetMobByID(floorNMs[index], instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                    SpawnMob(floorNMs[index], instance)
-
-                    table.remove(floorNMs, index)
-                    table.remove(spawnPoint, sPoint)
-
-                    spawnedNMs = spawnedNMs - 1
-
-                    if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
-                        instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
-                    end
-                end
-            end
-
-            -- Add rest of mobs for all Objectives
-            local groupAmount = math.random(6, #xi.nyzul.floorEntities[mobFamily])
-            local enemyGroup  = xi.nyzul.floorEntities[mobFamily]
-            local enemies     = {}
-
-            for i = 1, #enemyGroup do
-                table.insert(enemies, enemyGroup[i])
-            end
-
-            while groupAmount > 0 do
-                local randomEnemy = math.random(1, #enemies)
-                local enemy       = enemies[randomEnemy]
-                local sPoint      = math.random(1, #spawnPoint)
-                local sPointX     = spawnPoint[sPoint][1]
-                local sPointY     = spawnPoint[sPoint][2]
-                local sPointZ     = spawnPoint[sPoint][3]
-                local sPointRot   = spawnPoint[sPoint][4]
-
-                if instance:getStage() == xi.nyzul.objective.ELIMINATE_ALL_ENEMIES then
-                    instance:setLocalVar('Eliminate', instance:getLocalVar('Eliminate') + 1)
-                elseif
-                    instance:getStage() == xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMY and
-                    instance:getLocalVar('Nyzul_Specified_Enemy') == 0
-                then
-                    instance:setLocalVar('Nyzul_Specified_Enemy', enemy)
-                end
-
-                GetMobByID(enemy, instance):setSpawn(sPointX, sPointY, sPointZ, sPointRot)
-                SpawnMob(enemy, instance)
-                table.remove(enemies, randomEnemy)
-                table.remove(spawnPoint, sPoint)
-
-                groupAmount = groupAmount - 1
-            end
+            -- Decrease loop.
+            enemyAmount = enemyAmount - 1
         end
     end
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Part of nyzul's rewrite. This one focuses on simplifying the entity tables with a million entries.
- Renamed table names. This allows to have several tables instead of a giant table with several subtables inside.
- Addopted a "first mob, last mob" pattern across all tables. This way most tables have x entries with 2 values, instead of 5+
- Changed logic to reflect this changes. Performed some simplification and much commenting in the process.

Minor changes
- Renamed how dynamic tables are named inside , so we can now they are created and edited on the spot inside the logic.
- Changed how rates are handled, to make them clearer.

## Steps to test these changes

Do nyul. No changes compared to before should be notized
