### PR TITLE
Replace nil function call for spell:addEffectFlag()

### DIFF
--- a/scripts/actions/spells/black/death.lua
+++ b/scripts/actions/spells/black/death.lua
@@ -6,7 +6,7 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    spell:addEffectFlag(xi.magic.spellFlag.IGNORE_SHADOWS)
+    spell:setFlag(xi.magic.spellFlag.IGNORE_SHADOWS)
     return 0
 end
 

--- a/scripts/actions/spells/songs/maidens_virelai.lua
+++ b/scripts/actions/spells/songs/maidens_virelai.lua
@@ -13,7 +13,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 
     -- Per wiki, Virelai wipes all shadows even if it resists or the target is immune to charm
     -- This can't be done in the onSpellCast function (that runs after it "hits")
-    spell:addEffectFlag(xi.magic.spellFlag.WIPE_SHADOWS)
+    spell:setFlag(xi.magic.spellFlag.WIPE_SHADOWS)
 
     return 0
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Addresses an issue that was raised, where Maiden's Virelai could not be cast. A similar call was also found in death.lua, so I replaced that one as well.
![image](https://github.com/LandSandBoat/server/assets/65316697/82d1b5a6-8686-4a93-9d61-fb05fd80f2cb)

## Steps to test these changes
![image](https://github.com/LandSandBoat/server/assets/65316697/7d0ca017-cab4-46dd-8272-f93218958fd9)

<!-- Clear and detailed steps to test your changes here -->
