### PR TITLE
Adjust warp timings.

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -248,7 +248,7 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
 
     elseif addType == procType.SELF_BUFF then
         if addStatus == xi.effect.TELEPORT then -- WARP
-            attacker:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 1)
+            attacker:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
             msgID    = xi.msg.basic.ADD_EFFECT_WARP
             msgParam = 0
         elseif addStatus == xi.effect.BLINK then -- BLINK http://www.ffxiah.com/item/18830/gusterion

--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1202,7 +1202,7 @@ xi.regime.bookOnEventFinish = function(player, option, regimeType)
             end,
 
             ['HOMING_INSTINCT'] = function()
-                player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 1)
+                player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
             end,
 
             ['RERAISE'] = function()

--- a/scripts/items/scroll_of_instant_warp.lua
+++ b/scripts/items/scroll_of_instant_warp.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
 end
 
 return itemObject

--- a/scripts/items/warp_cudgel.lua
+++ b/scripts/items/warp_cudgel.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 2)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
 end
 
 return itemObject

--- a/scripts/items/warp_ring.lua
+++ b/scripts/items/warp_ring.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Retail takes just short of 3 seconds to animate this before warping you. It's closer to 2800ms but the code expects the answer to be in full seconds, so I am using 3 (3000ms).

That's not far off enough for a human to really notice considering there is also the somewhat random lag factor of packets going to japan and back on retail making _exactness_ tough to pin down. My estimate could be off by up to 300ms (so it could actually be 2500ms at the **lowest** - any faster is going to be abnormal).

Resolves #4769

## Steps to test these changes
`!additem warp_cudgel`
`additem scroll_of_instant_warp`
`additem warp_ring`

Try them out. see that the animation plays in full before you are zoned.

Go to any grounds of Valor tome and try "homing instinct" from the support menu. see the same there.
