### PR TITLE
Monstrosity 1.5: Minor fixes and safeguards

### DIFF
--- a/scripts/commands/monstrosity.lua
+++ b/scripts/commands/monstrosity.lua
@@ -11,6 +11,11 @@ commandObj.cmdprops =
 }
 
 commandObj.onTrigger = function(player)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        player:PrintToPlayer('Setting main.ENABLE_MONSTROSITY is not enabled.')
+        return
+    end
+
     if player:getMainJob() ~= xi.job.MON then
         local pos = player:getPos()
         player:setMonstrosityEntryData(pos.x, pos.y, pos.z, pos.rot, player:getZoneID(), player:getMainJob(), player:getSubJob())

--- a/scripts/globals/monstrosity.lua
+++ b/scripts/globals/monstrosity.lua
@@ -1221,6 +1221,10 @@ xi.monstrosity.odysseanPassageOnTrade = function(player, npc, trade)
 end
 
 xi.monstrosity.odysseanPassageOnTrigger = function(player, npc)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
     local monSize         = player:getMonstrositySize()
     local hasBelligerency = player:getBelligerencyFlag() and 1 or 0
 
@@ -1282,6 +1286,10 @@ xi.monstrosity.feretoryOnZoneIn = function(player, prevZone)
         player:setPos(-358.000, -3.400, -440.00, 63)
     end
 
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return cs
+    end
+
     if player:getMainJob() ~= xi.job.MON then
         player:changeJob(xi.job.MON)
     end
@@ -1294,10 +1302,13 @@ xi.monstrosity.feretoryOnZoneIn = function(player, prevZone)
 end
 
 xi.monstrosity.feretoryOnZoneOut = function(player)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
     -- Mark all status effects so they'll survive zoning
     -- (there are some routines that will force them off anyway)
     for _, effect in pairs(player:getStatusEffects()) do
-        print(effect)
         effect:delEffectFlag(xi.effectFlag.ON_ZONE)
         effect:delEffectFlag(xi.effectFlag.LOGOUT)
     end
@@ -1317,6 +1328,10 @@ xi.monstrosity.aengusOnTrade = function(player, npc, trade)
 end
 
 xi.monstrosity.aengusOnTrigger = function(player, npc)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
     local inBelligerency = player:getBelligerencyFlag() and 1 or 0
     player:startEvent(13, inBelligerency, player:getCurrency('infamy'), 0, 0, 0, 0, 0, 0)
 end
@@ -1339,6 +1354,10 @@ xi.monstrosity.teyrnonOnTrade = function(player, npc, trade)
 end
 
 xi.monstrosity.teyrnonOnTrigger = function(player, npc)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
     player:startEvent(7, player:getCurrency('infamy'), 0, 0, 0, 0, 0, 0, 0)
 end
 
@@ -1578,6 +1597,10 @@ xi.monstrosity.maccusOnTrade = function(player, npc, trade)
 end
 
 xi.monstrosity.maccusOnTrigger = function(player, npc)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
     player:startEvent(9, 285, 2, 2, 0, 0, 0, 0, 0)
 end
 

