### PR TITLE
Remove check for sleep status for wyrms prior to flight

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -57,12 +57,12 @@ entity.onMobFight = function(mob, target)
             setupFlightMode(mob, battleTime, mobHP)
 
         -- Flight mode.
+        -- TODO: Verify if sleep is broken on phase change.  Previous confirmation of
+        -- being able to sleep while mid-air.
+
         elseif
             animation == 1 and
             (mobHP / 1000 <= changeHP - 10 or battleTime - changeTime > 120) and
-            not target:hasStatusEffect(xi.effect.SLEEP_I) and
-            not target:hasStatusEffect(xi.effect.SLEEP_II) and
-            not target:hasStatusEffect(xi.effect.LULLABY) and
             mob:checkDistance(target) <= 6 -- This 2 checks are a hack until we can handle skills targeting a position and not an entity.
         then
             mob:useMobAbility(1282) -- This ability also handles animation change to 2.

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -45,12 +45,12 @@ entity.onMobFight = function(mob, target)
             setupFlightMode(mob, battleTime)
 
         -- Flight mode.
+        -- TODO: Verify if sleep is broken on phase change.  Previous confirmation of
+        -- being able to sleep while mid-air.
+
         elseif
             animation == 1 and
             battleTime - changeTime > 30 and
-            not target:hasStatusEffect(xi.effect.SLEEP_I) and
-            not target:hasStatusEffect(xi.effect.SLEEP_II) and
-            not target:hasStatusEffect(xi.effect.LULLABY) and
             mob:checkDistance(target) <= 6 -- This 2 checks are a hack until we can handle skills targeting a position and not an entity.
         then
             mob:useMobAbility(1292) -- This ability also handles animation change to 2.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #4591 

Removes sleep check on target (incorrect) prior to flight and adds TODO to verify if wake can occur on state change.  This one's gonna be a doozy to check.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
N/A
<!-- Clear and detailed steps to test your changes here -->
