### PR TITLE
DRG AF Quest: "Knight Stalker" NM Spawn Fix

### DIFF
--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
@@ -17,11 +17,11 @@ entity.onTrigger = function(player, npc)
         player:getCharVar('KnightStalker_Progress') == 4 and
         player:getCharVar('KnightStalker_Kill') == 0 and
         player:getMainJob() == xi.job.DRG and
-        pet and
-        pet:getPetID() == xi.petId.WYVERN and
-        npcUtil.popFromQM(player, npc, { ID.mob.CLEUVARION_M_RESOAIX, ID.mob.ROMPAULION_S_CITALLE }, { hide = 0, claim = false })
+        pet ~= nil and
+        pet:getPetID() == xi.petId.WYVERN
     then
         player:messageSpecial(ID.text.SOME_SORT_OF_CEREMONY + 1) -- Your wyvern reacts violently to this spot!
+        npcUtil.popFromQM(player, npc, { ID.mob.CLEUVARION_M_RESOAIX, ID.mob.ROMPAULION_S_CITALLE }, { hide = 0, claim = false })
     elseif player:getCharVar('KnightStalker_Kill') == 1 then
         player:startEvent(67)
     else

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm15.lua
@@ -18,10 +18,10 @@ entity.onTrigger = function(player, npc)
         player:getCharVar('KnightStalker_Kill') == 0 and
         player:getMainJob() == xi.job.DRG and
         pet ~= nil and
-        pet:getPetID() == xi.petId.WYVERN
+        pet:getPetID() == xi.petId.WYVERN and
+        npcUtil.popFromQM(player, npc, { ID.mob.CLEUVARION_M_RESOAIX, ID.mob.ROMPAULION_S_CITALLE }, { hide = 0, claim = false })
     then
         player:messageSpecial(ID.text.SOME_SORT_OF_CEREMONY + 1) -- Your wyvern reacts violently to this spot!
-        npcUtil.popFromQM(player, npc, { ID.mob.CLEUVARION_M_RESOAIX, ID.mob.ROMPAULION_S_CITALLE }, { hide = 0, claim = false })
     elseif player:getCharVar('KnightStalker_Kill') == 1 then
         player:startEvent(67)
     else


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows the 2 shadow NMs to spawn when:

- Player is DRG.
- Player has pet wyvern out and alive.

Previously the NMs would not spawn as intended, stopping quest progression.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- `!changejob drg 75' and flag quest (or comment out the charvar quest requirements).
- `!gotoid 17428862`
- Use Call Wyvern.
- Click on ??? (ID:17428862).
- See that 2 shadow NMs spawn.

Note: In future, this quest should be converted to the new framework but this will allow the quest to function in the mean time.
<!-- Clear and detailed steps to test your changes here -->
