### PR TITLE
Smite job trait should be additive with other attp

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -636,6 +636,7 @@ uint16 CBattleEntity::ATT()
     TracyZoneScoped;
     // TODO: consider which weapon!
     int32 ATT    = 8 + m_modStat[Mod::ATT];
+    auto  ATTP   = m_modStat[Mod::ATTP];
     auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
     if (weapon && weapon->isTwoHanded())
     {
@@ -661,10 +662,10 @@ uint16 CBattleEntity::ATT()
         {
             ATT += GetSkill(weapon->getSkillType()) + weapon->getILvlSkill();
 
-            // Smite applies when using 2H or H2H weapons
+            // Smite applies (bonus ATTP) when using 2H or H2H weapons
             if (weapon->isTwoHanded() || weapon->isHandToHand())
             {
-                ATT += static_cast<int32>(ATT * this->getMod(Mod::SMITE) / 256.f); // Divide Smite value by 256
+                ATTP += static_cast<int32>(this->getMod(Mod::SMITE) / 256.f * 100); // Divide Smite value by 256
             }
         }
     }
@@ -672,7 +673,7 @@ uint16 CBattleEntity::ATT()
     {
         ATT += this->GetSkill(SKILL_AUTOMATON_MELEE);
     }
-    return ATT + (ATT * m_modStat[Mod::ATTP] / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_ATTP] / 100), m_modStat[Mod::FOOD_ATT_CAP]);
+    return ATT + (ATT * ATTP / 100) + std::min<int16>((ATT * m_modStat[Mod::FOOD_ATTP] / 100), m_modStat[Mod::FOOD_ATT_CAP]);
 }
 
 uint16 CBattleEntity::RATT(uint8 skill, uint16 bonusSkill)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Smite is applying a percentage increase to base attack, then applying the rest of the `ATTP` modifiers. I can’t find evidence that the current code is how it should work. Other `ATTP` adjustments work by stacking onto `ATTP`, and [this thread](https://www.ffxiah.com/forum/topic/52498/smite-atk-bonus-not-calculating-correctly-w-buffs/) seems to corroborate that line of thinking

Before changes

![image](https://github.com/LandSandBoat/server/assets/131182600/afad8fe2-3daf-4290-b010-4102f932c910)

Base before attp or smite trait

![image](https://github.com/LandSandBoat/server/assets/131182600/bb254c9a-d6ca-4451-ba21-fde6d3747944)

Smite tier iv gives `64/256 = 25%` attack, shown above: `483/387 ~ 1.248` (rounding errors)

![image](https://github.com/LandSandBoat/server/assets/131182600/b5ba0415-0082-4435-850a-d3a67c321c55)

And after giving `25% ATTP`, we see double-dipping with the attack bonus: `603/387 ~ 1.558 => 55.8%` (since `1.248 * 1.25 = 1.56`) instead of `50%`. 

After compiling changes in this PR:

![image](https://github.com/LandSandBoat/server/assets/131182600/daa389bb-1559-4b9a-bcf4-691c0fc440cf)

Base is same as before ^^

![image](https://github.com/LandSandBoat/server/assets/131182600/d0bc4634-3d69-4c68-ac7f-db26b6b3a7f2)

With smite value 64, same as before ^^

![image](https://github.com/LandSandBoat/server/assets/131182600/c16dfb24-a4b3-4651-8065-a139074ce2d8)

With additional attp as before, we get only `580`, meaning we have `580 / 387 ~ 1.49` instead of `~ 1.56`

The discrepancy of course would get more extreme the more base attack you have and higher tiers of smite.

## Steps to test these changes

Testing outlined above, but confirm ATTP is additive with value of `SMITE` mod (the value is converted to ATTP via dividing by 256) when wielding 2h weapon or h2h.