### PR TITLE
[core] Add equality operator to Lua classes

### DIFF
--- a/src/map/lua/lua_ability.h
+++ b/src/map/lua/lua_ability.h
@@ -59,6 +59,11 @@ public:
     void   setVE(uint16 ve);
     void   setRange(float range);
 
+    bool operator==(const CLuaAbility& other) const
+    {
+        return this->m_PLuaAbility == other.m_PLuaAbility;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_action.h
+++ b/src/map/lua/lua_action.h
@@ -60,6 +60,11 @@ public:
     void   addEffectMessage(uint32 actionTargetID, uint16 addEffectMessage);
     bool   addAdditionalTarget(uint32 actionTargetID);
 
+    bool operator==(const CLuaAction& other) const
+    {
+        return this->m_PLuaAction == other.m_PLuaAction;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -870,6 +870,11 @@ public:
     void addPacketMod(uint16 packetId, uint16 offset, uint8 value);
     void clearPacketMods();
 
+    bool operator==(const CLuaBaseEntity& other) const
+    {
+        return this->m_PBaseEntity == other.m_PBaseEntity;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -79,6 +79,11 @@ public:
     void lose();
     void addGroups(sol::table const& groups, bool hasMultipleArenas);
 
+    bool operator==(const CLuaBattlefield& other) const
+    {
+        return this->m_PLuaBattlefield == other.m_PLuaBattlefield;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_instance.h
+++ b/src/map/lua/lua_instance.h
@@ -77,6 +77,11 @@ public:
 
     auto insertAlly(uint32 groupid) -> std::optional<CLuaBaseEntity>;
 
+    bool operator==(const CLuaInstance& other) const
+    {
+        return this->m_PLuaInstance == other.m_PLuaInstance;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -88,6 +88,11 @@ public:
     auto getExData() -> sol::table;            // NOTE: This is 0-indexed, to be in line with the underlying C++ data
     void setExData(sol::table const& newData); // NOTE: This is 0-indexed, to be in line with the underlying C++ data
 
+    bool operator==(const CLuaItem& other) const
+    {
+        return this->m_PLuaItem == other.m_PLuaItem;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_loot.h
+++ b/src/map/lua/lua_loot.h
@@ -42,6 +42,11 @@ public:
     void addItemFixed(uint16 item, uint16 rate, sol::variadic_args va);
     void addGroupFixed(uint16 groupRate, sol::table const& items);
 
+    bool operator==(const CLuaLootContainer& other) const
+    {
+        return this->m_PLootContainer == other.m_PLootContainer;
+    }
+
     static void Register();
 
 private:

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -53,6 +53,11 @@ public:
     uint16 getMsg();
     uint16 getTotalTargets();
 
+    bool operator==(const CLuaMobSkill& other) const
+    {
+        return this->m_PLuaMobSkill == other.m_PLuaMobSkill;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_petskill.h
+++ b/src/map/lua/lua_petskill.h
@@ -53,6 +53,11 @@ public:
     uint16 getMsg();
     uint16 getTotalTargets();
 
+    bool operator==(const CLuaPetSkill& other) const
+    {
+        return this->m_PLuaPetSkill == other.m_PLuaPetSkill;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_spell.h
+++ b/src/map/lua/lua_spell.h
@@ -63,6 +63,11 @@ public:
     uint32 getCastTime();
     uint32 getPrimaryTargetID();
 
+    bool operator==(const CLuaSpell& other) const
+    {
+        return this->m_PLuaSpell == other.m_PLuaSpell;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -70,6 +70,11 @@ public:
     void   delEffectFlag(uint32 flag);
     bool   hasEffectFlag(uint32 flag);
 
+    bool operator==(const CLuaStatusEffect& other) const
+    {
+        return this->m_PLuaStatusEffect == other.m_PLuaStatusEffect;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_trade_container.h
+++ b/src/map/lua/lua_trade_container.h
@@ -52,6 +52,11 @@ public:
     bool   confirmItem(uint16 itemID, sol::object const& amountObj);
     bool   confirmSlot(uint8 slotID, sol::object const& amountObj);
 
+    bool operator==(const CLuaTradeContainer& other) const
+    {
+        return this->m_pMyTradeContainer == other.m_pMyTradeContainer;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_trigger_area.h
+++ b/src/map/lua/lua_trigger_area.h
@@ -46,6 +46,11 @@ public:
     int16  AddCount(int16 count);
     int16  DelCount(int16 count);
 
+    bool operator==(const CLuaTriggerArea& other) const
+    {
+        return this->m_PLuaTriggerArea == other.m_PLuaTriggerArea;
+    }
+
     static void Register();
 };
 

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -72,6 +72,11 @@ public:
 
     sol::table queryEntitiesByName(std::string const& name);
 
+    bool operator==(const CLuaZone& other) const
+    {
+        return this->m_pLuaZone == other.m_pLuaZone;
+    }
+
     static void Register();
 };
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adding the equality operator to the Lua classes makes it possible to compare them directly while in Lua, and it will be true if they are the same underlying C++ entity, even though they are separate CLuaXYZ objects.

```lua
local mob1 = GetMobByID(mobId)
local mob2 = GetMobByID(mobId)
if mob1 == mob2 then
  -- This will succeed after this PR, even though they are separate Lua objects
end
```