### PR TITLE
[LUA] Update aoe teleport items

### DIFF
--- a/scripts/effects/teleport.lua
+++ b/scripts/effects/teleport.lua
@@ -27,6 +27,8 @@ effectObject.onEffectLose = function(target, effect)
         xi.teleport.toHomeNation(target)
     elseif destination == xi.teleport.id.RETRACE then
         xi.teleport.toAlliedNation(target)
+    elseif destination == xi.teleport.id.TIDAL_TALISMAN then
+        xi.teleport.tidalTeleport(target)
     else
         xi.teleport.to(target, destination)
     end

--- a/scripts/globals/teleports.lua
+++ b/scripts/globals/teleports.lua
@@ -77,7 +77,8 @@ local ids =
     ESCHA_ZITAH           = 64,
     QUFIM_CONFLUENCE      = 65,
     ESCHA_RUAUN           = 66,
-    MISAREAUX_CONFLUENCE  = 67
+    MISAREAUX_CONFLUENCE  = 67,
+    TIDAL_TALISMAN        = 69,
 }
 xi.teleport.id = ids
 
@@ -498,5 +499,39 @@ xi.teleport.explorerMoogleOnEventFinish = function(player, csid, option, event)
         elseif option == 5 and player:delGil(price) then
             xi.teleport.toExplorerMoogle(player, 249)
         end
+    end
+end
+
+xi.teleport.tidalDestinations =
+{
+    [xi.zone.CHATEAU_DORAGUILLE]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.NORTHERN_SAN_DORIA]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.SOUTHERN_SAN_DORIA]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.PORT_SAN_DORIA]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.BASTOK_MARKETS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.BASTOK_MINES]         = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.METALWORKS]           = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.PORT_BASTOK]          = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.PORT_WINDURST]        = {   0,   3,   2 , 64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.WINDURST_WALLS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.WINDURST_WATERS]      = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.WINDURST_WOODS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.KAZHAM]               = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
+    [xi.zone.LOWER_JEUNO]          = { -33,  -8, -71,  97, xi.zone.KAZHAM },
+    [xi.zone.PORT_JEUNO]           = { -33,  -8, -71,  97, xi.zone.KAZHAM },
+    [xi.zone.UPPER_JEUNO]          = { -33,  -8, -71,  97, xi.zone.KAZHAM },
+    [xi.zone.RULUDE_GARDENS]       = { -33,  -8, -71,  97, xi.zone.KAZHAM },
+    [xi.zone.MHAURA]               = {  18, -14,  79,  62, xi.zone.SELBINA },
+    [xi.zone.SELBINA]              = {   0,  -8,  59,  62, xi.zone.MHAURA },
+    [xi.zone.AHT_URHGAN_WHITEGATE] = {  12,  -6,  31,  63, xi.zone.NASHMAU },
+    [xi.zone.NASHMAU]              = { -73,   0,   0, 252, xi.zone.AHT_URHGAN_WHITEGATE },
+}
+
+xi.teleport.tidalTeleport = function(player)
+    local zone = player:getZoneID()
+    local destination = xi.teleport.tidalDestinations[zone]
+
+    if destination then
+        player:setPos(unpack(destination))
     end
 end

--- a/scripts/items/moogle_cap.lua
+++ b/scripts/items/moogle_cap.lua
@@ -3,6 +3,8 @@
 --  Moogle Cap
 --  Transports the user to their Home Nation
 -----------------------------------
+require('scripts/globals/teleports')
+-----------------------------------
 local itemObject = {}
 
 itemObject.onItemCheck = function(target)
@@ -10,15 +12,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local nation = target:getNation(target)
-
-    if nation == 0 then -- San d'Oria
-        target:setPos(126, 0, -1, 122, 231)
-    elseif nation == 1 then -- Bastok
-        target:setPos(106, 0, -71, 130, 234)
-    elseif nation == 2 then -- Windurst
-        target:setPos(197, -12, 224, 65, 240)
-    end
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/nomad_cap.lua
+++ b/scripts/items/nomad_cap.lua
@@ -4,24 +4,16 @@
 -- Transports the user to their Home Nation
 -- TODO: Confirm wiki claims of random zone destinations among a same nation.
 -----------------------------------
