### PR TITLE
[LUA] WS dual wield and H2H tp gain fixes

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -666,6 +666,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         finaldmg = finaldmg + hitdmg
         hitsDone = hitsDone + 1
 
+        calcParams.tpHitsLanded      = calcParams.tpHitsLanded + calcParams.hitsLanded
         calcParams.offhandHitsLanded = calcParams.hitsLanded
 
         numOffhandMultis = getMultiAttacks(attacker, target, wsParams, false, true)
@@ -760,7 +761,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
         calcParams.offhandHitsLanded = calcParams.offhandHitsLanded + calcParams.hitsLanded
     end
 
-    calcParams.extraHitsLanded = calcParams.hitsLanded + calcParams.offhandHitsLanded
+    calcParams.extraHitsLanded = calcParams.mainHitsLanded + calcParams.offhandHitsLanded
 
     -- Remove the TP hit landed from the count if it did -- otherwise we would gain extra TP
     if calcParams.tpHitsLanded > 1 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #4809 .

Looks like the refactor had a couple typos/oversights that caused H2H weaponskills to gain zero additional TP from multi-hits and offhand hits. 

## Steps to test these changes

Before these changes use backhand blow and raging fists to see you gain only the single main-hand hit TP

afterwards see that backhand blow gives 2 full hits worth of TP and raging fists gets 2 full TP hits plus 10 per additional hit (30 more)