### PR TITLE
Fix monstrosity rank display, add additional passage teleport location

### DIFF
--- a/scripts/globals/monstrosity.lua
+++ b/scripts/globals/monstrosity.lua
@@ -840,6 +840,11 @@ xi.monstrosity.teleports =
         { 161,     -20,  37, 192 },
     },
 
+    [xi.zone.SOUTH_GUSTABERG] =
+    {
+        { -115, -0.136, -165, 64 },
+    },
+
     [xi.zone.VALKURM_DUNES] =
     {
         { 838, 0, -162, 64 },

--- a/src/map/packets/monipulator1.cpp
+++ b/src/map/packets/monipulator1.cpp
@@ -48,13 +48,11 @@ CMonipulatorPacket1::CMonipulatorPacket1(CCharEntity* PChar)
     int32 infamy = charutils::GetPoints(PChar, "infamy");
 
     // Monstrosity Rank (0 = Mon, 1 = NM, 2 = HNM)
-    // TODO: The ranks are listed as:
+    // The ranks are listed as:
     // 0~10,000 Mon. (Monster)
     // 10,001~20,000 NM (Notorious Monster)
     // 20,001+ HNM (Highly Notorious Monster)
-    // But this integer division gives the next rank on 10'000 etc.
-    // FIXME
-    ref<uint8>(0x0C) = static_cast<uint8>(infamy / 10000);
+    ref<uint8>(0x0C) = static_cast<uint8>(std::min(2, (infamy - 1) / 10000));
 
     // Unknown
     ref<uint8>(0x10) = 0xEC;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Adds formula for monipulator1 packet to limit between 0..2, and apply correct rank at the appropriate interval
* Adds teleport location for Odyssean Passage to South Gustaberg
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* Boundary test infamy: 0, 10000, 10001, 20000, 20001, 50000
* Use Odyssean Passage in Feretory to travel to S. Gustaberg
<!-- Clear and detailed steps to test your changes here -->
