### PR TITLE
Trickattack rework

### DIFF
--- a/scripts/commands/getta.lua
+++ b/scripts/commands/getta.lua
@@ -2,18 +2,16 @@
 -- func: getta
 -- desc: returns the name of the entity that would be chosen for trick attack given the current (mob) target
 -----------------------------------
-cmdprops =
+local commandObj = {}
+
+commandObj.cmdprops =
 {
-    permission = 3,
+    permission = 1,
     parameters = ''
 }
 
-function error(player, msg)
-    player:PrintToPlayer(msg)
-    player:PrintToPlayer('!getta with a target')
-end
-
-function onTrigger(player)
+-- function onTrigger(player, extendedMode)
+commandObj.onTrigger = function(player)
     local targ = player:getCursorTarget()
     if targ ~= nil then
         local tatarget = player:getTrickAttackChar(targ)
@@ -26,3 +24,5 @@ function onTrigger(player)
         player:PrintToPlayer('Must select a target using in game cursor first.')
     end
 end
+
+return commandObj

--- a/scripts/commands/getta.lua
+++ b/scripts/commands/getta.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- func: getta
+-- desc: returns the name of the entity that would be chosen for trick attack given the current (mob) target
+-----------------------------------
+cmdprops =
+{
+    permission = 3,
+    parameters = ""
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!getta with a target")
+end
+
+function onTrigger(player)
+    local targ = player:getCursorTarget()
+    if targ ~= nil then
+        local tatarget = player:getTrickAttackChar(targ)
+        if tatarget ~= nil then
+            player:PrintToPlayer(string.format("Trick attack would select: %s", tatarget:getName()))
+        else
+            player:PrintToPlayer("No valid TA target found.")
+        end
+    else
+        player:PrintToPlayer("Must select a target using in game cursor first.")
+    end
+end

--- a/scripts/commands/getta.lua
+++ b/scripts/commands/getta.lua
@@ -5,12 +5,12 @@
 cmdprops =
 {
     permission = 3,
-    parameters = ""
+    parameters = ''
 }
 
 function error(player, msg)
     player:PrintToPlayer(msg)
-    player:PrintToPlayer("!getta with a target")
+    player:PrintToPlayer('!getta with a target')
 end
 
 function onTrigger(player)
@@ -18,11 +18,11 @@ function onTrigger(player)
     if targ ~= nil then
         local tatarget = player:getTrickAttackChar(targ)
         if tatarget ~= nil then
-            player:PrintToPlayer(string.format("Trick attack would select: %s", tatarget:getName()))
+            player:PrintToPlayer(string.format('Trick attack would select: %s', tatarget:getName()))
         else
-            player:PrintToPlayer("No valid TA target found.")
+            player:PrintToPlayer('No valid TA target found.')
         end
     else
-        player:PrintToPlayer("Must select a target using in game cursor first.")
+        player:PrintToPlayer('Must select a target using in game cursor first.')
     end
 end

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -103,9 +103,8 @@ namespace battleutils
      *                                                                       *
      ************************************************************************/
 
-    const float worldAngleMinDistance                = 0.5f;
-    const float worldAngleMinDistanceSquared         = worldAngleMinDistance * worldAngleMinDistance;
-    const uint8 worldAngleMaxDeviance                = 4;
+    const float worldAngleMinDistance = 0.5f;
+    const uint8 worldAngleMaxDeviance = 4;
 
     void LoadSkillTable()
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4255,8 +4255,9 @@ namespace battleutils
     }
 
     /*
-        pass worldAngle(anchorMob, firstPlayer) instead of calculating everytime to allow TA to be more efficient
-        Calculates world angle between otherPlayer and anchor mob,
+        pass result of worldAngle(anchorEntity, firstEntity) instead of calculating everytime to allow TA to be more efficient
+        Note the order of worldAngle calls, the anchor must be first in all comparisons
+        Calculates world angle between other entity and anchor entity,
         then determines if the difference of those angles is within acceptable range for moves that require the three to be "in a straight line"
         Used for Trick Attack and Cover: separate checks for distance/party membership must be done to confirm eligability
     */
@@ -4305,6 +4306,7 @@ namespace battleutils
                 taPartyList.emplace_back(taUser->PParty);
             }
 
