### PR TITLE
[CPP] Do not consume boost on counter attack

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -398,6 +398,7 @@ bool CAttack::IsCountered() const
 
 bool CAttack::CheckCounter()
 {
+    // TODO return false if boost is active (when boost gets refactored to be current retail accurate)
     if (m_attackType == PHYSICAL_ATTACK_TYPE::DAKEN)
     {
         return false;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2330,7 +2330,7 @@ namespace battleutils
             ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(PAttacker, 0);
         }
 
-        if (PAttacker->objtype == TYPE_PC && !isRanged)
+        if (PAttacker->objtype == TYPE_PC && !isRanged && !isCounter)
         {
             PAttacker->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK);
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Boost should not be consumed when countering an attack. This PR resolves it in a roundabout way. Technically we could check if `isCounter` and check if the player has boost. If they do then save the effect, remove its `effectflag_attack`, then add it back after `DelStatusEffectsByFlag(EFFECTFLAG_ATTACK);`

The current PR implementation will also not consume SA, TA, sneak, invis, etc on a counter. I am not sure if those should be removed when a monk counters, would be a huge pain to test for sure. Though, intuition seems to lead me to believe that counter should work similar to a dodge (since you gain no TP for it), which doesn't remove any of those effects either.

Closes https://github.com/LandSandBoat/server/issues/4774 .

## Steps to test these changes

very easy to test using paralysis:
- engage mob
- give 100% paralysis: `!addeffect paralysis 100 600`
- give 100% counter chance `!setmod counter 100`
- give boost effect `!addeffect boost 1`

see before that it wears, after that it doesn't afterwards

![image](https://github.com/LandSandBoat/server/assets/131182600/4fefc821-8f43-461f-960a-c7a566108ed5)

![image](https://github.com/LandSandBoat/server/assets/131182600/4e2f2e2a-7a09-4575-9b04-acdf5eeb8f11)
