### PR TITLE
Dark Ixion: Fight Mechanics

### DIFF
--- a/scripts/actions/mobskills/acheron_kick.lua
+++ b/scripts/actions/mobskills/acheron_kick.lua
@@ -1,0 +1,48 @@
+-----------------------------------
+--  Acheron Kick
+--
+--  Description: Physical Cone Attack damage behind user.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 2-3 shadows
+--  Range: Back
+--  Dark Ixion CAN turn around to use this move on anyone with hate, regardless of their original position or even distance.
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- to allow primary player to run out of conal and to respect the real range of the mobskill
+    if
+        not target:isBehind(mob, 64) or
+        target:checkDistance(mob) > 10
+    then
+        skill:setMsg(xi.msg.basic.SKILL_MISS)
+        return
+    end
+
+    local numhits = math.random(2, 3)
+    local accmod = 1
+    local dmgmod = 1
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod)
+
+    local dmg = 0
+    if info.hitslanded > 0 then
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    else
+        skill:setMsg(xi.msg.basic.SKILL_MISS)
+        return
+    end
+
+    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        skill:setMsg(xi.msg.basic.DAMAGE)
+    end
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/damsel_memento.lua
+++ b/scripts/actions/mobskills/damsel_memento.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Damsel Memento
+-- Recovers 5% (5,000) of his HP and removes all debuffs.
+-- If Dark Ixion's horn has been broken in battle, there's a chance that it will regenerate.
+-- Type: Magical
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if
+        mob:getAnimationSub() == 1 or
+        mob:getLocalVar('charging') == 1
+    then
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    mob:delStatusEffectsByFlag(xi.effectFlag.WALTZABLE, false)
+    mob:delStatusEffectsByFlag(xi.effectFlag.ERASABLE, false)
+    skill:setMsg(xi.msg.basic.SELF_HEAL)
+
+    return xi.mobskills.mobHealMove(mob, mob:getMaxHP() * 5 / 100)
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/di_glow.lua
+++ b/scripts/actions/mobskills/di_glow.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+--  Glow before Wrath of Zeus or Lightning Spear
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if
+        mob:getAnimationSub() == 1 or
+        mob:getLocalVar('charging') == 1
+    then
+        return 1
+    else
+        return 0
+    end
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    skill:setMsg(xi.msg.basic.NONE)
+    return 0 -- cosmetic move only
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/di_horn_attack.lua
+++ b/scripts/actions/mobskills/di_horn_attack.lua
@@ -1,0 +1,48 @@
+-----------------------------------
+-- Unnamed attack for use to gore the target
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    -- don't autoattack between TP moves
+    -- only initiate attack within 15 yalms, but db has higher range so you can't "outrun" an attack that starts
+    if
+        mob:getLocalVar('timeSinceWS') + 1 > os.time() or
+        mob:checkDistance(target) > 15
+    then
+        return 1
+    else
+        return 0
+    end
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 1
+
+    local typeEffect = xi.effect.BIND
+    local duration = math.random(3, 15)
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod)
+    local dmg = 0
+    if info.hitslanded > 0 then
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    else
+        skill:setMsg(xi.msg.basic.EVADES)
+        return
+    end
+
+    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+        if math.random(100) <= 75 then
+            xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, duration)
+        end
+
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        skill:setMsg(xi.msg.basic.HIT_DMG)
+    end
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/di_kick_attack.lua
+++ b/scripts/actions/mobskills/di_kick_attack.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+-- Unnamed attack for use to kick the target
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    -- don't autoattack between TP moves
+    -- only initiate attack within 15 yalms, but db has higher range so you can't "outrun" an attack that starts
+    if
+        mob:getLocalVar('timeSinceWS') + 1 > os.time() or
+        mob:checkDistance(target) > 15
+    then
+        return 1
+    else
+        return 0
+    end
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = .6
+
+    local typeEffect = xi.effect.WEIGHT
+    local duration = math.random(3, 15)
+    local power = 50
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod)
+    local dmg = 0
+    if info.hitslanded > 0 then
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
+    else
+        skill:setMsg(xi.msg.basic.EVADES)
+        return
+    end
+
+    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+        if math.random(100) <= 75 then
+            xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration)
+        end
+
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        skill:setMsg(xi.msg.basic.HIT_DMG)
+    end
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/di_trample.lua
+++ b/scripts/actions/mobskills/di_trample.lua
@@ -1,0 +1,40 @@
+-----------------------------------
+-- Trample: Charges forward, dealing high damage to,(400-1000) and lowering the MP (10-30%) of, anyone in his path.
+-- No message is displayed in the chat log.
+--
+-- This move is triggered during onMobFight and is only advertised by the fact that DI runs towards random players in range
+--
+-- When Dark Ixion's HP is low, he can do up to 3 Tramples in succession.
+--     Can be avoided easily by moving out of its path.
+--     May charge in the opposite, or an entirely random, direction from the one he is currently facing.
+--     Will load a set number of targets in his path before ramming forward. Occasionally,
+--     a person in his path will not be hit, as well as those wandering in its path after it has begun its charge.
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 3
+    local remainingMPP = 1 - math.random(10, 30) / 100
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod)
+    local dmg = 0
+    if info.hitslanded > 0 then
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        target:setMP(target:getMP() * remainingMPP)
+        skill:setMsg(xi.msg.basic.HIT_DMG)
+    else
+        skill:setMsg(xi.msg.basic.EVADES)
+        return
+    end
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/lightning_spear.lua
+++ b/scripts/actions/mobskills/lightning_spear.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+--  Lightning Spear
+--
+--  Description: Wide Cone Attack lightning damage (600-1500) and powerful Amnesia.
+--  Type: Magical
+--  Notes: Will pick a random person on the hate list for this attack.
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- to allow primary player to run out of conal and to respect the real range of the mobskill
+    if
+        not target:isInfront(mob, 64) or
+        target:checkDistance(mob) > 20
+    then
+        skill:setMsg(xi.msg.basic.NONE)
+        return
+    end
+
+    local typeEffect = xi.effect.AMNESIA
+    local duration = math.random(30, 120)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, duration)
+
+    local dmgmod = 10 -- unbuffed player hit for ~2k
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2, xi.element.THUNDER, dmgmod)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.THUNDER)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/rampant_stance.lua
+++ b/scripts/actions/mobskills/rampant_stance.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Rampant Stance
+-- Physical area of effect damage that inflicts stun.
+-- Utsusemi/Blink absorb: 1-4 shadows, wipes Third Eye
+-- Range: 7.0 (add 0.1-4 depending on terrain elevation)
+-- Notes: Takes roughly three seconds to charge the TP move up, enough time for anyone within range to easily back out and run back in directly after the animation begins.
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- to allow primary player to run out of range and to respect the real range of the mobskill
+    if target:checkDistance(mob) > 8 then
+        skill:setMsg(xi.msg.basic.NONE)
+        return
+    end
+
+    local numhits = 3
+    local accmod = 2
+    local dmgmod = 1
+
+    local typeEffect = xi.effect.STUN
+    local duration = math.random(1, 3)
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod)
+    local dmg = 0
+    if info.hitslanded > 0 then
+        dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
+    else
+        skill:setMsg(xi.msg.basic.EVADES)
+        return
+    end
+
+    if skill:getMsg() ~= xi.msg.basic.SHADOW_ABSORB then
+        xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, duration)
+
+        target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+        skill:setMsg(xi.msg.basic.HIT_DMG)
+    end
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/wrath_of_zeus.lua
+++ b/scripts/actions/mobskills/wrath_of_zeus.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+--  Wrath of Zeus
+--
+--  Description: Area of Effect lightning damage around Ixion (400-1000) and Silence.
+--  Type: Magical
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- to allow primary player to run out of range and to respect the real range of the mobskill
+    if target:checkDistance(mob) > 15 then
+        skill:setMsg(xi.msg.basic.NONE)
+        return
+    end
+
+    local typeEffect = xi.effect.SILENCE
+    local duration = math.random(30, 60)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, duration)
+
+    local dmgmod = 4.5 -- unbuffed hit for ~700
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2, xi.element.THUNDER, dmgmod)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
+    target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.THUNDER)
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/items/pinch_of_stygian_ash.lua
+++ b/scripts/items/pinch_of_stygian_ash.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- ID: 19210
+-- Stygian Ash
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemEquip = function(target, item)
+    target:addListener('RANGE_STATE_EXIT', 'STYGIAN_ASH_THROWN', function(playerArg, targetArg, action)
+        -- if throw didn't miss, set localvar
+        if targetArg then
+            local targID = targetArg:getID()
+            if action:getMsg(targID) ~= xi.msg.basic.RANGED_ATTACK_MISS then
+                targetArg:setLocalVar('StygianLanded', 1)
+            end
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(target, item)
+    -- item is unequipped when thrown, don't remove listener immediately
+    target:timer(500, function(targetArg)
+        targetArg:removeListener('STYGIAN_ASH_THROWN')
+    end)
+end
+
+return itemObject

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -186,7 +186,7 @@ void CTargetFind::findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, 
     }
 }
 
