### PR TITLE
Move Ashu Talif Captain logic into helper function, call in onMobEngaged

### DIFF
--- a/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Captain.lua
+++ b/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Captain.lua
@@ -6,8 +6,39 @@ local ID = zones[xi.zone.THE_ASHU_TALIF]
 -----------------------------------
 local entity = {}
 
+local captainEngageSequence = function(mob)
+    local jumped = mob:getLocalVar('jump')
+    local ready = mob:getLocalVar('ready')
+
+    -- Becomes ready when the Crew is engaged. Jump down!
+    if ready == 1 and jumped == 0 then
+        mob:setLocalVar('jump', 1)
+        mob:showText(mob, ID.text.OVERPOWERED_CREW)
+        mob:hideName(true)
+        mob:entityAnimationPacket('jmp0')
+        mob:timer(2000, function(m)
+            m:setPos(0, -22, 13, 192)
+            m:entityAnimationPacket('jmp1')
+            m:showText(mob, ID.text.TEST_YOUR_BLADES)
+            m:timer(2000, function(mAnimation)
+                mAnimation:hideName(false)
+                mAnimation:setUntargetable(false)
+            end)
+        end)
+    end
+end
+
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
+end
+
+entity.onMobEngaged = function(mob, target)
+    captainEngageSequence(mob)
+end
+
+entity.onMobRoam = function(mob)
+    -- failsafe in case of party wipe/reraise
+    captainEngageSequence(mob)
 end
 
 entity.onMobFight = function(mob, target)
@@ -29,29 +60,6 @@ entity.onMobFight = function(mob, target)
             m:showText(m, ID.text.FOR_THE_BLACK_COFFIN)
         end
     end)
-end
-
-entity.onMobRoam = function(mob)
-    local jumped = mob:getLocalVar('jump')
-    local ready = mob:getLocalVar('ready')
-
-    -- Becomes ready when the Crew is engaged. Jump down!
-    if ready == 1 and jumped == 0 then
-        mob:showText(mob, ID.text.OVERPOWERED_CREW)
-        mob:hideName(true)
-        mob:entityAnimationPacket('jmp0')
-        mob:timer(2000, function(m)
-            m:setPos(0, -22, 13, 192)
-            m:entityAnimationPacket('jmp1')
-            m:showText(mob, ID.text.TEST_YOUR_BLADES)
-            m:timer(2000, function(mAnimation)
-                mAnimation:hideName(false)
-                mAnimation:setUntargetable(false)
-            end)
-        end)
-
-        mob:setLocalVar('jump', 1)
-    end
 end
 
 entity.onMobDisengage = function(mob, target)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Placed the captain's logic in a new local function then called that function from his engaged and roam states. The mob does not roam upon spawn as he spawns engaged to the player or Gessho so as is the fight is bugged and cannot be completed.

Closes #4890 
Closes #4790 

## Steps to test these changes

Set TOAU mission progress to being on The Black Coffin or later.
`!addkeyitem 786 (player) `to add the Ephramadian Gold Coin.
`!zone 54` puts you right in front of the Cutter.
Start The Black Coffin fight.
Complete phase 1 by killing all 5 of the crew members.
Upon the start of phase 2, the captain should say his lines of dialogue, do his jump animation, and begin attacking either Gessho or the player. He should be able to be targetted/attacked.
