### PR TITLE
Adjust logic of lantern trades in den of rancor

### DIFF
--- a/scripts/zones/Den_of_Rancor/globals.lua
+++ b/scripts/zones/Den_of_Rancor/globals.lua
@@ -10,10 +10,13 @@ local denOfRancorGlobal =
         trade to lanterns next to Sacrificial Chamber (Rancor Flame)
         ..............................................................................................]]
     onTradeLanternChamber = function(player, npc, trade)
-        if npcUtil.tradeHas(trade, xi.item.RANCOR_FLAME) then -- Rancor Flame
-            if npc:getAnimation() == xi.anim.OPEN_DOOR then
-                player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
-            else
+        if
+            trade:getItemQty(xi.item.RANCOR_FLAME) > 0 and
+            npc:getAnimation() == xi.anim.OPEN_DOOR
+        then
+            player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
+        else
+            if npcUtil.tradeHas(trade, xi.item.RANCOR_FLAME) then -- Rancor Flame
                 player:confirmTrade()
                 player:addItem(xi.item.UNLIT_LANTERN) -- return unlit lantern
 
@@ -43,10 +46,13 @@ local denOfRancorGlobal =
         trade to lanterns next to Hakutaku (Rancor Flame)
         ..............................................................................................]]
     onTradeLanternHaku = function(player, npc, trade)
-        if npcUtil.tradeHas(trade, xi.item.RANCOR_FLAME) then -- Rancor Flame
-            if npc:getAnimation() == xi.anim.OPEN_DOOR then
-                player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
-            else
+        if
+            trade:getItemQty(xi.item.RANCOR_FLAME) > 0 and
+            npc:getAnimation() == xi.anim.OPEN_DOOR
+        then
+            player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
+        else
+            if npcUtil.tradeHas(trade, xi.item.RANCOR_FLAME) then -- Rancor Flame
                 player:confirmTrade()
                 player:addItem(xi.item.UNLIT_LANTERN) -- return unlit lantern
 
@@ -77,10 +83,13 @@ local denOfRancorGlobal =
     onTradeLanternBoss = function(player, npc, trade)
         local itemId = 1131 + npc:getID() - ID.npc.LANTERN_OFFSET
 
-        if npcUtil.tradeHas(trade, itemId) then -- Flame of Crimson or Blue Rancor
-            if npc:getAnimation() == xi.anim.OPEN_DOOR then
-                player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
-            else
+        if
+            trade:getItemQty(itemId) > 0 and  -- Flame of Crimson or Blue Rancor
+            npc:getAnimation() == xi.anim.OPEN_DOOR
+        then
+            player:messageSpecial(ID.text.LANTERN_OFFSET + 7) -- already lit
+        else
+            if npcUtil.tradeHas(trade, itemId) then -- Flame of Crimson or Blue Rancor
                 player:confirmTrade()
                 player:addItem(xi.item.UNLIT_LANTERN) -- return unlit lantern
 

--- a/scripts/zones/Den_of_Rancor/npcs/_4gb.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/_4gb.lua
@@ -3,20 +3,21 @@
 --  NPC: Altar of Rancor (flame of blue rancor)
 -- !pos 400.880 22.830 359.636 160
 -----------------------------------
-local ID = zones[xi.zone.DEN_OF_RANCOR]
+local denOfRancorID = zones[xi.zone.DEN_OF_RANCOR]
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.UNLIT_LANTERN) then -- Unlit Lantern
-        if npcUtil.giveItem(player, xi.item.FLAME_OF_BLUE_RANCOR) then -- Flame of Blue Rancor
+    if trade:getItemQty(xi.item.UNLIT_LANTERN) > 0 then
+        if npcUtil.giveItem(player, xi.item.FLAME_OF_BLUE_RANCOR) then
+            trade:confirmItem(xi.item.UNLIT_LANTERN, 1)
             player:confirmTrade()
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.LANTERN_OFFSET + 3) -- The altar glows an eerie blue. The lanterns have been put out.
+    player:messageSpecial(denOfRancorID.text.LANTERN_OFFSET + 3) -- The altar glows an eerie blue. The lanterns have been put out.
 end
 
 return entity

--- a/scripts/zones/Den_of_Rancor/npcs/_4gc.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/_4gc.lua
@@ -3,20 +3,21 @@
 --  NPC: Altar of Rancor (Flame of Crimson Rancor)
 -- !pos 199 32 -280 160
 -----------------------------------
