### PR TITLE
[SQL][Items] Item mods 19029-20625

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2484,6 +2484,15 @@ INSERT INTO `item_latents` VALUES (20540,23,10,6,1000);      -- Att+10 TP<1000
 INSERT INTO `item_latents` VALUES (20540,25,15,6,1000);      -- Acc+39 (24 normal, +15 more) TP<1000
 INSERT INTO `item_latents` VALUES (20540,287,4,6,1000);      -- Dmg+4  TP<1000
 
+-- Eminent Dagger
+INSERT INTO `item_latents` VALUES (20624,23,10,6,1000);  -- TP_UNDER: 1000 - ATT: 10
+INSERT INTO `item_latents` VALUES (20624,25,39,6,1000);  -- TP_UNDER: 1000 - ACC: 39
+INSERT INTO `item_latents` VALUES (20624,287,89,6,1000); -- TP_UNDER: 1000 - DMG_RATING: 89
+
+-- Surcoufs Jambiya +1
+INSERT INTO `item_latents` VALUES (20628,287,85,56,0);  -- WEAPON_DRAWN_MP_OVER: 0 - DMG_RATING: 85
+INSERT INTO `item_latents` VALUES (20628,369,-10,56,0); -- WEAPON_DRAWN_MP_OVER: 0 - REFRESH: -10
+
 -- Eminent Scimitar
 INSERT INTO `item_latents` VALUES (20726,23,10,6,1000);      -- Att+10 TP>1000
 INSERT INTO `item_latents` VALUES (20726,25,15,6,1000);      -- Acc+15 TP>1000

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -38665,6 +38665,9 @@ INSERT INTO `item_mods` VALUES (19027,165,3); -- CRITHITRATE: 3
 INSERT INTO `item_mods` VALUES (19028,5,23);  -- MP: 23
 INSERT INTO `item_mods` VALUES (19028,168,5); -- SPELLINTERRUPT: 5
 
+-- Brave Grip
+INSERT INTO `item_mods` VALUES (19029,421,3); -- CRIT_DMG_INCREASE: 3
+
 -- Wise Strap
 INSERT INTO `item_mods` VALUES (19030,562,3); -- MAGIC_CRITHITRATE: 3
 
@@ -39529,6 +39532,18 @@ INSERT INTO `item_mods` VALUES (19297,11,5); -- AGI: 5
 INSERT INTO `item_mods` VALUES (19298,9,10);  -- DEX: 10
 INSERT INTO `item_mods` VALUES (19298,68,10); -- EVA: 10
 
+-- Aisa
+INSERT INTO `item_mods` VALUES (19299,11,3); -- AGI:  3
+INSERT INTO `item_mods` VALUES (19299,30,2); -- MACC: 2
+
+-- Aisa +1
+INSERT INTO `item_mods` VALUES (19300,11,4); -- AGI:  4
+INSERT INTO `item_mods` VALUES (19300,30,3); -- MACC: 3
+
+-- Kawasemi
+INSERT INTO `item_mods` VALUES (19301,9,5);  -- DEX: 5
+INSERT INTO `item_mods` VALUES (19301,68,5); -- EVA: 5
+
 -- Uguisu
 INSERT INTO `item_mods` VALUES (19302,23,5);  -- ATT: 5
 INSERT INTO `item_mods` VALUES (19302,25,5);  -- ACC: 5
@@ -40105,6 +40120,24 @@ INSERT INTO `item_mods` VALUES (19739,73,4);  -- STORETP: 4
 -- Stoertebeker
 INSERT INTO `item_mods` VALUES (19740,26,7); -- RACC: 7
 
+-- Handgonne
+INSERT INTO `item_mods` VALUES (19741,26,7);  -- RACC: 7
+INSERT INTO `item_mods` VALUES (19741,305,5); -- RECYCLE: 5
+
+-- Handgonne +1
+INSERT INTO `item_mods` VALUES (19742,26,8);  -- RACC: 8
+INSERT INTO `item_mods` VALUES (19742,305,6); -- RECYCLE: 6
+
+-- Opprimo
+INSERT INTO `item_mods` VALUES (19743,24,9);  -- RATT: 9
+INSERT INTO `item_mods` VALUES (19743,26,6);  -- RACC: 6
+INSERT INTO `item_mods` VALUES (19743,27,-3); -- ENMITY: -3
+
+-- Opprimo +1
+INSERT INTO `item_mods` VALUES (19744,24,10); -- RATT: 10
+INSERT INTO `item_mods` VALUES (19744,26,7);  -- RACC: 7
+INSERT INTO `item_mods` VALUES (19744,27,-4); -- ENMITY: -4
+
 -- Spharai
 INSERT INTO `item_mods` VALUES (19746,23,40);   -- ATT: 40
 INSERT INTO `item_mods` VALUES (19746,256,1);   -- AFTERMATH: 1
