### PR TITLE
Add support for charVars and serverVars that expire based on timestamp

### DIFF
--- a/scripts/enum/vana_time.lua
+++ b/scripts/enum/vana_time.lua
@@ -1,0 +1,11 @@
+xi = xi or {}
+
+-- Number of earth seconds for each Vana'diel time interval
+xi.vanaTime =
+{
+    YEAR  = 518400,
+    MONTH = 43200,
+    WEEK  = 11520,
+    DAY   = 1440,
+    HOUR  = 60,
+}

--- a/scripts/enum/vana_time.lua
+++ b/scripts/enum/vana_time.lua
@@ -1,11 +1,14 @@
 xi = xi or {}
 
--- Number of earth seconds for each Vana'diel time interval
+-- Number of earth seconds for each Vana'diel time interval.
+-- See: https://www.bg-wiki.com/ffxi/Vana%27diel_Time
+local secondsPerTick = 2.4
+
 xi.vanaTime =
 {
-    YEAR  = 518400,
-    MONTH = 43200,
-    WEEK  = 11520,
-    DAY   = 1440,
-    HOUR  = 60,
+    YEAR  = 518400 * secondsPerTick,
+    MONTH = 43200 * secondsPerTick,
+    WEEK  = 11520 * secondsPerTick,
+    DAY   = 1440 * secondsPerTick,
+    HOUR  = 60 * secondsPerTick,
 }

--- a/scripts/globals/interaction/container.lua
+++ b/scripts/globals/interaction/container.lua
@@ -105,8 +105,19 @@ function Container:getVar(player, name)
     return player:getVar(self.varPrefix .. name)
 end
 
-function Container:setVar(player, name, value)
-    return player:setVar(self.varPrefix .. name, value)
+function Container:setVar(player, name, value, expiry)
+    return player:setVar(self.varPrefix .. name, value, expiry)
+end
+
+function Container:setVarExpiration(player, name, expiry)
+    return player:setCharVarExpiration(self.varPrefix .. name, expiry)
+end
+
+-- Wrapper for setVar where the expiration matters more than any other
+-- stored value.  There is no need to get specifically, since it will
+-- be removed.  (Returned value is either 1 or 0)
+function Container:setTimedVar(player, name, expiry)
+    return player:setVar(self.varPrefix .. name, 1, expiry)
 end
 
 function Container:isVarBitsSet(player, name, ...)

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -800,34 +800,38 @@ xi.mission.getMissionMask = function(player)
 end
 
 -- Interaction Framework Helper Functions
-local function getVarPrefix(areaId, questId)
-    return string.format('Mission[%d][%d]', areaId, questId)
+local function getVarPrefix(areaId, missionId)
+    return string.format('Mission[%d][%d]', areaId, missionId)
 end
 
-xi.mission.incrementVar = function(player, areaId, questId, name, value)
-    return player:incrementCharVar(getVarPrefix(areaId, questId) .. name, value)
+xi.mission.incrementVar = function(player, areaId, missionId, name, value)
+    return player:incrementCharVar(getVarPrefix(areaId, missionId) .. name, value)
 end
 
-xi.mission.getVar = function(player, areaId, questId, name)
-    return player:getVar(getVarPrefix(areaId, questId) .. name)
+xi.mission.getVar = function(player, areaId, missionId, name)
+    return player:getVar(getVarPrefix(areaId, missionId) .. name)
 end
 
-xi.mission.setVar = function(player, areaId, questId, name, value)
-    return player:setVar(getVarPrefix(areaId, questId) .. name, value)
+xi.mission.setVar = function(player, areaId, missionId, name, value, expiry)
+    return player:setVar(getVarPrefix(areaId, missionId) .. name, value, expiry)
 end
 
-xi.mission.getLocalVar = function(player, areaId, questId, name)
-    return player:getLocalVar(getVarPrefix(areaId, questId) .. name)
+xi.mission.setVarExpiration = function(player, areaId, missionId, name, expiry)
+    return player:setCharVarExpiration(getVarPrefix(areaId, missionId) .. name, expiry)
 end
 
-xi.mission.setLocalVar = function(player, areaId, questId, name, value)
-    return player:setLocalVar(getVarPrefix(areaId, questId) .. name, value)
+xi.mission.getLocalVar = function(player, areaId, missionId, name)
+    return player:getLocalVar(getVarPrefix(areaId, missionId) .. name)
 end
 
-xi.mission.getMustZone = function(player, areaId, questId)
-    return player:getLocalVar(getVarPrefix(areaId, questId) .. 'mustZone') == 1 and true or false
+xi.mission.setLocalVar = function(player, areaId, missionId, name, value)
+    return player:setLocalVar(getVarPrefix(areaId, missionId) .. name, value)
 end
 
-xi.mission.setMustZone = function(player, areaId, questId)
-    player:setLocalVar(getVarPrefix(areaId, questId) .. 'mustZone', 1)
+xi.mission.getMustZone = function(player, areaId, missionId)
+    return player:getLocalVar(getVarPrefix(areaId, missionId) .. 'mustZone') == 1 and true or false
+end
+
+xi.mission.setMustZone = function(player, areaId, missionId)
+    player:setLocalVar(getVarPrefix(areaId, missionId) .. 'mustZone', 1)
 end

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1268,8 +1268,12 @@ xi.quest.getVar = function(player, areaId, questId, name)
     return player:getVar(getVarPrefix(areaId, questId) .. name)
 end
 
