### PR TITLE
enable/disabling expansions in main.lua enables/disables appropriate zones

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,3 @@
+{
+    "workspace.maxPreload": 10000
+}

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -25,6 +25,8 @@ xi.settings.main =
     RESTRICT_CONTENT = 0,
 
     -- Enable Expansion (1 = Enabled, 0 = Disabled)
+    ENABLE_VANILLA   = 1;
+    ENABLE_ROZ       = 1;
     ENABLE_COP       = 1,
     ENABLE_TOAU      = 1,
     ENABLE_WOTG      = 1,

--- a/sql/zone_settings.sql
+++ b/sql/zone_settings.sql
@@ -1,7 +1,14 @@
+
+-- MariaDB dump 10.19  Distrib 10.11.4-MariaDB, for debian-linux-gnu (x86_64)
+--
+-- Host: localhost    Database: xidb
+-- ------------------------------------------------------
+-- Server version	10.11.4-MariaDB-1~deb12u1
+
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -17,333 +24,332 @@ DROP TABLE IF EXISTS `zone_settings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `zone_settings` (
-  `zoneid` smallint(3) unsigned NOT NULL DEFAULT '0',
-  `zonetype` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `zoneid` smallint(3) unsigned NOT NULL DEFAULT 0,
+  `zonetype` smallint(5) unsigned NOT NULL DEFAULT 0,
   `zoneip` tinytext NOT NULL,
-  `zoneport` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `zoneport` smallint(5) unsigned NOT NULL DEFAULT 0,
   `name` tinytext NOT NULL,
-  `music_day` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `music_night` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `battlesolo` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `battlemulti` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `restriction` tinyint(2) unsigned NOT NULL DEFAULT '0',
-  `tax` float(5,2) unsigned NOT NULL DEFAULT '0.00',
-  `misc` smallint(5) unsigned NOT NULL DEFAULT '0', -- ZONEMISC in zone.h
+  `music_day` smallint(3) unsigned NOT NULL DEFAULT 0,
+  `music_night` smallint(3) unsigned NOT NULL DEFAULT 0,
+  `battlesolo` smallint(3) unsigned NOT NULL DEFAULT 0,
+  `battlemulti` smallint(3) unsigned NOT NULL DEFAULT 0,
+  `restriction` tinyint(2) unsigned NOT NULL DEFAULT 0,
+  `tax` float(5,2) unsigned NOT NULL DEFAULT 0.00,
+  `misc` smallint(5) unsigned NOT NULL DEFAULT 0,
+  `updatedmesh` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `forcecarefulpathing` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `content_tag` tinytext DEFAULT NULL,
   PRIMARY KEY (`zoneid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 AVG_ROW_LENGTH=20 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=20 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `zone_settings`
 --
 
--- NOTE: To disable a zone, you must set the zoneip and zoneport to '' and 0 respectively!
-
 LOCK TABLES `zone_settings` WRITE;
 /*!40000 ALTER TABLE `zone_settings` DISABLE KEYS */;