@@ -40311,6 +40344,42 @@ INSERT INTO `item_mods` VALUES (19780,5,20); -- MP: 20
 INSERT INTO `item_mods` VALUES (19780,13,3); -- MND: 3
 INSERT INTO `item_mods` VALUES (19780,71,2); -- MPHEAL: 2
 
+-- Eluder's Sachet
+INSERT INTO `item_mods` VALUES (19781,160,200); -- DMG: 2%
+INSERT INTO `item_mods` VALUES (19781,166,-5);  -- ENEMYCRITRATE: -5
+
+-- Iron Gobbet
+INSERT INTO `item_mods` VALUES (19782,10,5);   -- VIT: 5
+INSERT INTO `item_mods` VALUES (19782,27,2);   -- ENMITY: 2
+INSERT INTO `item_mods` VALUES (19782,166,-2); -- ENEMYCRITRATE: -2
+
+-- Iga Shuriken
+INSERT INTO `item_mods` VALUES (19783,26,10); -- RACC: 10
+
+-- Lanner Bow
+INSERT INTO `item_mods` VALUES (19784,23,5);  -- ATT:  5
+INSERT INTO `item_mods` VALUES (19784,24,10); -- RATT: 10
+
+-- Lanner Bow +1
+INSERT INTO `item_mods` VALUES (19785,23,6);  -- ATT:  6
+INSERT INTO `item_mods` VALUES (19785,24,11); -- RATT: 11
+
+-- Nurigomeyumi
+INSERT INTO `item_mods` VALUES (19786,24,6); -- RATT: 6
+INSERT INTO `item_mods` VALUES (19786,26,9); -- RACC: 9
+
+-- Nurigomeyumi +1
+INSERT INTO `item_mods` VALUES (19787,24,7);  -- RATT: 6
+INSERT INTO `item_mods` VALUES (19787,26,10); -- RACC: 9
+
+-- Gorkhali Kukri
+INSERT INTO `item_mods` VALUES (19788,1,10); -- DEF: 10
+INSERT INTO `item_mods` VALUES (19788,29,3); -- MDEF: 3
+
+-- Mahakali's Kukri
+INSERT INTO `item_mods` VALUES (19789,1,15); -- DEF: 15
+INSERT INTO `item_mods` VALUES (19789,29,5); -- MDEF: 5
+
 -- Oneiros Lance
 INSERT INTO `item_mods` VALUES (19790,23,40); -- ATT: 40
 INSERT INTO `item_mods` VALUES (19790,27,8);  -- ENMITY: 8
@@ -40330,6 +40399,32 @@ INSERT INTO `item_mods` VALUES (19793,23,15); -- ATT: 15
 INSERT INTO `item_mods` VALUES (19794,10,10); -- VIT: 10
 INSERT INTO `item_mods` VALUES (19794,25,10); -- ACC: 10
 
