### PR TITLE
[core] Fix conquest logs / latent effects not applying when zoning into non conquest areas

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1040,26 +1040,30 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         case LATENT::NATION_CONTROL:
         {
             // player is logging in/zoning
-            if (m_POwner->loc.zone == nullptr)
+            // checking the state of the user's current zone and
+            // the destination zone in tandem seems to work.
+            if (m_POwner->loc.zone == nullptr && static_cast<uint16_t>(m_POwner->loc.destination) == 0)
             {
                 break;
             }
 
-            auto region      = m_POwner->loc.zone->GetRegionID();
+            // Grab the user's destination if they're zoning.
+            // Otherwise, grab their current zone.
+            auto region      = m_POwner->loc.zone == nullptr ? zoneutils::GetCurrentRegion(m_POwner->loc.destination) : zoneutils::GetCurrentRegion(playerZoneID);
             auto hasSignet   = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
             auto hasSanction = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
             auto hasSigil    = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL);
-
+            auto regionAlwaysOutOfControl = zoneutils::IsAlwaysOutOfNationControl(region);
             switch (latentEffect.GetConditionsValue())
             {
                 case 0:
                     // under own nation's control
-                    expression = region < REGION_TYPE::WEST_AHT_URHGAN && conquest::GetRegionOwner(region) == m_POwner->profile.nation &&
+                    expression = region < REGION_TYPE::WEST_AHT_URHGAN && (!regionAlwaysOutOfControl || conquest::GetRegionOwner(region) == m_POwner->profile.nation) &&
                                  (hasSignet || hasSanction || hasSigil);
                     break;
                 case 1:
                     // outside of own nation's control
-                    expression = region < REGION_TYPE::WEST_AHT_URHGAN && m_POwner->profile.nation != conquest::GetRegionOwner(region) &&
+                    expression = region < REGION_TYPE::WEST_AHT_URHGAN && (regionAlwaysOutOfControl || m_POwner->profile.nation != conquest::GetRegionOwner(region)) &&
                                  (hasSignet || hasSanction || hasSigil);
                     break;
             }
@@ -1067,25 +1071,28 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         }
         case LATENT::ZONE_HOME_NATION:
         {
+
             // player is logging in/zoning
-            if (m_POwner->loc.zone == nullptr)
+            // checking the state of the user's current zone and
+            // the destination zone in tandem seems to work.
+            if (m_POwner->loc.zone == nullptr && static_cast<uint16_t>(m_POwner->loc.destination) == 0)
             {
                 break;
             }
 
-            auto* PZone  = m_POwner->loc.zone;
-            auto  region = static_cast<REGION_TYPE>(latentEffect.GetConditionsValue());
+            auto  nationRegion = static_cast<REGION_TYPE>(latentEffect.GetConditionsValue());
+            auto  region = m_POwner->loc.zone == nullptr ? zoneutils::GetCurrentRegion(m_POwner->loc.destination) : zoneutils::GetCurrentRegion(playerZoneID);
 
-            switch (region)
+            switch (nationRegion)
             {
                 case REGION_TYPE::SANDORIA:
-                    expression = m_POwner->profile.nation == 0 && PZone->GetRegionID() == region;
+                    expression = m_POwner->profile.nation == 0 && region == nationRegion;
                     break;
                 case REGION_TYPE::BASTOK:
-                    expression = m_POwner->profile.nation == 1 && PZone->GetRegionID() == region;
+                    expression = m_POwner->profile.nation == 1 && region == nationRegion;
                     break;
                 case REGION_TYPE::WINDURST:
-                    expression = m_POwner->profile.nation == 2 && PZone->GetRegionID() == region;
+                    expression = m_POwner->profile.nation == 2 && region == nationRegion;
                     break;
                 default:
                     break;

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1212,4 +1212,9 @@ namespace zoneutils
         luautils::AfterZoneIn(PChar);
     }
 
+    bool IsAlwaysOutOfNationControl(REGION_TYPE region)
+    {
+        return region >= REGION_TYPE::SANDORIA && region <= REGION_TYPE::LIMBUS;
+    }
+
 }; // namespace zoneutils

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -57,8 +57,9 @@ namespace zoneutils
     CCharEntity* GetChar(uint32 id);                              // returns pointer to character by id
     CCharEntity* GetCharToUpdate(uint32 primary, uint32 ternary); // returns pointer to preferred char to update for party changes
     void         ForEachZone(const std::function<void(CZone*)>& func);
-    uint64       GetZoneIPP(uint16 zoneid);       // returns IPP for zone ID
-    bool         IsResidentialArea(CCharEntity*); // returns whether or not the area is a residential zone
+    uint64       GetZoneIPP(uint16 zoneid);                      // returns IPP for zone ID
+    bool         IsResidentialArea(CCharEntity*);                // returns whether or not the area is a residential zone
+    bool         IsAlwaysOutOfNationControl(REGION_TYPE region); // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
 
     void AfterZoneIn(CBaseEntity* PEntity); // triggers after a player has finished zoning in
 


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix latent effects from conquest related items not triggering when zoning into new areas.
Fix latent effects from conquest related items not triggering in zones that are not part of conquest, but should otherwise trigger these effects (I,e sky / sea)

## What does this pull request do? (Please be technical)

- Checks for destination region when zoning, to avoid issues with latent effects not triggering
- Fixes log spam for players in these non conquest but still latent applying regions (Fixes https://github.com/LandSandBoat/server/issues/4486)

## Steps to test these changes

Zone into a sea with items such as master caster bracelets. Check that latent applies and there are no errors logged about "Invalid conquest region passed to function"

## Special Deployment Considerations

I (@xkoredev) have smoke tested this. I am cherry picking from ASB, but **_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fix latent effects from conquest related items not triggering when zoning into new areas.
Fix latent effects from conquest related items not triggering in zones that are not part of conquest, but should otherwise trigger these effects (I,e sky / sea)

## What does this pull request do? (Please be technical)

- Checks for destination region when zoning, to avoid issues with latent effects not triggering
- Fixes log spam for players in these non conquest but still latent applying regions (Fixes https://github.com/LandSandBoat/server/issues/4486)

## Steps to test these changes

Zone into a sea with items such as master caster bracelets. Check that latent applies and there are no errors logged about "Invalid conquest region passed to function"

## Special Deployment Considerations

I (@xkoredev) have smoke tested this. I am cherry picking from ASB, but @Radegast-FFXIV will properly test this and answer any questions.
