### PR TITLE
Add gainExp listener to Magian Trials with example

### DIFF
--- a/scripts/commands/givemagianitem.lua
+++ b/scripts/commands/givemagianitem.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 local commandObj = {}
 
-commandObj.mdprops =
+commandObj.cmdprops =
 {
     permission = 1,
     parameters = 'sib'

--- a/scripts/globals/magian_data.lua
+++ b/scripts/globals/magian_data.lua
@@ -13250,6 +13250,29 @@ xi.magian.trials =
         },
     },
 
+    [4959] =
+    {
+        previousTrial = 4665,
+        requiredItem  =
+        {
+            itemId = xi.item.MELEE_CROWN_P2,
+        },
+
+        textOffset  = 1325,
+        gainExp     = true,
+        zoneId      = set{ xi.zone.DYNAMIS_XARCABARD, xi.zone.DYNAMIS_TAVNAZIA },
+        numRequired = 20000,
+
+        rewardItem =
+        {
+            itemId = xi.item.MELEE_CROWN_P2,
+            itemAugments =
+            {
+                [1] = { 1334, 0 }, -- Enhances 'Penance' Effect
+            },
+        },
+    },
+
     [5056] =
     {
         previousTrial = 4453,

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -171,8 +171,8 @@ xi.pets.wyvern.onMobSpawn = function(mob)
     end)
 
     -- https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)#Parameter_Increase
-    master:addListener('EXPERIENCE_POINTS', 'PET_WYVERN_EXP', function(player, exp)
-        xi.job_utils.dragoon.addWyvernExp(player, exp)
+    master:addListener('EXPERIENCE_POINTS', 'PET_WYVERN_EXP', function(playerObj, mobObj, exp)
+        xi.job_utils.dragoon.addWyvernExp(playerObj, exp)
     end)
 end
 

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -8010,7 +8010,7 @@ INSERT INTO `item_basic` VALUES (10646,0,'opima_pigaches','opima_pigaches',1,208
 INSERT INTO `item_basic` VALUES (10647,0,'areion_boots','areion_boots',1,2084,21,0,0);
 INSERT INTO `item_basic` VALUES (10648,0,'areion_boots_+1','areion_boots_+1',1,2080,21,0,0);
 INSERT INTO `item_basic` VALUES (10650,0,'warriors_mask_+2','war._mask_+2',1,63552,0,1,0);
-INSERT INTO `item_basic` VALUES (10651,0,'melee_crown_+2','mel._crown_+2',1,63552,0,1,0);
+INSERT INTO `item_basic` VALUES (10651,0,'melee_crown_p2','mel._crown_+2',1,63552,0,1,0);
 INSERT INTO `item_basic` VALUES (10652,0,'clerics_cap_+2','clr._cap_+2',1,63552,0,1,0);
 INSERT INTO `item_basic` VALUES (10653,0,'sorcerers_petasos_+2','src._petasos_+2',1,63552,0,1,0);
 INSERT INTO `item_basic` VALUES (10654,0,'duelists_chapeau_+2','dls._chapeau_+2',1,63552,0,1,0);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10433,7 +10433,7 @@ uint8 CLuaBaseEntity::checkSoloPartyAlliance()
 
 bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, sol::object const& minRange)
 {
-    if (m_PBaseEntity->objtype != TYPE_PC || PLuaBaseEntity->GetBaseEntity()->objtype != TYPE_MOB)
+    if (m_PBaseEntity->objtype != TYPE_PC || (PLuaBaseEntity && PLuaBaseEntity->GetBaseEntity()->objtype != TYPE_MOB))
     {
         ShowWarning("CLuaBaseEntity::checkKillCredit() - Non-PC type calling function, or PLuaBaseEntity is not a MOB.");
         return false;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4836,7 +4836,7 @@ namespace charutils
             }
         }
 
-        PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", CLuaBaseEntity(PChar), exp);
+        PChar->PAI->EventHandler.triggerListener("EXPERIENCE_POINTS", CLuaBaseEntity(PChar), CLuaBaseEntity(PMob), exp);
 
         // Player levels up
         if ((currentExp + exp) >= GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) && !onLimitMode)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Modifies `EXPERIENCE_POINTS` listener to pass back PMob
* Adds Experience Points listener for Magian Trials
* Adds zoneId condition for Magian Trials
* Fixes issue with givemagiantrial GM command

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Complete Trial 4959, attempt to gain XP with trial active in invalid zone
<!-- Clear and detailed steps to test your changes here -->
