### PR TITLE
Add missing parameters to dynamis win event, missing Beaucedine NPC

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -355,7 +355,9 @@ xi.dynamis.entryNpcOnTrigger = function(player, npc)
 
         -- victory cutscene
         elseif player:getCharVar(info.beatVar) == 1 then
-            player:startEvent(info.csBeat, info.beatKI)
+            -- NOTE: The hourglass and shrouded sand parameter is only required for Beaucedine, but has no
+            -- effect on the others.
+            player:startEvent(info.csBeat, info.beatKI, 0, xi.ki.PRISMATIC_HOURGLASS , xi.ki.VIAL_OF_SHROUDED_SAND)
 
         -- dynamis entry
         elseif not info.reqs or info.reqs(player) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #3772

Dynamis-Beaucedine has two additional required parameters for prismatic hourglass and shrouded sand.  Adds those parameters to all "win" events, but only impacts Beaucedine.

Added missing blank NPC which gets accessed in the Dynamis-Beaucedine win event.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Execute the win event in Beaucedine with updated parameters
2. Check all other win events to ensure that nothing has changed
<!-- Clear and detailed steps to test your changes here -->
