### PR TITLE
[core] Don't re-read mixins when applying them

### DIFF
--- a/scripts/mixins/spawn_casket.lua
+++ b/scripts/mixins/spawn_casket.lua
@@ -2,12 +2,10 @@
 require('scripts/globals/caskets')
 require('scripts/globals/mixins')
 
-g_mixins = g_mixins or {}
-
 -----------------------------------
 -- Casket zone check
 -----------------------------------
-g_mixins.spawn_casket = function(casketMob)
+local spawn_casket = function(casketMob)
     casketMob:addListener('DEATH', 'DEATH_SPAWN_CASKET', function(mob, player, isKiller)
         local mobPos = mob:getPos()
 
@@ -24,4 +22,4 @@ g_mixins.spawn_casket = function(casketMob)
     end)
 end
 
-return g_mixins.spawn_casket
+return spawn_casket

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -126,4 +126,21 @@ namespace utils
     auto toASCII(std::string const& target, unsigned char replacement = '\0') -> std::string;
 } // namespace utils
 
+class ScopeGuard
+{
+public:
+    ScopeGuard(std::function<void()> func)
+    : func(func)
+    {
+    }
+
+    ~ScopeGuard()
+    {
+        func();
+    }
+
+private:
+    std::function<void()> func;
+};
+
 #endif

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -911,11 +911,11 @@ void CMobController::DoRoamTick(time_point tick)
             }
             else
             {
-                // No longer including conditional for ROAMFLAG_AMBUSH now that using mixin to handle mob hiding
                 if (PMob->getMobMod(MOBMOD_SPECIAL_SKILL) != 0 &&
                     m_Tick >= m_LastSpecialTime + std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_SPECIAL_COOL)) && TrySpecialSkill())
                 {
                     // I spawned a pet
+                    // NOTE: TrySpecialSkill() is doing things!
                 }
                 else if (PMob->GetMJob() == JOB_SMN && CanCastSpells() && PMob->SpellContainer->HasBuffSpells() &&
                          m_Tick >= m_LastMagicTime + std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_MAGIC_COOL)))

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -280,34 +280,20 @@ CInstance* CInstanceLoader::LoadInstance()
         }
 
         // Finish setting up Mobs
-        for (auto PMob : instance->m_mobList)
+        for (auto const& [_, PMob] : instance->m_mobList)
         {
-            luautils::OnMobInitialize(PMob.second);
-            luautils::ApplyMixins(PMob.second);
-            ((CMobEntity*)PMob.second)->saveModifiers();
-            ((CMobEntity*)PMob.second)->saveMobModifiers();
-
-            // Add to cache
-            luautils::CacheLuaObjectFromFile(
-                fmt::format("./scripts/zones/{}/mobs/{}.lua",
-                            PMob.second->loc.zone->getName(),
-                            PMob.second->getName()));
+            luautils::OnEntityLoad(PMob);
+            luautils::OnMobInitialize(PMob);
+            static_cast<CMobEntity*>(PMob)->saveModifiers();
+            static_cast<CMobEntity*>(PMob)->saveMobModifiers();
         }
 
         // Finish setting up NPCs
-        for (auto PNpc : instance->m_npcList)
+        for (auto const& [_, PNpc] : instance->m_npcList)
         {
-            luautils::OnNpcSpawn(PNpc.second);
-
-            // Add to cache
-            luautils::CacheLuaObjectFromFile(
-                fmt::format("./scripts/zones/{}/npcs/{}.lua",
-                            PNpc.second->loc.zone->getName(),
-                            PNpc.second->getName()));
+            luautils::OnEntityLoad(PNpc);
+            luautils::OnNpcSpawn(PNpc);
         }
-
-        // Cache Instance script (TODO: This will be done multiple times, don't do that)
-        luautils::CacheLuaObjectFromFile(instanceutils::GetInstanceData(instance->GetID()).filename);
 
         // Finish setup
         luautils::OnInstanceCreatedCallback(requester, instance);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11394,8 +11394,8 @@ void CLuaBaseEntity::resetRecasts()
  *  Function: addListener()
  *  Purpose : Instructs the Event Handler to monitor for an Event, then
  *            execute a prepared Lua function once the Event has occurred
