### PR TITLE
Tenshodo Coffer minor augment tweaks

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -493,7 +493,7 @@ local keyitems =
                 augments =
                 {
                     {  25, 0, 4 }, -- Attack+1-5
-                    { 516, 0, 1 }, -- INT+1-2
+                    { 516, 0, 0 }, -- INT+1
                     {  97, 0, 4 }, -- Pet: Attack and Ranged Attack+1-5
                     {  29, 0, 4 }, -- Ranged Attack+1-5
                     { 512, 0, 1 }, -- STR+1-2
@@ -1473,7 +1473,7 @@ local keyitems =
                 augments =
                 {
                     -- assumed magic skill caps are all the same
-                    { 133, 0,  5 }, -- Magic Attack Bonus+1-2
+                    { 133, 0,  1 }, -- Magic Attack Bonus+1-2
                     {  35, 0,  1 }, -- Magic Accuracy+1-2
                     { 141, 0,  2 }, -- Conserve MP+1-3
                     {  53, 0,  4 }, -- Spell Interruption Rate-1-5%


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

No matter how thorough you think you are, there's always the chance of something falling through the cracks. While I found _a lot_ of incorrect augments, I apparently didn't find them all. After a few weeks of players repeating key items on WingsXI there have been 2 incorrect augment powers found. I'm not sure if it's all of them so up to you if we want to merge this or wait a bit longer more to be found.

https://ffxiclopedia.fandom.com/wiki/Chocobo_key

![image](https://github.com/LandSandBoat/server/assets/131182600/3f84aad2-5e0c-41ba-aaa8-fa0727144a46)

This aptus earring had a chance of +6 mab from before i did my rewrite (on WingsXI) and it slipped through the cracks :(

https://ffxiclopedia.fandom.com/wiki/Ivory_Key

![image](https://github.com/LandSandBoat/server/assets/131182600/addbdd9e-464c-41ec-b8b3-6875427f7266)

The pattern of the ivory key rewards seems to be one main stat (i.e. diamond earring is int) gets chance of +2 in that stat, but other stats are only chance of +1. 

## Steps to test these changes

Turn in Chocobo Key (`!addkeyitem xi.ki.CHOCOBO_KEY`) or Ivory key (`!addkeyitem xi.ki.IVORY_KEY`) many times and note that +6 mab and +2 int is not possible, respectively.