### PR TITLE
[core] Add PChar arg to cpp modules: PushPacket

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -313,7 +313,7 @@ void CCharEntity::pushPacket(CBasicPacket* packet)
     TracyZoneString(getName());
     TracyZoneHex16(packet->getType());
 
-    moduleutils::OnPushPacket(packet);
+    moduleutils::OnPushPacket(this, packet);
 
     if (packet->getType() == 0x5B)
     {

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -98,12 +98,12 @@ namespace moduleutils
         }
     }
 
-    void OnPushPacket(CBasicPacket* packet)
+    void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet)
     {
         TracyZoneScoped;
         for (auto* module : cppModules())
         {
-            module->OnPushPacket(packet);
+            module->OnPushPacket(PChar, packet);
         }
     }
 

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -56,7 +56,7 @@ public:
     virtual void OnTimeServerTick(){};
     virtual void OnCharZoneIn(CCharEntity* PChar){};
     virtual void OnCharZoneOut(CCharEntity* PChar){};
-    virtual void OnPushPacket(CBasicPacket* packet){};
+    virtual void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet){};
 
     template <typename T>
     static T* Register()
@@ -82,7 +82,7 @@ namespace moduleutils
     void OnTimeServerTick();
     void OnCharZoneIn(CCharEntity* PChar);
     void OnCharZoneOut(CCharEntity* PChar);
-    void OnPushPacket(CBasicPacket* packet);
+    void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet);
 
     // The program has two "states":
     // - Load-time: As all data is being loaded and init'd


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This is quite hard to use without the added context of PChar

Example:

```cpp

    std::vector<uint16> globalTreasurePoolZones =
    {
        ZONE_DYNAMIS_BUBURIMU,
        ZONE_DYNAMIS_VALKURM,
    };

    void OnPushPacket(CCharEntity* PChar, CBasicPacket* packet) override
    {
        // Is this the correct packet?
        if (packet->getType() != 0x37)
        {
            return;
        }

        // Is this the correct zone?
        if (std::find(globalTreasurePoolZones.begin(), globalTreasurePoolZones.end(), PChar->getZone()) == globalTreasurePoolZones.end())
        {
            return;
        }

        // this will display the old-style zone-wide treasure pool.
        // All claimed mobs will show red name regardless of which party has claim.
        packet->ref<uint8>(0x29) |= 0x02;
    };
```