### PR TITLE
[CPP] Reduce expensive calls to SaveCharEquip()

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6402,6 +6402,8 @@ namespace charutils
             PChar->resetPetZoningInfo();
         }
 
+        SaveCharEquip(PChar);
+        SaveCharLook(PChar);
         PChar->pushPacket(new CServerIPPacket(PChar, type, ipp));
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Intro via quote from my original PR at WingsXI gitlab:
> Problem: when latency between map server and mysql is >1ms, the map server lags hard due to the nature of all sql queries being run in series and the map process waiting for the completion to continue. For most operations this isn't a problem ,but one thing in particular causes real issues: gear swaps.
Example of a macro swapping to do a nuke spell:
![image](https://github.com/LandSandBoat/server/assets/131182600/fd02ccfc-e5bc-4b0f-ac7f-a4bf9e3df902)


>This MR simply rate-limits the UPDATE to sql for saving equipment to the database. The only thing that reads the equipment from the db is when a character zones in (or logs in), so I've also added a save before logging out and zoning out.

The situation is similar on LSB it seems. When I originally found this it was from Tracy logging seeing excessive time allocated to processing packet 0x050 and 0x051. Equipsets are somewhat more efficient as they send the whole list of gear that need to be swapped. 0x050 is sent by Ashita when gearswap is called. It sends separate packets for every piece of gear, which (before this PR) calls `SaveCharEquip()` for each packet. This function could possibly be made more efficient with a single transaction for all 18 slots, but it's also mostly unnecessary since the equipment is only read on login/zone. One thing I've found that LSB has but doesn't seem to use is `CCharEntity::PersistData()`. Curious if this change could come with some schedule of persisting equipment. I don't see any references in the code to flagging `dataToPersist & CHAR_PERSIST::EQUIP`. 

At any rate, this change greatly improves input latency when players use Ashitacast to swap gear. CatsEyeXI has a group event that had 50+ people in it over the weekend and input latency was multiple seconds. We implemented these changes with great success.

## Steps to test these changes

Testing can be mostly done by confirming that equipment is saved on every way to leave a zone (zoneline, logout, teleport, etc). AFAICT every teleport-type mechanism calls SendToZone, and WingsXI has used this code for a long while with no complaints of gear being unequipped.

Specifically, run

`SELECT * FROM char_look WHERE charid = 1;`

then change one piece and run it again, see that the slot you equipped updated, then swap and run a third time to see it doesn't save.

Furthermore, check equip saving on logout/zone via this query:

`SELECT * FROM char_equip WHERE charid = 1; `