### PR TITLE
[Interaction] Fix event parameter on Windurst 8-2

### DIFF
--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -13,7 +13,7 @@
 -- Tosuka-Porika    : !pos -26 -6 103 238
 -- Kupipi           : !pos 2 0.1 30 242
 -- Shantotto        : !pos 122 -2 112 239
--- _5e5 (Cr. Wall)  : !pos -424.255 -1.909 619.995 194
+-- _5e5 (Cr. Wall)  : !pos -423 0 619.75 194
 -- _5cb (Gate. Drk) : !pos -228 0 99 192
 -----------------------------------
 local outerHorutotoID = zones[xi.zone.OUTER_HORUTOTO_RUINS]
@@ -337,7 +337,7 @@ mission.sections =
 
         [xi.zone.WINDURST_WALLS] =
         {
-            ['Shantotto'] = mission:progressEvent(399, 0, 0, 282),
+            ['Shantotto'] = mission:progressEvent(399, 0, 0, 0, xi.ki.GLOVE_OF_PERPETUAL_TWILIGHT),
 
             onEventFinish =
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Imported from ASB: https://github.com/AirSkyBoat/AirSkyBoat/pull/3695

- Fix (adds) missing parameter.
- Uses Key item enum for parameter value.
- Makes !pos for cracked wall more convenient.

## Steps to test these changes

Set your mission, to Windurst 8-2, get to the event and see the KI being properly referenced in game.
