### PR TITLE
[Magic] Update aspir/drain spell floors to be last

### DIFF
--- a/scripts/actions/spells/black/aspir.lua
+++ b/scripts/actions/spells/black/aspir.lua
@@ -27,15 +27,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     dmg = adjustForTarget(target, dmg, spell:getElement())
     --add in final adjustments
 
+    dmg = dmg * xi.settings.main.DARK_POWER
+
     if dmg < 0 then
         dmg = 0
     end
 
-    dmg = dmg * xi.settings.main.DARK_POWER
-
     if target:isUndead() then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return dmg
+        return 0
     end
 
     if target:getMP() > dmg then

--- a/scripts/actions/spells/black/aspir_ii.lua
+++ b/scripts/actions/spells/black/aspir_ii.lua
@@ -25,15 +25,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     dmg = adjustForTarget(target, dmg, spell:getElement())
     --add in final adjustments
 
+    dmg = dmg * xi.settings.main.DARK_POWER
+
     if dmg < 0 then
         dmg = 0
     end
 
-    dmg = dmg * xi.settings.main.DARK_POWER
-
     if target:isUndead() then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return dmg
+        return 0
     end
 
     if target:getMP() > dmg then

--- a/scripts/actions/spells/black/drain.lua
+++ b/scripts/actions/spells/black/drain.lua
@@ -31,6 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add in target adjustment
     dmg = adjustForTarget(target, dmg, spell:getElement())
     --add in final adjustments
+    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     if dmg < 0 then
         dmg = 0
@@ -42,10 +43,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     if target:isUndead() then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return dmg
+        return 0
     end
-
-    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     caster:addHP(dmg)
     return dmg

--- a/scripts/actions/spells/black/drain_ii.lua
+++ b/scripts/actions/spells/black/drain_ii.lua
@@ -31,6 +31,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     --add in target adjustment
     dmg = adjustForTarget(target, dmg, spell:getElement())
     --add in final adjustments
+    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     if dmg < 0 then
         dmg = 0
@@ -42,10 +43,8 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     if target:isUndead() then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return dmg
+        return 0
     end
-
-    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     local leftOver = (caster:getHP() + dmg) - caster:getMaxHP()
 


### PR DESCRIPTION
cap amount after all adjustments are made
return 0 when target is undead

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When using drain spells, you cannot do more damage than the mob has HP. Due to the order of things before this PR, often times the resultant damage for a mob at low hp would be less than the mob's total hp due to the call of `target:magicDmgTaken`, which considers `UDMGMAGIC`, etc

This PR does two things:
- reorders the magic adjustments to do the cap of dmg after all other things are considered
  - This is done for drain and aspir for consistency
- returns 0 when target is undead for aspir/drain

## Steps to test these changes

Find a mob somewhat resistant to drain, drain it and see how much damage you do, set its hp to 10 and drain it, see that you _do_ kill it