### PR TITLE
Disable WP NPCs to prevent players hard-locking client

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Gamimi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Gamimi.lua
@@ -10,7 +10,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(10000) -- , 0, 0, 0, 0, 0, -1, 2)
+    -- Currently selecting option 1 will result in a hard lock of the player requiring them to force quit the client.
+    -- This likely needs special handling in the core.
+    -- player:startEvent(10000) -- , 0, 0, 0, 0, 0, -1, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Bastok/npcs/Kachada.lua
+++ b/scripts/zones/Port_Bastok/npcs/Kachada.lua
@@ -8,7 +8,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(96)--, 0, 0, 0, 0, 0, -1, 2)
+    -- Currently selecting option 1 will result in a hard lock of the player requiring them to force quit the client.
+    -- This likely needs special handling in the core.
+    -- player:startEvent(96)--, 0, 0, 0, 0, 0, -1, 2)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_San_dOria/npcs/Ambleon.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Ambleon.lua
@@ -10,7 +10,9 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(710)
+    -- Currently selecting option 1 will result in a hard lock of the player requiring them to force quit the client.
+    -- This likely needs special handling in the core.
+    -- player:startEvent(710)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Disables the World Pass NPC's as they currently cause the client to hard lock requiring players to force quit.

## Steps to test these changes
Speak to NPC and not get hard locked