-xi.quest.setVar = function(player, areaId, questId, name, value)
-    return player:setVar(getVarPrefix(areaId, questId) .. name, value)
+xi.quest.setVar = function(player, areaId, questId, name, value, expiry)
+    return player:setVar(getVarPrefix(areaId, questId) .. name, value, expiry)
+end
+
+xi.quest.setVarExpiration = function(player, areaId, questId, name, expiry)
+    return player:setCharVarExpiration(getVarPrefix(areaId, questId) .. name, expiry)
 end
 
 xi.quest.getLocalVar = function(player, areaId, questId, name)

--- a/sql/char_vars.sql
+++ b/sql/char_vars.sql
@@ -14,5 +14,6 @@ CREATE TABLE IF NOT EXISTS `char_vars` (
   `charid` int(10) unsigned NOT NULL,
   `varname` varchar(30) NOT NULL,
   `value` int(11) NOT NULL,
+  `expiry` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`charid`,`varname`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/sql/server_variables.sql
+++ b/sql/server_variables.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS `server_variables`;
 CREATE TABLE `server_variables` (
   `name` varchar(50) NOT NULL,
   `value` int(11) NOT NULL,
+  `expiry` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/src/common/vana_time.cpp
+++ b/src/common/vana_time.cpp
@@ -84,6 +84,11 @@ uint32 CVanaTime::getWeekday() const
     return m_vDay;
 }
 
+uint32 CVanaTime::getSysTime()
+{
+    return static_cast<uint32>(time(nullptr));
+}
+
 uint32 CVanaTime::getSysHour()
 {
     time_t now = time(nullptr);

--- a/src/common/vana_time.cpp
+++ b/src/common/vana_time.cpp
@@ -219,7 +219,12 @@ uint32 CVanaTime::getVanaTime() const
     return (uint32)time(nullptr) - (m_customEpoch ? m_customEpoch : VTIME_BASEDATE);
 }
 
-int32 CVanaTime::getCustomEpoch() const
+uint32 CVanaTime::getEpoch() const
+{
+    return m_customEpoch ? m_customEpoch : VTIME_BASEDATE;
+}
+
+uint32 CVanaTime::getCustomEpoch() const
 {
     return m_customEpoch;
 }

--- a/src/common/vana_time.h
+++ b/src/common/vana_time.h
@@ -81,6 +81,7 @@ public:
     uint8  getMoonDirection() const;
     uint8  getRSERace() const;
     uint8  getRSELocation() const;
+    uint32 getSysTime();
     uint32 getSysHour();
     uint32 getSysMinute();
     uint32 getSysSecond();

--- a/src/common/vana_time.h
+++ b/src/common/vana_time.h
@@ -96,7 +96,8 @@ public:
     uint32 getJstMidnight(); // Upcoming JST midnight in unix timestamp
 
     uint32 getVanaTime() const;
-    int32  getCustomEpoch() const;
+    uint32 getEpoch() const;
+    uint32 getCustomEpoch() const;
 
     void setCustomEpoch(int32 epoch);
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2750,7 +2750,7 @@ int32 CCharEntity::getCharVar(std::string const& charVarName)
     if (auto charVar = charVarCache.find(charVarName); charVar != charVarCache.end())
     {
         std::pair cachedVarData    = charVar->second;
-        uint32    currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+        uint32    currentTimestamp = CVanaTime::getInstance()->getSysTime();
 
         // If the cached variable is not expired, return it.  Else, fall through so that the
         // database can be cleaned up.

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -721,7 +721,7 @@ bool CCharEntity::PersistData()
     {
         for (auto&& charVarName : charVarChanges)
         {
-            charutils::PersistCharVar(this->id, charVarName.c_str(), charVarCache[charVarName]);
+            charutils::PersistCharVar(this->id, charVarName.c_str(), charVarCache[charVarName].first, charVarCache[charVarName].second);
         }
 
         charVarChanges.clear();
@@ -2749,30 +2749,38 @@ int32 CCharEntity::getCharVar(std::string const& charVarName)
 {
     if (auto charVar = charVarCache.find(charVarName); charVar != charVarCache.end())
     {
-        return charVar->second;
+        std::pair cachedVarData    = charVar->second;
+        uint32    currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+
+        // If the cached variable is not expired, return it.  Else, fall through so that the
+        // database can be cleaned up.
+        if (cachedVarData.second == 0 || cachedVarData.second > currentTimestamp)
+        {
+            return cachedVarData.first;
+        }
     }
 
     auto value = charutils::FetchCharVar(this->id, charVarName);
 
     charVarCache[charVarName] = value;
-    return value;
+    return value.first;
 }
 
-void CCharEntity::setCharVar(std::string const& charVarName, int32 value)
+void CCharEntity::setCharVar(std::string const& charVarName, int32 value, uint32 expiry /* = 0 */)
 {
-    charVarCache[charVarName] = value;
-    charutils::PersistCharVar(this->id, charVarName, value);
+    charVarCache[charVarName] = { value, expiry };
+    charutils::PersistCharVar(this->id, charVarName, value, expiry);
 }
 
-void CCharEntity::setVolatileCharVar(std::string const& charVarName, int32 value)
+void CCharEntity::setVolatileCharVar(std::string const& charVarName, int32 value, uint32 expiry /* = 0 */)
 {
-    charVarCache[charVarName] = value;
+    charVarCache[charVarName] = { value, expiry };
     charVarChanges.insert(charVarName);
 }
 
-void CCharEntity::updateCharVarCache(std::string const& charVarName, int32 value)
+void CCharEntity::updateCharVarCache(std::string const& charVarName, int32 value, uint32 expiry /* = 0 */)
 {
-    charVarCache[charVarName] = value;
+    charVarCache[charVarName] = { value, expiry };
 }
 
 void CCharEntity::removeFromCharVarCache(std::string const& varName)
@@ -2793,7 +2801,7 @@ void CCharEntity::clearCharVarsWithPrefix(std::string const& prefix)
     {
         if (iter->first.rfind(prefix, 0) == 0)
         {
-            iter->second = 0;
+            iter->second = { 0, 0 };
         }
         ++iter;
     }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -582,9 +582,9 @@ public:
     virtual void OnItemFinish(CItemState&, action_t&);
 
     int32 getCharVar(std::string const& varName);
-    void  setCharVar(std::string const& varName, int32 value);
-    void  setVolatileCharVar(std::string const& varName, int32 value);
-    void  updateCharVarCache(std::string const& varName, int32 value);
+    void  setCharVar(std::string const& varName, int32 value, uint32 expiry = 0);
+    void  setVolatileCharVar(std::string const& varName, int32 value, uint32 expiry = 0);
+    void  updateCharVarCache(std::string const& varName, int32 value, uint32 expiry = 0);
     void  removeFromCharVarCache(std::string const& varName);
 
     void clearCharVarsWithPrefix(std::string const& prefix);
@@ -623,8 +623,8 @@ private:
     bool m_isBlockingAid;
     bool m_reloadParty;
 
-    std::unordered_map<std::string, int32> charVarCache;
-    std::unordered_set<std::string>        charVarChanges;
+    std::unordered_map<std::string, std::pair<int32, uint32>> charVarCache;
+    std::unordered_set<std::string>                           charVarChanges;
 
     uint8      dataToPersist = 0;
     time_point nextDataPersistTime;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -582,7 +582,7 @@ void CLuaBaseEntity::setCharVar(std::string const& varName, int32 value, sol::ob
     {
         uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
 
-        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
             return;
@@ -603,7 +603,7 @@ void CLuaBaseEntity::setCharVarExpiration(std::string const& varName, uint32 exp
 {
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        if (expiry > 0 && expiry <= CVanaTime::getInstance()->getVanaTime())
+        if (expiry > 0 && expiry <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, expiry));
             return;
@@ -643,7 +643,7 @@ void CLuaBaseEntity::setVolatileCharVar(std::string const& varName, int32 value,
     {
         uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
 
-        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
             return;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -573,14 +573,43 @@ int32 CLuaBaseEntity::getCharVar(std::string const& varName)
  *  Function: setCharVar()
  *  Purpose : Updates PC's variable to an explicit value
  *  Example : player:setCharVar("[ZM]Status", 4)
- *  Notes   : Passing a '0' value will delete the variable
+ *  Notes   : Passing a '0' value will delete the variable.
  ************************************************************************/
 
-void CLuaBaseEntity::setCharVar(std::string const& varName, int32 value)
+void CLuaBaseEntity::setCharVar(std::string const& varName, int32 value, sol::object const& expiry)
 {
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->setCharVar(varName, value);
+        uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
+
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
+            return;
+        }
+
+        PChar->setCharVar(varName, value, varTimestamp);
+    }
+}
+
+/************************************************************************
+ *  Function: setCharVarExpiration()
+ *  Purpose : Updates PC's variable expiration to a specific timestamp
+ *  Example : player:setCharVarExpiration("Timer", VanadielTime() + 3600)
+ *  Notes   : Passing a '0' value will set the variable to not expire.
+ ************************************************************************/
+
+void CLuaBaseEntity::setCharVarExpiration(std::string const& varName, uint32 expiry)
+{
+    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        if (expiry > 0 && expiry <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, expiry));
+            return;
+        }
+
+        PChar->setCharVar(varName, PChar->getCharVar(varName), expiry);
     }
 }
 
@@ -588,7 +617,8 @@ void CLuaBaseEntity::setCharVar(std::string const& varName, int32 value)
  *  Function: incrementCharVar()
  *  Purpose : Increments PC's variable by an explicit amount
  *  Example : player:incrementCharVar("[ZM]Status", 1) -- if 4, becomes 5
- *  Notes   : Can use values greater than 1 to increment more
+ *  Notes   : Can use values greater than 1 to increment more.  This does
+ *            not handle expiration times.
  ************************************************************************/
 
 void CLuaBaseEntity::incrementCharVar(std::string const& varName, int32 value)
@@ -607,11 +637,19 @@ void CLuaBaseEntity::incrementCharVar(std::string const& varName, int32 value)
  *  Notes   : Passing a '0' value will delete the variable
  ************************************************************************/
 
-void CLuaBaseEntity::setVolatileCharVar(std::string const& varName, int32 value)
+void CLuaBaseEntity::setVolatileCharVar(std::string const& varName, int32 value, sol::object const& expiry)
 {
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->setVolatileCharVar(varName, value);
+        uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
+
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
+            return;
+        }
+
+        PChar->setVolatileCharVar(varName, value, varTimestamp);
     }
 }
 
@@ -16825,6 +16863,7 @@ void CLuaBaseEntity::Register()
     // Variables
     SOL_REGISTER("getCharVar", CLuaBaseEntity::getCharVar);
     SOL_REGISTER("setCharVar", CLuaBaseEntity::setCharVar);
+    SOL_REGISTER("setCharVarExpiration", CLuaBaseEntity::setCharVarExpiration);
     SOL_REGISTER("getVar", CLuaBaseEntity::getCharVar); // Compatibility binding
     SOL_REGISTER("setVar", CLuaBaseEntity::setCharVar); // Compatibility binding
     SOL_REGISTER("incrementCharVar", CLuaBaseEntity::incrementCharVar);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -66,10 +66,11 @@ public:
     void customMenu(sol::object const& obj);
 
     // Variables
-    int32  getCharVar(std::string const& varName);                    // Returns a character variable
-    void   setCharVar(std::string const& varname, int32 value);       // Sets a character variable
-    void   incrementCharVar(std::string const& varname, int32 value); // Increments/decriments/sets a character variable
-    void   setVolatileCharVar(std::string const& varName, int32 value);
+    int32  getCharVar(std::string const& varName);                                         // Returns a character variable
+    void   setCharVar(std::string const& varname, int32 value, sol::object const& expiry); // Sets a character variable
+    void   setCharVarExpiration(std::string const& varName, uint32 expiry);                // Sets character variable expiration timestamp
+    void   incrementCharVar(std::string const& varname, int32 value);                      // Increments/decriments/sets a character variable
+    void   setVolatileCharVar(std::string const& varName, int32 value, sol::object const& expiry);
     uint32 getLocalVar(std::string const& var);
     void   setLocalVar(std::string const& var, uint32 val);
     void   resetLocalVars();

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4718,13 +4718,21 @@ namespace luautils
 
     int32 GetCharVar(uint32 charId, std::string const& varName)
     {
-        return charutils::FetchCharVar(charId, varName);
+        return charutils::FetchCharVar(charId, varName).first;
     }
 
     // Using the charID set a char variable on the SQL DB
-    void SetCharVar(uint32 charId, std::string const& varName, int32 value)
+    void SetCharVar(uint32 charId, std::string const& varName, int32 value, sol::object const& expiry)
     {
-        charutils::SetCharVar(charId, varName, value);
+        uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
+
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
+            return;
+        }
+
+        charutils::SetCharVar(charId, varName, value, varTimestamp);
     }
 
     void ClearCharVarFromAll(std::string const& varName)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -4701,9 +4701,17 @@ namespace luautils
         return serverutils::GetServerVar(name);
     }
 
