### PR TITLE
[LUA] Battlefield:handleLootRolls squash chance of missing lootGroup drop

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1134,7 +1134,7 @@ function Battlefield:handleLootRolls(battlefield, lootTable, npc)
                     if type(entry) == 'table' then
                         current = current + entry.weight
 
-                        if current > roll then
+                        if current >= roll then
                             if entry.item == 0 then
                                 break
                             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`function Battlefield:handleLootRolls(` has a chance of dropping nothing in groups with guaranteed drops if `math.random(max)` rolls to be equal to `max`. This PR fixes that

I was going to emulate the logic in `function xi.battlefield.HandleLootRolls(` but due to the battlefield handler supporting `lootGroup.quantity` we can't just do `max = max - entry.weight`. Regardless, this solves the issue

## Steps to test these changes

without changes in this PR, change battlefield.lua line 1130 to `local roll = max` and run through western temenos. 

- `!zone 37`
- `!addkeyitem white_card`
- `!addkeyitem cosmo_cleanse`

you will get no drops from the final chest.

Do again with the changes in this PR and leave the forced `roll == max` to see we get drops from every group even with this "lucky" roll

![image](https://github.com/LandSandBoat/server/assets/131182600/1c197b5e-d969-4565-a88e-76aa98b4f2bf)
