### PR TITLE
[CPP] Set 60s cooldown on all blu spells

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -7610,6 +7610,20 @@ void SmallPacket0x102(map_session_data_t* const PSession, CCharEntity* const PCh
                 ShowDebug("No match found. ");
             }
         }
+
+        // Regardless what the set spell action is, force recast on all currently-set blu spells
+        for (uint8 i = 0; i < 20; i++)
+        {
+            if (PChar->m_SetBlueSpells[i] != 0)
+            {
+                auto  spellId = static_cast<SpellID>(PChar->m_SetBlueSpells[i] + 0x200);
+                auto* PSpell  = spell::GetSpell(spellId);
+                if (CBlueSpell* PBlueSpell = dynamic_cast<CBlueSpell*>(PSpell))
+                {
+                    PChar->PRecastContainer->Add(RECAST_MAGIC, static_cast<uint16>(PBlueSpell->getID()), 60);
+                }
+            }
+        }
     }
     else if ((PChar->GetMJob() == JOB_PUP || PChar->GetSJob() == JOB_PUP) && job == JOB_PUP && PChar->PAutomaton != nullptr && PChar->PPet == nullptr)
     {


### PR DESCRIPTION
when adding or removing spell set

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I was told at one point there was a cooldown for blu spells when setting (or removing) spells, but I couldn't find any remnants.

This code should be negligable performance-wise, and solves the problem 100%

## Steps to test these changes

Set blue spells, see 60s cooldown on using any blu spells
Remove blu spells, see same thing