### PR TITLE
Add functionality to Trust: Lion

### DIFF
--- a/scripts/actions/mobskills/grapeshot.lua
+++ b/scripts/actions/mobskills/grapeshot.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Grape Shot (Lion)
+-- Conal damage and stun effect.
+-- Type: Physical
+-- Skillchain Properties: Reverberation/Transfixion
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 0.3
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, mob:getWeaponDmg() * dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 10)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/pirate_pummel.lua
+++ b/scripts/actions/mobskills/pirate_pummel.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Pirate Pummel (Lion)
+-- Damage and burn effect
+-- Type: Physical
+-- Skillchain Properties: Fusion/Impaction
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    -- TODO: verify exact number of hits from this ability
+    local numhits = 2
+    local accmod = 1
+    local dmgmod = 0.3
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, mob:getWeaponDmg() * dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, 1, 0, 20)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/powder_keg.lua
+++ b/scripts/actions/mobskills/powder_keg.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Powder Keg (Lion)
+-- Conal damage, knock back, defense down, and magic defense down.
+-- Type: Physical
+-- Skillchain Properties: Fusion/Compression
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 2
+    local dmgmod = 0.3
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, mob:getWeaponDmg() * dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 20, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.MAGIC_DEF_DOWN, 20, 0, 60)
+
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/walk_the_plank.lua
+++ b/scripts/actions/mobskills/walk_the_plank.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Walk the Plank (Lion)
+-- AoE Damage, Bind, Knockback, dispel
+-- Type: Physical (AoE)
+-- Skillchain Properties: Light/Distortion
+-----------------------------------
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(target, mob, skill)
+    local numhits = 1
+    local accmod = 2
+    local dmgmod = 0.3
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, mob:getWeaponDmg() * dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
+    local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
+
+    target:dispelStatusEffect()
+    target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 20)
+
+    return dmg
+end
+
+return mobskillObject

--- a/scripts/actions/spells/trust/lion.lua
+++ b/scripts/actions/spells/trust/lion.lua
@@ -17,8 +17,6 @@ spellObject.onMobSpawn = function(mob)
 
     local kGrapeshot = 3198
 
-    xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
-
     xi.trust.teamworkMessage(mob, {
         [xi.magic.spell.ZEID] = xi.trust.messageOffset.TEAMWORK_1,
         [xi.magic.spell.ALDO] = xi.trust.messageOffset.TEAMWORK_2,

--- a/scripts/actions/spells/trust/lion.lua
+++ b/scripts/actions/spells/trust/lion.lua
@@ -12,7 +12,26 @@ spellObject.onSpellCast = function(caster, target, spell)
 end
 
 spellObject.onMobSpawn = function(mob)
+    -- TODO: Trust Synergy (Aldo/Lion/Zeid)
+    -- https://www.bg-wiki.com/ffxi/Cipher:_Lion
+
+    local kGrapeshot = 3198
+
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
+
+    xi.trust.teamworkMessage(mob, {
+        [xi.magic.spell.ZEID] = xi.trust.messageOffset.TEAMWORK_1,
+        [xi.magic.spell.ALDO] = xi.trust.messageOffset.TEAMWORK_2,
+        [xi.magic.spell.GILGAMESH] = xi.trust.messageOffset.TEAMWORK_3,
+    })
+
+    -- Stun all the things!
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0, ai.r.WS, ai.s.SPECIFIC, kGrapeshot)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_MS, 0, ai.r.WS, ai.s.SPECIFIC, kGrapeshot)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_JA, 0, ai.r.WS, ai.s.SPECIFIC, kGrapeshot)
+    mob:addSimpleGambit(ai.t.TARGET, ai.c.CASTING_MA,  0, ai.r.WS, ai.s.SPECIFIC, kGrapeshot)
+
+    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 end
 
 spellObject.onMobDespawn = function(mob)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3438,7 +3438,10 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,42);   -- Savage Blade
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3193); -- Royal Bash
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3194); -- Royal Saviour
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zeid',1021,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3198); -- Grapeshot
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3199); -- Pirate Pummel
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3200); -- Powder Keg
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3201); -- Walk the Plank
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Tenzen',1023,1390); -- Amatsu: Torimai
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Tenzen',1023,1391); -- Amatsu: Kazakiri
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Tenzen',1023,1392); -- Amatsu: Yukiarashi

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -3209,10 +3209,10 @@ INSERT INTO `mob_skills` VALUES (3194,670,'royal_savior',0,7.0,2000,1500,4,0,0,0
 INSERT INTO `mob_skills` VALUES (3195,671,'abyssal_drain',0,7.0,2000,1500,4,0,0,0,0,0,0); -- Zied
 INSERT INTO `mob_skills` VALUES (3196,672,'abyssal_strike',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3197,684,'ground_strike',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3198,2029,'grapeshot',0,7.0,2000,1500,4,0,0,0,0,0,0); -- Lion
-INSERT INTO `mob_skills` VALUES (3199,2030,'pirate_pummel',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3200,2031,'powder_keg',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3201,2032,'walk_the_plank',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3198,2029,'grapeshot',4,7.0,2000,1500,4,0,0,0,3,2,0); -- Lion
+INSERT INTO `mob_skills` VALUES (3199,2030,'pirate_pummel',0,7.0,2000,1500,4,0,0,0,9,0,0);
+INSERT INTO `mob_skills` VALUES (3200,2031,'powder_keg',4,7.0,2000,1500,4,0,0,0,5,1,0);
+INSERT INTO `mob_skills` VALUES (3201,2032,'walk_the_plank',1,7.0,2000,1500,4,0,2,0,11,0,0);
 INSERT INTO `mob_skills` VALUES (3202,257,'uriel_blade',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3203,1431,'scouring_bubbles',1,7.0,2000,1500,4,0,0,0,14,10,0);  -- Mihli
 INSERT INTO `mob_skills` VALUES (3204,1036,'amatsu_tsukikage',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements Trust: Lion based on information available from BG-Wiki as well as various videos online.
https://www.bg-wiki.com/ffxi/Cipher:_Lion
https://www.youtube.com/watch?v=J3pdkzlJ1CE

I'm not sure if this is of concern or not, but she throws a warning when casting her.
![image](https://github.com/LandSandBoat/server/assets/65316697/3dc6612c-aa71-4587-9a50-3b056cc4c971)


## Steps to test these changes

!zone Dragon's Aery
Round up a few mobs and position Lion conally to the mobs.
!trustengage her and watch her cycle through her moves.

