### PR TITLE
[core] Improve Auras

### DIFF
--- a/scripts/enum/effect_flag.lua
+++ b/scripts/enum/effect_flag.lua
@@ -35,4 +35,5 @@ xi.effectFlag =
     AURA            = 0x04000000,
     HIDE_TIMER      = 0x08000000,
     ON_ZONE_PATHOS  = 0x10000000,
+    ALWAYS_EXPIRING = 0x20000000,
 }

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -71,6 +71,7 @@ enum EFFECTFLAG
     EFFECTFLAG_AURA            = 0x04000000, // Is an aura type effect
     EFFECTFLAG_HIDE_TIMER      = 0x08000000, // Sends "Always" in the packet, even though timer is tracked
     EFFECTFLAG_ON_ZONE_PATHOS  = 0x10000000, // removes the effect zoning into a non instanced zone
+    EFFECTFLAG_ALWAYS_EXPIRING = 0x20000000, // Timer is always 4 seconds from now to have an illusion permanent "expiring", used for Auras
 };
 
 enum EFFECT

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1741,13 +1741,23 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                     distance(m_POwner->loc.p, PMember->loc.p) <= aura_range &&
                     !PMember->isDead())
                 {
-                    CStatusEffect* PEffect = new CStatusEffect((EFFECT)PStatusEffect->GetSubID(), // Effect ID
-                                                               PStatusEffect->GetSubID(),         // Effect Icon (Associated with ID)
-                                                               PStatusEffect->GetSubPower(),      // Power
-                                                               3,                                 // Tick
-                                                               4);                                // Duration
-                    PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
-                    PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()));
+
+                    if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
+                    {
+                        PEffect->SetStartTime(server_clock::now());
+                    }
+                    else
+                    {
+                        PEffect = new CStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()), // Effect ID
+                                                    PStatusEffect->GetSubID(),                      // Effect Icon (Associated with ID)
+                                                    PStatusEffect->GetSubPower(),                   // Power
+                                                    3,                                              // Tick
+                                                    4);                                             // Duration
+                        PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
+                        PEffect->AddEffectFlag(EFFECTFLAG_ALWAYS_EXPIRING);
+                        PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    }
                 }
             });
             // clang-format on
@@ -1759,13 +1769,23 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                 if (PTarget != nullptr && PTarget->objtype != TYPE_TRUST && PEntity->loc.zone->GetID() == PTarget->loc.zone->GetID() && distance(m_POwner->loc.p, PTarget->loc.p) <= aura_range &&
                     !PTarget->isDead())
                 {
-                    CStatusEffect* PEffect = new CStatusEffect((EFFECT)PStatusEffect->GetSubID(), // Effect ID
-                                                               PStatusEffect->GetSubID(),         // Effect Icon (Associated with ID)
-                                                               PStatusEffect->GetSubPower(),      // Power
-                                                               3,                                 // Tick
-                                                               4);                                // Duration
-                    PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
-                    PTarget->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    CStatusEffect* PEffect = PTarget->StatusEffectContainer->GetStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()));
+
+                    if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
+                    {
+                        PEffect->SetStartTime(server_clock::now());
+                    }
+                    else
+                    {
+                        PEffect = new CStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()), // Effect ID
+                                                    PStatusEffect->GetSubID(),                      // Effect Icon (Associated with ID)
+                                                    PStatusEffect->GetSubPower(),                   // Power
+                                                    3,                                              // Tick
+                                                    4);                                             // Duration
+                        PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
+                        PEffect->AddEffectFlag(EFFECTFLAG_ALWAYS_EXPIRING);
+                        PTarget->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    }
                 }
             }
         }
@@ -1780,13 +1800,23 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                 if (PMember != nullptr && PEntity->loc.zone->GetID() == PMember->loc.zone->GetID() && distance(m_POwner->loc.p, PMember->loc.p) <= aura_range &&
                     !PMember->isDead())
                 {
-                    CStatusEffect* PEffect = new CStatusEffect((EFFECT)PStatusEffect->GetSubID(), // Effect ID
-                                                               PStatusEffect->GetSubID(),         // Effect Icon (Associated with ID)
-                                                               PStatusEffect->GetSubPower(),      // Power
-                                                               3,                                 // Tick
-                                                               4);                                // Duration
-                    PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
-                    PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()));
+
+                    if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
+                    {
+                        PEffect->SetStartTime(server_clock::now());
+                    }
+                    else
+                    {
+                        PEffect = new CStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()), // Effect ID
+                                                    PStatusEffect->GetSubID(),                      // Effect Icon (Associated with ID)
+                                                    PStatusEffect->GetSubPower(),                   // Power
+                                                    3,                                              // Tick
+                                                    4);                                             // Duration
+                        PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
+                        PEffect->AddEffectFlag(EFFECTFLAG_ALWAYS_EXPIRING);
+                        PMember->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    }
                 }
             });
             // clang-format on
@@ -1801,13 +1831,23 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                 if (PTarget != nullptr && PEntity->loc.zone->GetID() == PTarget->loc.zone->GetID() && distance(m_POwner->loc.p, PTarget->loc.p) <= aura_range &&
                     !PTarget->isDead())
                 {
-                    CStatusEffect* PEffect = new CStatusEffect((EFFECT)PStatusEffect->GetSubID(), // Effect ID
-                                                               PStatusEffect->GetSubID(),         // Effect Icon (Associated with ID)
-                                                               PStatusEffect->GetSubPower(),      // Power
-                                                               3,                                 // Tick
-                                                               4);                                // Duration
-                    PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
-                    PTarget->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    CStatusEffect* PEffect = PTarget->StatusEffectContainer->GetStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()));
+
+                    if (PEffect && (PEffect->GetEffectFlags() & EFFECTFLAG_ALWAYS_EXPIRING) != 0)
+                    {
+                        PEffect->SetStartTime(server_clock::now());
+                    }
+                    else
+                    {
+                        PEffect = new CStatusEffect(static_cast<EFFECT>(PStatusEffect->GetSubID()), // Effect ID
+                                                    PStatusEffect->GetSubID(),                      // Effect Icon (Associated with ID)
+                                                    PStatusEffect->GetSubPower(),                   // Power
+                                                    3,                                              // Tick
+                                                    4);                                             // Duration
+                        PEffect->AddEffectFlag(EFFECTFLAG_NO_LOSS_MESSAGE);
+                        PEffect->AddEffectFlag(EFFECTFLAG_ALWAYS_EXPIRING);
+                        PTarget->StatusEffectContainer->AddStatusEffect(PEffect, true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Reduce `new` CStatusEffects on every update of Auras through means of tracking auras through a new effect flag
* Improve retail accuracy by constantly renewing the expiry time of the buff

Note: this may be followed up with future improvements, there may be some extreme corner case oddities moving from the same effect aura into another where power doesn't change. It's 3:30 AM give me a break :)

## Steps to test these changes

Use auras on mobs/players and see them work.

example: `!exec target:addStatusEffectEx(612, 612, 6, 3, 0, xi.effect.POISON, 4, 1, xi.effectFlag.AURA)` and get poisoned, see that the poison aura does _not_ flicker but stays constantly in a "going to wear off" state


