### PR TITLE
[LUA] Quick Draw: Set recast on the action, not the ability

### DIFF
--- a/scripts/actions/abilities/dark_shot.lua
+++ b/scripts/actions/abilities/dark_shot.lua
@@ -19,14 +19,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.DARK_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
     end
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local duration = 60
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     local resist   = applyResistanceAbility(player, target, xi.element.DARK, xi.skill.NONE, bonusAcc)

--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.EARTH_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.FIRE_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.ICE_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 

--- a/scripts/actions/abilities/light_shot.lua
+++ b/scripts/actions/abilities/light_shot.lua
@@ -19,14 +19,14 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.LIGHT_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
     end
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local duration = 60
     local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
     local resist   = applyResistanceAbility(player, target, xi.element.LIGHT, xi.skill.NONE, bonusAcc)

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.THUNDER_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.WATER_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -19,7 +19,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
         player:hasItem(xi.item.WIND_CARD, 0) or
         player:hasItem(xi.item.TRUMP_CARD, 0)
     then
-        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
         return 0, 0
     else
         return 71, 0
@@ -27,6 +26,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
+    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
     local params = {}
     params.includemab = true
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The person that coded `QUICK_DRAW_RECAST` (me) erroneously set the recast on the ability. Since this is a charge-based grouped ability, the recast is actually the charge cost. So `ability:getRecast()` was 1, subtract the 5s mod from ASA and you get 0 charge cost... this meant Quick Draw could be spammed nonstop.

This confusion was due to a few of the quick draw abilities not having an `action` param, and attempting to `ability:setRecast()` in `onUseAbility` does nothing... my mistake

I've tested and this is fixed now. Apologies I thought I had tested but I don't know COR very well and clearly I didn't test it properly

## Steps to test these changes

Give a weapon and bullets: `!additem martial_gun`, `!additem bronze_bullet 99`. Use a shot: `/ja "fire shot" <t>`, see the recast is 60s. give yourself the cooldown reduction: `!setmod QUICK_DRAW_RECAST 5`, shoot again and see lower cooldown