### PR TITLE
[SQL][Item] Add item mods to items 23092-23096.

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2634,6 +2634,8 @@ INSERT INTO `item_latents` VALUES (22118,944,5,13,198);  -- Venery Bow: Minuet: 
 -- INSERT INTO `item_latents` VALUES (22266,288,??,??,0); -- Antitail: Unity Ranking: "Double Attack"+1~3%
 -- INSERT INTO `item_latents` VALUES (22267,288,??,??,0); -- Antitail +1: Unity Ranking: "Double Attack"+1~3%
 
+INSERT INTO `item_latents` VALUES (23096,291,16,13,354); -- Kasuga Kabuto +2: EFFECT_SEIGAN: COUNTER: 16
+
 INSERT INTO `item_latents` VALUES (23197,518,10,13,57);  -- WAR AF2 119 +2 Hands Defender Shield Rate +10
 
 -- Hachiya Kyahan +2

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -46948,6 +46948,112 @@ INSERT INTO `item_mods` VALUES (23091,170,8);     -- FASTCAST: 8
 INSERT INTO `item_mods` VALUES (23091,384,700);   -- HASTE_GEAR: 7%
 INSERT INTO `item_mods` VALUES (23091,426,7);     -- ABSORB_PHYSDMG_TO_MP: 7
 
