### PR TITLE
[core] Party/Alliance zmq message audits

### DIFF
--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -132,6 +132,7 @@ enum MSGSERVTYPE : uint8
     MSG_LOGIN,
     MSG_CHAT_TELL,
     MSG_CHAT_PARTY,
+    MSG_CHAT_ALLIANCE,
     MSG_CHAT_LINKSHELL,
     MSG_CHAT_UNITY,
     MSG_CHAT_YELL,
@@ -140,7 +141,9 @@ enum MSGSERVTYPE : uint8
     MSG_PT_INV_RES,
     MSG_PT_RELOAD,
     MSG_PT_DISBAND,
+    MSG_ALLIANCE_RELOAD,
     MSG_ALLIANCE_DISSOLVE,
+    MSG_PLAYER_KICK,
     MSG_DIRECT,
     MSG_LINKSHELL_RANK_CHANGE,
     MSG_LINKSHELL_REMOVE,
@@ -206,6 +209,8 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_CHAT_TELL";
         case MSG_CHAT_PARTY:
             return "MSG_CHAT_PARTY";
+        case MSG_CHAT_ALLIANCE:
+            return "MSG_CHAT_ALLIANCE";
         case MSG_CHAT_LINKSHELL:
             return "MSG_CHAT_LINKSHELL";
         case MSG_CHAT_UNITY:
@@ -222,8 +227,12 @@ constexpr auto msgTypeToStr = [](uint8 msgtype)
             return "MSG_PT_RELOAD";
         case MSG_PT_DISBAND:
             return "MSG_PT_DISBAND";
+        case MSG_ALLIANCE_RELOAD:
+            return "MSG_ALLIANCE_RELOAD";
         case MSG_ALLIANCE_DISSOLVE:
             return "MSG_ALLIANCE_DISSOLVE";
+        case MSG_PLAYER_KICK:
+            return "MSG_PLAYER_KICK";
         case MSG_DIRECT:
             return "MSG_DIRECT";
         case MSG_LINKSHELL_RANK_CHANGE:

--- a/src/map/alliance.cpp
+++ b/src/map/alliance.cpp
@@ -154,8 +154,6 @@ void CAlliance::removeParty(CParty* party)
         }
     }
 
-    uint32 mainPartyID = getMainParty()->GetPartyID();
-
     delParty(party);
 
     sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE partyid = %u;",
@@ -163,8 +161,8 @@ void CAlliance::removeParty(CParty* party)
 
     // notify alliance
     uint8 data[4]{};
-    ref<uint32>(data, 0) = mainPartyID;
-    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    ref<uint32>(data, 0) = m_AllianceID;
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
 
     // notify leaving party
     ref<uint32>(data, 0) = party->GetPartyID();
@@ -261,10 +259,9 @@ void CAlliance::addParty(CParty* party)
                party->GetPartyID());
     party->SetPartyNumber(newparty);
 
-    // MSG_PT_RELOAD also reloads all the alliances parties if available
     uint8 data[4]{};
-    ref<uint32>(data, 0) = party->GetPartyID();
-    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    ref<uint32>(data, 0) = m_AllianceID;
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
 }
 
 void CAlliance::addParty(uint32 partyid) const
@@ -288,8 +285,8 @@ void CAlliance::addParty(uint32 partyid) const
     }
     sql->Query("UPDATE accounts_parties SET allianceid = %u, partyflag = partyflag | %d WHERE partyid = %u;", m_AllianceID, newparty, partyid);
     uint8 data[4]{};
