### PR TITLE
[AMK, Lua, SQL] Mission 9, stone hunt in quicksands caves complete

### DIFF
--- a/scripts/missions/amk/09_Rescue_A_Moogles_Labor_of_Love.lua
+++ b/scripts/missions/amk/09_Rescue_A_Moogles_Labor_of_Love.lua
@@ -2,9 +2,22 @@
 -- Rescue! A Moogle's Labor of Love
 -- A Moogle Kupo d'Etat M9
 -- !addmission 10 8
+-- Geologist cutscene args : csid, progress, has QC map: 1 or 0, markerset: 1-10
+-- Goblin Geologist        : !pos -737 -6 -550 208
+-- STONE_OF_SURYA          : !addkeyitem 1145
+-- STONE_OF_CHANDRA        : !addkeyitem 1146
+-- STONE_OF_MANGALA        : !addkeyitem 1147
+-- STONE_OF_BUDHA          : !addkeyitem 1148
+-- STONE_OF_BRIHASPATI     : !addkeyitem 1149
+-- STONE_OF_SHUKRA         : !addkeyitem 1150
+-- STONE_OF_SHANI          : !addkeyitem 1151
+-- STONE_OF_RAHU           : !addkeyitem 1152
+-- STONE_OF_KETU           : !addkeyitem 1153
+-- NAVARATNA_TALISMAN      : !addkeyitem 1158
 -----------------------------------
 require('scripts/globals/missions')
 require('scripts/globals/interaction/mission')
+local ID = zones[xi.zone.QUICKSAND_CAVES]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.AMK, xi.mission.id.amk.RESCUE_A_MOOGLES_LABOR_OF_LOVE)
@@ -14,83 +27,177 @@ mission.reward =
     nextMission = { xi.mission.log_id.AMK, xi.mission.id.amk.ROAR_A_CAT_BURGLAR_BARES_HER_FANGS },
 }
 
+local markerSets =
+{
+    { 1, 2, 5, 7,  8,  11, 14, 19, 20 },
+    { 3, 4, 6, 9,  11, 13, 16, 17, 18 },
+    { 2, 6, 7, 8,  10, 12, 15, 19, 20 },
+    { 1, 3, 4, 5,  8,  9,  10, 17, 18 },
+    { 2, 4, 7, 11, 12, 13, 15, 16, 20 },
+    { 1, 3, 5, 6,  8,  9,  14, 18, 19 },
+    { 2, 5, 7, 10, 11, 12, 15, 16, 17 },
+    { 1, 3, 4, 6,  8,  13, 14, 17, 20 },
+    { 2, 4, 7, 9,  10, 11, 16, 18, 19 },
+    { 3, 5, 6, 12, 13, 14, 15, 18, 20 },
+}
+
+local getMarkerSet = function(player)
+    -- markerSet is the setIndex of a random table within markerSets defined above
+    local markerSet = player:getCharVar('Mission[10][8]markerSet')
+    if markerSet == 0 then
+        markerSet = math.random(1, #markerSets)
+        player:setCharVar('Mission[10][8]markerSet', markerSet)
+    end
+
+    return markerSet
+end
+
+local hasAllStones = function(player)
+    for offset = 0, 8 do
+        if not player:hasKeyItem(xi.ki.STONE_OF_SURYA + offset) then
+            return false
+        end
+    end
+
+    return true
+end
+
 mission.sections =
 {
-    -- 0: Shady Sconce
+    -- 0: Initiate quest, get markers
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 0
+            return currentMission == mission.missionId and
+            player:getCharVar('Mission[10][8]progress') == 0
         end,
 
-        [xi.zone.SEA_SERPENT_GROTTO] =
+        [xi.zone.QUICKSAND_CAVES] =
         {
-            ['Shady_Sconce'] =
+            ['Goblin_Geologist'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(19, 176)
+                    local hasMap = player:hasKeyItem(xi.ki.MAP_OF_THE_QUICKSAND_CAVES) and 1 or 0
+                    return mission:progressEvent(100, 0, hasMap, getMarkerSet(player))
                 end,
             },
 
             onEventFinish =
             {
-                [19] = function(player, csid, option, npc)
-                    if option == 1 then
-                        player:setMissionStatus(xi.mission.log_id.AMK, 1)
+                [100] = function(player, csid, option, npc)
+                    player:setCharVar('Mission[10][8]progress', 1)
+                end,
+            },
+        },
+    },
+
+    -- 1: Have Markers, don't have all stones
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission >= mission.missionId and
+                player:getCharVar('Mission[10][8]progress') == 1 and
+                not hasAllStones(player) and
+                not player:hasKeyItem(xi.ki.NAVARATNA_TALISMAN)
+        end,
+
+        [xi.zone.QUICKSAND_CAVES] =
+        {
+            ['Goblin_Geologist'] =
+            {
+                onTrigger = function(player, npc)
+                    local hasMap = player:hasKeyItem(xi.ki.MAP_OF_THE_QUICKSAND_CAVES) and 1 or 0
+                    return mission:progressEvent(100, 2, hasMap, getMarkerSet(player))
+                end,
+            },
+
+            ['qm_amk'] =
+            {
+                onTrigger = function(player, npc)
+                    -- Get set of markers assigned by geologist
+                    local amkMarkerSet = player:getCharVar('Mission[10][8]markerSet')
+                    if amkMarkerSet == 0 then
+                        return mission:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+                    end
+
+                    -- Determine if QM triggered is in markerset
+                    local keyItem = 0
+                    for setIndex = 1, 9 do
+                        local markerIdIndex = markerSets[amkMarkerSet][setIndex]
+                        if npc:getID() == ID.npc.QM_AMK[markerIdIndex] then
+                            keyItem = xi.ki.STONE_OF_SURYA + setIndex - 1
+                        end
+                    end
+
+                    -- Give KI if QM is correct
+                    if keyItem ~= 0 and not player:hasKeyItem(keyItem) then
+                        player:addKeyItem(keyItem)
+                        return mission:messageSpecial(ID.text.KEYITEM_OBTAINED, keyItem)
                     end
                 end,
             },
         },
     },
 
