### PR TITLE
[core] linkshell.h: Comments audit

### DIFF
--- a/src/map/linkshell.h
+++ b/src/map/linkshell.h
@@ -41,7 +41,7 @@ public:
     uint8  getPostRights();
 
     void setColor(uint16 color);
-    void setPostRights(uint8 postrights); // Updates lsmes privilege and writes to db
+    void setPostRights(uint8 postrights);
 
     const std::string& getName();
     void               setName(const std::string& name);
@@ -57,7 +57,7 @@ public:
     void PushPacket(uint32 senderID, CBasicPacket* packet);
     void PushLinkshellMessage(CCharEntity* PChar, bool ls1);
 
-    std::vector<CCharEntity*> members; // список участников linkshell
+    std::vector<CCharEntity*> members;
     uint8                     m_postRights;
 
 private:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Within /src/map/**linkshell.h**
- Translated Russian comments to English but ultimately just removed the comments because they were deemed non-helpful/not needed as the code itself preceding the comments already gave sufficient explanation of what the code was doing.
  - Also removed any un-necessary/non-helpful translations/empty comment blocks
  - If more are deemed un-necessary/non-helpful, please let me know, I'm doing my best to weed out these.
- No, you are not experiencing deja vu, the changes in this PR were missed in my initial pass of this file in https://github.com/LandSandBoat/server/pull/4447, apologies.
  - Also, if you don't know French (and so that you don't have to google translate it), `le retour` = `the return`

## Steps to test these changes

No testing necessary, no code was changed, only comments.
