### PR TITLE
[LUA] Aymur listeners to enhance sic/ready with bonus tp

### DIFF
--- a/scripts/items/aymur.lua
+++ b/scripts/items/aymur.lua
@@ -1,0 +1,62 @@
+-----------------------------------
+-- Aymur
+-- BST mythic
+-- Enhances "Sic" and "Ready" effect
+-----------------------------------
+
+local itemObject = {}
+
+local addPetListener = function(pet)
+    pet:addListener('WEAPONSKILL_BEFORE_USE', 'AYMUR_ABILITY', function()
+        if pet:getMaster() then -- ensure we don't keep giving TP after charm wears off
+            if pet:getPetID() == 0 then -- charmed pets do not have petID
+                -- give remaining 500 tp just before ability
+                pet:addTP(500)
+            else
+                pet:addTP(1000)
+            end
+        else
+            pet:removeListener('AYMUR_ABILITY')
+        end
+    end)
+end
+
+itemObject.onItemEquip = function(target, item)
+    if item:getID() == 18979 then
+        return
+    end
+
+    local playerPet = target:getPet()
+    if playerPet then
+        addPetListener(playerPet)
+    end
+
+    target:addListener('ABILITY_USE', 'AYMUR_CREATE_PET', function(playerArg, targetArg, ability, action)
+        local pet = playerArg:getPet()
+        if pet then
+            if
+                ability:getID() == xi.jobAbility.CHARM or
+                ability:getID() == xi.jobAbility.CALL_BEAST
+            then
+                addPetListener(pet)
+            end
+        end
+
+        if ability:getID() == xi.jobAbility.SIC then
+            if pet:getPetID() == 0 then-- charmed pets do not have petID
+                -- give 500 tp to use an ability sooner
+                pet:addTP(500)
+            end
+        end
+    end)
+end
+
+itemObject.onItemUnequip = function(target, item)
+    target:removeListener('AYMUR_CREATE_PET')
+    local pet = target:getPet()
+    if pet then
+        pet:removeListener('AYMUR_ABILITY')
+    end
+end
+
+return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

A bit of trickery due to the flow of abilities with sic and ready, but a works well regardless.

Enhances "Sic" and "Ready" effect gives +500 tp immediately and 500 tp is added to the ability. This is done via a listener on the player and a listener on the pet. 

Player Listener:
- gives 500 tp immediately to charmed pets upon usage of `SIC`
- adds listener to pet if not already there

Pet listener:
- just before using any skill, if it's a jug pet, give 1000 TP
- if it's a charmed pet, give the remaining 500 TP

On item unequip, remove both listeners

## Steps to test these changes

To test, i added prints _everywhere_.

Inside `aymur.lua`:
- i added a print at the beginning and end of the pet's listener to confirm how much TP is being added
- Added one at each level of onItemEquip to confirm listeners were being added at the appropriate times
- finally printed ability:getID and ability:getRecastID to confirm the recastID of ready abilities (note that giving tp in player's `ABILITY_USE` is too late, as the pet readies its ability before `ABILITY_USE` is called, but `ABILITY_USE` is the only place in the chain you can see that the player used an ability with `recastID == 102`. This ended up being ok as the ready abilites are for jug pets, and those are perfectly fine getting the full 1000 tp in the pet's listener, but noteworthy discovery I think)

outside of all the obvious places in `aymur.lua`, i added to `foot_kick.lua` to `print(skill:getTP())` just to confirm we were getting the tp for a jug pet actualized in the skill.
