### PR TITLE
[SQL]item_usable Pluton, Beitetsu, Boulder Box

### DIFF
--- a/scripts/items/beitetsu_box.lua
+++ b/scripts/items/beitetsu_box.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- ID: 6184
+-- Beitetsu Box
+-- Breaks up a Beitetsu Box
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return xi.itemUtils.itemBoxOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    target:addItem(xi.item.BEITETSU, math.random(15, 30))
+end
+
+return itemObject

--- a/scripts/items/boulder_box.lua
+++ b/scripts/items/boulder_box.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- ID: 6185
+-- Boulder Box
+-- Breaks up a Boulder Box
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return xi.itemUtils.itemBoxOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    target:addItem(xi.item.RIFTBORN_BOULDER, math.random(15, 30))
+end
+
+return itemObject

--- a/scripts/items/pluton_box.lua
+++ b/scripts/items/pluton_box.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- ID: 6183
+-- Pluton Box
+-- Breaks up a Pluton Box
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return xi.itemUtils.itemBoxOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    target:addItem(xi.item.PLUTON, math.random(15, 30))
+end
+
+return itemObject

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -1859,6 +1859,9 @@ INSERT INTO `item_usable` VALUES (6177,'copy_of_life-form_study',1,1,117,0,0,0,0
 INSERT INTO `item_usable` VALUES (6178,'copy_of_hrohjs_record',1,1,117,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6179,'copy_of_the_bell_tolls',1,1,117,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6181,'beitetsu_parcel',1,1,24,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6183,'pluton_box',1,1,24,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6184,'beitetsu_box',1,1,24,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6185,'boulder_box',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6186,'slime_rocket',1,1,115,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6190,'spriggan_spark',1,1,114,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6211,'slice_of_marinara_pizza',1,1,28,0,0,0,0,0);


### PR DESCRIPTION
Adds in pluton, beitetsu and boulder box to be usable and give correct random amount

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds in pluton, beitetsu and boulder box to be usable and give correct random amount. Overlook it showing item_basic, I noticed it after I did PR. But title does reflect what is for the PR

## Steps to test these changes

!additem 6183 and then use the item to get random amount between 15~30 
https://ffxiclopedia.fandom.com/wiki/Pluton_Box

!additem 6184 and then use the item to get random amount between 15~30
https://www.bg-wiki.com/ffxi/Beitetsu_Box

!additem 6185 and then use the item to get random amount between 15~30 
https://ffxiclopedia.fandom.com/wiki/Boulder_Box
