### PR TITLE
Deprecate getConquestTally, replace forever vars with expiring charvars

### DIFF
--- a/scripts/globals/common.lua
+++ b/scripts/globals/common.lua
@@ -68,14 +68,3 @@ function getVanaMidnight(day)
     local finaltime = curtime + (23 - VanadielHour()) * 144 + (60 - VanadielMinute()) * 2.4
     return finaltime
 end
-
------------------------------------
---  getConquestTally()
---  Returns the end of the current conquest tally
------------------------------------
-
-function getConquestTally()
-    local lastTally = (JstWeekday() + 6) % 7
-    local daysToTally = 6 - lastTally
-    return getMidnight() + (daysToTally * (60 * 60 * 24))
-end

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -981,7 +981,7 @@ local function canBuyExpRing(player, item)
     -- one exp ring per conquest tally
     if
         xi.settings.main.BYPASS_EXP_RING_ONE_PER_WEEK ~= 1 and
-        player:getCharVar('CONQUEST_RING_RECHARGE') > os.time()
+        player:getCharVar('CONQUEST_RING_RECHARGE') ~= 0
     then
         player:messageSpecial(text.CONQUEST + 60, 0, 0, item)
         player:messageSpecial(text.CONQUEST + 50, 0, 0, item)
@@ -1125,7 +1125,7 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
         if not tradeConfirmed and expRings[item] and npcUtil.tradeHas(trade, item) then
             if
                 xi.settings.main.BYPASS_EXP_RING_ONE_PER_WEEK == 1 or
-                player:getCharVar('CONQUEST_RING_RECHARGE') < os.time()
+                player:getCharVar('CONQUEST_RING_RECHARGE') == 0
             then
                 local ring = expRings[item]
 
@@ -1133,7 +1133,7 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
                     player:delCP(ring.cp)
                     player:confirmTrade()
                     player:addItem(item)
-                    player:setCharVar('CONQUEST_RING_RECHARGE', getConquestTally())
+                    player:setCharVar('CONQUEST_RING_RECHARGE', 1, NextConquestTally())
                     player:showText(npc, mOffset + 58, item, ring.cp, ring.charges) -- 'Your ring is now fully recharged.'
                 else
                     player:showText(npc, mOffset + 55, item, ring.cp) -- 'You do not have the required conquest points to recharge.'
@@ -1344,7 +1344,7 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
             npcUtil.giveKeyItem(player, outpost.ki)
             player:setCharVar('supplyQuest_started', VanadielUniqueDay())
             player:setCharVar('supplyQuest_region', region)
-            player:setCharVar('supplyQuest_fresh', getConquestTally())
+            player:setCharVar('supplyQuest_fresh', NextConquestTally())
         end
 
     -- FINISH SUPPLY RUN
@@ -1397,7 +1397,7 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
         -- make sale
         if npcUtil.giveItem(player, stock.item) then
             if option >= 32933 and option <= 32935 then
-                player:setCharVar('CONQUEST_RING_RECHARGE', getConquestTally())
+                player:setCharVar('CONQUEST_RING_RECHARGE', 1, NextConquestTally())
 
                 if player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER) then
                     player:delKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -628,7 +628,7 @@ end
 local function isPlayerOnTallyLockout(player)
     if
         xi.settings.main.GARRISON_ONCE_PER_WEEK and
-        os.time() < player:getCharVar('[Garrison]NextEntryTime')
+        player:getCharVar('[Garrison]NextEntryTime') ~= 0
     then
         return true
     end
@@ -652,7 +652,7 @@ end
 -- Stores the next valid entry time on trading player based on next conquest tally.
 local function saveTallyLockout(player)
     if xi.settings.main.GARRISON_ONCE_PER_WEEK then
-        player:setCharVar('[Garrison]NextEntryTime', getConquestTally())
+        player:setCharVar('[Garrison]NextEntryTime', 1, NextConquestTally())
     end
 end
 

--- a/scripts/quests/crystalWar/Gifts_of_the_Griffon.lua
+++ b/scripts/quests/crystalWar/Gifts_of_the_Griffon.lua
@@ -163,7 +163,7 @@ quest.sections =
                 [31] = plumeOnEventFinish,
 
                 [34] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Timer', getConquestTally())
