### PR TITLE
Pass wsID to xi.weaponskills.takeWeaponskillDamage()

### DIFF
--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -45,6 +45,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     }
     local calcParams =
     {
+        wsID = wsID,
         criticalHit = false,
         tpHitsLanded = 0,
         extraHitsLanded = 0,

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -190,6 +190,7 @@ xi.autows.doAutoPhysicalWeaponskill = function(attacker, target, wsID, tp, prima
     }
 
     local calcParams = {}
+    calcParams.wsID = wsID
     calcParams.weaponDamage = xi.weaponskills.getMeleeDmg(attacker, attack.weaponType, wsParams.kick)
     calcParams.attackInfo = attack
     calcParams.fSTR = utils.clamp(attacker:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT), -10, 10)
@@ -282,6 +283,7 @@ xi.autows.doAutoRangedWeaponskill = function(attacker, target, wsID, wsParams, t
 
     local calcParams =
     {
+        wsID = wsID,
         weaponDamage = { wsParams.weaponDamage or rangedDamage },
         attackInfo = attack,
         fSTR = utils.clamp(attacker:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT), -10, 10),


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Before this patch, PUP's Automaton's ranged attack and weaponskill shows 0 damage done because of an error in xi.weaponskills.takeWeaponskillDamage():

[map][error] luautils::onUseWeaponSkill: ./scripts/globals/weaponskills.lua:1012: bad argument #1 to 'lshift' (number expected, got nil)

Strangely enough, Atonement still correctly shows its damage even though it causes the same error, fix this by passing wsID to xi.weaponskills.takeWeaponskillDamage() as expected.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Unlock PUP (I had to complete the PUP unlock quest to get the Automaton to be spawned correctly)
2. !addallattachments
3. Equip Sharpshot head and body
4. Deploy Automaton to an enemy
5. Observe how its ranged attack and weaponskill shows 0 damage (target HP is still correctly diminished)
6. Apply this patch
7. Observe how its ranged attack and weaponskill now shows the damage done
<!-- Clear and detailed steps to test your changes here -->
