### PR TITLE
[core, Lua] Add fmt() global binding

### DIFF
--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -36,6 +36,7 @@
 // TODO: Remove this
 #define FMT_CONSTEVAL
 
+#include <fmt/args.h>
 #include <fmt/chrono.h>
 #include <fmt/core.h>
 #include <fmt/format.h>

--- a/src/common/lua.h
+++ b/src/common/lua.h
@@ -31,5 +31,6 @@ void lua_init();
 auto lua_to_string_depth(sol::object const& obj, std::size_t depth) -> std::string;
 auto lua_to_string(sol::variadic_args va) -> std::string;
 void lua_print(sol::variadic_args va);
+auto lua_fmt(std::string fmtStr, sol::variadic_args va) -> std::string;
 
 #endif // _LUA_H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

```lua
print(fmt('{} {}', 42, 'hello'))
```

```
[12/19/23 19:59:46:006][map][lua] 42 hello (lua_print:203)
```
