### PR TITLE
Additions to Trust: Zeid II

### DIFF
--- a/scripts/actions/spells/trust/zeid_ii.lua
+++ b/scripts/actions/spells/trust/zeid_ii.lua
@@ -16,6 +16,13 @@ spellObject.onMobSpawn = function(mob)
         [xi.magic.spell.LION_II] = xi.trust.messageOffset.TEAMWORK_1,
     })
 
+    mob:addListener('WEAPONSKILL_USE', 'ZEID_II_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
+        if wsid == 56 then -- Ground Strike
+            -- Never again will I lose sight of who I am
+            xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
+        end
+    end)
+
     -- Stun all the things!
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0,
                         ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)

--- a/scripts/actions/spells/trust/zeid_ii.lua
+++ b/scripts/actions/spells/trust/zeid_ii.lua
@@ -14,6 +14,10 @@ end
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
 
+    xi.trust.teamworkMessage(mob, {
+        [xi.magic.spell.LION_II] = xi.trust.messageOffset.TEAMWORK_1,
+    })
+
     -- Stun all the things!
     mob:addSimpleGambit(ai.t.TARGET, ai.c.READYING_WS, 0,
                         ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.STUN)

--- a/scripts/actions/spells/trust/zeid_ii.lua
+++ b/scripts/actions/spells/trust/zeid_ii.lua
@@ -12,8 +12,6 @@ spellObject.onSpellCast = function(caster, target, spell)
 end
 
 spellObject.onMobSpawn = function(mob)
-    xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
-
     xi.trust.teamworkMessage(mob, {
         [xi.magic.spell.LION_II] = xi.trust.messageOffset.TEAMWORK_1,
     })

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -4256,6 +4256,7 @@ INSERT INTO `mob_spell_lists` VALUES ('TRUST_Lion_II',418,338,12,255); -- utsuse
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Lion_II',418,339,37,255); -- utsusemi_ni (37~255)
 
 -- TRUST_Zied_II (419)
+INSERT INTO `mob_spell_lists` VALUES ('TRUST_Zied_II',419,243,91,255); -- absorb-attri (91~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Zied_II',419,252,37,255); -- stun (37~255)
 
 -- TRUST_Prishe_II (420)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Builds off of the implementation of Zied II to add missing mob skills.
I need some feedback regarding the gambit creation for Absorb-Attri (#4921)
Typically this appears to be handled using `NOT_STATUS`, but in this case we'd need to check for many?
Do we define a set somehow? 

## Steps to test these changes
![image](https://github.com/LandSandBoat/server/assets/65316697/bfa54ca3-cad0-4b9a-9964-108ac446cee5)
![image](https://github.com/LandSandBoat/server/assets/65316697/3ba0c177-79ac-4b89-9867-ebf817e4653b)
![image](https://github.com/LandSandBoat/server/assets/65316697/58e87b3f-a69d-4d8c-ade3-d14036037c82)
