### PR TITLE
[core] Add 0x051 equipset to retrigger latents, retrigger on action

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -219,7 +219,7 @@ CCharEntity::CCharEntity()
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
 
-    retriggerLatentsAfterPacketParsing = false;
+    retriggerLatents = false;
 
     resetPetZoningInfo();
     petZoningInfo.petID = 0;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -422,7 +422,7 @@ public:
     bool           MeritMode;
 
     CLatentEffectContainer* PLatentEffectContainer;
-    bool                    retriggerLatentsAfterPacketParsing; // used to retrigger all latent effects after packet parsing is done in map.cpp
+    bool                    retriggerLatents; // used to retrigger all latent effects if some event requires them to be retriggered
 
     CItemContainer* PGuildShop;
     CItemContainer* getStorage(uint8 LocationID);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -806,7 +806,7 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
         }
     }
 
-    if (PChar->retriggerLatentsAfterPacketParsing)
+    if (PChar->retriggerLatents)
     {
         for (uint8 equipSlotID = 0; equipSlotID < 16; ++equipSlotID)
         {
@@ -815,7 +815,7 @@ int32 parse(int8* buff, size_t* buffsize, sockaddr_in* from, map_session_data_t*
                 PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
             }
         }
-        PChar->retriggerLatentsAfterPacketParsing = false; // reset for next packet parse
+        PChar->retriggerLatents = false; // reset as we have retriggered the latents somewhere
     }
 
     map_session_data->client_packet_id = SmallPD_Code;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -874,6 +874,19 @@ void SmallPacket0x01A(map_session_data_t* const PSession, CCharEntity* const PCh
     ShowTrace(actionStr);
     DebugActions(actionStr);
 
+    // Retrigger latents if the previous packet parse in this chunk included equip/equipset
+    if (PChar->retriggerLatents)
+    {
+        for (uint8 equipSlotID = 0; equipSlotID < 16; ++equipSlotID)
+        {
+            if (PChar->equip[equipSlotID] != 0)
+            {
+                PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
+            }
+        }
+        PChar->retriggerLatents = false; // reset as we have retriggered the latents somewhere
+    }
+
     switch (action)
     {
         case 0x00: // trigger
@@ -3478,7 +3491,7 @@ void SmallPacket0x050(map_session_data_t* const PSession, CCharEntity* const PCh
     charutils::SaveCharLook(PChar);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
-    PChar->retriggerLatentsAfterPacketParsing = true; // retrigger all latents after all equip packets are parsed
+    PChar->retriggerLatents = true; // retrigger all latents later because our gear has changed
 }
 
 /************************************************************************
@@ -3511,6 +3524,7 @@ void SmallPacket0x051(map_session_data_t* const PSession, CCharEntity* const PCh
     charutils::SaveCharLook(PChar);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
+    PChar->retriggerLatents = true; // retrigger all latents later because our gear has changed
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This commit refactors the retrigger latent variable in CCharEntity to be more generic in case latents need to be retriggered elsewhere
This commit also will allow retriggering of latents sent from equipsets, not just normal equip packets.
Actions (0x01A) will now reprocess latents if an equipset/equip was sent in the same chunk.

## Steps to test these changes
Try to trigger various latents that would exist only in precast (ala gearswap/luashitacast) and see they work correctly