-void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float angle, uint8 flags)
+void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float angle, uint8 flags, uint8 aoeType)
 {
     m_findFlags = flags;
     m_conal     = true;
@@ -197,7 +197,7 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
 
     // Confirmation on the center of cones is still needed for mob skills; player skills seem to be facing angle
     // uint8 angleToTarget = worldAngle(m_PBattleEntity->loc.p, PTarget->loc.p);
-    uint8 angleToTarget = m_APoint->rotation;
+    uint8 angleToTarget = relativeAngle(m_APoint->rotation, 128 * (aoeType == 8)); // adds 180 degree rotation if rear type
 
     // "Left" and "Right" are like the entity's face - "left" means "turning to the left" NOT "left when looking overhead"
     // Remember that rotation increases when turning to the right, and decreases when turning to the left
@@ -224,7 +224,7 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
     // calculate scalar
     m_scalar = (m_BPoint.x * m_CPoint.z) - (m_BPoint.z * m_CPoint.x);
 
-    findWithinArea(PTarget, AOE_RADIUS::ATTACKER, distance);
+    findWithinArea(PTarget, AOE_RADIUS::ATTACKER, distance, flags);
 }
 
 void CTargetFind::addAllInMobList(CBattleEntity* PTarget, bool withPet)

--- a/src/map/ai/helpers/targetfind.h
+++ b/src/map/ai/helpers/targetfind.h
@@ -101,7 +101,7 @@ public:
     // Main methods for finding targets
     void findSingleTarget(CBattleEntity* PTarget, uint8 flags = FINDFLAGS_NONE);
     void findWithinArea(CBattleEntity* PTarget, AOE_RADIUS radiusType, float radius, uint8 flags = FINDFLAGS_NONE);