- *  Example : See: scripts/mixins/families/chigoe.lua
- *  Notes   : Function along with statements must be passed in L3
+ *  Example : avatarMob:addListener('SPAWN', 'AVATAR_SPAWN', function(mob) print('Hello!') end)
+ *  Notes   :
  ************************************************************************/
 
 void CLuaBaseEntity::addListener(std::string const& eventName, std::string const& identifier, sol::function const& func)

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -305,9 +305,6 @@ void CLuaBattlefield::lose()
 
 void CLuaBattlefield::addGroups(sol::table const& groups, bool hasMultipleArenas)
 {
-    // get the global function "applyMixins"
-    sol::function applyMixins = lua["applyMixins"];
-
     // Ensure that each area has its own super linking
     int16 superlinkId = 1000 * m_PLuaBattlefield->GetArea();
     // The lowest entity ID allowed within the battlefield. Used for battlefields with multiple areas.
@@ -580,23 +577,6 @@ void CLuaBattlefield::addGroups(sol::table const& groups, bool hasMultipleArenas
                     PMob->setMobMod(modifier.first.as<uint16>(), modifier.second.as<uint16>());
                 }
                 PMob->saveMobModifiers();
-            }
-        }
-
-        auto mixins = groupData["mixins"];
-        if (mixins.valid() && applyMixins.valid())
-        {
-            // get the parameter "mixinOptions" (optional)
-            auto mixinOptions = groupData["mixinOptions"];
-
-            for (CBaseEntity* entity : groupEntities)
-            {
-                auto result = applyMixins(CLuaBaseEntity(entity), mixins, mixinOptions);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError("luautils::applyMixins: %s", err.what());
-                }
             }
         }
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2876,27 +2876,23 @@ namespace luautils
         return 0;
     }
 
-    // Called during server startup, file reads are OK!
     int32 ApplyMixins(CBaseEntity* PMob)
     {
         TracyZoneScoped;
 
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
+        // clang-format off
+        ScopeGuard sg([&]()
         {
-            return -1;
-        }
+            // Clear out globals
+            lua.set("mixins", sol::lua_nil);
+            lua.set("mixinOptions", sol::lua_nil);
+        });
+        // clang-format on
 
-        // Clear out globals
-        lua.set("mixins", sol::lua_nil);
-        lua.set("mixinOptions", sol::lua_nil);
+        // We are assuming that mixin and optionally mixinOptions have been populated by a file-read
+        // before this function is called!
 
-        auto zone_name = PMob->loc.zone->getName();
-        auto name      = PMob->getName();
-
-        auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", zone_name, name);
-
-        auto script_result = lua.safe_script_file(filename);
-        if (!script_result.valid())
+        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
         {
             return -1;
         }
@@ -2923,29 +2919,29 @@ namespace luautils
         {
             sol::error err = result;
             ShowError("luautils::applyMixins: %s", err.what());
+            return -1;
         }
 
         return 0;
     }
 
-    // Called during server startup, file reads are OK!
     int32 ApplyZoneMixins(CBaseEntity* PMob)
     {
         TracyZoneScoped;
 
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
+        // clang-format off
+        ScopeGuard sg([&]()
         {
-            return -1;
-        }
+            // Clear out globals
+            lua.set("mixins", sol::lua_nil);
+            lua.set("mixinOptions", sol::lua_nil);
+        });
+        // clang-format on
 
-        // Clear out any previous global definitions
-        lua.set("mixins", sol::lua_nil);
-        lua.set("mixinOptions", sol::lua_nil);
+        // We are assuming that mixin and optionally mixinOptions have been populated by a file-read
+        // before this function is called!
 
-        auto filename = fmt::format("./scripts/mixins/zones/{}.lua", PMob->loc.zone->getName());
-
-        auto script_result = lua.safe_script_file(filename);
-        if (!script_result.valid())
+        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
         {
             return -1;
         }
@@ -5714,6 +5710,8 @@ namespace luautils
             luautils::OnEntityLoad(PMob);
 
             luautils::OnMobInitialize(PMob);
+
+            // NOTE: These rely on the file read that just happened
             luautils::ApplyMixins(PMob);
             luautils::ApplyZoneMixins(PMob);
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2876,104 +2876,6 @@ namespace luautils
         return 0;
     }
 
