### PR TITLE
[SQL] Add Forgotten Journey for Vanguard mobs in Dynamis Bastok and Dynamis Jeuno

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -11763,21 +11763,7 @@ INSERT INTO `mob_droplist` VALUES (1441,2,0,1000,1455,0);       -- One Byne Bill
 -- ZoneID: 135 - Kindred Warrior
 -- ZoneID: 135 - Kindred Monk
 -- ZoneID: 135 - Kindred Thief
--- ZoneID: 135 - Kindred Warrior
--- ZoneID: 135 - Kindred White Mage
--- ZoneID: 135 - Kindred Red Mage
--- ZoneID: 135 - Kindred Monk
--- ZoneID: 135 - Kindred Black Mage
--- ZoneID: 135 - Kindred Thief
--- ZoneID: 135 - Kindred Paladin
--- ZoneID: 135 - Kindred Dark Knight
--- ZoneID: 135 - Kindred Beastmaster
--- ZoneID: 135 - Kindred Bard
--- ZoneID: 135 - Kindred Ranger
--- ZoneID: 135 - Kindred Samurai
--- ZoneID: 135 - Kindred Ninja
--- ZoneID: 135 - Kindred Dragoon
--- ZoneID: 135 - Kindred Summoner
+INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,3494,@RARE);   -- Forgotten Hope (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11305,@VRARE); -- Etoile Casaque (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11465,@VRARE); -- Mirage Keffiyeh (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (1442,0,0,1000,11468,@VRARE); -- Commodore Tricorne (Very Rare, 1%)
@@ -20190,20 +20176,9 @@ INSERT INTO `mob_droplist` VALUES (2542,2,0,1000,1455,0);       -- One Byne Bill
 -- ZoneID: 188 - Vanguard Ambusher
 -- ZoneID: 188 - Vanguard Necromancer
 -- ZoneID: 188 - Vanguard Ronin
--- ZoneID: 188 - Vanguard Smithy
--- ZoneID: 188 - Vanguard Pitfighter
--- ZoneID: 188 - Vanguard Welldigger
--- ZoneID: 188 - Vanguard Alchemist
--- ZoneID: 188 - Vanguard Shaman
--- ZoneID: 188 - Vanguard Tinkerer
--- ZoneID: 188 - Vanguard Maestro
--- ZoneID: 188 - Vanguard Ronin
--- ZoneID: 188 - Vanguard Armorer
--- ZoneID: 188 - Vanguard Necromancer
--- ZoneID: 188 - Vanguard Ambusher
--- ZoneID: 188 - Vanguard Hitman
 INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,1470,80);      -- Sparkling Stone (8.0%)
 INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,1520,80);      -- Jar Of Goblin Grease (8.0%)
+INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,3496,@VRARE);  -- Forgotten Journey (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,15028,20);     -- Commodore Gants (2.0%)
 INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,15066,20);     -- Relic Shield (2.0%)
 INSERT INTO `mob_droplist` VALUES (2543,0,0,1000,15102,20);     -- Warriors Mufflers (2.0%)
@@ -20926,25 +20901,10 @@ INSERT INTO `mob_droplist` VALUES (2557,2,0,1000,1455,0);       -- One Byne Bill
 -- ZoneID: 186 - Vanguard Minstrel
 -- ZoneID: 186 - Vanguard Mason
 -- ZoneID: 186 - Vanguard Undertaker
--- ZoneID: 186 - Vanguard Vindicator
--- ZoneID: 186 - Vanguard Militant
--- ZoneID: 186 - Vanguard Constable
--- ZoneID: 186 - Vanguard Thaumaturge
--- ZoneID: 186 - Vanguard Protector
--- ZoneID: 186 - Vanguard Defender
--- ZoneID: 186 - Vanguard Beasttender
--- ZoneID: 186 - Vanguard Drakekeeper
--- ZoneID: 186 - Vanguard Purloiner
--- ZoneID: 186 - Vanguard Vigilante
--- ZoneID: 186 - Vanguard Minstrel
--- ZoneID: 186 - Vanguard Hatamoto
--- ZoneID: 186 - Vanguard Mason
--- ZoneID: 186 - Vanguard Kusa
--- ZoneID: 186 - Vanguard Undertaker
--- ZoneID: 186 - Vanguard Defender
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,1469,80);      -- Chunk Of Wootz Ore (8.0%)
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,1470,80);      -- Sparkling Stone (8.0%)
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,1521,80);      -- Vial Of Slime Juice (8.0%)
+INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,3496,@RARE);   -- Forgotten Journey (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,18278,20);     -- Relic Blade (2.0%)
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,18284,20);     -- Relic Axe (2.0%)
 INSERT INTO `mob_droplist` VALUES (2558,0,0,1000,18302,20);     -- Relic Scythe (2.0%)