+require('scripts/globals/teleports')
+-----------------------------------
 local itemObject = {}
-
-local pos =
-{
-    -- Content  [Nation] = {   x,   y,  z, rot, zone },
-    [xi.nation.SANDORIA] = { 126,   0,  -1, 122, 231 },
-    [xi.nation.BASTOK  ] = { 106,   0, -71, 130, 234 },
-    [xi.nation.WINDURST] = { 197, -12, 224,  65, 240 },
-}
 
 itemObject.onItemCheck = function(target)
     return 0
 end
 
 itemObject.onItemUse = function(target)
-    local nation = target:getNation(target)
-
-    target:setPos(unpack(pos[nation]))
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOME_NATION, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/tidal_talisman.lua
+++ b/scripts/items/tidal_talisman.lua
@@ -2,39 +2,17 @@
 -- ID: 11290
 -- Item: tidal talisman
 -----------------------------------
+require('scripts/globals/teleports')
+-----------------------------------
 local itemObject = {}
-
-local teleportData =
-{
-    [xi.zone.CHATEAU_DORAGUILLE]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.NORTHERN_SAN_DORIA]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.SOUTHERN_SAN_DORIA]   = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.PORT_SAN_DORIA]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.BASTOK_MARKETS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.BASTOK_MINES]         = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.METALWORKS]           = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.PORT_BASTOK]          = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.PORT_WINDURST]        = {   0,   3,   2 , 64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.WINDURST_WALLS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.WINDURST_WATERS]      = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.WINDURST_WOODS]       = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.KAZHAM]               = {   0,   3,   2,  64, xi.zone.RULUDE_GARDENS },
-    [xi.zone.LOWER_JEUNO]          = { -33,  -8, -71,  97, xi.zone.KAZHAM },
-    [xi.zone.PORT_JEUNO]           = { -33,  -8, -71,  97, xi.zone.KAZHAM },
-    [xi.zone.UPPER_JEUNO]          = { -33,  -8, -71,  97, xi.zone.KAZHAM },
-    [xi.zone.RULUDE_GARDENS]       = { -33,  -8, -71,  97, xi.zone.KAZHAM },
-    [xi.zone.MHAURA]               = {  18, -14,  79,  62, xi.zone.SELBINA },
-    [xi.zone.SELBINA]              = {   0,  -8,  59,  62, xi.zone.MHAURA },
-    [xi.zone.AHT_URHGAN_WHITEGATE] = {  12,  -6,  31,  63, xi.zone.NASHMAU },
-    [xi.zone.NASHMAU]              = { -73,   0,   0, 252, xi.zone.AHT_URHGAN_WHITEGATE },
-}
 
 itemObject.onItemCheck = function(target)
     local zoneId = target:getZoneID()
+    local destZoneData = xi.teleport.tidalDestinations[zoneId]
 
     if
-        teleportData[zoneId] and
-        target:hasVisitedZone(teleportData[zoneId][5])
+        destZoneData and
+        target:hasVisitedZone(destZoneData[5])
     then
         return 0
     end
@@ -43,7 +21,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:setPos(unpack(teleportData[target:getZoneID()]))
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.TIDAL_TALISMAN, 0, 4)
 end
 
 return itemObject


### PR DESCRIPTION
add a small delay to whole party is warped

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

AoE teleport items: Tidal, Moogle/Nomad cap

They run onItemUse in whichever order cpp decides from the target list, but the `onItemUse` was immediately using `setPos`, so more often than not people would be left behind. This PR changes their behavior to update `xi.effect.teleport` with a `TIDAL_TALISMAN` type, and updates nomad/moogle cap to utilize the already-built `HOME_NATION` type

Confirmed behavior is similar for all three items:

![image](https://github.com/LandSandBoat/server/assets/131182600/b210f2b4-8840-4604-8304-1e357d6cb76c)


## Steps to test these changes

Get in party in single cluster, use tidal, if both players are teleported, give tidal to other member and use. Other member should be left behind

Update with changes from this PR and see that the party is reliably teleported.