### PR TITLE
Fixes an issue where Jeuno conquest NPCs wouldn't give Conquest titles.

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1409,7 +1409,7 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
 
             player:delCP(price)
             if stock.rank ~= nil then
-                player:setTitle(titlesGranted[guardNation][stock.rank])
+                player:setTitle(titlesGranted[pNation][stock.rank])
             end
         end
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where Jeuno Conquest NPCs would throw an error in the game log instead of changing the character's title when purchasing conquest rewards that require a rank. Previously, it was using the guard's nation to do the title lookup, this PR just changes that to use the player character's nation instead.

## Steps to test these changes

### Before
Give yourself a relevant nation rank and some CP. Try to buy a CP item that requires a minimum rank from a conquest NPC in Jeuno such as Alrauverat in Lower. The log should show something like this:

```
[01/23/24 22:08:15:662][map][error] luautils::onEventFinish .\scripts/globals/conquest.lua:1412: attempt to index a nil value
stack traceback:
        .\scripts/globals/conquest.lua:1412: in function 'overseerOnEventFinish'
        ./scripts/zones/Lower_Jeuno/npcs/Alrauverat.lua:25: in function 'fallbackHandler'
        .\scripts/globals/interaction/interaction_lookup.lua:400: in function <.\scripts/globals/interaction/interaction_lookup.lua:378> (luautils::OnEventFinish:2158)
```

Additionally, the character's title is not changed.

### After
Repeat the process as before, but no error is thrown and the character's title should change.