### PR TITLE
Fixes zone ID reference for Medusa

### DIFF
--- a/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Medusa.lua
@@ -4,7 +4,7 @@
 -- !pos -458 -20 458
 -- TODO: resists, attack/def boosts
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 mixins = { require('scripts/mixins/job_special') }
 -----------------------------------
 local entity = {}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Medusa's lua references the wrong zone ID which causes `ID.mob.MEDUSA` to be nil

## Steps to test these changes

Medusa's functions will no longer create errors