+                    quest:setVar(player, 'Timer', NextConquestTally())
                 end,
 
                 [35] = function(player, csid, option, npc)

--- a/scripts/zones/Altar_Room/Zone.lua
+++ b/scripts/zones/Altar_Room/Zone.lua
@@ -18,7 +18,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     elseif
         player:getQuestStatus(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST) == QUEST_AVAILABLE and
         player:getMainLvl() >= 60 and
-        player:getCharVar('moraldecline') <= os.time()
+        player:getCharVar('moraldecline') == 0
     then
         cs = 46
     elseif player:getCharVar('moral') == 4 and head == 15202 then -- Yagudo Headgear
@@ -55,7 +55,7 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('moral', 1)
         player:addQuest(xi.quest.log_id.OTHER_AREAS, xi.quest.id.otherAreas.A_MORAL_MANIFEST)
     elseif csid == 46 and option == 1 then
-        player:setCharVar('moraldecline', getConquestTally())
+        player:setCharVar('moraldecline', 1, NextConquestTally())
     elseif csid == 47 then
         npcUtil.giveKeyItem(player, xi.ki.VAULT_QUIPUS)
         player:setCharVar('moral', 5)

--- a/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
@@ -353,7 +353,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             player:setCharVar('RELIC_IN_PROGRESS', 0)
             player:setCharVar('RELIC_DUE_AT', 0)
             player:setCharVar('RELIC_MAKE_ANOTHER', 0)
-            player:setCharVar('RELIC_CONQUEST_WAIT', getConquestTally())
+            player:setCharVar('RELIC_CONQUEST_WAIT', NextConquestTally())
         end
 
         -- Picking up a finished relic stage 3>4.

--- a/scripts/zones/Port_Bastok/npcs/Raifa.lua
+++ b/scripts/zones/Port_Bastok/npcs/Raifa.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
     if
         ecoStatus == 0 and
         player:getFameLevel(xi.quest.fame_area.BASTOK) >= 1 and
-        player:getCharVar('EcoReset') < os.time()
+        player:getCharVar('EcoReset') == 0
     then
         player:startEvent(278) -- Offer Eco-Warrior quest
     elseif ecoStatus == 101 then
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         })
     then
         player:delKeyItem(xi.ki.INDIGESTED_ORE)
-        player:setCharVar('EcoReset', getConquestTally())
+        player:setCharVar('EcoReset', 1, NextConquestTally())
     end
 end
 

--- a/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
@@ -375,7 +375,6 @@ entity.onTrigger = function(player, npc)
         local arg1 = 0
         for bitPos, ki in pairs(menuMetadata[1]['initialList']) do
             local entry = menuMetadata[1][ki]
-            local hasKeyItem = player:hasKeyItem(ki)
             local hasCompletedExpansion = false
             if entry.expansion == 1 then
                 hasCompletedExpansion = finishedACP
@@ -387,8 +386,8 @@ entity.onTrigger = function(player, npc)
 
             -- Reminder that "True" here means the option should be excluded from the player's menu
             if
-                not hasCompletedExpansion               or
-                hasKeyItem                              or
+                not hasCompletedExpansion or
+                player:hasKeyItem(ki) or
                 now < player:getCharVar(entry.charVar)
             then
                 arg1 = utils.mask.setBit(arg1, bitPos, true)

--- a/scripts/zones/Rabao/npcs/Irmilant.lua
+++ b/scripts/zones/Rabao/npcs/Irmilant.lua
@@ -62,7 +62,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:addQuest(xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.INDOMITABLE_SPIRIT)
     elseif csid == 132 then
         player:confirmTrade()
-        player:setCharVar('IndomitableSpiritTimer', getConquestTally()) -- Player must wait until next CQ tally
+        player:setCharVar('IndomitableSpiritTimer', NextConquestTally()) -- Player must wait until next CQ tally
     elseif csid == 134 then
         npcUtil.completeQuest(player, xi.quest.log_id.OUTLANDS, xi.quest.id.outlands.INDOMITABLE_SPIRIT, { item = 17011, fameArea = xi.quest.fame_area.SELBINA_RABAO, fame = 100, title = xi.title.INDOMITABLE_FISHER, var = 'IndomitableSpiritTimer' })
     end

