### PR TITLE
Add GM command to test renaming non-player entities

### DIFF
--- a/scripts/commands/rename.lua
+++ b/scripts/commands/rename.lua
@@ -1,0 +1,41 @@
+-----------------------------------
+-- func: !rename
+-- desc: Renames target NPC or MOB. Limited to 16 character spaces.
+--       Does not work on players. Does not alter database.
+-----------------------------------
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 1,
+    parameters = 'si'
+}
+
+local function error(player, msg)
+    player:printToPlayer(msg)
+    player:printToPlayer('!rename (string) (optional npcID/mobID)')
+end
+
+commandObj.onTrigger = function(player, inputString, entityID)
+    local entity = player:getCursorTarget()
+
+    if entityID then
+        entity = GetMobByID(entityID)
+        if not entity then
+            entity = GetNPCByID(entityID)
+        end
+    end
+
+    if not entity then
+        error(player, 'Entity not found')
+        return
+    end
+
+    if inputString == '""' then
+        entity:renameEntity('', true)
+    else
+        entity:renameEntity(inputString, true)
+    end
+end
+
+return commandObj


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Sometimes it is helpful to see in game before finalizing a change
- Or maybe you want to prank your players

Does not work on players. Does not alter database. Limited to 16 characters in length (player sized names).

## Steps to test these changes
1. `!rename xyz` while cursor target is an NPC. see name became `xyz`
2. `!rename ""` while targeting the same NPC, see name change back to stock.
3. Try both again but adding the NPC's ID and not targeting it, or targeting anything else (won't matter). You can get the ID by using `!getid` if need be,
4. Now repeat the previous steps with a MOB.
5. Now try it on a player, and see the error message.
6. Now try with invalid IDs, and the cursor not on anything, also see same error message.

Enjoy ~~pranking your pla~~- I mean, _testing_, your rename powers.