### PR TITLE
[LUA] Drain/Aspir undead fixes

### DIFF
--- a/scripts/actions/spells/black/aspir.lua
+++ b/scripts/actions/spells/black/aspir.lua
@@ -9,6 +9,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
+    if target:isUndead() then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
+        return 0
+    end
+
     --calculate raw damage (unknown function  -> only dark skill though) - using http://www.bluegartr.com/threads/44518-Drain-Calculations
     -- also have small constant to account for 0 dark skill
     local dmg = 5 + 0.375 * caster:getSkillLevel(xi.skill.DARK_MAGIC)
@@ -31,11 +36,6 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     if dmg < 0 then
         dmg = 0
-    end
-
-    if target:isUndead() then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return 0
     end
 
     if target:getMP() > dmg then

--- a/scripts/actions/spells/black/aspir_ii.lua
+++ b/scripts/actions/spells/black/aspir_ii.lua
@@ -9,6 +9,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
+    if target:isUndead() then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
+        return 0
+    end
+
     local dmg = 10 + 0.575 * caster:getSkillLevel(xi.skill.DARK_MAGIC)
     --get resist multiplier (1x if no resist)
     local params = {}
@@ -29,11 +34,6 @@ spellObject.onSpellCast = function(caster, target, spell)
 
     if dmg < 0 then
         dmg = 0
-    end
-
-    if target:isUndead() then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return 0
     end
 
     if target:getMP() > dmg then

--- a/scripts/actions/spells/black/drain.lua
+++ b/scripts/actions/spells/black/drain.lua
@@ -9,9 +9,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
+    if target:isUndead() then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
+        return 0
+    end
+
     --calculate raw damage (unknown function  -> only dark skill though) - using http://www.bluegartr.com/threads/44518-Drain-Calculations
     -- also have small constant to account for 0 dark skill
     local dmg = 10 + (1.035 * caster:getSkillLevel(xi.skill.DARK_MAGIC))
+    local targetHP = target:getHP()
 
     if dmg > (caster:getSkillLevel(xi.skill.DARK_MAGIC) + 20) then
         dmg = (caster:getSkillLevel(xi.skill.DARK_MAGIC) + 20)
@@ -30,20 +36,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
     dmg = adjustForTarget(target, dmg, spell:getElement())
-    --add in final adjustments
-    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     if dmg < 0 then
         dmg = 0
     end
 
-    if target:getHP() < dmg then
-        dmg = target:getHP()
-    end
+    --add in final adjustments and deal damage
+    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
-    if target:isUndead() then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return 0
+    if targetHP < dmg then
+        dmg = targetHP
     end
 
     caster:addHP(dmg)

--- a/scripts/actions/spells/black/drain_ii.lua
+++ b/scripts/actions/spells/black/drain_ii.lua
@@ -9,9 +9,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
+    if target:isUndead() then
+        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
+        return 0
+    end
+
     --calculate raw damage (unknown function  -> only dark skill though) - using http://www.bluegartr.com/threads/44518-Drain-Calculations
     -- also have small constant to account for 0 dark skill
     local dmg = 20 + (1.236 * caster:getSkillLevel(xi.skill.DARK_MAGIC))
+    local targetHP = target:getHP()
 
     if dmg > (caster:getSkillLevel(xi.skill.DARK_MAGIC) + 85) then
         dmg = (caster:getSkillLevel(xi.skill.DARK_MAGIC) + 85)
@@ -30,20 +36,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     dmg = addBonuses(caster, spell, target, dmg)
     --add in target adjustment
     dmg = adjustForTarget(target, dmg, spell:getElement())
-    --add in final adjustments
-    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
     if dmg < 0 then
         dmg = 0
     end
 
-    if target:getHP() < dmg then
-        dmg = target:getHP()
-    end
+    --add in final adjustments and deal damage
+    dmg = finalMagicAdjustments(caster, target, spell, dmg)
 
-    if target:isUndead() then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT) -- No effect
-        return 0
+    if targetHP < dmg then
+        dmg = targetHP
     end
 
     local leftOver = (caster:getHP() + dmg) - caster:getMaxHP()


### PR DESCRIPTION
- Moved undead check to the top so we don't quietly deal dmg to undead
- save target's HP before finalMagicAdjustments to properly display the drain message and heal caster

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Unfortunate oversight in my previous PR for drain/aspir: undead should exit earlier.

In its current form, Drain actually does damage to undead, then displays the message about having no effect (doesn't heal the player at least)

For consistency i've put the aspir check at the top as well.

Also, when killing a mob with drain, the spell wasn't healing the player due to the fact that `finalMagicAdjustments` actually deals damage. Fixed to save the target's HP before calling that and tested all the permutations in kuftal on crabs and ghosts.

Also `finalMagicAdjustments` has checks to heal the target if `dmg < 0`, so moved this check above the call

## Steps to test these changes

drain a ghost and see that its hp stays full (would go down before this PR)
`!hp 50` a mob that's engaged with you and drain it to see you gain 50 hp and the mob dies