-    ref<uint32>(data, 0) = partyid;
-    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    ref<uint32>(data, 0) = m_AllianceID;
+    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
 }
 
 void CAlliance::pushParty(CParty* PParty, uint8 number)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -356,8 +356,19 @@ void CLuaBaseEntity::PrintToArea(std::string const& message, sol::object const& 
     }
     else if (messageRange == MESSAGE_AREA_PARTY)
     {
-        message::send(MSG_CHAT_PARTY, nullptr, 0, new CChatMessagePacket(PChar, messageLook, message, name));
-        PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE_SELF, new CChatMessagePacket(PChar, messageLook, message, name));
+        int8 packetData[8]{};
+        if (PChar->PParty->m_PAlliance)
+        {
+            ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+            ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
+            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof packetData, new CChatMessagePacket(PChar, messageLook, message, name));
+        }
+        else if (PChar->PParty)
+        {
+            ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
+            ref<uint32>(packetData, 4) = 0; // No ID so that the PChar sees the message too
+            message::send(MSG_CHAT_PARTY, packetData, sizeof packetData, new CChatMessagePacket(PChar, messageLook, message, name));
+        }
     }
     else if (messageRange == MESSAGE_AREA_YELL)
     {

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -140,8 +140,9 @@ namespace message
             }
             case MSG_CHAT_PARTY:
             {
-                uint32  partyid = ref<uint32>((uint8*)extra.data(), 0);
-                CParty* PParty  = nullptr;
+                uint32  partyid  = ref<uint32>((uint8*)extra.data(), 0);
+                uint32  senderid = ref<uint32>((uint8*)extra.data(), 4);
+                CParty* PParty   = nullptr;
 
                 // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachParty or some other accessor to reduce the amount of iterations significantly.
                 // clang-format off
@@ -165,20 +166,45 @@ namespace message
 
                 if (PParty)
                 {
-                    if (PParty->m_PAlliance != nullptr)
+                    CBasicPacket* newPacket = new CBasicPacket();
+                    memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
+                    PParty->PushPacket(senderid, 0, newPacket);
+                }
+                break;
+            }
+            case MSG_CHAT_ALLIANCE:
+            {
+                uint32     allianceid = ref<uint32>((uint8*)extra.data(), 0);
+                uint32     senderid   = ref<uint32>((uint8*)extra.data(), 4);
+                CAlliance* PAlliance  = nullptr;
+
+                // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachParty or some other accessor to reduce the amount of iterations significantly.
+                // clang-format off
+                zoneutils::ForEachZone([allianceid, &PAlliance](CZone* PZone)
+                {
+                    PZone->ForEachChar([allianceid, &PAlliance](CCharEntity* PChar)
                     {
-                        for (auto& currentParty : PParty->m_PAlliance->partyList)
+                        if (PChar->PParty && PChar->PParty && PChar->PParty->m_PAlliance && PChar->PParty->m_PAlliance->m_AllianceID == allianceid)
                         {
-                            CBasicPacket* newPacket = new CBasicPacket();
-                            memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                            currentParty->PushPacket(ref<uint32>((uint8*)extra.data(), 4), 0, newPacket);
+                            PAlliance = PChar->PParty->m_PAlliance;
+                            return;
                         }
+                    });
+
+                    if (PAlliance)
+                    {
+                        return;
                     }
-                    else
+                });
+                // clang-format on
+
+                if (PAlliance)
+                {
+                    for (auto& currentParty : PAlliance->partyList)
                     {
                         CBasicPacket* newPacket = new CBasicPacket();
                         memcpy(*newPacket, packet.data(), std::min<size_t>(packet.size(), PACKET_SIZE));
-                        PParty->PushPacket(ref<uint32>((uint8*)extra.data(), 4), 0, newPacket);
+                        currentParty->PushPacket(senderid, 0, newPacket);
                     }
                 }
                 break;
@@ -357,52 +383,17 @@ namespace message
             }
             case MSG_PT_RELOAD:
             {
-                uint32  partyid = ref<uint32>((uint8*)extra.data(), 0);
-                CParty* PParty  = nullptr;
+                uint32 partyid = ref<uint32>((uint8*)extra.data(), 0);
 
-                // TODO: when Party/Alliance gets a rewrite, make a zoneutils::ForEachParty or some other accessor to reduce the amount of iterations significantly.
-                // clang-format off
-                zoneutils::ForEachZone([partyid, &PParty](CZone* PZone)
+                int ret = sql->Query("SELECT charid FROM accounts_parties WHERE partyid = %u", partyid);
+                if (ret != SQL_ERROR && sql->NumRows() != 0)
                 {
-                    PZone->ForEachChar([partyid, &PParty](CCharEntity* PChar)
+                    while (sql->NextRow() == SQL_SUCCESS)
                     {
-                        if (PChar->PParty && PChar->PParty->GetPartyID() == partyid)
+                        CCharEntity* PChar = zoneutils::GetChar(sql->GetUIntData(0));
+                        if (PChar)
                         {
-                            PParty = PChar->PParty;
-                            return;
-                        }
-                    });
-
-                    if (PParty)
-                    {
-                        return;
-                    }
-                });
-                // clang-format on
-
-                if (PParty)
-                {
-                    if (PParty->m_PAlliance)
-                    {
-                        for (auto* entry : PParty->m_PAlliance->partyList)
-                        {
-                            for (auto* member : entry->members)
-                            {
-                                if (member->objtype == TYPE_PC)
-                                {
-                                    static_cast<CCharEntity*>(member)->ReloadPartyInc();
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        for (auto* member : PParty->members)
-                        {
-                            if (member->objtype == TYPE_PC)
-                            {
-                                static_cast<CCharEntity*>(member)->ReloadPartyInc();
-                            }
+                            PChar->ReloadPartyInc();
                         }
                     }
                 }
@@ -441,6 +432,25 @@ namespace message
 
                 break;
             }
+            case MSG_ALLIANCE_RELOAD:
+            {
+                uint32 allianceid = ref<uint32>((uint8*)extra.data(), 0);
+
+                int ret = sql->Query("SELECT charid FROM accounts_parties WHERE allianceid = %u", allianceid);
+                if (ret != SQL_ERROR && sql->NumRows() != 0)
+                {
+                    while (sql->NextRow() == SQL_SUCCESS)
+                    {
+                        CCharEntity* PChar = zoneutils::GetChar(sql->GetUIntData(0));
+                        if (PChar)
+                        {
+                            PChar->ReloadPartyInc();
+                        }
+                    }
+                }
+
+                break;
+            }
             case MSG_ALLIANCE_DISSOLVE:
             {
                 uint32     allianceid = ref<uint32>((uint8*)extra.data(), 0);
@@ -471,6 +481,18 @@ namespace message
                     PAlliance->dissolveAlliance(false);
                 }
 
+                break;
+            }
+            case MSG_PLAYER_KICK:
+            {
+                uint32 charid = ref<uint32>((uint8*)extra.data(), 0);
+
+                // player was kicked and is no longer in alliance/party db -- they need a direct update.
+                CCharEntity* PChar = zoneutils::GetChar(charid);
+                if (PChar)
+                {
+                    PChar->ReloadPartyInc();
+                }
                 break;
             }
             case MSG_DIRECT:

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -4462,9 +4462,22 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                             sql->AffectedRows())
                         {
                             ShowDebug("%s has removed %s from party", PChar->GetName(), data[0x0C]);
-                            uint8 removeData[4]{};
-                            ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
-                            message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
+
+                            uint8 reloadData[4]{};
+                            if (PChar->PParty && PChar->PParty->m_PAlliance)
+                            {
+                                ref<uint32>(reloadData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+                                message::send(MSG_ALLIANCE_RELOAD, reloadData, sizeof reloadData, nullptr);
+                            }
+                            else // No alliance, notify party.
+                            {
+                                ref<uint32>(reloadData, 0) = PChar->PParty->GetPartyID();
+                                message::send(MSG_PT_RELOAD, reloadData, sizeof reloadData, nullptr);
+                            }
+
+                            // Notify the player they were just kicked -- they are no longer in the DB and party/alliance reloads won't notify them.
+                            ref<uint32>(reloadData, 0) = id;
+                            message::send(MSG_PLAYER_KICK, reloadData, sizeof reloadData, nullptr);
                         }
                     }
                 }
