### PR TITLE
[Fix] Correct "jeunoan_tree" furnishing element

### DIFF
--- a/sql/item_furnishing.sql
+++ b/sql/item_furnishing.sql
@@ -102,7 +102,7 @@ INSERT INTO `item_furnishing` VALUES (134,'copy_of_emeralda',1,530,5,9);
 INSERT INTO `item_furnishing` VALUES (135,'magic_tome_set',1,513,2,2);
 INSERT INTO `item_furnishing` VALUES (136,'set_of_kaiserin_cosmetics',1,513,2,1);
 INSERT INTO `item_furnishing` VALUES (137,'cordon_bleu_cooking_set',1,531,3,9);
-INSERT INTO `item_furnishing` VALUES (138,'jeunoan_tree',4,532,5,3);
+INSERT INTO `item_furnishing` VALUES (138,'jeunoan_tree',4,532,2,3);
 INSERT INTO `item_furnishing` VALUES (139,'star_globe',1,533,8,9);
 INSERT INTO `item_furnishing` VALUES (140,'dream_platter',2,522,5,3);
 INSERT INTO `item_furnishing` VALUES (141,'dream_coffer',2,522,5,3);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fizes Jeunoan Tree using thunder instead of ice as element.
https://github.com/AirSkyBoat/AirSkyBoat/pull/3676

Requested by Winter.

## Steps to test these changes

!additem 208 2
!additem 138
place all in mog house, should give 4 ice element (2x2) from lamps and 3 ice element from tree resulting in Conquest moghancement. with incorrect thunder element, it would give Ice moghancement from lamps