--- a/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Norejaie.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
     if
         ecoStatus == 0 and
         player:getFameLevel(xi.quest.fame_area.SANDORIA) >= 1 and
-        player:getCharVar('EcoReset') < os.time()
+        player:getCharVar('EcoReset') == 0
     then
         player:startEvent(677) -- Offer Eco-Warrior quest
     elseif ecoStatus == 1 then
@@ -50,7 +50,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         })
     then
         player:delKeyItem(xi.ki.INDIGESTED_STALAGMITE)
-        player:setCharVar('EcoReset', getConquestTally())
+        player:setCharVar('EcoReset', 1, NextConquestTally())
     end
 end
 

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Thierride.lua
@@ -36,7 +36,7 @@ entity.onTrigger = function(player, npc)
         player:startEvent(335) -- Quest Active, NPC Repeats what he says but as normal 'text' instead of cutscene.
     elseif
         beansAhoy == QUEST_COMPLETED and
-        os.time() > player:getCharVar('BeansAhoy_ConquestWeek')
+        player:getCharVar('BeansAhoy_ConquestWeek') == 0
     then
         player:startEvent(342)
     elseif beansAhoy == QUEST_COMPLETED then
@@ -63,7 +63,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         else
             player:addItem(xi.item.ANGLERS_CASSOULET, 1)
             player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.ANGLERS_CASSOULET)
-            player:setCharVar('BeansAhoy_ConquestWeek', getConquestTally())
+            player:setCharVar('BeansAhoy_ConquestWeek', 1, NextConquestTally())
             if csid == 340 then
                 player:completeQuest(xi.quest.log_id.CRYSTAL_WAR, xi.quest.id.crystalWar.BEANS_AHOY)
                 player:setCharVar('BeansAhoy', 0)

--- a/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Lumomo.lua
@@ -15,7 +15,7 @@ entity.onTrigger = function(player, npc)
     if
         ecoStatus == 0 and
         player:getFameLevel(xi.quest.fame_area.WINDURST) >= 1 and
-        player:getCharVar('EcoReset') < os.time()
+        player:getCharVar('EcoReset') == 0
     then
         player:startEvent(818) -- Offer Eco-Warrior quest
     elseif ecoStatus == 201 then
@@ -51,7 +51,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         })
     then
         player:delKeyItem(xi.ki.INDIGESTED_MEAT)
-        player:setCharVar('EcoReset', getConquestTally())
+        player:setCharVar('EcoReset', 1, NextConquestTally())
     end
 end
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -172,6 +172,7 @@ namespace luautils
         lua.set_function("GetSystemTime", &luautils::GetSystemTime);
         lua.set_function("JstMidnight", &luautils::JstMidnight);
         lua.set_function("JstWeekday", &luautils::JstWeekday);
+        lua.set_function("NextConquestTally", &luautils::NextJstWeek);
         lua.set_function("NextGameTime", &luautils::NextGameTime);
         lua.set_function("NextJstDay", &luautils::JstMidnight);
         lua.set_function("NextJstWeek", &luautils::NextJstWeek);
@@ -1430,6 +1431,8 @@ namespace luautils
         // Start with the "Next" Midnight, and apply N days worth of time to it
         return nextJstMidnight + (7 - jstWeekday) * 60 * 60 * 24;
     }
+
+    // NOTE: NextConquestTally exists for clarity, and is bound to the above function
 
     uint32 VanadielMoonPhase()
     {

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -47,7 +47,6 @@ global_objects=(
     switch
     getVanaMidnight
     getMidnight
-    getConquestTally
 
     Mission
     Quest


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Removes getConquestTally in common.lua in favor of NextConquestTally in luautils (alias for NextJstWeek for clarity)
* Replaces usage of getConquestTally with the above function
* When the variable was being treated as a forever var, converts to expiring charvar

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
