### PR TITLE
[SQL] Adjust multiplicative augments to behave properly

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -100,20 +100,20 @@ INSERT INTO `augments` VALUES (69,0,26,1,0,0); -- Rng.Acc. +1 Rng.Atk. +1
 INSERT INTO `augments` VALUES (69,0,24,1,0,0); -- Cont.
 INSERT INTO `augments` VALUES (70,0,30,33,0,0); -- Mag. Acc. +33 Mag.Atk.Bns +33
 INSERT INTO `augments` VALUES (70,0,28,33,0,0); -- Cont.
-INSERT INTO `augments` VALUES (71,0,160,-100,0,0); -- Damage Taken -1%
+INSERT INTO `augments` VALUES (71,100,160,-1,0,0); -- Damage Taken -1%
 INSERT INTO `augments` VALUES (72,0,0,1,0,0); -- Exp. Point +1%
 INSERT INTO `augments` VALUES (73,0,0,33,0,0); -- Exp. Point +33%
 INSERT INTO `augments` VALUES (74,0,915,1,0,0); -- Cap. Point +1%
 INSERT INTO `augments` VALUES (75,0,915,33,0,0); -- Cap. Point +33%
 INSERT INTO `augments` VALUES (76,0,0,0,0,0); -- DMG +33 Unsure if main hand or off hand so leaving values blank for now,goes up in increments of 1 after the initial 33.
 INSERT INTO `augments` VALUES (77,0,0,0,0,0); -- Delay -33% Unsure if main hand or off hand so leaving values blank for now,goes up in increments of 1 after the initial 33.
-INSERT INTO `augments` VALUES (78,0,2,2,0,0); -- HP +2 (count by 2)
-INSERT INTO `augments` VALUES (79,0,2,3,0,0); -- HP +3 (count by 3)
+INSERT INTO `augments` VALUES (78,2,2,1,0,0); -- HP +2 (count by 2)
+INSERT INTO `augments` VALUES (79,3,2,1,0,0); -- HP +3 (count by 3)
 INSERT INTO `augments` VALUES (80,0,30,1,0,0); -- Mag. Acc. +1/Mag. Dmg. +1
 INSERT INTO `augments` VALUES (80,0,311,1,0,0); -- Cont.
 INSERT INTO `augments` VALUES (81,0,0,0,0,0); -- Eva +1/Mag. Eva + d (corrupted)
-INSERT INTO `augments` VALUES (82,0,5,2,0,0); -- MP +2 (count by 2)
-INSERT INTO `augments` VALUES (83,0,5,3,0,0); -- MP +3 (count by 3)
+INSERT INTO `augments` VALUES (82,2,5,1,0,0); -- MP +2 (count by 2)
+INSERT INTO `augments` VALUES (83,3,5,1,0,0); -- MP +3 (count by 3)
 
 -- 84 to 95 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (84,0,0,0,0,0);
@@ -151,8 +151,8 @@ INSERT INTO `augments` VALUES (108,0,28,1,1,0); -- Cont.
 INSERT INTO `augments` VALUES (109,0,288,1,1,0); -- Pet: Dbl.Atk.+1% Crit.hit rate+1
 INSERT INTO `augments` VALUES (109,0,165,1,1,0); -- Cont.
 INSERT INTO `augments` VALUES (110,0,370,1,1,0); -- Pet: Regen+1
-INSERT INTO `augments` VALUES (111,0,384,100,1,0); -- Pet: Haste+1
-INSERT INTO `augments` VALUES (112,0,160,-100,1,0); -- Pet: Damage taken -1%
+INSERT INTO `augments` VALUES (111,100,384,1,1,0); -- Pet: Haste+1
+INSERT INTO `augments` VALUES (112,100,160,-1,1,0); -- Pet: Damage taken -1%
 INSERT INTO `augments` VALUES (113,0,26,1,1,0); -- Pet: Rng.Acc.+1
 INSERT INTO `augments` VALUES (114,0,24,1,1,0); -- Pet: Rng.Atk.+1
 INSERT INTO `augments` VALUES (115,0,73,1,1,0); -- Pet: Store TP+1
@@ -319,7 +319,7 @@ INSERT INTO `augments` VALUES (249,0,0,0,0,0);
 INSERT INTO `augments` VALUES (250,0,0,0,0,0);
 -- End unused block
 
-INSERT INTO `augments` VALUES (251,1,911,0,0,0); -- Daken +1
+INSERT INTO `augments` VALUES (251,1,911,1,0,0); -- Daken +1
 
 -- 252 to 256 currently unused. Leave at zero. Edit+move or remove this note as new augments get discovered.
 INSERT INTO `augments` VALUES (252,0,0,0,0,0);
