### PR TITLE
[Fishing] Remove era's 100 skill cap

### DIFF
--- a/src/map/utils/fishingutils.cpp
+++ b/src/map/utils/fishingutils.cpp
@@ -1076,9 +1076,7 @@ namespace fishingutils
 
     uint8 GetFishingSkill(CCharEntity* PChar)
     {
-        uint8 rawSkill = (uint8)std::min(100, (int)std::floor(PChar->RealSkills.skill[SKILL_FISHING] / 10));
-
-        return rawSkill + PChar->getMod(Mod::FISH);
+        return static_cast<uint8>(std::floor(PChar->RealSkills.skill[SKILL_FISHING] / 10) + PChar->getMod(Mod::FISH));
     }
 
     uint8 GetBaitPower(bait_t* bait, fish_t* fish)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes a cap placed in fishing skill for no reason.

## Steps to test these changes

Set yourself at fishing skill 200 and see how you actually are able to fish anything with ease.
