### PR TITLE
[SQL] Remove flag on Quickening effect

### DIFF
--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -210,7 +210,7 @@ INSERT INTO `status_effects` VALUES (172,'intension',40,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (173,'dread_spikes',41,34,0,0,0,0,0,0,800);
 INSERT INTO `status_effects` VALUES (174,'magic_acc_down',16418,0,0,0,0,0,1,0,0);
 INSERT INTO `status_effects` VALUES (175,'magic_atk_down',16418,0,0,0,0,0,4,0,0);
-INSERT INTO `status_effects` VALUES (176,'quickening',4194476,0,0,0,0,0,0,0,0);
+INSERT INTO `status_effects` VALUES (176,'quickening',4194348,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (177,'encumbrance',8388608,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (178,'firestorm',4194336,0,0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (179,'hailstorm',4194336,0,0,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Quickening, for a long time it seems, has had the flag `EFFECTFLAG_MAGIC_END` (0x80 = 128). This PR removes that. Hard to prove as absence of evidence is not evidence of absence, but hopefully someone with retail access can confirm. should be simple to test



## Steps to test these changes

Before changes, addeffect quickening and cast any spell. You will lose quickening.

After changes, see that it stays

Notice the buff still in effects bar after casting and zoning
![image](https://github.com/LandSandBoat/server/assets/131182600/320a6aed-eaa6-44af-a315-8428b7a2e1a0)
