### PR TITLE
[core] Filter outgoing 0x028 (action packet) by spawnlists

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1245,14 +1245,38 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                         if (distanceSquared(PEntity->loc.p, PCurrentChar->loc.p) < checkDistanceSq &&
                             ((PEntity->objtype != TYPE_PC) || (((CCharEntity*)PEntity)->m_moghouseID == PCurrentChar->m_moghouseID)))
                         {
-                            if (packet->getType() == 0x00E && (packet->ref<uint8>(0x0A) != 0x20 || packet->ref<uint8>(0x0A) != 0x0F))
+                            uint16 packetType = packet->getType();
+                            if
+                                ((packetType == 0x00E && // Entity Update
+                                (packet->ref<uint8>(0x0A) != 0x20 ||
+                                packet->ref<uint8>(0x0A) != 0x0F)) ||
+                                packetType == 0x028) // Action packet
                             {
-                                uint32 id     = packet->ref<uint32>(0x04);
-                                uint16 targid = packet->ref<uint16>(0x08);
+                                uint32 id           = 0;
+                                uint16 targid       = 0;
+                                CBaseEntity* entity = nullptr;
 
-                                CBaseEntity* entity = GetEntity(targid);
+                                if (packetType == 0x00E) // Entity update
+                                {
+                                    id     = packet->ref<uint32>(0x04);
+                                    targid = packet->ref<uint16>(0x08);
+                                    entity = GetEntity(targid);
+                                }
+                                else if (packetType == 0x028) // Action packet
+                                {
+                                    id     = packet->ref<uint32>(0x05);
+                                    // Try char
+                                    entity = GetCharByID(id);
 
-                                SpawnIDList_t spawnlist;
+                                    // Try everything else
+                                    if (!entity)
+                                    {
+                                        entity = zoneutils::GetEntity(id);
+                                    }
+                                }
+
+                                // No real reason to pick SpawnMOBList, just need a reference here initially.
+                                SpawnIDList_t& spawnlist = PCurrentChar->SpawnMOBList;
 
                                 if (entity)
                                 {
@@ -1272,6 +1296,10 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                     {
                                         spawnlist = PCurrentChar->SpawnTRUSTList;
                                     }
+                                    else if (entity->objtype == TYPE_PC)
+                                    {
+                                        spawnlist = PCurrentChar->SpawnPCList;
+                                    }
                                     else
                                     {
                                         entity = nullptr;
@@ -1279,8 +1307,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                 }
                                 if (!entity)
                                 {
-                                    // got a char or nothing as the target of this entity update (which really shouldn't happen ever)
-                                    // so we're just going to skip this packet
+                                    // No target entity in spawnlists found, so we're just going to skip this packet
                                     break;
                                 }
                                 SpawnIDList_t::iterator iter = spawnlist.lower_bound(id);


### PR DESCRIPTION

<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This should reduce excess action packets that go to a client who is not "aware" of certain entities (e.g. players above >32 that arent in SpawnPCList, entities that never got an 0x00E to the client to begin with and arent in SpawnMobList)
Free performance gain from not copying `SpawnIDList_t spawnlist` and using a reference instead

See spam in pic that would never be sent (client isnt aware of these PCs names and these packets are useless to the client):
![image](https://github.com/LandSandBoat/server/assets/60417494/9c36e003-f926-4867-b8f8-cbe94973e645)

## Steps to test these changes
Nothing should be obviously different without addons that would track 0x028s for entities they havent seen for some reason