### PR TITLE
[core] Add process args to dump tombstone

### DIFF
--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -143,6 +143,12 @@ ConsoleService::ConsoleService()
         }
     });
 
+    RegisterCommand("crash", "Crash the process",
+    [](std::vector<std::string>& inputs)
+    {
+        crash();
+    });
+
     bool attached = isatty(0);
     if (attached)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Collects and prints process launch args on Windows when Wheaty fires up - will help peeps on multi-process setups

Launch with:
```
PS C:\ffxi\server> .\xi_search.exe --port 1
```

```
=====================================================
!!! CRASH !!!
Exception code: C0000005 (ACCESS_VIOLATION)
Fault address: 00007FF6F0AA5B82 01:0000000000074B82
Process Name: C:\ffxi\server\xi_search.exe --port 1
Full crash report: C:\ffxi\server\dmp\xi_search.exe_10-11_10-3-12.log
Memory dump: C:\ffxi\server\dmp\xi_search.exe_10-11_10-3-12.dmp
Time of crash: 2023/11/10 10:03:12
Process Uptime: 1 seconds
```

^ Note the args available with Process Name now

## Steps to test these changes

Start a process (search is good), use `crash` command, get tombstone