### PR TITLE
[AMK][Lua] Cardian orb drop mechanic

### DIFF
--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -58,9 +58,8 @@ end
 -- The rest of the players in alliance get the same outcome as the first
 xi.amk.helpers.cardianOrbDrop = function(mob, player, orb)
     if
-        player:getCurrentMission(xi.mission.log_id.AMK) < xi.mission.id.amk.AN_ERRAND_THE_PROFESSORS_PRICE or
         player == nil or
-        orb == nil
+        player:getCurrentMission(xi.mission.log_id.AMK) < xi.mission.id.amk.AN_ERRAND_THE_PROFESSORS_PRICE
     then
         return
     end

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -52,6 +52,45 @@ xi.amk.helpers.helmTrade = function(player, helmType, broke)
     end
 end
 
+-- AMK 6 (index 5) - An Errand! The Professor's Price
+-- Cardian orb KI logic: All or nothing drop of the orb is handled by
+-- a local var that is set once by the first player is called by onMobDeath
+-- The rest of the players in alliance get the same outcome as the first
+xi.amk.helpers.cardianOrbDrop = function(mob, player, orb)
+    if
+        player:getCurrentMission(xi.mission.log_id.AMK) < xi.mission.id.amk.AN_ERRAND_THE_PROFESSORS_PRICE or
+        player == nil or
+        orb == nil
+    then
+        return
+    end
+
+    -- Chance of drop increases both based on size of party and level of mob killed
+    if mob:getLocalVar('Mission[10][5]cardianOrbDrop') == 0 then
+        local partySize = 0
+        for _, member in pairs(player:getAlliance()) do
+            if member:getZoneID() == xi.zone.OUTER_HORUTOTO_RUINS then
+                partySize = partySize + 1
+            end
+        end
+
+        -- Chance ranges from 4% to 25.8% (based on max mob lvl of 44)
+        local dropChance = (3 * mob:getMainLvl()) + (30 * utils.clamp(partySize, 1, 6)) - 10
+        local roll = math.random(1000)
+
+        if roll < dropChance then
+            mob:setLocalVar('Mission[10][5]cardianOrbDrop', 1)
+        else
+            mob:setLocalVar('Mission[10][5]cardianOrbDrop', 2)
+        end
+    end
+
+    -- Give orb
+    if mob:getLocalVar('Mission[10][5]cardianOrbDrop') == 1 then
+        npcUtil.giveKeyItem(player, orb)
+    end
+end
+
 -- AMK 7 (index 6) - Select/lookup the digging zone
 local digZoneIds =
 {

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 667, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Coins.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
     xi.regime.checkRegime(player, mob, 667, 4, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 667, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 667, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 664, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 664, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 664, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 663, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Coins.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
     xi.regime.checkRegime(player, mob, 663, 4, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 663, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 663, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 668, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Coins.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
     xi.regime.checkRegime(player, mob, 668, 4, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 668, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 668, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 666, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Coins.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
     xi.regime.checkRegime(player, mob, 666, 4, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 666, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 666, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Batons.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
     xi.regime.checkRegime(player, mob, 665, 2, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Coins.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
     xi.regime.checkRegime(player, mob, 665, 4, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Cups.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
     xi.regime.checkRegime(player, mob, 665, 1, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Swords.lua
@@ -5,6 +5,7 @@
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
     xi.regime.checkRegime(player, mob, 665, 3, xi.regime.type.GROUNDS)
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Batons.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Ten of Batons
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Coins.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Ten of Coins
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Cups.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Ten of Cups
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ten_of_Swords.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Ten of Swords
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Batons.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Three of Batons
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Coins.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Three of Coins
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Cups.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Three of Cups
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Three_of_Swords.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Three of Swords
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Batons.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Two of Batons
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_BATONS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Coins.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Two of Coins
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Cups.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Two of Cups
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_CUPS)
 end
 
 return entity

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Two_of_Swords.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  Mob: Five of Coins
+--  Mob: Two of Swords
 -----------------------------------
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
-    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_COINS)
-    xi.regime.checkRegime(player, mob, 664, 4, xi.regime.type.GROUNDS)
+    xi.amk.helpers.cardianOrbDrop(mob, player, xi.ki.ORB_OF_SWORDS)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a function to cardians in outer horutoto ruins that allows them to drop their respective key items "orb of sword/baton/coin/cup" for AMK mission 6. 

## Steps to test these changes

`!addmission 10 5`
Kill cardians in outer horutoto ruins until they cause the player to obtain their key items.  If the player isn't on the right mission, or already has the orb, the orb won't drop and no error is caused.

The drop rate has very little information other than the level of the mob is involved, and the higher the level, the higher the droprate. Some sources say drop rate on lower level mobs is very poor, so the range is set it at is between 4 - 25.8%, which increases with size of the party as well.

![image](https://github.com/LandSandBoat/server/assets/85970456/997aa6f8-9b94-401c-ab20-43c758771f57)