-local ID = zones[xi.zone.DEN_OF_RANCOR]
+local denOfRancorID = zones[xi.zone.DEN_OF_RANCOR]
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.UNLIT_LANTERN) then -- Unlit Lantern
-        if npcUtil.giveItem(player, xi.item.FLAME_OF_CRIMSON_RANCOR) then -- Flame of Crimson Rancor
+    if trade:getItemQty(xi.item.UNLIT_LANTERN) > 0 then
+        if npcUtil.giveItem(player, xi.item.FLAME_OF_CRIMSON_RANCOR) then
+            trade:confirmItem(xi.item.UNLIT_LANTERN, 1)
             player:confirmTrade()
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.LANTERN_OFFSET + 2) -- The altar glows an eerie red. The lanterns have been put out.
+    player:messageSpecial(denOfRancorID.text.LANTERN_OFFSET + 2) -- The altar glows an eerie red. The lanterns have been put out.
 end
 
 return entity

--- a/scripts/zones/Den_of_Rancor/npcs/_4gd.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/_4gd.lua
@@ -3,20 +3,21 @@
 --  NPC: Altar of Rancor (Rancor Flame)
 -- !pos -76 16 -1 160
 -----------------------------------
-local ID = zones[xi.zone.DEN_OF_RANCOR]
+local denOfRancorID = zones[xi.zone.DEN_OF_RANCOR]
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.UNLIT_LANTERN) then -- Unlit Lantern
-        if npcUtil.giveItem(player, xi.item.RANCOR_FLAME) then -- Rancor Flame
+    if trade:getItemQty(xi.item.UNLIT_LANTERN) > 0 then
+        if npcUtil.giveItem(player, xi.item.RANCOR_FLAME) then
+            trade:confirmItem(xi.item.UNLIT_LANTERN, 1)
             player:confirmTrade()
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.LANTERN_OFFSET + 13, xi.item.RANCOR_FLAME, xi.item.UNLIT_LANTERN) -- You could use this flame to light an unlit lantern.
+    player:messageSpecial(denOfRancorID.text.LANTERN_OFFSET + 13, xi.item.RANCOR_FLAME, xi.item.UNLIT_LANTERN) -- You could use this flame to light an unlit lantern.
 end
 
 return entity

--- a/scripts/zones/Den_of_Rancor/npcs/_4ge.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/_4ge.lua
@@ -3,20 +3,21 @@
 --  NPC: Altar of Rancor (Rancor Flame)
 -- !pos -76 16 -1 160
 -----------------------------------
-local ID = zones[xi.zone.DEN_OF_RANCOR]
+local denOfRancorID = zones[xi.zone.DEN_OF_RANCOR]
 -----------------------------------
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.UNLIT_LANTERN) then -- Unlit Lantern
-        if npcUtil.giveItem(player, xi.item.RANCOR_FLAME) then -- Rancor Flame
+    if trade:getItemQty(xi.item.UNLIT_LANTERN) > 0 then
+        if npcUtil.giveItem(player, xi.item.RANCOR_FLAME) then
+            trade:confirmItem(xi.item.UNLIT_LANTERN, 1)
             player:confirmTrade()
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.LANTERN_OFFSET + 13, xi.item.RANCOR_FLAME, xi.item.UNLIT_LANTERN) -- You could use this flame to light an unlit lantern.
+    player:messageSpecial(denOfRancorID.text.LANTERN_OFFSET + 13, xi.item.RANCOR_FLAME, xi.item.UNLIT_LANTERN) -- You could use this flame to light an unlit lantern.
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This was likely to go unnoticed given the error is not easily observable from the client side.

`npcUtil.tradeHas()` does not handle full inventory or messages about the item you cannot get (it can't - how would it know?) and can't be used here.

Fortunately, `npcUtil.giveItem()` does handle that properly.

Also adjusted some login in the zone's global to avoid locking lanterns on failed trades to already lit NPCs

## Steps to test these changes
- !zone den**tabkey** to den of rancor.
- `!speed 200` and zoom yourself to the upper level lamp lighting area
- `!additem unlit_lantern`
- trade and see that it functions as expected to get rancor flame
- zoom down to the gates and trade a rancor flame to see it lights
- `!additem rancor_flame` to get another, and trade to the already lit one, see it tell you its already lit, then light the other 3 while continuing to add more as needed with the gm command till you light all 4 and the gate opens.

If you want to see what the hidden error is, you'll need to debug on the server side without these changes to check the items state before and after each trade attempt while also filling your inventory and pre-lighting the lamps at the gate. As stated previously, you'd normally never know anything was wrong at the client side.