-    int32 ApplyMixins(CBaseEntity* PMob)
-    {
-        TracyZoneScoped;
-
-        // clang-format off
-        ScopeGuard sg([&]()
-        {
-            // Clear out globals
-            lua.set("mixins", sol::lua_nil);
-            lua.set("mixinOptions", sol::lua_nil);
-        });
-        // clang-format on
-
-        // We are assuming that mixin and optionally mixinOptions have been populated by a file-read
-        // before this function is called!
-
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
-        {
-            return -1;
-        }
-
-        // get the global function "applyMixins"
-        sol::function applyMixins = lua["applyMixins"];
-        if (!applyMixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixins"
-        auto mixins = lua["mixins"];
-        if (!mixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixinOptions" (optional)
-        auto mixinOptions = lua["mixinOptions"];
-
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::applyMixins: %s", err.what());
-            return -1;
-        }
-
-        return 0;
-    }
-
-    int32 ApplyZoneMixins(CBaseEntity* PMob)
-    {
-        TracyZoneScoped;
-
-        // clang-format off
-        ScopeGuard sg([&]()
-        {
-            // Clear out globals
-            lua.set("mixins", sol::lua_nil);
-            lua.set("mixinOptions", sol::lua_nil);
-        });
-        // clang-format on
-
-        // We are assuming that mixin and optionally mixinOptions have been populated by a file-read
-        // before this function is called!
-
-        if (PMob == nullptr || PMob->objtype != TYPE_MOB)
-        {
-            return -1;
-        }
-
-        // get the global function "applyMixins"
-        sol::function applyMixins = lua["applyMixins"];
-        if (!applyMixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixins"
-        auto mixins = lua["mixins"];
-        if (!mixins.valid())
-        {
-            return -1;
-        }
-
-        // get the parameter "mixinOptions" (optional)
-        auto mixinOptions = lua["mixinOptions"];
-
-        auto result = applyMixins(CLuaBaseEntity(PMob), mixins, mixinOptions);
-        if (!result.valid())
-        {
-            sol::error err = result;
-            ShowError("luautils::applyMixins %s", err.what());
-            return -1;
-        }
-
-        return 0;
-    }
-
     int32 OnPath(CBaseEntity* PEntity)
     {
         TracyZoneScoped;
@@ -5695,25 +5597,9 @@ namespace luautils
         }
         else if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity))
         {
-            auto mixins = table["mixins"].get_or<sol::table>(sol::lua_nil);
-            if (mixins.valid())
-            {
-                // Use the global function "applyMixins"
-                auto result = lua["applyMixins"](CLuaBaseEntity(PMob), mixins);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError("applyMixins: %s: %s", PMob->name.c_str(), err.what());
-                }
-            }
-
             luautils::OnEntityLoad(PMob);
 
             luautils::OnMobInitialize(PMob);
-
-            // NOTE: These rely on the file read that just happened
-            luautils::ApplyMixins(PMob);
-            luautils::ApplyZoneMixins(PMob);
 
             PMob->saveModifiers();
             PMob->saveMobModifiers();

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -250,8 +250,6 @@ namespace luautils
     bool  OnTrustSpellCastCheckBattlefieldTrusts(CBattleEntity* PCaster); // Triggered if spell is a trust spell during onCast to determine to interrupt spell or not
 
     int32 OnMobInitialize(CBaseEntity* PMob);
-    int32 ApplyMixins(CBaseEntity* PMob);
-    int32 ApplyZoneMixins(CBaseEntity* PMob);
     int32 OnMobSpawn(CBaseEntity* PMob);
     int32 OnMobRoamAction(CBaseEntity* PMob); // triggers when event mob is ready for a custom roam action
     int32 OnMobRoam(CBaseEntity* PMob);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1593,6 +1593,8 @@ namespace mobutils
                 luautils::OnEntityLoad(PMob);
 
                 luautils::OnMobInitialize(PMob);
+
+                // NOTE: These rely on the file read that just happened
                 luautils::ApplyMixins(PMob);
                 luautils::ApplyZoneMixins(PMob);
 

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1594,10 +1594,6 @@ namespace mobutils
 
                 luautils::OnMobInitialize(PMob);
 
-                // NOTE: These rely on the file read that just happened
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
-
                 PMob->saveModifiers();
                 PMob->saveMobModifiers();
             }

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -646,10 +646,6 @@ namespace zoneutils
             {
                 // Cache Mob Lua
                 luautils::OnEntityLoad(PMob);
-
-                // NOTE: These rely on the file read that just happened
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
             });
 
             PZone->ForEachMob([](CMobEntity* PMob)

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -646,6 +646,10 @@ namespace zoneutils
             {
                 // Cache Mob Lua
                 luautils::OnEntityLoad(PMob);
+
+                // NOTE: These rely on the file read that just happened
+                luautils::ApplyMixins(PMob);
+                luautils::ApplyZoneMixins(PMob);
             });
 
             PZone->ForEachMob([](CMobEntity* PMob)
@@ -653,8 +657,6 @@ namespace zoneutils
                 mobutils::AddSqlModifiers(PMob);
 
                 luautils::OnMobInitialize(PMob);
-                luautils::ApplyMixins(PMob);
-                luautils::ApplyZoneMixins(PMob);
 
                 PMob->saveModifiers();
                 PMob->saveMobModifiers();

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -37,11 +37,6 @@ global_objects=(
     utils
     npcUtil
 
-    mixins
-    g_mixins
-    applyMixins
-    mixinOptions
-
     set
     printf
     switch


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Despite my rambling in https://github.com/LandSandBoat/server/issues/4493, with some careful planning its possible to keep the current API and script layout of mixins, and still get rid of the file reads. It does rely on us holding onto global state _between function calls_, which is bad and confusing juju. 

This is a good first step for performance, while leaving the door open to refactoring later on if we want it.

I'm not sure why the magian stuff has come in with this, I'll clean it up another time.
