### PR TITLE
[core] Don't mutate ELEVATOR or SHIP NPCs stored name

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2088,7 +2088,6 @@ void CLuaBaseEntity::setElevator(uint8 id, uint32 lowerDoor, uint32 upperDoor, u
 
     elevator.zoneID = m_PBaseEntity->loc.zone->GetID();
 
-    elevator.Elevator->name.resize(10);
     CTransportHandler::getInstance()->insertElevator(elevator);
 }
 
@@ -2706,9 +2705,7 @@ void CLuaBaseEntity::updateToEntireZone(uint8 statusID, uint8 animation, sol::ob
     // If this flag is high, update the NPC's name to match the current time
     if (updateForTime == true)
     {
-        PNpc->name.resize(10);
-        ref<uint32>(&PNpc->name[0], 4) = CVanaTime::getInstance()->getVanaTime();
-        PNpc->name[8]                  = 8;
+        PNpc->SetLocalVar("TransportTimestamp", CVanaTime::getInstance()->getVanaTime());
     }
 
     PNpc->loc.zone->UpdateEntityPacket(PNpc, ENTITY_UPDATE, UPDATE_COMBAT, true);

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -53,18 +53,13 @@ void Transport_Ship::setVisible(bool visible) const
 void Transport_Ship::animateSetup(uint8 animationID, uint32 horizonTime) const
 {
     this->npc->animation = animationID;
-    this->setName(horizonTime);
+    this->npc->SetLocalVar("TransportTimestamp", horizonTime);
 }
 
 void Transport_Ship::spawn() const
 {
     this->npc->loc = this->dock;
     this->setVisible(true);
-}
-
-void Transport_Ship::setName(uint32 value) const
-{
-    ref<uint32>(&this->npc->name[0], 4) = value;
 }
 
 void TransportZone_Town::updateShip() const
@@ -150,11 +145,7 @@ void CTransportHandler::InitializeTransport()
 
             zoneTown.npcDoor  = zoneutils::GetEntity(sql->GetUIntData(2), TYPE_NPC);
             zoneTown.ship.npc = zoneutils::GetEntity(sql->GetUIntData(1), TYPE_SHIP);
-            if (zoneTown.ship.npc)
-            {
-                zoneTown.ship.npc->name.resize(8);
-            }
-            else
+            if (!zoneTown.ship.npc)
             {
                 ShowError("Transport <%u>: transport not found", (uint8)sql->GetIntData(0));
                 continue;
@@ -451,9 +442,8 @@ void CTransportHandler::insertElevator(Elevator_t elevator)
     }
 
     // Have permanent elevators wait until their next cycle to begin moving
-    uint32 VanaTime            = CVanaTime::getInstance()->getDate();
-    elevator.lastTrigger       = VanaTime - (VanaTime % elevator.interval) + elevator.interval;
-    elevator.Elevator->name[8] = 8;
+    uint32 VanaTime      = CVanaTime::getInstance()->getDate();
+    elevator.lastTrigger = VanaTime - (VanaTime % elevator.interval) + elevator.interval;
 
     // Initialize the elevator into the correct state based on
     // its animation value in the database.
@@ -544,7 +534,7 @@ void CTransportHandler::startElevator(Elevator_t* elevator)
         elevator->lastTrigger = VanaTime - VanaTime % elevator->interval; // Keep the elevators synced to Vanadiel time
     }
 
-    ref<uint32>(&elevator->Elevator->name[0], 4) = CVanaTime::getInstance()->getVanaTime();
+    elevator->Elevator->SetLocalVar("TransportTimestamp", CVanaTime::getInstance()->getVanaTime());
 
     zoneutils::GetZone(elevator->zoneID)->UpdateEntityPacket(elevator->Elevator, ENTITY_UPDATE, UPDATE_COMBAT, true);
 }

--- a/src/map/transport.h
+++ b/src/map/transport.h
@@ -74,7 +74,6 @@ struct Transport_Ship : Transport_Time
     void setVisible(bool) const;
     void animateSetup(uint8, uint32) const;
     void spawn() const;
-    void setName(uint32) const;
 };
 
 struct TransportZone_Town


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When we call string::resize(), the increased buffer is uninitialised. If this buffer ends up containing a % character, if that gets passed to one of our old-style sprintf-based loggers it'll explode. While I want to migrate to the fmt-based loggers over time, that's not the answer here. We shouldn't be mutating the stored name of entities for the benefit of the client, that should be done on a temporary copy of the name just before the packet is sent.

Tested:
- Got retail caps to compare
- Metalworks elevators still work
- Port Bastok Bridge + Airship still work (got booted off the bridge and it was still up for a little bit, then closed slowly)
- Mhaura ship came and went

No truncation:
<img width="301" alt="image" src="https://github.com/LandSandBoat/server/assets/1389729/76921f0f-a015-4743-9dea-1edaa8e527c5">

Closes https://github.com/LandSandBoat/server/issues/4879
