### PR TITLE
[CPP] Fix player charm bugs inactive state and autodisengage

### DIFF
--- a/src/map/ai/states/inactive_state.cpp
+++ b/src/map/ai/states/inactive_state.cpp
@@ -46,7 +46,8 @@ bool CInactiveState::Update(time_point tick)
             return true;
         }
 
-        if (!PBattleEntity->StatusEffectContainer->HasPreventActionEffect())
+        if (!PBattleEntity->StatusEffectContainer->HasPreventActionEffect() ||
+            (PBattleEntity->StatusEffectContainer->HasStatusEffect({ EFFECT_CHARM, EFFECT_CHARM_II }) && !PBattleEntity->StatusEffectContainer->HasPreventActionEffect(true)))
         {
             return true;
         }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -995,7 +995,7 @@ bool CCharEntity::CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket
         PAI->Disengage();
         return false;
     }
-    else if (dist > 30)
+    else if (!this->StatusEffectContainer->HasStatusEffect({ EFFECT_CHARM, EFFECT_CHARM_II }) && dist > 30)
     {
         errMsg = std::make_unique<CMessageBasicPacket>(this, PTarget, 0, 0, MSGBASIC_LOSE_SIGHT);
         PAI->Disengage();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes #2839

Allow inactive state to update while charmed. Resolves players becoming permanently inactive (until charm wears) if slept while charmed.
Also, prevent charmed players from entering a disengage/engage loop due to distance > 30. Charmed players should only disengage along with their master.
## Steps to test these changes

Find any mob that you can execute a mob ability on (710 is charm),
Have a 2nd char get hate, just barely put the 1st char on the hate pool.
Use !exec target:useMobAbility(710) to charm the 2nd char.
Sleep, stun, or use any prevent action effect on the 2nd char.
2nd char WILL continue to attack and move once the prevent action effect wears.
<!-- Clear and detailed steps to test your changes here -->
