### PR TITLE
[ci] Fix 8649 workaround from updated repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3
@@ -272,7 +272,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3
@@ -431,7 +431,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3
@@ -612,7 +612,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     steps:
     # workaround for broken clang on ubuntu runner until fixed: https://github.com/actions/runner-images/issues/8659
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
+    - uses: claywar/workaround8649@b59699cec47ef4f0db8cf5564e0dc30a74cc8888
       with:
         os: ubuntu-22.04
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Uses updated fork of the 8649 workaround to resolve CI package download failures (updates versions)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
_Hopefully_ CI should pass on this one
<!-- Clear and detailed steps to test your changes here -->