-    void findWithinCone(CBattleEntity* PTarget, float distance, float angle, uint8 flags = FINDFLAGS_NONE);
+    void findWithinCone(CBattleEntity* PTarget, float distance, float angle, uint8 flags = FINDFLAGS_NONE, uint8 aoeType = 4);
 
     // add all targets in contexts
     void addAllInZone(CBattleEntity* PTarget, bool withPet);

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1867,7 +1867,7 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         else if (PSkill->isConal())
         {
             float angle = 45.0f;
-            PAI->TargetFind->findWithinCone(PTarget, distance, angle, findFlags);
+            PAI->TargetFind->findWithinCone(PTarget, distance, angle, findFlags, PSkill->getAoe());
         }
         else
         {
@@ -2006,7 +2006,15 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         if (target.speceffect == SPECEFFECT::HIT) // Formerly bitwise and, though nothing in this function adds additional bits to the field
         {
             target.speceffect = SPECEFFECT::RECOIL;
-            target.knockback  = PSkill->getKnockback();
+            if (target.reaction == REACTION::HIT)
+            {
+                target.knockback = PSkill->getKnockback();
+            }
+            else
+            {
+                target.knockback = 0;
+            }
+
             if (first && (PSkill->getPrimarySkillchain() != 0))
             {
                 SUBEFFECT effect = battleutils::GetSkillChainEffect(PTargetFound, PSkill->getPrimarySkillchain(), PSkill->getSecondarySkillchain(),

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10080,6 +10080,7 @@ sol::table CLuaBaseEntity::getPlayersInRange(uint32 dist = 0)
 {
     auto players = lua.create_table();
 
+    // clang-format off
     zoneutils::GetZone(m_PBaseEntity->getZone())->ForEachChar([&](CCharEntity* PChar)
     {
         if (!dist || distance(PChar->loc.p, m_PBaseEntity->loc.p) < dist)
@@ -10087,6 +10088,7 @@ sol::table CLuaBaseEntity::getPlayersInRange(uint32 dist = 0)
             players.add(CLuaBaseEntity(PChar));
         }
     });
+    // clang-format on
 
     return players;
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10070,6 +10070,28 @@ void CLuaBaseEntity::recalculateAbilitiesTable()
 }
 
 /************************************************************************
+ *  Function: getPlayersInRange()
+ *  Purpose : Returns a Lua table of players within range of the base entity
+ *  Example : local players = npc:getPlayersInRange(50)
+ *  Notes   : if the passed argument is nil or 0, just returns all players in the zone
+ ************************************************************************/
+
+sol::table CLuaBaseEntity::getPlayersInRange(uint32 dist = 0)
+{
+    auto players = lua.create_table();
+
+    zoneutils::GetZone(m_PBaseEntity->getZone())->ForEachChar([&](CCharEntity* PChar)
+    {
+        if (!dist || distance(PChar->loc.p, m_PBaseEntity->loc.p) < dist)
+        {
+            players.add(CLuaBaseEntity(PChar));
+        }
+    });
+
+    return players;
+}
+
+/************************************************************************
  *  Function: getParty()
  *  Purpose : Returns a Lua table of party member Entity objects
  *  Example : local party = player:getParty()
@@ -17643,6 +17665,7 @@ void CLuaBaseEntity::Register()
 
     SOL_REGISTER("recalculateSkillsTable", CLuaBaseEntity::recalculateSkillsTable);
     SOL_REGISTER("recalculateAbilitiesTable", CLuaBaseEntity::recalculateAbilitiesTable);
+    SOL_REGISTER("getPlayersInRange", CLuaBaseEntity::getPlayersInRange);
 
     // Parties and Alliances
     SOL_REGISTER("getParty", CLuaBaseEntity::getParty);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -510,8 +510,9 @@ public:
     uint32 canLearnSpell(uint16 spellID);
     void   delSpell(uint16 spellID);
 
-    void recalculateSkillsTable();
-    void recalculateAbilitiesTable();
+    void       recalculateSkillsTable();
+    void       recalculateAbilitiesTable();
+    sol::table getPlayersInRange(uint32 dist);
 
     // Parties and Alliances
     auto   getParty() -> sol::table;

--- a/src/map/mobskill.cpp
+++ b/src/map/mobskill.cpp
@@ -56,7 +56,7 @@ bool CMobSkill::isAoE() const
 
 bool CMobSkill::isConal() const
 {
-    return m_Aoe == 4;
+    return m_Aoe == 4 || m_Aoe == 8;
 }
 
 bool CMobSkill::isSingle() const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Recreated my PR as I was doing cleanup and didn't realize my older LSB PRs were linked to the Wings-XI repo

Please see previous PR for any lingering info: https://github.com/LandSandBoat/server/pull/4617

Makes the pony fight

Claim mechanic confirmed to work via new range exit listener

Once the fight starts, mobskills are all used via logic in onMobFight and TP is preserved via localvar each time his "auto attack" swings happen (since we use `mob:setMobSkillAttack(39)`)

DI's animation subs define mobskill behavior:
- 0 is normal
- 1 is Charging (trample)
- 2 is broken horn, cannot trample
- 3 is glowing and uses double offensive mobskills
  - also goes into this briefly when repairing horn, goes back to 0 afterwards

everytime DI autoattacks there's a chance (which grows as his HP lowers) to stack a localvar "run" counter. If this is nonzero and trample is available, then he starts the trample sequence.
- finds a random player within 30 yalms to trample. if found, he looks in that direction and starts trampling
- immediately places previous target (current battle target) in the `hitlist` and does damage if that player is in front of DI
- every onMobFight tick nearby players are placed in the hitlist and trampled if in front
- each trample path can only hit a player once (though if "run" is > 1 he may trample then immediately trample again and a player will get hit twice)
- Note that he can choose and hit _any_ player (doesn't have to be on the hate table or even in the alliance with claim)

All of his damage mobskills have flag 8 meaning they can hit any player/pet in range

Core fixes needed during testing:
- targetfind wasn't respecting findflags when an ability was conal
- rear conals weren't properly flagged as conal, so they were defaulting to single target. The `findWithinCone` function also didn't support a rear conal angle shift.
  - The only other mobskill with aoe type > 4 is rear lasers so i assume this also fixes it to work like acheron kick :)
- new lua util function `entity:getPlayersInRange()` to get all players within X range of entity. pass zero or nothing to get all players in zone.
- knockback was still applied even for miss/shadow absorb (This fix doesn't work 100% when there's multiple targets, but it _is_ better than it was)
  - I believe the issue is related to checking `PSkill->hasMissMsg()` in the loop of each target. Might be fundamentally flawed for aoe abilities, but i'll leave that for the reviewers to decide a course of action


Finally, there's a few things not perfectly accurate:
- his mobskills should not be able to be ranged to cancel the animation. 
  - I.E. if two players are standing in front of him and he uses acheron kick twice, the second one should go off even though the player got pushed out of range
  - I fixed this in WingsXI with a very hacky change to `targetfind.cpp` (allowed aoe mobskills to target the mob itself) that I'd rather not repeat unless 
    - it's generalized to not specifically only work for DI 
    - and fixes the animations to not show on the mob itself (really silly to see that)
  - It's fixed in this PR by making the db range for his aoe skills 35 and setting the message to NONE if the target is out of range
    - this is a bit of trickery I've done to make the fight work _mechanically_ closer to retail, by not letting a player cause the mob to cancel his ability if the primary target gets too far
- His mobskills shouldn't show an animation on the target if they aren't in range 
  - This may be fixable by setting the animation id in the same section that we adjust knockback, but I imagine that is not the best way to accomplish any of this. I am striving for fight difficulty/accuracy first and foremost, the animation without a combat message is minor imo.
- He should take reduced damage from the front (or increased from the back would work too). I attempted a few methods of using takedmg listeners but couldn't come up with something clean

Overall the fight feels very similar to WingsXI, which has had DI roaming around for close to a year now.

## Steps to test these changes

Previous PR on DI spawn/spook mechanics outlines how to get him to spawn, but the short version is
```
!zone 81
!exec SetServerVariable('DarkIxion_ZoneID', 81)
!spawnmob 17109367
!gotoid 17109367
<target DI and quickly run !stun>
<repeat these 3 until name turns red (you must land the hit)>
   !additem 19210
   <equip the ash>
   /ra <t>
<test fight>
```

The fight is fairly straightforward I think, there are multiple failsafes to avoid DI getting stuck in any particular phase/form