-    void SetServerVariable(std::string const& name, int32 value)
+    void SetServerVariable(std::string const& name, int32 value, sol::object const& expiry)
     {
-        serverutils::SetServerVar(name, value);
+        uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
+
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", name, varTimestamp));
+            return;
+        }
+
+        serverutils::SetServerVar(name, value, varTimestamp);
     }
 
     int32 GetVolatileServerVariable(std::string const& varName)
@@ -4711,9 +4719,17 @@ namespace luautils
         return serverutils::GetVolatileServerVar(varName);
     }
 
-    void SetVolatileServerVariable(std::string const& varName, int32 value)
+    void SetVolatileServerVariable(std::string const& varName, int32 value, sol::object const& expiry)
     {
-        serverutils::SetVolatileServerVar(varName, value);
+        uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
+
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        {
+            ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
+            return;
+        }
+
+        serverutils::SetVolatileServerVar(varName, value, varTimestamp);
     }
 
     int32 GetCharVar(uint32 charId, std::string const& varName)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1483,13 +1483,14 @@ namespace luautils
      * See: VTIME_x defintions, or xi.vanaType for the values to pass
      *                                                                       *
      ************************************************************************/
-    uint32 NextGameTime(uint16 intervalSeconds)
+    uint32 NextGameTime(uint32 intervalSeconds)
     {
         TracyZoneScoped;
-        uint32 vanaTime         = CVanaTime::getInstance()->getVanaTime();
-        uint32 secondsRemaining = vanaTime % intervalSeconds;
+        uint32 timeElapsed      = CVanaTime::getInstance()->getVanaTime();
+        uint32 numPassed        = timeElapsed / intervalSeconds;
+        uint32 secondsRemaining = intervalSeconds - (timeElapsed - (numPassed * intervalSeconds));
 
-        return CVanaTime::getInstance()->getEpoch() + vanaTime + secondsRemaining;
+        return CVanaTime::getInstance()->getSysTime() + secondsRemaining;
     }
 
     // NOTE: NextJstDay is also defined, and maps to JstMidnight
