### PR TITLE
Seismostomp wrong tp modifier

### DIFF
--- a/scripts/actions/mobskills/seismostomp.lua
+++ b/scripts/actions/mobskills/seismostomp.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         dmgmod = dmgmod + math.random()
     end
 
-    local info           = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local info           = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES)
     local shadowsRemoved = math.random(1, 2)
     local dmg            = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, shadowsRemoved)
     local typeEffect     = xi.effect.STUN


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The enum being used resolves to the physical TP mod "ACC varies with TP", which results in very low damage all the time

## Steps to test these changes

Seismostomp is used by statues in dynamis and their damage correlates of course with statue level but also by TP fed to it, highly discouraging melee killing them. This change makes the damage output a function of TP when using the skill

![image](https://github.com/LandSandBoat/server/assets/131182600/c1c7c697-dd9e-42a8-ba27-99832f008de6)
