### PR TITLE
Fix gysahl greens bonus effect from chocobo shirt

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -671,8 +671,10 @@ xi.mod =
     MYTHIC_OCC_ATT_TWICE            = 865, -- Proc rate for "Occasionally attacks twice"
     MYTHIC_OCC_ATT_THRICE           = 866, -- Proc rate for "Occasionally attacks thrice"
 
-    EAT_RAW_FISH                    = 412, --
-    EAT_RAW_MEAT                    = 413, --
+    APPRECIATE_GYSAHL_GREENS        = 156, -- Enhances food effect of Gysahl Greens
+
+    EAT_RAW_FISH                    = 412, -- Without this, only Mithra can eat raw fish.
+    EAT_RAW_MEAT                    = 413, -- Without this, only Galka can eat raw meat.
 
     ENHANCES_CURSNA_RCVD            = 67,   -- Potency of "Cursna" effects received
     ENHANCES_CURSNA                 = 310,  -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove

--- a/scripts/items/bunch_of_gysahl_greens.lua
+++ b/scripts/items/bunch_of_gysahl_greens.lua
@@ -15,31 +15,28 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local chocoboShirt = target:getEquipID(xi.slot.BODY) == 10293
+    local chocoboShirt = target:getMod(xi.mod.APPRECIATE_GYSAHL_GREENS)
     target:addStatusEffect(xi.effect.FOOD, chocoboShirt, 0, 300, 4545)
 end
 
 itemObject.onEffectGain = function(target, effect)
     local power = effect:getPower()
-    if power == 1 then
-        target:addMod(xi.mod.AGI, 13)
+    if power == 0 then
+        target:addMod(xi.mod.AGI, 3)
         target:addMod(xi.mod.VIT, -5)
     else
-        target:addMod(xi.mod.AGI, 3)
+        target:addMod(xi.mod.AGI, 13)
         target:addMod(xi.mod.VIT, -5)
     end
 end
 
------------------------------------
--- onEffectLose Action
------------------------------------
 itemObject.onEffectLose = function(target, effect)
     local power = effect:getPower()
-    if power == 1 then
-        target:delMod(xi.mod.AGI, 13)
+    if power == 0 then
+        target:delMod(xi.mod.AGI, 3)
         target:delMod(xi.mod.VIT, -5)
     else
-        target:delMod(xi.mod.AGI, 3)
+        target:delMod(xi.mod.AGI, 13)
         target:delMod(xi.mod.VIT, -5)
     end
 end

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -284,7 +284,8 @@ INSERT INTO `item_mods` VALUES (10292,30,10);  -- MACC: 10
 INSERT INTO `item_mods` VALUES (10292,114,18); -- ENFEEBLE: 18
 
 -- Chocobo Shirt
-INSERT INTO `item_mods` VALUES (10293,1,2); -- DEF: 2
+INSERT INTO `item_mods` VALUES (10293,1,2);   -- DEF: 2
+INSERT INTO `item_mods` VALUES (10293,156,1); -- APPRECIATE_GYSAHL_GREENS: 1
 
 -- Kokous Earring
 INSERT INTO `item_mods` VALUES (10295,8,4);  -- STR: 4

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -836,8 +836,10 @@ enum class Mod
     MYTHIC_OCC_ATT_TWICE  = 865, // Proc rate for "Occasionally attacks twice"
     MYTHIC_OCC_ATT_THRICE = 866, // Proc rate for "Occasionally attacks thrice"
 
-    EAT_RAW_FISH = 412, //
-    EAT_RAW_MEAT = 413, //
+    APPRECIATE_GYSAHL_GREENS = 156, // Enhances food effect of Gysahl Greens
+
+    EAT_RAW_FISH = 412, // Without this, only Mithra can eat raw fish.
+    EAT_RAW_MEAT = 413, // Without this, only Galka can eat raw meat.
 
     ENHANCES_CURSNA_RCVD     = 67,   // Potency of "Cursna" effects received
     ENHANCES_CURSNA          = 310,  // Used by gear with the "Enhances Cursna" or "Cursna+" attribute
@@ -980,7 +982,7 @@ enum class Mod
     // SPARE IDs:
     // 75 to 79
     // 138 to 143
-    // 156 to 159
+    // 157 to 159
     // 217 to 223
     // 271 to 280
     //


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- The script used shirts item ID as effect power, but then checked for power equaling 1 before applying bonus modifiers. It now will take any non zero value.
- HARD CODED ITEM ID CHECKS ARE NEVER EVER A GOOD IDEA. It now uses a modifier.
- Script had an ancient block header that escaped the great purge, it is gone now.

## Steps to test these changes
GM yourself a chocobo shirt on your lv 1 nooblet. Eat greens. Enjoy allegedly tasty greens. See AGI stat increase. GM yourself an antacid to remove it. See same amount of AGI go away.
