### PR TITLE
bug fixes for nyzul_isle_investigation

### DIFF
--- a/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
@@ -43,7 +43,7 @@ local function pickSetPoint(instance)
         end
 
         -- Randomly pick the objective from the generated list
-        instance:setStage(utils.pickRandom(objective))
+        instance:setStage(utils.randomEntry(objective))
 
         if math.random(1, 30) <= 5 then
             instance:setLocalVar('gearObjective', math.random(xi.nyzul.gearObjective.AVOID_AGRO, xi.nyzul.gearObjective.DO_NOT_DESTROY))
@@ -416,6 +416,9 @@ instanceObject.afterInstanceRegister = function(player)
     player:messageName(ID.text.TIME_TO_COMPLETE, player, instance:getTimeLimit())
 
     player:addTempItem(xi.item.UNDERSEA_RUINS_FIREFLIES)
+    player:setCharVar('assaultEntered', 1)
+    player:delKeyItem(xi.ki.NYZUL_ISLE_ASSAULT_ORDERS)
+    player:messageSpecial(ID.text.KEYITEM_LOST, xi.ki.NYZUL_ISLE_ASSAULT_ORDERS)
 end
 
 -- Instance 'tick'


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes issues in Nyzul Isle Investigation where Rune of Transfer won't trigger, and players will not lose their Assault tags, enabling them to go in for free perpetually.

## Steps to test these changes

Accept Nyzul Isle assault orders and entry.
You will lose key item on entry, and rune of transfer will work.