-    -- 1: Waterfall Basin
+    -- 2: Have all stones, award talisman
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 1
+            return currentMission >= mission.missionId and
+                hasAllStones(player) and
+                not player:hasKeyItem(xi.ki.NAVARATNA_TALISMAN)
         end,
 
-        [xi.zone.SEA_SERPENT_GROTTO] =
+        [xi.zone.QUICKSAND_CAVES] =
         {
-            ['Shady_Sconce'] =
+            ['Goblin_Geologist'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:event(22)
-                end,
-            },
-
-            ['Waterfall_Basin'] =
-            {
-                onTrigger = function(player, npc)
-                    return mission:progressEvent(20)
+                    local hasMap = player:hasKeyItem(xi.ki.MAP_OF_THE_QUICKSAND_CAVES) and 1 or 0
+                    return mission:progressEvent(100, 1, hasMap, 0)
                 end,
             },
 
             onEventFinish =
             {
-                [20] = function(player, csid, option, npc)
-                    player:setMissionStatus(xi.mission.log_id.AMK, 2)
+                [100] = function(player, csid, option, npc)
+                    for i = 0, 8 do
+                        player:delKeyItem(xi.ki.STONE_OF_SURYA + i)
+                    end
+
+                    player:setCharVar('Mission[10][8]markerSet', 0)
+                    npcUtil.giveKeyItem(player, xi.ki.NAVARATNA_TALISMAN)
                 end,
             },
         },
     },
 
-    -- 2: Inconspicuous Door
+    -- 3: Have talisman, CS at shimmering cicle
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and missionStatus == 2
+            return currentMission == mission.missionId and
+                player:hasKeyItem(xi.ki.NAVARATNA_TALISMAN)
         end,
 
