### PR TITLE
consume lamian fang key upon opening door

### DIFF
--- a/scripts/zones/Arrapago_Reef/npcs/_1ie.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_1ie.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
         if npcUtil.tradeHas(trade, xi.item.LAMIAN_FANG_KEY) then
             npc:openDoor()
             player:messageSpecial(ID.text.KEY_BREAKS, xi.item.LAMIAN_FANG_KEY)
-            player:confirmTrade()
+            player:tradeComplete()
         elseif
             npcUtil.tradeHas(trade, xi.item.SET_OF_THIEFS_TOOLS) and
             player:getMainJob() == xi.job.THF


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Currently allows players to indefinitely keep their Lamian Fang keys when opening door in Arrapago Reef. Key should be consumed on use.

https://www.bg-wiki.com/ffxi/Lamian_Fang_Key

## Steps to test these changes

Trade Lamian Fang key to door, it will break and be consumed.
