### PR TITLE
[LUA] Violent Flourish combat log fix

### DIFF
--- a/scripts/actions/abilities/violent_flourish.lua
+++ b/scripts/actions/abilities/violent_flourish.lua
@@ -13,7 +13,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.dancer.useViolentFlourishAbility(player, target, ability, action)
+    return xi.job_utils.dancer.useViolentFlourishAbility(player, target, ability, action)
 end
 
 return abilityObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Violent Flourish always returns zero dmg in the combat log due to the helper function's return not being forwarded in the `onUseAbility` function. This fixes it

## Steps to test these changes

Use Violent Flourish, see that it now shows nonzero dmg