### PR TITLE
Table some optional parameters for `phOnDespawn()`

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -32,9 +32,24 @@ local function lotteryPrimed(phList)
 end
 
 -- potential lottery placeholder was killed
-xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
-    if type(immediate) ~= 'boolean' then
-        immediate = false
+xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, params)
+    params = params or {}
+    --[[
+        params = { immediate   = true }    pop NM without waiting for next PH pop time
+        params = { nightOnly   = true }    spawn NM only at night time
+        params = { noPosUpdate = true }    do not run UpdateNMSpawnPoint()
+    ]]
+
+    if type(params.immediate) ~= 'boolean' then
+        params.immediate = false
+    end
+
+    if type(params.nightOnly) ~= 'boolean' then
+        params.nightOnly = false
+    end
+
+    if type(params.noPosUpdate) ~= 'boolean' then
+        params.noPosUpdate = false
     end
 
     if xi.settings.main.NM_LOTTERY_CHANCE then
@@ -54,17 +69,37 @@ xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
             local pop = nm:getLocalVar('pop')
 
             chance = math.ceil(chance * 10) -- chance / 1000.
+
             if
                 os.time() > pop and
                 not lotteryPrimed(phList) and
                 math.random(1, 1000) <= chance
             then
+                local nextRepopTime = os.time() + GetMobRespawnTime(phId)
+                -- That's earth time, subtract SE epoch to get Vanatime
+                nextRepopTime = nextRepopTime - 1009810800
+                -- The enum bakes in a multiplication of 2.4, gotta reverse that to get accurate hour
+                local nextRepopDate = (nextRepopTime / 60 * 25) + 886 * (xi.vanaTime.YEAR / 2.4)
+                local nextRepopHour = (nextRepopDate % (xi.vanaTime.DAY / 2.4)) / (xi.vanaTime.HOUR / 2.4)
+                -- If the NM is night only and spawn would happen during the day, bail out
+                if
+                    params.nightOnly and
+                    nextRepopHour >= 4 and
+                    nextRepopHour < 20
+                then
+                    return false
+                end
 
                 -- on PH death, replace PH repop with NM repop
                 DisallowRespawn(phId, true)
                 DisallowRespawn(nmId, false)
-                UpdateNMSpawnPoint(nmId)
-                nm:setRespawnTime(immediate and 1 or GetMobRespawnTime(phId)) -- if immediate is true, spawn the nm immediately (1ms) else use placeholder's timer
+
+                if not params.noPosUpdate then
+                    UpdateNMSpawnPoint(nmId)
+                end
+
+                -- if params.immediate is true, spawn the nm params.immediately (1ms) else use placeholder's timer
+                nm:setRespawnTime(params.immediate and 1 or GetMobRespawnTime(phId))
 
                 nm:addListener('DESPAWN', 'DESPAWN_' .. nmId, function(m)
                     -- on NM death, replace NM repop with PH repop

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -35,9 +35,9 @@ end
 xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, params)
     params = params or {}
     --[[
-        params = { immediate   = true }    pop NM without waiting for next PH pop time
-        params = { nightOnly   = true }    spawn NM only at night time
-        params = { noPosUpdate = true }    do not run UpdateNMSpawnPoint()
+        params.immediate   = true    pop NM without waiting for next PH pop time
+        params.nightOnly   = true    spawn NM only at night time
+        params.noPosUpdate = true    do not run UpdateNMSpawnPoint()
     ]]
 
     if type(params.immediate) ~= 'boolean' then
@@ -106,7 +106,11 @@ xi.mob.phOnDespawn = function(ph, phList, chance, cooldown, params)
                     DisallowRespawn(nmId, true)
                     DisallowRespawn(phId, false)
                     GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId))
-                    m:setLocalVar('pop', os.time() + cooldown)
+
+                    if m:getLocalVar('doNotInvokeCooldown') == 0 then
+                        m:setLocalVar('pop', os.time() + cooldown)
+                    end
+
                     m:removeListener('DESPAWN_' .. nmId)
                 end)
 

--- a/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
@@ -4,6 +4,15 @@
 -----------------------------------
 local entity = {}
 
+entity.onMobRoam = function(mob)
+    -- Since DisallowRespawn() doesn't care about SPAWNTYPE_NIGHT we have to get creative
+    local totd = VanadielTOTD()
+    if totd ~= xi.time.NIGHT and totd ~= xi.time.MIDNIGHT then
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+        DespawnMob(mob:getID())
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 278)
 end

