### PR TITLE
[build] Add /utf-8 flag to MSVC build

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -60,6 +60,7 @@ if(MSVC)
         /Oy- # Frame-Pointer Omission
         /MP # Build with Multiple Processes
         /bigobj # Allow bigger .obj files, which we have from mainly the sol templating
+        /utf-8 # Treat source files as UTF-8. This is needed because of certain symbols inside fmtlib's code. u-second, etc.
     )
 
     if(CMAKE_BUILD_TYPE STREQUAL Debug)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

https://github.com/fmtlib/fmt/issues/3289

Adds /utf-8 flag to our Windows build. We periodically get someone with a non-EN Windows/Visual Studio which chokes on the u-second character inside fmt/chrono.h. This _should_ fix that by telling the compiler to treat all code its compiling as UTF-8, allowing it to recognise these characters. None of us have repro on this bug locally, so its a shot in the dark!

## Steps to test these changes

It builds and runs 👍 

Related to:
https://github.com/LandSandBoat/server/discussions/4952
https://github.com/LandSandBoat/server/discussions/1566
https://github.com/LandSandBoat/server/discussions/542
