### PR TITLE
Improve Messaging on Monk's Mantra Ability

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -130,12 +130,15 @@ xi.job_utils.monk.useInnerStrength = function(player, target, ability)
 end
 
 xi.job_utils.monk.useMantra = function(player, target, ability)
-    local merits = player:getMerit(xi.merit.MANTRA)
+    local hpBoost = player:getMerit(xi.merit.MANTRA) -- TODO: Add augment boost here aswell
 
-    player:delStatusEffect(xi.effect.MAX_HP_BOOST)
-    target:addStatusEffect(xi.effect.MAX_HP_BOOST, merits, 0, 180)
+    if not target:hasStatusEffect(xi.effect.MAX_HP_BOOST) then
+        target:addStatusEffect(xi.effect.MAX_HP_BOOST, hpBoost, 0, 180)
 
-    return xi.effect.MANTRA -- TODO: implement xi.effect.MANTRA
+        return xi.effect.MANTRA
+    else
+        return target:messageBasic(xi.msg.basic.NO_EFFECT)
+    end
 end
 
 xi.job_utils.monk.usePerfectCounter = function(player, target, ability)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implement Monk's Mantra ability so that it provides an HP boost to party members based on the Monk's merits.

https://www.bg-wiki.com/ffxi/Mantra

## Steps to test these changes
Join a party
Use Mantra
Enjoy HP Boost with percentage consistent with Monk's merit points rank
