### PR TITLE
Add battlefieldWin variable to ASA4 Leviathan fight

### DIFF
--- a/scripts/zones/Cloister_of_Tides/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/sugar-coated_directive.lua
@@ -18,8 +18,10 @@ battlefieldObject.onBattlefieldLeave = function(player, battlefield, leavecode)
     if leavecode == xi.battlefield.leaveCode.WON then
         local _, clearTime, partySize = battlefield:getRecord()
         local arg8 = (player:hasCompletedMission(xi.mission.log_id.ASA, xi.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 211, battlefield:getLocalVar('[cs]bit'), arg8)
-        player:setCharVar('Mission[11][3]Leviathan', 2)
     elseif leavecode == xi.battlefield.leaveCode.LOST then
         player:startEvent(32002)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3830 

Adds battlefieldWin localvar to Leviathan fight in ASA4 and removes errant setting for the "Leviathan" mission variable to align with the implementation and function of other fights in this mission.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Win fight, and see the proper event displayed
<!-- Clear and detailed steps to test your changes here -->
