### PR TITLE
[lua] Add Wall of Banishing open/close animation

### DIFF
--- a/scripts/zones/Davoi/npcs/_45d.lua
+++ b/scripts/zones/Davoi/npcs/_45d.lua
@@ -25,7 +25,13 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 42 and option == 0 then
         player:messageSpecial(ID.text.POWER_OF_THE_ORB_ALLOW_PASS)
-        npc:openDoor(16)
+        npc:openDoor(20)
+
+        -- Animation for the "door" being open
+        npc:setAnimation(8)
+        npc:timer(1000 * 20, function(npcArg)
+            npcArg:setAnimation(9)
+        end)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Add wall of banishing open/close animation

animation 8:
![image](https://github.com/LandSandBoat/server/assets/60417494/823893a9-3f48-426a-a836-f39512ebe6a6)
animation 9:
![image](https://github.com/LandSandBoat/server/assets/60417494/85688207-b3c6-49fb-bb1d-9b751405cae5)
approximately 20~ seconds

![image](https://github.com/LandSandBoat/server/assets/60417494/61235617-8e57-44dd-adcf-ac8108fc63e1)



## Steps to test these changes

open the wall of banishing, see the portal open a bit.
