### PR TITLE
[c++] Correct some data types in synthutils and fix HQ modifier just not working

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -226,7 +226,7 @@ namespace synthutils
         // Section 1: Variable definitions.
         //------------------------------
         uint8 synthResult = SYNTHESIS_SUCCESS; // We assume that we succeed.
-        float successRate = 95;                // We assume that success rate is maxed (95%).
+        uint8 successRate = 95;                // We assume that success rate is maxed (95%).
         uint8 finalHQTier = 4;                 // We assume that max HQ tier is available.
         bool  canHQ       = true;              // We assume that we can HQ.
 
@@ -312,7 +312,7 @@ namespace synthutils
                     successRate = successRate + 1; // The crafting rings that block HQ synthesis all also increase their respective craft's success rate by 1%
                 }
 
-                // Clamp success rate to 0.99
+                // Clamp success rate to 99%
                 // https://www.bluegartr.com/threads/120352-CraftyMath
                 // http://www.ffxiah.com/item/5781/kitron-macaron
                 if (successRate > 99)
@@ -320,7 +320,7 @@ namespace synthutils
                     successRate = 99;
                 }
 
-                if (randomRoll > successRate) // Synthesis broke
+                if (randomRoll > successRate) // Synthesis broke. This is not a mistake, the break check HAS to be done per craft skill involved.
                 {
                     // Keep the skill because of which the synthesis failed.
                     // Use the slotID of the crystal cell, because it was removed at the beginning of the synthesis.
@@ -358,12 +358,12 @@ namespace synthutils
 
             if (PChar->CraftContainer->getCraftType() == CRAFT_DESYNTHESIS) // if it's a desynth raise HQ chance
             {
-                chanceHQ = chanceHQ * 1.5;
+                chanceHQ = chanceHQ * 1.5f;
             }
 
             // HQ success rate modifier.
             // See: https://www.bluegartr.com/threads/130586-CraftyMath-v2-Post-September-2017-Update page 3.
-            chanceHQ = chanceHQ + PChar->getMod(Mod::SYNTH_HQ_RATE) * 100 / 512;
+            chanceHQ = chanceHQ + 100.0f * PChar->getMod(Mod::SYNTH_HQ_RATE) / 512.0f;
 
             // limit max hq chance
             if (chanceHQ > maxChanceHQ)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- HQ rate modifier was not propely casted to a float, making the bonus always 0 in the end.
Before:
![imagen](https://github.com/LandSandBoat/server/assets/60053999/3a74273e-c8b0-47e0-a4d6-9e11017cffcb)
After:
![imagen](https://github.com/LandSandBoat/server/assets/60053999/54debe57-ce58-4e3f-a8f3-08e17a21f5bb)

- Also changed success rate data type from float to uint8, couse thats how it was being used all across anyway.

## Steps to test these changes
Add prints to show values and craft away until your soul burns in flames and start wondering what you have ever done to deserve such a punishment.
