### PR TITLE
[CPP] scale +hq mod by 100 to match adjustments to chanceHQ

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -362,7 +362,7 @@ namespace synthutils
 
             // HQ success rate modifier.
             // See: https://www.bluegartr.com/threads/130586-CraftyMath-v2-Post-September-2017-Update page 3.
-            chanceHQ = chanceHQ + PChar->getMod(Mod::SYNTH_HQ_RATE) / 512;
+            chanceHQ = chanceHQ + 100 * PChar->getMod(Mod::SYNTH_HQ_RATE) / 512;
 
             // limit max hq chance
             if (chanceHQ > maxChanceHQ)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

After the change in this commit: https://github.com/LandSandBoat/server/commit/bdfcae0bd22e208d4dce55e15e729cc487f6efcf

the modifier for synth HQ rate no longer modifies appropriately. It was originally adding X/512 to the float between 0 and 1, which represented the chance of an HQ result. Now that `chanceHQ` is between 0 and 100, we need to adjust this accordingly.

## Steps to test these changes

I haven't done extensive testing on the statistics of the results here, but simply going with logical conclusions based on the changes from the relevant commit.