### PR TITLE
[LUA]Corrects typo that causes issues with Royal Jelly

### DIFF
--- a/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
@@ -418,7 +418,7 @@ local loot =
         },
         {
             { itemid = xi.item.MANA_RING,             droprate = 469 },
-            { itemid = xi.item.GRUDGE_SWORD0,         droprate = 152 },
+            { itemid = xi.item.GRUDGE_SWORD,          droprate = 152 },
             { itemid = xi.item.DE_SAINTRES_AXE,       droprate = 120 },
             { itemid = xi.item.BUZZARD_TUCK,          droprate = 118 },
             { itemid = xi.item.SCROLL_OF_UTSUSEMI_NI, droprate = 106 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Prevents Exploit within "Royal Jelly" due to a bad ENUM. The chest may be triggered multiple times currently since #4606 was merged.
![image](https://github.com/LandSandBoat/server/assets/98081508/b8a178ca-0f69-42f3-b776-86a3a3a9cc34)


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Apply changes and see no map errors for a "nil" value
