### PR TITLE
Weaponskills: fix edge case allowing 9 hits

### DIFF
--- a/scripts/actions/weaponskills/ascetics_fury.lua
+++ b/scripts/actions/weaponskills/ascetics_fury.lua
@@ -16,7 +16,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0

--- a/scripts/actions/weaponskills/asuran_fists.lua
+++ b/scripts/actions/weaponskills/asuran_fists.lua
@@ -17,8 +17,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 7
-    -- This is a 8 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 8
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.1 params.dex_wsc = 0.0 params.vit_wsc = 0.1 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/backhand_blow.lua
+++ b/scripts/actions/weaponskills/backhand_blow.lua
@@ -15,7 +15,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.4 params.crit200 = 0.6 params.crit300 = 0.8

--- a/scripts/actions/weaponskills/combo.lua
+++ b/scripts/actions/weaponskills/combo.lua
@@ -15,8 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 2
-    -- This is a 3 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/dragon_kick.lua
+++ b/scripts/actions/weaponskills/dragon_kick.lua
@@ -15,8 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3.5
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/final_heaven.lua
+++ b/scripts/actions/weaponskills/final_heaven.lua
@@ -13,8 +13,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     -- number of normal hits for ws
-    params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 2
     -- stat-modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
     params.str_wsc = 0.0        params.dex_wsc = 0.0
     params.vit_wsc = 0.6        params.agi_wsc = 0.0

--- a/scripts/actions/weaponskills/final_paradise.lua
+++ b/scripts/actions/weaponskills/final_paradise.lua
@@ -13,7 +13,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 2
+    params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/howling_fist.lua
+++ b/scripts/actions/weaponskills/howling_fist.lua
@@ -17,7 +17,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 2.5 params.ftp200 = 2.75 params.ftp300 = 3
     params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/one_inch_punch.lua
+++ b/scripts/actions/weaponskills/one_inch_punch.lua
@@ -16,7 +16,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.4 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/raging_fists.lua
+++ b/scripts/actions/weaponskills/raging_fists.lua
@@ -15,8 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 4
-    -- This is a 5 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/shijin_spiral.lua
+++ b/scripts/actions/weaponskills/shijin_spiral.lua
@@ -15,8 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 4
-    -- This is a 5 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 5
     params.ftp100 = 1.0625 params.ftp200 = 1.0625 params.ftp300 = 1.0625
     params.str_wsc = 0.0 params.dex_wsc = 0.0 + (player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17) params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/shoulder_tackle.lua
+++ b/scripts/actions/weaponskills/shoulder_tackle.lua
@@ -16,7 +16,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/spinning_attack.lua
+++ b/scripts/actions/weaponskills/spinning_attack.lua
@@ -16,7 +16,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 1
-    -- This is a 2 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0

--- a/scripts/actions/weaponskills/stringing_pummel.lua
+++ b/scripts/actions/weaponskills/stringing_pummel.lua
@@ -15,8 +15,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 5
-    -- This is a 6 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 6
     params.ftp100 = 0.75 params.ftp200 = 0.75 params.ftp300 = 0.75
     params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.32 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0

--- a/scripts/actions/weaponskills/tornado_kick.lua
+++ b/scripts/actions/weaponskills/tornado_kick.lua
@@ -12,8 +12,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     -- number of normal hits for ws
-    params.numHits = 2
-    -- This is a 3 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 3
     -- stat-modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
     params.str_wsc = 0.32        params.dex_wsc = 0.0
     params.vit_wsc = 0.32        params.agi_wsc = 0.0

--- a/scripts/actions/weaponskills/victory_smite.lua
+++ b/scripts/actions/weaponskills/victory_smite.lua
@@ -20,8 +20,7 @@ local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
-    params.numHits = 3
-    -- This is a 4 hit ws but H2H ws are done in a different way, the off hand hit is been taking into account in another place
+    params.numHits = 4
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
     params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.45


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The changes in https://github.com/LandSandBoat/server/pull/1355 were useful and numerous, but swept H2H numHits under the rug. H2H weaponskills get the exact number defined in `numHits`, but have a minimum of 2 hits (things like backhand blow, etc). Conversely, dual-wield gives an extra hit to a weaponskill's `numHits`. 

Both scenarios have a hard cap of 8 total swings.

This PR adjusts H2H weaponskills to have sane `numHits` values and updates the `weaponskills.lua` functions to track actual `hitsDone` and handles the extra DW hit in `getMultiAttacks` before doing the clamp on 8 total hits.

The end result solves two issues:
- Clears up confusion of H2H weaponskill `numHits` settings
- Resolves edge case where weaponskills could get 9 hits:
  - H2H or DW weaponskills with specific procs of DA or TA. Screenshot is from before and after code changes printing out the initial hits and the extra hits:
  
![image](https://github.com/LandSandBoat/server/assets/131182600/ca61d052-96aa-4f1e-9619-cb9cd10b50d7)

some clarification on the above: 
the issue fixed here lies in a bit of a kludge/abuse of variables. This PR attempts to fix it by standardizing what is being tracked:
- `hitsDone` is updated to track the _actual_ number of hits attempted
- `numHits` is updated to track the _actual_ total number of hits for the ws (this is now properly clamped at 8 regardless of extra offhand hit or not)

## Steps to test these changes

Simplest way to test is to 
- add `printf("%u - %u", calcParams.tpHitsLanded, calcParams.hitsLanded)` before the return in `doPhysicalWeaponSkill` ([right here](https://github.com/LandSandBoat/server/blob/2b45287b702fcf2118d59588216a73267a3118c5/scripts/globals/weaponskills.lua#L766))
- give 50% DA and 50% TA to player
- run many raging fists, stringing pummel, and dancing edge (with dual wield) before and after these changes

Due to the limit being on _swings_ not _landed hits_ you won't always get 8 hits printed, but the point is that this new code tracks explicitly total `hitsDone` (really swing count) and `numHits` including extra swings from dual wield, multi attacks, and hard cap of 8.