### PR TITLE
[Lua] Fix Colibri's Snatch Morsel message id

### DIFF
--- a/scripts/actions/mobskills/snatch_morsel.lua
+++ b/scripts/actions/mobskills/snatch_morsel.lua
@@ -14,8 +14,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         -- local foodID = target:getStatusEffect(xi.effect.FOOD):getSubType()
         -- local duration = target:getStatusEffect(xi.effect.FOOD):getDuration()
         -- mob:addStatusEffect(xi.effect.FOOD, 0, 0, duration, foodID) -- Gives Colibri the players food.
-        target:delStatusEffect(xi.effect.FOOD)
-        skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
+        target:delStatusEffectSilent(xi.effect.FOOD)
+        skill:setMsg(xi.msg.basic.SKILL_ERASE)
     else
         skill:setMsg(xi.msg.basic.SKILL_MISS) -- no effect
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Snatch morsel was using the generic `SKILL_ENFEEB_IS` message, which does `<target> is <effect>`. Which resulted in the ~~funny~~ wrong message being displayed:

![image](https://github.com/LandSandBoat/server/assets/131182600/8e4a220c-bc3c-417d-8f88-c0bdcbafe7e3)

This updates the message:

![image](https://github.com/LandSandBoat/server/assets/131182600/09786512-b119-4bdb-a143-4e22b9557388)


## Steps to test these changes

Eat food, give regain to colibri, wait