### PR TITLE
[Magic] Implement AoE damage reduction

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -185,6 +185,7 @@ xi.mod =
     DMGMAGIC                        = 163,
     DMGMAGIC_II                     = 831, -- Magic Damage Taken II % (Aegis)
     DMGRANGE                        = 164,
+    DMG_AOE                         = 158, -- Damage Taken % when not main target of an AoE action. (Ex: Locus Mobs)
     UDMGPHYS                        = 387,
     UDMGBREATH                      = 388,
     UDMGMAGIC                       = 389,

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -812,6 +812,16 @@ xi.spells.damage.calculateHelixMeritMultiplier = function(caster, spellId)
     return helixMeritMultiplier
 end
 
+xi.spells.damage.calculateAreaOfEffectResistance = function(target, spell)
+    local areaOfEffectMultiplier = 1
+
+    if target:getID() ~= spell:getPrimaryTargetID() then
+        areaOfEffectMultiplier = utils.clamp(areaOfEffectMultiplier + target:getMod(xi.mod.DMG_AOE) / 10000, 0, 2)
+    end
+
+    return areaOfEffectMultiplier
+end
+
 xi.spells.damage.calculateNukeAbsorbOrNullify = function(target, spellElement)
     local nukeAbsorbOrNullify = 1
 
@@ -911,6 +921,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local undeadDivinePenalty         = xi.spells.damage.calculateUndeadDivinePenalty(target, skillType)
     local scarletDeliriumMultiplier   = xi.spells.damage.calculateScarletDeliriumMultiplier(caster)
     local helixMeritMultiplier        = xi.spells.damage.calculateHelixMeritMultiplier(caster, spellId)
+    local areaOfEffectResistance      = xi.spells.damage.calculateAreaOfEffectResistance(target, spell)
     local nukeAbsorbOrNullify         = xi.spells.damage.calculateNukeAbsorbOrNullify(target, spellElement)
 
     -- Calculate finalDamage. It MUST be floored after EACH multiplication.
@@ -933,6 +944,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     finalDamage = math.floor(finalDamage * undeadDivinePenalty)
     finalDamage = math.floor(finalDamage * scarletDeliriumMultiplier)
     finalDamage = math.floor(finalDamage * helixMeritMultiplier)
+    finalDamage = math.floor(finalDamage * areaOfEffectResistance)
     finalDamage = math.floor(finalDamage * nukeAbsorbOrNullify)
 
     -- Handle "Nuke Wall". It must be handled after all previous calculations, but before clamp.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -211,6 +211,7 @@ enum class Mod
     DMGMAGIC    = 163, // Magic Damage Taken %
     DMGMAGIC_II = 831, // Magic Damage Taken II % (Aegis)
     DMGRANGE    = 164, // Range Damage Taken %
+    DMG_AOE     = 158, // Damage Taken % when not main target of an AoE action. (Ex: Locus Mobs)
 
     // Uncapped damage - 10000 base, 375 = 3.75%
     UDMGPHYS   = 387, // Uncapped Damage Multipliers
@@ -997,7 +998,7 @@ enum class Mod
     //
     // SPARE IDs:
     // 141 to 143
-    // 158, 159
+    // 159
     // 217 to 223
     // 271 to 280
     //


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements a modifier for AoE damage reduction and logic for AoE spells.
Modifier works EXACTLY the same way as other DMG reduction modifiers:
- Value of 0 = Neutral damage/no change
- Value < 0 = Less damage. -10000 = no damage
- Value > 0 = More damage. I added a cap of x2 dmg.

I dont intend to implement it for other actions until I finish reworking weaponskills.

NOTE: AoE spells already return reduced numbers depending on number of targets. However, this is intended for mobs that have an specific resistance to AoE actions when not the primary target. Example: Locus mobs

## Steps to test these changes

We need to add the modifier to a mob first. Then, use an AoE on a different but in range mob and see reduced (or amplified) damage, depending on value.
