### PR TITLE
More teleport timing adjustments

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -247,11 +247,7 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
         end
 
     elseif addType == procType.SELF_BUFF then
-        if addStatus == xi.effect.TELEPORT then -- WARP
-            attacker:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 3)
-            msgID    = xi.msg.basic.ADD_EFFECT_WARP
-            msgParam = 0
-        elseif addStatus == xi.effect.BLINK then -- BLINK http://www.ffxiah.com/item/18830/gusterion
+        if addStatus == xi.effect.BLINK then -- BLINK http://www.ffxiah.com/item/18830/gusterion
             -- Does not stack with or replace other shadows
             if
                 attacker:hasStatusEffect(xi.effect.BLINK) or
@@ -268,6 +264,15 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
             -- Todo: verify power/duration/tier/overwrite etc
             msgID    = xi.msg.basic.ADD_EFFECT_SELFBUFF
             msgParam = xi.effect.HASTE
+        elseif
+            -- Treat Staff
+            addStatus == xi.effect.TELEPORT and
+            xi.events.harvestFestival.isHalloweenEnabled()
+            -- https://ffxiclopedia.fandom.com/wiki/Treat_Staff
+        then
+            attacker:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 0) -- It's faster than normal warp
+            msgID    = xi.msg.basic.ADD_EFFECT_WARP
+            msgParam = 0
         else
             print('scripts/globals/additional_effects.lua : unhandled additional effect selfbuff! Effect ID: '..addStatus)
         end

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -264,15 +264,6 @@ xi.additionalEffect.attack = function(attacker, defender, baseAttackDamage, item
             -- Todo: verify power/duration/tier/overwrite etc
             msgID    = xi.msg.basic.ADD_EFFECT_SELFBUFF
             msgParam = xi.effect.HASTE
-        elseif
-            -- Treat Staff
-            addStatus == xi.effect.TELEPORT and
-            xi.events.harvestFestival.isHalloweenEnabled()
-            -- https://ffxiclopedia.fandom.com/wiki/Treat_Staff
-        then
-            attacker:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WARP, 0, 0) -- It's faster than normal warp
-            msgID    = xi.msg.basic.ADD_EFFECT_WARP
-            msgParam = 0
         else
             print('scripts/globals/additional_effects.lua : unhandled additional effect selfbuff! Effect ID: '..addStatus)
         end

