### PR TITLE
Used Timed variable for Trial by Earth repeat condition

### DIFF
--- a/scripts/quests/bastok/Trial_by_Earth.lua
+++ b/scripts/quests/bastok/Trial_by_Earth.lua
@@ -107,12 +107,8 @@ quest.sections =
                 [252] = function(player, csid, option, npc)
                     if giveQuestReward(player, option) then
                         quest:complete(player)
-
                         player:delKeyItem(xi.ki.WHISPER_OF_TREMORS)
-
-                        -- TODO: This is currently a potential forever var.  Implement a system to remove
-                        -- a defined list of vars in OnJstMidnight.
-                        quest:setVar(player, 'Timer', JstMidnight())
+                        quest:setTimedVar(player, 'Timer', NextJstDay())
                     end
                 end,
 
@@ -139,7 +135,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_COMPLETED and
-                os.time() > quest:getVar(player, 'Timer')
+                quest:getVar(player, 'Timer') == 0
         end,
 
         [xi.zone.PORT_BASTOK] =
@@ -154,7 +150,6 @@ quest.sections =
 
                         npcUtil.giveKeyItem(player, xi.ki.TUNING_FORK_OF_EARTH)
 
-                        quest:setVar(player, 'Timer', 0)
                         quest:begin(player)
                     end
                 end,

--- a/tools/ci/check_lua_binding_usage.py
+++ b/tools/ci/check_lua_binding_usage.py
@@ -46,6 +46,8 @@ def main():
     function_names.append("keyItem")
     function_names.append("setMustZone")
     function_names.append("getMustZone")
+    function_names.append("setTimedVar")
+    function_names.append("setVarExpiration")
     function_names.append("oncePerZone")
     function_names.append("incrementVar")
     function_names.append("replaceDefault")


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Uses a Timed charvar to handle repeating Trial by Earth
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Variable will clear after JST Midnight, and quest will be repeatable
<!-- Clear and detailed steps to test your changes here -->
