### PR TITLE
[core] Implements mob Subjob stats based on rank

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -191,6 +191,210 @@ namespace mobutils
 
     /************************************************************************
      *                                                                       *
+     *  Calculation for subjob stats                                         *
+     *                                                                       *
+     ************************************************************************/
+    uint16 GetSubJobStats(uint8 rank, uint16 level, uint16 stat)
+    {
+        // These ranks A through G are used by all known JP sources. Please note this is equivalent to the US usage of A+ through F
+        // https://w.atwiki.jp/studiogobli/pages/27.html
+        float sJobStat = 0;
+
+        switch (rank)
+        {
+            case 1: // A
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (4.0f - 0.225f * (level - 30)))), 2.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (3.25f - 0.073f * (level - 30)));
+                else if (level <= 46)
+                    sJobStat = std::floor(stat / (2.55f - 0.001f * (level - 41)));
+                else
+                    sJobStat = std::floor(stat / (2.7f - 0.001f * (level - 45)));
+                break;
+
+            case 2: // B
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (3.1f - 0.075f * (level - 32)))), 2.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (3.1f - 0.075f * (level - 32)));
+                else if (level <= 45)
+                    sJobStat = std::floor(stat / (2.5f - 0.025f * (level - 40)));
+                else
+                    sJobStat = std::floor(stat / (2.35f - 0.04f * (level - 44)));
+                break;
+
+            case 3: // C
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (4.5f - 0.15f * (level - 26)))), 2.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (3.28f - 0.001f * (level - 30)));
+                else if (level <= 45)
+                    sJobStat = std::floor(stat / (2.6f - 0.025f * (level - 40)));
+                else
+                    sJobStat = std::floor(stat / (2.1f - 0.2f * (level - 49)));
+                break;
+
+            case 4: // D
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (5.0f - 0.05f * (level - 21)))), 1.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (3.2f - 0.001f * (level - 29)));
+                else if (level <= 45)
+                    sJobStat = std::floor(stat / (3.5f - 0.08f * (level - 32)));
+                else
+                    sJobStat = std::floor(stat / (3.25f - 0.045f * (level - 32)));
+                break;
+
+            case 5: // E
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (3.8f - 0.1f * (level - 32)))), 1.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (3.8f - 0.15f * (level - 32)));
+                else if (level <= 45)
+                    sJobStat = std::floor(stat / (2.7f - 0.075f * (level - 40)));
+                else
+                    sJobStat = std::floor(stat / (2.7f - 0.05f * (level - 45)));
+                break;
+
+            case 6: // F
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (4.0f - 0.15f * (level - 35)))), 1.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (4.0f - 0.15f * (level - 30)));
+                else if (level <= 46)
+                    sJobStat = std::floor(stat / (3.0f - 0.1125f * (level - 40)));
+                else
+                    sJobStat = std::floor(stat / (3.0f - 0.07f * (level - 40)));
+                break;
+
+            case 7: // G
+                if (level <= 30)
+                    sJobStat = std::max((std::floor(stat / (4.0f - 0.15f * (level - 35)))), 1.0f);
+                else if (level <= 40)
+                    sJobStat = std::floor(stat / (4.0f - 0.2f * (level - 31)));
+                else if (level <= 46)
+                    sJobStat = std::floor(stat / (2.5f - 0.09f * (level - 40)));
+                else
+                    sJobStat = std::floor(stat / 2);
+                break;
+            default:
+                sJobStat = stat / 2;
+                break;
+        }
+        return sJobStat;
+    }
+
+    /************************************************************************
+     *                                                                       *
+     *  Checks if the mob is in any Original/RoZ zone                        *
+     *                                                                       *
+     ************************************************************************/
+    bool CheckSubJobZone(CMobEntity* PMob)
+    {
+        auto zoneId = PMob->getZone();
+        if (zoneId != 0 && (zoneId == ZONE_WEST_RONFAURE ||
+                            zoneId == ZONE_EAST_RONFAURE ||
+                            zoneId == ZONE_LA_THEINE_PLATEAU ||
+                            zoneId == ZONE_VALKURM_DUNES ||
+                            zoneId == ZONE_JUGNER_FOREST ||
+                            zoneId == ZONE_BATALLIA_DOWNS ||
+                            zoneId == ZONE_NORTH_GUSTABERG ||
+                            zoneId == ZONE_SOUTH_GUSTABERG ||
+                            zoneId == ZONE_KONSCHTAT_HIGHLANDS ||
+                            zoneId == ZONE_PASHHOW_MARSHLANDS ||
+                            zoneId == ZONE_ROLANBERRY_FIELDS ||
+                            zoneId == ZONE_BEAUCEDINE_GLACIER ||
+                            zoneId == ZONE_XARCABARD ||
+                            zoneId == ZONE_CAPE_TERIGGAN ||
+                            zoneId == ZONE_EASTERN_ALTEPA_DESERT ||
+                            zoneId == ZONE_WEST_SARUTABARUTA ||
+                            zoneId == ZONE_EAST_SARUTABARUTA ||
+                            zoneId == ZONE_TAHRONGI_CANYON ||
+                            zoneId == ZONE_BUBURIMU_PENINSULA ||
+                            zoneId == ZONE_MERIPHATAUD_MOUNTAINS ||
+                            zoneId == ZONE_SAUROMUGUE_CHAMPAIGN ||
+                            zoneId == ZONE_THE_SANCTUARY_OF_ZITAH ||
+                            zoneId == ZONE_ROMAEVE ||
+                            zoneId == ZONE_YUHTUNGA_JUNGLE ||
+                            zoneId == ZONE_YHOATOR_JUNGLE ||
+                            zoneId == ZONE_WESTERN_ALTEPA_DESERT ||
+                            zoneId == ZONE_QUFIM_ISLAND ||
+                            zoneId == ZONE_BEHEMOTHS_DOMINION ||
+                            zoneId == ZONE_VALLEY_OF_SORROWS ||
+                            zoneId == ZONE_HORLAIS_PEAK ||
+                            zoneId == ZONE_GHELSBA_OUTPOST ||
+                            zoneId == ZONE_FORT_GHELSBA ||
+                            zoneId == ZONE_YUGHOTT_GROTTO ||
+                            zoneId == ZONE_PALBOROUGH_MINES ||
+                            zoneId == ZONE_WAUGHROON_SHRINE ||
+                            zoneId == ZONE_GIDDEUS ||
+                            zoneId == ZONE_BALGAS_DAIS ||
+                            zoneId == ZONE_BEADEAUX ||
+                            zoneId == ZONE_QULUN_DOME ||
+                            zoneId == ZONE_DAVOI ||
+                            zoneId == ZONE_MONASTIC_CAVERN ||
+                            zoneId == ZONE_CASTLE_OZTROJA ||
+                            zoneId == ZONE_ALTAR_ROOM ||
+                            zoneId == ZONE_THE_BOYAHDA_TREE ||
+                            zoneId == ZONE_DRAGONS_AERY ||
+                            zoneId == ZONE_MIDDLE_DELKFUTTS_TOWER ||
+                            zoneId == ZONE_UPPER_DELKFUTTS_TOWER ||
+                            zoneId == ZONE_TEMPLE_OF_UGGALEPIH ||
+                            zoneId == ZONE_DEN_OF_RANCOR ||
+                            zoneId == ZONE_CASTLE_ZVAHL_BAILEYS ||
+                            zoneId == ZONE_CASTLE_ZVAHL_KEEP ||
+                            zoneId == ZONE_SACRIFICIAL_CHAMBER ||
+                            zoneId == ZONE_THRONE_ROOM ||
+                            zoneId == ZONE_RANGUEMONT_PASS ||
+                            zoneId == ZONE_BOSTAUNIEUX_OUBLIETTE ||
+                            zoneId == ZONE_CHAMBER_OF_ORACLES ||
+                            zoneId == ZONE_TORAIMARAI_CANAL ||
+                            zoneId == ZONE_FULL_MOON_FOUNTAIN ||
+                            zoneId == ZONE_ZERUHN_MINES ||
+                            zoneId == ZONE_KORROLOKA_TUNNEL ||
+                            zoneId == ZONE_KUFTAL_TUNNEL ||
+                            zoneId == ZONE_SEA_SERPENT_GROTTO ||
+                            zoneId == ZONE_VELUGANNON_PALACE ||
+                            zoneId == ZONE_THE_SHRINE_OF_RUAVITAU ||
+                            zoneId == ZONE_STELLAR_FULCRUM ||
+                            zoneId == ZONE_LALOFF_AMPHITHEATER ||
+                            zoneId == ZONE_THE_CELESTIAL_NEXUS ||
+                            zoneId == ZONE_LOWER_DELKFUTTS_TOWER ||
+                            zoneId == ZONE_KING_RANPERRES_TOMB ||
+                            zoneId == ZONE_DANGRUF_WADI ||
+                            zoneId == ZONE_INNER_HORUTOTO_RUINS ||
+                            zoneId == ZONE_ORDELLES_CAVES ||
+                            zoneId == ZONE_OUTER_HORUTOTO_RUINS ||
+                            zoneId == ZONE_THE_ELDIEME_NECROPOLIS ||
+                            zoneId == ZONE_GUSGEN_MINES ||
+                            zoneId == ZONE_CRAWLERS_NEST ||
+                            zoneId == ZONE_MAZE_OF_SHAKHRAMI ||
+                            zoneId == ZONE_GARLAIGE_CITADEL ||
+                            zoneId == ZONE_CLOISTER_OF_GALES ||
+                            zoneId == ZONE_CLOISTER_OF_STORMS ||
+                            zoneId == ZONE_CLOISTER_OF_FROST ||
+                            zoneId == ZONE_FEIYIN ||
+                            zoneId == ZONE_IFRITS_CAULDRON ||
+                            zoneId == ZONE_QUBIA_ARENA ||
+                            zoneId == ZONE_CLOISTER_OF_FLAMES ||
+                            zoneId == ZONE_QUICKSAND_CAVES ||
+                            zoneId == ZONE_CLOISTER_OF_TREMORS ||
+                            zoneId == ZONE_CLOISTER_OF_TIDES ||
+                            zoneId == ZONE_GUSTAV_TUNNEL ||
+                            zoneId == ZONE_LABYRINTH_OF_ONZOZO ||
+                            zoneId == ZONE_SHIP_BOUND_FOR_SELBINA ||
+                            zoneId == ZONE_SHIP_BOUND_FOR_MHAURA ||
+                            zoneId == ZONE_SHIP_BOUND_FOR_SELBINA_PIRATES ||
+                            zoneId == ZONE_SHIP_BOUND_FOR_MHAURA_PIRATES))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /************************************************************************
+     *                                                                       *
      *  Calculate mob stats                                                  *
      *                                                                       *
      ************************************************************************/
@@ -425,10 +629,21 @@ namespace mobutils
         uint16 sMND = GetBaseToRank(grade::GetJobGrade(PMob->GetSJob(), 7), sLvl);
         uint16 sCHR = GetBaseToRank(grade::GetJobGrade(PMob->GetSJob(), 8), sLvl);
 
-        // As per conversation with Jimmayus, all mobs at any level get bonus stats from subjobs.
-        // From lvl 45 onwards, 1/2. Before lvl 30, 1/4. In between, the value gets progresively higher, from 1/4 at 30 to 1/2 at 44.
-        // Im leaving that range at 1/3, for now.
-        if (mLvl >= 45)
+        // Each subjob stat is determined by where the mob is located and what level the mob is.
+        // Each rank has their own formula as shown in GetSubJobStats
+        // Sub-level 50 monsters implemented in "Chains of Promathia" and onward (i.e. "Wings of the Goddess" as well) will use rank/2 at all levels.
+        // Note: Subjob Level will ALWAYS = Main Job Level but we use sLvl so it makes it easier to know what stat we are calculating
+        if (CheckSubJobZone(PMob) && (sLvl < 50))
+        {
+            sSTR = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 2), sLvl, sSTR);
+            sDEX = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 3), sLvl, sDEX);
+            sVIT = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 4), sLvl, sVIT);
+            sAGI = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 5), sLvl, sAGI);
+            sINT = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 6), sLvl, sINT);
+            sMND = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 7), sLvl, sMND);
+            sCHR = GetSubJobStats(grade::GetJobGrade(PMob->GetSJob(), 8), sLvl, sCHR);
+        }
+        else
         {
             sSTR /= 2;
             sDEX /= 2;
@@ -437,26 +652,6 @@ namespace mobutils
             sMND /= 2;
             sCHR /= 2;
             sVIT /= 2;
-        }
-        else if (mLvl > 30)
-        {
-            sSTR /= 3;
-            sDEX /= 3;
-            sAGI /= 3;
-            sINT /= 3;
-            sMND /= 3;
-            sCHR /= 3;
-            sVIT /= 3;
-        }
-        else
-        {
-            sSTR /= 4;
-            sDEX /= 4;
-            sAGI /= 4;
-            sINT /= 4;
-            sMND /= 4;
-            sCHR /= 4;
-            sVIT /= 4;
         }
 
         // [stat] = floor[family Stat] + floor[main job Stat] + floor[sub job Stat]

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -69,6 +69,7 @@ namespace mobutils
     uint16 GetBaseDefEva(CMobEntity* PMob, uint8 rank);
     uint16 GetBaseSkill(CMobEntity* PMob, uint8 rank);
     uint16 GetBaseToRank(uint8 rank, uint16 level);
