### PR TITLE
Make geo_attack_boost and geo_accuracy_boost affect ranged att and acc

### DIFF
--- a/scripts/effects/geo_accuracy_boost.lua
+++ b/scripts/effects/geo_accuracy_boost.lua
@@ -5,6 +5,7 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ACC, effect:getPower())
+    target:addMod(xi.mod.RACC, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -12,6 +13,7 @@ end
 
 effectObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ACC, effect:getPower())
+    target:delMod(xi.mod.RACC, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/geo_attack_boost.lua
+++ b/scripts/effects/geo_attack_boost.lua
@@ -5,6 +5,7 @@ local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
     target:addMod(xi.mod.ATTP, effect:getPower())
+    target:addMod(xi.mod.RATTP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -12,6 +13,7 @@ end
 
 effectObject.onEffectLose = function(target, effect)
     target:delMod(xi.mod.ATTP, effect:getPower())
+    target:delMod(xi.mod.RATTP, effect:getPower())
 end
 
 return effectObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This patch adds ranged attack/accuracy to geo fury 

## Steps to test these changes

Create the changes to the geo_fury effect and geo precision effect (indy versions as well).  Equip a ranged weapon and test that both regular attack/accuracy and ranged attack/accuracy accurately get increased.  Verify that upon buff wearing that the accuracy/attack boost are removed.
https://www.bg-wiki.com/ffxi/Geo-Fury
https://www.bg-wiki.com/ffxi/Geo-Precision