### PR TITLE
[SQL] Oneiros grip latent mpp was greater than 100

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2262,7 +2262,7 @@ INSERT INTO `item_latents` VALUES (18771,23,1,16,6);     -- ATT +1~4,party size 
 -- INSERT INTO `item_latents` VALUES (18776,355,10,?,13);     -- Final Heaven available after 13 weapon skills
 
 -- Oneiros Grip
-INSERT INTO `item_latents` VALUES (18811,369,1,4,750);  -- Refresh MP <= 75%
+INSERT INTO `item_latents` VALUES (18811,369,1,4,75);  -- Refresh MP <= 75%
 
 -- Perdu Wand
 INSERT INTO `item_latents` VALUES (18850,23,14,6,1000);  -- Attack+14 while TP <100%


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Confirmed via code but also loaded up server to confirm. latentid 4 is real mpp, so oneiros grip was giving refresh if mp % was less than 750... so all the time

## Steps to test these changes

Equip oneiros grip and see `!getmod refresh` increment only after dipping below 75% mp