### PR TITLE
Fix typo in event functions

### DIFF
--- a/scripts/zones/Chocobo_Circuit/npcs/Vaihilique.lua
+++ b/scripts/zones/Chocobo_Circuit/npcs/Vaihilique.lua
@@ -15,7 +15,7 @@ end
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
-entity.onEventFinsih = function(player, csid, option, npc)
+entity.onEventFinish = function(player, csid, option, npc)
 end
 
 return entity

--- a/scripts/zones/Chocobo_Circuit/npcs/Valerio.lua
+++ b/scripts/zones/Chocobo_Circuit/npcs/Valerio.lua
@@ -15,7 +15,7 @@ end
 entity.onEventUpdate = function(player, csid, option, npc)
 end
 
-entity.onEventFinsih = function(player, csid, option, npc)
+entity.onEventFinish = function(player, csid, option, npc)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I came across this typo by chance... fixes typo in the event functions

## Steps to test these changes
:crossed_fingers: 
