### PR TITLE
[Fix] unqualified call error when building with clang versions above 14

### DIFF
--- a/ext/backward/backward.hpp
+++ b/ext/backward/backward.hpp
@@ -1639,9 +1639,9 @@ private:
       return r; // damned, that's a stripped file that you got there!
     }
 
-    r->handle = move(bfd_handle);
-    r->symtab = move(symtab);
-    r->dynamic_symtab = move(dynamic_symtab);
+    r->handle = std::move(bfd_handle);
+    r->symtab = std::move(symtab);
+    r->dynamic_symtab = std::move(dynamic_symtab);
     return r;
   }
 


### PR DESCRIPTION
Resolves ```unqualified call to 'std::move'``` error when building with clang versions above 14. Tested with clang 15.0.7 & 16.0.6 on Gentoo, as well as the standard clang 14.0.0 on Ubuntu 22.04 LTS.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Build the project successfully with clang 15 and above. 

## Steps to test these changes

Compile using clang-15 or clang-16.
