### PR TITLE
correct settings paths in comments

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1380,7 +1380,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         return
     end
 
-    -- people in alliance get no fields credit unless FOV_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
+    -- people in alliance get no fields credit unless FOV_REWARD_ALLIANCE is 1 in settings/main.lua
     if
         xi.settings.main.FOV_REWARD_ALLIANCE ~= 1 and
         regimeType == xi.regime.type.FIELDS and
@@ -1389,7 +1389,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         return
     end
 
-    -- people in alliance get no grounds credit unless GOV_REWARD_ALLIANCE is 1 in scripts/globals/settings.lua
+    -- people in alliance get no grounds credit unless GOV_REWARD_ALLIANCE is 1 in settings/main.lua
     if
         xi.settings.main.GOV_REWARD_ALLIANCE ~= 1 and
         regimeType == xi.regime.type.GROUNDS and

--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -3,7 +3,7 @@
 -- Promathia 1-1
 -----------------------------------
 -- NOTE: xi.mission.id.cop.THE_RITES_OF_LIFE is set when zoning into Lower Delkfutt's Tower from Qufim
---       ENABLE_COP must be set to 1 in scripts/globals/settings.lua
+--       ENABLE_COP must be set to 1 in settings/main.lua
 -- 1. Enter Lower Delkfutt: !pos -286 -20 320 126
 -- 2. Enter Upper Jeuno:    !pos 2.2 -3.2 58.4 245
 -- 3. Talk to Monberaux:    !pos -43 0 -1 244


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
updates settings paths in comments

## Steps to test these changes
N/A no code  changes
