### PR TITLE
[core] Fix issue with skill loading after Monstrosity changes

### DIFF
--- a/src/map/packets/monipulator2.cpp
+++ b/src/map/packets/monipulator2.cpp
@@ -33,14 +33,8 @@ CMonipulatorPacket2::CMonipulatorPacket2(CCharEntity* PChar)
     // NOTE: These packets have to be at least partially populated, or the
     // player will lose their abilities and get a big selection of incorrect traits.
 
-    std::memset(data + 4, 0, PACKET_SIZE - 4);
-
-    // NOTE: These are the equivalent entries from Monipulator1 packet
-    // ref<uint8>(0x04) = 0x03; // Update Type
-    // ref<uint8>(0x06) = 0xD8; // Variable Data Size
-
-    std::array<uint8, 3> packet2 = { 0x04, 0x00, 0xB0 };
-    std::memcpy(data + 0x04, &packet2, sizeof(packet2));
+    ref<uint8>(0x04) = 0x04; // Update Type
+    ref<uint8>(0x06) = 0xB0; // Variable Data Size
 
     if (PChar->m_PMonstrosity == nullptr)
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -125,13 +125,13 @@ namespace battleutils
 
         ret = sql->Query(fmtQuery);
 
-        // NOTE: Skip over Monstrosity, they re-use other jobs ranks
         if (ret != SQL_ERROR && sql->NumRows() != 0)
         {
-            for (uint32 x = 0; x < JOB_MON && sql->NextRow() == SQL_SUCCESS; ++x)
+            for (uint32 x = 0; x < MAX_SKILLTYPE && sql->NextRow() == SQL_SUCCESS; ++x)
             {
-                auto SkillID = std::clamp<uint8>(sql->GetIntData(0), 0, JOB_MON - 1);
+                auto SkillID = std::clamp<uint8>(sql->GetIntData(0), 0, MAX_SKILLTYPE - 1);
 
+                // NOTE: Skip over Monstrosity, they re-use other jobs ranks
                 for (uint32 y = 1; y < JOB_MON; ++y)
                 {
                     g_SkillRanks[SkillID][y] = std::clamp<uint8>(sql->GetIntData(y), 0, 11);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes some copy/paste errors while I was getting Monstrosity off the ground - magic skills menu works again, and combat skills are properly populated