@@ -1497,11 +1498,11 @@ namespace luautils
     uint32 NextJstWeek()
     {
         TracyZoneScoped;
-        uint32 jstWeekday      = CVanaTime::getInstance()->getJstWeekDay(); // 0..6 Days since Sunday
+        uint32 jstWeekday      = CVanaTime::getInstance()->getJstWeekDay();
         uint32 nextJstMidnight = CVanaTime::getInstance()->getJstMidnight();
 
         // Start with the "Next" Midnight, and apply N days worth of time to it
-        return nextJstMidnight + (6 - jstWeekday) * 60 * 60 * 24;
+        return nextJstMidnight + (7 - jstWeekday) * 60 * 60 * 24;
     }
 
     /************************************************************************

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -171,6 +171,7 @@ namespace luautils
         lua.set_function("GetPlayerByID", &luautils::GetPlayerByID);
         lua.set_function("GetMagianTrial", &luautils::GetMagianTrial);
         lua.set_function("GetMagianTrialsWithParent", &luautils::GetMagianTrialsWithParent);
+        lua.set_function("GetSystemTime", &luautils::GetSystemTime);
         lua.set_function("JstMidnight", &luautils::JstMidnight);
         lua.set_function("JstWeekday", &luautils::JstWeekday);
         lua.set_function("VanadielTime", &luautils::VanadielTime);
@@ -1436,6 +1437,16 @@ namespace luautils
     {
         TracyZoneScoped;
         return static_cast<uint8>(battleutils::GetDayElement());
+    }
+
+    /************************************************************************
+     *                                                                       *
+     * Returns current UTC timestamp
+     *                                                                       *
+     ************************************************************************/
+    uint32 GetSystemTime()
+    {
+        return CVanaTime::getInstance()->getSysTime();
     }
 
     /************************************************************************
@@ -4705,7 +4716,7 @@ namespace luautils
     {
         uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
 
-        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", name, varTimestamp));
             return;
@@ -4723,7 +4734,7 @@ namespace luautils
     {
         uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
 
-        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
             return;
@@ -4742,7 +4753,7 @@ namespace luautils
     {
         uint32 varTimestamp = expiry.is<uint32>() ? expiry.as<uint32>() : 0;
 
-        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getVanaTime())
+        if (varTimestamp > 0 && varTimestamp <= CVanaTime::getInstance()->getSysTime())
         {
             ShowWarning(fmt::format("Attempting to set variable '{}' with an expired time: {}", varName, varTimestamp));
             return;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -160,6 +160,7 @@ namespace luautils
     auto GetMagianTrial(sol::variadic_args va) -> sol::table;
     auto GetMagianTrialsWithParent(int32 parentTrial) -> sol::table;
 
+    uint32 GetSystemTime();
     uint32 JstMidnight();
     uint32 JstWeekday();
     uint32 VanadielTime();          // Gets the current Vanadiel Time in timestamp format (SE epoch in earth seconds)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -163,6 +163,8 @@ namespace luautils
     uint32 GetSystemTime();
     uint32 JstMidnight();
     uint32 JstWeekday();
+    uint32 NextGameTime(uint16 intervalSeconds);
+    uint32 NextJstWeek();
     uint32 VanadielTime();          // Gets the current Vanadiel Time in timestamp format (SE epoch in earth seconds)
     uint8  VanadielTOTD();          // текущее игровое время суток
     uint32 VanadielHour();          // текущие Vanadiel часы

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -163,7 +163,7 @@ namespace luautils
     uint32 GetSystemTime();
     uint32 JstMidnight();
     uint32 JstWeekday();
-    uint32 NextGameTime(uint16 intervalSeconds);
+    uint32 NextGameTime(uint32 intervalSeconds);
     uint32 NextJstWeek();
     uint32 VanadielTime();          // Gets the current Vanadiel Time in timestamp format (SE epoch in earth seconds)
     uint8  VanadielTOTD();          // текущее игровое время суток

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -184,9 +184,9 @@ namespace luautils
     int16  GetElevatorState(uint8 id); // Returns -1 if elevator is not found. Otherwise, returns the uint8 state.
 
     int32 GetServerVariable(std::string const& name);
-    void  SetServerVariable(std::string const& name, int32 value);
+    void  SetServerVariable(std::string const& name, int32 value, sol::object const& expiry);
     int32 GetVolatileServerVariable(std::string const& varName);
-    void  SetVolatileServerVariable(std::string const& varName, int32 value);
+    void  SetVolatileServerVariable(std::string const& varName, int32 value, sol::object const& expiry);
     int32 GetCharVar(uint32 charId, std::string const& varName);                                         // Get player var directly from SQL DB
     void  SetCharVar(uint32 charId, std::string const& varName, int32 value, sol::object const& expiry); // Set player var in SQL DB using charId
     void  ClearCharVarFromAll(std::string const& varName);                                               // Deletes a specific player variable from all players

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -187,10 +187,10 @@ namespace luautils
     void  SetServerVariable(std::string const& name, int32 value);
     int32 GetVolatileServerVariable(std::string const& varName);
     void  SetVolatileServerVariable(std::string const& varName, int32 value);
-    int32 GetCharVar(uint32 charId, std::string const& varName);              // Get player var directly from SQL DB
-    void  SetCharVar(uint32 charId, std::string const& varName, int32 value); // Set player var in SQL DB using charId
-    void  ClearCharVarFromAll(std::string const& varName);                    // Deletes a specific player variable from all players
-    void  Terminate();                                                        // Logs off all characters and terminates the server
+    int32 GetCharVar(uint32 charId, std::string const& varName);                                         // Get player var directly from SQL DB
+    void  SetCharVar(uint32 charId, std::string const& varName, int32 value, sol::object const& expiry); // Set player var in SQL DB using charId
+    void  ClearCharVarFromAll(std::string const& varName);                                               // Deletes a specific player variable from all players
+    void  Terminate();                                                                                   // Logs off all characters and terminates the server
 
     int32 GetTextIDVariable(uint16 ZoneID, const char* variable); // загружаем значение переменной TextID указанной зоны
     bool  IsContentEnabled(const char* content);                  // Check if the content is enabled in settings.lua

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -287,7 +287,7 @@ int32 do_init(int32 argc, char** argv)
     CTaskMgr::getInstance()->AddTask("persist_server_vars", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, serverutils::PersistVolatileServerVars, 1min);
 
     ShowInfo("do_init: Removing expired database variables");
-    uint32 currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+    uint32 currentTimestamp = CVanaTime::getInstance()->getSysTime();
     sql->Query("DELETE FROM char_vars WHERE expiry > 0 AND expiry <= %d", currentTimestamp);
     sql->Query("DELETE FROM server_variables WHERE expiry > 0 AND expiry <= %d", currentTimestamp);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -286,6 +286,9 @@ int32 do_init(int32 argc, char** argv)
     CTaskMgr::getInstance()->AddTask("garbage_collect", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, map_garbage_collect, 15min);
     CTaskMgr::getInstance()->AddTask("persist_server_vars", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, serverutils::PersistVolatileServerVars, 1min);
 
+    ShowInfo("do_init: Removing expired database variables");
+    sql->Query("DELETE FROM char_vars WHERE expiry > 0 AND expiry <= %d", CVanaTime::getInstance()->getVanaTime());
+
     g_PBuff   = new int8[MAX_BUFFER_SIZE + 20];
     PTempBuff = new int8[MAX_BUFFER_SIZE + 20];
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -287,7 +287,9 @@ int32 do_init(int32 argc, char** argv)
     CTaskMgr::getInstance()->AddTask("persist_server_vars", server_clock::now(), nullptr, CTaskMgr::TASK_INTERVAL, serverutils::PersistVolatileServerVars, 1min);
 
     ShowInfo("do_init: Removing expired database variables");
-    sql->Query("DELETE FROM char_vars WHERE expiry > 0 AND expiry <= %d", CVanaTime::getInstance()->getVanaTime());
+    uint32 currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+    sql->Query("DELETE FROM char_vars WHERE expiry > 0 AND expiry <= %d", currentTimestamp);
+    sql->Query("DELETE FROM server_variables WHERE expiry > 0 AND expiry <= %d", currentTimestamp);
 
     g_PBuff   = new int8[MAX_BUFFER_SIZE + 20];
     PTempBuff = new int8[MAX_BUFFER_SIZE + 20];

--- a/src/map/message.h
+++ b/src/map/message.h
@@ -78,7 +78,7 @@ namespace message
     void send(uint16 zone, std::string const& luaFunc);
     void send(uint32 playerId, CBasicPacket* packet);
     void send(std::string const& playerName, CBasicPacket* packet);
-    void send_charvar_update(uint32 charId, std::string const& varName, uint32 value);
+    void send_charvar_update(uint32 charId, std::string const& varName, uint32 value, uint32 expiry);
     void rpc_send(uint16 sendZone, uint16 recvZone, std::string const& sendStr, sol::function recvFunc);
 
     void close();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6496,7 +6496,7 @@ namespace charutils
             value  = sql->GetIntData(0);
             expiry = sql->GetUIntData(1);
 
-            uint32 currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+            uint32 currentTimestamp = CVanaTime::getInstance()->getSysTime();
 
             if (expiry > 0 && expiry <= currentTimestamp)
             {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6407,26 +6407,26 @@ namespace charutils
         return PChar->getCharVar(var);
     }
 
-    void SetCharVar(uint32 charId, std::string const& var, int32 value)
+    void SetCharVar(uint32 charId, std::string const& var, int32 value, uint32 expiry /* = 0 */)
     {
         if (auto player = zoneutils::GetChar(charId))
         {
-            player->setCharVar(var, value);
+            player->setCharVar(var, value, expiry);
             return;
         }
 
-        PersistCharVar(charId, var, value);
-        message::send_charvar_update(charId, var, value);
+        PersistCharVar(charId, var, value, expiry);
+        message::send_charvar_update(charId, var, value, expiry);
     }
 
