### PR TITLE
Fix math for multiple augments applied in magian giveItem

### DIFF
--- a/scripts/globals/magian.lua
+++ b/scripts/globals/magian.lua
@@ -313,8 +313,8 @@ local function giveMagianItem(player, itemData, inscribeTrialId)
 
     if itemData.itemAugments then
         for augIndex, augData in pairs(itemData.itemAugments) do
-            itemParameters[augIndex + 2] = augData[1]
-            itemParameters[augIndex + 3] = augData[2]
+            itemParameters[augIndex * 2 + 1] = augData[1]
+            itemParameters[augIndex * 2 + 2] = augData[2]
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Was obo iterating through multiple augments when parsing parameters in the magian table.  This fixes that
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Items with more than one augment should be applied successfully
<!-- Clear and detailed steps to test your changes here -->
