### PR TITLE
[lua] ToAU26 - Remove RoyalPalaceArmorCheck requirement

### DIFF
--- a/scripts/missions/toau/26_Seal_of_the_Serpent.lua
+++ b/scripts/missions/toau/26_Seal_of_the_Serpent.lua
@@ -5,8 +5,6 @@
 -- !addmission 4 25
 -- Imperial Whitegate : !pos 152 -2 0 50
 -----------------------------------
-local whitegateShared = require('scripts/zones/Aht_Urhgan_Whitegate/Shared')
------------------------------------
 
 local mission = Mission:new(xi.mission.log_id.TOAU, xi.mission.id.toau.SEAL_OF_THE_SERPENT)
 
@@ -29,8 +27,7 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if
                         player:getEquipID(xi.slot.MAIN) == 0 and
-                        player:getEquipID(xi.slot.SUB) == 0 and
-                        whitegateShared.doRoyalPalaceArmorCheck(player)
+                        player:getEquipID(xi.slot.SUB) == 0
                     then
                         return mission:progressEvent(3111)
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes the Royal Palace Armor Check from the list of requirements to receive the CS at the Imperial Whitegate and continue on with the rest of ToAU26 and further.

Please reference this Youtube video (https://www.youtube.com/watch?v=SPOPmjeRgi4&t=560) (video is courtesy of the Captures discord) (video is skipped to the pertinent section of the video for ToAU26) where the player interacts with the Imperial Whitegate first with having weapons equipped (no change in body armors), receiving no response from the Imperial Whitegate, then the player removed only their weapons (still no change in body armors) and interacted with the Imperial Whitegate again and received the correct CS.

Please also reference ffxiclopedia/BG-wiki guides (https://ffxiclopedia.fandom.com/wiki/Aht_Urhgan_Mission_26:_Seal_of_the_Serpent / https://www.bg-wiki.com/ffxi/Aht_Urhgan_Mission_26) for this mission, neither of which indicate a requirement for the specific armors necessary for interaction with the Imperial Whitegate to receive the relevant CS.

## Steps to test these changes

Prior to this PR:
- Be a GM with the correct GM level to be able to use the below GM commands.
- **!addmission 4 25 <me>**
- **!pos 152 -2 0 50**
- Remove no main hand/offhand weapons/shields and armors.
- Interact with the Imperial Whitegate and receive expected hostile response from the guards and also don't receive the relevant necessary cutscene.
- Remove only your main hand/offhand weapons/shields (as indicated by the above video/ffxiclopedia/BG-wiki).
- Interact with the Imperial Whitegate and be confused because you still receive a hostile response from the guards.
- Search around in your inventories for whatever armors you equipped for other interactions with the Imperial Whitegate and equip them.
- Interact with the Imperial Whitegate and be confused because you actually received the correct response when you should have only needed to remove your weapons (and not also need to put on your fancy Aht Urhgan royal garb).

After this PR has been merged (or after you have cherry-picked this PR):
- Be a GM with the correct GM level to be able to use the below GM commands.
- **!addmission 4 25 <me>**
- **!pos 152 -2 0 50**
- Remove no main hand/offhand weapons/shields and armors.
- Interact with the Imperial Whitegate and receive expected hostile response from the guards and also don't receive the relevant necessary cutscene.
- Remove only your main hand/offhand weapons/shields (as indicated by the above video/ffxiclopedia/BG-wiki).
- Interact with the Imperial Whitegate and receive the relevant cutscene needed to continue on with the rest of the mission and the remainder of the ToAU mission storyline.
- Mumble under your breath after you exit the Imperial Palace that you'll show those guards exactly what a sellsword is useful for!