--- a/scripts/globals/spells/enhancing_teleport.lua
+++ b/scripts/globals/spells/enhancing_teleport.lua
@@ -10,20 +10,20 @@ xi.spells.enhancing = xi.spells.enhancing or {}
 -- Table variables.
 local pTable =
 {
--- Structure:       [spellId] = { Teleport, Key_Item, unknown_parameter, campaign },
-    [xi.magic.spell.ESCAPE        ] = { xi.teleport.id.ESCAPE,  0,                                4, false },
-    [xi.magic.spell.RECALL_JUGNER ] = { xi.teleport.id.JUGNER,  xi.ki.JUGNER_GATE_CRYSTAL,      4.7, false },
-    [xi.magic.spell.RECALL_MERIPH ] = { xi.teleport.id.MERIPH,  xi.ki.MERIPHATAUD_GATE_CRYSTAL, 4.7, false },
-    [xi.magic.spell.RECALL_PASHH  ] = { xi.teleport.id.PASHH,   xi.ki.PASHHOW_GATE_CRYSTAL,     4.7, false },
-    [xi.magic.spell.RETRACE       ] = { xi.teleport.id.RETRACE, 0,                                4, true  },
-    [xi.magic.spell.TELEPORT_ALTEP] = { xi.teleport.id.ALTEP,   xi.ki.ALTEPA_GATE_CRYSTAL,      4.7, false },
-    [xi.magic.spell.TELEPORT_DEM  ] = { xi.teleport.id.DEM,     xi.ki.DEM_GATE_CRYSTAL,         4.7, false },
-    [xi.magic.spell.TELEPORT_HOLLA] = { xi.teleport.id.HOLLA,   xi.ki.HOLLA_GATE_CRYSTAL,       4.7, false },
-    [xi.magic.spell.TELEPORT_MEA  ] = { xi.teleport.id.MEA,     xi.ki.MEA_GATE_CRYSTAL,         4.7, false },
-    [xi.magic.spell.TELEPORT_VAHZL] = { xi.teleport.id.VAHZL,   xi.ki.VAHZL_GATE_CRYSTAL,       4.7, false },
-    [xi.magic.spell.TELEPORT_YHOAT] = { xi.teleport.id.YHOAT,   xi.ki.YHOATOR_GATE_CRYSTAL,     4.7, false },
-    [xi.magic.spell.WARP          ] = { xi.teleport.id.WARP,    0,                                4, false },
-    [xi.magic.spell.WARP_II       ] = { xi.teleport.id.WARP,    0,                              3.4, false },
+-- Structure:       [spellId] = { Teleport, Key_Item, duration, campaign },
+    [xi.magic.spell.ESCAPE        ] = { xi.teleport.id.ESCAPE,  0,                              4, false },
+    [xi.magic.spell.RECALL_JUGNER ] = { xi.teleport.id.JUGNER,  xi.ki.JUGNER_GATE_CRYSTAL,      4, false },
+    [xi.magic.spell.RECALL_MERIPH ] = { xi.teleport.id.MERIPH,  xi.ki.MERIPHATAUD_GATE_CRYSTAL, 4, false },
+    [xi.magic.spell.RECALL_PASHH  ] = { xi.teleport.id.PASHH,   xi.ki.PASHHOW_GATE_CRYSTAL,     4, false },
+    [xi.magic.spell.RETRACE       ] = { xi.teleport.id.RETRACE, 0,                              3, true  },
+    [xi.magic.spell.TELEPORT_ALTEP] = { xi.teleport.id.ALTEP,   xi.ki.ALTEPA_GATE_CRYSTAL,      4, false },
+    [xi.magic.spell.TELEPORT_DEM  ] = { xi.teleport.id.DEM,     xi.ki.DEM_GATE_CRYSTAL,         4, false },
+    [xi.magic.spell.TELEPORT_HOLLA] = { xi.teleport.id.HOLLA,   xi.ki.HOLLA_GATE_CRYSTAL,       4, false },
+    [xi.magic.spell.TELEPORT_MEA  ] = { xi.teleport.id.MEA,     xi.ki.MEA_GATE_CRYSTAL,         4, false },
+    [xi.magic.spell.TELEPORT_VAHZL] = { xi.teleport.id.VAHZL,   xi.ki.VAHZL_GATE_CRYSTAL,       4, false },
+    [xi.magic.spell.TELEPORT_YHOAT] = { xi.teleport.id.YHOAT,   xi.ki.YHOATOR_GATE_CRYSTAL,     4, false },
+    [xi.magic.spell.WARP          ] = { xi.teleport.id.WARP,    0,                              3, false },
+    [xi.magic.spell.WARP_II       ] = { xi.teleport.id.WARP,    0,                              3, false },
 }
 
 -- Check for "Retrace" Spell.
@@ -40,7 +40,7 @@ xi.spells.enhancing.useTeleportSpell = function(caster, target, spell)
     local spellId    = spell:getID()
     local teleportId = pTable[spellId][1]
     local keyItem    = pTable[spellId][2]
-    local paramFive  = pTable[spellId][3]
+    local duration   = pTable[spellId][3]
     local campaign   = pTable[spellId][4]
 
     if
@@ -48,7 +48,7 @@ xi.spells.enhancing.useTeleportSpell = function(caster, target, spell)
         (keyItem == 0 or (keyItem > 0 and target:hasKeyItem(keyItem))) and
         (not campaign or (campaign and target:getCampaignAllegiance() > 0))
     then
-        target:addStatusEffectEx(xi.effect.TELEPORT, 0, teleportId, 0, paramFive)
+        target:addStatusEffectEx(xi.effect.TELEPORT, 0, teleportId, 0, duration)
         spell:setMsg(xi.msg.basic.MAGIC_TELEPORT)
     else
         spell:setMsg(xi.msg.basic.NONE)

--- a/scripts/items/cobra_staff.lua
+++ b/scripts/items/cobra_staff.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WINDURST_WATERS_S, 0, 4)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.WINDURST_WATERS_S, 0, 3)
 end
 
 return itemObject

--- a/scripts/items/ducal_guards_ring.lua
+++ b/scripts/items/ducal_guards_ring.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.DUCALGUARD, 0, 3)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.DUCALGUARD, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/fourth_staff.lua
+++ b/scripts/items/fourth_staff.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.BASTOK_MARKETS_S, 0, 4)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.BASTOK_MARKETS_S, 0, 3)
 end
 
 return itemObject

--- a/scripts/items/homing_ring.lua
+++ b/scripts/items/homing_ring.lua
@@ -21,7 +21,7 @@ end
 
 itemObject.onItemUse = function(target)
     local region = target:getCurrentRegion()
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.OUTPOST, 0, 1, 0, region)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.OUTPOST, 0, 4, 0, region)
 end
 
 return itemObject

