### PR TITLE
Setting: EXP_PARTY_GAP_NO_EXP

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -55,6 +55,8 @@ xi.settings.map =
     EXP_RATE                = 1.0,
     EXP_LOSS_RATE           = 1.0,
     EXP_PARTY_GAP_PENALTIES = true,
+    -- A party member's experience points are nullified if the level difference with the highest-level party member exceeds this value.
+    EXP_PARTY_GAP_NO_EXP    = 0,
 
     -- Capacity Point Settings
     CAPACITY_RATE = 1.0,

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -55,8 +55,11 @@ xi.settings.map =
     EXP_RATE                = 1.0,
     EXP_LOSS_RATE           = 1.0,
     EXP_PARTY_GAP_PENALTIES = true,
+
     -- A party member's experience points are nullified if the level difference with the highest-level party member exceeds this value.
-    EXP_PARTY_GAP_NO_EXP    = 0,
+    -- When set to 0, there is no nullification of EXP regardless of how wide the gap is between party members.
+    -- When set to 10, if you are level 65 or below in a party with a level 75, you will receive no EXP.
+    EXP_PARTY_GAP_NO_EXP = 0,
 
     -- Capacity Point Settings
     CAPACITY_RATE = 1.0,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4138,7 +4138,11 @@ namespace charutils
                 {
                     if (settings::get<bool>("map.EXP_PARTY_GAP_PENALTIES"))
                     {
-                        if (maxlevel > 50 || maxlevel > (memberlevel + 7))
+                        if (settings::get<uint8>("map.EXP_PARTY_GAP_NO_EXP") > 0 && maxlevel >= (memberlevel + settings::get<uint8>("map.EXP_PARTY_GAP_NO_EXP")))
+                        {
+                            exp = 0;
+                        }                        
+                        else if (maxlevel > 50 || maxlevel > (memberlevel + 7))
                         {
                             exp *= memberlevel / (float)maxlevel;
                         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4138,10 +4138,12 @@ namespace charutils
                 {
                     if (settings::get<bool>("map.EXP_PARTY_GAP_PENALTIES"))
                     {
-                        if (settings::get<uint8>("map.EXP_PARTY_GAP_NO_EXP") > 0 && maxlevel >= (memberlevel + settings::get<uint8>("map.EXP_PARTY_GAP_NO_EXP")))
+                        uint8 partyGapNoExp = settings::get<uint8>("map.EXP_PARTY_GAP_NO_EXP");
+
+                        if (partyGapNoExp > 0 && maxlevel >= (memberlevel + partyGapNoExp))
                         {
                             exp = 0;
-                        }                        
+                        }
                         else if (maxlevel > 50 || maxlevel > (memberlevel + 7))
                         {
                             exp *= memberlevel / (float)maxlevel;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Provides an optional setting for server operators to use that will nullify a party member's experience points if the level difference with the highest-level party member exceeds a given value.

## Steps to test these changes
1. Join an exp party with two level 75's, both will get experience points,
2. Adjust the value of the setting as desired, and !changejob to a level past the allowed threshold and the offending party member will receive no exp.
