### PR TITLE
[CPP] Mob name color fixes for small player models

### DIFF
--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -68,7 +68,8 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
         ref<uint8>(0x38) |= 0x08; // New player ?
     }
 
-    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // + model sizing : 0x02 - 0; 0x08 - 1; 0x10 - 2;
+    ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size << 3);
+    // ref<uint8>(0x29) |= 0x02; // this will display the old-style zone-wide treasure pool. All claimed mobs will show red name regardless of which party has claim.
     ref<uint8>(0x2C) = PChar->GetSpeed();
     ref<uint16>(0x2E) |= PChar->speedsub << 1; // Not sure about this, it was a work around when we set speedsub incorrectly..
     ref<uint8>(0x30) = PChar->isInEvent() ? (uint8)ANIMATION_EVENT : PChar->animation;


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

So here's a fun one that almost felt like a hoax when reported. But without this PR, small player characters (char size zero) will see others' claimed mobs with a red name. This is due to the client interpreting `ref<uint8>(0x29) == 0x02`  as old style dynamis where claim is zone-wide. Having a small player model before this PR also shows a different style of treasure pool listing:

![image](https://github.com/LandSandBoat/server/assets/131182600/c6a8ee4f-d9c2-4ee9-b154-c14cc49681e5)

This could also be fixed by changing the line to 

```
ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 0);
```
or simply
```
ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size * 8);
```

but i'm opting to use the same syntax as https://github.com/airskyboat/airskyboat/pull/1100

## Steps to test these changes

have 2 chars next to eachother. The one that has small size character model witnesses the other fighting a mob. Without this PR the mob's name will be red, with this PR the name will be purple.