### PR TITLE
[Food] Add "HP recovered while healing" mod to "marinara sauce"

### DIFF
--- a/scripts/items/jar_of_marinara_sauce.lua
+++ b/scripts/items/jar_of_marinara_sauce.lua
@@ -5,6 +5,7 @@
 -----------------------------------
 -- Mind 2
 -- Intelligence 1
+-- HP recovered while healing +1
 -----------------------------------
 local itemObject = {}
 
@@ -19,11 +20,13 @@ end
 itemObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.MND, 2)
     target:addMod(xi.mod.INT, 1)
+    target:addMod(xi.mod.HPHEAL, 1)
 end
 
 itemObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.MND, 2)
     target:delMod(xi.mod.INT, 1)
+    target:delMod(xi.mod.HPHEAL, 1)
 end
 
 return itemObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Closes #4696
- Adds HP recovered while healing +1 to Marinara Sauce, as per wiki: https://www.bg-wiki.com/ffxi/Marinara_Sauce

## Steps to test these changes

- Eat a raw nasty whole Jar of Marinara sauce, by itself.
- See how it somehow makes you heal faster instead of killing you.
