### PR TITLE
[LUA] Add none bucket for cloud evoker drop groups

### DIFF
--- a/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
@@ -48,7 +48,8 @@ local loot =
         },
 
         {
-            { itemid = xi.item.CLOUD_EVOKER, droprate = 56 },   -- Cloud Evoker (5.6% Drop Rate)
+            { itemid = xi.item.NONE,         droprate = 944 }, -- nothing
+            { itemid = xi.item.CLOUD_EVOKER, droprate =  56 }, -- Cloud Evoker
         },
 
         {
@@ -70,7 +71,8 @@ local loot =
         },
 
         {
-            { itemid = xi.item.CLOUD_EVOKER, droprate = 188 },  -- Cloud Evoker
+            { itemid = xi.item.NONE,         droprate = 812 }, -- nothing
+            { itemid = xi.item.CLOUD_EVOKER, droprate = 188 }, -- Cloud Evoker
         },
 
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cloud Evoker should not be 100% drop in any battlefield. This corrects it by adding the proper empty section of the bucket to make these two groups "Zero to One of:"

## Steps to test these changes

Run "Sheep in Antlion's Clothing" or "Shell We Dance" to see cloud evoker is no longer 100%