### PR TITLE
[ci] Add padding check for logical operators

### DIFF
--- a/scripts/actions/abilities/scavenge.lua
+++ b/scripts/actions/abilities/scavenge.lua
@@ -33,8 +33,8 @@ abilityObject.onUseAbility = function(player, target, ability, action)
         end
 
     else
-        local bonuses        = (player:getMod(xi.mod.SCAVENGE_EFFECT)  + player:getMerit(xi.merit.SCAVENGE_EFFECT)) / 100
-        local arrowsToReturn = math.floor(math.floor(player:getLocalVar('ArrowsUsed')  % 10000) * (player:getMainLvl() / 200 + bonuses))
+        local bonuses        = (player:getMod(xi.mod.SCAVENGE_EFFECT) + player:getMerit(xi.merit.SCAVENGE_EFFECT)) / 100
+        local arrowsToReturn = math.floor(math.floor(player:getLocalVar('ArrowsUsed') % 10000) * (player:getMainLvl() / 200 + bonuses))
         local playerID       = target:getID()
 
         if arrowsToReturn == 0 then

--- a/scripts/commands/addlights.lua
+++ b/scripts/commands/addlights.lua
@@ -43,7 +43,7 @@ commandObj.onTrigger = function(player, light, amount, target)
 
     local selectedLight = tostring(light)
 
-    if lightType[selectedLight] == nil  or selectedLight == nil then
+    if lightType[selectedLight] == nil or selectedLight == nil then
         error(player, 'Invalid light type.\nValid light types: pearl, azure, ruby, amber, gold, silver, ebon')
         return
     end

--- a/scripts/events/egg_hunt_egg-stravaganza.lua
+++ b/scripts/events/egg_hunt_egg-stravaganza.lua
@@ -722,8 +722,8 @@ local getSecondInitial = function(player, option)
 
     for _, member in pairs(party) do
         if
-            member             ~= nil and              -- Player exists
-            player:getName()   ~= member:getName() and -- Different player
+            member ~= nil and                          -- Player exists
+            player:getName() ~= member:getName() and   -- Different player
             player:getZoneID() == member:getZoneID()   -- Same zone
         then
             local playerName   = member:getName()
@@ -797,9 +797,9 @@ xi.events.eggHunt.onTrigger = function(player, npc)
 
         for _, member in pairs(party) do
             if
-                member             ~= nil and                -- Player exists
-                player:getName()   ~= member:getName() and -- Different player
-                player:getZoneID() == member:getZoneID()   -- Same zone
+                member ~= nil and                        -- Player exists
+                player:getName() ~= member:getName() and -- Different player
+                player:getZoneID() == member:getZoneID() -- Same zone
             then
                 local initial = string.sub(member:getName(), 1, 1)
                 local letter = string.byte(string.lower(initial)) - 97

--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -152,7 +152,7 @@ xi.chocoboRaising.getPlayerRidingSpeedAndTime = function(player)
     local endRank = numberToRank(chocoState.endurance)
 
     local outSpeed = utils.clamp(baseSpeed + (strRank * xi.chocoboRaising.ridingSpeedPerRank), 0, xi.chocoboRaising.ridingSpeedCap)
-    local outTime  = utils.clamp(baseTime  + (endRank * xi.chocoboRaising.ridingTimePerRank), 0, xi.chocoboRaising.ridingTimeCap)
+    local outTime  = utils.clamp(baseTime + (endRank * xi.chocoboRaising.ridingTimePerRank), 0, xi.chocoboRaising.ridingTimeCap)
 
     return outSpeed, outTime
 end

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -110,11 +110,11 @@ xi.garrison.getAllyInfo = function(zoneID, zoneData, nationID)
     local pos         = xi.garrison.zoneData[zoneID].pos
 
     if
-        allyName    == nil or
+        allyName == nil or
         allyGroupId == nil or
