### PR TITLE
[SQL] Add Forgotten Hope for Kindred mobs in Dynamis Xarcabard

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -11763,21 +11763,7 @@ INSERT INTO `mob_droplist` VALUES (1441,2,0,1000,1455,0);       -- One Byne Bill
 -- ZoneID: 135 - Kindred Warrior
 -- ZoneID: 135 - Kindred Monk
 -- ZoneID: 135 - Kindred Thief
--- ZoneID: 135 - Kindred Warrior
--- ZoneID: 135 - Kindred White Mage
--- ZoneID: 135 - Kindred Red Mage
--- ZoneID: 135 - Kindred Monk
--- ZoneID: 135 - Kindred Black Mage
--- ZoneID: 135 - Kindred Thief
--- ZoneID: 135 - Kindred Paladin
--- ZoneID: 135 - Kindred Dark Knight
--- ZoneID: 135 - Kindred Beastmaster
--- ZoneID: 135 - Kindred Bard
--- ZoneID: 135 - Kindred Ranger
--- ZoneID: 135 - Kindred Samurai
--- ZoneID: 135 - Kindred Ninja
--- ZoneID: 135 - Kindred Dragoon
--- ZoneID: 135 - Kindred Summoner
+INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,3494,@RARE);   -- Forgotten Hope (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11305,@VRARE); -- Etoile Casaque (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11465,@VRARE); -- Mirage Keffiyeh (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11468,@VRARE); -- Commodore Tricorne (Very Rare, 1%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

removes duplicate comments for dropId 1442
adds Forgotten Hope rare drop to kindred in dynamis xarcabard

~~This is not tested as its just an entry add to droplist belonging to the kindred mobs in Dynamis Xarcabard. Please let me know if need to test.~~ UPDATE: tested and rarely dropping from mobs assigned with a non thief job

drop rate is based on information from ffxidb (see table bellow), and adjusted to 5% being the closest drop rate (kindred bard being an outlier)

mob | item | drop rate % (TH0) | zone
-- | -- | -- | --
Kindred Bard | Forgotten Hope | 10.6 | Dynamis – Xarcabard
Kindred Beastmaster | Forgotten Hope | 6.1 | Dynamis – Xarcabard
Kindred Black Mage | Forgotten Hope | 5.3 | Dynamis – Xarcabard
Kindred Dark Knight | Forgotten Hope | 5.7 | Dynamis – Xarcabard
Kindred Dragoon | Forgotten Hope | 7.7 | Dynamis – Xarcabard
Kindred Monk | Forgotten Hope | 5.6 | Dynamis – Xarcabard
Kindred Ninja | Forgotten Hope | 5 | Dynamis – Xarcabard
Kindred Paladin | Forgotten Hope | 7.1 | Dynamis – Xarcabard
Kindred Ranger | Forgotten Hope | 6.5 | Dynamis – Xarcabard
Kindred Red Mage | Forgotten Hope | 8.1 | Dynamis – Xarcabard
Kindred Samurai | Forgotten Hope | 9.3 | Dynamis – Xarcabard
Kindred Summoner | Forgotten Hope | 7.4 | Dynamis – Xarcabard
Kindred Thief | Forgotten Hope | 5.2 | Dynamis – Xarcabard
Kindred Warrior | Forgotten Hope | 6.8 | Dynamis – Xarcabard
Kindred White Mage | Forgotten Hope | 8.5 | Dynamis – Xarcabard

## Steps to test these changes

Go to dynamis xarcabard and defeat kindred mobs (non NM)
see Forgotten Hope item drop after defeating them (5% chance drop)
