### PR TITLE
Add additional NPCs from captures, default actions

### DIFF
--- a/scripts/zones/Eastern_Adoulin/DefaultActions.lua
+++ b/scripts/zones/Eastern_Adoulin/DefaultActions.lua
@@ -2,10 +2,12 @@ local ID = zones[xi.zone.EASTERN_ADOULIN]
 
 return {
     ['Door_Boarding_House'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Huss']                = { event = 503 },
     ['Irate_Destrier']      = { event = 505 },
     ['Fostaig']             = { event = 513 },
     ['Ndah_Tolohjin']       = { event = 512 },
     ['Nhili_Uvolep']        = { event = 545 },
     ['Oscairn']             = { event = 525 },
     ['Ploh_Trishbahk']      = { event = 563 },
+    ['Stavalian']           = { event = 533 },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds various NPC db entries from recent captures, and two default actions in Adoulin
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Most NPCs are from CS, but default actions for Huss and Stavalian will now work
<!-- Clear and detailed steps to test your changes here -->