@@ -20977,7 +20937,7 @@ INSERT INTO `mob_droplist` VALUES (2559,0,0,1000,1453,@VRARE);  -- Montiont Silv
 INSERT INTO `mob_droplist` VALUES (2559,0,0,1000,1456,@VRARE);  -- One Hundred Byne Bill (Very Rare, 1%)
 
 -- ZoneID: 188 - Vanguard Enchanter
--- ZoneID: 188 - Vanguard Enchanter
+INSERT INTO `mob_droplist` VALUES (2560,0,0,1000,3496,@VRARE);  -- Forgotten Journey (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2560,0,0,1000,15028,20);     -- Commodore Gants (2.0%)
 INSERT INTO `mob_droplist` VALUES (2560,0,0,1000,15066,20);     -- Relic Shield (2.0%)
 INSERT INTO `mob_droplist` VALUES (2560,0,0,1000,15102,20);     -- Warriors Mufflers (2.0%)
@@ -21046,8 +21006,8 @@ INSERT INTO `mob_droplist` VALUES (2562,0,0,1000,16349,@VRARE); -- Commodore Tre
 INSERT INTO `mob_droplist` VALUES (2562,2,0,1000,1452,0);       -- Ordelle Bronzepiece (Steal)
 
 -- ZoneID: 188 - Vanguard Pathfinder
--- ZoneID: 188 - Vanguard Pathfinder
 INSERT INTO `mob_droplist` VALUES (2563,0,0,1000,1520,80);      -- Jar Of Goblin Grease (8.0%)
+INSERT INTO `mob_droplist` VALUES (2563,0,0,1000,3496,@VRARE);  -- Forgotten Journey (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2563,0,0,1000,15028,20);     -- Commodore Gants (2.0%)
 INSERT INTO `mob_droplist` VALUES (2563,0,0,1000,15066,20);     -- Relic Shield (2.0%)
 INSERT INTO `mob_droplist` VALUES (2563,0,0,1000,15102,20);     -- Warriors Mufflers (2.0%)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

removes duplicate comments
adds Forgotten Journey rare drop to vanguards in dynamis bastok and very rare in dynamis jeuno

tested and rarely dropping from mobs assigned with a non thief job (specially the drops in jeuno)

drop rate is based on information from ffxidb (see table bellow), and adjusted to 5% being the closest drop rate in bastok, Jeuno is lower thean 5%, mostly around 2.5% so didnt feel like being generous and increase it to 5% so lowered it to 1% since it kinda matches higher treasure hunter stats. If you guys think it should be increased to be 5% appreciate feedback.


dynamis jeuno – mob | th0
-- | --
Vanguard Alchemist | 2
Vanguard Ambusher | 2.9
Vanguard Armorer | 1.8
Vanguard Dragontamer | 3.7
Vanguard Enchanter | 2.9
Vanguard Hitman | 4.1
Vanguard Maestro | 1.5
Vanguard Necromancer | 1.7
Vanguard Pathfinder | 1.4
Vanguard Pitfighter | 2.6
Vanguard Ronin | 2.5
Vanguard Shaman | 1.9
Vanguard Smithy | 2.5
Vanguard Tinkerer | 1.7
Vanguard Welldigger | 2.1



dynamis bastok – mob | Th0 %
-- | --
Vanguard Beasttender | 8.1
Vanguard Constable | 7
Vanguard Defender | 4.6
Vanguard Drakekeeper | 6.1
Vanguard Hatamoto | 6.9
Vanguard Kusa | 6.8
Vanguard Mason | 3.6
Vanguard Militant | 5
Vanguard Minstrel | 6.8
Vanguard Protector | 7.1
Vanguard Purloiner | 3.7
Vanguard Thaumaturge | 8.7
Vanguard Undertaker | 7.1
Vanguard Vigilante | 8.3
Vanguard Vindicator | 5.5



## Steps to test these changes

Go to dynamis bastok or dynamis qufim and defeat vanguard mobs (non NM)
see Forgotten Journey item drop after defeating them (5% chance drop in bastok, 1% in Jeuno)