### PR TITLE
[Trust] Check for valid item before attempting to Despoil

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -91,13 +91,16 @@ xi.job_utils.thief.checkCollaborator = function(player, target, ability)
 end
 
 xi.job_utils.thief.checkDespoil = function(player, target, ability)
-    if player:getFreeSlotsCount() == 0 then
-        return xi.msg.basic.FULL_INVENTORY, 0
-    end
-
-    if player:getObjType() == xi.objType.TRUST then
-        if player:getMaster():getFreeSlotsCount() == 0 then
+    if player:getObjType() == xi.objType.TRUST then -- Trust
+        if
+            player:getMaster():getFreeSlotsCount() == 0 or
+            not target:getDespoilItem()
+        then
             return 1, 0
+        end
+    else -- Player
+        if player:getFreeSlotsCount() == 0 then
+            return xi.msg.basic.FULL_INVENTORY, 0
         end
     end
 
@@ -212,7 +215,11 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
 
     local stolen = target:getDespoilItem()
 
-    if target:isMob() and math.random(100) < despoilChance and stolen then
+    if
+        target:isMob() and
+        math.random(1, 100) <= despoilChance and
+        stolen
+    then
         if player:getObjType() == xi.objType.TRUST then
             player:getMaster():addItem(stolen)
         else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Nanaa Mihgo will try to add a nil item to the player when Despoil fails.
This adds a check to prevent trusts from using Despoil when no item is able to be despoiled.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Hang out with Nanaa Mihgo out and fight until she tries to Despoil a mob and fails. You should not get a 'blank' item message.