### PR TITLE
[Magic] Implement player Death damage

### DIFF
--- a/scripts/actions/spells/black/death.lua
+++ b/scripts/actions/spells/black/death.lua
@@ -1,30 +1,63 @@
 -----------------------------------
 -- Spell: Death
--- Consumes all MP. Has a chance to knock out the target. If Death fails to knock out the target, it
--- will instead deal darkness damage. Ineffective against undead.
+-- Has a chance to insta-kill the target. Ineffective against undead or notorious monsters.
+-- (Player only) Consumes all MP no matter what.
+-- (Player only) If Death fails to knock out the target, it will instead deal darkness damage.
 -----------------------------------
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
     spell:setFlag(xi.magic.spellFlag.IGNORE_SHADOWS)
+
     return 0
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    if
-        target:isUndead() or
-        target:hasStatusEffect(xi.effect.MAGIC_SHIELD) or
-        -- Todo: DeathRes has no place in the resistance functions so far..
-        math.random(1, 100) <= target:getMod(xi.mod.DEATHRES)
-    then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    -- Player spell.
+    if caster:isPC() then
+        local instaDeath = false
+        local result     = 0
+
+        -- Insta-death calculations.
+        if
+            not target:isUndead() and
+            not target:isNM() and
+            not target:hasStatusEffect(xi.effect.MAGIC_SHIELD)
+        then
+            local magicAcc     = xi.combat.magicHitRate.calculateActorMagicAccuracy(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, xi.element.DARK, 0, 0)
+            local magicEva     = xi.combat.magicHitRate.calculateTargetMagicEvasion(caster, target, xi.element.DARK, true, 0, 0)
+            local magicHitRate = utils.clamp(xi.combat.magicHitRate.calculateMagicHitRate(magicAcc, magicEva), 5, 30) -- Sources suggest a 30% max rate for players.
+            local resistRate   = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.skill.DARK_MAGIC, xi.element.DARK, magicHitRate, 0)
+
+            if resistRate == 1 then
+                instaDeath = true
+            end
+        end
+
+        if instaDeath then
+            spell:setMsg(xi.msg.basic.FALL_TO_GROUND)
+            target:setHP(0)
+        else
+            spell:setMsg(xi.msg.basic.MAGIC_DMG)
+            result = xi.spells.damage.useDamageSpell(caster, target, spell)
+        end
+
+        -- Handle MP comsumption. It bypasses "conserve MP" and any other form of mp reduction.
+        caster:setMP(0)
+
+        return result
+
+    -- Not-player spell.
+    else
+        if math.random(1, 100) <= target:getMod(xi.mod.DEATHRES) then
+            spell:setMsg(xi.msg.basic.FALL_TO_GROUND)
+            target:setHP(0)
+        else
+            spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+        end
+
         return 0
     end
-
-    spell:setMsg(xi.msg.basic.FALL_TO_GROUND)
-    target:setHP(0)
-
-    return 0
 end
 
 return spellObject

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -81,6 +81,7 @@ local pTable =
     [xi.magic.spell.FLOOD       ] = { xi.mod.INT,    0,  552,    2,  700, 657,   2,    2,    2,    2,    2,    2,    2 },
     [xi.magic.spell.FLOOD_II    ] = { xi.mod.INT,   10,  710,    2,  800, 780,   2,    2,    2,    2,    2,    2,    2 },
     [xi.magic.spell.COMET       ] = { xi.mod.INT,    0,  964,  2.3, 1000, 850,   4, 3.75,  3.5,    3,    2,    1,    1 }, -- I value unknown. Guesstimate used.
+    [xi.magic.spell.DEATH       ] = {          0,    0,   32,    0,   32,   0,   0,    0,    0,    0,    0,    0,    0 },
 
 -- Multiple target spells:
 --                                     1          2     3     4      5      6   7    8    9     10    11    12    13
@@ -288,6 +289,13 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, skillTy
     -- No negative base damage value allowed.
     if spellDamage < 0 then
         spellDamage = 0
+    end
+
+    -----------------------------------
+    -- STEP 5: Exceptions
+    -----------------------------------
+    if spellId == xi.magic.spell.DEATH then
+        spellDamage = baseSpellDamage + caster:getMP() * 3
     end
 
     return spellDamage


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Separates logic for Death when used by players.
- (Player only) Implements death as a nuke when insta-kill fails.
- (Player only) Makes player death insta-kill trigger as shitty as retail. Or worse.
- (Player only) Makes spell consume all your MP, no matter what.

## Steps to test these changes

Get BLM job point death spell. Cast it. See it consume all your MP and either do damage or, sometimes, insta-kill an enemy.
