### PR TITLE
Move Jailer of Faith QM every 30 minutes

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -56,10 +56,6 @@ zoneObject.onInitialize = function(zone)
     qmDrk:setPos(unpack(ID.npc.QM_IXAERN_DRK_POS[qmDrkPos]))
     qmDrk:setLocalVar('hatedPlayer', 0)
 
-    -- Give the Faith ??? a random spawn
-    local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH)
-    qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
-
     -- Give Ix'DRG a random placeholder by picking one of the four groups at random, then adding a random number of 0-2 for the specific mob.
     local groups = ID.mob.AWAERN_DRG_GROUPS
     SetServerVariable('[SEA]IxAernDRG_PH', groups[math.random(1, #groups)] + math.random(0, 2))
@@ -83,14 +79,6 @@ end
 zoneObject.onGameHour = function(zone)
     local vanadielHour = VanadielHour()
     local qmDrk = GetNPCByID(ID.npc.QM_IXAERN_DRK) -- Ix'aern drk
-    local s = math.random(6, 12) -- wait time till change to next spawn pos, random 15~30 mins.
-
-    -- Jailer of Faith spawn randomiser
-    if vanadielHour % s == 0 then
-        local qmFaith = GetNPCByID(ID.npc.QM_JAILER_OF_FAITH) -- Jailer of Faith
-        qmFaith:hideNPC(60) -- Hide it for 60 seconds
-        qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)])) -- Set the new position
-    end
 
     -- Ix'DRK spawn randomiser
     if vanadielHour % 12 == 0 and qmDrk:getStatus() ~= xi.status.DISAPPEAR then -- Change ??? position every 12 hours Vana'diel time (30 mins)

--- a/scripts/zones/The_Garden_of_RuHmet/globals.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/globals.lua
@@ -1,0 +1,44 @@
+-- Zone: The_Garden_of_RuHmet (35)
+-----------------------------------
+local ID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
+-----------------------------------
+
+local moveJailerOfFaithQM
+moveJailerOfFaithQM = function(qmFaith, respawnDelay)
+    local timersRunning = qmFaith:getLocalVar('timersRunning')
+    local shouldMove = true
+
+    -- If respawnDelay is not set, this is a timer callback. An extra timer may be
+    -- running if JoF is spawned and killed before the previous timer triggers
+    if respawnDelay == nil then
+        timersRunning = timersRunning - 1
+        -- Only move the QM if the QM is not hidden and there's no other timers running
+        shouldMove = qmFaith:getStatus() ~= xi.status.DISAPPEAR and timersRunning == 0
+    end
+
+    if shouldMove then
+        -- Move to a random predefined position
+        qmFaith:setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
+
+        -- Base delay before next move is 30 minutes
+        local delay = utils.minutes(30)
+
+        if respawnDelay ~= nil then
+            -- If this was triggered from a JoF despawn, add the QM respawn time to the delay
+            delay = delay + respawnDelay
+        else
+            -- For a regular move, hide the QM for 60s and add that to the delay
+            qmFaith:hideNPC(60)
+            delay = delay + 60
+        end
+
+        timersRunning = timersRunning + 1
+        qmFaith:timer(delay * 1000, moveJailerOfFaithQM)
+    end
+
+    qmFaith:setLocalVar('timersRunning', timersRunning)
+end
+
+local ruhmetGlobal = {}
+ruhmetGlobal.moveJailerOfFaithQM = moveJailerOfFaithQM
+return ruhmetGlobal

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
@@ -3,6 +3,7 @@
 --   NM: Jailer of Faith
 -----------------------------------
 local ID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
+local ruhmetGlobal = require('scripts/zones/The_Garden_of_RuHmet/globals')
 mixins = { require('scripts/mixins/job_special') }
 -----------------------------------
 local entity = {}
@@ -33,8 +34,7 @@ entity.onMobDeath = function(mob)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Move QM to random location
-    GetNPCByID(ID.npc.QM_JAILER_OF_FAITH):setPos(unpack(ID.npc.QM_JAILER_OF_FAITH_POS[math.random(1, 5)]))
+    ruhmetGlobal.moveJailerOfFaithQM(GetNPCByID(ID.npc.QM_JAILER_OF_FAITH), xi.settings.main.FORCE_SPAWN_QM_RESET_TIME)
 end
 
 return entity

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm_jailer_of_faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm_jailer_of_faith.lua
@@ -9,8 +9,15 @@
 -- NW / Mithra tower   !pos -683 0 -340 35
 -----------------------------------
 local ID = zones[xi.zone.THE_GARDEN_OF_RUHMET]
+local ruhmetGlobal = require('scripts/zones/The_Garden_of_RuHmet/globals')
 -----------------------------------
 local entity = {}
+
+entity.onSpawn = function(npc)
+    -- Move QM with a respawnDelay of 0 to mimic as if this was
+    -- triggered from the QM reapparing after JoF despawns
+    ruhmetGlobal.moveJailerOfFaithQM(npc, 0)
+end
 
 entity.onTrade = function(player, npc, trade)
     if


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves the Jailer of Faith QM exactly every 30 minutes from when it lasts appears. The original implementation is completely broken, as mentioned in #3632. There is some slight contention on whether it moves every 30 minutes or 15 minutes, but as best as I can tell it was either updated in a patch to 30 minutes, or people are confusing the generic 15m (at the time) respawn on QMs vs the 30m move timer.

The code mimics Phantom Worm's movement code but requires some extra logic to track the case where JoF may pop and die before the timer triggers, requiring the timer to be reset (which is not particularly easy and instead I opted to just start a second timer and ignore the initial timer when it triggers). Phantom Worm conveniently ignores this problem because the move timer is so short it's not really noticeable.

I did not update Ix'Drk but if this PR goes through I can give it similar treatment.

## Steps to test these changes

5 locations for pop:
-- North / Hume tower  !pos -420 0 -157 35
-- NE / Elvaan tower   !pos -157 0 -340 35
-- SE / Galka tower    !pos -260 0 -643 35
-- SW / Tarutaru tower !pos -580 0 -644 35
-- NW / Mithra tower   !pos -683 0 -340 35

!additem 1899 for HQ euvhi organ

1. Find ??? and wait for it to hide
2. Wait 60s then find ??? in new location
3. Wait for it to hide again exactly 30m after it re-appeared (test default move logic)
4. Spawn Jailer of Faith and kill before the 30m timer triggers (test timer overlap code)
5. Make sure the QM moves exactly 30m from when the QM reappears after killing him
6. Spawn Jailer of Faith, and hold it for 30 minutes, then kill it (test timer cancel code)
7. Make sure the QM moves exactly 30m from when the QM reappears after killing him
It's much easier to test by changing the timer to 30 seconds!
