### PR TITLE
[core] Remove DE's based on presence in spawn lists, not by distance

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1423,7 +1423,7 @@ void CZoneEntities::ZoneServer(time_point tick)
                     PChar->currentEvent->targetEntity = nullptr;
                 }
 
-                if (distance(PChar->loc.p, PMob->loc.p) < 50)
+                if (PChar->SpawnMOBList.find(PMob->id) != PChar->SpawnMOBList.end())
                 {
                     PChar->SpawnMOBList.erase(PMob->id);
                 }
@@ -1476,7 +1476,7 @@ void CZoneEntities::ZoneServer(time_point tick)
             for (EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
             {
                 CCharEntity* PChar = (CCharEntity*)it->second;
-                if (distance(PChar->loc.p, PNpc->loc.p) < 50)
+                if (PChar->SpawnNPCList.find(PNpc->id) != PChar->SpawnNPCList.end())
                 {
                     PChar->SpawnNPCList.erase(PNpc->id);
                 }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -712,7 +712,13 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
 
     for (auto mobEntry : PChar->SpawnMOBList)
     {
-        CState* state = mobEntry.second->PAI->GetCurrentState();
+        auto* PMob = mobEntry.second;
+        if (PMob == nullptr)
+        {
+            continue;
+        }
+
+        CState* state = PMob->PAI->GetCurrentState();
         if (!state)
         {
             continue;


### PR DESCRIPTION
…to players

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I was poking around in the conditions inside ZoneServer for when mobs (and npcs) are removed from players spawn lists. This condition sticks out to me. Theoretically, if an entity is further than 50' away from the player they should have been removed from the spawn lists. But logically a check for distance isn't as safe as a check for general presence in the list. `container.find()` is fast an reliable. 

## Steps to test these changes

Things work as normal, maybe DEs are more stable if you use them with delete/reuse ID (which I don't ever recommend as anything other than a last resort)