### PR TITLE
[Fix] Dances with Luopans (GEO unlock quest)

### DIFF
--- a/scripts/effects/healing.lua
+++ b/scripts/effects/healing.lua
@@ -26,21 +26,20 @@ effectObject.onEffectGain = function(target, effect)
         target:getCharVar('GEO_DWL_Luopan') == 0
     then
         local ID                = zones[target:getZoneID()]
-        local currentTime       = os.time()
         local maxWaitTime       = 480 -- Max wait of 8 minutes.
         local secondsPerTick    = xi.settings.map.HEALING_TICK_DELAY
         local minWaitTime       = math.min(3 * secondsPerTick, maxWaitTime)
         local waitTimeInSeconds = math.random(minWaitTime, maxWaitTime)
 
         target:messageSpecial(ID.text.ENERGIES_COURSE)
-        target:setLocalVar('GEO_DWL_Resting', currentTime + waitTimeInSeconds)
+        target:setLocalVar('GEO_DWL_Resting', os.time() + waitTimeInSeconds)
 
         target:timer(waitTimeInSeconds * 1000, function(targetArg)
             local finishTime = targetArg:getLocalVar('GEO_DWL_Resting')
 
             if
                 finishTime > 0 and
-                currentTime >= finishTime
+                os.time() >= finishTime
             then
                 targetArg:messageSpecial(ID.text.MYSTICAL_WARMTH) -- You feel a mystical warmth welling up inside you!
                 targetArg:setLocalVar('GEO_DWL_Resting', 0)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes issue with "You feel a mystical warmth welling up inside you!" text and associated variable handling never happening.

This is because we (me, concretely) stored `os.time()` in a variable that was later checked inside a timer function.
Long story short: We actually need to re-run `os.time()` to get the new time.

This bug was introduced in PR #4744 by yours truly.
Closes #4761 

## Steps to test these changes

Unlock GEO
