### PR TITLE
Colibri Spell Mimic Fix

### DIFF
--- a/scripts/mixins/families/colibri_mimic.lua
+++ b/scripts/mixins/families/colibri_mimic.lua
@@ -19,7 +19,7 @@ g_mixins.families = g_mixins.families or {}
 g_mixins.families.colibri_mimic = function(colibriMob)
     colibriMob:addListener('MAGIC_TAKE', 'COLIBRI_MIMIC_MAGIC_TAKE', function(target, caster, spell)
         if
-            target:getAnimationSub() == 0 and
+            target:getAnimationSub() == 4 and
             spell:tookEffect() and
             (caster:isPC() or caster:isPet()) and
             (spell:getSpellGroup() ~= xi.magic.spellGroup.BLUE or target:getLocalVar('[colibri]reflect_blue_magic') == 1)
@@ -48,12 +48,12 @@ g_mixins.families.colibri_mimic = function(colibriMob)
                 mob:setLocalVar('[colibri]spellToMimic', 0)
                 mob:setLocalVar('[colibri]castWindow', 0)
                 mob:setLocalVar('[colibri]castTime', 0)
-                mob:setAnimationSub(0)
+                mob:setAnimationSub(4)
             elseif spellToMimic == 0 or osTime > castWindow then
                 mob:setLocalVar('[colibri]spellToMimic', 0)
                 mob:setLocalVar('[colibri]castWindow', 0)
                 mob:setLocalVar('[colibri]castTime', 0)
-                mob:setAnimationSub(0)
+                mob:setAnimationSub(4)
             end
         end
     end)
@@ -63,7 +63,7 @@ g_mixins.families.colibri_mimic = function(colibriMob)
         mob:setLocalVar('[colibri]castWindow', 0)
         mob:setLocalVar('[colibri]castTime', 0)
         if mob:getAnimationSub() == 1 then
-            mob:setAnimationSub(0)
+            mob:setAnimationSub(4)
         end
     end)
 end


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjusts the animation sub checks in the colibri mimic mixin to match the mob's default animation sub from the database.
This lets the Colibri pass the animation sub checks so that it can reflect magic back at players.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- `!gotoid 16990300` (Example Colibri with mixin applied)
- Cast a spell on the Colibri
- See that it changes its animationsub (Beak open) and reflects the spell shortly after. Colibri should also return to closed beak state(animation sub 4)


<!-- Clear and detailed steps to test your changes here -->