@@ -794,7 +794,7 @@ INSERT INTO `augments` VALUES (636,0,0,0,0,0);
 INSERT INTO `augments` VALUES (637,0,0,0,0,0);
 INSERT INTO `augments` VALUES (638,0,0,0,0,0);
 INSERT INTO `augments` VALUES (639,0,0,0,0,0);
-INSERT INTO `augments` VALUES (640,2,291,2,0,0); -- Counter +2 (increases by 2)
+INSERT INTO `augments` VALUES (640,2,291,1,0,0); -- Counter +2 (increases by 2)
 INSERT INTO `augments` VALUES (641,0,0,0,0,0);
 INSERT INTO `augments` VALUES (642,0,0,0,0,0);
 INSERT INTO `augments` VALUES (643,0,0,0,0,0);
@@ -1427,8 +1427,8 @@ INSERT INTO `augments` VALUES (1151,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1152,0,1,10,0,0); -- DEF +10
 INSERT INTO `augments` VALUES (1153,0,68,3,0,0); -- Evasion +3
 INSERT INTO `augments` VALUES (1154,0,31,3,0,0); -- Mag. Evasion +3
-INSERT INTO `augments` VALUES (1155,100,161,-2,0,0); -- Physical Damage Taken -2%
-INSERT INTO `augments` VALUES (1156,100,163,-2,0,0); -- Magic Damage Taken -2%
+INSERT INTO `augments` VALUES (1155,200,161,-1,0,0); -- Physical Damage Taken -2%
+INSERT INTO `augments` VALUES (1156,200,163,-1,0,0); -- Magic Damage Taken -2%
 INSERT INTO `augments` VALUES (1157,0,168,2,0,0); -- Spell Interruption Rate Down 2%
 INSERT INTO `augments` VALUES (1158,0,958,2,0,0); -- Occ. Resistance to Status Ailments +2
 
@@ -1522,8 +1522,8 @@ INSERT INTO `augments` VALUES (1244,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1245,0,0,0,0,0);
 -- End unused block
 
-INSERT INTO `augments` VALUES (1246,100,161,-2,1,0); -- Pet: Phy. Dmg. Taken -2%
-INSERT INTO `augments` VALUES (1247,100,163,-2,1,0); -- Pet: Magic Dmg. Taken -2%
+INSERT INTO `augments` VALUES (1246,200,161,-1,1,0); -- Pet: Phy. Dmg. Taken -2%
+INSERT INTO `augments` VALUES (1247,200,163,-1,1,0); -- Pet: Magic Dmg. Taken -2%
 INSERT INTO `augments` VALUES (1248,0,890,1,0,0); -- Enhancing Magic Effect Duration +1
 INSERT INTO `augments` VALUES (1249,0,477,1,0,0); -- Helix Effect Duration+1
 INSERT INTO `augments` VALUES (1250,0,960,1,0,0); -- Indi Effect Duration+1


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Augments have a particular mod they enact (or multiple mods). Each mod is given a power and a multiplier. I think whoever implemented augments intended for power to always be 1 or -1 when multiplier was nonzero.

Finding augments via this query:
`SELECT * FROM augments WHERE multiplier <> 0 AND ABS(VALUE) <> 1`

we can see various mismatches between what the client shows and what mods get applied:

![image](https://github.com/LandSandBoat/server/assets/131182600/5bb6aca3-699a-4137-9572-432b9e9f3947)

![image](https://github.com/LandSandBoat/server/assets/131182600/4b1b87ac-d19b-4727-9203-22c610aa1746)

![image](https://github.com/LandSandBoat/server/assets/131182600/3766a18d-84be-4b6a-b0d9-c5f9f0586837)

This PR attempts to correct them all in one fell swoop. I am aware of an over-arching issue with augments not being packet-correct and thus sometimes giving incorrect display when augmentid/power aren't within certain parameters (i.e. [this issue](https://github.com/LandSandBoat/server/issues/2772)), but I don't believe that is related to this particular PR's resolution

Basically, the intent of this PR is to find all augments that the client interprets as counting by multiples other than 1 and fixing the SQL side to make the CPP side work in the expected way.

## Steps to test these changes

after changes:
![image](https://github.com/LandSandBoat/server/assets/131182600/24e5da8f-6b85-4378-9c25-ca816133dc44)
etc

specifically, you test by giving yourself an item with the particular augment/power and see that the game client reflects the underlying mods being applied (I like to use bronze dagger myself):
- `!additem bronze_dagger 1 78 0`
  - ![image](https://github.com/LandSandBoat/server/assets/131182600/111ff27c-72be-4b4e-97db-11d798227d1e)
- `!additem bronze_dagger 1 78 2`
  - ![image](https://github.com/LandSandBoat/server/assets/131182600/f194dd04-2dff-400c-aff9-ba8f819aeae1)
- `!additem bronze_dagger 1 83 1`
  - ![image](https://github.com/LandSandBoat/server/assets/131182600/032d2fba-d8da-40e2-851a-ee46d6c2467b)
etc, etc