### PR TITLE
[blue spells] "crit/acc varies with tp" adjustments

### DIFF
--- a/scripts/actions/spells/blue/1000_needles.lua
+++ b/scripts/actions/spells/blue/1000_needles.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = TPMOD_DAMAGE
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.LIGHT
     params.skillType = xi.skill.BLUE_MAGIC

--- a/scripts/actions/spells/blue/asuran_claws.lua
+++ b/scripts/actions/spells/blue/asuran_claws.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.LIQUEFACTION

--- a/scripts/actions/spells/blue/bludgeon.lua
+++ b/scripts/actions/spells/blue/bludgeon.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.ARCANA
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.H2H
     params.scattr = xi.skillchainType.LIQUEFACTION

--- a/scripts/actions/spells/blue/disseverment.lua
+++ b/scripts/actions/spells/blue/disseverment.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.LUMINIAN
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.DISTORTION

--- a/scripts/actions/spells/blue/feather_storm.lua
+++ b/scripts/actions/spells/blue/feather_storm.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
     params.tpmod = TPMOD_CRITICAL
+    params.critchance = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.critchance = 55
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.critchance = math.floor(caster:getTP() / 75)
+    end
+
     params.attackType = xi.attackType.RANGED
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/foot_kick.lua
+++ b/scripts/actions/spells/blue/foot_kick.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
     params.tpmod = TPMOD_CRITICAL
+    params.critchance = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.critchance = 55
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.critchance = math.floor(caster:getTP() / 75)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.DETONATION

--- a/scripts/actions/spells/blue/frypan.lua
+++ b/scripts/actions/spells/blue/frypan.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.IMPACTION

--- a/scripts/actions/spells/blue/jet_stream.lua
+++ b/scripts/actions/spells/blue/jet_stream.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BIRD
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.IMPACTION

--- a/scripts/actions/spells/blue/power_attack.lua
+++ b/scripts/actions/spells/blue/power_attack.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
     params.tpmod = TPMOD_CRITICAL
+    params.critchance = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.critchance = 55
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.critchance = math.floor(caster:getTP() / 75)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.REVERBERATION

--- a/scripts/actions/spells/blue/queasyshroom.lua
+++ b/scripts/actions/spells/blue/queasyshroom.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = TPMOD_DURATION
     params.attackType = xi.attackType.RANGED
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.COMPRESSION

--- a/scripts/actions/spells/blue/screwdriver.lua
+++ b/scripts/actions/spells/blue/screwdriver.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.AQUAN
     params.tpmod = TPMOD_CRITICAL
+    params.critchance = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.critchance = 55
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.critchance = math.floor(caster:getTP() / 75)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/seedspray.lua
+++ b/scripts/actions/spells/blue/seedspray.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = TPMOD_DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.INDURATION

--- a/scripts/actions/spells/blue/sickle_slash.lua
+++ b/scripts/actions/spells/blue/sickle_slash.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
     params.tpmod = TPMOD_CRITICAL
+    params.critchance = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.critchance = 55
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.critchance = math.floor(caster:getTP() / 75)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.COMPRESSION

--- a/scripts/actions/spells/blue/spinal_cleave.lua
+++ b/scripts/actions/spells/blue/spinal_cleave.lua
@@ -22,6 +22,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.UNDEAD
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.SCISSION

--- a/scripts/actions/spells/blue/spiral_spin.lua
+++ b/scripts/actions/spells/blue/spiral_spin.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = TPMOD_DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/sub-zero_smash.lua
+++ b/scripts/actions/spells/blue/sub-zero_smash.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.AQUAN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = TPMOD_DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.FRAGMENTATION

--- a/scripts/actions/spells/blue/terror_touch.lua
+++ b/scripts/actions/spells/blue/terror_touch.lua
@@ -23,6 +23,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.UNDEAD
     params.tpmod = TPMOD_ACC
+    params.bonusacc = 0
+    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+        params.bonusacc = 70
+    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        params.bonusacc = math.floor(caster:getTP() / 50)
+    end
+
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.COMPRESSION


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Goes in tandem with #4698 . Essentially handles the "crit/acc varies with TP" outside of `bluemagic.lua` for simplicity.

Ideally one day the tpmod param would define what happens inside `bluemagic.lua`. I would love to do it one day, but I don't have the time to fully audit all of them (also looks like we're missing a tpmod_chance to increase chance to apply debuffs instead of duration).

Note that the changes in the other PR are required for this to affect any change

## Steps to test these changes

Have 3k tp, use blu skills that vary acc or crit with TP, see that they do not get a bonus. Use CA and see that they do. Azure Lore gives a flat (large) bonus as well