### PR TITLE
Fixes incorrect logic in FoV EXP threshold

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1494,9 +1494,9 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         player:setCharVar('[regime]lastReward', vanadielEpoch)
     end
 
-    -- award XP every page completion.  If the player is more than REGIME_REWARD_THRESHOLD below
-    -- the minimum suggested level, then do not award.
-    if player:getMainLvl() < math.max(1, page[5] - xi.settings.main.REGIME_REWARD_THRESHOLD) then
+    -- Award EXP for page completion
+    -- Player must be equal or greater than REGIME_REWARD_THRESHOLD levels below the minimum suggested level
+    if player:getMainLvl() >= math.max(1, page[5] - xi.settings.main.REGIME_REWARD_THRESHOLD) then
         player:addExp(reward * xi.settings.main.BOOK_EXP_RATE)
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Original PR #4466 causing players to receive no EXP for level appropriate pages. It is the wrong way around. As an aside, I can't find any evidence for this feature and it doesn't seem retail accurate (For example, Cape Terrigan page 1 would award nothing at 75). The retail level limit on pages was related to the relevant mobs giving EXP to progress the page, I've never seen a cut off for the page reward itself, and this isn't documented on any of the usual resources. It would be helpful if this could be verified, to avoid future bug reports.

Current version:
```lua
player:getMainLvl() < math.max(1, page[5] - xi.settings.main.REGIME_REWARD_THRESHOLD)
```

Step through:
```lua
{ 7, 1, 0, 0, 15, 19, 475,  7 }, -- Valkurm Dunes Page 1

page[5] --15
xi.settings.main.REGIME_REWARD_THRESHOLD -- 15 (Default)
math.max(1, 15 - 15) -- 1

-- Award EXP if
player:getMainLvl() < 1
```

## Steps to test these changes
Complete level appropriate FoV and EXP should be awarded
