### PR TITLE
Add latent NATION_CITIZEN

### DIFF
--- a/scripts/enum/latent.lua
+++ b/scripts/enum/latent.lua
@@ -45,7 +45,7 @@ xi.latent =
     -- 41 free to use
     -- 42 free to use
     WEAPON_DRAWN_HP_UNDER    = 43, -- PARAM: HP PERCENT
-    -- 44 free to use
+    NATION_CITIZEN           = 44, -- Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
     MP_UNDER_VISIBLE_GEAR    = 45, -- mp less than or equal to %, calculated using MP bonuses from visible gear only
     HP_OVER_VISIBLE_GEAR     = 46, -- hp more than or equal to %, calculated using HP bonuses from visible gear only
     WEAPON_BROKEN            = 47,

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1553,7 +1553,12 @@ INSERT INTO `item_latents` VALUES (16883,25,10,52,6);    -- Spear: Accuracy +10 
 INSERT INTO `item_latents` VALUES (16892,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (16892,20,-10,47,0);
 INSERT INTO `item_latents` VALUES (16892,22,-10,47,0);
-INSERT INTO `item_latents` VALUES (16899,110,5,25,0);    -- Hototogisu,parry skill +5 song/roll active
+
+-- Reserve Captain's lance
+INSERT INTO `item_latents` VALUES (16893,1,10,44,0);  -- Citizens of San d'Oria: Defense +10
+
+-- Hototogisu
+INSERT INTO `item_latents` VALUES (16899,110,5,25,0); -- parry skill +5 song/roll active
 
 -- Amanojaku
 INSERT INTO `item_latents` VALUES (16911,287,1,0,1);     -- DMG 29~40, increases as HP% decreases
@@ -1577,6 +1582,10 @@ INSERT INTO `item_latents` VALUES (16949,10,3,53,1);     -- VIT +3 in areas outs
 INSERT INTO `item_latents` VALUES (16952,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (16952,16,-10,47,0);
 INSERT INTO `item_latents` VALUES (16952,18,-10,47,0);
+
+-- Reserve Captain's greatsword
+INSERT INTO `item_latents` VALUES (16953,25,7,44,0);  -- Citizens of San d'Oria:  Accuracy +7
+
 INSERT INTO `item_latents` VALUES (16968,165,7,59,3);    -- Kamewari - Vs. arcana: Critical hit rate +7%
 INSERT INTO `item_latents` VALUES (16969,165,5,59,9);    -- Onikiri - Vs. demons: Critical hit rate +5%
 
@@ -1626,12 +1635,6 @@ INSERT INTO `item_latents` VALUES (17212,26,20,37,3);
 INSERT INTO `item_latents` VALUES (17212,26,20,37,5);
 INSERT INTO `item_latents` VALUES (17212,26,25,37,4);
 
--- Shigeto Bow
-INSERT INTO `item_latents` VALUES (18142,26,7,62,12);     -- RACC +7 for Samurai main job
-
--- Shigeto Bow +1
-INSERT INTO `item_latents` VALUES (18143,26,8,62,12);     -- RACC +8 for Samurai main job
-
 -- Musketeer Gun +1/+2
 INSERT INTO `item_latents` VALUES (17269,24,8,53,1);     -- RATT +8 in areas outside own nation's control
 INSERT INTO `item_latents` VALUES (17270,24,9,53,1);     -- RATT +9 in areas outside own nation's control
@@ -1657,6 +1660,10 @@ INSERT INTO `item_latents` VALUES (17456,2,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,5,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,18,-10,47,0);
 INSERT INTO `item_latents` VALUES (17456,20,-10,47,0);
+
+-- Reserve Captain's mace
+INSERT INTO `item_latents` VALUES (17458,71,7,44,0);  -- Citizens of San d'Oria: MP recovered while healing +7
+
 INSERT INTO `item_latents` VALUES (17461,23,10,56,0);    -- Rune Rod +10 Atk.
 INSERT INTO `item_latents` VALUES (17461,112,6,56,0);    -- Rune Rod +6 Healing Magic Skill
 INSERT INTO `item_latents` VALUES (17461,369,-4,56,0);   -- Rune Rod -4MP/tic
@@ -1847,6 +1854,10 @@ INSERT INTO `item_latents` VALUES (17932,9,3,53,1);      -- DEX +3 in areas outs
 INSERT INTO `item_latents` VALUES (17933,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (17933,17,-10,47,0);
 INSERT INTO `item_latents` VALUES (17933,19,-10,47,0);
+
+-- Reserve Captain's Pick
+INSERT INTO `item_latents` VALUES (17934,23,10,44,0); -- Citizens of San d'Oria: Attack +10
+
 INSERT INTO `item_latents` VALUES (17941,17,15,31,0);    -- Mighty Pick [Element: Wind]+15 on Windsday
 INSERT INTO `item_latents` VALUES (17941,287,5,31,0);    -- Mighty Pick DMG+5 on Windsday
 INSERT INTO `item_latents` VALUES (17944,165,6,47,0);    -- Retributor Crit Rate +6% when broken (500 WS points)
@@ -1977,6 +1988,12 @@ INSERT INTO `item_latents` VALUES (18133,26,5,53,1);     -- RACC +5 in areas out
 -- Junior Musketeer's Chakram +1/+2
 INSERT INTO `item_latents` VALUES (18134,8,2,53,1);      -- STR +2 in areas outside own nation's control
 INSERT INTO `item_latents` VALUES (18135,8,3,53,1);      -- STR +3 in areas outside own nation's control
+
+-- Shigeto Bow
+INSERT INTO `item_latents` VALUES (18142,26,7,62,12);     -- RACC +7 for Samurai main job
+
+-- Shigeto Bow +1
+INSERT INTO `item_latents` VALUES (18143,26,8,62,12);     -- RACC +8 for Samurai main job
 
 INSERT INTO `item_latents` VALUES (18144,2,-20,47,0);
 INSERT INTO `item_latents` VALUES (18144,17,-10,47,0);

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -73,7 +73,7 @@ enum class LATENT : uint16
     // 41 free to use
     // 42 free to use
     WEAPON_DRAWN_HP_UNDER = 43, // PARAM: HP PERCENT
-    // 44 free to use
+    NATION_CITIZEN        = 44, // Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
     MP_UNDER_VISIBLE_GEAR = 45, // mp less than or equal to %, calculated using MP bonuses from visible gear only
     HP_OVER_VISIBLE_GEAR  = 46, // hp more than or equal to %, calculated using HP bonuses from visible gear only
     WEAPON_BROKEN         = 47, //

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -574,6 +574,7 @@ void CLatentEffectContainer::CheckLatentsZone()
             case LATENT::IN_DYNAMIS:
             case LATENT::WEATHER_ELEMENT:
             case LATENT::NATION_CONTROL:
+            case LATENT::NATION_CITIZEN:
             case LATENT::ZONE_HOME_NATION:
                 return ProcessLatentEffect(latentEffect);
                 break;
@@ -1071,6 +1072,11 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
                                  (hasSignet || hasSanction || hasSigil);
                     break;
             }
+            break;
+        }
+        case LATENT::NATION_CITIZEN:
+        {
+            expression = m_POwner->profile.nation == latentEffect.GetConditionsValue();
             break;
         }
         case LATENT::ZONE_HOME_NATION:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Add latent NATION_CITIZEN...and related sql rows for Reserve Captain's conquest gear

additionally moved some out of order rows

***Did not add other modifiers these items might use, JUST the latent.***

## Steps to test these changes
- Create a San d'Orian character
- `!additem 17934`
- `!changejob war 99`
- `!getmod 23` (attack)
- equip the Reserve Captains pick
- `!getmod 23` again and see that attack is now 10 higher than previously

![Tallman_2023 12 05_231335](https://github.com/LandSandBoat/server/assets/6871475/83b8bf05-3a02-40ab-baf8-188fe3c9b920)