-INSERT INTO `zone_settings` VALUES (0,1,'127.0.0.1',54230,'unknown',0,0,0,0,0,0.00,4128); -- Demonstration Area from pre-release: Has no client side mesh, use wallhack to get around.
-INSERT INTO `zone_settings` VALUES (1,2,'127.0.0.1',54230,'Phanauet_Channel',229,229,101,219,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (2,2,'127.0.0.1',54230,'Carpenters_Landing',0,0,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (3,2,'127.0.0.1',54230,'Manaclipper',229,229,101,219,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (4,2,'127.0.0.1',54230,'Bibiki_Bay',0,0,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (5,2,'127.0.0.1',54230,'Uleguerand_Range',0,0,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (6,0,'127.0.0.1',54230,'Bearclaw_Pinnacle',0,0,220,220,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (7,2,'127.0.0.1',54230,'Attohwa_Chasm',0,0,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (8,0,'127.0.0.1',54230,'Boneyard_Gully',0,0,220,220,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (9,4,'127.0.0.1',54230,'PsoXja',225,225,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (10,0,'127.0.0.1',54230,'The_Shrouded_Maw',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (11,4,'127.0.0.1',54230,'Oldton_Movalpolos',221,221,115,218,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (12,4,'127.0.0.1',54230,'Newton_Movalpolos',221,221,115,218,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (13,0,'127.0.0.1',54230,'Mine_Shaft_2716',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (14,4,'127.0.0.1',54230,'Hall_of_Transference',0,0,115,218,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (15,2,'127.0.0.1',54230,'Abyssea-Konschtat',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (16,4,'127.0.0.1',54230,'Promyvion-Holla',222,222,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (17,0,'127.0.0.1',54230,'Spire_of_Holla',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (18,4,'127.0.0.1',54230,'Promyvion-Dem',222,222,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (19,0,'127.0.0.1',54230,'Spire_of_Dem',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (20,4,'127.0.0.1',54230,'Promyvion-Mea',222,222,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (21,0,'127.0.0.1',54230,'Spire_of_Mea',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (22,4,'127.0.0.1',54230,'Promyvion-Vahzl',222,222,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (23,0,'127.0.0.1',54230,'Spire_of_Vahzl',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (24,2,'127.0.0.1',54230,'Lufaise_Meadows',230,230,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (25,2,'127.0.0.1',54230,'Misareaux_Coast',230,230,101,219,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (26,1,'127.0.0.1',54230,'Tavnazian_Safehold',245,245,245,245,0,0.00,5736);
-INSERT INTO `zone_settings` VALUES (27,4,'127.0.0.1',54230,'Phomiuna_Aqueducts',0,0,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (28,4,'127.0.0.1',54230,'Sacrarium',0,0,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (29,4,'127.0.0.1',54230,'Riverne-Site_B01',0,0,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (30,4,'127.0.0.1',54230,'Riverne-Site_A01',0,0,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (31,0,'127.0.0.1',54230,'Monarch_Linn',0,0,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (32,1,'127.0.0.1',54230,'Sealions_Den',245,245,220,220,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (33,2,'127.0.0.1',54230,'AlTaieu',233,233,101,219,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (34,4,'127.0.0.1',54230,'Grand_Palace_of_HuXzoi',0,0,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (35,4,'127.0.0.1',54230,'The_Garden_of_RuHmet',228,228,115,218,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (36,0,'127.0.0.1',54230,'Empyreal_Paradox',0,0,224,224,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (37,0,'127.0.0.1',54230,'Temenos',0,0,218,219,0,0.00,4248);
-INSERT INTO `zone_settings` VALUES (38,0,'127.0.0.1',54230,'Apollyon',0,0,218,219,0,0.00,4248);
-INSERT INTO `zone_settings` VALUES (39,128,'127.0.0.1',54230,'Dynamis-Valkurm',121,121,121,121,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (40,128,'127.0.0.1',54230,'Dynamis-Buburimu',121,121,121,121,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (41,128,'127.0.0.1',54230,'Dynamis-Qufim',121,121,121,121,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (42,128,'127.0.0.1',54230,'Dynamis-Tavnazia',121,121,121,121,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (43,2,'127.0.0.1',54230,'Diorama_Abdhaljs-Ghelsba',0,0,218,219,0,0.00,152);
-INSERT INTO `zone_settings` VALUES (44,2,'127.0.0.1',54230,'Abdhaljs_Isle-Purgonorgo',0,0,226,226,0,0.00,152);
-INSERT INTO `zone_settings` VALUES (45,2,'127.0.0.1',54230,'Abyssea-Tahrongi',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (46,2,'127.0.0.1',54230,'Open_sea_route_to_Al_Zahbi',147,147,101,138,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (47,2,'127.0.0.1',54230,'Open_sea_route_to_Mhaura',147,147,101,138,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (48,1,'127.0.0.1',54230,'Al_Zahbi',178,178,178,178,0,0.00,5784);
-INSERT INTO `zone_settings` VALUES (49,0,'127.0.0.1',54230,'none',0,0,0,0,0,0.00,0); -- Empty grid. Like z210 but with no entity or string dats at all.
-INSERT INTO `zone_settings` VALUES (50,1,'127.0.0.1',54230,'Aht_Urhgan_Whitegate',178,178,178,178,0,0.00,5640);
-INSERT INTO `zone_settings` VALUES (51,2,'127.0.0.1',54230,'Wajaom_Woodlands',149,149,101,138,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (52,2,'127.0.0.1',54230,'Bhaflau_Thickets',149,149,101,138,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (53,2,'127.0.0.1',54230,'Nashmau',175,175,175,175,0,0.00,1576);
-INSERT INTO `zone_settings` VALUES (54,2,'127.0.0.1',54230,'Arrapago_Reef',150,150,115,139,0,0.00,2201);
-INSERT INTO `zone_settings` VALUES (55,256,'127.0.0.1',54230,'Ilrusi_Atoll',0,0,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (56,256,'127.0.0.1',54230,'Periqia',0,0,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (57,0,'127.0.0.1',54230,'Talacca_Cove',0,0,143,143,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (58,2,'127.0.0.1',54230,'Silver_Sea_route_to_Nashmau',147,147,101,138,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (59,2,'127.0.0.1',54230,'Silver_Sea_route_to_Al_Zahbi',147,147,101,138,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (60,256,'127.0.0.1',54230,'The_Ashu_Talif',172,172,143,143,0,0.00,6272);
-INSERT INTO `zone_settings` VALUES (61,2,'127.0.0.1',54230,'Mount_Zhayolm',0,0,101,138,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (62,4,'127.0.0.1',54230,'Halvung',0,0,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (63,256,'127.0.0.1',54230,'Lebros_Cavern',0,0,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (64,0,'127.0.0.1',54230,'Navukgo_Execution_Chamber',0,0,143,143,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (65,4,'127.0.0.1',54230,'Mamook',0,0,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (66,256,'127.0.0.1',54230,'Mamool_Ja_Training_Grounds',0,0,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (67,0,'127.0.0.1',54230,'Jade_Sepulcher',0,0,143,143,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (68,4,'127.0.0.1',54230,'Aydeewa_Subterrane',174,174,115,139,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (69,256,'127.0.0.1',54230,'Leujaoam_Sanctum',0,0,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (70,1,'127.0.0.1',54230,'Chocobo_Circuit',176,176,176,176,0,0.00,5132); -- MISC includes chocobo flag, cant call chocobos here on retail
-INSERT INTO `zone_settings` VALUES (71,1,'127.0.0.1',54230,'The_Colosseum',0,0,139,139,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (72,4,'127.0.0.1',54230,'Alzadaal_Undersea_Ruins',0,0,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (73,256,'127.0.0.1',54230,'Zhayolm_Remnants',148,148,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (74,256,'127.0.0.1',54230,'Arrapago_Remnants',148,148,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (75,256,'127.0.0.1',54230,'Bhaflau_Remnants',148,148,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (76,256,'127.0.0.1',54230,'Silver_Sea_Remnants',148,148,115,139,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (77,256,'127.0.0.1',54230,'Nyzul_Isle',148,148,144,144,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (78,0,'127.0.0.1',54230,'Hazhalm_Testing_Grounds',0,0,0,0,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (79,2,'127.0.0.1',54230,'Caedarva_Mire',173,173,101,138,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (80,1,'127.0.0.1',54230,'Southern_San_dOria_[S]',254,254,254,254,0,0.00,4200);
-INSERT INTO `zone_settings` VALUES (81,2,'127.0.0.1',54230,'East_Ronfaure_[S]',251,251,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (82,2,'127.0.0.1',54230,'Jugner_Forest_[S]',0,0,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (83,2,'127.0.0.1',54230,'Vunkerl_Inlet_[S]',0,0,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (84,2,'127.0.0.1',54230,'Batallia_Downs_[S]',252,252,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (85,2,'127.0.0.1',54230,'La_Vaule_[S]',44,44,115,216,0,0.00,2201);
-INSERT INTO `zone_settings` VALUES (86,256,'127.0.0.1',54230,'Everbloom_Hollow',0,0,216,216,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (87,1,'127.0.0.1',54230,'Bastok_Markets_[S]',180,180,180,180,0,0.00,4200);
-INSERT INTO `zone_settings` VALUES (88,2,'127.0.0.1',54230,'North_Gustaberg_[S]',253,253,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (89,2,'127.0.0.1',54230,'Grauberg_[S]',0,0,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (90,2,'127.0.0.1',54230,'Pashhow_Marshlands_[S]',0,0,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (91,2,'127.0.0.1',54230,'Rolanberry_Fields_[S]',252,252,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (92,4,'127.0.0.1',54230,'Beadeaux_[S]',44,44,115,216,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (93,256,'127.0.0.1',54230,'Ruhotz_Silvermines',0,0,216,216,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (94,1,'127.0.0.1',54230,'Windurst_Waters_[S]',182,182,182,182,0,0.00,4200);
-INSERT INTO `zone_settings` VALUES (95,2,'127.0.0.1',54230,'West_Sarutabaruta_[S]',141,141,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (96,4,'127.0.0.1',54230,'Fort_Karugo-Narugo_[S]',0,0,101,215,0,0.00,6302);
-INSERT INTO `zone_settings` VALUES (97,2,'127.0.0.1',54230,'Meriphataud_Mountains_[S]',0,0,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (98,2,'127.0.0.1',54230,'Sauromugue_Champaign_[S]',252,252,101,215,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (99,4,'127.0.0.1',54230,'Castle_Oztroja_[S]',44,44,115,216,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (100,2,'127.0.0.1',54230,'West_Ronfaure',109,109,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (101,2,'127.0.0.1',54230,'East_Ronfaure',109,109,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (102,2,'127.0.0.1',54230,'La_Theine_Plateau',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (103,2,'127.0.0.1',54230,'Valkurm_Dunes',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (104,2,'127.0.0.1',54230,'Jugner_Forest',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (105,2,'127.0.0.1',54230,'Batallia_Downs',114,114,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (106,2,'127.0.0.1',54230,'North_Gustaberg',116,116,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (107,2,'127.0.0.1',54230,'South_Gustaberg',116,116,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (108,2,'127.0.0.1',54230,'Konschtat_Highlands',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (109,2,'127.0.0.1',54230,'Pashhow_Marshlands',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (110,2,'127.0.0.1',54230,'Rolanberry_Fields',118,118,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (111,2,'127.0.0.1',54230,'Beaucedine_Glacier',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (112,2,'127.0.0.1',54230,'Xarcabard',164,164,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (113,2,'127.0.0.1',54230,'Cape_Teriggan',0,0,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (114,2,'127.0.0.1',54230,'Eastern_Altepa_Desert',171,171,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (115,2,'127.0.0.1',54230,'West_Sarutabaruta',113,113,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (116,2,'127.0.0.1',54230,'East_Sarutabaruta',113,113,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (117,2,'127.0.0.1',54230,'Tahrongi_Canyon',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (118,2,'127.0.0.1',54230,'Buburimu_Peninsula',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (119,2,'127.0.0.1',54230,'Meriphataud_Mountains',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (120,2,'127.0.0.1',54230,'Sauromugue_Champaign',158,158,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (121,2,'127.0.0.1',54230,'The_Sanctuary_of_ZiTah',190,190,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (122,2,'127.0.0.1',54230,'RoMaeve',211,211,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (123,2,'127.0.0.1',54230,'Yuhtunga_Jungle',134,134,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (124,2,'127.0.0.1',54230,'Yhoator_Jungle',134,134,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (125,2,'127.0.0.1',54230,'Western_Altepa_Desert',171,171,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (126,2,'127.0.0.1',54230,'Qufim_Island',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (127,2,'127.0.0.1',54230,'Behemoths_Dominion',0,0,101,103,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (128,2,'127.0.0.1',54230,'Valley_of_Sorrows',0,0,101,191,0,0.00,2206);
-INSERT INTO `zone_settings` VALUES (129,256,'127.0.0.1',54230,'Ghoyus_Reverie',0,0,216,216,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (130,2,'127.0.0.1',54230,'RuAun_Gardens',210,210,101,191,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (131,4,'127.0.0.1',54230,'Mordion_Gaol',0,0,0,0,0,0.00,4096);
-INSERT INTO `zone_settings` VALUES (132,2,'127.0.0.1',54230,'Abyssea-La_Theine',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (133,0,'127.0.0.1',54230,'Outer_RaKaznar_[U2]',0,0,0,0,0,0.00,2048);
-INSERT INTO `zone_settings` VALUES (134,128,'127.0.0.1',54230,'Dynamis-Beaucedine',121,121,121,121,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (135,128,'127.0.0.1',54230,'Dynamis-Xarcabard',119,119,119,119,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (136,2,'127.0.0.1',54230,'Beaucedine_Glacier_[S]',0,0,101,215,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (137,2,'127.0.0.1',54230,'Xarcabard_[S]',42,42,101,215,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (138,4,'127.0.0.1',54230,'Castle_Zvahl_Baileys_[S]',43,43,101,215,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (139,0,'127.0.0.1',54230,'Horlais_Peak',0,0,125,125,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (140,4,'127.0.0.1',54230,'Ghelsba_Outpost',0,0,115,102,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (141,4,'127.0.0.1',54230,'Fort_Ghelsba',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (142,4,'127.0.0.1',54230,'Yughott_Grotto',0,0,115,102,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (143,4,'127.0.0.1',54230,'Palborough_Mines',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (144,0,'127.0.0.1',54230,'Waughroon_Shrine',0,0,125,125,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (145,4,'127.0.0.1',54230,'Giddeus',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (146,0,'127.0.0.1',54230,'Balgas_Dais',0,0,125,125,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (147,4,'127.0.0.1',54230,'Beadeaux',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (148,4,'127.0.0.1',54230,'Qulun_Dome',0,0,115,102,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (149,4,'127.0.0.1',54230,'Davoi',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (150,4,'127.0.0.1',54230,'Monastic_Cavern',0,0,115,102,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (151,4,'127.0.0.1',54230,'Castle_Oztroja',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (152,4,'127.0.0.1',54230,'Altar_Room',0,0,115,102,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (153,4,'127.0.0.1',54230,'The_Boyahda_Tree',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (154,4,'127.0.0.1',54230,'Dragons_Aery',0,0,115,192,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (155,4,'127.0.0.1',54230,'Castle_Zvahl_Keep_[S]',43,43,101,215,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (156,0,'127.0.0.1',54230,'Throne_Room_[S]',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (157,4,'127.0.0.1',54230,'Middle_Delkfutts_Tower',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (158,4,'127.0.0.1',54230,'Upper_Delkfutts_Tower',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (159,4,'127.0.0.1',54230,'Temple_of_Uggalepih',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (160,4,'127.0.0.1',54230,'Den_of_Rancor',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (161,4,'127.0.0.1',54230,'Castle_Zvahl_Baileys',155,155,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (162,4,'127.0.0.1',54230,'Castle_Zvahl_Keep',155,155,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (163,0,'127.0.0.1',54230,'Sacrificial_Chamber',0,0,193,193,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (164,4,'127.0.0.1',54230,'Garlaige_Citadel_[S]',0,0,115,216,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (165,0,'127.0.0.1',54230,'Throne_Room',155,155,119,119,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (166,4,'127.0.0.1',54230,'Ranguemont_Pass',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (167,4,'127.0.0.1',54230,'Bostaunieux_Oubliette',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (168,0,'127.0.0.1',54230,'Chamber_of_Oracles',0,0,193,193,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (169,4,'127.0.0.1',54230,'Toraimarai_Canal',0,0,115,102,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (170,0,'127.0.0.1',54230,'Full_Moon_Fountain',0,0,193,193,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (171,4,'127.0.0.1',54230,'Crawlers_Nest_[S]',0,0,115,216,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (172,4,'127.0.0.1',54230,'Zeruhn_Mines',0,0,115,102,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (173,4,'127.0.0.1',54230,'Korroloka_Tunnel',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (174,4,'127.0.0.1',54230,'Kuftal_Tunnel',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (175,4,'127.0.0.1',54230,'The_Eldieme_Necropolis_[S]',0,0,115,216,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (176,4,'127.0.0.1',54230,'Sea_Serpent_Grotto',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (177,4,'127.0.0.1',54230,'VeLugannon_Palace',207,207,115,192,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (178,4,'127.0.0.1',54230,'The_Shrine_of_RuAvitau',207,207,115,192,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (179,0,'127.0.0.1',54230,'Stellar_Fulcrum',0,0,193,193,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (180,0,'127.0.0.1',54230,'LaLoff_Amphitheater',0,0,196,196,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (181,0,'127.0.0.1',54230,'The_Celestial_Nexus',0,0,198,198,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (182,0,'127.0.0.1',54230,'Walk_of_Echoes',0,0,215,215,0,0.00,4096);
-INSERT INTO `zone_settings` VALUES (183,256,'127.0.0.1',54230,'Maquette_Abdhaljs-Legion_A',0,0,143,143,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (184,4,'127.0.0.1',54230,'Lower_Delkfutts_Tower',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (185,128,'127.0.0.1',54230,'Dynamis-San_dOria',121,121,121,121,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (186,128,'127.0.0.1',54230,'Dynamis-Bastok',121,121,121,121,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (187,128,'127.0.0.1',54230,'Dynamis-Windurst',121,121,121,121,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (188,128,'127.0.0.1',54230,'Dynamis-Jeuno',121,121,121,121,0,0.00,6296);
-INSERT INTO `zone_settings` VALUES (189,1,'127.0.0.1',54230,'Outer_RaKaznar_[U3]',0,0,0,0,0,0.00,2048);
-INSERT INTO `zone_settings` VALUES (190,4,'127.0.0.1',54230,'King_Ranperres_Tomb',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (191,4,'127.0.0.1',54230,'Dangruf_Wadi',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (192,4,'127.0.0.1',54230,'Inner_Horutoto_Ruins',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (193,4,'127.0.0.1',54230,'Ordelles_Caves',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (194,4,'127.0.0.1',54230,'Outer_Horutoto_Ruins',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (195,4,'127.0.0.1',54230,'The_Eldieme_Necropolis',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (196,4,'127.0.0.1',54230,'Gusgen_Mines',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (197,4,'127.0.0.1',54230,'Crawlers_Nest',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (198,4,'127.0.0.1',54230,'Maze_of_Shakhrami',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (199,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128);
-INSERT INTO `zone_settings` VALUES (200,4,'127.0.0.1',54230,'Garlaige_Citadel',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (201,0,'127.0.0.1',54230,'Cloister_of_Gales',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (202,0,'127.0.0.1',54230,'Cloister_of_Storms',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (203,0,'127.0.0.1',54230,'Cloister_of_Frost',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (204,4,'127.0.0.1',54230,'FeiYin',0,0,115,102,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (205,4,'127.0.0.1',54230,'Ifrits_Cauldron',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (206,0,'127.0.0.1',54230,'QuBia_Arena',0,0,125,125,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (207,0,'127.0.0.1',54230,'Cloister_of_Flames',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (208,4,'127.0.0.1',54230,'Quicksand_Caves',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (209,0,'127.0.0.1',54230,'Cloister_of_Tremors',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (210,0,'127.0.0.1',54230,'GM_Home',0,0,0,0,0,0.00,4095); -- NPC debug zone, where GMs idle on retail.
-INSERT INTO `zone_settings` VALUES (211,0,'127.0.0.1',54230,'Cloister_of_Tides',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (212,4,'127.0.0.1',54230,'Gustav_Tunnel',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (213,4,'127.0.0.1',54230,'Labyrinth_of_Onzozo',0,0,115,192,0,0.00,6299);
-INSERT INTO `zone_settings` VALUES (214,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128);
-INSERT INTO `zone_settings` VALUES (215,2,'127.0.0.1',54230,'Abyssea-Attohwa',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (216,2,'127.0.0.1',54230,'Abyssea-Misareaux',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (217,2,'127.0.0.1',54230,'Abyssea-Vunkerl',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (218,2,'127.0.0.1',54230,'Abyssea-Altepa',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (219,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128);
-INSERT INTO `zone_settings` VALUES (220,0,'127.0.0.1',54230,'Ship_bound_for_Selbina',106,106,101,103,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (221,0,'127.0.0.1',54230,'Ship_bound_for_Mhaura',106,106,101,103,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (222,0,'127.0.0.1',54230,'Provenance',56,56,56,56,0,0.00,4096);
-INSERT INTO `zone_settings` VALUES (223,2,'127.0.0.1',54230,'San_dOria-Jeuno_Airship',128,128,128,128,0,0.00,8);
-INSERT INTO `zone_settings` VALUES (224,2,'127.0.0.1',54230,'Bastok-Jeuno_Airship',128,128,128,128,0,0.00,8);
-INSERT INTO `zone_settings` VALUES (225,2,'127.0.0.1',54230,'Windurst-Jeuno_Airship',128,128,128,128,0,0.00,8);
-INSERT INTO `zone_settings` VALUES (226,2,'127.0.0.1',54230,'Kazham-Jeuno_Airship',128,128,128,128,0,0.00,8);
-INSERT INTO `zone_settings` VALUES (227,2,'127.0.0.1',54230,'Ship_bound_for_Selbina_Pirates',106,106,101,103,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (228,2,'127.0.0.1',54230,'Ship_bound_for_Mhaura_Pirates',106,106,101,103,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (229,0,'127.0.0.1',54230,'Throne_Room_[V]',0,0,0,0,0,0.00,6297);
-INSERT INTO `zone_settings` VALUES (230,1,'127.0.0.1',54230,'Southern_San_dOria',107,107,107,107,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (231,1,'127.0.0.1',54230,'Northern_San_dOria',107,107,107,107,0,0.00,5192);
-INSERT INTO `zone_settings` VALUES (232,1,'127.0.0.1',54230,'Port_San_dOria',107,107,107,107,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (233,1,'127.0.0.1',54230,'Chateau_dOraguille',156,156,156,156,0,0.00,5128);
-INSERT INTO `zone_settings` VALUES (234,1,'127.0.0.1',54230,'Bastok_Mines',152,152,152,152,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (235,1,'127.0.0.1',54230,'Bastok_Markets',152,152,152,152,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (236,1,'127.0.0.1',54230,'Port_Bastok',152,152,152,152,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (237,1,'127.0.0.1',54230,'Metalworks',154,154,154,154,0,0.00,5128);
-INSERT INTO `zone_settings` VALUES (238,1,'127.0.0.1',54230,'Windurst_Waters',151,151,151,151,0,0.00,5192);
-INSERT INTO `zone_settings` VALUES (239,1,'127.0.0.1',54230,'Windurst_Walls',151,151,151,151,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (240,1,'127.0.0.1',54230,'Port_Windurst',151,151,151,151,0,0.00,5192);
-INSERT INTO `zone_settings` VALUES (241,1,'127.0.0.1',54230,'Windurst_Woods',151,151,151,151,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (242,1,'127.0.0.1',54230,'Heavens_Tower',162,162,151,151,0,0.00,5128);
-INSERT INTO `zone_settings` VALUES (243,1,'127.0.0.1',54230,'RuLude_Gardens',117,117,117,117,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (244,1,'127.0.0.1',54230,'Upper_Jeuno',110,110,110,110,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (245,1,'127.0.0.1',54230,'Lower_Jeuno',110,110,110,110,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (246,1,'127.0.0.1',54230,'Port_Jeuno',110,110,110,110,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (247,1,'127.0.0.1',54230,'Rabao',208,208,208,208,0,0.00,5736);
-INSERT INTO `zone_settings` VALUES (248,1,'127.0.0.1',54230,'Selbina',112,112,112,112,0,0.00,5160);
-INSERT INTO `zone_settings` VALUES (249,1,'127.0.0.1',54230,'Mhaura',105,105,105,105,0,0.00,5160);
-INSERT INTO `zone_settings` VALUES (250,1,'127.0.0.1',54230,'Kazham',135,135,135,135,0,0.00,5672);
-INSERT INTO `zone_settings` VALUES (251,1,'127.0.0.1',54230,'Hall_of_the_Gods',213,213,213,213,0,0.00,4104);
-INSERT INTO `zone_settings` VALUES (252,1,'127.0.0.1',54230,'Norg',209,209,209,209,0,0.00,5736);
-INSERT INTO `zone_settings` VALUES (253,2,'127.0.0.1',54230,'Abyssea-Uleguerand',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (254,2,'127.0.0.1',54230,'Abyssea-Grauberg',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (255,2,'127.0.0.1',54230,'Abyssea-Empyreal_Paradox',51,51,52,52,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (256,1,'127.0.0.1',54230,'Western_Adoulin',59,59,59,59,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (257,1,'127.0.0.1',54230,'Eastern_Adoulin',63,63,63,63,0,0.00,5704);
-INSERT INTO `zone_settings` VALUES (258,4,'127.0.0.1',54230,'Rala_Waterways',61,61,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (259,256,'127.0.0.1',54230,'Rala_Waterways_U',61,61,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (260,2,'127.0.0.1',54230,'Yahse_Hunting_Grounds',60,60,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (261,2,'127.0.0.1',54230,'Ceizak_Battlegrounds',60,60,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (262,2,'127.0.0.1',54230,'Foret_de_Hennetiel',60,60,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (263,2,'127.0.0.1',54230,'Yorcia_Weald',61,61,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (264,256,'127.0.0.1',54230,'Yorcia_Weald_U',62,62,62,62,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (265,2,'127.0.0.1',54230,'Morimar_Basalt_Fields',60,60,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (266,2,'127.0.0.1',54230,'Marjami_Ravine',60,60,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (267,2,'127.0.0.1',54230,'Kamihr_Drifts',72,72,57,57,0,0.00,2204);
-INSERT INTO `zone_settings` VALUES (268,4,'127.0.0.1',54230,'Sih_Gates',0,0,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (269,4,'127.0.0.1',54230,'Moh_Gates',0,0,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (270,4,'127.0.0.1',54230,'Cirdas_Caverns',0,0,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (271,256,'127.0.0.1',54230,'Cirdas_Caverns_U',62,62,62,62,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (272,4,'127.0.0.1',54230,'Dho_Gates',0,0,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (273,4,'127.0.0.1',54230,'Woh_Gates',0,0,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (274,4,'127.0.0.1',54230,'Outer_RaKaznar',73,73,57,57,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (275,0,'127.0.0.1',54230,'Outer_RaKaznar_[U1]',62,62,62,62,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (276,0,'127.0.0.1',54230,'RaKaznar_Inner_Court',73,73,57,57,0,0.00,2202);
-INSERT INTO `zone_settings` VALUES (277,0,'127.0.0.1',54230,'RaKaznar_Turris',0,0,0,0,0,0.00,0);
-INSERT INTO `zone_settings` VALUES (278,0,'127.0.0.1',54230,'Gwora-Corridor',0,0,0,0,0,0.00,0);
-INSERT INTO `zone_settings` VALUES (279,0,'127.0.0.1',54230,'Walk_of_Echoes_[P2]',0,0,0,0,0,0.00,2048);
-INSERT INTO `zone_settings` VALUES (280,1,'127.0.0.1',54230,'Mog_Garden',67,67,67,67,0,0.00,4128);
-INSERT INTO `zone_settings` VALUES (281,0,'127.0.0.1',54230,'Leafallia',0,0,0,0,0,0.00,0);
-INSERT INTO `zone_settings` VALUES (282,0,'127.0.0.1',54230,'Mount_Kamihr',0,0,0,0,0,0.00,0);
-INSERT INTO `zone_settings` VALUES (283,0,'127.0.0.1',54230,'Silver_Knife',0,0,0,0,0,0.00,0);
-INSERT INTO `zone_settings` VALUES (284,1,'127.0.0.1',54230,'Celennia_Memorial_Library',63,63,0,0,0,0.00,4096);
-INSERT INTO `zone_settings` VALUES (285,1,'127.0.0.1',54230,'Feretory',0,0,0,0,0,0.00,4128);
-INSERT INTO `zone_settings` VALUES (286,0,'127.0.0.1',0,'286',0,0,0,0,0,0.00,0); -- Crashes the client if enabled and you try to go there
-INSERT INTO `zone_settings` VALUES (287,256,'127.0.0.1',54230,'Maquette_Abdhaljs-Legion_B',0,0,143,143,0,0.00,6298);
-INSERT INTO `zone_settings` VALUES (288,2,'127.0.0.1',54230,'Escha_ZiTah',80,80,80,80,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (289,2,'127.0.0.1',54230,'Escha_RuAun',80,80,80,80,0,0.00,2200);
-INSERT INTO `zone_settings` VALUES (290,0,'127.0.0.1',54230,'Desuetia_Empyreal_Paradox',0,0,0,0,0,0.00,2176);
-INSERT INTO `zone_settings` VALUES (291,0,'127.0.0.1',54230,'Reisenjima',79,79,79,79,0,0.00,2176);
-INSERT INTO `zone_settings` VALUES (292,0,'127.0.0.1',54230,'Reisenjima_Henge',0,0,0,0,0,0.00,2048);
-INSERT INTO `zone_settings` VALUES (293,0,'127.0.0.1',54230,'Reisenjima_Sanctorium',0,0,0,0,0,0.00,2176);
-INSERT INTO `zone_settings` VALUES (294,128,'127.0.0.1',54230,'Dynamis-San_dOria_[D]',88,88,88,88,0,0.00,6544);
-INSERT INTO `zone_settings` VALUES (295,128,'127.0.0.1',54230,'Dynamis-Bastok_[D]',88,88,88,88,0,0.00,6544);
-INSERT INTO `zone_settings` VALUES (296,128,'127.0.0.1',54230,'Dynamis-Windurst_[D]',88,88,88,88,0,0.00,6544);
-INSERT INTO `zone_settings` VALUES (297,128,'127.0.0.1',54230,'Dynamis-Jeuno_[D]',88,88,88,88,0,0.00,6544);
-INSERT INTO `zone_settings` VALUES (298,0,'127.0.0.1',54230,'Walk_of_Echoes_[P1]',186,186,186,186,0,0.00,2048);
-INSERT INTO `zone_settings` VALUES (299,0,'127.0.0.1',54230,'Gwora-Throne_Room',0,0,0,0,0,0.00,0);
-
--- NOTE: To disable a zone, you must set the zoneip and zoneport to '' and 0 respectively!
-
+INSERT INTO `zone_settings` VALUES
+(0,1,'127.0.0.1',54230,'unknown',0,0,0,0,0,0.00,4128,0,0,'Vanilla'),
+(1,2,'127.0.0.1',54230,'Phanauet_Channel',229,229,101,219,0,0.00,2200,0,0,'COP'),
+(2,2,'127.0.0.1',54230,'Carpenters_Landing',0,0,101,219,0,0.00,2206,0,0,'COP'),
+(3,2,'127.0.0.1',54230,'Manaclipper',229,229,101,219,0,0.00,2200,0,0,'COP'),
+(4,2,'127.0.0.1',54230,'Bibiki_Bay',0,0,101,219,0,0.00,2206,0,0,'COP'),
+(5,2,'127.0.0.1',54230,'Uleguerand_Range',0,0,101,219,0,0.00,2202,0,0,'COP'),
+(6,4,'127.0.0.1',54230,'Bearclaw_Pinnacle',0,0,220,220,0,0.00,6296,0,0,'COP'),
+(7,2,'127.0.0.1',54230,'Attohwa_Chasm',0,0,101,219,0,0.00,2202,0,0,'COP'),
+(8,4,'127.0.0.1',54230,'Boneyard_Gully',0,0,220,220,0,0.00,6296,0,0,'COP'),
+(9,3,'127.0.0.1',54230,'PsoXja',225,225,115,218,0,0.00,6297,0,0,'COP'),
+(10,4,'127.0.0.1',54230,'The_Shrouded_Maw',0,0,220,220,0,0.00,6297,1,1,'WOTG'),
+(11,3,'127.0.0.1',54230,'Oldton_Movalpolos',221,221,115,218,0,0.00,6299,0,0,'COP'),
+(12,3,'127.0.0.1',54230,'Newton_Movalpolos',221,221,115,218,0,0.00,6299,0,0,'COP'),
+(13,4,'127.0.0.1',54230,'Mine_Shaft_2716',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(14,3,'127.0.0.1',54230,'Hall_of_Transference',0,0,115,218,0,0.00,6296,0,0,'COP'),
+(15,2,'127.0.0.1',54230,'Abyssea-Konschtat',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(16,3,'127.0.0.1',54230,'Promyvion-Holla',222,222,115,218,30,0.00,6297,0,0,'COP'),
+(17,4,'127.0.0.1',54230,'Spire_of_Holla',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(18,3,'127.0.0.1',54230,'Promyvion-Dem',222,222,115,218,30,0.00,6297,0,0,'COP'),
+(19,4,'127.0.0.1',54230,'Spire_of_Dem',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(20,3,'127.0.0.1',54230,'Promyvion-Mea',222,222,115,218,30,0.00,6297,0,0,'COP'),
+(21,4,'127.0.0.1',54230,'Spire_of_Mea',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(22,3,'127.0.0.1',54230,'Promyvion-Vahzl',222,222,115,218,50,0.00,6297,0,0,'COP'),
+(23,4,'127.0.0.1',54230,'Spire_of_Vahzl',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(24,2,'127.0.0.1',54230,'Lufaise_Meadows',230,230,101,219,0,0.00,2202,0,0,'COP'),
+(25,2,'127.0.0.1',54230,'Misareaux_Coast',230,230,101,219,0,0.00,2202,0,0,'COP'),
+(26,1,'127.0.0.1',54230,'Tavnazian_Safehold',245,245,245,245,0,0.00,5736,0,0,'COP'),
+(27,3,'127.0.0.1',54230,'Phomiuna_Aqueducts',0,0,115,218,40,0.00,6297,0,0,'COP'),
+(28,3,'127.0.0.1',54230,'Sacrarium',0,0,115,218,50,0.00,6297,0,0,'COP'),
+(29,3,'127.0.0.1',54230,'Riverne-Site_B01',0,0,115,218,50,0.00,6297,0,0,'COP'),
+(30,3,'127.0.0.1',54230,'Riverne-Site_A01',0,0,115,218,40,0.00,6297,0,0,'COP'),
+(31,4,'127.0.0.1',54230,'Monarch_Linn',0,0,220,220,0,0.00,6297,0,0,'COP'),
+(32,1,'127.0.0.1',54230,'Sealions_Den',245,245,220,220,0,0.00,6297,0,0,'COP'),
+(33,2,'127.0.0.1',54230,'AlTaieu',233,233,101,219,0,0.00,2200,0,0,'COP'),
+(34,3,'127.0.0.1',54230,'Grand_Palace_of_HuXzoi',0,0,115,218,0,0.00,6297,0,0,'COP'),
+(35,3,'127.0.0.1',54230,'The_Garden_of_RuHmet',228,228,115,218,0,0.00,6297,0,0,'COP'),
+(36,4,'127.0.0.1',54230,'Empyreal_Paradox',0,0,224,224,0,0.00,6297,0,0,'COP'),
+(37,4,'127.0.0.1',54230,'Temenos',0,0,218,219,0,0.00,4248,0,0,'COP'),
+(38,4,'127.0.0.1',54230,'Apollyon',0,0,218,219,0,0.00,4248,0,0,'COP'),
+(39,5,'127.0.0.1',54230,'Dynamis-Valkurm',121,121,121,121,0,0.00,2456,0,0,'COP'),
+(40,5,'127.0.0.1',54230,'Dynamis-Buburimu',121,121,121,121,0,0.00,2456,0,0,'COP'),
+(41,5,'127.0.0.1',54230,'Dynamis-Qufim',121,121,121,121,0,0.00,2456,0,0,'COP'),
+(42,5,'127.0.0.1',54230,'Dynamis-Tavnazia',121,121,121,121,0,0.00,6544,0,0,'COP'),
+(43,2,'127.0.0.1',54230,'Diorama_Abdhaljs-Ghelsba',0,0,218,219,0,0.00,152,0,0,'COP'),
+(44,2,'127.0.0.1',54230,'Abdhaljs_Isle-Purgonorgo',0,0,226,226,0,0.00,152,0,0,'COP'),
+(45,2,'127.0.0.1',54230,'Abyssea-Tahrongi',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(46,2,'127.0.0.1',54230,'Open_sea_route_to_Al_Zahbi',147,147,101,138,0,0.00,2200,0,0,'TOAU'),
+(47,2,'127.0.0.1',54230,'Open_sea_route_to_Mhaura',147,147,101,138,0,0.00,2200,0,0,'TOAU'),
+(48,1,'127.0.0.1',54230,'Al_Zahbi',178,178,178,178,0,0.00,5784,0,0,'TOAU'),
+(49,0,'127.0.0.1',54230,'49',0,0,0,0,0,0.00,0,0,0,'Vanilla'),
+(50,1,'127.0.0.1',54230,'Aht_Urhgan_Whitegate',178,178,178,178,0,0.00,5640,0,0,'TOAU'),
+(51,2,'127.0.0.1',54230,'Wajaom_Woodlands',149,149,101,138,0,0.00,2206,0,0,'TOAU'),
+(52,2,'127.0.0.1',54230,'Bhaflau_Thickets',149,149,101,138,0,0.00,2206,0,0,'TOAU'),
+(53,2,'127.0.0.1',54230,'Nashmau',175,175,175,175,0,0.00,1576,0,0,'TOAU'),
+(54,2,'127.0.0.1',54230,'Arrapago_Reef',150,150,115,139,0,0.00,2201,0,0,'TOAU'),
+(55,6,'127.0.0.1',54230,'Ilrusi_Atoll',0,0,144,144,0,0.00,6297,0,0,'TOAU'),
+(56,6,'127.0.0.1',54230,'Periqia',0,0,144,144,0,0.00,6297,0,0,'TOAU'),
+(57,4,'127.0.0.1',54230,'Talacca_Cove',0,0,143,143,0,0.00,6297,0,0,'TOAU'),
+(58,2,'127.0.0.1',54230,'Silver_Sea_route_to_Nashmau',147,147,101,138,0,0.00,2200,0,0,'TOAU'),
+(59,2,'127.0.0.1',54230,'Silver_Sea_route_to_Al_Zahbi',147,147,101,138,0,0.00,2200,0,0,'TOAU'),
+(60,6,'127.0.0.1',54230,'The_Ashu_Talif',172,172,143,143,0,0.00,6272,0,0,'TOAU'),
+(61,2,'127.0.0.1',54230,'Mount_Zhayolm',0,0,101,138,0,0.00,2206,0,0,'TOAU'),
+(62,3,'127.0.0.1',54230,'Halvung',0,0,115,139,0,0.00,6297,0,0,'TOAU'),
+(63,6,'127.0.0.1',54230,'Lebros_Cavern',0,0,144,144,0,0.00,6297,0,0,'TOAU'),
+(64,4,'127.0.0.1',54230,'Navukgo_Execution_Chamber',0,0,143,143,0,0.00,6297,0,0,'TOAU'),
+(65,3,'127.0.0.1',54230,'Mamook',0,0,115,139,0,0.00,6297,0,0,'TOAU'),
+(66,6,'127.0.0.1',54230,'Mamool_Ja_Training_Grounds',0,0,144,144,0,0.00,6297,0,0,'TOAU'),
+(67,4,'127.0.0.1',54230,'Jade_Sepulcher',0,0,143,143,0,0.00,6297,0,0,'TOAU'),
+(68,3,'127.0.0.1',54230,'Aydeewa_Subterrane',174,174,115,139,0,0.00,6299,0,0,'TOAU'),
+(69,6,'127.0.0.1',54230,'Leujaoam_Sanctum',0,0,144,144,0,0.00,6297,0,0,'TOAU'),
+(70,1,'127.0.0.1',54230,'Chocobo_Circuit',176,176,176,176,0,0.00,5132,0,0,'TOAU'),
+(71,1,'127.0.0.1',54230,'The_Colosseum',0,0,139,139,0,0.00,6296,0,0,'TOAU'),
+(72,3,'127.0.0.1',54230,'Alzadaal_Undersea_Ruins',0,0,115,139,0,0.00,6297,0,0,'TOAU'),
+(73,6,'127.0.0.1',54230,'Zhayolm_Remnants',148,148,115,139,0,0.00,6297,0,0,'TOAU'),
+(74,6,'127.0.0.1',54230,'Arrapago_Remnants',148,148,115,139,0,0.00,6297,0,0,'TOAU'),
+(75,6,'127.0.0.1',54230,'Bhaflau_Remnants',148,148,115,139,0,0.00,6297,0,0,'TOAU'),
+(76,6,'127.0.0.1',54230,'Silver_Sea_Remnants',148,148,115,139,0,0.00,6297,0,0,'TOAU'),
+(77,6,'127.0.0.1',54230,'Nyzul_Isle',148,148,144,144,0,0.00,6297,0,0,'TOAU'),
+(78,4,'127.0.0.1',54230,'Hazhalm_Testing_Grounds',0,0,0,0,0,0.00,6296,0,0,'TOAU'),
+(79,2,'127.0.0.1',54230,'Caedarva_Mire',173,173,101,138,0,0.00,2206,0,0,'TOAU'),
+(80,1,'127.0.0.1',54230,'Southern_San_dOria_[S]',254,254,254,254,0,0.00,4168,0,0,'WOTG'),
+(81,2,'127.0.0.1',54230,'East_Ronfaure_[S]',251,251,101,215,0,0.00,2206,0,0,'WOTG'),
+(82,2,'127.0.0.1',54230,'Jugner_Forest_[S]',0,0,101,215,0,0.00,2206,0,0,'WOTG'),
+(83,2,'127.0.0.1',54230,'Vunkerl_Inlet_[S]',0,0,101,215,0,0.00,2206,0,0,'WOTG'),
+(84,2,'127.0.0.1',54230,'Batallia_Downs_[S]',252,252,101,215,0,0.00,2206,0,0,'WOTG'),
+(85,2,'127.0.0.1',54230,'La_Vaule_[S]',44,44,115,216,0,0.00,2201,0,0,'WOTG'),
+(86,6,'127.0.0.1',54230,'Everbloom_Hollow',0,0,216,216,0,0.00,6296,0,0,'WOTG'),
+(87,1,'127.0.0.1',54230,'Bastok_Markets_[S]',180,180,180,180,0,0.00,4168,0,0,'WOTG'),
+(88,2,'127.0.0.1',54230,'North_Gustaberg_[S]',253,253,101,215,0,0.00,2206,0,0,'WOTG'),
+(89,2,'127.0.0.1',54230,'Grauberg_[S]',0,0,101,215,0,0.00,2206,0,0,'WOTG'),
+(90,2,'127.0.0.1',54230,'Pashhow_Marshlands_[S]',0,0,101,215,0,0.00,2206,0,0,'WOTG'),
+(91,2,'127.0.0.1',54230,'Rolanberry_Fields_[S]',252,252,101,215,0,0.00,2206,0,0,'WOTG'),
+(92,3,'127.0.0.1',54230,'Beadeaux_[S]',44,44,115,216,0,0.00,6297,0,0,'WOTG'),
+(93,6,'127.0.0.1',54230,'Ruhotz_Silvermines',0,0,216,216,0,0.00,6297,0,0,'WOTG'),
+(94,1,'127.0.0.1',54230,'Windurst_Waters_[S]',182,182,182,182,0,0.00,4168,0,0,'WOTG'),
+(95,2,'127.0.0.1',54230,'West_Sarutabaruta_[S]',141,141,101,215,0,0.00,2206,0,0,'WOTG'),
+(96,3,'127.0.0.1',54230,'Fort_Karugo-Narugo_[S]',0,0,101,215,0,0.00,6302,0,0,'WOTG'),
+(97,2,'127.0.0.1',54230,'Meriphataud_Mountains_[S]',0,0,101,215,0,0.00,2206,0,0,'WOTG'),
+(98,2,'127.0.0.1',54230,'Sauromugue_Champaign_[S]',252,252,101,215,0,0.00,2206,0,0,'WOTG'),
+(99,3,'127.0.0.1',54230,'Castle_Oztroja_[S]',44,44,115,216,0,0.00,6297,0,0,'WOTG'),
+(100,2,'127.0.0.1',54230,'West_Ronfaure',109,109,101,103,0,0.00,2206,1,1,'Vanilla'),
+(101,2,'127.0.0.1',54230,'East_Ronfaure',109,109,101,103,0,0.00,2206,1,1,'Vanilla'),
+(102,2,'127.0.0.1',54230,'La_Theine_Plateau',0,0,101,103,0,0.00,2206,0,0,'Vanilla'),
+(103,2,'127.0.0.1',54230,'Valkurm_Dunes',0,0,101,103,0,0.00,2206,0,0,'Vanilla'),
+(104,2,'127.0.0.1',54230,'Jugner_Forest',0,0,101,103,0,0.00,2206,0,0,'Vanilla'),
+(105,2,'127.0.0.1',54230,'Batallia_Downs',114,114,101,103,0,0.00,2206,1,1,'Vanilla'),
+(106,2,'127.0.0.1',54230,'North_Gustaberg',116,116,101,103,0,0.00,2206,1,1,'Vanilla'),
+(107,2,'127.0.0.1',54230,'South_Gustaberg',116,116,101,103,0,0.00,2206,1,1,'Vanilla'),
+(108,2,'127.0.0.1',54230,'Konschtat_Highlands',0,0,101,103,0,0.00,2206,1,1,'Vanilla'),
+(109,2,'127.0.0.1',54230,'Pashhow_Marshlands',0,0,101,103,0,0.00,2206,1,1,'Vanilla'),
+(110,2,'127.0.0.1',54230,'Rolanberry_Fields',118,118,101,103,0,0.00,2206,0,0,'Vanilla'),
+(111,2,'127.0.0.1',54230,'Beaucedine_Glacier',0,0,101,103,0,0.00,2202,0,0,'Vanilla'),
+(112,2,'127.0.0.1',54230,'Xarcabard',164,164,101,103,0,0.00,2202,0,0,'Vanilla'),
+(113,2,'127.0.0.1',54230,'Cape_Teriggan',0,0,101,191,0,0.00,2202,0,0,'ROZ'),
+(114,2,'127.0.0.1',54230,'Eastern_Altepa_Desert',171,171,101,191,0,0.00,2206,0,0,'ROZ'),
+(115,2,'127.0.0.1',54230,'West_Sarutabaruta',113,113,101,103,0,0.00,2206,1,1,'Vanilla'),
+(116,2,'127.0.0.1',54230,'East_Sarutabaruta',113,113,101,103,0,0.00,2206,1,1,'Vanilla'),
+(117,2,'127.0.0.1',54230,'Tahrongi_Canyon',0,0,101,103,0,0.00,2206,1,1,'Vanilla'),
+(118,2,'127.0.0.1',54230,'Buburimu_Peninsula',0,0,101,103,0,0.00,2206,0,0,'Vanilla'),
+(119,2,'127.0.0.1',54230,'Meriphataud_Mountains',0,0,101,103,0,0.00,2206,0,0,'Vanilla'),
+(120,2,'127.0.0.1',54230,'Sauromugue_Champaign',158,158,101,103,0,0.00,2206,1,1,'Vanilla'),
+(121,2,'127.0.0.1',54230,'The_Sanctuary_of_ZiTah',190,190,101,191,0,0.00,2206,0,0,'ROZ'),
+(122,2,'127.0.0.1',54230,'RoMaeve',211,211,101,191,0,0.00,2202,0,0,'ROZ'),
+(123,2,'127.0.0.1',54230,'Yuhtunga_Jungle',134,134,101,191,0,0.00,2206,0,0,'ROZ'),
+(124,2,'127.0.0.1',54230,'Yhoator_Jungle',134,134,101,191,0,0.00,2206,0,0,'ROZ'),
+(125,2,'127.0.0.1',54230,'Western_Altepa_Desert',171,171,101,191,0,0.00,2206,0,0,'ROZ'),
+(126,2,'127.0.0.1',54230,'Qufim_Island',0,0,101,103,0,0.00,2202,0,0,'Vanilla'),
+(127,2,'127.0.0.1',54230,'Behemoths_Dominion',0,0,101,103,0,0.00,2202,0,0,'Vanilla'),
+(128,2,'127.0.0.1',54230,'Valley_of_Sorrows',0,0,101,191,0,0.00,2202,1,1,'ROZ'),
+(129,6,'127.0.0.1',54230,'Ghoyus_Reverie',0,0,216,216,0,0.00,6297,0,0,'WOTG'),
+(130,2,'127.0.0.1',54230,'RuAun_Gardens',210,210,101,191,0,0.00,2200,0,0,'ROZ'),
+(131,3,'127.0.0.1',54230,'Mordion_Gaol',0,0,0,0,0,0.00,4096,0,0,'Vanilla'),
+(132,2,'127.0.0.1',54230,'Abyssea-La_Theine',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(133,0,'127.0.0.1',54230,'Outer_RaKaznar_[U2]',0,0,0,0,0,0.00,2048,0,0,'SOA'),
+(134,5,'127.0.0.1',54230,'Dynamis-Beaucedine',121,121,121,121,0,0.00,2456,0,0,'ROZ'),
+(135,5,'127.0.0.1',54230,'Dynamis-Xarcabard',119,119,119,119,0,0.00,2456,0,0,'ROZ'),
+(136,2,'127.0.0.1',54230,'Beaucedine_Glacier_[S]',0,0,101,215,0,0.00,2204,0,0,'WOTG'),
+(137,2,'127.0.0.1',54230,'Xarcabard_[S]',42,42,101,215,0,0.00,2204,0,0,'WOTG'),
+(138,3,'127.0.0.1',54230,'Castle_Zvahl_Baileys_[S]',43,43,101,215,0,0.00,6297,0,0,'WOTG'),
+(139,4,'127.0.0.1',54230,'Horlais_Peak',0,0,125,125,0,0.00,6297,1,1,'Vanilla'),
+(140,3,'127.0.0.1',54230,'Ghelsba_Outpost',0,0,115,102,0,0.00,6297,0,0,'Vanilla'),
+(141,3,'127.0.0.1',54230,'Fort_Ghelsba',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(142,3,'127.0.0.1',54230,'Yughott_Grotto',0,0,115,102,0,0.00,6298,0,0,'Vanilla'),
+(143,3,'127.0.0.1',54230,'Palborough_Mines',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(144,4,'127.0.0.1',54230,'Waughroon_Shrine',0,0,125,125,0,0.00,6299,0,0,'Vanilla'),
+(145,3,'127.0.0.1',54230,'Giddeus',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(146,4,'127.0.0.1',54230,'Balgas_Dais',0,0,125,125,0,0.00,6297,1,1,'Vanilla'),
+(147,3,'127.0.0.1',54230,'Beadeaux',0,0,115,102,0,0.00,6299,1,1,'Vanilla'),
+(148,3,'127.0.0.1',54230,'Qulun_Dome',0,0,115,102,0,0.00,6297,0,0,'Vanilla'),
+(149,3,'127.0.0.1',54230,'Davoi',0,0,115,102,0,0.00,6299,1,1,'Vanilla'),
+(150,3,'127.0.0.1',54230,'Monastic_Cavern',0,0,115,102,0,0.00,6297,0,0,'Vanilla'),
+(151,3,'127.0.0.1',54230,'Castle_Oztroja',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(152,3,'127.0.0.1',54230,'Altar_Room',0,0,115,102,0,0.00,6297,0,0,'Vanilla'),
+(153,3,'127.0.0.1',54230,'The_Boyahda_Tree',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(154,3,'127.0.0.1',54230,'Dragons_Aery',0,0,115,192,0,0.00,6297,0,0,'ROZ'),
+(155,3,'127.0.0.1',54230,'Castle_Zvahl_Keep_[S]',43,43,101,215,0,0.00,6297,0,0,'WOTG'),
+(156,4,'127.0.0.1',54230,'Throne_Room_[S]',0,0,0,0,0,0.00,6297,0,0,'WOTG'),
+(157,3,'127.0.0.1',54230,'Middle_Delkfutts_Tower',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(158,3,'127.0.0.1',54230,'Upper_Delkfutts_Tower',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(159,3,'127.0.0.1',54230,'Temple_of_Uggalepih',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(160,3,'127.0.0.1',54230,'Den_of_Rancor',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(161,3,'127.0.0.1',54230,'Castle_Zvahl_Baileys',155,155,115,102,0,0.00,6299,0,0,'Vanilla'),
+(162,3,'127.0.0.1',54230,'Castle_Zvahl_Keep',155,155,115,102,0,0.00,6299,0,0,'Vanilla'),
+(163,4,'127.0.0.1',54230,'Sacrificial_Chamber',0,0,193,193,0,0.00,6297,0,0,'ROZ'),
+(164,3,'127.0.0.1',54230,'Garlaige_Citadel_[S]',0,0,115,216,0,0.00,6299,0,0,'WOTG'),
+(165,4,'127.0.0.1',54230,'Throne_Room',155,155,119,119,0,0.00,6297,0,0,'Vanilla'),
+(166,3,'127.0.0.1',54230,'Ranguemont_Pass',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(167,3,'127.0.0.1',54230,'Bostaunieux_Oubliette',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(168,4,'127.0.0.1',54230,'Chamber_of_Oracles',0,0,193,193,0,0.00,6297,0,0,'ROZ'),
+(169,3,'127.0.0.1',54230,'Toraimarai_Canal',0,0,115,102,0,0.00,6297,0,0,'Vanilla'),
+(170,4,'127.0.0.1',54230,'Full_Moon_Fountain',0,0,193,193,0,0.00,6297,0,0,'ROZ'),
+(171,3,'127.0.0.1',54230,'Crawlers_Nest_[S]',0,0,115,216,0,0.00,6299,0,0,'WOTG'),
+(172,3,'127.0.0.1',54230,'Zeruhn_Mines',0,0,115,102,0,0.00,6298,0,0,'Vanilla'),
+(173,3,'127.0.0.1',54230,'Korroloka_Tunnel',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(174,3,'127.0.0.1',54230,'Kuftal_Tunnel',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(175,3,'127.0.0.1',54230,'The_Eldieme_Necropolis_[S]',0,0,115,216,0,0.00,6299,0,0,'WOTG'),
+(176,3,'127.0.0.1',54230,'Sea_Serpent_Grotto',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(177,3,'127.0.0.1',54230,'VeLugannon_Palace',207,207,115,192,0,0.00,6297,0,0,'ROZ'),
+(178,3,'127.0.0.1',54230,'The_Shrine_of_RuAvitau',207,207,115,192,0,0.00,6297,0,0,'ROZ'),
+(179,4,'127.0.0.1',54230,'Stellar_Fulcrum',0,0,193,193,0,0.00,6297,0,0,'ROZ'),
+(180,4,'127.0.0.1',54230,'LaLoff_Amphitheater',0,0,196,196,0,0.00,6297,0,0,'ROZ'),
+(181,4,'127.0.0.1',54230,'The_Celestial_Nexus',0,0,198,198,0,0.00,6297,0,0,'ROZ'),
+(182,4,'127.0.0.1',54230,'Walk_of_Echoes',0,0,215,215,0,0.00,4096,0,0,'WOTG'),
+(183,6,'127.0.0.1',54230,'Maquette_Abdhaljs-Legion_A',0,0,143,143,0,0.00,6298,0,0,NULL),
+(184,3,'127.0.0.1',54230,'Lower_Delkfutts_Tower',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(185,5,'127.0.0.1',54230,'Dynamis-San_dOria',121,121,121,121,0,0.00,6544,1,1,'ROZ'),
+(186,5,'127.0.0.1',54230,'Dynamis-Bastok',121,121,121,121,0,0.00,6544,0,0,'ROZ'),
+(187,5,'127.0.0.1',54230,'Dynamis-Windurst',121,121,121,121,0,0.00,6544,0,0,'ROZ'),
+(188,5,'127.0.0.1',54230,'Dynamis-Jeuno',121,121,121,121,0,0.00,6544,1,1,'ROZ'),
+(189,1,'127.0.0.1',54230,'Outer_RaKaznar_[U3]',0,0,0,0,0,0.00,2048,0,0,'SOA'),
+(190,3,'127.0.0.1',54230,'King_Ranperres_Tomb',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(191,3,'127.0.0.1',54230,'Dangruf_Wadi',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(192,3,'127.0.0.1',54230,'Inner_Horutoto_Ruins',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(193,3,'127.0.0.1',54230,'Ordelles_Caves',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(194,3,'127.0.0.1',54230,'Outer_Horutoto_Ruins',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(195,3,'127.0.0.1',54230,'The_Eldieme_Necropolis',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(196,3,'127.0.0.1',54230,'Gusgen_Mines',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(197,3,'127.0.0.1',54230,'Crawlers_Nest',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(198,3,'127.0.0.1',54230,'Maze_of_Shakhrami',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(199,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128,0,0,'Vanilla'),
+(200,3,'127.0.0.1',54230,'Garlaige_Citadel',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(201,4,'127.0.0.1',54230,'Cloister_of_Gales',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(202,4,'127.0.0.1',54230,'Cloister_of_Storms',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(203,4,'127.0.0.1',54230,'Cloister_of_Frost',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(204,3,'127.0.0.1',54230,'FeiYin',0,0,115,102,0,0.00,6299,0,0,'Vanilla'),
+(205,3,'127.0.0.1',54230,'Ifrits_Cauldron',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(206,4,'127.0.0.1',54230,'QuBia_Arena',0,0,125,125,0,0.00,6297,0,0,'Vanilla'),
+(207,4,'127.0.0.1',54230,'Cloister_of_Flames',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(208,3,'127.0.0.1',54230,'Quicksand_Caves',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(209,4,'127.0.0.1',54230,'Cloister_of_Tremors',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(210,0,'127.0.0.1',54230,'GM_Home',0,0,0,0,0,0.00,4095,0,0,'Vanilla'),
+(211,4,'127.0.0.1',54230,'Cloister_of_Tides',0,0,0,0,0,0.00,6297,0,0,'ROZ'),
+(212,3,'127.0.0.1',54230,'Gustav_Tunnel',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(213,3,'127.0.0.1',54230,'Labyrinth_of_Onzozo',0,0,115,192,0,0.00,6299,0,0,'ROZ'),
+(214,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128,0,0,'Vanilla'),
+(215,2,'127.0.0.1',54230,'Abyssea-Attohwa',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(216,2,'127.0.0.1',54230,'Abyssea-Misareaux',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(217,2,'127.0.0.1',54230,'Abyssea-Vunkerl',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(218,2,'127.0.0.1',54230,'Abyssea-Altepa',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(219,1,'127.0.0.1',54230,'Residential_Area',0,0,0,0,0,0.00,4128,0,0,'Vanilla'),
+(220,0,'127.0.0.1',54230,'Ship_bound_for_Selbina',106,106,101,103,0,0.00,2200,0,0,'Vanilla'),
+(221,0,'127.0.0.1',54230,'Ship_bound_for_Mhaura',106,106,101,103,0,0.00,2200,0,0,'Vanilla'),
+(222,4,'127.0.0.1',54230,'Provenance',56,56,56,56,0,0.00,4096,0,0,'WOTG'),
+(223,2,'127.0.0.1',54230,'San_dOria-Jeuno_Airship',128,128,128,128,0,0.00,8,0,0,'Vanilla'),
+(224,2,'127.0.0.1',54230,'Bastok-Jeuno_Airship',128,128,128,128,0,0.00,8,0,0,'Vanilla'),
+(225,2,'127.0.0.1',54230,'Windurst-Jeuno_Airship',128,128,128,128,0,0.00,8,0,0,'Vanilla'),
+(226,2,'127.0.0.1',54230,'Kazham-Jeuno_Airship',128,128,128,128,0,0.00,8,0,0,'ROZ'),
+(227,2,'127.0.0.1',54230,'Ship_bound_for_Selbina_Pirates',106,106,101,103,0,0.00,2200,0,0,'Vanilla'),
+(228,2,'127.0.0.1',54230,'Ship_bound_for_Mhaura_Pirates',106,106,101,103,0,0.00,2200,0,0,'Vanilla'),
+(229,4,'127.0.0.1',54230,'Throne_Room_[V]',0,0,0,0,0,0.00,6297,0,0,NULL),
+(230,1,'127.0.0.1',54230,'Southern_San_dOria',107,107,107,107,0,0.00,5704,0,0,'Vanilla'),
+(231,1,'127.0.0.1',54230,'Northern_San_dOria',107,107,107,107,0,0.00,5192,0,0,'Vanilla'),
+(232,1,'127.0.0.1',54230,'Port_San_dOria',107,107,107,107,0,0.00,5704,0,0,'Vanilla'),
+(233,1,'127.0.0.1',54230,'Chateau_dOraguille',156,156,156,156,0,0.00,5128,0,0,'Vanilla'),
+(234,1,'127.0.0.1',54230,'Bastok_Mines',152,152,152,152,0,0.00,5704,0,0,'Vanilla'),
+(235,1,'127.0.0.1',54230,'Bastok_Markets',152,152,152,152,0,0.00,5704,0,0,'Vanilla'),
+(236,1,'127.0.0.1',54230,'Port_Bastok',152,152,152,152,0,0.00,5704,0,0,'Vanilla'),
+(237,1,'127.0.0.1',54230,'Metalworks',154,154,154,154,0,0.00,5128,0,0,'Vanilla'),
+(238,1,'127.0.0.1',54230,'Windurst_Waters',151,151,151,151,0,0.00,5192,0,0,'Vanilla'),
+(239,1,'127.0.0.1',54230,'Windurst_Walls',151,151,151,151,0,0.00,5704,0,0,'Vanilla'),
+(240,1,'127.0.0.1',54230,'Port_Windurst',151,151,151,151,0,0.00,5192,0,0,'Vanilla'),
+(241,1,'127.0.0.1',54230,'Windurst_Woods',151,151,151,151,0,0.00,5704,0,0,'Vanilla'),
+(242,1,'127.0.0.1',54230,'Heavens_Tower',162,162,151,151,0,0.00,5128,0,0,'Vanilla'),
+(243,1,'127.0.0.1',54230,'RuLude_Gardens',117,117,117,117,0,0.00,5704,0,0,'Vanilla'),
+(244,1,'127.0.0.1',54230,'Upper_Jeuno',110,110,110,110,0,0.00,5704,0,0,'Vanilla'),
+(245,1,'127.0.0.1',54230,'Lower_Jeuno',110,110,110,110,0,0.00,5704,0,0,'Vanilla'),
+(246,1,'127.0.0.1',54230,'Port_Jeuno',110,110,110,110,0,0.00,5704,0,0,'Vanilla'),
+(247,1,'127.0.0.1',54230,'Rabao',208,208,208,208,0,0.00,5736,0,0,'ROZ'),
+(248,1,'127.0.0.1',54230,'Selbina',112,112,112,112,0,0.00,5160,0,0,'Vanilla'),
+(249,1,'127.0.0.1',54230,'Mhaura',105,105,105,105,0,0.00,5160,0,0,'Vanilla'),
+(250,1,'127.0.0.1',54230,'Kazham',135,135,135,135,0,0.00,5672,0,0,'ROZ'),
+(251,1,'127.0.0.1',54230,'Hall_of_the_Gods',213,213,213,213,0,0.00,4104,0,0,'ROZ'),
+(252,1,'127.0.0.1',54230,'Norg',209,209,209,209,0,0.00,5736,0,0,'ROZ'),
+(253,2,'127.0.0.1',54230,'Abyssea-Uleguerand',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(254,2,'127.0.0.1',54230,'Abyssea-Grauberg',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(255,2,'127.0.0.1',54230,'Abyssea-Empyreal_Paradox',51,51,52,52,0,0.00,2202,0,0,'Abyssea'),
+(256,1,'127.0.0.1',54230,'Western_Adoulin',59,59,59,59,0,0.00,5704,0,0,'SOA'),
+(257,1,'127.0.0.1',54230,'Eastern_Adoulin',63,63,63,63,0,0.00,5704,0,0,'SOA'),
+(258,3,'127.0.0.1',54230,'Rala_Waterways',61,61,57,57,0,0.00,6298,0,0,'SOA'),
+(259,6,'127.0.0.1',54230,'Rala_Waterways_U',61,61,57,57,0,0.00,6298,0,0,'SOA'),
+(260,2,'127.0.0.1',54230,'Yahse_Hunting_Grounds',60,60,57,57,0,0.00,2204,0,0,'SOA'),
+(261,2,'127.0.0.1',54230,'Ceizak_Battlegrounds',60,60,57,57,0,0.00,2204,0,0,'SOA'),
+(262,2,'127.0.0.1',54230,'Foret_de_Hennetiel',60,60,57,57,0,0.00,2204,0,0,'SOA'),
+(263,2,'127.0.0.1',54230,'Yorcia_Weald',61,61,57,57,0,0.00,2204,0,0,'SOA'),
+(264,6,'127.0.0.1',54230,'Yorcia_Weald_U',62,62,62,62,0,0.00,6298,0,0,'SOA'),
+(265,2,'127.0.0.1',54230,'Morimar_Basalt_Fields',60,60,57,57,0,0.00,2204,0,0,'SOA'),
+(266,2,'127.0.0.1',54230,'Marjami_Ravine',60,60,57,57,0,0.00,2204,0,0,'SOA'),
+(267,2,'127.0.0.1',54230,'Kamihr_Drifts',72,72,57,57,0,0.00,2204,0,0,'SOA'),
+(268,3,'127.0.0.1',54230,'Sih_Gates',0,0,57,57,0,0.00,6298,0,0,'SOA'),
+(269,3,'127.0.0.1',54230,'Moh_Gates',0,0,57,57,0,0.00,6298,0,0,'SOA'),
+(270,3,'127.0.0.1',54230,'Cirdas_Caverns',0,0,57,57,0,0.00,6298,0,0,'SOA'),
+(271,6,'127.0.0.1',54230,'Cirdas_Caverns_U',62,62,62,62,0,0.00,6298,0,0,'SOA'),
+(272,3,'127.0.0.1',54230,'Dho_Gates',0,0,57,57,0,0.00,6298,0,0,'SOA'),
+(273,3,'127.0.0.1',54230,'Woh_Gates',0,0,57,57,0,0.00,6298,0,0,'SOA'),
+(274,3,'127.0.0.1',54230,'Outer_RaKaznar',73,73,57,57,0,0.00,6298,0,0,'SOA'),
+(275,0,'127.0.0.1',54230,'Outer_RaKaznar_[U1]',62,62,62,62,0,0.00,2202,0,0,'SOA'),
+(276,0,'127.0.0.1',54230,'RaKaznar_Inner_Court',73,73,57,57,0,0.00,2202,0,0,'SOA'),
+(277,0,'127.0.0.1',54230,'RaKaznar_Turris',0,0,0,0,0,0.00,0,0,0,'SOA'),
+(278,0,'127.0.0.1',54230,'Gwora-Corridor',0,0,0,0,0,0.00,0,0,0,NULL),
+(279,0,'127.0.0.1',54230,'Walk_of_Echoes_[P2]',0,0,0,0,0,0.00,2048,0,0,'WOTG'),
+(280,1,'127.0.0.1',54230,'Mog_Garden',67,67,67,67,0,0.00,4128,0,0,'SOA'),
+(281,0,'127.0.0.1',54230,'Leafallia',0,0,0,0,0,0.00,0,0,0,'SOA'),
+(282,0,'127.0.0.1',54230,'Mount_Kamihr',0,0,0,0,0,0.00,0,0,0,'SOA'),
+(283,0,'127.0.0.1',54230,'Silver_Knife',0,0,0,0,0,0.00,0,0,0,'SOA'),
+(284,1,'127.0.0.1',54230,'Celennia_Memorial_Library',63,63,0,0,0,0.00,4096,0,0,'SOA'),
+(285,1,'127.0.0.1',54230,'Feretory',0,0,0,0,0,0.00,4128,0,0,NULL),
+(286,0,'127.0.0.1',54230,'286',0,0,0,0,0,0.00,0,0,0,NULL),
+(287,6,'127.0.0.1',54230,'Maquette_Abdhaljs-Legion_B',0,0,143,143,0,0.00,6298,0,0,NULL),
+(288,2,'127.0.0.1',54230,'Escha_ZiTah',80,80,80,80,0,0.00,2200,0,0,'ROV'),
+(289,2,'127.0.0.1',54230,'Escha_RuAun',80,80,80,80,0,0.00,2200,0,0,'ROV'),
+(290,0,'127.0.0.1',54230,'Desuetia_Empyreal_Paradox',0,0,0,0,0,0.00,2176,0,0,'ROV'),
+(291,0,'127.0.0.1',54230,'Reisenjima',79,79,79,79,0,0.00,2176,0,0,'ROV'),
+(292,0,'127.0.0.1',54230,'Reisenjima_Henge',0,0,0,0,0,0.00,2048,0,0,'ROV'),
+(293,0,'127.0.0.1',54230,'Reisenjima_Sanctorium',0,0,0,0,0,0.00,2176,0,0,'ROV'),
+(294,5,'127.0.0.1',54230,'Dynamis-San_dOria_[D]',88,88,88,88,0,0.00,6544,0,0,'ROV'),
+(295,5,'127.0.0.1',54230,'Dynamis-Bastok_[D]',88,88,88,88,0,0.00,6544,0,0,'ROV'),
+(296,5,'127.0.0.1',54230,'Dynamis-Windurst_[D]',88,88,88,88,0,0.00,6544,0,0,'ROV'),
+(297,5,'127.0.0.1',54230,'Dynamis-Jeuno_[D]',88,88,88,88,0,0.00,6544,0,0,'ROV'),
+(298,0,'127.0.0.1',54230,'Walk_of_Echoes_[P1]',186,186,186,186,0,0.00,2048,0,0,'WOTG'),
+(299,0,'127.0.0.1',54230,'Gwora-Throne_Room',0,0,0,0,0,0.00,0,0,0,NULL);
 /*!40000 ALTER TABLE `zone_settings` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -355,3 +361,6 @@ UNLOCK TABLES;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2023-11-01 17:20:27
+

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2894,6 +2894,22 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
                 return;
             }
 
+            const char* fmtQuery = "SELECT content_tag FROM zone_settings WHERE zoneid = %u";
+            int32       ret      = sql->Query(fmtQuery, zoneid);
+            if (ret != SQL_ERROR && sql->NumRows() != 0)
+            {
+                while (sql->NextRow() == SQL_SUCCESS)
+                {
+                    std::string contentTagZoningInto = sql->GetStringData(0);
+                    if (!luautils::IsContentEnabled(contentTagZoningInto.c_str()))
+                    {
+                        ShowWarning(fmt::format("Char {} requested zone ({}) but that zone's content tag isn't enabled", PChar->name, zoneid));
+                        PChar->pushPacket(new CMessageSystemPacket(0, 0, 2)); // You could not enter the next area.
+                        return;
+                    }
+                }
+            }
+
             auto ipp = zoneutils::GetZoneIPP(zoneid);
             if (ipp == 0)
             {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x ] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR makes it so that when you enable an expansion via main.lua then that expansions zones will be available. If you disable an expansion in main.lua than that expansions zones will be disables.  People can leave their IP address alone in the zone_settings.sql (unless they want to disable individual zones).

## Steps to test these changes

Disable an expansion and try to zone to one of its zones. You will get a message from the map program stating the expansion is disabled. 
