### PR TITLE
[core] Fix issue with set-update-style packets (CMonipulatorPacket1 & 2)

### DIFF
--- a/src/map/packets/monipulator1.cpp
+++ b/src/map/packets/monipulator1.cpp
@@ -31,13 +31,16 @@ CMonipulatorPacket1::CMonipulatorPacket1(CCharEntity* PChar)
     this->setType(0x63);
     this->setSize(0xDC);
 
+    // NOTE: These packets have to be at least partially populated, or the
+    // player will lose their abilities and get a big selection of incorrect traits.
+
+    ref<uint8>(0x04) = 0x03; // Update Type
+    ref<uint8>(0x06) = 0xD8; // Variable Data Size
+
     if (PChar->m_PMonstrosity == nullptr)
     {
         return;
     }
-
-    ref<uint8>(0x04) = 0x03; // Update Type
-    ref<uint8>(0x06) = 0xD8; // Variable Data Size
 
     ref<uint16>(0x08) = PChar->m_PMonstrosity->Species;
     ref<uint16>(0x0A) = PChar->m_PMonstrosity->Flags;

--- a/src/map/packets/monipulator2.cpp
+++ b/src/map/packets/monipulator2.cpp
@@ -30,16 +30,22 @@ CMonipulatorPacket2::CMonipulatorPacket2(CCharEntity* PChar)
     this->setType(0x63);
     this->setSize(0xB4);
 
+    // NOTE: These packets have to be at least partially populated, or the
+    // player will lose their abilities and get a big selection of incorrect traits.
+
+    std::memset(data + 4, 0, PACKET_SIZE - 4);
+
+    // NOTE: These are the equivalent entries from Monipulator1 packet
+    // ref<uint8>(0x04) = 0x03; // Update Type
+    // ref<uint8>(0x06) = 0xD8; // Variable Data Size
+
+    std::array<uint8, 3> packet2 = { 0x04, 0x00, 0xB0 };
+    std::memcpy(data + 0x04, &packet2, sizeof(packet2));
+
     if (PChar->m_PMonstrosity == nullptr)
     {
         return;
     }
-
-    std::memset(data + 4, 0, PACKET_SIZE - 4);
-
-    // TODO: What are these?
-    std::array<uint8, 3> packet2 = { 0x04, 0x00, 0xB0 };
-    std::memcpy(data + 0x04, &packet2, sizeof(packet2));
 
     // NOTE: SE added these after-the-fact, so they're not sent in Monipulator1 and they're at the end of the array!
     // Slime Level


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

```
    // NOTE: These packets have to be at least partially populated, or the
    // player will lose their abilities and get a big selection of incorrect traits.
```
