### PR TITLE
Do not consume ammo with Unlimited Shot active

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1831,11 +1831,15 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
         recycleChance += this->PJobPoints->GetJobPointValue(JP_AMMO_CONSUMPTION);
 
-        // Only remove unlimited shot on hit
-        if (hitOccured && this->StatusEffectContainer->HasStatusEffect(EFFECT_UNLIMITED_SHOT))
+        if (this->StatusEffectContainer->HasStatusEffect(EFFECT_UNLIMITED_SHOT))
         {
-            StatusEffectContainer->DelStatusEffect(EFFECT_UNLIMITED_SHOT);
+            // Never consume ammo with Unlimited Shot active
             recycleChance = 100;
+            // Only remove unlimited shot on hit
+            if (hitOccured)
+            {
+                StatusEffectContainer->DelStatusEffect(EFFECT_UNLIMITED_SHOT);
+            }
         }
 
         if (PAmmo != nullptr && xirand::GetRandomNumber(100) > recycleChance)


### PR DESCRIPTION
Also do not consume Unlimited Shot if RA missed

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Unlimited shot currently is coded to only prevent consumption of ammo on a landed Ranged Attack. The buff is preserved if the attack misses (correctly), but it should _also_ not consume the ammo if the attack misses. This resolves the latter.

https://ffxiclopedia.fandom.com/wiki/Unlimited_Shot

> Duration: 1:00 or One Successful Ranged Attack

and 

> Once activated, this ability will remain in effect until you successfully hit your mark.

## Steps to test these changes

Use Unlimited Shot and equip a single pebble as level 1, throw at a high level mob to see that the pebble is not consumed nor is the buff consumed. Throw until it lands (or enable godmode to speed that part up) to see that Unlimited Shot buff wears, but the pebble is _still_ not consumed on that particular throw. Throw once more to see the pebble consumed as normal