@@ -4534,25 +4547,33 @@ void SmallPacket0x071(map_session_data_t* const PSession, CCharEntity* const PCh
                 }
                 if (!PVictim && PChar->PParty->m_PAlliance->getMainParty() == PChar->PParty)
                 {
-                    char victimName[31]{};
+                    char   victimName[31]{};
+                    uint32 allianceID = PChar->PParty->m_PAlliance->m_AllianceID;
+
                     sql->EscapeStringLen(victimName, (const char*)data[0x0C], std::min<size_t>(strlen((const char*)data[0x0C]), 15));
                     int32 ret = sql->Query("SELECT charid FROM chars WHERE charname = '%s';", victimName);
                     if (ret != SQL_ERROR && sql->NumRows() == 1 && sql->NextRow() == SQL_SUCCESS)
                     {
-                        uint32 id = sql->GetUIntData(0);
-                        ret       = sql->Query(
-                                  "SELECT partyid FROM accounts_parties WHERE charid = %u AND allianceid = %u AND partyflag & %d AND partyflag & %d", id,
-                                  PChar->PParty->m_PAlliance->m_AllianceID, PARTY_LEADER, PARTY_SECOND | PARTY_THIRD);
+                        uint32 charid = sql->GetUIntData(0);
+                        ret           = sql->Query(
+                                      "SELECT partyid FROM accounts_parties WHERE charid = %u AND allianceid = %u AND partyflag & %d",
+                                      charid, PChar->PParty->m_PAlliance->m_AllianceID, PARTY_LEADER | PARTY_SECOND | PARTY_THIRD);
                         if (ret != SQL_ERROR && sql->NumRows() == 1 && sql->NextRow() == SQL_SUCCESS)
                         {
+                            uint32 partyid = sql->GetUIntData(0);
                             if (sql->Query("UPDATE accounts_parties SET allianceid = 0, partyflag = partyflag & ~%d WHERE partyid = %u;",
-                                           PARTY_SECOND | PARTY_THIRD, id) == SQL_SUCCESS &&
+                                           PARTY_SECOND | PARTY_THIRD, partyid) == SQL_SUCCESS &&
                                 sql->AffectedRows())
                             {
                                 ShowDebug("%s has removed %s party from alliance", PChar->GetName(), data[0x0C]);
+                                // notify party they were removed
                                 uint8 removeData[4]{};
-                                ref<uint32>(removeData, 0) = PChar->PParty->GetPartyID();
+                                ref<uint32>(removeData, 0) = partyid;
                                 message::send(MSG_PT_RELOAD, removeData, sizeof removeData, nullptr);
+
+                                // notify alliance a party was removed
+                                ref<uint32>(removeData, 0) = allianceID;
+                                message::send(MSG_ALLIANCE_RELOAD, removeData, sizeof removeData, nullptr);
                             }
                         }
                     }
