### PR TITLE
[sql] Speed up Aria table inserts

### DIFF
--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -25,7 +25,7 @@ CREATE TABLE `abilities` (
   `addType` smallint(2) NOT NULL DEFAULT '0',
   `content_tag` varchar(7) DEFAULT NULL,
   PRIMARY KEY (`abilityId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
 
 --
 -- Dumping data for table `abilities`

--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -11,7 +11,7 @@ CREATE TABLE `augments` (
   `isPet` tinyint(1) NOT NULL DEFAULT 0,
   `petType` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`augmentId`,`multiplier`,`modId`,`isPet`,`petType`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `augments`

--- a/sql/automaton_spells.sql
+++ b/sql/automaton_spells.sql
@@ -24,7 +24,7 @@ CREATE TABLE `automaton_spells` (
   `immunity` smallint(4) unsigned NOT NULL DEFAULT '0',
   `removes` int(6) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`spellid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=14;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=14;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/bcnm_battlefield.sql
+++ b/sql/bcnm_battlefield.sql
@@ -8,7 +8,7 @@ CREATE TABLE `bcnm_battlefield` (
   `battlefieldNumber` tinyint(3) DEFAULT NULL,
   `monsterId` int(10) NOT NULL,
   `conditions` tinyint(2) NOT NULL DEFAULT '0'
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
 
 --
 -- Dumping data for table `bcnm_battlefield`

--- a/sql/bcnm_treasure_chests.sql
+++ b/sql/bcnm_treasure_chests.sql
@@ -8,7 +8,7 @@ CREATE TABLE `bcnm_treasure_chests` (
   `bcnmId` smallint(5) unsigned NOT NULL,
   `battlefieldNumber` tinyint(3),
   `npcId` int(10) NOT NULL
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=56;
 
 -- ----------------------------
 -- Records of instance

--- a/sql/blue_spell_list.sql
+++ b/sql/blue_spell_list.sql
@@ -13,7 +13,7 @@ CREATE TABLE `blue_spell_list` (
   `secondary_sc` smallint(2) NOT NULL,
   `tertiary_sc` smallint(2) NOT NULL,
   PRIMARY KEY (`spellid`,`mob_skill_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Records

--- a/sql/blue_spell_mods.sql
+++ b/sql/blue_spell_mods.sql
@@ -8,7 +8,7 @@ CREATE TABLE `blue_spell_mods` (
   `modid` smallint(5) unsigned NOT NULL,
   `value` smallint(5) NOT NULL DEFAULT '0',
   PRIMARY KEY (`spellId`,`modid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Venom Shell

--- a/sql/blue_traits.sql
+++ b/sql/blue_traits.sql
@@ -10,7 +10,7 @@ CREATE TABLE `blue_traits` (
   `modifier` smallint(5) unsigned NOT NULL,
   `value` smallint(5) NOT NULL,
   PRIMARY KEY (`trait_category`,`trait_points_needed`,`modifier`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Records

--- a/sql/despoil_effects.sql
+++ b/sql/despoil_effects.sql
@@ -20,7 +20,7 @@ CREATE TABLE `despoil_effects` (
   `itemId` smallint(5) unsigned NOT NULL,
   `effectId` smallint(5) unsigned NOT NULL,
   PRIMARY KEY (`itemId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/exp_base.sql
+++ b/sql/exp_base.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `exp_base` (
   `level` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `exp` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`level`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=9;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=9;
 
 --
 -- Contenu de la table `exp_base`

--- a/sql/exp_table.sql
+++ b/sql/exp_table.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS `exp_table` (
   `r19` smallint(4) unsigned NOT NULL DEFAULT '0', -- 91 to 95
   `r20` smallint(4) unsigned NOT NULL DEFAULT '0', -- 96 to 99
   PRIMARY KEY (`level`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=65;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=65;
 
 --
 -- Contenu de la table `exp_table`

--- a/sql/fishing_area.sql
+++ b/sql/fishing_area.sql
@@ -34,7 +34,7 @@ CREATE TABLE `fishing_area` (
   `center_y` float(7,3) NOT NULL DEFAULT '0.000',
   `center_z` float(7,3) NOT NULL DEFAULT '0.000',
   PRIMARY KEY (`zoneid`,`areaid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_bait.sql
+++ b/sql/fishing_bait.sql
@@ -32,7 +32,7 @@ CREATE TABLE `fishing_bait` (
   `mmm` tinyint(2) unsigned NOT NULL,
   `rankmod` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`baitid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_bait_affinity.sql
+++ b/sql/fishing_bait_affinity.sql
@@ -27,7 +27,7 @@ CREATE TABLE `fishing_bait_affinity` (
   `fishid` smallint(5) unsigned NOT NULL DEFAULT '0',
   `power` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`baitid`,`fishid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=28;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=28;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_catch.sql
+++ b/sql/fishing_catch.sql
@@ -27,7 +27,7 @@ CREATE TABLE `fishing_catch` (
   `areaid` tinyint(3) unsigned NOT NULL,
   `groupid` smallint(5) unsigned NOT NULL,
   PRIMARY KEY (`zoneid`,`areaid`,`groupid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=27;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=27;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_fish.sql
+++ b/sql/fishing_fish.sql
@@ -53,7 +53,7 @@ CREATE TABLE `fishing_fish` (
   `contest` tinyint(2) NOT NULL DEFAULT '0',
   `disabled` tinyint(2) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`fishid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=23;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=23;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_group.sql
+++ b/sql/fishing_group.sql
@@ -29,7 +29,7 @@ CREATE TABLE `fishing_group` (
   `pool_size` smallint(5) unsigned NOT NULL DEFAULT '0',
   `restock_rate` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`groupid`,`fishid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_mob.sql
+++ b/sql/fishing_mob.sql
@@ -47,7 +47,7 @@ CREATE TABLE `fishing_mob` (
   `quest_only` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `disabled` tinyint(2) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`mobid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_rod.sql
+++ b/sql/fishing_rod.sql
@@ -46,7 +46,7 @@ CREATE TABLE `fishing_rod` (
   `legendary` tinyint(2) unsigned NOT NULL,
   `rating` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`rodid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/fishing_zone.sql
+++ b/sql/fishing_zone.sql
@@ -27,7 +27,7 @@ CREATE TABLE `fishing_zone` (
   `name` varchar(64) NOT NULL,
   `difficulty` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`zoneid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/gardening_results.sql
+++ b/sql/gardening_results.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS `gardening_results` (
   `max_quantity` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `weight` smallint(4) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`resultId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=23;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=23;
 
 INSERT INTO `gardening_results` VALUES (1,1,0,0,936,12,24,30); -- Rock Salt
 INSERT INTO `gardening_results` VALUES (2,1,0,0,4449,1,2,30); -- Reishi Mushroom

--- a/sql/guild_item_points.sql
+++ b/sql/guild_item_points.sql
@@ -11,7 +11,7 @@ CREATE TABLE `guild_item_points` (
   `max_points` smallint(5) unsigned NOT NULL DEFAULT '0',
   `pattern` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guildid`,`itemid`,`pattern`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Records

--- a/sql/guild_shops.sql
+++ b/sql/guild_shops.sql
@@ -23,7 +23,7 @@ CREATE TABLE `guild_shops` (
   `daily_increase` smallint(5) unsigned NOT NULL DEFAULT '0',
   `initial_quantity` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guildid`,`itemid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/guilds.sql
+++ b/sql/guilds.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `guilds` (
   `id` tinyint(1) unsigned NOT NULL,
   `points_name` varchar(20) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 
 LOCK TABLES `guilds` WRITE;
 

--- a/sql/instance_entities.sql
+++ b/sql/instance_entities.sql
@@ -20,7 +20,7 @@ CREATE TABLE `instance_entities` (
   `instanceid` smallint(3) unsigned NOT NULL DEFAULT '0',
   `id` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`instanceid`, `id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/instance_list.sql
+++ b/sql/instance_list.sql
@@ -31,7 +31,7 @@ CREATE TABLE `instance_list` (
   `battlesolo` smallint(3) NOT NULL DEFAULT '-1',
   `battlemulti` smallint(3) NOT NULL DEFAULT '-1',
   PRIMARY KEY (`instanceid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -27,7 +27,7 @@ CREATE TABLE `item_basic` (
   `NoSale` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `BaseSell` int(10) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`itemid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=34 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=34 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -29,7 +29,7 @@ CREATE TABLE `item_equipment` (
   `rslot` smallint(5) unsigned NOT NULL DEFAULT 0,
   `su_level` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`itemId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=37 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=37 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/item_furnishing.sql
+++ b/sql/item_furnishing.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `item_furnishing` (
   `element` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `aura` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`itemid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=25 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=25 PACK_KEYS=1 CHECKSUM=1;
 
 --
 -- Contenu de la table `item_furnishing`

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `item_latents` (
   `latentId` smallint(5) NOT NULL,
   `latentParam` smallint(5) NOT NULL,
   PRIMARY KEY (`itemId`,`modId`,`value`,`latentId`,`latentParam`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 
 -- Item name
 -- INSERT INTO `item_latents` VALUES (itemID,modId,modValue,latentId,latentParam); -- Human readable latent & mod

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -21,7 +21,7 @@ CREATE TABLE `item_mods` (
   `modId` smallint(5) unsigned NOT NULL,
   `value` smallint(5) NOT NULL DEFAULT 0,
   PRIMARY KEY (`itemId`,`modId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS `item_mods_pet` (
  `value` smallint(5) NOT NULL DEFAULT '0',
  `petType` tinyint(3) unsigned NOT NULL DEFAULT '0',
  PRIMARY KEY (`itemId`,`modId`,`petType`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 
 -- (Please keep item ID sequential)
 -- Charivari Earring

--- a/sql/item_puppet.sql
+++ b/sql/item_puppet.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS `item_puppet` (
   `slot` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `element` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`itemid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Contenu de la table `item_puppet`

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -28,7 +28,7 @@ CREATE TABLE `item_usable` (
   `reuseDelay` int(10) unsigned NOT NULL DEFAULT '0',
   `aoe` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`itemid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -30,7 +30,7 @@ CREATE TABLE `item_weapon` (
   `dmg` int(10) unsigned NOT NULL DEFAULT '0',
   `unlock_points` smallint(5) NOT NULL DEFAULT '0',
   PRIMARY KEY (`itemId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=54 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=54 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/job_point_gifts.sql
+++ b/sql/job_point_gifts.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `job_point_gifts` (
   `modid` smallint(6) NOT NULL DEFAULT 0,
   `value` tinyint(4) NOT NULL DEFAULT 0,
   `desc` tinytext NOT NULL DEFAULT ''
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 /*!40000 ALTER TABLE `job_point_gifts` DISABLE KEYS */;
 INSERT INTO `job_point_gifts` VALUES (1,5,1,10,'WAR_Physical Defense Bonus');

--- a/sql/job_points.sql
+++ b/sql/job_points.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `job_points` (
   `upgrade` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `jobs` int(10) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`job_pointid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 /*!40000 ALTER TABLE `job_points` DISABLE KEYS */;
 INSERT INTO `job_points` (`job_pointid`, `name`, `upgrade`, `jobs`) VALUES (32, 'mighty_strikes_effect', 2, 1);

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -12,7 +12,7 @@ CREATE TABLE `merits` (
   `upgradeid` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `catagoryid` tinyint(2) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`meritid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `merits`

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -24,7 +24,7 @@ CREATE TABLE `mob_droplist` (
   `itemId` smallint(5) unsigned NOT NULL DEFAULT '0',
   `itemRate` smallint(4) unsigned NOT NULL DEFAULT '0',
   KEY `dropId` (`dropId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=9;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=9;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 -- Variables

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -22,7 +22,7 @@ CREATE TABLE `mob_family_mods` (
   `value` smallint(5) NOT NULL DEFAULT '0',
   `is_mob_mod` boolean NOT NULL DEFAULT '0',
   PRIMARY KEY (`familyid`,`modid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_family_system.sql
+++ b/sql/mob_family_system.sql
@@ -42,7 +42,7 @@ CREATE TABLE `mob_family_system` (
   `detects` smallint(5) NOT NULL DEFAULT 0,
   `charmable` tinyint(2) NOT NULL DEFAULT 0,
   PRIMARY KEY (`familyID`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=128;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=128;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -30,7 +30,7 @@ CREATE TABLE `mob_groups` (
   `maxLevel` tinyint(2) unsigned NOT NULL DEFAULT 0,
   `allegiance` tinyint(2) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`zoneid`,`groupid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=22;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=22;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_pets.sql
+++ b/sql/mob_pets.sql
@@ -23,7 +23,7 @@ CREATE TABLE `mob_pets` (
   `mobname` varchar(24) DEFAULT NULL,
   `petname` varchar(24) DEFAULT NULL,
   PRIMARY KEY (`mob_mobid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -22,7 +22,7 @@ CREATE TABLE `mob_pool_mods` (
   `value` smallint(5) NOT NULL DEFAULT '0',
   `is_mob_mod` boolean NOT NULL DEFAULT '0',
   PRIMARY KEY (`poolid`,`modid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -44,7 +44,7 @@ CREATE TABLE `mob_pools` (
   `skill_list_id` smallint(5) unsigned NOT NULL DEFAULT 0,
   `resist_id` smallint(5) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`poolid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_resistances.sql
+++ b/sql/mob_resistances.sql
@@ -26,7 +26,7 @@ CREATE TABLE `mob_resistances` (
   `light_res_rank` smallint(3) NOT NULL DEFAULT 0,
   `dark_res_rank` smallint(3) NOT NULL DEFAULT 0,
   PRIMARY KEY (`resist_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=128;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=128;
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `mob_skill_lists` (
   `skill_list_id` smallint(5) unsigned NOT NULL,
   `mob_skill_id` smallint(3) unsigned NOT NULL,
   PRIMARY KEY (`skill_list_id`,`mob_skill_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Contenu de la table `mob_skill_lists`

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `mob_skills` (
   `secondary_sc` tinyint(4) NOT NULL DEFAULT '0',
   `tertiary_sc` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`mob_skill_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Table contents for `mob_skills`

--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -22,7 +22,7 @@ CREATE TABLE `mob_spawn_mods` (
   `value` smallint(5) NOT NULL DEFAULT '0',
   `is_mob_mod` boolean NOT NULL DEFAULT '0',
   PRIMARY KEY (`mobid`,`modid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=13 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -23,7 +23,7 @@ CREATE TABLE `mob_spell_lists` (
   `min_level` tinyint(3) unsigned NOT NULL,
   `max_level` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`spell_list_id`,`spell_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/monstrosity_exp_table.sql
+++ b/sql/monstrosity_exp_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `monstrosity_exp_table` (
   `level` tinyint(2) NOT NULL,
   `amount` smallint(4) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`level`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- https://www.bg-wiki.com/ffxi/Category:Monstrosity
 INSERT INTO `monstrosity_exp_table` VALUES (1,300);

--- a/sql/monstrosity_instinct_mods.sql
+++ b/sql/monstrosity_instinct_mods.sql
@@ -4,7 +4,7 @@ CREATE TABLE `monstrosity_instinct_mods` (
   `modId` smallint(5) unsigned NOT NULL,
   `value` smallint(5) NOT NULL DEFAULT 0,
   PRIMARY KEY (`monstrosity_instinct_id`,`modId`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- Rabbit instinct I
 INSERT INTO `monstrosity_instinct_mods` VALUES (3,3,2);   -- HPP: 2

--- a/sql/monstrosity_instincts.sql
+++ b/sql/monstrosity_instincts.sql
@@ -4,7 +4,7 @@ CREATE TABLE `monstrosity_instincts` (
     `cost` smallint(30) unsigned NOT NULL,
     `name` varchar(60) DEFAULT NULL,
     PRIMARY KEY (`monstrosity_instinct_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO `monstrosity_instincts` VALUES (3,2,'Rabbit instinct I');
 INSERT INTO `monstrosity_instincts` VALUES (4,4,'Rabbit instinct II');

--- a/sql/monstrosity_species.sql
+++ b/sql/monstrosity_species.sql
@@ -8,7 +8,7 @@ CREATE TABLE `monstrosity_species` (
     `size` tinyint(3) unsigned NOT NULL, -- 0: small, 1: medium, 2: large
     `look` varbinary(4) NOT NULL,
     PRIMARY KEY (`monstrosity_id`, `monstrosity_species_code`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- TODO: Double check the mjob/sjob values for everything using both resources:
 -- https://ffxiclopedia.fandom.com/wiki/Category:Monipulators

--- a/sql/nm_spawn_points.sql
+++ b/sql/nm_spawn_points.sql
@@ -23,7 +23,7 @@ CREATE TABLE `nm_spawn_points` (
   `pos_y` float(7,3) NOT NULL DEFAULT '0.000',
   `pos_z` float(7,3) NOT NULL DEFAULT '0.000',
   PRIMARY KEY (`mobid`,`pos`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/pet_list.sql
+++ b/sql/pet_list.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `pet_list` (
   `time` int(10) unsigned NOT NULL DEFAULT '0',
   `element` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`petid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Contenu de la table `pet_list`

--- a/sql/pet_name.sql
+++ b/sql/pet_name.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS `pet_name` (
   `id` smallint(3) unsigned NOT NULL,
   `name` char(15) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=Aria  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 INSERT INTO `pet_name` VALUES (0,'');
 INSERT INTO `pet_name` VALUES (1,'Azure');

--- a/sql/pet_skills.sql
+++ b/sql/pet_skills.sql
@@ -36,7 +36,7 @@ CREATE TABLE `pet_skills` (
   `secondary_sc` tinyint(4) NOT NULL DEFAULT 0,
   `tertiary_sc` tinyint(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`pet_skill_id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Table contents for `pet_skills`

--- a/sql/skill_caps.sql
+++ b/sql/skill_caps.sql
@@ -25,7 +25,7 @@ CREATE TABLE `skill_caps` (
   `r12` smallint(3) unsigned NOT NULL DEFAULT '0',
   `r13` smallint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`level`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=32 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=32 PACK_KEYS=1;
 
 --
 -- Dumping data for table `skill_caps`

--- a/sql/skill_ranks.sql
+++ b/sql/skill_ranks.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `skill_ranks` (
   `geo` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `run` tinyint(2) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`skillid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=44 PACK_KEYS=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=44 PACK_KEYS=1;
 
 --
 -- Contenu de la table `skill_ranks`

--- a/sql/skillchain_damage_modifiers.sql
+++ b/sql/skillchain_damage_modifiers.sql
@@ -9,7 +9,7 @@ CREATE TABLE `skillchain_damage_modifiers` (
   `initial_modifier` int(3) NOT NULL DEFAULT '1',
   `magic_burst_modifier` int(3) NOT NULL DEFAULT '1',
   PRIMARY KEY (`chain_level`,`chain_count`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Records of skillchain_damage_modifiers

--- a/sql/spell_list.sql
+++ b/sql/spell_list.sql
@@ -42,7 +42,7 @@ CREATE TABLE `spell_list` (
   `spell_range` smallint(3) unsigned NOT NULL DEFAULT '0',
   `content_tag` varchar(7) DEFAULT NULL,
   PRIMARY KEY (`spellid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=68;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=68;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -29,7 +29,7 @@ CREATE TABLE `status_effects` (
   `min_duration` smallint(5) unsigned NOT NULL DEFAULT 0,
   `sort_key` smallint(5) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -47,7 +47,7 @@ CREATE TABLE `synth_recipes` (
   `ResultHQ3Qty` tinyint(2) unsigned NOT NULL,
   `ResultName` tinytext NOT NULL,
   PRIMARY KEY (`ID`)
-) ENGINE=Aria AUTO_INCREMENT=3500 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=79;
+) ENGINE=Aria TRANSACTIONAL=0 AUTO_INCREMENT=3500 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=79;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 DELIMITER $$

--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -27,7 +27,7 @@ CREATE TABLE `traits` (
   `content_tag` varchar(7) DEFAULT NULL,
   `meritid` smallint(5) NOT NULL DEFAULT 0,
   PRIMARY KEY (`traitid`,`job`,`level`,`rank`,`modifier`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/transport.sql
+++ b/sql/transport.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS `transport` (
   `time_anim_depart` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `zone` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Contenu de la table `transport`

--- a/sql/water_points.sql
+++ b/sql/water_points.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `water_points` (
   `pos_y` float(7,2) NOT NULL DEFAULT '0.00',
   `pos_z` float(7,2) NOT NULL DEFAULT '0.00',
   PRIMARY KEY (`waterid`)
-) ENGINE=Aria  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Contenu de la table `water_points`

--- a/sql/weapon_skills.sql
+++ b/sql/weapon_skills.sql
@@ -33,7 +33,7 @@ CREATE TABLE `weapon_skills` (
   `main_only` tinyint(1) NOT NULL DEFAULT '0',
   `unlock_id` tinyint(2) NOT NULL DEFAULT '0',
   PRIMARY KEY (`weaponskillid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/zone_settings.sql
+++ b/sql/zone_settings.sql
@@ -30,7 +30,7 @@ CREATE TABLE `zone_settings` (
   `tax` float(5,2) unsigned NOT NULL DEFAULT '0.00',
   `misc` smallint(5) unsigned NOT NULL DEFAULT '0', -- ZONEMISC in zone.h
   PRIMARY KEY (`zoneid`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=20 PACK_KEYS=1 CHECKSUM=1;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AVG_ROW_LENGTH=20 PACK_KEYS=1 CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/zone_weather.sql
+++ b/sql/zone_weather.sql
@@ -21,7 +21,7 @@ CREATE TABLE `zone_weather` (
   `weather` varbinary(4320) DEFAULT NULL,
   PRIMARY KEY (`zone`),
   UNIQUE KEY `zone` (`zone`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/zonelines.sql
+++ b/sql/zonelines.sql
@@ -13,7 +13,7 @@ CREATE TABLE `zonelines` (
   `toz` float(7,3) NOT NULL DEFAULT'0.000',
   `rotation` tinyint(3) unsigned NOT NULL DEFAULT'0',
   PRIMARY KEY (`zoneline`)
-) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Records of zonelines


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sets Aria tables to not be "transactional." (In this context, transactional just means crash-safe.)

Crash-safeness doesn't really matter for these tables, and the switch to Aria _massively_ slowed down imports. Here's some numbers representing a whole DB import:

MyISAM (old):
![myisam](https://github.com/LandSandBoat/server/assets/2593549/0d654811-032c-4be0-adea-4d1fc60fa1bb)

Aria crash-safe (current) 👀:
![aria transactional](https://github.com/LandSandBoat/server/assets/2593549/1f4e1a85-6cf0-4384-8028-f8b2631b1584)

Aria transactional=0 (this PR):
![aria no transactional](https://github.com/LandSandBoat/server/assets/2593549/96df3c32-bfcc-45cb-ac92-c50b01459fc1)

Yeah that's over an hour to import.

I think this is a reasonable change, but open to any other ideas.

See:
https://mariadb.com/kb/en/aria-storage-engine/

## Steps to test these changes

Run a dbtool full update.
