### PR TITLE
[Lua] Scarlette_CA: incorrect default event id

### DIFF
--- a/scripts/zones/Southern_San_dOria_[S]/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/DefaultActions.lua
@@ -54,7 +54,7 @@ return {
     ['Rongelouts_N_Distaud']     = { event = 604 },
     ['Sabiliont']                = { event = 608 },
     ['Saphiriance_TK']           = { event = 450 },
-    ['Scarlette_CA']             = { event = 489 },
+    ['Scarlette_CA']             = { event = 459 },
     ['Suspicious_Object']        = { text = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Thierride']                = { event = 333 },
     ['Touttaures']               = { event = 603 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The PR fixes a typo in the event id for this NPC. 

Partner PR with https://github.com/LandSandBoat/server/pull/4721

I'm splitting this out for my own information because I'd love to know what exactly the reasoning is for `DefaultActions.lua` to be round robined with an actual `onTrigger` function for an NPC.

Tracked the history for this entry to just when this zone's `DefaultActions.lua` file was created, the event id was copied wrong...but I'd like to know why exactly it's used when an NPC has a proper `onTrigger` function.

Story:
I updated `Scarlette_CA.lua` to perform an actual startevent, but hitting Scarlette the first time would lock the client. You could hit esc to unlock and interact again to get the menu to function properly (sounds trivial, but it actually wasted a solid hour of my time trying to figure out wth was going on there). So basically an NPC defined in `DefaultActions.lua` uses round robin between the npc's lua and the default action lua event id

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
