### PR TITLE
[ci] Add job to check for blocking PR labels

### DIFF
--- a/.github/workflows/pr_checkboxes.yml
+++ b/.github/workflows/pr_checkboxes.yml
@@ -1,4 +1,4 @@
-name: "github"
+name: "pr_checkboxes"
 
 on:
   pull_request_target:

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,0 +1,32 @@
+name: "pr_labels"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  Check_Blocking_Labels:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.rest.issues.listLabelsOnIssue({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+            });
+
+            for (const idx in response.data)
+            {
+                const entry = response.data[idx];
+                if (entry.name === "hold" || entry.name === "squash")
+                {
+                    console.log("Found PR-blocking label: " + entry.name)
+                    core.setFailed("Found PR-blocking label: " + entry.name)
+                }
+            }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Once merged, we can set this new job to be required to be passing for PRs to be merge-able: which means you'll have to actively click-off the squash or hold labels before you merge. This should be enough to remind reviewers to squash if squash was asked for, and to skirt GH's limitation of not being able to block on labels 🤷 

(These won't run properly until they're merged into base, as I learned after fighting with my fork)
