### PR TITLE
Fix Rampart effect to not include Souleater_Bonus_II

### DIFF
--- a/scripts/effects/rampart.lua
+++ b/scripts/effects/rampart.lua
@@ -17,9 +17,18 @@ effectObject.onEffectGain = function(target, effect)
         effect:setSubPower(subPower)
     end
 
-    for i = xi.mod.SLASH_SDT, xi.mod.DARK_SDT do
-        target:addMod(i, power)
-    end
+    target:addMod(xi.mod.SLASH_SDT, power)
+    target:addMod(xi.mod.PIERCE_SDT, power)
+    target:addMod(xi.mod.IMPACT_SDT, power)
+    target:addMod(xi.mod.HTH_SDT, power)
+    target:addMod(xi.mod.FIRE_SDT, power)
+    target:addMod(xi.mod.ICE_SDT, power)
+    target:addMod(xi.mod.WIND_SDT, power)
+    target:addMod(xi.mod.EARTH_SDT, power)
+    target:addMod(xi.mod.THUNDER_SDT, power)
+    target:addMod(xi.mod.WATER_SDT, power)
+    target:addMod(xi.mod.LIGHT_SDT, power)
+    target:addMod(xi.mod.DARK_SDT, power)
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -37,9 +46,18 @@ effectObject.onEffectLose = function(target, effect)
         target:delMod(xi.mod.FASTCAST, subPower)
     end
 
-    for i = xi.mod.SLASH_SDT, xi.mod.DARK_SDT do
-        target:delMod(i, power)
-    end
+    target:delMod(xi.mod.SLASH_SDT, power)
+    target:delMod(xi.mod.PIERCE_SDT, power)
+    target:delMod(xi.mod.IMPACT_SDT, power)
+    target:delMod(xi.mod.HTH_SDT, power)
+    target:delMod(xi.mod.FIRE_SDT, power)
+    target:delMod(xi.mod.ICE_SDT, power)
+    target:delMod(xi.mod.WIND_SDT, power)
+    target:delMod(xi.mod.EARTH_SDT, power)
+    target:delMod(xi.mod.THUNDER_SDT, power)
+    target:delMod(xi.mod.WATER_SDT, power)
+    target:delMod(xi.mod.LIGHT_SDT, power)
+    target:delMod(xi.mod.DARK_SDT, power)
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rampart was using a loop to add mods SLASH_SDT(Mod 49) to DARK_SDT(Mod 61), however SOULEATER_BONUS_II (Mod 53) was in the middle causing players to get a 2500(25%) mod also applied to souleater. This caused players to deal absurd damage and also kill themselves in 1 hit when they used souleater and rampart together.

We had a large discussion figuring this out in discord. Thanks to Frank, Teo, Carver, Xaver and Shoganai for the helping resolve this.

https://discord.com/channels/392903136336936960/832349765718900827/1169087176181555270

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

!changejob DRK 75
!changesjob PLD 75

Use souleater, use Rampart, auto attack/weapon skill a mod, see that you do not get 1 shot or do unexpected 5/6 digit damage.

<!-- Clear and detailed steps to test your changes here -->
