### PR TITLE
Wall of Banishing followup: Remove openDoor method and comment why.

### DIFF
--- a/scripts/zones/Davoi/npcs/_45d.lua
+++ b/scripts/zones/Davoi/npcs/_45d.lua
@@ -12,7 +12,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if npc:getAnimation() == 9 then
+    if npc:getAnimation() == xi.animation.CLOSE_DOOR then
         if player:hasKeyItem(xi.ki.CRIMSON_ORB) then
             player:startEvent(42)
         end
@@ -23,14 +23,22 @@ entity.onEventUpdate = function(player, csid, option, npc)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    if csid == 42 and option == 0 then
+    if
+        csid == 42 and
+        option == 0 and
+        npc:getAnimation() == xi.animation.CLOSE_DOOR
+    then
         player:messageSpecial(ID.text.POWER_OF_THE_ORB_ALLOW_PASS)
 
-        -- Animation for the "door" being open.
         -- NOTE: npc:openDoor sends a different animation packet and doesn't work.
-        npc:setAnimation(8)
-        npc:timer(1000 * 20, function(npcArg)
-            npcArg:setAnimation(9)
+        -- TODO: Decide what to do with openDoor(). Replace this with it if we do change it.
+
+        -- Animation for the "door" being open.
+        npc:setAnimation(xi.animation.OPEN_DOOR)
+
+        -- Close door after 20 seconds.
+        npc:timer(20000, function(npcArg)
+            npcArg:setAnimation(xi.animation.CLOSE_DOOR)
         end)
     end
 end

--- a/scripts/zones/Davoi/npcs/_45d.lua
+++ b/scripts/zones/Davoi/npcs/_45d.lua
@@ -25,9 +25,9 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 42 and option == 0 then
         player:messageSpecial(ID.text.POWER_OF_THE_ORB_ALLOW_PASS)
-        npc:openDoor(20)
 
-        -- Animation for the "door" being open
+        -- Animation for the "door" being open.
+        -- NOTE: npc:openDoor sends a different animation packet and doesn't work.
         npc:setAnimation(8)
         npc:timer(1000 * 20, function(npcArg)
             npcArg:setAnimation(9)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes original method from script, which doesn't seem to work properly for this concrete door.
openDoor() uses a different animation packet than setAnimation.
- Adds comment explaining the reason and a TODO.
- Replaces animation IDs with their enums.
- Adds check for door closed on event finish, just in case.

## Steps to test these changes

None. This change removes a duplicate (the original) non working method. No changes can be observed.