-        allyLooks   == nil or
-        #allyLooks  == 0   or
-        pos         == nil
+        allyLooks == nil or
+        #allyLooks == 0 or
+        pos == nil
     then
         local zone = GetZone(zoneID)
         debugLogf('Garrison NPC data missing for %s level %u (%s).', nationName[nationID], zoneData.levelCap, zone:getName())

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -26,7 +26,7 @@ local function applyRuneEnhancement(effectType, player)
     local jobPointBonus = player:getJobPointLevel(xi.jp.RUNE_ENCHANTMENT_EFFECT) -- 1 more elemental resistance per level for a maximum total of 20
 
     -- see https://www.bg-wiki.com/ffxi/Category:Rune
-    local power = math.floor((49 * runLevel / 99) + 5.5) + meritBonus  + jobPointBonus
+    local power = math.floor((49 * runLevel / 99) + 5.5) + meritBonus + jobPointBonus
     player:addStatusEffect(effectType, power, 0, 300)
 end
 
@@ -457,7 +457,7 @@ end
 -- see https://www.bg-wiki.com/ffxi/Battuta
 xi.job_utils.rune_fencer.useBattuta = function(player, target, ability, action)
     local meritPower      = player:getMerit(xi.merit.MERIT_BATTUTA) -- power is 4
-    local modBonus        = (100 + (player:getMod(xi.mod.ENHANCES_BATTUTA) *  meritPower / 4)) / 100
+    local modBonus        = (100 + (player:getMod(xi.mod.ENHANCES_BATTUTA) * meritPower / 4)) / 100
     local inquartataPower = 36 + meritPower -- base 36% + merit power of 4% each = max of 56%
     local spikesPower     = 6 + meritPower  -- damage is static 26 per rune barring SDT/MDT at 5/5 Battuta merits. 6 + 4*5 = 26.
     local runeCount       = target:getActiveRuneCount()
@@ -505,7 +505,7 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
 end
 
 local function calculateSwipeLungeDamage(player, target, skillModifier, gearBonus, numHits, multipliers)
-    local damage = math.floor(skillModifier *  (0.50 + 0.25 * numHits  + (gearBonus / 100)))
+    local damage = math.floor(skillModifier * (0.50 + 0.25 * numHits + (gearBonus / 100)))
 
     damage = damage + player:getMod(xi.mod.MAGIC_DAMAGE) -- add mdamage to base damage
 

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -490,7 +490,7 @@ xi.mobskills.mobBreathMove = function(mob, target, percent, base, element, cap)
 
     local globalDamageTaken   = target:getMod(xi.mod.DMG) / 10000          -- Mod is base 10000
     local breathDamageTaken   = target:getMod(xi.mod.DMGBREATH) / 10000    -- Mod is base 10000
-    local combinedDamageTaken = 1.0 +  utils.clamp(breathDamageTaken + globalDamageTaken, -0.5, 0.5) -- The combination of regular "Damage Taken" and "Breath Damage Taken" caps at 50%. There is no BDTII known as of yet.
+    local combinedDamageTaken = 1.0 + utils.clamp(breathDamageTaken + globalDamageTaken, -0.5, 0.5) -- The combination of regular "Damage Taken" and "Breath Damage Taken" caps at 50%. There is no BDTII known as of yet.
 
     damage = math.floor(damage * combinedDamageTaken)
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -693,7 +693,7 @@ xi.spells.damage.calculateNinFutaeBonus = function(caster, skillType)
         skillType == xi.skill.NINJUTSU and
         caster:hasStatusEffect(xi.effect.FUTAE)
     then
-        ninFutaeBonus = (150  + caster:getJobPointLevel(xi.jp.FUTAE_EFFECT) * 5) / 100
+        ninFutaeBonus = (150 + caster:getJobPointLevel(xi.jp.FUTAE_EFFECT) * 5) / 100
         caster:delStatusEffect(xi.effect.FUTAE)
     end
 

