### PR TITLE
[magian] Add support for day/weather condition to trials

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -5785,6 +5785,7 @@ xi.item =
     PUGILISTS                       = 19327,
     SIMIAN_FISTS                    = 19328,
     MANTIS                          = 19329,
+    CATS_CLAWS                      = 19331,
     PEELER                          = 19332,
     RENEGADE                        = 19333,
     KARTIKA                         = 19334,

--- a/scripts/enum/magian_element.lua
+++ b/scripts/enum/magian_element.lua
@@ -1,0 +1,19 @@
+xi = xi or {}
+
+-- NOTE: These values align with the optParam in the event update for a trial, and are the
+-- only groupings supported by the message.  These enum is to be used in the dayWeather
+-- condition for trial data.
+xi.magianElement =
+{
+    FIRE      = 0,
+    ICE       = 1,
+    WIND      = 2,
+    EARTH     = 3,
+    THUNDER   = 4,
+    WATER     = 5,
+    LIGHT     = 6,
+    DARK      = 7,
+    ANY_LIGHT = 8,
+    ANY_DARK  = 9,
+    ANY       = 10,
+}

--- a/scripts/globals/magian_data.lua
+++ b/scripts/globals/magian_data.lua
@@ -500,6 +500,26 @@ xi.magian.trials =
         },
     },
 
+    [82] =
+    {
+        previousTrial = 0,
+        requiredItem  =
+        {
+            itemId = xi.item.PUGILISTS,
+        },
+
+        textOffset     = 99,
+        dayWeather     = xi.magianElement.ANY,
+        defeatMob      = true,
+        mobSuperFamily = set{ 56 },
+        numRequired    = 50,
+
+        rewardItem =
+        {
+            itemId = xi.item.CATS_CLAWS,
+        },
+    },
+
     [150] = -- Serpopard Ishtar x3
     {
         previousTrial = 0,

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2204,13 +2204,14 @@ void CLuaBaseEntity::updateNPCHideTime(sol::object const& seconds)
  *  Example : if player:getWeather() == xi.weather.WIND then
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getWeather()
+uint8 CLuaBaseEntity::getWeather(sol::object const& ignoreScholar)
 {
     WEATHER weather = WEATHER_NONE;
 
     if (m_PBaseEntity->objtype & TYPE_PC || m_PBaseEntity->objtype & TYPE_MOB)
     {
-        weather = battleutils::GetWeather(static_cast<CBattleEntity*>(m_PBaseEntity), false);
+        bool ignoreScholarWeather = ignoreScholar.is<bool>() ? ignoreScholar.as<bool>() : false;
+        weather                   = battleutils::GetWeather(static_cast<CBattleEntity*>(m_PBaseEntity), ignoreScholarWeather);
     }
     else
     {

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -150,7 +150,7 @@ public:
     void hideNPC(sol::object const& seconds);                           // hide an NPC
     void updateNPCHideTime(sol::object const& seconds);                 // Updates the length of time a NPC remains hidden, if shorter than the original hide time.
 
-    uint8 getWeather();
+    uint8 getWeather(sol::object const& ignoreScholar);
     void  setWeather(uint8 weatherType); // Set Weather condition (GM COMMAND)
 
     // PC Instructions

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -114,10 +114,6 @@ global_objects=(
     TPMOD_ATTACK
     TPMOD_DURATION
 
-    INT_BASED
-    CHR_BASED
-    MND_BASED
-
     ForceCrash
     BuildString
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds `dayWeather` and `mobSuperFamily` conditions and support for Magian Trials
* Adds Trial 82 to demonstrate usage for the new conditions
* Adds `ignoreScholar` optional parameter to CLuaBaseEntity::getWeather
* Removes 3 global exceptions in Lua CI that were unused

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Accept Trial 82, test with valid and invalid mobs (Skeletons are valid), also change weather requirement between various element groups

<!-- Clear and detailed steps to test your changes here -->