--- a/scripts/quests/hiddenQuests/Monstrosity_Bee.lua
+++ b/scripts/quests/hiddenQuests/Monstrosity_Bee.lua
@@ -42,7 +42,8 @@ quest.sections =
 {
     {
         check = function(player, questVars, vars)
-            return quest:getVar(player, 'Timer') <= VanadielUniqueDay() and
+            return xi.settings.main.ENABLE_MONSTROSITY == 1 and
+                quest:getVar(player, 'Timer') <= VanadielUniqueDay() and
                 not xi.monstrosity.hasUnlockedSpecies(player, xi.monstrosity.species.BEE)
         end,
 

--- a/scripts/zones/Feretory/DefaultActions.lua
+++ b/scripts/zones/Feretory/DefaultActions.lua
@@ -1,5 +1,4 @@
 -- local ID = zones[xi.zone.FERETORY]
 
 return {
-    ['Suibhne'] = { event = 11 },
 }

--- a/scripts/zones/Feretory/npcs/Suibhne.lua
+++ b/scripts/zones/Feretory/npcs/Suibhne.lua
@@ -9,6 +9,11 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
+    if xi.settings.main.ENABLE_MONSTROSITY ~= 1 then
+        return
+    end
+
+    player:startEvent(11)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -72,7 +72,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
         actionTarget.animation  = 0;
         actionTarget.param      = m_PSkill->getID();
         actionTarget.messageID  = 43;
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", CLuaBaseEntity(m_PEntity), m_PSkill->getID());
     SpendCost();
@@ -153,7 +153,7 @@ void CMobSkillState::Cleanup(time_point tick)
         actionTarget.animation       = 0x1FC; // Not perfectly accurate, this animation ID can change from time to time for unknown reasons.
         actionTarget.reaction        = REACTION::HIT;
 
-        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, new CActionPacket(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
 
         // On retail testing, mobs lose 33% of their TP at 2900 or higher TP
         // But lose 25% at < 2900 TP.

--- a/src/map/monstrosity.cpp
+++ b/src/map/monstrosity.cpp
@@ -277,7 +277,7 @@ void monstrosity::WriteMonstrosityData(CCharEntity* PChar)
 
 void monstrosity::TryPopulateMonstrosityData(CCharEntity* PChar)
 {
-    if (PChar->GetMJob() == JOB_MON)
+    if (settings::get<bool>("main.ENABLE_MONSTROSITY") && PChar->GetMJob() == JOB_MON)
     {
         // Populates PChar->m_PMonstrosity
         ReadMonstrosityData(PChar);
@@ -289,6 +289,11 @@ void monstrosity::TryPopulateMonstrosityData(CCharEntity* PChar)
 
 void monstrosity::HandleZoneIn(CCharEntity* PChar)
 {
+    if (!settings::get<bool>("main.ENABLE_MONSTROSITY"))
+    {
+        return;
+    }
+
     if (PChar->m_PMonstrosity == nullptr)
     {
         return;
@@ -587,6 +592,7 @@ void monstrosity::SetLevel(CCharEntity* PChar, uint8 id, uint8 level)
     {
         return;
     }
+
     // TODO: Validate id and level
     // TODO: If not unlocked, unlock whatever id is
     PChar->m_PMonstrosity->levels[id] = level;

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -196,6 +196,11 @@ void CCharPacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 update
                 ref<uint32>(0x3E) = monstrosity::GetPackedMonstrosityName(PChar);
                 ref<uint16>(0x48) = PChar->m_PMonstrosity->Look;
                 ref<uint16>(0x58) = 0xFFFF;
+
+                if (PChar->m_PMonstrosity->Belligerency)
+                {
+                    ref<uint8>(0x29) |= 0x08;
+                }
             }
         }
         break;

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1209,7 +1209,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
         // clang-format off
         switch (message_type)
         {
-            case CHAR_INRANGE_SELF:
+            case CHAR_INRANGE_SELF: // NOTE!!!: This falls through to CHAR_INRANGE so both self and the local area get the packet
             {
                 TracyZoneCString("CHAR_INRANGE_SELF");
                 if (PEntity->objtype == TYPE_PC)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ports some small fixes from the Monstrosity 2.0 branch, and adds more safeguards for if you find yourself in the Monstrosity-only Feretory zone without Monstrosity enabled.

Closes https://github.com/LandSandBoat/server/issues/4714

## Steps to test these changes

make sure ENABLE_MONSTROSITY is zero in your settings, zone in and out of Feretory and try to fanny around with the NPCs - nothing should happen. You can only get there as a GM, so you can GM your way out of it too at that point.

ENABLE_MONSTROSITY is still defaulted to zero.
