### PR TITLE
Adjust drop list for Burning Hakutaku Eye

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -7706,6 +7706,7 @@ INSERT INTO `mob_droplist` VALUES (941,0,0,1000,1061,30); -- Sacrarium Chest Key
 -- ZoneID: 195 - Gazer
 INSERT INTO `mob_droplist` VALUES (942,0,0,1000,914,770); -- Vial Of Mercury (77.0%)
 INSERT INTO `mob_droplist` VALUES (942,0,0,1000,939,660); -- Hecteyes Eye (66.0%)
+INSERT INTO `mob_droplist` VALUES (942,0,0,1000,1289,70); -- Burning Hakutaku Eye (7.0%)
 
 -- ZoneID: 149 - Geezard
 INSERT INTO `mob_droplist` VALUES (943,0,0,1000,926,@ALWAYS); -- Lizard Tail (Always, 100%)


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/Burning_Hakutaku_Eye

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Player on my server brought up that Burning Hakutaku Eye is not obtainable. The Thousand Eyes it dropped from in King Ramperre's Tomb were replaced with high level versions in 2022. Burning Hakutaku Eye was then added to the droplist of Gazers in Eldieme.

https://ffxiclopedia.fandom.com/wiki/Burning_Hakutaku_Eye
https://forum.square-enix.com/ffxi/threads/60247-Some-items-are-now-unobtainable-because-monsters-were-removed-from-the-game

I copied over the entry from the former Thousand Eyes to the Eldieme Gazers with no modifications. The droplist is also not used anywhere else but Eldieme Gazers.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

- Kill Gazers in Eldieme until a Burning Hakutaku Eye drops.

<!-- Clear and detailed steps to test your changes here -->
