### PR TITLE
Faster server variable handling

### DIFF
--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -16,7 +16,7 @@ zoneObject.onGameHour = function(zone)
         GetNPCByID(ID.npc.LAUGHING_BISON):setAnimationSub(0)
     end
 
-    SetServerVariable('Mhaura_Deastination', math.random(1, 100))
+    SetServerVariable('Mhaura_Destination', math.random(1, 100))
 end
 
 zoneObject.onInitialize = function(zone)
@@ -83,7 +83,7 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
         local DepartureTime = VanadielHour()
 
         if DepartureTime % 8 == 0 then
-            if GetServerVariable('Mhaura_Deastination') > 89 then
+            if GetServerVariable('Mhaura_Destination') > 89 then
                 player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES)
             else
                 player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_SELBINA)

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -10,7 +10,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onGameHour = function(zone)
-    SetServerVariable('Selbina_Deastination', math.random(1, 100))
+    SetServerVariable('Selbina_Destination', math.random(1, 100))
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
@@ -55,7 +55,7 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 200 then
-        if GetServerVariable('Selbina_Deastination') > 89 then
+        if GetServerVariable('Selbina_Destination') > 89 then
             player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_MHAURA_PIRATES)
         else
             player:setPos(0, 0, 0, 0, xi.zone.SHIP_BOUND_FOR_MHAURA)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This definitely DOES speed it up:
- Before: 277ms - 550ms
- After:  7ms - 329ms

Buuuuut...

The thing is that range on these bothers me. those are quite large gaps between the smallest and largest times I saw. Different sources online make conflicting claims about which operations are faster. One person claiming REPLACE statements are 32x slower than  ON DUPLICATE KEY UPDATE yet in my testing REPLACE was 200% faster, other claiming ON DUPLICATE KEY UPDATE was faster than a regular UPDATE statement, which I don't see how that can be physically possible - on duplicate attempt an insert and then when it fails, does an update. its literally the same update. REPLACE does a delete followed by an insert, and has minefields for situations involving foreign keys and auto increments.

So I did "real world testing" my dang self. You clearly can't trust what you read. And then I reached out to some experts I'm waiting to hear back from. 

I'm not sure I want to move forward wit this yet, so its in draft mode pending response from persons more experienced than myself in SQL communities.

Here's some data in the meantime:

![image](https://github.com/LandSandBoat/server/assets/6871475/8985f299-7642-4b4b-8134-53241f8a0cc2)


## Steps to test these changes
Print those sql times
https://github.com/LandSandBoat/server/blob/8f2779f9bbacb7f5e7ee8cffb3112de6508dde7c/src/common/sql.cpp#L353
```cpp
        else
        {
            ShowInfo(fmt::format("SQL query took {}ms: {}", dTime.count(), self->buf));
        }
```
and run some queries that were updated in this pr.
