### PR TITLE
[SQL] Fix syntax error in item_latents table

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -237,9 +237,7 @@ INSERT INTO `item_latents` VALUES (13143,368,25,13,193);
 -- Uggalepih Pendant
 INSERT INTO `item_latents` VALUES (13145,28,8,4,51);     -- "Magic Atk. Bonus" while MP <51%
 
-----------------------------------------------------------
--- Brisingamen+1
-----------------------------------------------------------
+-- Brisingamen +1
 INSERT INTO `item_latents` VALUES (13162,2,12,26,0);     -- Daytime: HP +12
 INSERT INTO `item_latents` VALUES (13162,5,12,26,1);     -- Nighttime: MP +12
 INSERT INTO `item_latents` VALUES (13162,8,7,28,0);      -- Firesday: STR +7


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes syntax error that prevented properly importing the table to the database. At least, manually.

## Steps to test these changes

Import item_latents with no errors