--- a/scripts/items/maats_cap.lua
+++ b/scripts/items/maats_cap.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MAAT, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MAAT, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/nexus_cape.lua
+++ b/scripts/items/nexus_cape.lua
@@ -134,7 +134,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.LEADER, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.LEADER, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/ram_staff.lua
+++ b/scripts/items/ram_staff.lua
@@ -10,7 +10,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.SOUTHERN_SAN_DORIA_S, 0, 4)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.SOUTHERN_SAN_DORIA_S, 0, 3)
 end
 
 return itemObject

--- a/scripts/items/recall_ring_jugner.lua
+++ b/scripts/items/recall_ring_jugner.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.JUGNER, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.JUGNER, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/recall_ring_meriphataud.lua
+++ b/scripts/items/recall_ring_meriphataud.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MERIPH, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MERIPH, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/recall_ring_pashhow.lua
+++ b/scripts/items/recall_ring_pashhow.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.PASHH, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.PASHH, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/return_ring.lua
+++ b/scripts/items/return_ring.lua
@@ -21,7 +21,7 @@ end
 
 itemObject.onItemUse = function(target)
     local region = target:getCurrentRegion()
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.OUTPOST, 0, 1, 0, region)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.OUTPOST, 0, 4, 0, region)
 end
 
 return itemObject

--- a/scripts/items/scroll_of_instant_retrace.lua
+++ b/scripts/items/scroll_of_instant_retrace.lua
@@ -15,7 +15,7 @@ end
 
 itemObject.onItemUse = function(target)
     if target:getCampaignAllegiance() > 0 then
-        target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.RETRACE, 0, 2)
+        target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.RETRACE, 0, 3)
     end
 end
 

--- a/scripts/items/teleport_ring_altep.lua
+++ b/scripts/items/teleport_ring_altep.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.ALTEP, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.ALTEP, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/teleport_ring_dem.lua
+++ b/scripts/items/teleport_ring_dem.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.DEM, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.DEM, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/teleport_ring_holla.lua
+++ b/scripts/items/teleport_ring_holla.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOLLA, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.HOLLA, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/teleport_ring_mea.lua
+++ b/scripts/items/teleport_ring_mea.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MEA, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.MEA, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/teleport_ring_vahzl.lua
+++ b/scripts/items/teleport_ring_vahzl.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.VAHZL, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.VAHZL, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/teleport_ring_yhoat.lua
+++ b/scripts/items/teleport_ring_yhoat.lua
@@ -15,7 +15,7 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.YHOAT, 0, 1)
+    target:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.YHOAT, 0, 4)
 end
 
 return itemObject

--- a/scripts/items/treat_staff.lua
+++ b/scripts/items/treat_staff.lua
@@ -1,0 +1,44 @@
+-----------------------------------
+-- ID: 17566
+-- Treat Staff
+-- Latent effect during Harvest Festival events
+--
+-- This effect is triggered similar to an Additional Effect when attacking monsters.
+-- when the effect activates, you will be Warped to your Home Point.
+-- This allegedly can trigger on missed attacks and Weapon Skills. TODO: confirm
+-- There is no animation present when this effect activates, you will simply disappear and reappear at your Home Point.
+-- According to https://wiki.ffo.jp/html/3736.html the effect is
+-- only moon phase based when the Harvest Festival event is NOT active but ...
+-- Hours were spent attempting to trigger a proc during the moon conditions describe to no avail.
+-- (it wasn't changed, seems that information was simply incorrect)
+--
+-- Calling it 10% proc rate, this is tough to get a decent sample for even during harvest fest event.
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return 0
+end
+
+itemObject.onItemEquip  = function(user, item)
+    user:addListener('ATTACK', 'TREAT_STAFF_MELEE', function(player, target, action)
+        if
+            math.random(1, 100) <= 10 and
+            xi.events.harvestFestival.isHalloweenEnabled()
+        then
+            -- Need a small delay for the swing animation.
+            player:timer(100, function(playerArg)
+                -- We normally NEVER do this, but we want to skip animating the warp itself.
+                playerArg:warp()
+            end)
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(user, item)
+    user:removeListener('TREAT_STAFF_MELEE')
+    -- user:removeListener('TREAT_STAFF_WS')
+    -- user:removeListener('TREAT_STAFF_MISSED')
+end
+
+return itemObject

--- a/scripts/zones/Southern_San_dOria_[S]/npcs/Saphiriance_TK.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/npcs/Saphiriance_TK.lua
@@ -23,7 +23,7 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 454 then
-        player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.RETRACE, 0, 2)
+        player:addStatusEffectEx(xi.effect.TELEPORT, 0, xi.teleport.id.RETRACE, 0, 3)
         player:delCurrency('allied_notes', 30)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This is a follow-up on #4770 with more corrections. Its in draft till I verify a few things.

## Steps to test these changes
try rings of recall and teleport, see that the full animations plays before you get zoned.
