### PR TITLE
Fix garrison check to return correct result in invalid regions

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1123,6 +1123,7 @@ xi.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTyp
 
         -- RECHARGE EXP RING
         if not tradeConfirmed and expRings[item] and npcUtil.tradeHas(trade, item) then
+            -- TODO: Can you recharge a full ring? This case would need to be handled.
             if
                 xi.settings.main.BYPASS_EXP_RING_ONE_PER_WEEK == 1 or
                 player:getCharVar('CONQUEST_RING_RECHARGE') == 0

--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -758,13 +758,14 @@ xi.garrison.onTrade = function(player, npc, trade, guardNation)
     -- Get zone information
     local zone     = player:getZone()
     local zoneID   = zone:getID()
-    local nationID = GetRegionOwner(zone:getRegionID())
     local zoneData = xi.garrison.zoneData[zoneID]
 
     -- If called outside of Garrison areas
-    if zoneData == nil then
+    if not zoneData then
         return
     end
+
+    local nationID = GetRegionOwner(zone:getRegionID())
 
     -- If info is missing, a debug message will be logged and Garrison will not begin
     if xi.garrison.getAllyInfo(zoneID, zoneData, nationID) == nil then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes #4647 

This issue above was not with variables not resetting, but when an invalid region was passed to `xi.garrison.onTrade()` (which since overseers are everywhere, will happen in cities).  Moves the zoneData check for garrison up and bails prior to trying to get the region owner.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Recharge a conquest exp ring
![image](https://github.com/LandSandBoat/server/assets/81713309/64fdf342-a7ed-42c0-b3e0-164cf21c6057)

<!-- Clear and detailed steps to test your changes here -->
