### PR TITLE
Arrapago Reef ID Fix

### DIFF
--- a/scripts/zones/Arrapago_Reef/DefaultActions.lua
+++ b/scripts/zones/Arrapago_Reef/DefaultActions.lua
@@ -1,4 +1,4 @@
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 
 return {
     ['qm1']  = { messageSpecial = ID.text.SLIMY_TOUCH },

--- a/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
@@ -3,7 +3,7 @@
 --  Mob: Draugar Servant
 -- Note: PH for Bloody Bones
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
@@ -4,7 +4,7 @@
 -- The ship for The Black Coffin Battle (TOAU-15)
 -- !pos -462 -2 -394 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/Meyaada.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Meyaada.lua
@@ -4,7 +4,7 @@
 -- Type: Assault
 -- !pos 22.446 -7.920 573.390 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/Runic_Portal.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Runic_Portal.lua
@@ -4,7 +4,7 @@
 -- Arrapago Reef Teleporter Back to Aht Urhgan Whitegate
 -- !pos 15 -7 627 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/_1ie.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_1ie.lua
@@ -3,7 +3,7 @@
 -- Door: Iron Gate (Lamian Fang Key)
 -- !pos 580 -17 120
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/_jib.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jib.lua
@@ -3,7 +3,7 @@
 -- Door: Heavy Iron Gate
 -- !pos 5 -9 579 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/_jic.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jic.lua
@@ -3,7 +3,7 @@
 -- Door: Runic Seal
 -- !pos 36 -10 620 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/qm1.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm1.lua
@@ -3,7 +3,7 @@
 --  NPC: ??? (Spawn Lil'Apkallu(ZNM T1))
 -- !pos 488 -1 166 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/qm2.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm2.lua
@@ -3,7 +3,7 @@
 --  NPC: ??? (Spawn Velionis(ZNM T1))
 -- !pos 311 -3 27 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/qm3.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm3.lua
@@ -3,7 +3,7 @@
 --  NPC: ??? (Spawn Zareehkl the Jubilant(ZNM T2))
 -- !pos 176 -4 182 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/qm4.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm4.lua
@@ -3,7 +3,7 @@
 --  NPC: ??? (Spawn Nuhn(ZNM T3))
 -- !pos -451 -7 389 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 

--- a/scripts/zones/Arrapago_Reef/npcs/qm6.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm6.lua
@@ -4,7 +4,7 @@
 -- Involved in Quests: 'Luck of the Draw', 'Equipped for All Occasions', 'Navigating the Unfriendly Seas'
 -- !pos 468.767 -12.292 111.817 54
 -----------------------------------
-local ID = zones[xi.zone.ARRAPAGO_REMNANTS]
+local ID = zones[xi.zone.ARRAPAGO_REEF]
 -----------------------------------
 local entity = {}
 


### PR DESCRIPTION
local IDs in lua scripts were referencing[xi.zone.ARRAPAGO_REMNANTS] instead of zones[xi.zone.ARRAPAGO_REEF]

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Corrects local ID requirements for the Arrapago Reef zone lua scripts.  They were incorrectly referencing Arrapago Remnants.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
