### PR TITLE
Monk mob weapon damage adjustments to match PC

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -56,6 +56,7 @@ namespace mobutils
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot)
     {
         uint16 lvl    = PMob->GetMLevel();
+        auto*  weapon = dynamic_cast<CItemWeapon*>(PMob->m_Weapons[SLOT_MAIN]);
         int8   bonus  = 2;
         uint16 damage = 0;
 
@@ -69,7 +70,17 @@ namespace mobutils
             bonus = 0;
         }
 
-        damage = lvl + bonus;
+        if (slot == SLOT_MAIN && (weapon == nullptr || weapon->getSkillType() == SKILL_HAND_TO_HAND))
+        {
+            // https://ffxiclopedia.fandom.com/wiki/Category:Hand-to-Hand
+            // base h2h weapon dmg for a given h2h skill: (0.11 * h2h skill) + 3
+            uint16 h2hskill = battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_MNK, lvl);
+            damage          = 0.11f * h2hskill + 3;
+        }
+        else
+        {
+            damage = lvl + bonus;
+        }
 
         damage = (uint16)(damage * PMob->m_dmgMult / 100.0f);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Monk mobs hit like a truck because their weapon damage is calculated the same as all other mob types: `mlvl + bonus`

This adjusts them to follow the h2h curve for weapon damage based on skill for that level. I've also added a bit of bonus I had added on WingsXI to simulate a h2h weapon's additional bonus to weapon damage. I assume we'd remove it but better to include at the start for more information.

Before:
![image](https://github.com/LandSandBoat/server/assets/131182600/377cf537-88c2-4220-9c10-4f37875605ce)

After:
![image](https://github.com/LandSandBoat/server/assets/131182600/435104ad-dd9e-4f1d-8ce6-b81cb1dd6ed1)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Simple enough, fight various monk mobs and notice they don't Dual Wield 2h weapons with h2h delay anymore.