### PR TITLE
Fix a bug with SSG coin doors.

### DIFF
--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w3.lua
@@ -8,7 +8,8 @@ local ID = zones[xi.zone.SEA_SERPENT_GROTTO]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.MYTHRIL_BEASTCOIN) then
+    -- The coin isn't consumed, so we only need to know if one was in the trade window
+    if trade:getItemQty(xi.item.MYTHRIL_BEASTCOIN) > 0 then
         if player:getCharVar('SSG_MythrilDoor') == 7 then
             npc:openDoor(5) -- Open the door if a mythril beastcoin has been traded after checking the door the required number of times
         end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w4.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w4.lua
@@ -8,7 +8,8 @@ local ID = zones[xi.zone.SEA_SERPENT_GROTTO]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.GOLD_BEASTCOIN) then
+    -- The coin isn't consumed, so we only need to know if one was in the trade window
+    if trade:getItemQty(xi.item.GOLD_BEASTCOIN) > 0 then
         if player:getCharVar('SSG_GoldDoor') == 7 then
             npc:openDoor(5) -- Open the door if a gold beastcoin has been traded after checking the door the required number of times
         end

--- a/scripts/zones/Sea_Serpent_Grotto/npcs/_4w5.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/npcs/_4w5.lua
@@ -8,7 +8,8 @@ local ID = zones[xi.zone.SEA_SERPENT_GROTTO]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.SILVER_BEASTCOIN) then
+    -- The coin isn't consumed, so we only need to know if one was in the trade window
+    if trade:getItemQty(xi.item.SILVER_BEASTCOIN) > 0 then
         if player:getCharVar('SSG_SilverDoor') == 7 then
             npc:openDoor(5) -- Open the door if a silver beastcoin has been traded after checking the door the required number of times
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
SSG beastmen coin doors don't consume the coin, so there is no reason to use `npcUtil.tradeHas()` here.  
**sometimes the old ways are the best** 
![HWWitchSmiley01](https://github.com/LandSandBoat/server/assets/6871475/01e7dede-95a1-4a9b-a9db-d9bb8712f21b)


## Steps to test these changes
- Trade the matching coin. door works
- Trade a stack of the coin. door works
- Trade the coin along with some random junk, still works!
- Note that during none of these trades did any items get eaten or locked out. 

All we're doing is checking that the item existed in the trade window. Pretty simple. Didn't need a utils call for it.

