### PR TITLE
[lua] Remove PromathiaStatus variable from beginning of CoP 8-1

### DIFF
--- a/scripts/zones/AlTaieu/npcs/_0x0.lua
+++ b/scripts/zones/AlTaieu/npcs/_0x0.lua
@@ -24,7 +24,7 @@ entity.onTrigger = function(player, npc)
 
     if
         player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.GARDEN_OF_ANTIQUITY and
-        player:getCharVar('PromathiaStatus') == 1
+        player:getCharVar('PromathiaStatus') == 0
     then
         player:startEvent(164)
     elseif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes requirement for variable of **PromathiaStatus** variable from the beginning of CoP 8-1 (the part where you interact with the Crystalline Field npc (npc scripts/zones/AlTaieu/npcs/`_0x0.lua`).

- Re-organizes the flow of the code block so that false-positives (character being teleported inside of The Grand Palace of HuXzoi prior to completion of the 3 tower fights) don't occur due to removal of the **PromathiaStatus** variable from the beginning part of 8-1.

Due to CoP Chapters 7 and prior now being written in the Interaction Framework, the **PromathiaStatus** variable does not exist at all prior to CoP 8-1.  The requirement for the variable to be listed/have a value interferes with the necessary CS being obtained from the Crystalline Field npc (and the **PromathiaStatus** variable then being created/set to the necessary value) for the remainder of CoP 8-1 onwards to be performed as coded.

## Steps to test these changes

- Before this PR is merged
  - `!pos .1 -10 -464 33`
  - `!addmission 6 800 <me>`
  - Interact with the Crystalline Field npc and be disappointed that it shakes its head and refuses to react at all.
- After cherry-picking this PR (or waiting until after it is merged)
  - `!pos .1 -10 -464 33`
  - `!addmission 6 800 <me>`
  - Interact with the Crystalline Field npc and rejoice that you receive the necessary CS and that the **PromathiaStatus** variable now exists (`!checkvar <me> PromathiaStatus`) with the correct variable value (`2`) needed for the next step(s), the 3 tower fights, to occur.  
  - Be happy now knowing that you can proceed with the remainder of CoP, rejoicing that since you like Promathia so much, you can finally put a ring on it. ♫