+    uint16 GetSubJobStats(uint8 rank, uint16 level, uint16 stat);
     void   GetAvailableSpells(CMobEntity* PMob);
     void   InitializeMob(CMobEntity* PMob);
     void   LoadSqlModifiers();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Explanation provided by **Jimmayus**
### Introduction

It's been known for sometime that the base stats that monsters below a certain level get from their subjobs follow a different calculation than the one that Studio Gobli derived many years ago. From previous related work we were able to derive a "good enough" line, but it has bothered me for a few years now that this only really got monsters to within 1 stat for some levels, and then in the 40s got progressively weaker until finally the gobli formula kicked in at level 50. So, in order to correct this imbalance I went to retail this last week and a half to derive the actual formula. What follows is a complete set of formula for the different stat ranks and the level breaks. If you want to skip to those then they are in the conclusion, along with an explanation.

As an aside, I'd like to add in the introduction up here that sub-level 50 monsters implemented in "Chains of Promathia" and onward (i.e. "Wings of the Goddess" as well) will use rank/2 at all levels. This even includes Goblin Bounty Hunters for some reason.

### Background

Base stats in Final Fantasy 11 work on a 7-tier scale. If you're familiar with the concept of combat skill ranks it is very similar. These ranks we have listed as 1-7 or A-G, with 1/A being the strongest (INT for BLM, STR for WAR, that sort of thing) and 7/G being the weakest (INT for PLD, MND for DRK). Every job has ranks for each of these, and also individual monster families and players have them as well. In general any given base stat is derived by combining the values: Family rank + Main job rank + sub job rank.

