### PR TITLE
[core, Lua] Add additional Lua bindings for locking/reserving items

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - labeled
       - unlabeled
+      - synchronize
+      - reopened
 
 jobs:
   Check_Blocking_Labels:

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ _ReSharper*
 
 # Jetbrains directories
 .idea
+.fleet
 cmake-*
 
 # NCrunch

--- a/src/map/items/item.h
+++ b/src/map/items/item.h
@@ -36,7 +36,7 @@ enum ITEM_TYPE
     ITEM_WEAPON     = 0x10,
     ITEM_CURRENCY   = 0x20,
     ITEM_FURNISHING = 0x40,
-    ITEM_LINKSHELL  = 0x80
+    ITEM_LINKSHELL  = 0x80,
 };
 
 // Additional type of object m_subtype
@@ -46,7 +46,7 @@ enum ITEM_SUBTYPE
     ITEM_LOCKED    = 0x01,
     ITEM_CHARGED   = 0x02,
     ITEM_AUGMENTED = 0x04,
-    ITEM_UNLOCKED  = 0xFE
+    ITEM_UNLOCKED  = 0xFE,
 };
 
 // Flags of objects
@@ -67,7 +67,7 @@ enum ITEM_FLAG
     ITEM_FLAG_NOSALE       = 0x1000,
     ITEM_FLAG_NODELIVERY   = 0x2000,
     ITEM_FLAG_EX           = 0x4000, // NoTradePC Polutils Value
-    ITEM_FLAG_RARE         = 0x8000
+    ITEM_FLAG_RARE         = 0x8000,
 };
 
 class CItem

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -93,9 +93,24 @@ bool CLuaItem::isType(uint8 type)
     return m_PLuaItem->isType(static_cast<ITEM_TYPE>(type));
 }
 
+void CLuaItem::setSubType(uint8 subtype)
+{
+    m_PLuaItem->setSubType(static_cast<ITEM_SUBTYPE>(subtype));
+}
+
 bool CLuaItem::isSubType(uint8 subtype)
 {
     return m_PLuaItem->isSubType(static_cast<ITEM_SUBTYPE>(subtype));
+}
+
+void CLuaItem::setReservedValue(uint8 reserved)
+{
+    m_PLuaItem->setReserve(reserved);
+}
+
+uint8 CLuaItem::getReservedValue()
+{
+    return m_PLuaItem->getReserve();
 }
 
 auto CLuaItem::getName() -> std::string
@@ -319,7 +334,10 @@ void CLuaItem::Register()
     SOL_REGISTER("getTrialNumber", CLuaItem::getTrialNumber);
     SOL_REGISTER("getWornUses", CLuaItem::getWornUses);
     SOL_REGISTER("isType", CLuaItem::isType);
+    SOL_REGISTER("setSubType", CLuaItem::setSubType);
     SOL_REGISTER("isSubType", CLuaItem::isSubType);
+    SOL_REGISTER("setReservedValue", CLuaItem::setReservedValue);
+    SOL_REGISTER("getReservedValue", CLuaItem::getReservedValue);
     SOL_REGISTER("getName", CLuaItem::getName);
     SOL_REGISTER("getILvl", CLuaItem::getILvl);
     SOL_REGISTER("getReqLvl", CLuaItem::getReqLvl);

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -54,8 +54,12 @@ public:
     uint8  getWornUses();  // check if the item has been used
     uint32 getBasePrice(); // get the base sell price
 
-    bool isType(uint8 type);       // check the item type
-    bool isSubType(uint8 subtype); // check the item's sub type
+    bool isType(uint8 type);        // check the item type
+    void setSubType(uint8 subtype); // set the item's sub type
+    bool isSubType(uint8 subtype);  // check the item's sub type
+
+    void  setReservedValue(uint8 reserved); // set the item's reserved value
+    uint8 getReservedValue();               // get the item's reserved value
 
     auto   getName() -> std::string; // get the item's name
     uint16 getILvl();                // get the item's ilvl

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -6937,7 +6937,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
 
         // Update installed furniture placement orders
         // First we place the furniture into placed items using the order number as the index
-        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE * 2> placedItems = { nullptr };
+        std::array<CItemFurnishing*, MAX_CONTAINER_SIZE* 2> placedItems = { nullptr };
         for (auto safeContainerId : { LOC_MOGSAFE, LOC_MOGSAFE2 })
         {
             CItemContainer* PContainer = PChar->getStorage(safeContainerId);
@@ -6961,7 +6961,7 @@ void SmallPacket0x0FA(map_session_data_t* const PSession, CCharEntity* const PCh
         }
 
         // Update the item's order number
-        for (int32 i = 0; i < MAX_CONTAINER_SIZE* 2; ++i)
+        for (int32 i = 0; i < MAX_CONTAINER_SIZE * 2; ++i)
         {
             // We can stop updating the order numbers once we hit an empty order number
             if (placedItems[i] == nullptr)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

These don't have any value for regular developers or users, these are for core team debugging.

## Steps to test these changes

- To find a target item: `!exec print(player:getStorageItem(0, 24, 255):getName())`
- To lock: `!exec player:getStorageItem(0, 24, 255):setSubType(1)`
- To reserve: `!exec player:getStorageItem(0, 24, 255):setReservedValue(1)`