### PR TITLE
Bug Fix: Account for full inventory when trading Ghebi Damomohe

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
@@ -5,15 +5,23 @@
 -- Starts and Finishes Quest: Tenshodo Membership
 -- !pos 16 0 -5 245
 -----------------------------------
+local lowerJeunoID = zones[xi.zone.LOWER_JEUNO]
+-----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if
-        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.TENSHODO_MEMBERSHIP) ~= QUEST_COMPLETED and
-        npcUtil.tradeHas(trade, xi.item.TENSHODO_INVITE)
+        trade:getItemQty(xi.item.TENSHODO_INVITE) > 0 and
+        player:getQuestStatus(xi.quest.log_id.JEUNO, xi.quest.id.jeuno.TENSHODO_MEMBERSHIP) ~= QUEST_COMPLETED
     then
-        -- Finish Quest: Tenshodo Membership (Invitation)
-        player:startEvent(108)
+        if player:getFreeSlotsCount() > 0 then
+            if npcUtil.tradeHas(trade, xi.item.TENSHODO_INVITE) then
+                -- Finish Quest: Tenshodo Membership (Invitation)
+                player:startEvent(108)
+            end
+        else
+            player:messageSpecial(lowerJeunoID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.TENSHODO_INVITE)
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
A full inventory would bug out this script because `npcUtil.tradeHas()` will succeed reaching the event finish where `npcUtil.completeQuest()` would fail and bail out trying to add the resulting reward.

## Steps to test these changes
- `!addquest 3 TENSHODO_MEMBERSHIP`
- `!additem tenshodo_invite`
- spam `additem 1` till your inventory is completely filled with chocobo bedding
- try and complete the quest, should get the message stating you can't obtain, and your trade item is not locked
- throw away a bedding and re-trade the invite. quest completes you get a new invite and nothing is bugged, yay.