As a quick aside, monster jobs work differently than player jobs. If a player is level 75, their subjob is for all intents and purposes level 37, regardless of if you've leveled past 37 or not. Some exceptions exist, most notably beastmaster charm formula but in general this is true. Monsters, on the other hand, have two jobs of the same level. For example, an Orcish Serjeant lvl 27 would be a level 27 Paladin and a level 27 Warrior at the same time. That means they get the job traits of both jobs, and just like players if both jobs have Defense Bonus for example then monsters only use the highest version. The same is true with magic skills and such. However, Square Enix clearly saw this would be a problem if they gave two main job's worth of base stats, so they reduced the amount of base stat that monsters get from their "second job". We know that they take the normal calculation, divide by 2, and then round down to the nearest integer for monsters levels 50+. The purpose of this survey was to see how much stat exactly should our friend the level 27 Orcish Serjeant receive from his warrior second job.

### Methodology

Research into base stats is best done with methods that a precise, stable and easily manipulable. For our purposes the things that fit the bill are lower tier nukes, because lower tier nukes scales on a 1:1 basis with enemy base stats and their damage does not vary unlike in an auto attack. The general data gathering methodology was as follows:

Determine which monsters would have subjobs with the rank I am working on. For example if I was doing rank F scaling I could use Rabbits, because Rabbits are WAR main and WAR second and WAR has rank F INT and MND.

