### PR TITLE
[CPP] Weaponskill list accuracy fixes

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6069,6 +6069,7 @@ void CLuaBaseEntity::setLevel(uint8 level)
         jobpointutils::RefreshGiftMods(PChar);
         charutils::BuildingCharSkillsTable(PChar);
         charutils::BuildingCharAbilityTable(PChar);
+        charutils::BuildingCharWeaponSkills(PChar);
         charutils::BuildingCharTraitsTable(PChar);
 
         PChar->UpdateHealth();

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -1237,6 +1237,7 @@ void CParty::RefreshSync()
             charutils::CalculateStats(member);
             charutils::BuildingCharTraitsTable(member);
             charutils::BuildingCharAbilityTable(member);
+            charutils::BuildingCharWeaponSkills(member);
             charutils::CheckValidEquipment(member);
             member->pushPacket(new CCharAbilitiesPacket(member));
         }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -396,7 +396,8 @@ namespace battleutils
     {
         return ((PSkill->getSkillLevel() > 0 && PChar->GetSkill(PSkill->getType()) >= PSkill->getSkillLevel() &&
                  (PSkill->getUnlockId() == 0 || charutils::hasLearnedWeaponskill(PChar, PSkill->getUnlockId()))) ||
-                (PSkill->getSkillLevel() == 0 && (PSkill->getUnlockId() == 0 || charutils::hasLearnedWeaponskill(PChar, PSkill->getUnlockId())))) &&
+                (PSkill->getSkillLevel() == 0 && (PSkill->getUnlockId() == 0 ||
+                                                  (charutils::hasLearnedWeaponskill(PChar, PSkill->getUnlockId()) && PChar->GetMLevel() >= 75)))) &&
                (PSkill->getJob(PChar->GetMJob()) > 0 || (PSkill->getJob(PChar->GetSJob()) > 0 && !PSkill->mainOnly()));
     }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves https://github.com/LandSandBoat/server/issues/4181 by adding a call to `charutils::BuildingCharWeaponSkills()` in `RefreshSync()` and (for gm sanity) in the lua binding `setLevel()`

Also appends logic to the `CanUseWeaponskill()` function to not display learned WS that lack a skill requirement in the db, until level 75. This includes Mythic and Empyrean weaponskills once the quest is completed (nothing is changed when the Weapon has the WS unlocked on its own, as it's not _learned_, it's just _available_ via the main weapon)

## Steps to test these changes

`!exec player:addLearnedWeaponskill(60)` will learn the Shijin Spiral Aeonic WS, which has a skill requirement of 357. Before these changes you could sync down and still have the WS until you switched weapons.

Another to test with would be `!exec player:addLearnedWeaponskill(19)`. This is Pyrrhic Kleos (a Mythic WS unlockable via quest). Same behavior as above except it has no skill requirement, so this is set to require level 75 to be available once unlocked.