--- a/scripts/missions/windurst/8_1_Vain.lua
+++ b/scripts/missions/windurst/8_1_Vain.lua
@@ -117,7 +117,7 @@ mission.sections =
             onEventUpdate =
             {
                 [903] = function(player, csid, option, npc)
-                    if player:getZPos() >  -331 then
+                    if player:getZPos() > -331 then
                         player:updateEvent(0, 0, 0, 0, 0, 3)
                     else
                         player:updateEvent(0, 0, 0, 0, 0, 2)
@@ -397,7 +397,7 @@ mission.sections =
             onEventUpdate =
             {
                 [4] = function(player, csid, option, npc)
-                    if player:getZPos() <  75 then
+                    if player:getZPos() < 75 then
                         player:updateEvent(0, 0, 0, 0, 0, 1)
                     else
                         player:updateEvent(0, 0, 0, 0, 0, 2)

--- a/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
+++ b/scripts/missions/wotg/04_The_Queen_of_the_Dance.lua
@@ -21,8 +21,8 @@ mission.sections =
     -- 0: Try to enter without a ticket
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 0
-            and xi.wotg.helpers.meetsMission4Reqs(player)
+            return currentMission == mission.missionId and missionStatus == 0 and
+                xi.wotg.helpers.meetsMission4Reqs(player)
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =

--- a/scripts/mixins/families/hpemde.lua
+++ b/scripts/mixins/families/hpemde.lua
@@ -94,7 +94,7 @@ g_mixins.families.hpemde = function(hpemdeMob)
                 openMouth(mob)
             elseif
                 mob:getAnimationSub() == 3 and
-                mob:getHP() <  mob:getLocalVar('[hpemde]closeMouthHP')
+                mob:getHP() < mob:getLocalVar('[hpemde]closeMouthHP')
             then
                 closeMouth(mob)
             end

--- a/scripts/quests/ahtUrhgan/Promotion_Superior_Private.lua
+++ b/scripts/quests/ahtUrhgan/Promotion_Superior_Private.lua
@@ -15,8 +15,8 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == QUEST_AVAILABLE and player:getCharVar('AssaultPromotion') >= 25
-            and player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.PROMOTION_PRIVATE_FIRST_CLASS) == QUEST_COMPLETED
+            return status == QUEST_AVAILABLE and player:getCharVar('AssaultPromotion') >= 25 and
+            player:getQuestStatus(xi.quest.log_id.AHT_URHGAN, xi.quest.id.ahtUrhgan.PROMOTION_PRIVATE_FIRST_CLASS) == QUEST_COMPLETED
         end,
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =

--- a/scripts/quests/crystalWar/Downward_Helix.lua
+++ b/scripts/quests/crystalWar/Downward_Helix.lua
@@ -2,8 +2,8 @@
 -- Downward Helix
 -----------------------------------
 -- !addquest 7 33
--- Erlene                : !pos 376.936 -39.999 17.914 175
--- Indescript Markings   : !pos 322 24 113 98
+-- Erlene              : !pos 376.936 -39.999 17.914 175
+-- Indescript Markings : !pos 322 24 113 98
 -----------------------------------
 
 local quest = Quest:new(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.DOWNWARD_HELIX)
@@ -18,7 +18,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == QUEST_AVAILABLE and
-                xi.quest.getVar(player, xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.ON_SABBATICAL, 'Timer') <= VanadielUniqueDay()  and
+                xi.quest.getVar(player, xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.ON_SABBATICAL, 'Timer') <= VanadielUniqueDay() and
                 player:getMainJob() == xi.job.SCH and
                 player:getMainLvl() >= xi.settings.main.AF2_QUEST_LEVEL
         end,

--- a/scripts/zones/Bastok-Jeuno_Airship/npcs/Dereck.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/npcs/Dereck.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
 
     local message = ID.text.WILL_REACH_BASTOK
 
-    if vHour ==  0 then
+    if vHour == 0 then
         if vMin >= 13 then
             vHour = 3
             message = ID.text.WILL_REACH_JEUNO

--- a/scripts/zones/Bastok-Jeuno_Airship/npcs/Michele.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/npcs/Michele.lua
@@ -19,7 +19,7 @@ entity.onTrigger = function(player, npc)
 
     local message = ID.text.WILL_REACH_BASTOK
 
-    if vHour ==  0 then
+    if vHour == 0 then
         if vMin >= 13 then
             vHour = 3
             message = ID.text.WILL_REACH_JEUNO

--- a/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Lamepaue.lua
@@ -129,9 +129,9 @@ entity.onTrigger = function(player, npc)
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
     if
-        bastokMissions   == 0xFFFFFFFE and
-        bastokQuests     == 0xFFFFFFFE and
-        otherQuests      == 0xFFFFFFFE and
+        bastokMissions == 0xFFFFFFFE and
+        bastokQuests == 0xFFFFFFFE and
+        otherQuests == 0xFFFFFFFE and
         seekersOfAdoulin == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/DE_Quasilumin.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/DE_Quasilumin.lua
@@ -237,7 +237,7 @@ entity.onMobRoam = function(mob)
 
     for _, doorID in ipairs(escort.doors) do
         local npc = GetNPCByID(doorID)
-        if doorID ~= openedDoor and  mob:checkDistance(npc) <= 8 then
+        if doorID ~= openedDoor and mob:checkDistance(npc) <= 8 then
             npc:setAnimation(xi.animation.OPEN_DOOR)
             mob:setLocalVar('opened_door', doorID)
         end

--- a/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_MR.lua
+++ b/scripts/zones/LaLoff_Amphitheater/mobs/Ark_Angel_MR.lua
@@ -35,7 +35,7 @@ entity.onMobEngaged = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    if mob:getLocalVar('Charm') == 0 and mob:getHPP() <  50 then
+    if mob:getLocalVar('Charm') == 0 and mob:getHPP() < 50 then
         mob:useMobAbility(710)
         mob:setLocalVar('Charm', 1)
     end

--- a/scripts/zones/Norg/npcs/Magephaud.lua
+++ b/scripts/zones/Norg/npcs/Magephaud.lua
@@ -27,7 +27,7 @@ entity.onTrigger = function(player, npc)
         nFame >= 2
     then
         player:startEvent(116, xi.item.GOLD_BEASTCOIN)  -- Quest start - you have tonberry kills?! I got yo back ^.-
-    elseif player:getCharVar('EveryonesGrudgeStarted')  == 1 then
+    elseif player:getCharVar('EveryonesGrudgeStarted') == 1 then
         player:startEvent(117, xi.item.GOLD_BEASTCOIN)
     elseif player:getQuestStatus(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.EVERYONES_GRUDGE) == QUEST_COMPLETED then
         player:startEvent(119)  -- After completion cs

--- a/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Durogg.lua
@@ -30,8 +30,8 @@ entity.onTrigger = function(player, npc)
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
     if
-        addonScenarios    == 0xFFFFFFFE and
-        seekersOfAdoulin  == 0xFFFFFFFE
+        addonScenarios == 0xFFFFFFFE and
+        seekersOfAdoulin == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.
     end

--- a/scripts/zones/Port_Bastok/npcs/Dalba.lua
+++ b/scripts/zones/Port_Bastok/npcs/Dalba.lua
@@ -146,11 +146,11 @@ entity.onTrigger = function(player, npc)
     -- Determine if any cutscenes are available for the player.
     local gil = player:getGil()
     if
-        bastokMissions    == 0xFFFFFFFE and
-        bastokQuests      == 0xFFFFFFFE and
-        otherQuests       == 0xFFFFFFFE and
+        bastokMissions == 0xFFFFFFFE and
+        bastokQuests == 0xFFFFFFFE and
+        otherQuests == 0xFFFFFFFE and
         promathiaMissions == 0xFFFFFFFE and
-        addonScenarios    == 0xFFFFFFFE
+        addonScenarios == 0xFFFFFFFE
     then -- Player has no cutscenes available to be viewed.
         gil = 0 -- Setting gil to a value less than 10(cost) will trigger the appropriate response from this npc.
     end

--- a/scripts/zones/Rolanberry_Fields/npcs/Saarlan.lua
+++ b/scripts/zones/Rolanberry_Fields/npcs/Saarlan.lua
@@ -59,12 +59,14 @@ entity.onTrigger = function(player, npc)
     elseif player:getCharVar('LegionStatus') == 1 then
         local maximus = player:hasKeyItem(xi.ki.LEGION_TOME_PAGE_MAXIMUS) and 1 or 0
         local minimus = player:hasKeyItem(xi.ki.LEGION_TOME_PAGE_MINIMUS) and 1 or 0
+
+        -- TODO: Table these and iterate
         local title =
-            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_LOFTY)   and  1 or 0) +
-            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_MIRED)   and  2 or 0) +
-            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_SOARING) and  4 or 0) +
-            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_VEILED)  and  8 or 0) +
-            (player:hasTitle(xi.title.LEGENDARY_LEGIONNAIRE)     and 16 or 0)
+            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_LOFTY) and 1 or 0) +
+            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_MIRED) and 2 or 0) +
+            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_SOARING) and 4 or 0) +
+            (player:hasTitle(xi.title.SUBJUGATOR_OF_THE_VEILED) and 8 or 0) +
+            (player:hasTitle(xi.title.LEGENDARY_LEGIONNAIRE) and 16 or 0)
 
         player:startEvent(8005, 0, title, maximus, player:getCurrency('legion_point'), minimus)
     end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
