### PR TITLE
[core] Fix warnings with GCC13 build

### DIFF
--- a/src/common/zlib.cpp
+++ b/src/common/zlib.cpp
@@ -62,9 +62,17 @@ static void swap32_if_be(const uint32* v, const size_t memb)
 #endif
 }
 
+struct fclose_deleter
+{
+    void operator()(FILE* f) const
+    {
+        fclose(f);
+    }
+};
+
 static bool read_to_vector(std::string const& file, std::vector<uint32>& vec)
 {
-    std::unique_ptr<FILE, decltype(&fclose)> fp(fopen(file.c_str(), "rb"), &fclose);
+    std::unique_ptr<FILE, fclose_deleter> fp(fopen(file.c_str(), "rb"));
     if (!fp)
     {
         ShowCritical("zlib: can't open file <%s>", file.c_str());


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Some very up-to-date Linux people are getting a warning-as-error that's halting their build. I spun up an Ubuntu 23.10 instance and installed GCC13 and fixed the warning.

GCC13 also complains loudly about things that are fixed in these PRs:

https://github.com/LandSandBoat/server/pull/4812
https://github.com/LandSandBoat/server/pull/4794
https://github.com/LandSandBoat/server/pull/4671