### PR TITLE
[xi_connect] Add very obvious logging for incompatible xiloader versions

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -38,8 +38,14 @@ void auth_session::start()
             }
             else
             {
-                ShowWarning(fmt::format("Error from {}: ({}), {}", ipAddress, ec.value(), ec.message()));
+                auto errStr = fmt::format("Error from {}: (EC: {}), {}", ipAddress, ec.value(), ec.message());
+                ShowWarning(errStr);
                 ShowWarning("Failed to handshake!");
+                if (errStr.find("wrong version number (SSL routines)") != std::string::npos)
+                {
+                    ShowWarning("This is likely due to the client using an outdated/incompatible version of xiloader.");
+                    ShowWarning("Please make sure you're using the latest release: https://github.com/LandSandBoat/xiloader/releases");
+                }
                 socket_.next_layer().close();
             }
         });


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Trying to make it very very hard for people to continually try to connect with old/incompatible xiloader versions. This does rely on people reading their logs, so, we'll never truly be free.

https://github.com/LandSandBoat/server/issues/4138