+-- Ereptor Lance
+INSERT INTO `item_mods` VALUES (19795,10,7);  -- VIT: 7
+INSERT INTO `item_mods` VALUES (19795,11,5);  -- AGI: 5
+INSERT INTO `item_mods` VALUES (19795,23,17); -- ATT: 17
+INSERT INTO `item_mods` VALUES (19795,431,7); -- ITEM_ADDEFFECT_TYPE: TP_DRAIN: 7
+INSERT INTO `item_mods` VALUES (19795,500,2); -- ITEM_ADDEFFECT_DMG: 2
+INSERT INTO `item_mods` VALUES (19795,501,8); -- ITEM_ADDEFFECT_CHANCE: 8
+
+-- Rosschinder
+INSERT INTO `item_mods` VALUES (19796,9,4);    -- DEX: 4
+INSERT INTO `item_mods` VALUES (19796,11,4);   -- AGI: 4
+INSERT INTO `item_mods` VALUES (19796,431,2);  -- ITEM_ADDEFFECT_TYPE: DEBUFF: 2
+INSERT INTO `item_mods` VALUES (19796,951,4);  -- ITEM_ADDEFFECT_STATUS: EFFECT_PARALYSIS: 4
+INSERT INTO `item_mods` VALUES (19796,953,30); -- ITEM_ADDEFFECT_DURATION: 30
+
+-- Rosschinder +1
+INSERT INTO `item_mods` VALUES (19797,9,5);    -- DEX: 5
+INSERT INTO `item_mods` VALUES (19797,11,5);   -- AGI: 5
+INSERT INTO `item_mods` VALUES (19797,431,2);  -- ITEM_ADDEFFECT_TYPE: DEBUFF: 2
+INSERT INTO `item_mods` VALUES (19797,951,4);  -- ITEM_ADDEFFECT_STATUS: EFFECT_PARALYSIS: 4
+INSERT INTO `item_mods` VALUES (19797,953,30); -- ITEM_ADDEFFECT_DURATION: 30
+
+-- Drakaina Lance
+INSERT INTO `item_mods` VALUES (19798,10,5); -- VIT: 5
+INSERT INTO `item_mods` VALUES (19798,25,5); -- ACC: 5
+
 -- Herjas Fork
 INSERT INTO `item_mods` VALUES (19799,23,10); -- ATT: 10
 INSERT INTO `item_mods` VALUES (19799,25,10); -- ACC: 10
@@ -40338,6 +40433,9 @@ INSERT INTO `item_mods` VALUES (19799,430,3); -- QUAD_ATTACK: 3
 
 -- Gargouille Arrow
 INSERT INTO `item_mods` VALUES (19800,26,5); -- RACC: 5
+
+-- Adaman Bolt
+INSERT INTO `item_mods` VALUES (19801,24,5); -- RATT: 5
 
 -- Orichalcum Bullet
 INSERT INTO `item_mods` VALUES (19802,28,2); -- MATT: 2
@@ -41354,10 +41452,27 @@ INSERT INTO `item_mods` VALUES (20618,303,1);  -- TREASURE_HUNTER: 1
 INSERT INTO `item_mods` VALUES (20620,11,4);  -- AGI: 4
 INSERT INTO `item_mods` VALUES (20620,68,27); -- EVA: 27
 
+-- Nanti Knife
+INSERT INTO `item_mods` VALUES (20621,9,5);   -- DEX: 5
+INSERT INTO `item_mods` VALUES (20621,68,19); -- EVA: 19
+INSERT INTO `item_mods` VALUES (20621,289,3); -- SUBTLE_BLOW: 3
+
+-- Nanti Knife +1
+INSERT INTO `item_mods` VALUES (20622,9,6);   -- DEX: 6
+INSERT INTO `item_mods` VALUES (20622,68,20); -- EVA: 20
+INSERT INTO `item_mods` VALUES (20622,289,4); -- SUBTLE_BLOW: 4
+
+-- Leisilonu +2
+INSERT INTO `item_mods` VALUES (20623,68,22); -- EVA: 22
+
 -- Eminent Dagger
-INSERT INTO `item_mods` VALUES (20624,23,10); -- ATT: 10
-INSERT INTO `item_mods` VALUES (20624,25,63); -- ACC: 63
-INSERT INTO `item_mods` VALUES (20624,68,48); -- EVA: 48
+INSERT INTO `item_mods` VALUES (20624,25,24); -- ACC: 24
+INSERT INTO `item_mods` VALUES (20624,68,24); -- EVA: 24
+
+-- Secespita
+INSERT INTO `item_mods` VALUES (20625,68,10);  -- EVA: 10
+INSERT INTO `item_mods` VALUES (20625,113,10); -- ENHANCE: 10
+INSERT INTO `item_mods` VALUES (20625,432,8);  -- ENSPELL_DMG_BONUS: 8
 
 -- Legato Dagger
 INSERT INTO `item_mods` VALUES (20629,25,12); -- ACC: 12
