### PR TITLE
Correct relic magian dmg augment being missing

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -896,13 +896,13 @@ INSERT INTO `augments` VALUES (738,0,0,0,0,0);
 INSERT INTO `augments` VALUES (739,0,0,0,0,0);
 -- End unused block
 
-INSERT INTO `augments` VALUES (740,0,0,0,0,0); -- DMG:+1
+INSERT INTO `augments` VALUES (740,0,287,1,0,0); -- DMG:+1
 insert into `augments` values (741,0,0,0,0,0); -- Dmg:+33   Needs to work in either hand,whichever one the weapon is equipped in.
 insert into `augments` values (742,0,0,0,0,0); -- Dmg:+65   Ranged weapons use diff AugID (starts at 746) and diff ModID.
 insert into `augments` values (743,0,0,0,0,0); -- Dmg:+97    (melee,not ranged)
 insert into `augments` values (744,0,0,0,0,0); -- Dmg:-1    (melee,not ranged)
 insert into `augments` values (745,0,0,0,0,0); -- Dmg:-33    (melee,not ranged)
-insert into `augments` values (746,0,0,0,0,0); -- Dmg:+1    (ranged,not melee)
+insert into `augments` values (746,0,287,1,0,0); -- Dmg:+1    (ranged,not melee)
 insert into `augments` values (747,0,0,0,0,0); -- Dmg:+33    (ranged,not melee)
 insert into `augments` values (748,0,0,0,0,0); -- Dmg:+65    (ranged,not melee)
 insert into `augments` values (749,0,0,0,0,0); -- Dmg:+97    (ranged,not melee)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/4853 .

The mod `287: DMG_RATING` applies on a weapon/ammo level, while the `376: RANGED_DMG_RATING` is applied at the end from the battle entity, so we should use the former for both main and ranged relic augments.

## Steps to test these changes

Can be confirmed by giving a relic weapon with the +DMG augment and using `!exec player:getRangedDmg()` and `!exec player:getWeaponDmg()`