### PR TITLE
[LUA] Squintrox Copy/Paste fix

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Squintrox_Dryeyes.lua
@@ -143,7 +143,7 @@ local menuMetadata =
             costSeals        = 5,
             relevantKeyItems =
             {
-                xi.ki.SEEDSPALL_ASTRUM,
+                xi.ki.SEEDSPALL_ROSEUM,
                 xi.ki.SEEDSPALL_CAERULUM,
                 xi.ki.SEEDSPALL_VIRIDIS,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Retrieving the 3 seedspall _key items_ fails as one of the names I erroneously copied from the seedspall _items_

Tested and confirmed to work now

## Steps to test these changes

Ensure ACP is enabled and you have mission 9, 10 completed and 11 in the log:
`!addmission 9 10`
`!completemission 9 10`
`!addmission 9 11`

talk to squintrox and retrieve the 3 seedspall key items