### PR TITLE
Remove a few out of many guild items that do not belong at all

### DIFF
--- a/sql/guild_shops.sql
+++ b/sql/guild_shops.sql
@@ -652,7 +652,6 @@ INSERT INTO `guild_shops` VALUES (5272,13333,1186,1238,20,0,20);     -- amethyst
 INSERT INTO `guild_shops` VALUES (5272,13334,1186,1238,20,0,20);     -- lapis_laz._earring
 INSERT INTO `guild_shops` VALUES (5272,13340,12880,12880,20,0,10);   -- ametrine_earring
 INSERT INTO `guild_shops` VALUES (5272,13342,12250,12250,20,0,10);   -- sphene_earring
-INSERT INTO `guild_shops` VALUES (5272,13343,1987,5000,20,0,10);     -- green_earring
 INSERT INTO `guild_shops` VALUES (5272,13344,1987,5000,20,0,10);     -- sun_earring
 INSERT INTO `guild_shops` VALUES (5272,13454,72,179,20,0,20);        -- copper_ring
 INSERT INTO `guild_shops` VALUES (5272,13468,1875,2400,20,0,15);     -- tourmaline_ring
@@ -723,7 +722,6 @@ INSERT INTO `guild_shops` VALUES (529,12697,2700,7092,20,0,15);      -- lizard_g
 INSERT INTO `guild_shops` VALUES (529,12698,11610,53625,20,0,10);    -- studded_gloves
 INSERT INTO `guild_shops` VALUES (529,12699,17052,44789,20,0,5);     -- cuir_gloves
 INSERT INTO `guild_shops` VALUES (529,12700,29700,150480,20,0,5);    -- raptor_gloves
-INSERT INTO `guild_shops` VALUES (529,12724,589,1055,20,0,20);       -- battle_bracers
 INSERT INTO `guild_shops` VALUES (529,12825,5819,10714,20,0,15);     -- lizard_trousers
 INSERT INTO `guild_shops` VALUES (529,12826,32002,36232,20,0,10);    -- studded_trousers
 INSERT INTO `guild_shops` VALUES (529,12827,25200,66192,20,0,5);     -- cuir_trousers

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -10059,7 +10059,7 @@ INSERT INTO `item_basic` VALUES (12720,0,'gloves','gloves',1,2084,19,0,303);
 INSERT INTO `item_basic` VALUES (12721,0,'cotton_gloves','cotton_gloves',1,2084,19,0,372);
 INSERT INTO `item_basic` VALUES (12722,0,'bracers','bracers',1,2084,19,0,315);
 INSERT INTO `item_basic` VALUES (12723,0,'wool_bracers','wool_bracers',1,2084,19,0,3440);
-INSERT INTO `item_basic` VALUES (12724,0,'battle_bracers','battle_bracers',1,2084,19,0,1); -- TODO: Replace with actual value
+INSERT INTO `item_basic` VALUES (12724,0,'battle_bracers','battle_bracers',1,2084,19,0,4207);
 INSERT INTO `item_basic` VALUES (12725,0,'war_gloves','war_gloves',1,2084,19,0,6140);
 INSERT INTO `item_basic` VALUES (12726,0,'mercenary_captains_gloves','mrc.cpt._gloves',1,2084,19,0,1634);
 INSERT INTO `item_basic` VALUES (12727,0,'engineers_gloves','engineers_gloves',1,26704,0,0,3179);
@@ -10675,7 +10675,7 @@ INSERT INTO `item_basic` VALUES (13339,0,'goshenite_earring','goshenite_earring'
 INSERT INTO `item_basic` VALUES (13340,0,'ametrine_earring','ametrine_earring',1,2084,24,0,1253);
 INSERT INTO `item_basic` VALUES (13341,0,'turquoise_earring','turquoise_earring',1,2084,24,0,1253);
 INSERT INTO `item_basic` VALUES (13342,0,'sphene_earring','sphene_earring',1,2084,24,0,1253);
-INSERT INTO `item_basic` VALUES (13343,0,'green_earring','green_earring',1,2084,24,0,1981);
+INSERT INTO `item_basic` VALUES (13343,0,'green_earring','green_earring',1,2084,24,0,2062);
 INSERT INTO `item_basic` VALUES (13344,0,'sun_earring','sun_earring',1,2084,24,0,1981);
 INSERT INTO `item_basic` VALUES (13345,0,'zircon_earring','zircon_earring',1,2084,24,0,1981);
 INSERT INTO `item_basic` VALUES (13346,0,'purple_earring','purple_earring',1,2084,24,0,1981);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Puts back the basesell of battle bracers: its actually correct as verified by the recommended fame neutral NPC.

Adjusts basesell of Green Earing to match price at that same NPC.

Removes both items from Guild sql table.

The guild shops however, have 50-100+ items across multiple guilds that simply do not belong. **battle bracers aren't even a leathercraft item! they are cloth!** ***wth!*** These need completely redone. See #1191 which was originally intended to focus mainly on prices.

## Steps to test these changes
visit Challoux with items in inventory (port jeuno by the Chocobo stable door) and try and sell them. see correct prices matching retail. Visit guilds. See guilds do not even have these items in their list.
