### PR TITLE
[core] Remove exceptions from AI states

### DIFF
--- a/src/map/ai/CMakeLists.txt
+++ b/src/map/ai/CMakeLists.txt
@@ -8,5 +8,7 @@ set(AI_SOURCES
     ${AI_STATE_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/ai_container.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ai_container.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/state.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/state.h
     PARENT_SCOPE
 )

--- a/src/map/ai/helpers/action_queue.cpp
+++ b/src/map/ai/helpers/action_queue.cpp
@@ -58,6 +58,7 @@ void CAIActionQueue::checkAction(time_point tick)
             break;
         }
     }
+
     while (!actionQueue.empty())
     {
         const auto& topaction = actionQueue.top();

--- a/src/map/ai/helpers/event_handler.cpp
+++ b/src/map/ai/helpers/event_handler.cpp
@@ -26,14 +26,19 @@ void CAIEventHandler::addListener(std::string const& eventname, sol::function co
     TracyZoneScoped;
     TracyZoneString(eventname);
     TracyZoneString(identifier);
+
+    // clang-format off
     // Remove entries with same identifier (if they exist)
     eventListeners[eventname]
-        .erase(std::remove_if(eventListeners[eventname].begin(), eventListeners[eventname].end(),
-                              [&identifier](const ai_event_t& event)
-                              {
-                                  return identifier == event.identifier;
-                              }),
-               eventListeners[eventname].end());
+        .erase(std::remove_if(
+            eventListeners[eventname].begin(),
+            eventListeners[eventname].end(),
+            [&identifier](const ai_event_t& event)
+            {
+                return identifier == event.identifier;
+            }),
+            eventListeners[eventname].end());
+    // clang-format on
 
     eventListeners[eventname].emplace_back(identifier, lua_func);
 }
@@ -42,6 +47,7 @@ void CAIEventHandler::removeListener(std::string const& identifier)
 {
     TracyZoneScoped;
     TracyZoneString(identifier);
+
     for (auto&& eventListener : eventListeners)
     {
         auto remove = [&identifier](const ai_event_t& event)

--- a/src/map/ai/state.cpp
+++ b/src/map/ai/state.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 */
 
 #include "state.h"
+
 #include "entities/baseentity.h"
 
 CState::CState(CBaseEntity* PEntity, uint16 _targid)

--- a/src/map/ai/state.h
+++ b/src/map/ai/state.h
@@ -25,27 +25,23 @@
 
 #include "common/mmo.h"
 #include "packets/message_basic.h"
+
 #include <memory>
+#include <nonstd/expected.hpp>
+#include <optional>
 
 class CBattleEntity;
-
-class CStateInitException : public std::exception
-{
-public:
-    explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg)
-    : std::exception()
-    , packet(std::move(_msg))
-    {
-    }
-    std::unique_ptr<CBasicPacket> packet;
-};
 
 class CState
 {
 public:
+    typedef nonstd::expected<void, std::optional<std::unique_ptr<CBasicPacket>>> StateResult;
+
     CState(CBaseEntity* PEntity, uint16 _targid);
 
     virtual ~CState() = default;
+
+    virtual StateResult Initialize() = 0;
 
     CBaseEntity* GetTarget() const;
     void         SetTarget(uint16 targid);

--- a/src/map/ai/states/CMakeLists.txt
+++ b/src/map/ai/states/CMakeLists.txt
@@ -23,8 +23,6 @@ set(AI_STATE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/range_state.h
     ${CMAKE_CURRENT_SOURCE_DIR}/respawn_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/respawn_state.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/state.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/state.h
     ${CMAKE_CURRENT_SOURCE_DIR}/trigger_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trigger_state.h
     ${CMAKE_CURRENT_SOURCE_DIR}/weaponskill_state.cpp

--- a/src/map/ai/states/ability_state.h
+++ b/src/map/ai/states/ability_state.h
@@ -23,31 +23,35 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #define _CABILITY_STATE_H
 
 #include "ability.h"
-#include "state.h"
+#include "ai/state.h"
 
 class CCharEntity;
 
-class CAbilityState : public CState
+class CAbilityState final : public CState
 {
 public:
     CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abilityid);
+
+    auto Initialize() -> CState::StateResult override;
 
     CAbility* GetAbility();
 
     void ApplyEnmity();
 
 protected:
-    virtual bool CanChangeState() override;
-    virtual bool CanFollowPath() override
+    bool CanChangeState() override;
+    bool CanFollowPath() override
     {
         return true;
     }
-    virtual bool CanInterrupt() override
+
+    bool CanInterrupt() override
     {
         return true;
     }
-    virtual bool Update(time_point tick) override;
-    virtual void Cleanup(time_point tick) override
+
+    bool Update(time_point tick) override;
+    void Cleanup(time_point tick) override
     {
     }
 
@@ -55,7 +59,8 @@ protected:
 
 private:
     duration                  m_castTime{ 0s };
-    CBattleEntity* const      m_PEntity;
+    CBattleEntity* const      m_PBattleEntity;
+    uint16                    m_abilityId;
     std::unique_ptr<CAbility> m_PAbility;
 };
 

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -34,16 +34,22 @@ CAttackState::CAttackState(CBattleEntity* PEntity, uint16 targid)
 {
     PEntity->SetBattleTargetID(targid);
     PEntity->SetBattleStartTime(server_clock::now());
+
     CAttackState::UpdateTarget();
     if (!GetTarget() || m_errorMsg)
     {
         PEntity->SetBattleTargetID(0);
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
+
     if (PEntity->PAI->PathFind)
     {
         PEntity->PAI->PathFind->Clear();
     }
+}
+
+CState::StateResult Initialize()
+{
 }
 
 bool CAttackState::Update(time_point tick)

--- a/src/map/ai/states/attack_state.h
+++ b/src/map/ai/states/attack_state.h
@@ -22,12 +22,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CATTACK_STATE_H
 #define _CATTACK_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CAttackState : public CState
 {
 public:
     CAttackState(CBattleEntity* PEntity, uint16 targid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     // state logic done per tick - returns whether to exit the state or not
     virtual bool Update(time_point tick) override;

--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -22,12 +22,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CDEATH_STATE_H
 #define _CDEATH_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CDeathState : public CState
 {
 public:
     CDeathState(CBattleEntity* PEntity, duration death_time);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     // state logic done per tick - returns whether to exit the state or not
     virtual bool Update(time_point tick) override;

--- a/src/map/ai/states/despawn_state.h
+++ b/src/map/ai/states/despawn_state.h
@@ -22,12 +22,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CSPAWN_STATE_H
 #define _CSPAWN_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CDespawnState : public CState
 {
 public:
     CDespawnState(CBaseEntity* PEntity, bool instantDespawn);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
+
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override;
     virtual bool CanChangeState() override;

--- a/src/map/ai/states/inactive_state.h
+++ b/src/map/ai/states/inactive_state.h
@@ -22,12 +22,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CINACTIVE_STATE_H
 #define _CINACTIVE_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CInactiveState : public CState
 {
 public:
     CInactiveState(CBaseEntity* PEntity, duration _duration, bool canChangeState, bool untargetable);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     bool GetUntargetable()
     {

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -74,7 +74,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
 
     if (!m_PItem)
     {
-        throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, 0, 0, 56));
+        // throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, 0, 0, 56));
     }
 
     UpdateTarget(PEntity->IsValidTarget(targid, m_PItem->getValidTarget(), m_errorMsg));
@@ -82,7 +82,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     auto [error, param, value] = luautils::OnItemCheck(PTarget, m_PItem, ITEMCHECK::NONE, m_PEntity);
@@ -90,7 +90,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
     {
         if (error == -1)
         {
-            throw CStateInitException(nullptr);
+            // throw CStateInitException(nullptr);
         }
         else
         {
@@ -98,7 +98,7 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
             {
                 param = m_PItem->getFlag() & ITEM_FLAG_SCROLL ? m_PItem->getSubID() : m_PItem->getID();
             }
-            throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget ? PTarget : m_PEntity, param, value, error));
+            // throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget ? PTarget : m_PEntity, param, value, error));
         }
     }
 

--- a/src/map/ai/states/item_state.h
+++ b/src/map/ai/states/item_state.h
@@ -22,7 +22,7 @@
 #ifndef _CITEM_STATE_H
 #define _CITEM_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CBattleEntity;
 class CCharEntity;
@@ -34,6 +34,9 @@ class CItemState : public CState
 {
 public:
     CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slotid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
+
     void UpdateTarget(CBaseEntity* target) override;
     void UpdateTarget(uint16 targid) override;
     bool Update(time_point tick) override;

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -44,7 +44,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     auto* PSpell = spell::GetSpell(spellid);
     if (PSpell == nullptr)
     {
-        throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, static_cast<uint16>(spellid), 0, MSGBASIC_CANNOT_CAST_SPELL));
+        // throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, static_cast<uint16>(spellid), 0, MSGBASIC_CANNOT_CAST_SPELL));
     }
 
     m_PSpell = PSpell->clone();
@@ -52,19 +52,19 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     auto* PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     if (!CanCastSpell(PTarget, false))
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     auto errorMsg = luautils::OnMagicCastingCheck(m_PEntity, PTarget, GetSpell());
     if (errorMsg)
     {
-        throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, static_cast<uint16>(m_PSpell->getID()), 0,
-                                                                        errorMsg == 1 ? MSGBASIC_CANNOT_CAST_SPELL : errorMsg));
+        // throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, static_cast<uint16>(m_PSpell->getID()), 0,
+        //                                                                 errorMsg == 1 ? MSGBASIC_CANNOT_CAST_SPELL : errorMsg));
     }
 
     m_castTime = std::chrono::milliseconds(battleutils::CalculateSpellCastTime(m_PEntity, this));

--- a/src/map/ai/states/magic_state.h
+++ b/src/map/ai/states/magic_state.h
@@ -23,7 +23,7 @@
 #define _CMAGIC_STATE_H
 
 #include "spell.h"
-#include "state.h"
+#include "ai/state.h"
 
 struct action_t;
 
@@ -38,6 +38,9 @@ class CMagicState : public CState
 {
 public:
     CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid, uint8 flags = 0);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
+
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override;
     virtual bool CanChangeState() override;

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -37,19 +37,19 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
     auto* skill = battleutils::GetMobSkill(wsid);
     if (!skill)
     {
-        throw CStateInitException(nullptr);
+        // throw CStateInitException(nullptr);
     }
 
     if (m_PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT_AMNESIA, EFFECT_IMPAIRMENT }))
     {
-        throw CStateInitException(nullptr);
+        // throw CStateInitException(nullptr);
     }
 
     auto* PTarget = m_PEntity->IsValidTarget(m_targid, skill->getValidTargets(), m_errorMsg);
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     m_PSkill = std::make_unique<CMobSkill>(*skill);

--- a/src/map/ai/states/mobskill_state.h
+++ b/src/map/ai/states/mobskill_state.h
@@ -23,7 +23,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #define _CMOBSKILL_TATE_H
 
 #include "mobskill.h"
-#include "state.h"
+#include "ai/state.h"
 
 class CBattleEntity;
 
@@ -31,6 +31,8 @@ class CMobSkillState : public CState
 {
 public:
     CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     CMobSkill* GetSkill();
 

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -36,19 +36,19 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
     auto* skill = battleutils::GetPetSkill(wsid);
     if (!skill)
     {
-        throw CStateInitException(nullptr);
+        // throw CStateInitException(nullptr);
     }
 
     if (m_PEntity->StatusEffectContainer->HasStatusEffect({ EFFECT_AMNESIA, EFFECT_IMPAIRMENT }))
     {
-        throw CStateInitException(nullptr);
+        // throw CStateInitException(nullptr);
     }
 
     auto* PTarget = m_PEntity->IsValidTarget(m_targid, skill->getValidTargets(), m_errorMsg);
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     m_PSkill = std::make_unique<CPetSkill>(*skill);

--- a/src/map/ai/states/petskill_state.h
+++ b/src/map/ai/states/petskill_state.h
@@ -23,7 +23,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #define _CPETSKILL_TATE_H
 
 #include "petskill.h"
-#include "state.h"
+#include "ai/state.h"
 
 class CPetEntity;
 
@@ -31,6 +31,8 @@ class CPetSkillState : public CState
 {
 public:
     CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     CPetSkill* GetPetSkill();
 

--- a/src/map/ai/states/raise_state.h
+++ b/src/map/ai/states/raise_state.h
@@ -22,12 +22,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CRAISE_STATE_H
 #define _CRAISE_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CRaiseState : public CState
 {
 public:
     CRaiseState(CBattleEntity* PEntity);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     // state logic done per tick - returns whether to exit the state or not
     virtual bool Update(time_point tick) override;

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -38,18 +38,18 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     if (!CanUseRangedAttack(PTarget, false))
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     if (distance(m_PEntity->loc.p, PTarget->loc.p) > 25)
     {
         m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_TOO_FAR_AWAY);
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     auto delay = m_PEntity->GetRangedWeaponDelay(false);

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -22,13 +22,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CRANGE_STATE_H
 #define _CRANGE_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 class CCharEntity;
 
 class CRangeState : public CState
 {
 public:
     CRangeState(CBattleEntity* PEntity, uint16 targid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     void SpendCost();
     bool IsRapidShot()

--- a/src/map/ai/states/respawn_state.cpp
+++ b/src/map/ai/states/respawn_state.cpp
@@ -30,6 +30,8 @@ CRespawnState::CRespawnState(CBaseEntity* _PEntity, duration spawnTime)
 {
 }
 
+
+
 bool CRespawnState::Update(time_point tick)
 {
     // make sure that the respawn time is up to date

--- a/src/map/ai/states/respawn_state.h
+++ b/src/map/ai/states/respawn_state.h
@@ -22,20 +22,25 @@
 #ifndef _CRESPAWN_STATE_H
 #define _CRESPAWN_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CRespawnState : public CState
 {
 public:
     CRespawnState(CBaseEntity* PEntity, duration spawnTime);
-    virtual bool Update(time_point tick) override;
-    virtual void Cleanup(time_point tick) override;
-    virtual bool CanChangeState() override;
-    virtual bool CanFollowPath() override
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
+
+    bool Update(time_point tick) override;
+    void Cleanup(time_point tick) override;
+    bool CanChangeState() override;
+
+    bool CanFollowPath() override
     {
         return false;
     }
-    virtual bool CanInterrupt() override
+
+    bool CanInterrupt() override
     {
         return false;
     }

--- a/src/map/ai/states/trigger_state.h
+++ b/src/map/ai/states/trigger_state.h
@@ -22,12 +22,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CTRIGGER_STATE_H
 #define _CTRIGGER_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 
 class CTriggerState : public CState
 {
 public:
     CTriggerState(CBaseEntity* PEntity, uint16 targid, bool door = false);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
+
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override
     {

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -36,7 +36,7 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
     auto* skill = battleutils::GetWeaponSkill(wsid);
     if (!skill)
     {
-        throw CStateInitException(std::make_unique<CMessageBasicPacket>(PEntity, PEntity, 0, 0, MSGBASIC_CANNOT_USE_WS));
+        // throw CStateInitException(std::make_unique<CMessageBasicPacket>(PEntity, PEntity, 0, 0, MSGBASIC_CANNOT_USE_WS));
     }
 
     auto  target_flags = battleutils::isValidSelfTargetWeaponskill(wsid) ? TARGET_SELF : TARGET_ENEMY;
@@ -44,12 +44,12 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
 
     if (!PTarget || m_errorMsg)
     {
-        throw CStateInitException(std::move(m_errorMsg));
+        // throw CStateInitException(std::move(m_errorMsg));
     }
 
     if (!m_PEntity->CanSeeTarget(PTarget, false))
     {
-        throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_CANNOT_PERFORM_ACTION));
+        // throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_CANNOT_PERFORM_ACTION));
     }
 
     m_PSkill = std::make_unique<CWeaponSkill>(*skill);

--- a/src/map/ai/states/weaponskill_state.h
+++ b/src/map/ai/states/weaponskill_state.h
@@ -22,13 +22,15 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #ifndef _CWEAPONSKILL_STATE_H
 #define _CWEAPONSKILL_STATE_H
 
-#include "state.h"
+#include "ai/state.h"
 #include "weapon_skill.h"
 
 class CWeaponSkillState : public CState
 {
 public:
     CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid);
+
+    auto Initialize() -> CState::StateResult override { return CState::StateResult(); }
 
     CWeaponSkill* GetSkill();
 

--- a/src/map/pch.h
+++ b/src/map/pch.h
@@ -100,6 +100,8 @@
 #include <fmt/format.h>
 #include <fmt/printf.h>
 
+#include <nonstd/expected.hpp>
+
 #include <spdlog/common.h>
 #include <spdlog/spdlog.h>
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prepare for a lesson in Core + C++.

- Inside ChangeState, the template argument tells the function what state it needs to construct and then put onto the state stack.
- While it's doing this, it's listening (via a try/catch block) for exceptions to be bubbled up.
- This custom exception we have carries a packet that will be emitted to the entity - if they can receive it (players).
- We have done it this way because the only way to bail out of a class constructor early is to set flags or throw an exception.
- We're also unable to ferry values out of a constructor, unless we throw a custom exception and attach the data to it, and then catch it in a try/catch block.

===

- What I'm going to do instead is make the construction of a state _very simple_, it will take the arguments passed in (maybe I should capture these as a tuple?), and store them. Nothing else.
- Next up we will call state->Initialize(), which will return `StateResult`.
- This is a typedef of `nonstd::expected<void, std::unique_ptr<CBasicPacket>>`. In the happy case it holds nothing (void), and in the error case it holds our error packet.
- All the other logic is replacing `throw` with `return nonstd::make_unexpected(...)`

## Steps to test these changes

Everything works as normal.

Closes https://github.com/LandSandBoat/server/issues/4024