Calculate the amount of base stat these monsters get from their family and from their main job. In the rabbit example: rabbits have rank D INT, and war main has rank F INT. So, I made a list of rank D + rank F for each level 1-49. If I had to use monsters with family rank C, E, F or G INT I calculated the difference and adjusted accordingly.

Control my own base stats such that I would always be scaling at 1:1. This step is related to some technical aspects of how magic damage works, but for our purposes just know this means "keep my INT, MND and CHR at extremely low values and hold them static".

Travel to various places in the world and get a few samples per-level per-rank, record the change in stats from level to level and determine how much of those stats comes from the subjob.

Once as much data 1-49 as possible has been collected, create a series of rational functions that describe the rate of change to within +-0.

For the fifth step, it's important to know that I'm not interested in what the actual formula SE is using looks like, because that's impossible to know for sure. Instead what I was after is a set of formulae that describes what is happening with accuracy. To that end I would not be surprised if there was a different-looking set of formula that work just as well.

To do this study I used two jobs: SCH69/PLD34 and BLU99/PUP2. My base stats for SCH were 60 INT and 60 MND, and for BLU was 49 CHR. The three spells I used were Helix, Banish II and Mysterious Light (with supplementary confirmation using Eyes on Me).

Helix:

The damage formula for Helix, when I control for day/weather, staff, mab and such is: 25 + (My INT - Enemy INT). Since my INT for this test is 60, I can simplify to: 25 + (My INT - Enemy INT) 25 + (60 - Enemy INT) 85 - Enemy INT: Damage observed in combat log

Banish II:

The damage formula for Banish II, when I control for day/weather, staff, mab and such is: 85 + (My MND - Enemy MND). Since my MND for this test is 60, I can simplify to: 85 + (My MND - Enemy MND) 85 + (60 - Enemy MND) 145 - Enemy MND = Damage observed in combat log