@@ -4762,10 +4783,9 @@ void SmallPacket0x077(map_session_data_t* const PSession, CCharEntity* const PCh
                 ShowDebug(fmt::format("(Alliance)Changing leader to {}", memberName));
                 PChar->PParty->m_PAlliance->assignAllianceLeader((const char*)data[0x04]);
 
-                // MSG_PT_RELOAD also reloads all the alliances parties if available
-                uint8 leaderData[4]{};
-                ref<uint32>(leaderData, 0) = PChar->PParty->GetPartyID();
-                message::send(MSG_PT_RELOAD, leaderData, sizeof leaderData, nullptr);
+                uint8 allianceData[4]{};
+                ref<uint32>(allianceData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+                message::send(MSG_ALLIANCE_RELOAD, allianceData, sizeof allianceData, nullptr);
             }
         }
         break;
@@ -5314,9 +5334,18 @@ void SmallPacket0x0B5(map_session_data_t* const PSession, CCharEntity* const PCh
                     if (PChar->PParty != nullptr)
                     {
                         int8 packetData[8]{};
-                        ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
-                        ref<uint32>(packetData, 4) = PChar->id;
-                        message::send(MSG_CHAT_PARTY, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                        if(PChar->PParty->m_PAlliance)
+                        {
+                            ref<uint32>(packetData, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+                            ref<uint32>(packetData, 4) = PChar->id;
+                            message::send(MSG_CHAT_ALLIANCE, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                        }
+                        else
+                        {
+                            ref<uint32>(packetData, 0) = PChar->PParty->GetPartyID();
+                            ref<uint32>(packetData, 4) = PChar->id;
+                            message::send(MSG_CHAT_PARTY, packetData, sizeof packetData, new CChatMessagePacket(PChar, MESSAGE_PARTY, (const char*)data[6]));
+                        }
 
                         if (settings::get<bool>("map.AUDIT_CHAT") && settings::get<uint8>("map.AUDIT_PARTY"))
                         {

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -205,8 +205,16 @@ void CParty::AssignPartyRole(const std::string& MemberName, uint8 role)
             break;
     }
     uint8 data[4]{};
-    ref<uint32>(data, 0) = m_PartyID;
-    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    if (m_PAlliance)
+    {
+        ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
+        message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+    }
+    else
+    {
+        ref<uint32>(data, 0) = m_PartyID;
+        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+    }
 }
 
 // get number of members in specified zone
@@ -327,8 +335,16 @@ void CParty::RemoveMember(CBattleEntity* PEntity)
                 sql->Query("DELETE FROM accounts_parties WHERE charid = %u;", PChar->id);
 
                 uint8 data[4]{};
-                ref<uint32>(data, 0) = m_PartyID;
-                message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+                if (m_PAlliance)
+                {
+                    ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
+                    message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+                }
+                else
+                {
+                    ref<uint32>(data, 0) = m_PartyID;
+                    message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+                }
 
                 if (PChar->PTreasurePool != nullptr && PChar->PTreasurePool->GetPoolType() != TREASUREPOOL_ZONE)
                 {
@@ -573,8 +589,17 @@ void CParty::AddMember(CBattleEntity* PEntity)
         sql->Query("INSERT INTO accounts_parties (charid, partyid, allianceid, partyflag) VALUES (%u, %u, %u, %u);", PChar->id, m_PartyID, allianceid,
                    GetMemberFlags(PChar));
         uint8 data[4]{};
-        ref<uint32>(data, 0) = m_PartyID;
-        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        if (m_PAlliance)
+        {
+            ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+        }
+        else
+        {
+            ref<uint32>(data, 0) = m_PartyID;
+            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        }
+
         ReloadTreasurePool(PChar);
 
         if (PChar->nameflags.flags & FLAG_INVITE)
@@ -636,8 +661,16 @@ void CParty::AddMember(uint32 id)
         sql->Query("INSERT INTO accounts_parties (charid, partyid, allianceid, partyflag) VALUES (%u, %u, %u, %u);", id, m_PartyID, allianceid,
                    Flags);
         uint8 data[4]{};
-        ref<uint32>(data, 0) = m_PartyID;
-        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        if (m_PAlliance)
+        {
+            ref<uint32>(data, 0) = m_PAlliance->m_AllianceID;
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+        }
+        else
+        {
+            ref<uint32>(data, 0) = m_PartyID;
+            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        }
 
         /*if (PChar->nameflags.flags & FLAG_INVITE)
         {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1190,8 +1190,17 @@ void CZone::CharZoneOut(CCharEntity* PChar)
     if (PChar->PParty && PChar->loc.destination != 0 && PChar->m_moghouseID == 0)
     {
         uint8 data[4]{};
-        ref<uint32>(data, 0) = PChar->PParty->GetPartyID();
-        message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+
+        if (PChar->PParty->m_PAlliance)
+        {
+            ref<uint32>(data, 0) = PChar->PParty->m_PAlliance->m_AllianceID;
+            message::send(MSG_ALLIANCE_RELOAD, data, sizeof data, nullptr);
+        }
+        else
+        {
+            ref<uint32>(data, 0) = PChar->PParty->GetPartyID();
+            message::send(MSG_PT_RELOAD, data, sizeof data, nullptr);
+        }
     }
 
     if (PChar->PParty)

--- a/src/world/message_server.cpp
+++ b/src/world/message_server.cpp
@@ -145,6 +145,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         case MSG_PT_RELOAD:
         case MSG_PT_DISBAND:
         {
+            // TODO: simplify query now that there's alliance versions?
             const char* query = "SELECT server_addr, server_port, MIN(charid) FROM accounts_sessions JOIN accounts_parties USING (charid) "
                                 "WHERE IF (allianceid <> 0, allianceid = (SELECT MAX(allianceid) FROM accounts_parties WHERE partyid = %d), "
                                 "partyid = %d) GROUP BY server_addr, server_port;";
@@ -153,6 +154,8 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
             ret            = sql->Query(query, partyid, partyid);
             break;
         }
+        case MSG_CHAT_ALLIANCE:
+        case MSG_ALLIANCE_RELOAD:
         case MSG_ALLIANCE_DISSOLVE:
         {
             const char* query = "SELECT server_addr, server_port, MIN(charid) FROM accounts_sessions JOIN accounts_parties USING (charid) "
@@ -197,6 +200,7 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
         }
         case MSG_PT_INVITE:
         case MSG_PT_INV_RES:
+        case MSG_PLAYER_KICK:
         case MSG_DIRECT:
         case MSG_SEND_TO_ZONE:
         {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes some crashes; lots of little changes to use party/alliance IDs more sanely with less crashing
Party/alliance message fixes

this code is "battle tested" to work on horizon, there's some subtle issues occasionally that I can't trace down because my brain is melted from the marathon debugging yesterday, but no more crashes = better

## Steps to test these changes

cross-process and not:
change party leader, see it update
change alliance leader, see it update
kick a player, they will be kicked and both the party and the player will see that correctly
kick a party, they will be kicked and both the alliance and party will see that correctly
