### PR TITLE
Monk mob weapon damage adjustments to match PC

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -56,6 +56,7 @@ namespace mobutils
     uint16 GetWeaponDamage(CMobEntity* PMob, uint16 slot)
     {
         uint16 lvl    = PMob->GetMLevel();
+        auto*  weapon = dynamic_cast<CItemWeapon*>(PMob->m_Weapons[SLOT_MAIN]);
         int8   bonus  = 2;
         uint16 damage = 0;
 
@@ -69,7 +70,17 @@ namespace mobutils
             bonus = 0;
         }
 
-        damage = lvl + bonus;
+        if (slot == SLOT_MAIN && (weapon == nullptr || weapon->getSkillType() == SKILL_HAND_TO_HAND))
+        {
+            // https://ffxiclopedia.fandom.com/wiki/Category:Hand-to-Hand
+            // base h2h weapon dmg for a given h2h skill: (0.11 * h2h skill) + 3
+            uint16 h2hskill = battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_MNK, lvl);
+            damage          = 0.11f * h2hskill + 3;
+        }
+        else
+        {
+            damage = lvl + bonus;
+        }
 
         damage = (uint16)(damage * PMob->m_dmgMult / 100.0f);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Recreated my PR as I was doing cleanup and didn't realize my older LSB PRs were linked to the Wings-XI repo

Please see https://github.com/LandSandBoat/server/pull/4674

TL;DR - monk mobs that hit twice due to having a h2h weapon should not have the same weapon damage as mobs that only hit once.

## Steps to test these changes

Monk mobs like Lycopodiums should have reduced damage, but monk mobs like Sea Monks in Arrapago Reef should be unchanged.