### PR TITLE
[Fix] Magian Trials +DMG augment audit

### DIFF
--- a/scripts/globals/magian_data.lua
+++ b/scripts/globals/magian_data.lua
@@ -4036,7 +4036,7 @@ xi.magian.trials =
             itemId       = xi.item.SPHARAI,
             itemAugments =
             {
-                [1] = { 740, 5 }, -- DMG:+8
+                [1] = { 740, 7 }, -- DMG:+8
             },
         },
     },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Was found that Trial 1826 rewarded an incorrect +DMG augment. Wrote a quick script to parse the file for any other instances... and found none:

![image](https://github.com/LandSandBoat/server/assets/131182600/172c91ee-3676-43d5-ae1f-46c94fb0a086)


```
with open("magian_data.lua") as file:
   data = file.read()

lines = data.split("\n")

for line in [line for line in lines if '-- DMG' in line]:
   dmg = int(line.split('DMG:')[1].strip().split(' ')[0].strip()[1:])
   aug = int(line.split('{')[1].split(',')[1].strip().split(' ')[0].strip()) + 1
   if dmg - aug != 0:
     print(line)
     print('{} - {}'.format(dmg,aug))
```

## Steps to test these changes

Trade spharai with +6 dmg augment for trial 1826, see that you receive sparai with +8 dmg