Mysterious Light

The damage formula for Mysterious Light, when I control for day/weather, staff, mab and such is: INT(((Level +2 [caps at 57]) + INT(My Charisma * .3)) * 31/16) + (My CHR - Enemy CHR). For the non-coders who may be reading, I when I say INT in that formula I mean "round down to nearest whole number" or "floor". In my case since my CHR is a static 49 I can simplify the formula in the following way:

INT(((Level +2 [caps at 57]) + INT(My Charisma * .3)) * 31/16) + (My CHR - Enemy CHR) INT((57 + INT(49 * .3)) * 31/16) + (49 - Enemy CHR) INT((57 + 14) * 31/16) + (49 - Enemy CHR) INT( 71 * 31/16) + (49 - Enemy CHR) 137 + 49 - Enemy CHR 186 - Enemy CHR = Damage

Results: https://docs.google.com/spreadsheets/d/1oBYRxJClubLuJh39mIggzNh7eKit2oW3M7G8OLwl7GE/edit?usp=sharing

### Conclusion:
The updated subjob formula are as follows:
Rank A:
1-30: Floor(Rank A/(4-0.225*(level-30))), MIN = 2
31-40: Floor(rank A / (3.25-0.073*(Level-30)))
41-46: Floor(rank A / (2.55-0.001*(Level-41)))
47-49: Floor(rank A / (2.7-0.001*(Level-45)))
50+ Floor(Rank A/2)

Rank B:
1-30: Floor(rank B / (3.1-.075 * (Level-32))), MIN = 2 
31-40: Floor(rank B / (3.1-.075 * (Level-32)))
41-45: Floor(rank B / (2.5-.025 * (Level-40)))
46-49: Floor(rank B / (2.35 -.04 * (Level-44)))
50+: Floor(rank B /2)

Rank C:
1-30: Floor(rank C / (4.5 -.15*(Level-26))), Min = 2
31-40: Floor(rank C / (3.28-.001 * (Level-30)))
41-45: Floor(rank C / (2.6-.025 * (Level-40)))
46-49: Floor(rank C / (2.1 -.2 * (Level-49)))
50+: Floor(rank C /2)

Rank D:
1-30: Floor(rank D / (5 -.05*(Level-21))), Min = 1
31-40: Floor(rank D / (3.2-.001 * (Level-29)))
41-45: Floor(rank D / (3.5-.08 * (Level-32)))
46-49: Floor(rank D / (3.25-.045 * (Level-32)))
50+: Floor(rank D /2)

Rank E:
1-30: Floor(rank E / (3.8 -.1*(Level-32))), Min = 1
31-40: Floor(rank E / (3.8-.15 * (Level-32)))
41-45: Floor(rank E / (2.7-.075 * (Level-40)))
46-49: Floor(rank E / (2.7-.05 * (Level-45)))
50+: Floor(rank E /2)

Rank F:
1-30: Floor(rank F / (4-.15*(Level-35))), Min = 1
31-40: Floor(rank F / (4-.15*(Level-30)))
41-46: Floor(rank F / (3-.1125(Level-40)))
47-49: Floor(rank F / (3-.07(Level-40)))
50+: Floor(rank F /2)

Rank G:
1-30: Floor(rank G / (4-.15*(Level-35))), Min = 1
31-40: Floor(rank G / (4-.2 * (Level-31)))
41-46: Floor(rank G / (2.5-.09 * (Level-40)))
47-49: Floor(rank G /2)
50+: Floor(rank G /2)

Essentially it seems like Square Enix created a series of rational functions for reducing the base stat contributions from subjobs. I've done my best to keep them organized in level brackets, but who knows what they actually use. In general, if a line says, for example: "Floor(rank G /2)" that means run the normal formula for rank G at that level including the flooring part, then divide by 2 and floor again. Likewise the rest of the list should be mostly self explanatory, and if you need explanations feel free to ask, and if you just want to see the data in action there are relevant columns in the data presented above for your perusal. This has been a long project, but I think this will dramatically help the leveling experience on emulated servers in ways very few people would even think to ask about. Thanks for your time and good luck with your implementation.

Example shown is a wanderer in Promy Dem. Stats are before/after. All mobs below 45 that are in a COP+ zone will now have significantly more stats.

![image](https://github.com/LandSandBoat/server/assets/105882754/89bf4f87-d7b1-4174-b970-3dda826bc8a6)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
`!getstats` on any mob and see that the stats follow the formulas above for subjob stats.

You will need to calculate the `family + mainjob` stats separately to make sure the math is correct.
<!-- Clear and detailed steps to test your changes here -->