-    void SetCharVar(CCharEntity* PChar, std::string const& var, int32 value)
+    void SetCharVar(CCharEntity* PChar, std::string const& var, int32 value, uint32 expiry /* = 0 */)
     {
         if (PChar == nullptr)
         {
             return;
         }
 
-        return PChar->setCharVar(var, value);
+        return PChar->setCharVar(var, value, expiry);
     }
 
     int32 ClearCharVarsWithPrefix(CCharEntity* PChar, std::string const& prefix)
@@ -6483,22 +6483,32 @@ namespace charutils
         PChar->removeFromCharVarCache(var);
     }
 
-    int32 FetchCharVar(uint32 charId, std::string const& varName)
+    auto FetchCharVar(uint32 charId, std::string const& varName) -> std::pair<int32, uint32>
     {
-        const char* fmtQuery = "SELECT value FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;";
+        const char* fmtQuery = "SELECT value, expiry FROM char_vars WHERE charid = %u AND varname = '%s' LIMIT 1;";
 
         int32 ret = sql->Query(fmtQuery, charId, varName);
 
-        int32 value = 0;
+        int32  value  = 0;
+        uint32 expiry = 0;
         if (ret != SQL_ERROR && sql->NumRows() != 0 && sql->NextRow() == SQL_SUCCESS)
         {
-            value = sql->GetIntData(0);
+            value  = sql->GetIntData(0);
+            expiry = sql->GetUIntData(1);
+
+            uint32 currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+
+            if (expiry > 0 && expiry <= currentTimestamp)
+            {
+                value = 0;
+                sql->Query("DELETE FROM char_vars WHERE charid = %u AND varname = '%s';", charId, varName);
+            }
         }
 
-        return value;
+        return { value, expiry };
     }
 