@@ -20,7 +20,7 @@ entity.onTrigger = function(player, npc)
     local zPos = player:getZPos()
     local mythrilDoorCheck = player:getCharVar('SSG_MythrilDoor')
 
-    if xPos >= 40  and zPos >= 15 then
+    if xPos >= 40 and zPos >= 15 then
         if mythrilDoorCheck == 0 then -- Door has never been checked
             player:messageSpecial(ID.text.FIRST_CHECK)
             player:setCharVar('SSG_MythrilDoor', 1)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm2.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm2.lua
@@ -8,11 +8,11 @@ local ID = zones[xi.zone.YUHTUNGA_JUNGLE]
 local entity = {}
 
 local function isFightInProgress()
-    return GetMobByID(ID.mob.NASUS_OFFSET):isAlive()
-        or GetMobByID(ID.mob.NASUS_OFFSET + 1):isAlive()
-        or GetMobByID(ID.mob.NASUS_OFFSET + 2):isAlive()
-        or GetMobByID(ID.mob.NASUS_OFFSET + 3):isAlive()
-        or GetMobByID(ID.mob.NASUS_OFFSET + 4):isAlive()
+    return GetMobByID(ID.mob.NASUS_OFFSET):isAlive() or
+        GetMobByID(ID.mob.NASUS_OFFSET + 1):isAlive() or
+        GetMobByID(ID.mob.NASUS_OFFSET + 2):isAlive() or
+        GetMobByID(ID.mob.NASUS_OFFSET + 3):isAlive() or
+        GetMobByID(ID.mob.NASUS_OFFSET + 4):isAlive()
 end
 
 local function spawnNMs(player)