@@ -43318,8 +43433,6 @@ INSERT INTO `item_mods` VALUES (21367,289,3); -- SUBTLE_BLOW: 3
 INSERT INTO `item_mods` VALUES (21371,23,10);   -- ATT: 10
 INSERT INTO `item_mods` VALUES (21371,25,5);    -- ACC: 5
 INSERT INTO `item_mods` VALUES (21371,73,3);    -- STORETP: 3
-INSERT INTO `item_mods` VALUES (21371,302,2);   -- TRIPLE_ATTACK: 2
-INSERT INTO `item_mods` VALUES (21371,384,900); -- HASTE_GEAR: 900
 
 -- Dunna
 INSERT INTO `item_mods` VALUES (21372,124,18); -- HANDBELL_SKILL: 18
@@ -43362,7 +43475,6 @@ INSERT INTO `item_mods` VALUES (21381,541,5);   -- BP_DELAY_II: 5
 INSERT INTO `item_mods` VALUES (21381,1040,20); -- AVATAR_LVL_BONUS: 20
 
 -- Dosis Tathlum
-INSERT INTO `item_mods` VALUES (21382,28,6);   -- MATT: 6
 INSERT INTO `item_mods` VALUES (21382,311,13); -- MAGIC_DAMAGE: 13
 
 -- Eminent Sachet
@@ -43396,7 +43508,6 @@ INSERT INTO `item_mods` VALUES (21389,25,15); -- ACC: 15
 INSERT INTO `item_mods` VALUES (21391,2,25);    -- HP: 25
 INSERT INTO `item_mods` VALUES (21391,23,13);   -- ATT: 13
 INSERT INTO `item_mods` VALUES (21391,73,2);    -- STORETP: 2
-INSERT INTO `item_mods` VALUES (21391,171,192); -- DELAY: 192
 
 -- Animator Z
 INSERT INTO `item_mods` VALUES (21392,1044,20); -- AUTOMATON_LVL_BONUS: 20
@@ -43448,7 +43559,7 @@ INSERT INTO `item_mods` VALUES (21409,121,10); -- WIND: 10
 -- Capitoline Strap
 INSERT INTO `item_mods` VALUES (21412,8,2);   -- STR: 2
 INSERT INTO `item_mods` VALUES (21412,12,2);  -- INT: 2
-INSERT INTO `item_mods` VALUES (21412,62,15); -- ATTP: 15
+INSERT INTO `item_mods` VALUES (21412,23,15); -- ATT: 15
 INSERT INTO `item_mods` VALUES (21412,73,2);  -- STORETP: 2
 INSERT INTO `item_mods` VALUES (21412,288,1); -- DOUBLE_ATTACK: 1
 

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -3601,7 +3601,7 @@ INSERT INTO `item_weapon` VALUES (20617,'homestead_dagger',2,0,228,228,188,1,1,1
 INSERT INTO `item_weapon` VALUES (20618,'sandung',2,0,242,242,188,1,1,200,102,0);
 INSERT INTO `item_weapon` VALUES (20619,'polyhymnia',2,0,242,242,188,1,1,194,95,0);
 INSERT INTO `item_weapon` VALUES (20620,'sabebus',2,0,242,242,188,1,1,196,101,0);
-INSERT INTO `item_weapon` VALUES (20621,'nanti_knife',2,0,228,228,167,1,1,195,100,0);
+INSERT INTO `item_weapon` VALUES (20621,'nanti_knife',2,0,215,215,167,1,1,195,100,0);
 INSERT INTO `item_weapon` VALUES (20622,'nanti_knife_+1',2,0,228,228,177,1,1,190,101,0);
 INSERT INTO `item_weapon` VALUES (20623,'leisilonu_+2',2,0,242,242,188,1,1,183,90,0);
 INSERT INTO `item_weapon` VALUES (20624,'eminent_dagger',2,0,203,203,167,1,1,183,85,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds item mods (and latents as needed) to items 19029, 19299-19301, 19741-19744, 19781-19789, 19795-19798, 19801, 20621-20625 with a correction to 20624. Also corrects items 21371, 21382, 21391, and 21412. Fixed item weapons for item 20621, as it had the wrong ilvl values.

## Steps to test these changes

As GM, !additem 19029|19299|19300|19301|19741|19742|19743|19744|19781|19782|19783|19784|19785|19786|19787|19788|19789|19795|19796|19797|19798|19801|20621|20622|20623|20624|20625
Equip item and make sure stats change as expected.