### PR TITLE
[core] Improve map_cleanup for hung sessions in multiprocess

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1084,45 +1084,102 @@ int32 map_cleanup(time_point tick, CTaskMgr::CTask* PTask)
             {
                 if (PChar != nullptr)
                 {
-                    if (map_session_data->shuttingDown == 0)
+                    // Check if the PChar current zone is on this server
+                    CZone* PZone    = nullptr;
+                    bool   otherMap = false;
+
+                    // Get zone if available
+                    if (PChar->loc.zone && PChar->loc.zone->GetID() && (g_PZoneList.find(PChar->loc.zone->GetID()) != g_PZoneList.end()))
                     {
-                        // [Alliance] fix to stop server crashing:
-                        // if a party within an alliance only has 1 char (that char will be party leader)
-                        // if char then disconnects we need to tell the server about the alliance change
-                        if (PChar->PParty != nullptr && PChar->PParty->m_PAlliance != nullptr && PChar->PParty->GetLeader() == PChar)
+                        PZone = PChar->loc.zone;
+                    }
+
+                    // if PChar->loc.zone != null, maybe we didn't receive 0x00D, check accounts_sessions
+                    if (PZone)
+                    {
+                        const char* fmtQuery = "select server_addr, server_port from accounts_sessions WHERE charid = %u";
+                        sql->Query(fmtQuery, PChar->id);
+                        if (sql->NextRow() == SQL_SUCCESS)
                         {
-                            if (PChar->PParty->HasOnlyOneMember())
+                            uint32 server_addr = sql->GetUIntData(0);
+                            uint32 server_port = sql->GetUIntData(1);
+
+                            if (server_addr != PZone->GetIP() || server_port != PZone->GetPort())
                             {
-                                if (PChar->PParty->m_PAlliance->hasOnlyOneParty())
-                                {
-                                    PChar->PParty->m_PAlliance->dissolveAlliance();
-                                }
-                                else
-                                {
-                                    PChar->PParty->m_PAlliance->removeParty(PChar->PParty);
-                                }
+                                otherMap = true;
                             }
                         }
+                    }
 
-                        // uncharm pet if player d/c
-                        if (PChar->PPet != nullptr && PChar->PPet->objtype == TYPE_MOB)
+                    if (map_session_data->shuttingDown == 0)
+                    {
+                        if (!otherMap)
                         {
-                            petutils::DespawnPet(PChar);
+                            // [Alliance] fix to stop server crashing:
+                            // if a party within an alliance only has 1 char (that char will be party leader)
+                            // if char then disconnects we need to tell the server about the alliance change
+                            if (PChar->PParty != nullptr && PChar->PParty->m_PAlliance != nullptr && PChar->PParty->GetLeader() == PChar)
+                            {
+                                if (PChar->PParty->HasOnlyOneMember())
+                                {
+                                    if (PChar->PParty->m_PAlliance->hasOnlyOneParty())
+                                    {
+                                        PChar->PParty->m_PAlliance->dissolveAlliance();
+                                    }
+                                    else
+                                    {
+                                        PChar->PParty->m_PAlliance->removeParty(PChar->PParty);
+                                    }
+                                }
+                            }
+
+                            // uncharm pet if player d/c
+                            if (PChar->PPet != nullptr && PChar->PPet->objtype == TYPE_MOB)
+                            {
+                                petutils::DespawnPet(PChar);
+                            }
+
+                            PChar->StatusEffectContainer->SaveStatusEffects(true);
+                            charutils::SaveCharPosition(PChar);
+
+                            ShowDebug("map_cleanup: %s timed out, closing session", PChar->GetName());
+
+                            PChar->status    = STATUS_TYPE::SHUTDOWN;
+                            auto basicPacket = CBasicPacket();
+                            PacketParser[0x00D](map_session_data, PChar, basicPacket);
                         }
+                        else
+                        {
+                            ShowDebug(fmt::format("Clearing map server session for player: {} in zone: {} (On other map server = {})", PChar->name, PChar->loc.zone ? PChar->loc.zone->GetName() : "None", otherMap ? "Yes" : "No"));
 
-                        PChar->StatusEffectContainer->SaveStatusEffects(true);
-                        charutils::SaveCharPosition(PChar);
+                            if (PZone)
+                            {
+                                PZone->DecreaseZoneCounter(PChar);
+                            }
 
-                        ShowDebug("map_cleanup: %s timed out, closing session", PChar->GetName());
+                            destroy_arr(map_session_data->server_packet_data);
+                            destroy(map_session_data->PChar);
+                            destroy(map_session_data);
 
-                        PChar->status    = STATUS_TYPE::SHUTDOWN;
-                        auto basicPacket = CBasicPacket();
-                        PacketParser[0x00D](map_session_data, PChar, basicPacket);
+                            map_session_list.erase(it++);
+                            continue;
+                        }
                     }
                     else
                     {
-                        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
-                        sql->Query("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
+                        if (!otherMap)
+                        {
+                            // Player session is attached to this map process and has stopped responding.
+                            map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
+                            sql->Query("DELETE FROM accounts_sessions WHERE charid = %u;", map_session_data->PChar->id);
+                        }
+
+                        ShowDebug(fmt::format("Clearing map server session for player: {} in zone: {} (On other map server = {})", PChar->name, PChar->loc.zone ? PChar->loc.zone->GetName() : "None", otherMap ? "Yes" : "No"));
+
+                        if (PZone)
+                        {
+                            PZone->DecreaseZoneCounter(PChar);
+                        }
 
                         destroy_arr(map_session_data->server_packet_data);
                         destroy(map_session_data->PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This commit adds better checking if a player has moved to another map process in multiprocess setups. This change will help with "ghosting" where accounts_sesssions is deleted when it should not yet be.

## Steps to test these changes
Breakpoint in 0x00D packet handler in packet_system.cpp, force return early after zoning into another zone process on a different IP/port and not get your session deleted early.