--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -145,6 +145,14 @@ class LuaStyleCheck:
         for _ in re.finditer(",[^ \n]", line):
             self.error("Multiple parameters used without an appropriate following space or newline")
 
+    def check_conditional_padding(self, line):
+        # \s{2,}(and|or)(\s{1,}|$)|\s{1,}(and|or)\s{2,}
+
+        # lstrip current line to prevent false-positives from indentation
+        code_line = line.lstrip()
+        if re.search("\s{2,}(and|or)(\s{1,}|$)|\s{1,}(and|or)\s{2,}", code_line):
+            self.error("Multiple spaces detected around logical operator.")
+
     def check_semicolon(self, line):
         """No semi-colons should be used in Lua scripts.
 
@@ -200,6 +208,13 @@ class LuaStyleCheck:
 
         for _ in re.finditer("[^ =~\<\>][\=\+\*\~\/\>\<]|[\=\+\*\/\>\<][^ =\n]", line):
             self.error("Operator or comparator without padding detected at end of line")
+
+        # For now, ignore all content in single-line tables to allow for formatting
+        stripped_line = line.lstrip()
+        brace_regex = regex.compile("\{(([^\}\{]+)|(?R))*+\}", re.S)
+        stripped_line = regex.sub(brace_regex, "", stripped_line)
+        for _ in re.finditer("\s{2,}(>=|<=|==|~=|\+|\*|%|>|<|\^)|(>=|<=|==|~=|\+|\*|%|>|<|\^)\s{2,}", stripped_line):
+            self.error("Excessive padding detected around operator or comparator.")
 
     def check_parentheses_padding(self, line):
         """Parentheses should have padding prior to opening and after closing, but must not contain padding after
