### PR TITLE
[CPP] Slight plumbing changes for spirit pacts to cast outside combat

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -425,7 +425,7 @@ bool CMobController::TrySpecialSkill()
 bool CMobController::TryCastSpell()
 {
     TracyZoneScoped;
-    if (!PTarget || !CanCastSpells())
+    if (!CanCastSpells())
     {
         return false;
     }
@@ -446,7 +446,8 @@ bool CMobController::TryCastSpell()
     }
 
     // Try to get an override spell from the script (if available)
-    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, PTarget, chosenSpellId);
+    auto PSpellTarget            = PTarget ? PTarget : PMob;
+    auto possibleOverriddenSpell = luautils::OnMobMagicPrepare(PMob, PSpellTarget, chosenSpellId);
     if (possibleOverriddenSpell.has_value())
     {
         chosenSpellId = possibleOverriddenSpell;

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -68,6 +68,14 @@ void CPetController::DoRoamTick(time_point tick)
     {
         return;
     }
+    else if (PPet->m_PetID <= PETID_DARKSPIRIT)
+    {
+        // this will respect the pet's mob casting cooldown properties via MOBMOD_MAGIC_COOL
+        if (CMobController::IsSpellReady(0) && CMobController::TryCastSpell())
+        {
+            return;
+        }
+    }
 
     float currentDistance = distance(PPet->loc.p, PPet->PMaster->loc.p);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adjusts the behavior of smn spirit pacts to attempt casting outside combat. This plumbing will allow lua-based logic handling for their casting behavior via the use of 

- `xi.pets.avatar.onMobSpawn` to set their initial magic cooldown and adding a roam/combat tick listener to adjust their magic cool afterwards
- `xi.pets.avatar.onMobMagicPrepare` to do the heavy lifting of deciding which spells to cast when

To be clear though, this PR doesn't make the spirits any smarter, it just allows them to randomly buff/heal outside of combat. I will be working on a separate PR to create `scripts/globals/pets/avatar.lua`

## Steps to test these changes

Summon light spirit and see that it will randomly cast cures/buffs even while idle.

See that there are no errors when calling `onMobMagicPrepare`.