### PR TITLE
[LUA] Fixes self target in "!givemagianitem" command

### DIFF
--- a/scripts/commands/givemagianitem.lua
+++ b/scripts/commands/givemagianitem.lua
@@ -32,9 +32,9 @@ commandObj.onTrigger = function(player, target, trialId, isRewardItem)
         player:PrintToPlayer(string.format('Player \'%s\' does not have free space for that item!', target))
     else
         if giveRewardItem then
-            xi.magian.giveRewardItem(player, trialId)
+            xi.magian.giveRewardItem(target, trialId)
         else
-            xi.magian.giveRequiredItem(player, trialId)
+            xi.magian.giveRequiredItem(target, trialId)
         end
 
         player:PrintToPlayer(string.format('Gave player \'%s\' Item for Trial ID \'%u\' ', target, trialId))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Corrects issue with "target" in the !givemagianitem command

![image](https://github.com/LandSandBoat/server/assets/98081508/bcdd0cf5-9b5c-483a-b30c-dce0a8e6c96a)
![image](https://github.com/LandSandBoat/server/assets/98081508/91360536-6892-418a-a34b-5193fdfd921a)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Use command and give the item to a player, rather than yourself