+-- Heathen's burgeonet +2
+INSERT INTO `item_mods` VALUES (23092,1,135);   -- DEF: 135
+INSERT INTO `item_mods` VALUES (23092,2,61);    -- HP: 61
+INSERT INTO `item_mods` VALUES (23092,5,49);    -- MP: 49
+INSERT INTO `item_mods` VALUES (23092,8,37);    -- STR: 37
+INSERT INTO `item_mods` VALUES (23092,9,21);    -- DEX: 21
+INSERT INTO `item_mods` VALUES (23092,10,28);   -- VIT: 28
+INSERT INTO `item_mods` VALUES (23092,11,23);   -- AGI: 23
+INSERT INTO `item_mods` VALUES (23092,12,26);   -- INT: 26
+INSERT INTO `item_mods` VALUES (23092,13,22);   -- MND: 22
+INSERT INTO `item_mods` VALUES (23092,14,24);   -- CHR: 24
+INSERT INTO `item_mods` VALUES (23092,23,51);   -- ATT: 51
+INSERT INTO `item_mods` VALUES (23092,25,51);   -- ACC: 51
+INSERT INTO `item_mods` VALUES (23092,29,5);    -- MDEF: 5
+INSERT INTO `item_mods` VALUES (23092,30,51);   -- MACC: 51
+INSERT INTO `item_mods` VALUES (23092,31,77);   -- MEVA: 77
+INSERT INTO `item_mods` VALUES (23092,68,76);   -- EVA: 76
+INSERT INTO `item_mods` VALUES (23092,86,33);   -- SCYTHE: 33
+INSERT INTO `item_mods` VALUES (23092,288,5);   -- DOUBLE_ATTACK: 5
+INSERT INTO `item_mods` VALUES (23092,384,700); -- HASTE_GEAR: 7%
+-- TODO: Physical damage limit +7%
+
+-- Nukumi cabasset +2
+INSERT INTO `item_mods` VALUES (23093,1,122);     -- DEF: 122
+INSERT INTO `item_mods` VALUES (23093,2,63);      -- HP: 63
+INSERT INTO `item_mods` VALUES (23093,8,31);      -- STR: 31
+INSERT INTO `item_mods` VALUES (23093,9,30);      -- DEX: 30
+INSERT INTO `item_mods` VALUES (23093,10,30);     -- VIT: 30
+INSERT INTO `item_mods` VALUES (23093,11,25);     -- AGI: 25
+INSERT INTO `item_mods` VALUES (23093,12,21);     -- INT: 21
+INSERT INTO `item_mods` VALUES (23093,13,21);     -- MND: 21
+INSERT INTO `item_mods` VALUES (23093,14,24);     -- CHR: 24
+INSERT INTO `item_mods` VALUES (23093,23,51);     -- ATT: 51
+INSERT INTO `item_mods` VALUES (23093,25,51);     -- ACC: 51
+INSERT INTO `item_mods` VALUES (23093,29,5);      -- MDEF: 5
+INSERT INTO `item_mods` VALUES (23093,30,51);     -- MACC: 51
+INSERT INTO `item_mods` VALUES (23093,31,88);     -- MEVA: 88
+INSERT INTO `item_mods` VALUES (23093,68,76);     -- EVA: 76
+INSERT INTO `item_mods` VALUES (23093,160,-1000); -- DMG: -10%
+INSERT INTO `item_mods` VALUES (23093,384,800);   -- HASTE_GEAR: 8%
+
+-- Fili Calot +2 23094
+INSERT INTO `item_mods` VALUES (23094,1,115);     -- DEF: 115
+INSERT INTO `item_mods` VALUES (23094,2,56);      -- HP: 56
+INSERT INTO `item_mods` VALUES (23094,5,55);      -- MP: 55
+INSERT INTO `item_mods` VALUES (23094,8,18);      -- STR: 18
+INSERT INTO `item_mods` VALUES (23094,9,26);      -- DEX: 26
+INSERT INTO `item_mods` VALUES (23094,10,17);     -- VIT: 17
+INSERT INTO `item_mods` VALUES (23094,11,21);     -- AGI: 21
+INSERT INTO `item_mods` VALUES (23094,12,25);     -- INT: 25
+INSERT INTO `item_mods` VALUES (23094,13,27);     -- MND: 27
+INSERT INTO `item_mods` VALUES (23094,14,37);     -- CHR: 37
+INSERT INTO `item_mods` VALUES (23094,25,51);     -- ACC: 51
+INSERT INTO `item_mods` VALUES (23094,27,-10);    -- ENMITY: -10
+INSERT INTO `item_mods` VALUES (23094,29,9);      -- MDEF: 9
+INSERT INTO `item_mods` VALUES (23094,30,51);     -- MACC: 51
+INSERT INTO `item_mods` VALUES (23094,31,120);    -- MEVA: 120
+INSERT INTO `item_mods` VALUES (23094,68,78);     -- EVA: 78
+INSERT INTO `item_mods` VALUES (23094,160,-1000); -- DMG: -10%
+INSERT INTO `item_mods` VALUES (23094,384,600);   -- HASTE_GEAR: 6%
+INSERT INTO `item_mods` VALUES (23094,438,1);     -- MADRIGAL_EFFECT: 1
+INSERT INTO `item_mods` VALUES (23094,455,15);    -- SONG_SPELLCASTING_TIME: -15%
+
+-- Amini Gapette +2
+INSERT INTO `item_mods` VALUES (23095,1,118);     -- DEF: 118
+INSERT INTO `item_mods` VALUES (23095,2,54);      -- HP: 54
+INSERT INTO `item_mods` VALUES (23095,8,26);      -- STR: 26
+INSERT INTO `item_mods` VALUES (23095,9,28);      -- DEX: 28
+INSERT INTO `item_mods` VALUES (23095,10,16);     -- VIT: 16
+INSERT INTO `item_mods` VALUES (23095,11,35);     -- AGI: 35
+INSERT INTO `item_mods` VALUES (23095,12,22);     -- INT: 22
+INSERT INTO `item_mods` VALUES (23095,13,22);     -- MND: 22
+INSERT INTO `item_mods` VALUES (23095,14,17);     -- CHR: 17
+INSERT INTO `item_mods` VALUES (23095,24,61);     -- RATT: 61
+INSERT INTO `item_mods` VALUES (23095,25,51);     -- ACC: 51
+INSERT INTO `item_mods` VALUES (23095,26,51);     -- RACC: 51
+INSERT INTO `item_mods` VALUES (23095,29,6);      -- MDEF: 6
+INSERT INTO `item_mods` VALUES (23095,30,51);     -- MACC: 51
+INSERT INTO `item_mods` VALUES (23095,31,99);     -- MEVA: 99
+INSERT INTO `item_mods` VALUES (23095,68,87);     -- EVA: 87
+INSERT INTO `item_mods` VALUES (23095,160,-1000); -- DMG: -10
+INSERT INTO `item_mods` VALUES (23095,289,13);    -- SUBTLE_BLOW: 13
+INSERT INTO `item_mods` VALUES (23095,365,8);     -- SNAP_SHOT: 8
+INSERT INTO `item_mods` VALUES (23095,384,800);   -- HASTE_GEAR: 8%
+-- TODO: ENMITY: "Double Shot" -56. Exceeds ENMITY cap by being calculated in an additional step at the end
+
+-- Kasuga Kabuto +2
+INSERT INTO `item_mods` VALUES (23096,1,134);    -- DEF: 134
+INSERT INTO `item_mods` VALUES (23096,2,63);     -- HP: 63
+INSERT INTO `item_mods` VALUES (23096,8,31);     -- STR: 31
+INSERT INTO `item_mods` VALUES (23096,9,29);     -- DEX: 29
+INSERT INTO `item_mods` VALUES (23096,10,30);    -- VIT: 30
+INSERT INTO `item_mods` VALUES (23096,11,25);    -- AGI: 25
+INSERT INTO `item_mods` VALUES (23096,12,21);    -- INT: 21
+INSERT INTO `item_mods` VALUES (23096,13,21);    -- MND: 21
+INSERT INTO `item_mods` VALUES (23096,14,21);    -- CHR: 21
+INSERT INTO `item_mods` VALUES (23096,23,51);    -- ATT: 51
+INSERT INTO `item_mods` VALUES (23096,25,51);    -- ACC: 51
+INSERT INTO `item_mods` VALUES (23096,29,5);     -- MDEF: 5
+INSERT INTO `item_mods` VALUES (23096,30,51);    -- MACC: 51
+INSERT INTO `item_mods` VALUES (23096,31,88);    -- MEVA: 88
+INSERT INTO `item_mods` VALUES (23096,68,76);    -- EVA: 76
+INSERT INTO `item_mods` VALUES (23096,73,11);    -- STORETP: 11
+INSERT INTO `item_mods` VALUES (23096,160,-900); -- DMG: -9%
+INSERT INTO `item_mods` VALUES (23096,384,700);  -- HASTE_GEAR: 7%
+
 -- Pummelers Lorica +2
 INSERT INTO `item_mods` VALUES (23107,1,153);   -- DEF: 153
 INSERT INTO `item_mods` VALUES (23107,2,91);    -- HP: 91

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -741,6 +741,12 @@ INSERT INTO `item_mods_pet` VALUES (23080,370,4,3); -- Automaton: REGEN: 4
 -- Bagua Galero +2
 INSERT INTO `item_mods_pet` VALUES (23083,2,500,8); -- Luopan - HP: 500
 
+-- Nukumi Cabasset +2
+INSERT INTO `item_mods_pet` VALUES (23093,25,51,0); -- Pet: ACC: 51
+INSERT INTO `item_mods_pet` VALUES (23093,26,51,0); -- Pet: RACC: 51
+INSERT INTO `item_mods_pet` VALUES (23093,30,51,0); -- Pet: MACC: 51
+-- TODO: Monster correlation effects +26
+
 -- Vishap Mail +2
 INSERT INTO `item_mods_pet` VALUES (23120,370,10,2); -- Wyvern - REGEN: 10
 


### PR DESCRIPTION
Also add missing latents and pet mods.

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds missing mods to items 23092-23096. It also adds the missing pet mods (except for one, which is noted, as no mods seems to exist for that case) and one latent mod.

## Steps to test these changes

As GM, !add item 23092|23093|23094|23095|23096
Make sure proper attributes change. 