### PR TITLE
[core] Remove usage of "*std::find_if" pattern

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -740,11 +740,19 @@ namespace petutils
         uint32 petID = PPet->m_PetID;
 
         // clang-format off
-        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
+        auto maybePetData = std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
         {
             return t->PetID == petID;
         });
         // clang-format on
+
+        if (maybePetData == g_PPetList.end())
+        {
+            ShowError(fmt::format("Could not look up pet data for id: {}", petID));
+            return;
+        }
+
+        auto* PPetData = *maybePetData;
 
         uint8 mLvl = PMaster->GetMLevel();
 
@@ -920,11 +928,19 @@ namespace petutils
         uint32 petID = PPet->m_PetID;
 
         // clang-format off
-        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
+        auto maybePetData = std::find_if(g_PPetList.begin(), g_PPetList.end(), [petID](Pet_t* t)
         {
             return t->PetID == petID;
         });
         // clang-format on
+
+        if (maybePetData == g_PPetList.end())
+        {
+            ShowError(fmt::format("Could not look up pet data for id: {}", petID));
+            return;
+        }
+
+        auto* PPetData = *maybePetData;
 
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setBaseDelay((uint16)(floor(1000.0f * (240.0f / 60.0f))));
@@ -1581,11 +1597,19 @@ namespace petutils
         }
 
         // clang-format off
-        Pet_t* PPetData = *std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)
+        auto maybePetData = std::find_if(g_PPetList.begin(), g_PPetList.end(), [PetID](Pet_t* t)
         {
             return t->PetID == PetID;
         });
         // clang-format on
+
+        if (maybePetData == g_PPetList.end())
+        {
+            ShowError(fmt::format("Could not look up pet data for id: {}", PetID));
+            return;
+        }
+
+        auto* PPetData = *maybePetData;
 
         if (PMaster->GetMJob() != JOB_DRG && PetID == PETID_WYVERN)
         {

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -341,12 +341,17 @@ namespace trustutils
 
     CTrustEntity* SpawnTrust(CCharEntity* PMaster, uint32 TrustID)
     {
+        CTrustEntity* PTrust = LoadTrust(PMaster, TrustID);
+        if (PTrust == nullptr)
+        {
+            return nullptr;
+        }
+
         if (PMaster->PParty == nullptr)
         {
             PMaster->PParty = new CParty(PMaster);
         }
 
-        CTrustEntity* PTrust = LoadTrust(PMaster, TrustID);
         PMaster->PTrusts.insert(PMaster->PTrusts.end(), PTrust);
         PMaster->StatusEffectContainer->CopyConfrontationEffect(PTrust);
         PTrust->setBattleID(PMaster->getBattleID());
@@ -374,11 +379,19 @@ namespace trustutils
         auto* PTrust = new CTrustEntity(PMaster);
 
         // clang-format off
-        auto* trustData = *std::find_if(g_PTrustList.begin(), g_PTrustList.end(), [TrustID](Trust_t* t)
+        auto maybeTrustData = std::find_if(g_PTrustList.begin(), g_PTrustList.end(), [TrustID](Trust_t* t)
         {
             return t->trustID == TrustID;
         });
         // clang-format on
+
+        if (maybeTrustData == g_PTrustList.end())
+        {
+            ShowError(fmt::format("Could not look up trust data for id: {}", TrustID));
+            return PTrust;
+        }
+
+        auto* trustData = *maybeTrustData;
 
         PTrust->loc              = PMaster->loc;
         PTrust->m_OwnerID.id     = PMaster->id;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes a pattern that immediately tries to dereference a "maybe" value - replaces them with intermediate checks and logging.
