### PR TITLE
[LUA] stack tomahawk mods on effect to simplify logic

### DIFF
--- a/scripts/effects/tomahawk.lua
+++ b/scripts/effects/tomahawk.lua
@@ -9,14 +9,14 @@ effectObject.onEffectGain = function(target, effect)
         local sdtModPhys = target:getMod(physSDT[i])
         local reductionPhys = (1000 - sdtModPhys) * 0.25
 
-        target:addMod(physSDT[i], reductionPhys)
+        effect:addMod(physSDT[i], reductionPhys)
     end
 
     for i = 1, #xi.magic.specificDmgTakenMod do
         local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
         local reductionMagic = sdtModMagic * 0.25
 
-        target:addMod(xi.magic.specificDmgTakenMod[i], -reductionMagic)
+        effect:addMod(xi.magic.specificDmgTakenMod[i], -reductionMagic)
     end
 end
 
@@ -24,25 +24,7 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    for i = 1, #physSDT do
-        local sdtModPhys = target:getMod(physSDT[i])
-        local restorePhys = (1000 - sdtModPhys) / 0.75
-
-        if sdtModPhys <= 250 then
-            restorePhys = sdtModPhys
-        elseif sdtModPhys >= 1000 then
-            restorePhys = 0
-        end
-
-        target:delMod(physSDT[i], restorePhys)
-    end
-
-    for i = 1, #xi.magic.specificDmgTakenMod do
-        local sdtModMagic = target:getMod(xi.magic.specificDmgTakenMod[i])
-        local restoreMagic = (sdtModMagic / 0.75) - sdtModMagic
-
-        target:delMod(xi.magic.specificDmgTakenMod[i], -restoreMagic)
-    end
+    -- Mods are stacked on the effect and will be removed automatically when the effect wears off
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #4856 .

![image](https://github.com/LandSandBoat/server/assets/131182600/332d7607-fcb2-4370-bdc1-cd3d035f4d8b)

Adding mods to the _effect_ instead of directly on the _target_ will remove them cleanly when the effect wears off

## Steps to test these changes

Steps in the original issue as well as screenshot above.