+            // Collect all potential TA targets who are closer to the mob than the TA user
             for (auto&& party : taPartyList)
             {
                 for (auto&& member : party->members)
@@ -6960,6 +6962,7 @@ namespace battleutils
                 uint8 angleTAmob = worldAngle(PMob->loc.p, PCoverAbilityUser->loc.p);
                 float distTAmob  = distanceSquared(PCoverAbilityUser->loc.p, PMob->loc.p);
 
+                // check if cover user is within melee range and that cover target is in-line behind
                 if (distTAmob <= static_cast<float>(PMob->GetMeleeRange() * PMob->GetMeleeRange()) && // make sure cover user is within melee range
                     distTAmob >= worldAngleMinDistanceSquared &&                                      // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
                     distTAmob < distanceSquared(PCoverAbilityTarget->loc.p, PMob->loc.p) &&           // make sure cover user is closer to the mob than cover target

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4291,7 +4291,7 @@ namespace battleutils
 
         // angle and distance between mob and TA user
         uint8                                         angleTAmob = worldAngle(PMob->loc.p, taUser->loc.p);
-        auto                                          distTAmob  = distanceSquared(taUser->loc.p, PMob->loc.p);
+        auto                                          distTAmob  = distance(taUser->loc.p, PMob->loc.p);
         std::vector<std::pair<float, CBattleEntity*>> taTargetList;
 
         if (taUser->PParty != nullptr)
@@ -4311,9 +4311,9 @@ namespace battleutils
             {
                 for (auto&& member : party->members)
                 {
-                    float distTAtarget = distanceSquared(member->loc.p, PMob->loc.p);
+                    float distTAtarget = distance(member->loc.p, PMob->loc.p);
                     // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                    if (distTAtarget >= worldAngleMinDistanceSquared && distTAtarget < distTAmob)
+                    if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
                     {
                         taTargetList.emplace_back(distTAtarget, member);
                     }
@@ -4322,9 +4322,9 @@ namespace battleutils
                     {
                         for (auto* PTrust : PChar->PTrusts)
                         {
-                            float distTAtarget = distanceSquared(PTrust->loc.p, PMob->loc.p);
+                            float distTAtarget = distance(PTrust->loc.p, PMob->loc.p);
                             // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                            if (distTAtarget >= worldAngleMinDistanceSquared && distTAtarget < distTAmob)
+                            if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
                             {
                                 taTargetList.emplace_back(distTAtarget, PTrust);
                             }
@@ -4342,9 +4342,9 @@ namespace battleutils
             {
                 if (auto* fellow = dynamic_cast<CBattleEntity*>(PChar->PFellow))
                 {
-                    float distTAtarget = distanceSquared(fellow->loc.p, PMob->loc.p);
+                    float distTAtarget = distance(fellow->loc.p, PMob->loc.p);
                     // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                    if (distTAtarget >= worldAngleMinDistanceSquared && distTAtarget < distTAmob)
+                    if (distTAtarget >= worldAngleMinDistance && distTAtarget < distTAmob)
                     {
                         taTargetList.emplace_back(distTAtarget, fellow);
                     }
@@ -6960,12 +6960,12 @@ namespace battleutils
             {
                 // using same variable names as trick attack function, for consistent understanding
                 uint8 angleTAmob = worldAngle(PMob->loc.p, PCoverAbilityUser->loc.p);
-                float distTAmob  = distanceSquared(PCoverAbilityUser->loc.p, PMob->loc.p);
+                float distTAmob  = distance(PCoverAbilityUser->loc.p, PMob->loc.p);
 
                 // check if cover user is within melee range and that cover target is in-line behind
-                if (distTAmob <= static_cast<float>(PMob->GetMeleeRange() * PMob->GetMeleeRange()) && // make sure cover user is within melee range
-                    distTAmob >= worldAngleMinDistanceSquared &&                                      // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                    distTAmob < distanceSquared(PCoverAbilityTarget->loc.p, PMob->loc.p) &&           // make sure cover user is closer to the mob than cover target
+                if (distTAmob <= static_cast<float>(PMob->GetMeleeRange()) &&        // make sure cover user is within melee range
+                    distTAmob >= worldAngleMinDistance &&                            // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
+                    distTAmob < distance(PCoverAbilityTarget->loc.p, PMob->loc.p) && // make sure cover user is closer to the mob than cover target
                     areInLine(angleTAmob, PMob, PCoverAbilityTarget))
                 {
                     return PCoverAbilityUser;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4261,14 +4261,13 @@ namespace battleutils
         // X-degree angle threshold, centered on the firstPlayer's world angle
         // X = 10 => 10/2 * 255 / 360 ~ 3.5 rotation diff, rounded to 4 which really gives X~11.3
         int16 angleDiff = angleDifference(firstPlayerWA, worldAngle(anchorMob->loc.p, otherPlayer->loc.p));
-        ShowDebug("InLine check angleDiff: %d\n",angleDiff);
+        ShowDebug("InLine check angleDiff: %d\n", angleDiff);
         if (abs(angleDiff) <= 4)
         {
             return true;
         }
         return false;
     }
-
 
     /*
      *  Find if any party members are in position for trick attack.  Do this by comparing the world angle between:
@@ -4287,8 +4286,8 @@ namespace battleutils
         }
 
         // angle and distance between mob and TA user
-        uint8 angleTAmob = worldAngle(PMob->loc.p, taUser->loc.p);
-        auto distTAmob = distanceSquared(taUser->loc.p, PMob->loc.p);
+        uint8                                         angleTAmob = worldAngle(PMob->loc.p, taUser->loc.p);
+        auto                                          distTAmob  = distanceSquared(taUser->loc.p, PMob->loc.p);
         std::vector<std::pair<float, CBattleEntity*>> taTargetList;
 
         if (taUser->PParty != nullptr)
@@ -4299,8 +4298,8 @@ namespace battleutils
                 {
                     for (std::size_t i = 0; i < a->members.size(); ++i)
                     {
-                        CBattleEntity* member = a->members.at(i);
-                        float distTAtarget = distanceSquared(member->loc.p, PMob->loc.p);
+                        CBattleEntity* member       = a->members.at(i);
+                        float          distTAtarget = distanceSquared(member->loc.p, PMob->loc.p);
                         // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
                         if (distTAtarget > 0.25f && distTAtarget < distTAmob)
                         {
@@ -4371,11 +4370,12 @@ namespace battleutils
         if (taTargetList.size() > 0)
         {
             // sorts by distance then by pointer id (only if floats are equal)
-            sort(taTargetList.begin(),taTargetList.end());
-            for(const auto potentialTAtarget : taTargetList)
+            sort(taTargetList.begin(), taTargetList.end());
+            for (const auto potentialTAtarget : taTargetList)
             {
-                if (taUser->id == potentialTAtarget.second->id ||   // can't TA self
-                    potentialTAtarget.second->isDead()) {           //Dead entity should not be TA-able
+                if (taUser->id == potentialTAtarget.second->id || // can't TA self
+                    potentialTAtarget.second->isDead())           // Dead entity should not be TA-able
+                {
                     continue;
                 }
                 if (areInLine(angleTAmob, PMob, potentialTAtarget.second))
@@ -6971,11 +6971,11 @@ namespace battleutils
             {
                 // using same variable names as trick attack function, for consistent understanding
                 uint8 angleTAmob = worldAngle(PMob->loc.p, PCoverAbilityUser->loc.p);
-                float distTAmob = distanceSquared(PCoverAbilityUser->loc.p, PMob->loc.p);
+                float distTAmob  = distanceSquared(PCoverAbilityUser->loc.p, PMob->loc.p);
 
-                if (sqrt(distTAmob) <= (float)PMob->GetMeleeRange() &&                      //make sure cover user is within melee range
-                   distTAmob >= 0.25f &&                                                    // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
-                   distTAmob < distanceSquared(PCoverAbilityTarget->loc.p, PMob->loc.p) &&  //make sure cover user is closer to the mob than cover target
+                if (sqrt(distTAmob) <= (float)PMob->GetMeleeRange() &&                      // make sure cover user is within melee range
+                    distTAmob >= 0.25f &&                                                   // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
+                    distTAmob < distanceSquared(PCoverAbilityTarget->loc.p, PMob->loc.p) && // make sure cover user is closer to the mob than cover target
                     areInLine(angleTAmob, PMob, PCoverAbilityTarget))
                 {
                     return PCoverAbilityUser;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4263,7 +4263,7 @@ namespace battleutils
         int16 angleDiff = angleDifference(firstEntityWorldAngle, worldAngle(anchorMob->loc.p, otherEntity->loc.p));
 
         // Useful for debugging if trick attack/cover aren't reliably calculating eligability, but chatty otherwise
-        //ShowDebug("InLine check angleDiff: %d\n", angleDiff);
+        // ShowDebug("InLine check angleDiff: %d\n", angleDiff);
 
         return std::abs(angleDiff) <= 4;
     }
@@ -4304,7 +4304,7 @@ namespace battleutils
             {
                 for (auto&& member : party->members)
                 {
-                    float          distTAtarget = distanceSquared(member->loc.p, PMob->loc.p);
+                    float distTAtarget = distanceSquared(member->loc.p, PMob->loc.p);
                     // require closer target not be closer than .5 yalms (.5*.5=.25 distsquared) to mob
                     if (distTAtarget > 0.25f && distTAtarget < distTAmob)
                     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4371,7 +4371,7 @@ namespace battleutils
         {
             // sorts by distance then by pointer id (only if floats are equal)
             sort(taTargetList.begin(), taTargetList.end());
-            for (const auto potentialTAtarget : taTargetList)
+            for (std::pair<float, CBattleEntity*> const& potentialTAtarget : taTargetList)
             {
                 if (taUser->id == potentialTAtarget.second->id || // can't TA self
                     potentialTAtarget.second->isDead())           // Dead entity should not be TA-able

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -187,6 +187,7 @@ namespace battleutils
     CItemEquipment* GetEntityArmor(CBattleEntity* PEntity, SLOTTYPE Slot);
 
     void           MakeEntityStandUp(CBattleEntity* PEntity);
+    inline bool    areInLine(uint8 firstPlayerWA, CBattleEntity* insidePlayer, CBattleEntity* outidePlayer);
     CBattleEntity* getAvailableTrickAttackChar(CBattleEntity* taUser, CBattleEntity* PMob);
 
     bool HasNinjaTool(CBattleEntity* PEntity, CSpell* PSpell, bool ConsumeTool);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Trick Attack is, by many accounts, unreliable. In trying to dismantle how it works most people give up due to the complex nature of the code. Also Cover utilizes the same code. I've got to assume the many floats and trig functions carry over approximations that make it not always behave as expected.

This PR:
 - Simplifies the logic for determining if 3 entities are "in a line with a little wiggle room" for use in TA and Cover functions
 - Makes TA work by first collecting all potential TA targets (based on distance), then returning the closest to the mob that is positioned properly.

Note that there are 2 "magic numbers" in this new code (I'm unsure of how many the old code has, but there's at least one to to determine minimum and maximum slope):
 - Minimum distance from mob: .5 yalms
   - This is being careful not to get close to the `worldAngle()` defaulting to mob's rotation
 - Angle Diff threshold: 4 world angle rotation units in either direction (5 degress in either direction, rounded to the nearest rotation which really gives about 11.3 degress, cenetered on the angle between mob and TA user)

I originally brought this up https://github.com/LandSandBoat/server/discussions/3784 to see if there would be interest in making the change, but after utilizing it ourselves over at WingsXI for a bit over a week, i'm glad to say it's very reliable. 

The paradigm shift for this code is to approach the problem a different way. Instead of extrapolating various lines to build triangles around the mob, we just consider what it means to draw a line from mob to thf. 

The algorithm is best understood thinking of looking from the sky with a compass overlay on top. The line drawn could be simply represented as a compass direction. You can then also represent the potential ta target as another compass direction. The resulting angles can be subtracted to know how close to linear the three points are.


## Steps to test these changes

Included is a new function `!getta`, which reports the TA target that would be selected if the player running the command attacked the cursor target (Note that this is utilizing `getTrickAttackChar()` directly, so the player running the command does need Trick Attack buff active).

Simply join parties with another player and try various positions in front of and behind while using the `!getta` function. Gifs included of this testing:

Before changes: https://imgur.com/QEO1kJb

After changes: https://imgur.com/Nxvg6Hi
