### PR TITLE
Implement Amigo Sabotender Ability: ??? Needles

### DIFF
--- a/scripts/actions/mobskills/questionmarks_needles.lua
+++ b/scripts/actions/mobskills/questionmarks_needles.lua
@@ -1,6 +1,8 @@
 -----------------------------------
 -- ??? Needles
 -- Description: Shoots multiple needles at enemies within range.
+-- 'The Amigo Sabotender's special ability 1000 Needles has been renamed ??? Needles.''
+-- https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-(JST)-Version-Update
 -----------------------------------
 local mobskillObject = {}
 
@@ -9,15 +11,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- from http://ffxiclopedia.wikia.com/wiki/%3F%3F%3F_Needles
-    -- "Seen totals ranging from 15, 000 to 55, 000 needles."
-    local needles = math.random(15000, 55000) / skill:getTotalTargets()
+        -- from http://ffxiclopedia.wikia.com/wiki/%3F%3F%3F_Needles
+        -- "Seen totals ranging from 15, 000 to 55, 000 needles."
+    if mob:getID() == zones[xi.zone.ABYSSEA_ALTEPA].mob.CUIJATENDER then
+        local needles = math.random(15000, 55000) / skill:getTotalTargets()
+        local dmg     = xi.mobskills.mobFinalAdjustments(needles, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    local dmg = xi.mobskills.mobFinalAdjustments(needles, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.LIGHT)
 
-    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.LIGHT)
+        return dmg
+    else
+        local needles = math.random(1000, 10000) / skill:getTotalTargets()
+        local dmg     = xi.mobskills.mobFinalAdjustments(needles, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.LIGHT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    return dmg
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.LIGHT)
+
+        return dmg
+    end
 end
 
 return mobskillObject

--- a/scripts/zones/Abyssea-Altepa/IDs.lua
+++ b/scripts/zones/Abyssea-Altepa/IDs.lua
@@ -93,6 +93,7 @@ zones[xi.zone.ABYSSEA_ALTEPA] =
         CHICKCHARNEY                = 17670577,
         VADLEANY                    = 17670578,
         BUGUL_NOZ                   = 17670579,
+        CUIJATENDER                 = GetFirstID('Cuijatender'),
     },
     npc =
     {

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -551,7 +551,7 @@ INSERT INTO `abilities` VALUES (695,'big_scissors',9,25,257,1,102,0,0,0,2000,0,6
 INSERT INTO `abilities` VALUES (696,'scissor_guard',9,25,257,2,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (697,'metallic_body',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (698,'needleshot',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
-INSERT INTO `abilities` VALUES (699,'qmqmqm_needles',9,25,257,3,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
+INSERT INTO `abilities` VALUES (699,'questionmarks_needles',9,25,257,3,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (700,'frogkick',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (701,'spore',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);
 INSERT INTO `abilities` VALUES (702,'queasyshroom',9,25,257,1,102,0,0,0,2000,0,6,18.0,0,1,60,0,0,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, BSTs using this 'Ready' ability will simply burn charges with no action being taken by the pet.
This corrects that issue, and add's handling inside the ??? Needles mobskill to align with changes by SE 'renaming'  Amigo Sabotender's 1000 Needles to ??? Needles.

https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-(JST)-Version-Update

## Steps to test these changes
1. Add jug of sun water and equip
2. Call Beast
3. Fight an enemy, and Ready ??? Needles, it will do 1000 damage on a single target as 1000 Needles currently does.