@@ -357,7 +372,7 @@ class LuaStyleCheck:
                     self.error("Standard comment block lines of '-' should be 35 characters.")
 
                 # Remove in-line comments
-                code_line = re.sub("(?=--)(.*?)(?=\r\n|\n)", "", line)
+                code_line = re.sub("(?=--)(.*?)(?=\r\n|\n)", "", line).rstrip()
 
                 # Before replacing strings, see if we're only using single quotes and check requires
                 if re.search(r"\"[^\"']*\"(?=(?:[^']*'[^']*')*[^']*$)", code_line):
@@ -377,6 +392,7 @@ class LuaStyleCheck:
                 self.check_variable_names(code_line)
                 self.check_semicolon(code_line)
                 self.check_indentation(code_line)
+                self.check_conditional_padding(code_line)
                 self.check_operator_padding(code_line)
                 self.check_parentheses_padding(code_line)
                 self.check_no_single_line_functions(code_line)
@@ -401,6 +417,15 @@ class LuaStyleCheck:
 
                 self.check_deprecated_functions(code_line)
                 self.check_function_parameters(code_line)
+
+                # Multiple line conditions can occur in several places.  Check every individual
+                # line to ensure none start with and|or, or end with not
+                stripped_line = code_line.strip()
+                if stripped_line.startswith('and ') or stripped_line.startswith('or '):
+                    self.error('Multiline conditions should not start with and|or')
+
+                if stripped_line.endswith('not'):
+                    self.error('Multiline conditions should not end with not')
 
                 # Condition blocks/lines should not have outer parentheses
                 # Find all strings contained in parentheses: \((([^\)\(]+)|(?R))*+\)
@@ -434,15 +459,6 @@ class LuaStyleCheck:
                     # Multiline conditions
                     else:
                         in_condition = True
-
-                    # Do single line rules for condition here, space in string check is intentional to allow
-                    # and|or on its own line in some cases.
-                    stripped_line = code_line.strip()
-                    if stripped_line.startswith('and ') or stripped_line.startswith('or '):
-                        self.error('Multiline conditions should not start with and|or')
-
-                    if stripped_line.endswith('not'):
-                        self.error('Multiline conditions should not end with not')
                 
             if "DefaultActions" not in self.filename and uses_id == True and not has_id_ref:
                 self.error("ID variable is assigned but unused", suppress_line_ref = True)
@@ -480,7 +496,7 @@ elif target == 'scripts':
         total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
-    expected_errors = 72
+    expected_errors = 82
 else:
     total_errors = LuaStyleCheck(target).errcount
 

--- a/tools/ci/tests/stylecheck.lua
+++ b/tools/ci/tests/stylecheck.lua
@@ -220,3 +220,23 @@ require('scripts/zones/Bastok_Markets/IDs') -- FAIL
 -- Bad:
 -------------------------------------
 ---------------------------------
+
+this and this -- PASS
+this or this -- PASS
+this  and -- FAIL
+this and  this -- FAIL
+this  or -- FAIL
+this or  this -- FAIL
+
+local testVar = this
+    and this -- FAIL
+    or this and -- FAIL
+    this not -- FAIL
+    that
+
+x  + y -- FAIL
+x +  y -- FAIL
+x ==   y -- FAIL
+x  ~= y -- FAIL
+
+x = { x  + y } -- PASS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds checks for all lines to ensure the logical operators "and" and "or" do not contain excess padding (Note: Need to handle `not` as a special case in the future, since indented lines can start with this
* Corrects scripts failing this new check
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
CI should pass
<!-- Clear and detailed steps to test your changes here -->
