### PR TITLE
[CPP] Send inventory update after equipment change

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2616,6 +2616,8 @@ namespace charutils
             }
 
             PChar->pushPacket(new CEquipPacket(slotID, equipSlotID, containerID));
+            PChar->pushPacket(new CInventoryFinishPacket(static_cast<CONTAINER_ID>(containerID)));
+            PChar->pushPacket(new CInventoryFinishPacket());
         }
         else
         {
@@ -2637,7 +2639,6 @@ namespace charutils
                         // Do not forget to update the timer when equipping the subject
 
                         PChar->pushPacket(new CInventoryItemPacket(PItem, containerID, slotID));
-                        PChar->pushPacket(new CInventoryFinishPacket());
                     }
                     PItem->setSubType(ITEM_LOCKED);
 
@@ -2657,6 +2658,8 @@ namespace charutils
 
                     PChar->pushPacket(new CEquipPacket(slotID, equipSlotID, containerID));
                     PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_NODROP));
+                    PChar->pushPacket(new CInventoryFinishPacket(static_cast<CONTAINER_ID>(containerID)));
+                    PChar->pushPacket(new CInventoryFinishPacket());
                 }
             }
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Temporary items disappear from item menu after changing equipment. Come back after sorting inventory or moving items between inventory and satchel/wardrobes.

Traced it down to `PChar->pushPacket(new CInventoryFinishPacket());` needing to be sent after `CEquipPacket`.

Note that the changes here are do the `charutils::EquipItem` function so the catch equipment changes via both `0x050` and `0x051`

## Steps to test these changes

Before this change, replicate the issue via:
- `!exec player:addTempItem(5393)`
- open quick item menu to see temp item available
- Then equip any pieced of gear and see that the temp item disappears from quick item menu

same process for unequipping an item.

After change see that the item stays visible after equipping and unequipping gear