### PR TITLE
Use Unique Event for tracking initial Nexus Cape received

### DIFF
--- a/scripts/enum/unique_event.lua
+++ b/scripts/enum/unique_event.lua
@@ -13,4 +13,5 @@ xi = xi or {}
 xi.uniqueEvent =
 {
     EKOKOKO_INTRODUCTION = 0,
+    RECEIVED_NEXUS_CAPE  = 1,
 }

--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -1873,7 +1873,7 @@ entity.onTrigger = function(player, npc)
                             xi.settings.main.ENABLE_ASA == 1 and
                             not player:hasItem(xi.item.NEXUS_CAPE)
 
-    local receivedNexusCape = player:getCharVar('receivedNexusCape') == 1
+    local receivedNexusCape = player:hasCompletedUniqueEvent(xi.uniqueEvent.RECEIVED_NEXUS_CAPE)
     local kiArgs = { 0, 0, 0, 0 }
 
     -- Reminder that a "true" here removes the option from the player's menu
@@ -1922,13 +1922,13 @@ entity.onEventFinish = function(player, csid, option, npc)
     if csid == 10099 then
         if
             option == 16777216 and
-            player:getCharVar('receivedNexusCape') == 0 and
+            not player:hasCompletedUniqueEvent(xi.uniqueEvent.RECEIVED_NEXUS_CAPE) and
             npcUtil.giveItem(player, xi.item.NEXUS_CAPE)
         then
-            player:setCharVar('receivedNexusCape', 1)
+            player:setUniqueEvent(xi.uniqueEvent.RECEIVED_NEXUS_CAPE)
         elseif
             option == 33554432 or
-            (option == 16777216 and player:getCharVar('receivedNexusCape') == 1)
+            (option == 16777216 and player:hasCompletedUniqueEvent(xi.uniqueEvent.RECEIVED_NEXUS_CAPE))
         then
             player:addUsedItem(xi.item.NEXUS_CAPE)
         elseif option >= 1 and option <= 20 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #4527 

Changes Nexus Cape tracking from forever charvar to unique event
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed to gameplay, charvar no longer used
<!-- Clear and detailed steps to test your changes here -->
