### PR TITLE
Missing augments from mini expansions

### DIFF
--- a/scripts/actions/abilities/call_beast.lua
+++ b/scripts/actions/abilities/call_beast.lua
@@ -16,6 +16,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         return xi.msg.basic.CANT_BE_USED_IN_AREA, 0
     end
 
+    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.CALL_BEAST_DELAY)))
     return 0, 0
 end
 

--- a/scripts/actions/abilities/dark_shot.lua
+++ b/scripts/actions/abilities/dark_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.DARK_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -83,6 +84,7 @@ abilityObject.onUseAbility = function(player, target, ability)
 
     local _ = player:delItem(xi.item.DARK_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
     target:updateClaim(player)
+
     return dispelledEffect
 end
 

--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.EARTH_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.FIRE_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -74,7 +75,6 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     end
 
     local _ = player:delItem(xi.item.FIRE_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-
     target:updateClaim(player)
 
     return dmg

--- a/scripts/actions/abilities/healing_waltz.lua
+++ b/scripts/actions/abilities/healing_waltz.lua
@@ -8,13 +8,14 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    local waltzCost = 200 - player:getMod(xi.mod.WALTZ_COST) * 10
     if target:getHP() == 0 then
         return xi.msg.basic.CANNOT_ON_THAT_TARG, 0
     elseif player:hasStatusEffect(xi.effect.SABER_DANCE) then
         return xi.msg.basic.UNABLE_TO_USE_JA2, 0
     elseif player:hasStatusEffect(xi.effect.TRANCE) then
         return 0, 0
-    elseif player:getTP() < 200 then
+    elseif player:getTP() < waltzCost then
         return xi.msg.basic.NOT_ENOUGH_TP, 0
     else
         --[[ Apply "Waltz Ability Delay" reduction
@@ -39,9 +40,10 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability)
+    local waltzCost = 200 - player:getMod(xi.mod.WALTZ_COST) * 10
     -- Only remove TP if the player doesn't have Trance.
     if not player:hasStatusEffect(xi.effect.TRANCE) then
-        player:delTP(200)
+        player:delTP(waltzCost)
     end
 
     local effect = target:healingWaltz()

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.ICE_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -79,7 +80,6 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     end
 
     local _ = player:delItem(xi.item.ICE_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-
     target:updateClaim(player)
 
     return dmg

--- a/scripts/actions/abilities/light_shot.lua
+++ b/scripts/actions/abilities/light_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.LIGHT_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.THUNDER_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.WATER_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -19,6 +19,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.WIND_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -367,8 +367,10 @@ xi.mod =
     STEP_ACCURACY                   = 403, -- Accuracy bonus for steps
     WALTZ_DELAY                     = 497, -- Waltz Ability Delay modifier (-1 mod is -1 second)
     SAMBA_PDURATION                 = 498, -- Samba percent duration bonus
+    WALTZ_COST                      = 139, -- Reduce Waltz cost by 5tp (50 post 1000tp scale)
     WIDESCAN                        = 340,
     BARRAGE_ACC                     = 420,
+    BARRAGE_COUNT                   = 138, -- Increases Barrage shots by 1
     ENSPELL                         = 341,
     SPIKES                          = 342,
     ENSPELL_DMG                     = 343,
@@ -852,6 +854,7 @@ xi.mod =
     COVER_DURATION                  = 967, -- Increases Cover Duration
     WYVERN_SUBJOB_TRAITS            = 974, -- Adds subjob traits to wyvern
     GARDENING_WILT_BONUS            = 975, -- Increases the number of Vanadays a plant can survive before it wilts
+    CALL_BEAST_DELAY                = 572, -- Lowers Call Beast recast
 
     WYVERN_BREATH_MACC              = 986,
     REGEN_BONUS                     = 989,
@@ -892,7 +895,7 @@ xi.mod =
     GEOMANCY_MP_NO_DEPLETE = 1037, -- Percent chance for Geomancy to cost 0 MP (GEO AF3 Sets)
 
     -- Job Point Gifts
-    SIC_READY_RECAST        = 1052, -- TODO: SIC/Ready recast reduction (seconds)
+    SIC_READY_RECAST        = 1052, -- SIC/Ready recast reduction (seconds)
     TRUE_SHOT_EFFECT        = 1053, -- TODO: True Shot Ranged Damage increase (percent)
     DEAD_AIM_EFFECT         = 1054, -- TODO: Dead Aim Critical Damage increase (percent)
     THIRD_EYE_BONUS         = 1055, -- TODO: Bonus Third Eye Evasions (count)
@@ -900,7 +903,7 @@ xi.mod =
     DRAGOON_BREATH_RECAST   = 1057, -- Restoring/Smithing Breath Recast Reduction (seconds)
     BLUE_JOB_TRAIT_BONUS    = 1058, -- TODO: Increases job traits gained from equipped blue magic (percent)
     BLUE_MAGIC_EFFECT       = 1059, -- TODO: Bonus to Attribute Value of spell (percent)
-    QUICK_DRAW_RECAST       = 1060, -- TODO: Quick Draw Charge Reduction (seconds)
+    QUICK_DRAW_RECAST       = 1060, -- Quick Draw Charge Reduction (seconds)
 
     DIG_BYPASS_FATIGUE      = 1074, -- Chocobo digging modifier found in "Blue Race Silks". Modifier works as a direct percent.
     BREATH_DMG_DEALT        = 1075, -- Breath damage dealt

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -189,6 +189,7 @@ end
 
 xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
     local waltzInfo = waltzAbilities[ability:getID()]
+    local waltzCost = waltzInfo[1] - player:getMod(xi.mod.WALTZ_COST) * 10
 
     if target:getHP() == 0 then
         return xi.msg.basic.CANNOT_ON_THAT_TARG, 0
@@ -198,7 +199,7 @@ xi.job_utils.dancer.checkWaltzAbility = function(player, target, ability)
         ability:setRecast(math.min(ability:getRecast(), 6))
 
         return 0, 0
-    elseif player:getTP() < waltzInfo[1] then
+    elseif player:getTP() < waltzCost then
         return xi.msg.basic.NOT_ENOUGH_TP, 0
     else
         local newRecast = ability:getRecast()
@@ -467,6 +468,7 @@ end
 xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
     local abilityId      = ability:getID()
     local waltzInfo      = waltzAbilities[abilityId]
+    local waltzCost      = waltzInfo[1] - player:getMod(xi.mod.WALTZ_COST) * 10
     local statMultiplier = waltzInfo[2]
     local amtCured       = 0
 
@@ -477,10 +479,10 @@ xi.job_utils.dancer.useWaltzAbility = function(player, target, ability, action)
             abilityId == xi.jobAbility.DIVINE_WALTZ_II
         then
             if player:getID() == target:getID() then
-                player:delTP(waltzInfo[1])
+                player:delTP(waltzCost)
             end
         else
-            player:delTP(waltzInfo[1])
+            player:delTP(waltzCost)
         end
     end
 

--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -404,10 +404,10 @@ INSERT INTO `augments` VALUES (320,0,357,1,0,0); -- Blood Pact ability delay -1
 INSERT INTO `augments` VALUES (321,0,346,1,0,0); -- Avatar perpetuation cost -1
 INSERT INTO `augments` VALUES (322,0,455,1,0,0); -- Song spellcasting time -1%
 INSERT INTO `augments` VALUES (323,0,519,1,0,0); -- Cure spellcasting time -1%
-INSERT INTO `augments` VALUES (324,0,0,0,0,0); -- Call Beast ability delay -1
-INSERT INTO `augments` VALUES (325,0,0,0,0,0); -- Quick Draw ability delay -1
+INSERT INTO `augments` VALUES (324,0,572,1,0,0); -- Call Beast ability delay -1
+INSERT INTO `augments` VALUES (325,0,1060,1,0,0); -- Quick Draw ability delay -1
 INSERT INTO `augments` VALUES (326,0,48,1,0,0); -- Weapon Skill Acc.+1
-INSERT INTO `augments` VALUES (327,0,0,0,0,0); -- Weapon skill damage+1% (unsure if this is all hits damage or first hit damage, leaving blank until determined)
+INSERT INTO `augments` VALUES (327,0,840,1,0,0); -- Weapon skill damage+1% "However, some sources apply to all swings of the weapon skill (like Magian Trials Weapon Skill Damage +n% weapons)" (i.e. this indicates the augment is for all hits)
 INSERT INTO `augments` VALUES (328,0,421,1,0,0); -- Crit. hit damage+1%
 INSERT INTO `augments` VALUES (329,0,374,1,0,0); -- Cure potency+1%
 INSERT INTO `augments` VALUES (330,0,491,1,0,0); -- Waltz potency+1%
@@ -416,13 +416,13 @@ INSERT INTO `augments` VALUES (332,100,175,1,0,0); -- Sklchn.dmg.+1%
 INSERT INTO `augments` VALUES (333,0,944,1,0,0); -- Conserve TP+1
 INSERT INTO `augments` VALUES (334,0,487,1,0,0); -- Magic burst dmg.+1%
 INSERT INTO `augments` VALUES (335,0,563,1,0,0); -- Mag. crit. hit dmg.+1%
-INSERT INTO `augments` VALUES (336,0,0,0,0,0); -- Sic and Ready ability delay -1
+INSERT INTO `augments` VALUES (336,0,1052,1,0,0); -- Sic and Ready ability delay -1
 INSERT INTO `augments` VALUES (337,0,833,1,0,0); -- Song recast delay -1
-INSERT INTO `augments` VALUES (338,0,0,0,0,0); -- Barrage+1 (additional shots,NOT acc)
+INSERT INTO `augments` VALUES (338,0,138,1,0,0); -- Barrage+1 (additional shots,NOT acc)
 INSERT INTO `augments` VALUES (339,5,540,1,0,0); -- Elemental Siphon+5 (value*5) Use Multiplier field.
-INSERT INTO `augments` VALUES (340,0,1076,1,0,0); -- Phantom Roll ability recast -1
+INSERT INTO `augments` VALUES (340,0,1076,1,0,0); -- Phantom Roll ability delay -1
 INSERT INTO `augments` VALUES (341,0,854,1,0,0); -- Repair potency+1%
-INSERT INTO `augments` VALUES (342,0,0,0,0,0); -- Waltz TP cost -1
+INSERT INTO `augments` VALUES (342,0,139,1,0,0); -- Waltz TP cost -1
 INSERT INTO `augments` VALUES (343,0,315,1,0,0); -- "Drain" and "Aspir" Potency +1
 
 -- 344 to 346 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
@@ -1114,7 +1114,7 @@ INSERT INTO `augments` VALUES (909,0,0,0,0,0);
 INSERT INTO `augments` VALUES (910,0,0,0,0,0);
 INSERT INTO `augments` VALUES (911,0,0,0,0,0);
 INSERT INTO `augments` VALUES (912,0,0,0,0,0);
-INSERT INTO `augments` VALUES (913,0,0,0,0,0);
+INSERT INTO `augments` VALUES (913,0,169,6,0,0); -- Movement Speed
 INSERT INTO `augments` VALUES (914,0,0,0,0,0);
 INSERT INTO `augments` VALUES (915,0,0,0,0,0);
 INSERT INTO `augments` VALUES (916,0,0,0,0,0);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1408,6 +1408,10 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
                 action.recast -= 10; // remove 10 seconds
             }
         }
+        else if (PAbility->getID() == ABILITY_READY || PAbility->getID() == ABILITY_SIC)
+        {
+            action.recast = static_cast<uint16>(std::max<int16>(0, action.recast - getMod(Mod::SIC_READY_RECAST)));
+        }
 
         action.id         = this->id;
         action.actiontype = PAbility->getActionType();

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -447,7 +447,8 @@ enum class Mod
     CHARM_CHANCE        = 391,  // extra chance to charm (light+apollo staff ect)
     FERAL_HOWL_DURATION = 503,  // +20% duration per merit when wearing augmented Monster Jackcoat +2
     JUG_LEVEL_RANGE     = 564,  // Decreases the level range of spawned jug pets. Maxes out at 2.
-    SIC_READY_RECAST    = 1052, // TODO: SIC/Ready recast reduction (seconds)
+    CALL_BEAST_DELAY    = 572,  // Lowers Call Beast recast
+    SIC_READY_RECAST    = 1052, // SIC/Ready recast reduction (seconds)
 
     // Bard
     MINNE_EFFECT           = 433,  //
@@ -483,6 +484,7 @@ enum class Mod
     RAPID_SHOT              = 359,  // Percent chance to proc rapid shot
     WIDESCAN                = 340,  //
     BARRAGE_ACC             = 420,  // Barrage accuracy
+    BARRAGE_COUNT           = 138,  // Increases Barrage shots by 1
     DOUBLE_SHOT_RATE        = 422,  // The rate that double shot can proc. Without this, the default is 40%.
     VELOCITY_SNAPSHOT_BONUS = 423,  // Increases Snapshot whilst Velocity Shot is up.
     VELOCITY_RATT_BONUS     = 424,  // Increases Ranged Attack whilst Velocity Shot is up.
@@ -556,7 +558,7 @@ enum class Mod
     ROLL_RANGE        = 528,  // Additional range for COR roll abilities.
     JOB_BONUS_CHANCE  = 542,  // Chance to apply job bonus to COR roll without having the job in the party.
     TRIPLE_SHOT_RATE  = 999,  // Percent increase to Triple Shot Rate
-    QUICK_DRAW_RECAST = 1060, // TODO: Quick Draw Charge Reduction (seconds)
+    QUICK_DRAW_RECAST = 1060, // Quick Draw Charge Reduction (seconds)
 
     DMG_REFLECT            = 316,  // Tracks totals
     ROLL_ROGUES            = 317,  // Tracks totals
@@ -632,6 +634,7 @@ enum class Mod
     SAMBA_PDURATION          = 498,  // Samba percent duration bonus
     REVERSE_FLOURISH_EFFECT  = 836,  // Reverse Flourish effect in tenths of squared term multiplier
     MAX_FINISHING_MOVE_BONUS = 988,  // Increases the maximum number of finishing moves that may be stored
+    WALTZ_COST               = 139,  // Reduce Waltz cost by 5tp (50 post 1000tp scale)
     STEP_TP_CONSUMED         = 1077, // Modifies the amount of TP consumed when using steps
 
     // Scholar

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4627,6 +4627,8 @@ namespace battleutils
             shotCount += 7;
         }
 
+        shotCount += PChar->getMod(Mod::BARRAGE_COUNT);
+
         // make sure we have enough ammo for all these shots
         CItemWeapon* PAmmo = (CItemWeapon*)PChar->getEquip(SLOT_AMMO);
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing augments defined in the Tenshodo Treasure Coffer rewards:

- Call beast recast reduction
- Sic/Ready recast reduction
- Quick Draw recast reduction
- Waltz cost reduction
- Barrage shot count increase
- Phantom recast reduction
- WS total dmg increase

## Steps to test these changes

Set the following mods or purchase tenshodo coffer rewards and use chat commands to send the /ja twice in quick succession to see recast before and after (use `!reset` between tests for sanity's sake)

 - `CALL_BEAST_DELAY`
 - `SIC_READY_RECAST`
 - `QUICK_DRAW_RECAST`
 - `PHANTOM_RECAST`

Set `waltz_cost` mod to X and see waltzes cost X*10 tp less

Set `BARRAGE_COUNT` and trust that you're getting extra potential hits