### PR TITLE
[LUA] clean up sigil buff power calculations

### DIFF
--- a/scripts/effects/sigil.lua
+++ b/scripts/effects/sigil.lua
@@ -3,52 +3,25 @@
 -----------------------------------
 local effectObject = {}
 
--- TODO: Find a way to simplify this.  Is this a bitfield?
 effectObject.onEffectGain = function(target, effect)
     local power = effect:getPower() -- Tracks which bonus effects are in use.
 
-    if
-        power == 1 or
-        power == 3 or
-        power == 5 or
-        power == 7 or
-        power == 9 or
-        power == 11 or
-        power == 13 or
-        power == 15
-    then
+    if utils.mask.getBit(power, 1) then
         local percentage = 70 -- TODO: This should be based off of controlled areas in Campaign
         target:addLatent(xi.latent.SIGIL_REGEN_BONUS, percentage, xi.mod.REGEN, 1)
     end
 
-    if
-        power == 2 or
-        power == 3 or
-        power == 6 or
-        power == 7 or
-        power == 10 or
-        power == 11 or
-        power >= 14
-    then
+    if utils.mask.getBit(power, 2) then
         local percentage = 60 -- TODO: This should be based off of controlled areas in Campaign
         target:addLatent(xi.latent.SIGIL_REFRESH_BONUS, percentage, xi.mod.REFRESH, 1)
     end
 
-    if
-        power >= 4 and
-        power <= 7
-    then
+    if utils.mask.getBit(power, 3) then
         target:addMod(xi.mod.FOOD_DURATION, 100)
-    elseif
-        power >= 8 and
-        power <= 11
-    then
+    end
+
+    if utils.mask.getBit(power, 4) then
         -- target:addMod(xi.mod.EXPLOSS_REDUCTION), ???)
-        -- exp loss reduction not implemented.
-    elseif power >= 12 then
-        -- Possibly handle exp loss reduction in core instead..Maybe the food bonus also?
-        target:addMod(xi.mod.FOOD_DURATION, 100)
-        -- target:addLatent(LATENT_SIGIL_EXPLOSS, ?, MOD_EXPLOSS_REDUCTION, ?)
         -- exp loss reduction not implemented.
     end
 end
@@ -60,46 +33,21 @@ effectObject.onEffectLose = function(target, effect)
     local power = effect:getPower() -- Tracks which bonus effects are in use.
     -- local subPower = effect:getSubPower() -- subPower sets % required to trigger regen/refresh.
 
-    if
-        power == 1 or
-        power == 3 or
-        power == 5 or
-        power == 7 or
-        power == 9 or
-        power == 11 or
-        power == 13 or
-        power == 15
-    then
+    if utils.mask.getBit(power, 1) then
         local percentage = 70 -- TODO: This should be based off of controlled areas in Campaign
         target:delLatent(xi.latent.SIGIL_REGEN_BONUS, percentage, xi.mod.REGEN, 1)
     end
 
-    if
-        power == 2 or
-        power == 3 or
-        power == 6 or
-        power == 7 or
-        power == 10 or
-        power == 11 or
-        power >= 14
-    then
+    if utils.mask.getBit(power, 2) then
         local percentage = 60 -- TODO: This should be based off of controlled areas in Campaign
         target:delLatent(xi.latent.SIGIL_REFRESH_BONUS, percentage, xi.mod.REFRESH, 1)
     end
 
-    if
-        effect:getPower() >= 4 and
-        effect:getPower() <= 7
-    then
+    if utils.mask.getBit(power, 3) then
         target:delMod(xi.mod.FOOD_DURATION, 100)
-    elseif
-        effect:getPower() >= 8 and
-        effect:getPower() <= 11
-    then
-        -- target:delMod(xi.mod.EXPLOSS_REDUCTION), ???)
-        -- exp loss reduction not implemented.
-    elseif effect:getPower() >= 12 then
-        target:delMod(xi.mod.FOOD_DURATION, 100)
+    end
+
+    if utils.mask.getBit(power, 4) then
         -- target:delMod(xi.mod.EXPLOSS_REDUCTION), ???)
         -- exp loss reduction not implemented.
     end

--- a/scripts/globals/campaign.lua
+++ b/scripts/globals/campaign.lua
@@ -225,27 +225,6 @@ local sigilNpcInfo =
     [xi.zone.WINDURST_WATERS_S   ] = {  13, 3 }, -- !pos -31.869 -6.009 226.793 94
 }
 
--- There appears to be no mathematical correlation between combination of effects and their
--- cost.  Each index in the table represents the bitmask value, and corresponding cost.
-local bonusEffectCosts =
-{
-    [ 1] = 50,
-    [ 2] = 50,
-    [ 3] = 100,
-    [ 4] = 50,
-    [ 5] = 100,
-    [ 6] = 100,
-    [ 7] = 150,
-    [ 8] = 100,
-    [ 9] = 150,
-    [10] = 150,
-    [11] = 150,
-    [12] = 100,
-    [13] = 150,
-    [14] = 150,
-    [15] = 200,
-}
-
 -- Returns the Vanadiel time in which Sigil will expire or 0
 local function getSigilTimeStamp(player)
     local sigilTimestamp = VanadielTime()
@@ -379,8 +358,14 @@ xi.campaign.sigilOnEventFinish = function(player, csid, option, npc)
         local optionType = bit.band(option, 0xF)
 
         if optionType == 1 then
-            local selectedEffects = bit.rshift(option, 16)
-            local bonusCost       = bonusEffectCosts[selectedEffects] and bonusEffectCosts[selectedEffects] or 0
+            local selectedEffects = bit.rshift(option, 11) -- selections are shifted by 11: 1, 4097, 8193, etc
+            local bonusCost = 0 -- base cost of zero, +50 for additional options chosen
+            for i = 1, 4 do
+                if utils.mask.getBit(selectedEffects, i) then
+                    bonusCost = bonusCost + 50
+                end
+            end
+
             local duration        = 10800 + ((15 * xi.campaign.getMedalRank(player)) * 60) -- 3hrs +15 min per medal (minimum 3hr 15 min with 1st medal)
             local subPower        = 35 -- Sets % trigger for regen/refresh. Static at minimum value (35%) for now.
             -- Selected Effect Mask:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, SIGIL doesn't give any buffs as the bit shift is coded incorrectly. This resolves both the `selectedEffects` not being always zero as well as the `sigil.lua` magic numbers to be more well-defined.

The pattern to `option` in event finish for applying sigil is 1, 4097, 8193, etc. So `bit.rshift(option, 11)` captures all the options nicely in an bit var where the bits are, in order:

none
regen
refresh
duration

i.e. if you choose regen and refresh you get a return of `6` from the `rshift`

Knowing this info, I was able to simplify the `bonusCost` calculation as well as the buff selection in `sigil.lua`

Note: This updated code supports a 4th option for decreased exp loss (assuming the pattern continues) but I don't know how to make the NPC display that option... and also the mod for that doesn't appear to be coded anyway.

## Steps to test these changes

Choose options from a sigil NPC in any of the past nations and see that the power of your sigil buff ranges from 1 (no bonus effects) to 14 (all 3 main effects)