### PR TITLE
Lower priority for non-progress events, fix completed quest event

### DIFF
--- a/scripts/quests/sandoria/A_Taste_for_Meat.lua
+++ b/scripts/quests/sandoria/A_Taste_for_Meat.lua
@@ -36,7 +36,7 @@ quest.sections =
                     then
                         return quest:progressEvent(531)
                     else
-                        return quest:progressEvent(532)
+                        return quest:event(532)
                     end
                 end,
 
@@ -44,7 +44,7 @@ quest.sections =
                     if quest:getVar(player, 'Prog') == 0 then
                         return quest:progressEvent(527)
                     else
-                        return quest:progressEvent(525)
+                        return quest:event(525)
                     end
                 end,
             },
@@ -58,7 +58,7 @@ quest.sections =
                     then
                         return quest:progressEvent(528)
                     else
-                        return quest:progressEvent(529)
+                        return quest:event(529)
                     end
                 end,
 
@@ -113,7 +113,7 @@ quest.sections =
                     if npcUtil.giveItem(player, xi.item.SLICE_OF_GRILLED_HARE) then
                         quest:setVar(player, 'Option', 0)
                     else
-                        return quest:progressEvent(538)
+                        player:startEvent(538)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Lowers priority for events that do not progress "A Taste for Meat" and fixes the event that occurs after complete in an onEventFinish (which does not accept a returned event)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Completed event should occur, and non-progressing events should not conflict (This still may depend on converting other quests)
<!-- Clear and detailed steps to test your changes here -->
