### PR TITLE
Correct typo in server variable names "Deastination" -> "Destination"

### DIFF
--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -16,7 +16,7 @@ zoneObject.onGameHour = function(zone)
         GetNPCByID(ID.npc.LAUGHING_BISON):setAnimationSub(0)
     end
 
-    SetServerVariable('Mhaura_Deastination', math.random(1, 100))
+    SetServerVariable('Mhaura_Destination', math.random(1, 100))
 end
 
 zoneObject.onInitialize = function(zone)
@@ -83,7 +83,7 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
         local DepartureTime = VanadielHour()
 
         if DepartureTime % 8 == 0 then
-            if GetServerVariable('Mhaura_Deastination') > 89 then
+            if GetServerVariable('Mhaura_Destination') > 89 then
                 player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES)
             else
                 player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_SELBINA)

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -10,7 +10,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onGameHour = function(zone)
-    SetServerVariable('Selbina_Deastination', math.random(1, 100))
+    SetServerVariable('Selbina_Destination', math.random(1, 100))
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
@@ -55,7 +55,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 200 then
-        if GetServerVariable('Selbina_Deastination') > 89 then
+        if GetServerVariable('Selbina_Destination') > 89 then
             player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_MHAURA_PIRATES)
         else
             player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_MHAURA)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes the name of 2 server variables. Server operators will want to delete the old ones from their database - I'm not making a migration just for this trivial matter. if they do not, they just have 2 unused dangling forever variables that do no harm. Nota  huge deal.

## Steps to test these changes
N/A no logic changes.