-        [xi.zone.UPPER_JEUNO] =
+        [xi.zone.QUICKSAND_CAVES] =
         {
-            ['Inconspicuous_Door'] =
+            ['Goblin_Geologist'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(10184)
+                    player:messageSpecial(ID.text.GRANT_YOU_EASY_ENTRANCE, xi.ki.NAVARATNA_TALISMAN)
                 end,
+            },
+        },
+
+        [xi.zone.CHAMBER_OF_ORACLES] =
+        {
+            ['Shimmering_Circle'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:progressEvent(5)
+                end
             },
 
             onEventFinish =
             {
-                [10184] = function(player, csid, option, npc)
+                [5] = function(player, csid, option, npc)
                     mission:complete(player)
                 end,
             },

--- a/scripts/zones/Qufim_Island/IDs.lua
+++ b/scripts/zones/Qufim_Island/IDs.lua
@@ -46,7 +46,6 @@ zones[xi.zone.QUFIM_ISLAND] =
         COMMON_SENSE_SURVIVAL          = 12665, -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
         HOMEPOINT_SET                  = 12707, -- Home point set!
     },
-
     mob =
     {
         SLIPPERY_SUCKER_PH =
@@ -65,7 +64,6 @@ zones[xi.zone.QUFIM_ISLAND] =
         },
         OPHIOTAURUS = 17293666
     },
-
     npc =
     {
         OVERSEER_BASE = GetFirstID('Pitoire_RK'),

--- a/scripts/zones/Quicksand_Caves/DefaultActions.lua
+++ b/scripts/zones/Quicksand_Caves/DefaultActions.lua
@@ -1,6 +1,7 @@
 local ID = zones[xi.zone.QUICKSAND_CAVES]
 
 return {
+    ['qm_amk']             = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm3']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm4']               = { messageSpecial = ID.text.YOU_FIND_NOTHING_OUT },
     ['qm6']               = { messageSpecial = ID.text.ANCIENT_LETTERS_UNREAD },

--- a/scripts/zones/Quicksand_Caves/IDs.lua
+++ b/scripts/zones/Quicksand_Caves/IDs.lua
@@ -31,6 +31,7 @@ zones[xi.zone.QUICKSAND_CAVES] =
         SOMETHING_ATTACKING_YOU       = 7374,  -- Something is attacking from behind you!
         SOMETHING_IS_BURIED           = 7375,  -- Something is buried in this fallen pillar.
         SENSE_OMINOUS_PRESENCE        = 7379,  -- You sense an ominous presence...
+        GRANT_YOU_EASY_ENTRANCE       = 7411,  -- This <keyitem> should grant you easy entrance to your destination. I haven't a clue what you plan to do there, but...good luck! I'd accompany you, but I'm kind of...stuck here, you see. Oh ho...
         PLAYER_OBTAINS_ITEM           = 8287,  -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM         = 8288,  -- You were unable to obtain the item.
         PLAYER_OBTAINS_TEMP_ITEM      = 8289,  -- <name> obtains the temporary item: <item>!
@@ -117,6 +118,7 @@ zones[xi.zone.QUICKSAND_CAVES] =
         CHAINS_THAT_BIND_US_QM = 17629746,
         TREASURE_COFFER        = 17629747,
         ANTICAN_TAG_QM         = 17629769,
+        QM_AMK                 = GetTableOfIDs('qm_amk')
     },
 }
 

--- a/scripts/zones/Quicksand_Caves/npcs/Goblin_Geologist.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/Goblin_Geologist.lua
@@ -10,7 +10,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(100)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Quicksand_Caves/npcs/qm_amk.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/qm_amk.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Area: Quicksand Caves
+-- NPC: qm_amk (???)
+-- Mission: AMK9 - Rescue! A Moogle's Labor of Love
+-- This script is shared across 20 qm npcs to handle logic for AMK mission 9
+-----------------------------------
+
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+end
+
+return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implementation of Rescue! A Moogles Labor of Love, mission 9 of AMK.  The player needs to collect 9 'stone' key items by clicking various question marks in quicksands caves.  There are 20 possible QMs, and 10 possible sets of combinations required to check.  The set which is assigned randomly in this commit is then passed as an arg to the geologist event which marks the map.

## Steps to test these changes

`!addmission 10 8`
`!pos -737 -6 -550 208`
Talk to goblin geologist, he will assign a marker set to you.  Go around quicksands and click the markers shown on the map for your stone KIs.  (alternatively, `!gotoid ###`, ids are in the mission lua file)
Return to goblin to get KI Navaratna Talisman. 
Get CS at shimmering circle in chamber of oracles.
