### PR TITLE
samba power formulas adjusted

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1388,30 +1388,30 @@ namespace battleutils
 
                 if (daze == EFFECT_DRAIN_DAZE && power > 0)
                 {
-                    uint16 multiplier = (uint16)(3 + (5.5f * power - 1));
+                    uint16 multiplier = (uint16)(3 + 5.5f * (power - 1));
                     int8   Samba      = xirand::GetRandomNumber(1, (delay * multiplier) / 100 + 1);
 
                     // vary damage based on lvl diff
-                    int8 lvlDiff = (PDefender->GetMLevel() - PAttacker->GetMLevel()) / 2;
+                    int8 lvlDiff = (PDefender->GetMLevel() - PAttacker->GetMLevel());
 
-                    if (lvlDiff < -5)
+                    if (lvlDiff > 0)
                     {
-                        lvlDiff = -5;
-                    }
-
-                    Samba -= lvlDiff;
-
-                    if (Samba > (finaldamage / 2))
-                    {
-                        Samba = finaldamage / 2;
+                        if (lvlDiff > 10)
+                        {
+                            lvlDiff = 10;
+                        }
+                        Samba -= ceil(Samba * lvlDiff * .04); // 4% penalty per level
                     }
 
                     if (finaldamage <= 2)
                     {
                         Samba = 0;
                     }
-
-                    if (Samba < 0)
+                    else if (Samba > (finaldamage / 2))
+                    {
+                        Samba = finaldamage / 2;
+                    }
+                    else if (Samba < 0)
                     {
                         Samba = 0;
                     }
@@ -1420,7 +1420,7 @@ namespace battleutils
                     Action->addEffectMessage = 161;
                     Action->addEffectParam   = Samba;
 
-                    PAttacker->addHP(Samba); // does not do any additional drain to targets HP, only a portion of it
+                    PAttacker->addHP(Samba); // does not do any additional damage to targets HP, only heals the attacker
 
                     if (PChar != nullptr)
                     {
@@ -1429,20 +1429,18 @@ namespace battleutils
                 }
                 else if (daze == EFFECT_ASPIR_DAZE && power > 0 && PDefender->GetMaxMP() > 0)
                 {
-                    uint16 multiplier = 1 + (2 * power - 1);
+                    uint16 multiplier = 1 + 2 * (power - 1);
                     int8   Samba      = xirand::GetRandomNumber(1, (delay * multiplier) / 100 + 1);
-
-                    if (Samba >= finaldamage / 4)
-                    {
-                        Samba = finaldamage / 4;
-                    }
 
                     if (finaldamage <= 2)
                     {
                         Samba = 0;
                     }
-
-                    if (Samba < 0)
+                    else if (Samba >= finaldamage / 4)
+                    {
+                        Samba = finaldamage / 4;
+                    }
+                    else if (Samba < 0)
                     {
                         Samba = 0;
                     }


### PR DESCRIPTION
- to match wiki descriptions
- to scale on level and not give bonus for being above defender's lvl

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Here, Drain Samba and Aspir Samba seemed to have dropped this: `(`

The formulas for both were giving a tier higher for the base bonus, according to ffxiclopedia.

> https://ffxiclopedia.fandom.com/wiki/Drain_Samba
> 
> Drain amount varies between 1 and Drain cap, where Cap = floor(mDelay*3/100) where mDelay is modified delay after haste, slow, etc. Verification Needed See discussion.
> Cannot drain more than 1/2 damage dealt.
> 
> https://ffxiclopedia.fandom.com/wiki/Drain_Samba_II
> 
> Same as Drain Samba, with the cap on Drain potency increased to Delay*8/100.
> 
> https://ffxiclopedia.fandom.com/wiki/Drain_Samba_III
> 
> Same as Drain Samba but with a cap of Delay*14/100.
> 
> https://ffxiclopedia.fandom.com/wiki/Aspir_Samba
> 
> Drains 1-8 MP per regular melee strike; one-handed weapons drain 1 to 4 per hit, two-handed weapons drain 3 to 7 (and rarely 8) per hit.
> 
> https://ffxiclopedia.fandom.com/wiki/Aspir_Samba_II
> 
> Drains 1-15 MP, one-handed weapons drain 1 to 8 per hit, two-handed weapons drain 3 to 15 per hit.
> 
> From [Talk page](https://ffxiclopedia.fandom.com/wiki/Talk:Aspir_Samba)
> "I've been throwing calculations around and I think I nailed down AS1 as being [Cap = floor(mDelay*1/100)], with all the variables being the same as those used in DS1. It seems to fit in testing as well. I got the idea when i noticed Aspir was draining around half as much (in terms of pure numbers) as Drain Samba 1. Likewise, Aspir Samba 2 drains nearly as much (if not the same as) Drain Samba 1, making its formula [Cap = floor(mDelay*(3/100)]"

Also, for Drain Samba, the level difference made no sense and has no real basis for precedent in other aspects of ffxi (giving a raw subtraction of samba amount based on level difference?). Adjusted to what WingsXI has been using for a while now and seems to scale nicely: 4% reduction per level.

I kept the bonus up to 10 levels whereas WingsXI has been using 5. Unsure if there's good info anywhere on those specifics

Finally, the level difference adjustment was giving a boost to the base drain after the random number generator up to 10 levels _above_ the defender. There's no evidence of that anywhere that I can see, and generally you're getting that bonus already due to half your damage being higher on average, so you already get a bonus for being over level.

A screenshot of before and 2 after

Drain samba II before change, always doing half the damage dealt (note I have spherai sorry about that, sometimes the dmg is tripled, throwing off the numbers)
![image](https://github.com/LandSandBoat/server/assets/131182600/f81d98f5-336d-4ded-82fd-eaeb866ac25d)

Drain samba II after change, 
![image](https://github.com/LandSandBoat/server/assets/131182600/a3731fc6-3e49-49e1-82d9-a7037495ecc3)

Drain samba I for comparison, also after change
![image](https://github.com/LandSandBoat/server/assets/131182600/46e83ca4-8047-46cb-b4d2-cba90e8a37ae)

Edit: even though the aspir samba changes were simple, screenshot for it after changes for posterity:

![image](https://github.com/LandSandBoat/server/assets/131182600/500252e7-be55-4fc5-b271-4fc9c0ec55ba)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Drain samba tier 1 was the power of Tier 2, T2 was 3, and 3 was the mythical DS4
Same for Aspir Samba

pull out weapons and see that they do less max per tier, and specifically Drain Samba doesn't cap at half the damage dealt most attack rounds.