-    void PersistCharVar(uint32 charId, std::string const& var, int32 value)
+    void PersistCharVar(uint32 charId, std::string const& var, int32 value, uint32 expiry /* = 0 */)
     {
         if (value == 0)
         {
@@ -6506,7 +6516,7 @@ namespace charutils
         }
         else
         {
-            sql->Query("INSERT INTO char_vars SET charid = %u, varname = '%s', value = %i ON DUPLICATE KEY UPDATE value = %i;", charId, var, value, value);
+            sql->Query("INSERT INTO char_vars SET charid = %u, varname = '%s', value = %i, expiry = %d ON DUPLICATE KEY UPDATE value = %i, expiry = %i;", charId, var, value, expiry, value, expiry);
         }
     }
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -239,15 +239,15 @@ namespace charutils
     bool  AddWeaponSkillPoints(CCharEntity*, SLOTTYPE, int);
 
     int32 GetCharVar(CCharEntity* PChar, std::string const& var);
-    void  SetCharVar(uint32 charId, std::string const& var, int32 value);
-    void  SetCharVar(CCharEntity* PChar, std::string const& var, int32 value);
+    void  SetCharVar(uint32 charId, std::string const& var, int32 value, uint32 expiry = 0);
+    void  SetCharVar(CCharEntity* PChar, std::string const& var, int32 value, uint32 expiry = 0);
     int32 ClearCharVarsWithPrefix(CCharEntity* PChar, std::string const& prefix);
     int32 RemoveCharVarsWithTag(CCharEntity* PChar, std::string const& varsTag);
     void  ClearCharVarFromAll(std::string const& varName, bool localOnly = false);
     void  IncrementCharVar(CCharEntity* PChar, std::string const& var, int32 value);
 
