### PR TITLE
NM Olgoi-Khorkhoi's first spawn fix 

### DIFF
--- a/scripts/zones/North_Gustaberg_[S]/Zone.lua
+++ b/scripts/zones/North_Gustaberg_[S]/Zone.lua
@@ -6,6 +6,10 @@ local ID = zones[xi.zone.NORTH_GUSTABERG_S]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    local olgoikhorkhoi = zone:queryEntitiesByName('Olgoi-Khorkhoi')[1]
+    -- UpdatSpawnPoint(OLGOI_KHORKHOI:getID()) TODO: need rows in nm_spawn_points.sql
+    olgoikhorkhoi:setRespawnTime(math.random(3600, 5400))
+
     xi.helm.initZone(zone, xi.helm.type.MINING)
     xi.voidwalker.zoneOnInit(zone)
 end

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
@@ -13,7 +13,7 @@ end
 
 entity.onMobDespawn = function(mob)
     -- Sets to respawn between 90 to 120 minutes
-    UpdateNMSpawnPoint(mob:getID())
+    -- UpdateNMSpawnPoint(mob:getID()) TODO: need rows in nm_spawn_points.sql
     mob:setRespawnTime(math.random(5400, 7200))
 end
 

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Olgoi-Khorkhoi.lua
@@ -13,6 +13,7 @@ end
 
 entity.onMobDespawn = function(mob)
     -- Sets to respawn between 90 to 120 minutes
+    UpdateNMSpawnPoint(mob:getID())
     mob:setRespawnTime(math.random(5400, 7200))
 end
 

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -5298,7 +5298,7 @@ INSERT INTO `mob_groups` VALUES (23,6546,88,'Enchanted_Bones_blm',330,1,677,0,0,
 INSERT INTO `mob_groups` VALUES (24,6419,88,'Rock_Eater',330,0,1725,0,0,32,35,0);
 INSERT INTO `mob_groups` VALUES (25,1623,88,'Gloomanita',0,32,1006,0,0,42,53,0);
 INSERT INTO `mob_groups` VALUES (26,6464,88,'Fledermaus',330,2,82,0,0,45,47,0);
-INSERT INTO `mob_groups` VALUES (27,5870,88,'Olgoi-Khorkhoi',0,128,3285,4500,0,53,54,0);
+INSERT INTO `mob_groups` VALUES (27,5870,88,'Olgoi-Khorkhoi',0,0,3285,4500,0,53,54,0);
 INSERT INTO `mob_groups` VALUES (28,6239,88,'Veteran_Quadav',330,0,2578,0,0,59,63,0);
 INSERT INTO `mob_groups` VALUES (29,6237,88,'Greater_Quadav',330,0,1233,0,0,59,64,0);
 INSERT INTO `mob_groups` VALUES (30,6238,88,'Onyx_Quadav',330,0,1861,0,0,59,63,0);

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -5298,7 +5298,7 @@ INSERT INTO `mob_groups` VALUES (23,6546,88,'Enchanted_Bones_blm',330,1,677,0,0,
 INSERT INTO `mob_groups` VALUES (24,6419,88,'Rock_Eater',330,0,1725,0,0,32,35,0);
 INSERT INTO `mob_groups` VALUES (25,1623,88,'Gloomanita',0,32,1006,0,0,42,53,0);
 INSERT INTO `mob_groups` VALUES (26,6464,88,'Fledermaus',330,2,82,0,0,45,47,0);
-INSERT INTO `mob_groups` VALUES (27,5870,88,'Olgoi-Khorkhoi',0,0,3285,4500,0,53,54,0);
+INSERT INTO `mob_groups` VALUES (27,5870,88,'Olgoi-Khorkhoi',0,128,3285,4500,0,53,54,0);
 INSERT INTO `mob_groups` VALUES (28,6239,88,'Veteran_Quadav',330,0,2578,0,0,59,63,0);
 INSERT INTO `mob_groups` VALUES (29,6237,88,'Greater_Quadav',330,0,1233,0,0,59,64,0);
 INSERT INTO `mob_groups` VALUES (30,6238,88,'Onyx_Quadav',330,0,1861,0,0,59,63,0);


### PR DESCRIPTION
Retains spawntype to 128. First spawn in zone.lua and respawn in it's mob lua. Uses name to get ID instead of calling ID directly. 

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Olgoi is set to 128 for scripted spawn so working with that, I've coded within zone.lua to have a 60-90 minute respawn on initialization of the zone. Instead of calling for a mobID, I have set it to spawn entity by name to save ourselves any future trouble of any ID shifts. The correct respawn is located within it's lua when it despawns. This originally was not spawning so this fixes this. 

## Steps to test these changes

Go to North Gustaberg S, up in the northeast corner in I-4, finally see the NM pop, fight it, kill it, watch it repop for up to a couple hours later. 
