### PR TITLE
[Fix] Skill negative modifier and possible underflow

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3097,19 +3097,19 @@ namespace charutils
                 PChar->WorkingSkills.skill[i] = 0x8000;
                 continue;
             }
-            uint16 MaxMSkill  = battleutils::GetMaxSkill((SKILLTYPE)i, PChar->GetMJob(), PChar->GetMLevel());
-            uint16 MaxSSkill  = battleutils::GetMaxSkill((SKILLTYPE)i, PChar->GetSJob(), PChar->GetSLevel());
-            uint16 skillBonus = 0;
+            uint16 MaxMainSkill = battleutils::GetMaxSkill((SKILLTYPE)i, PChar->GetMJob(), PChar->GetMLevel());
+            uint16 MaxSubSkill  = battleutils::GetMaxSkill((SKILLTYPE)i, PChar->GetSJob(), PChar->GetSLevel());
+            uint16 skillBonus   = 0;
 
             // apply arts bonuses
             if ((i >= SKILL_DIVINE_MAGIC && i <= SKILL_ENFEEBLING_MAGIC && PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_LIGHT_ARTS, EFFECT_ADDENDUM_WHITE })) ||
                 (i >= SKILL_ENFEEBLING_MAGIC && i <= SKILL_DARK_MAGIC && PChar->StatusEffectContainer->HasStatusEffect({ EFFECT_DARK_ARTS, EFFECT_ADDENDUM_BLACK })))
             {
-                uint16 artsSkill    = battleutils::GetMaxSkill(SKILL_ENHANCING_MAGIC, JOB_RDM, PChar->GetMLevel());             // B+ skill
-                uint16 skillCapD    = battleutils::GetMaxSkill((SKILLTYPE)i, JOB_SCH, PChar->GetMLevel());                      // D skill cap
-                uint16 skillCapE    = battleutils::GetMaxSkill(SKILL_DARK_MAGIC, JOB_RDM, PChar->GetMLevel());                  // E skill cap
-                auto   currentSkill = std::clamp<uint16>((PChar->RealSkills.skill[i] / 10), 0, std::max(MaxMSkill, MaxSSkill)); // working skill before bonuses
-                uint16 artsBaseline = 0;                                                                                        // Level based baseline to which to raise skills
+                uint16 artsSkill    = battleutils::GetMaxSkill(SKILL_ENHANCING_MAGIC, JOB_RDM, PChar->GetMLevel());                  // B+ skill
+                uint16 skillCapD    = battleutils::GetMaxSkill((SKILLTYPE)i, JOB_SCH, PChar->GetMLevel());                           // D skill cap
+                uint16 skillCapE    = battleutils::GetMaxSkill(SKILL_DARK_MAGIC, JOB_RDM, PChar->GetMLevel());                       // E skill cap
+                auto   currentSkill = std::clamp<uint16>((PChar->RealSkills.skill[i] / 10), 0, std::max(MaxMainSkill, MaxSubSkill)); // working skill before bonuses
+                uint16 artsBaseline = 0;                                                                                             // Level based baseline to which to raise skills
                 uint8  mLevel       = PChar->GetMLevel();
                 if (mLevel < 51)
                 {
@@ -3165,7 +3165,7 @@ namespace charutils
             {
                 if (PChar->PAutomaton)
                 {
-                    MaxMSkill = battleutils::GetMaxSkill(1, PChar->GetMLevel()); // A+ capped down to the Automaton's rating
+                    MaxMainSkill = battleutils::GetMaxSkill(1, PChar->GetMLevel()); // A+ capped down to the Automaton's rating
                 }
             }
 
@@ -3189,19 +3189,23 @@ namespace charutils
                 PChar->RealSkills.rank[i] = subSkillRank;
             }
 
-            if (MaxMSkill != 0)
+            if (MaxMainSkill != 0)
             {
-                auto cap{ PChar->RealSkills.skill[i] / 10 >= MaxMSkill };
-                PChar->WorkingSkills.skill[i] = std::max(0, cap ? skillBonus + MaxMSkill : skillBonus + PChar->RealSkills.skill[i] / 10);
+                auto cap{ PChar->RealSkills.skill[i] / 10 >= MaxMainSkill };
+                PChar->WorkingSkills.skill[i] = std::max(0, cap ? skillBonus + MaxMainSkill : skillBonus + PChar->RealSkills.skill[i] / 10);
+
+                // Blue text
                 if (cap)
                 {
                     PChar->WorkingSkills.skill[i] |= 0x8000;
                 }
             }
-            else if (MaxSSkill != 0)
+            else if (MaxSubSkill != 0)
             {
-                auto cap{ PChar->RealSkills.skill[i] / 10 >= MaxSSkill };
-                PChar->WorkingSkills.skill[i] = std::max(0, cap ? skillBonus + MaxSSkill : skillBonus + PChar->RealSkills.skill[i] / 10);
+                auto cap{ PChar->RealSkills.skill[i] / 10 >= MaxSubSkill };
+                PChar->WorkingSkills.skill[i] = std::max(0, cap ? skillBonus + MaxSubSkill : skillBonus + PChar->RealSkills.skill[i] / 10);
+
+                // Blue text
                 if (cap)
                 {
                     PChar->WorkingSkills.skill[i] |= 0x8000;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Allows modifiers for skills to be negative, like in Shiva's Shotel case.
- Reworks skill logic to account for a possible negative bonus.
- Adds a lot of comments because reading is healthy.

Based on: https://github.com/AirSkyBoat/AirSkyBoat/pull/3678

## Steps to test these changes

To Test Main Job:

    1. Set main job to one that has the shield skill and can equip Shiva's Shotel
    2. Set your shield skill to any value <= 4
    3. Give yourself the item Shiva's Shotel and equip it
    4. Check your combat skills. If fixed it will be at 0, but if not it will underflow to a value around 32763

To Test Sub Job:

    1. Set main job to one that DOES NOT have the shield skill and can equip Shiva's Shotel (DRK works)
    2. Set your sub job to one that does have the shield skill
    3. Set your shield skill to any value <= 4
    4. Give yourself the item Shiva's Shotel and equip it
    5. Check your combat skills. If fixed it will be at 0, but if not it will underflow to a value around 32763

To test no shield skill at all:

    1. Set both your main job and sub job to one that doesn't have the shield skill (DRK/DRK does work)
    2. Set your shield to any value <= 4
    3. Give yourself the item Shiva's Shotel and equip it
    4. Check your combat skills. If fixed it will be at 0 or not displayed, but if not it will underflow to a value around 32763