-    int32 FetchCharVar(uint32 charId, std::string const& var);
-    void  PersistCharVar(uint32 charId, std::string const& var, int32 value);
+    auto FetchCharVar(uint32 charId, std::string const& var) -> std::pair<int32, uint32>;
+    void PersistCharVar(uint32 charId, std::string const& var, int32 value, uint32 expiry = 0);
 
     uint16 getWideScanRange(JOBTYPE job, uint8 level);
     uint16 getWideScanRange(CCharEntity* PChar);

--- a/src/map/utils/serverutils.cpp
+++ b/src/map/utils/serverutils.cpp
@@ -47,7 +47,7 @@ namespace serverutils
             value  = sql->GetIntData(0);
             expiry = sql->GetUIntData(1);
 
-            uint32 currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+            uint32 currentTimestamp = CVanaTime::getInstance()->getSysTime();
 
             if (expiry > 0 && expiry <= currentTimestamp)
             {
@@ -76,7 +76,7 @@ namespace serverutils
         if (auto var = serverVarCache.find(name); var != serverVarCache.end())
         {
             std::pair cachedVarData    = var->second;
-            uint32    currentTimestamp = CVanaTime::getInstance()->getVanaTime();
+            uint32    currentTimestamp = CVanaTime::getInstance()->getSysTime();
 
             // If the cached variable is not expired, return it.  Else, fall through so that the
             // database can be cleaned up.

--- a/src/map/utils/serverutils.h
+++ b/src/map/utils/serverutils.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -30,12 +30,12 @@
 
 namespace serverutils
 {
-    int32 GetServerVar(std::string const& var);
-    void  SetServerVar(std::string const& var, int32 value);
-    void  PersistServerVar(std::string const& var, int32 value);
+    uint32 GetServerVar(std::string const& var);
+    void   SetServerVar(std::string const& var, int32 value, uint32 expiry = 0);
+    void   PersistServerVar(std::string const& var, int32 value, uint32 expiry = 0);
 
     int32 GetVolatileServerVar(std::string const& var);
-    void  SetVolatileServerVar(std::string const& var, int32 value);
+    void  SetVolatileServerVar(std::string const& var, int32 value, uint32 expiry = 0);
 
     int32 PersistVolatileServerVars(time_point tick, CTaskMgr::CTask* PTask);
 } // namespace serverutils

--- a/tools/migrations/38_timed_vars.py
+++ b/tools/migrations/38_timed_vars.py
@@ -1,0 +1,32 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding expiry column to char_vars and server_variables table"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # Ensure unity_leader column exists in char_profile
+    cur.execute("SHOW COLUMNS FROM char_vars LIKE 'expiry'")
+    if not cur.fetchone():
+        return True
+    return False
+
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE char_vars \
+        ADD COLUMN `expiry` int(11) NOT NULL DEFAULT 0;"
+        )
+        cur.execute(
+            "ALTER TABLE server_variables \
+        ADD COLUMN `expiry` int(11) NOT NULL DEFAULT 0;"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds an additional column to char_vars and server_variables which accepts a unix timestamp for when the variable will expire.  On next access, if expired the variable will be deleted from the db.  No changes are required, and this addition is backwards compatible with existing charvar usage.

**NOTE**: All times referenced are based on the CVanaTime instance of `getSysTime()`.  The helper functions created will return system time offsets, and _NOT_ vanadiel time.

### Why?
Between this and unique events, this should be one of the final nails in the coffin for "Forever" vars.  There are some things that we track in the database that can never go away (such as reset times for Avatar fights).  This allows for an alternative, where we can set a variable to expire, instead of persisting when the next time is available.

An expired variable as described above, is one that is either deleted on access, or on server startup if its timestamp exists in the past.

### Usage
An optional parameter has been added to setCharVar (and its variants, including Interaction Framework) for an optional expiry field.  In addition, the following helper functions have been added/updated:

**Lua**
```
xi.mission.setVar           = function(player, areaId, missionId, name, value, expiry)
xi.mission.setVarExpiration = function(player, areaId, missionId, name, expiry)
xi.quest.setVar             = function(player, areaId, missionId, name, value, expiry)
xi.quest.setVarExpiration   = function(player, areaId, missionId, name, expiry)
```

**Interaction**
```
function Container:setVar(player, name, value, expiry)
function Container:setVarExpiration(player, name, expiry)

-- Wrapper for setVar where the expiration matters more than any other
-- stored value.  There is no need to get specifically, since it will
-- be removed.  (Returned value is either 1 or 0)
function Container:setTimedVar(player, name, expiry)
```

**Core**
```
CLuaBaseEntity::setCharVar(std::string const& varName, int32 value, sol::object const& expiry)
CLuaBaseEntity::setCharVarExpiration(std::string const& varName, uint32 expiry)
```

This is system-time based, and there have been the following Lua bindings created to assist:

* `NextGameTime(uint32 intervalSeconds)`

This function accepts any value, but should be exclusively used with the xi.vanaTime enum (see below):
```lua
local secondsPerTick = 2.4

xi.vanaTime =
{
    YEAR  = 518400 * secondsPerTick,
    MONTH = 43200 * secondsPerTick,
    WEEK  = 11520 * secondsPerTick,
    DAY   = 1440 * secondsPerTick,
    HOUR  = 60 * secondsPerTick,
}
```

By passing one of these enum values in, you will receive a system timestamp for when the next event will occur.

* `NextJstDay()` -> This is just another name for `JstMidnight`, since there will most likely be a CI rule to ensure that a vanaTime value is not passed into these functions

* `NextJstWeek()` -> This will return the next time a weekly reset can occur, such as Conquest Tally

### What if what I need isn't covered?
There's a lot of potential things that we could possibly need to time, so this solution gives you a starting point, and then math can be applied to get the desired value.  For example, let's say you need 3 Vana'diel days from now:

`NextGameTime(xi.vanaTime.DAY)` will get you through one, but we now need two more, so:

`NextGameTime(xi.vanaTime.DAY) + xi.vanaTime.DAY * 2` will get you the rest of the way.

### But I need real time!
Simple!  Just take your current system timestamp, and apply the offset, so if I needed Exactly 3 Vana'diel days from right now:

`GetSystemTime() + xi.vanaTime.DAY * 3`

(Foreshadowing, do not rely on os.time(), since things will be changing soon)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
#### Char Vars
* [x] Set a charVar in lua with no expiration time set
* [x]  Set a charVar in lua with an expiration in the future
* [x]  Set a charVar with expiration in the past
* [x]  Get a charVar with no expiration
* [x]  Get an unexpired charVar
* [x]  Get an expired charVar
* [x]  Set a charVar with the player on a separate process that expires in the future
* [x]  Set a charVar with the player on a separate process that does not expire
* [x] Set a charVar with the player on a separate process that exists in the past
* [x]  Get a charVar with the player on a separate process that does not expire
* [x]  Get a charVar with the player on a separate process with expiration in the past
* [x]  Get a charVar with the player on a separate process with expiration in the future
* [x]  Set a volatile charVar with no expiration
* [x]  Set a volatile charVar with expiration in the past
* [x]  Set a volatile charVar with expiration in the future
* [x]  Test DB migration script
* [x]  Test Fresh DB without migration
* [x]  Set a charVar in Lua without specifying an expiration time
* [x] Test expired charVar removal on server start
* [x] Verify unexpired charVars are retained after server start
* [x] Verify non-expiring charVars are retained after server start
* [x] Increment an Expired variable
* [x] Set Expiration of an expired variable
* [x] Set Expiration of an unexpired variable
* [x] Set Expiration of a variable that does not expire

#### Server Vars
NOTE: Server Vars don't have the same logic to notify separate processes at this time.

* [x] Set a Server Var with no expiration
* [x] Set a Server Var with an empty expiration field
* [x] Set a Server Var with an expiration value in the past
* [x] Set a Server Var with an expiration value in the future
* [x] Set a Volatile Server Var with no expiration
* [x] Set a Volatile Server Var with an empty expiration field
* [x] Set a Volatile Server Var with an expiration value in the past
* [x] Set a Volatile Server Var with an expiration value in the future
* [x] Get a non-expiring Volatile Server Var
* [x] Get an Unexpired Volatile Server Var
* [x] Get an Expired Volatile Server Var
* [x] Get a Server Var with no expiration
* [x] Get an Unexpired Server Var
* [x] Get an Expired Server Var
* [x] Verify Expired Server Var removal on server start
* [x] Verify Non-Expiring Server Var on server start is retained
* [x] Verify Server Var with expiration in the future is retained on server start
* [x] Test DB Migration Script
* [x] Test Fresh DB without Migration

#### Helper Functions
* [x] Verify returned value for NextGameTime (Hour, Day, Week, Month, Year intervals)
* [x] Verify returned value for NextJstWeek
* [x] Set an expiring charvar with Interaction Framework (`quest:setVar, mission:setVar`)
* [x] Check Interaction Container: setTimedVar
* [x] Check xi.quest helper: setVar
* [x] Check xi.quest helper: setVarExpiration
* [x] Check xi.mission helper: setVar
* [x] Check xi.mission helper: setVarExpiration

<!-- Clear and detailed steps to test your changes here -->
