### PR TITLE
Fix NextJstWeek function to use Monday as starting reference

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1438,11 +1438,13 @@ namespace luautils
     uint32 NextJstWeek()
     {
         TracyZoneScoped;
-        uint32 jstWeekday      = CVanaTime::getInstance()->getJstWeekDay();
+        uint32 jstWeekday      = (CVanaTime::getInstance()->getJstWeekDay() + 6) % 7;
         uint32 nextJstMidnight = CVanaTime::getInstance()->getJstMidnight();
 
         // Start with the "Next" Midnight, and apply N days worth of time to it
-        return nextJstMidnight + (7 - jstWeekday) * 60 * 60 * 24;
+        // jstWeekday is offset by 1 here, so that Monday (JST) is the reference.
+
+        return nextJstMidnight + (6 - jstWeekday) * 60 * 60 * 24;
     }
 
     // NOTE: NextConquestTally exists for clarity, and is bound to the above function


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
NextJstWeek was using Sunday as a starting point instead of monday, thus returning incorrect values when it was Sunday JST.  Uses existing calculations in other areas of code to return expected value.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* [x] Verify correct value is returned when not Sunday JST
* [x] Verify correct value is returned when Sunday JST
<!-- Clear and detailed steps to test your changes here -->
