### PR TITLE
[tools] Update VSCode tasks to run with cmd on windows.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,4 +1,12 @@
 {
+    "windows": {
+        "options": {
+            "shell": {
+            "executable": "cmd.exe",
+            "args": ["/d", "/c"]
+            }
+        }
+    },
     "tasks": [
         {
             "label": "Kill xi_connect",


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Short and sweet.  

This PR resolves an issue with the "Run Everything" launch task on Windows in which you need to specify that it has to be run with cmd.exe.  Windows, by default, does not know how to handle shell execute through VSCode. All other platforms remain the same.

## Steps to test these changes

Open the project in VSCode, in the Debug pane select "(Windows) Run Everything" and hit go.
The expected behavior is that it runs cmake configuration and spawns terminal tabs for each process after compiling the project.
