### PR TITLE
[SQL] set scouts beret to 25 recycle chance

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -25205,7 +25205,7 @@ INSERT INTO `item_mods` VALUES (15082,1,24);  -- DEF: 24
 INSERT INTO `item_mods` VALUES (15082,2,15);  -- HP: 15
 INSERT INTO `item_mods` VALUES (15082,13,4);  -- MND: 4
 INSERT INTO `item_mods` VALUES (15082,27,-3); -- ENMITY: -3
-INSERT INTO `item_mods` VALUES (15082,305,5); -- RECYCLE: 5
+INSERT INTO `item_mods` VALUES (15082,305,25); -- RECYCLE: 25
 
 -- Saotome Kabuto
 INSERT INTO `item_mods` VALUES (15083,1,25);  -- DEF: 25
@@ -26287,7 +26287,7 @@ INSERT INTO `item_mods` VALUES (15255,1,25);  -- DEF: 25
 INSERT INTO `item_mods` VALUES (15255,2,15);  -- HP: 15
 INSERT INTO `item_mods` VALUES (15255,13,5);  -- MND: 5
 INSERT INTO `item_mods` VALUES (15255,27,-4); -- ENMITY: -4
-INSERT INTO `item_mods` VALUES (15255,305,5); -- RECYCLE: 5
+INSERT INTO `item_mods` VALUES (15255,305,25); -- RECYCLE: 25
 
 -- Saotome Kabuto +1
 INSERT INTO `item_mods` VALUES (15256,1,26);  -- DEF: 26


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Scout's Beret and Scout's Beret +1 to have a 25% recycle chance, which matches Scout's Beret +2's current value.

https://ffxiclopedia.fandom.com/wiki/Scout's_Beret Wiki puts it at 20-30% which is likely where the 25% on Scout's Beret +2 comes from. My theory for what happened is that someone put the original 5 recycle under the assumption that each recycle merit was 5%. It might have been right a long time ago and then been refactored, but the item mod never got updated. Or someone just typed it in wrong, who knows!

## Steps to test these changes

!additem 15082
!additem 15255
I fired 20 arrows with only Scout's Beret +1 equipped and only used up 13.
