### PR TITLE
Replace event cancelled magic number with utils.EVENT_CANCELLED_OPTION

### DIFF
--- a/scripts/globals/abyssea/conflux.lua
+++ b/scripts/globals/abyssea/conflux.lua
@@ -222,7 +222,7 @@ xi.conflux.confluxEventFinish = function(player, csid, option, npc)
     if
         option ~= 0 and
         option ~= 9 and -- Conflux 0 option, always free
-        option ~= 1073741824 and
+        option ~= utils.EVENT_CANCELLED_OPTION and
         utils.mask.getBit(activatedMask, confluxInfo[1])
     then
         player:delCurrency('cruor', confluxInfo[3][option])

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -526,7 +526,10 @@ xi.crafting.guildPointOnEventFinish = function(player, option, target, guildId)
         end
 
     -- HQ crystal Option.
-    elseif category == 0 and option ~= 1073741824 then
+    elseif
+        category == 0 and
+        option ~= utils.EVENT_CANCELLED_OPTION
+    then
         local crystal  = hqCrystals[bit.band(bit.rshift(option, 5), 15)]
         local quantity = bit.rshift(option, 9)
         local cost     = quantity * crystal.cost

--- a/scripts/globals/teleports/eschan_portals.lua
+++ b/scripts/globals/teleports/eschan_portals.lua
@@ -119,7 +119,7 @@ xi.escha.portals.eschanPortalEventFinish = function(player, csid, option, npc)
     elseif
         option ~= 0 and
         option ~= 4 and -- Scintillating Rhapsody usage.
-        option ~= 1073741824
+        option ~= utils.EVENT_CANCELLED_OPTION
     then
         player:delCurrency('escha_silt', portalCost)
     end

--- a/scripts/missions/wotg/54_Lest_We_Forget.lua
+++ b/scripts/missions/wotg/54_Lest_We_Forget.lua
@@ -98,7 +98,7 @@ mission.sections =
             onEventFinish =
             {
                 [39] = function(player, csid, option, npc)
-                    if option ~= 1073741824 then
+                    if option ~= utils.EVENT_CANCELLED_OPTION then
                         local ID           = zones[player:getZoneID()]
                         local firstAugSel  = bit.band(bit.rshift(option, 1), 0xF)
                         local secondAugSel = bit.band(bit.rshift(option, 17), 0xF)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20m.lua
@@ -33,7 +33,7 @@ entity.onEventFinish = function(player, csid, option, npc)
     --       here as a special case
     if
         csid == 405 and
-        option == 1073741824 and
+        option == utils.EVENT_CANCELLED_OPTION and
         player:getLocalVar('NYZUL_INSTANCE') == 1
     then
         player:startEvent(116, 2) -- This means the event was force terminated. Loop into the entrance animation.

--- a/scripts/zones/Nashmau/npcs/Kilusha.lua
+++ b/scripts/zones/Nashmau/npcs/Kilusha.lua
@@ -66,7 +66,11 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 23 then
         player:setCharVar('EinherjarIntro', 0) -- deletes CharVar set at character creation
-    elseif csid == 24 and option ~= 1073741824 and option ~= 0 then
+    elseif
+        csid == 24 and
+        option ~= utils.EVENT_CANCELLED_OPTION and
+        option ~= 0
+    then
         local kilushaItems =
         {
             [1] =  { item = xi.item.ANIMATOR_P1,          cost =  15000 },

--- a/scripts/zones/Norg/npcs/Fouvia.lua
+++ b/scripts/zones/Norg/npcs/Fouvia.lua
@@ -25,7 +25,10 @@ entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 130 and option ~= 1073741824 then -- Player didn't cancel out
+    if
+        csid == 130 and
+        option ~= utils.EVENT_CANCELLED_OPTION
+    then
         player:delGil(9800)
         player:setCharVar('ChangedWyvernName', 1)
         player:setPetName(xi.petType.WYVERN, option + 1)

--- a/scripts/zones/Nyzul_Isle/npcs/Rune_of_Transfer.lua
+++ b/scripts/zones/Nyzul_Isle/npcs/Rune_of_Transfer.lua
@@ -30,7 +30,7 @@ entity.onEventUpdate = function(player, csid, option, npc)
 
     if
         csid == 201 and
-        option ~= 1073741824 and
+        option ~= utils.EVENT_CANCELLED_OPTION and
         instance:getLocalVar('runeHandler') == 0
     then
         local chars = instance:getChars()
@@ -57,7 +57,7 @@ entity.onEventFinish = function(player, csid, option, npc)
         end
     elseif
         csid == 201 and
-        option ~= 1073741824 and
+        option ~= utils.EVENT_CANCELLED_OPTION and
         instance:getLocalVar('runeHandler') == player:getID()
     then
         -- Leave Assault

--- a/scripts/zones/Port_Jeuno/npcs/Shami.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Shami.lua
@@ -128,8 +128,11 @@ entity.onEventFinish = function(player, csid, option, npc)
     if csid == 22 then
         player:confirmTrade()
 
-    -- Retrieving Seals (Option 1073741824 is escaping out of cutscene, and we do not process on this)
-    elseif option >= 508 and option ~= 1073741824 then
+    -- Retrieving Seals
+    elseif
+        option >= 508 and
+        option ~= utils.EVENT_CANCELLED_OPTION
+    then
         local itemID, sealID, retrievedSealCount = convertSealRetrieveOption(option)
 
         if npcUtil.giveItem(player, { { itemID, retrievedSealCount } }) then

--- a/scripts/zones/RuLude_Gardens/npcs/Splintery_Chest.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Splintery_Chest.lua
@@ -74,7 +74,7 @@ entity.onEventFinish = function(player, csid, option, npc)
 
     local itemId = optionTable[option] and optionTable[option] or nil
 
-    if option ~= 1073741824 then
+    if option ~= utils.EVENT_CANCELLED_OPTION then
         if not itemId then
             -- How did you get here??
             player:PrintToPlayer('itemId or OptionID related script error!')


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces the magic number `1073741824` with `utils.EVENT_CANCELLED_OPTION`
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes to gameplay should occur.  All globals impacted already require scripts/globals/utils, and all other occurrences are loaded after globals
<!-- Clear and detailed steps to test your changes here -->