--- a/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
@@ -11,7 +11,9 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.CITIPATI_PH, 20, math.random(10800, 21600)) -- 3 to 6 hours
+    local params = {}
+    params.nightOnly = true
+    xi.mob.phOnDespawn(mob, ID.mob.CITIPATI_PH, 20, math.random(10800, 21600), params) -- 3 to 6 hours, night only
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Thug.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Thug.lua
@@ -11,7 +11,10 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, { [ID.mob.MAGICKED_BONES - 2] = ID.mob.MAGICKED_BONES }, 50, 1) -- { [Goblin Thug] = Club_Magicked_Bones }
+    -- This is a work around until "spawn slots" are a thing
+    local params = {}
+    params.nightOnly = true
+    xi.mob.phOnDespawn(mob, { [ID.mob.MAGICKED_BONES - 2] = ID.mob.MAGICKED_BONES }, 50, 1, params) -- { [Goblin Thug] = Club_Magicked_Bones }
 end
 
 return entity

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Weaver.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Weaver.lua
@@ -11,7 +11,10 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, { [ID.mob.MAGICKED_BONES - 1] = ID.mob.MAGICKED_BONES + 1 }, 50, 1) -- { [Goblin Weaver] = Dagger_Magicked_Bones }
+    -- This is a work around until "spawn slots" are a thing
+    local params = {}
+    params.nightOnly = true
+    xi.mob.phOnDespawn(mob, { [ID.mob.MAGICKED_BONES - 1] = ID.mob.MAGICKED_BONES + 1 }, 50, 1, params) -- { [Goblin Weaver] = Dagger_Magicked_Bones }
 end
 
 return entity

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -16,7 +16,9 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    if xi.mob.phOnDespawn(mob, ID.mob.DESPOT_PH, 5, 7200, true) then -- 2 hours
+    local params = {}
+    params.immediate = true
+    if xi.mob.phOnDespawn(mob, ID.mob.DESPOT_PH, 5, 7200, params) then -- 2 hours
         local phId = mob:getID()
         local nmId = ID.mob.DESPOT_PH[phId]
         GetMobByID(nmId):addListener('SPAWN', 'PH_VAR', function(m)

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
@@ -11,7 +11,9 @@ entity.onMobRoam = function(mob)
     local weather = mob:getWeather()
 
     if weather == xi.weather.RAIN or weather == xi.weather.SQUALL then
-        if xi.mob.phOnDespawn(mob, ID.mob.NOBLE_MOLD_PH, 100, math.random(43200, 57600), true) then -- 12 to 16 hours
+        local params = {}
+        params.immediate = true
+        if xi.mob.phOnDespawn(mob, ID.mob.NOBLE_MOLD_PH, 100, math.random(43200, 57600), params) then -- 12 to 16 hours
             local p = mob:getPos()
             GetMobByID(ID.mob.NOBLE_MOLD):setSpawn(p.x, p.y, p.z, p.rot)
             DespawnMob(mob:getID())

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1426,7 +1426,7 @@ namespace luautils
     /************************************************************************
      *                                                                       *
      * NextGameTime - Returns System Time for the next Vana'diel interval    *
-     * See: VTIME_x defintions, or xi.vanaType for the values to pass        *
+     * See: VTIME_x definitions, or xi.vanaTime for the values to pass       *
      *                                                                       *
      ************************************************************************/
     uint32 NextGameTime(uint32 intervalSeconds)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Tables some optional parameters for `phOnDespawn()`
- Also adds new check for nighttime only NMs, because `disallowRespawn()` bypasses that spawnType.
- And another to not call UpdateNMSpawnPoint() because that errors on the ones that we should not be using it on in the 1st place. 

All the _required_ args still live outside the table. anything that is optional and can be fully omitted will live in the params table.

Have additionally introduced a localVar method of preventing cooldown trigger on mobs that were not actually fought. default behavior is exactly as it was before this since non existing variable return 0. An example usage lives in citipati.lua

## Steps to test these changes
cooldown avoidance:
- go to attohwa chasm at night, kill corses till citipati spawns. Leave him up till daytime and watch him despawn
- after he despawns note that he is still "lottery primed" to pop again.

`params.nightOnly`:
- copy the same params in the corses script over to any NM placeholder that spawns during day (corses do not), lets say rock lizards.
- crank pop rate to 100% for the test
- note the NM will not pop in daytime (4:00 to 20:00)
- retest after night, notice NM spawn right away

`params.noPosUpdate`:
- You might want to do this at the same time as the nightOnly test. Spawn the same NM repeatedly, notice its position is not being updated. In several cases this is desired behavior either because positioning is handled in script or because the mob simply doe snot HAVE multiple locations - in any case if there are no entries in the NM spawn pos table the function that updates the NMs spawn position will error. Having this parameter set simply prevents that from being attempted.

`params.immediate`:
- This used to be a stand alone argument. its merely been tabled.
- To verify its still working, go to sky and kill groundskeepers till you get Despot