### PR TITLE
[Combat][Spells] Refactor critical hit rate. Add SA and TA to ble spells.

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -610,6 +610,7 @@ xi.combat.physical.calculateSwingCriticalRate = function(actor, target, isWeapon
     local buildingFlourishBonus = xi.combat.physical.criticalRateFromFlourish(actor)
     local modifierBonus         = actor:getMod(xi.mod.CRITHITRATE) / 100
     local meritBonus            = actor:getMerit(xi.merit.CRIT_HIT_RATE) / 100
+    local targetModifierBonus   = target:getMod(xi.mod.ENEMYCRITRATE) / 100
     local meritPenalty          = target:getMerit(xi.merit.ENEMY_CRIT_RATE) / 100
     local tpFactor              = 0
 
@@ -619,7 +620,7 @@ xi.combat.physical.calculateSwingCriticalRate = function(actor, target, isWeapon
     end
 
     -- Add all different bonuses and clamp.
-    finalCriticalRate = baseCriticalRate + statBonus + inninBonus + fencerBonus + buildingFlourishBonus + modifierBonus + meritBonus - meritPenalty + tpFactor
+    finalCriticalRate = baseCriticalRate + statBonus + inninBonus + fencerBonus + buildingFlourishBonus + modifierBonus + meritBonus + targetModifierBonus - meritPenalty + tpFactor
 
     return utils.clamp(finalCriticalRate, 0.05, 1) -- TODO: Need confirmation of no upper cap.
 end

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -522,6 +522,108 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     return pDif
 end
 
+-----------------------------------
+-- Critical hit rate operations
+-----------------------------------
+-- dStat: Critical hit rate bonus from DEX vs AGI difference.
+xi.combat.physical.criticalRateFromStatDiff = function(actor, target)
+    local statBonus = 0
+
+    local dDex = actor:getStat(xi.mod.DEX) - target:getStat(xi.mod.AGI)
+
+    if dDex > 50 then
+        statBonus = 0.15
+    elseif dDex >= 40 then
+        statBonus = (dDex - 35) / 100
+    elseif dDex >= 30 then
+        statBonus = 0.04
+    elseif dDex >= 20 then
+        statBonus = 0.03
+    elseif dDex >= 14 then
+        statBonus = 0.02
+    elseif dDex >= 7 then
+        statBonus = 0.01
+    end
+
+    return statBonus
+end
+
+-- Innin: Critical hit rate bonus when actor is behind target.
+xi.combat.physical.criticalRateFromInnin = function(actor, target)
+    local inninBonus = 0
+
+    if
+        actor:hasStatusEffect(xi.effect.INNIN) and
+        actor:isBehind(target, 23)
+    then
+        inninBonus = actor:getStatusEffect(xi.effect.INNIN):getPower()
+    end
+
+    return inninBonus
+end
+
+-- Fencer: Critical hit rate bonus when actor is only wielding with main hand.
+xi.combat.physical.criticalRateFromFencer = function(actor)
+    local fencerBonus = 0
+
+    local mainEquip = actor:getStorageItem(0, 0, xi.slot.MAIN)
+    local subEquip  = actor:getStorageItem(0, 0, xi.slot.SUB)
+
+    if
+        actor:getObjType() == xi.objType.PC and
+        mainEquip and
+        not mainEquip:isTwoHanded() and                                                      -- No 2 handed weapons.
+        not mainEquip:isHandToHand() and                                                     -- No 2 handed weapons.
+        (subEquip == nil or subEquip:getSkillType() == xi.skill.NONE or subEquip:isShield()) -- Only shields allowed in sub.
+    then
+        fencerBonus = actor:getMod(xi.mod.FENCER_CRITHITRATE) / 100
+    end
+
+    return fencerBonus
+end
+
+-- Critical rate from Building Flourish.
+-- TODO: Study case were if we can attach modifiers to the effect itself, both this and the effect may need refactoring.
+xi.combat.physical.criticalRateFromFlourish = function(actor)
+    local buildingFlourishBonus = 0
+
+    if actor:hasStatusEffect(xi.effect.BUILDING_FLOURISH) then
+        local effectPower    = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH):getPower()
+        local effectSubPower = actor:getStatusEffect(xi.effect.BUILDING_FLOURISH):getSubPower()
+
+        if effectPower >= 3 then
+            buildingFlourishBonus = (10 + effectSubPower) / 100
+        end
+    end
+
+    return buildingFlourishBonus
+end
+
+-- Critical rate master function.
+xi.combat.physical.calculateSwingCriticalRate = function(actor, target, isWeaponskill, TP1000, TP2000, TP3000)
+    -- See reference at https://www.bg-wiki.com/ffxi/Critical_Hit_Rate
+    local finalCriticalRate     = 0
+    local baseCriticalRate      = 0.05
+    local statBonus             = xi.combat.physical.criticalRateFromStatDiff(actor, target)
+    local inninBonus            = xi.combat.physical.criticalRateFromInnin(actor, target)
+    local fencerBonus           = xi.combat.physical.criticalRateFromFencer(actor)
+    local buildingFlourishBonus = xi.combat.physical.criticalRateFromFlourish(actor)
+    local modifierBonus         = actor:getMod(xi.mod.CRITHITRATE) / 100
+    local meritBonus            = actor:getMerit(xi.merit.CRIT_HIT_RATE) / 100
+    local meritPenalty          = target:getMerit(xi.merit.ENEMY_CRIT_RATE) / 100
+    local tpFactor              = 0
+
+    -- For weaponskills.
+    if isWeaponskill then
+        tpFactor = xi.combat.physical.calculateTPfactor(actor, TP1000, TP2000, TP3000)
+    end
+
+    -- Add all different bonuses and clamp.
+    finalCriticalRate = baseCriticalRate + statBonus + inninBonus + fencerBonus + buildingFlourishBonus + modifierBonus + meritBonus - meritPenalty + tpFactor
+
+    return utils.clamp(finalCriticalRate, 0.05, 1) -- TODO: Need confirmation of no upper cap.
+end
+
 xi.combat.physical.calculateNumberOfHits = function(actor, additionalParamsHere)
 end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -502,7 +502,7 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- TODO: calc per-hit with weapon crit+% on each hand (if dual wielding)
     if wsParams.canCrit then -- Work out critical hit ratios
-        criticalRate = xi.combat.physical.calculateSwingCriticalRate(actor, target, true, wsParams.crit100, wsParams.crit200, wsParams.crit300)
+        criticalRate = xi.combat.physical.calculateSwingCriticalRate(attacker, target, true, wsParams.crit100, wsParams.crit200, wsParams.crit300)
     end
 
     calcParams.critRate = criticalRate

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1027,10 +1027,22 @@ bool CCharEntity::OnAttack(CAttackState& state, action_t& action)
 void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
 {
     TracyZoneScoped;
-    CBattleEntity::OnCastFinished(state, action);
 
     auto* PSpell  = state.GetSpell();
     auto* PTarget = static_cast<CBattleEntity*>(state.GetTarget());
+
+    // not ideal, since Trick Attack character (taChar) is also calculated on the lua side for the base spell.
+    // Only blue spells that act as a physical WS can TA.
+    CBattleEntity* taChar = nullptr;
+
+    if (StatusEffectContainer->HasStatusEffect(EFFECT_TRICK_ATTACK) &&
+        PSpell->getSpellGroup() == SPELLGROUP_BLUE &&
+        PSpell->dealsDamage())
+    {
+        taChar = battleutils::getAvailableTrickAttackChar(this, PTarget);
+    }
+
+    CBattleEntity::OnCastFinished(state, action);
 
     PRecastContainer->Add(RECAST_MAGIC, static_cast<uint16>(PSpell->getID()), action.recast);
 
@@ -1038,7 +1050,9 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
     {
         for (auto&& actionTarget : actionList.actionTargets)
         {
-            if (actionTarget.param > 0 && PSpell->dealsDamage() && PSpell->getSpellGroup() == SPELLGROUP_BLUE &&
+            if (actionTarget.param > 0 &&
+                PSpell->dealsDamage() &&
+                PSpell->getSpellGroup() == SPELLGROUP_BLUE &&
                 (StatusEffectContainer->HasStatusEffect(EFFECT_CHAIN_AFFINITY) || StatusEffectContainer->HasStatusEffect(EFFECT_AZURE_LORE)) &&
                 static_cast<CBlueSpell*>(PSpell)->getPrimarySkillchain() != 0)
             {
@@ -1046,7 +1060,7 @@ void CCharEntity::OnCastFinished(CMagicState& state, action_t& action)
                 SUBEFFECT effect     = battleutils::GetSkillChainEffect(PTarget, PBlueSpell->getPrimarySkillchain(), PBlueSpell->getSecondarySkillchain(), 0);
                 if (effect != SUBEFFECT_NONE)
                 {
-                    uint16 skillChainDamage = battleutils::TakeSkillchainDamage(static_cast<CBattleEntity*>(this), PTarget, actionTarget.param, nullptr);
+                    uint16 skillChainDamage = battleutils::TakeSkillchainDamage(static_cast<CBattleEntity*>(this), PTarget, actionTarget.param, taChar);
 
                     actionTarget.addEffectParam   = skillChainDamage;
                     actionTarget.addEffectMessage = 287 + effect;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes critical hit rate from dStat being added to all WSs no matter if they could actually crit or not.

And as Mowford said in his PR: #4698 
- PHYSICAL_POTENCY now gives acc and bonus to cratio
- This ports the SATA code from CEXI for blu magic.
- It also enables TA to function for blu magic skillchain damage

End result is (using cannonball as an example)

    a SA cannonball will auto crit
    if taChar is in position
        a TA cannonball will transfer enmity
        a TA cannonball that skillchains will transfer enmity of both spell and skillchain

- Finally, some adjustments were made to support params.bonusacc and params.critchance. If these params aren't passed both will be zero by default
- Also (sorry for the late discovery, but didn't want to make a new PR since this one is still open): Found that the base multiplier is being set to 1 unless Chain Affinity is in effect. This is wrong: https://www.bg-wiki.com/ffxi/Calculating_Blue_Magic_Damage. The base multiplier is in the table as ftp0 and is only applied to the first hit.

## Steps to test these changes

REVIEW BY COMMIT for your sanity.

- !stun and !immortal a mob
- position for SA and compare damage before and after cannonball
- position for TA and remove !stun after to see the mob target the player
- TA for skillchain damage is a bit trickier to test, but you can use !getenmity to confirm your enmity doesn't spike after using TA (open the skillchain with the second player)
