### PR TITLE
[core] Enable hack for Pso'Xja mobs sometimes not being visible

### DIFF
--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -191,6 +191,16 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
                     ref<uint8>(0x27) |= 0x08;
                 }
                 ref<uint8>(0x28) |= PMob->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR) ? 0x10 : 0x00;
+
+                // Giga hack -- mobs in Pso'Xja for some reason are less "visible"
+                // Set CliPriorityFlag to force them to render on the client if they receive 0x00Es
+                // TODO: make this a MOBMOD or some other way to set this flag without hardcoding.
+                if (PMob->getZone() == ZONEID::ZONE_PSOXJA)
+                {
+                    // Enable CliPriorityFlag, see https://github.com/atom0s/XiPackets/tree/main/world/server/0x0037 (documentation for 0x00E is not on the repo yet)
+                    ref<uint8>(0x28) |= 0x20;
+                }
+
                 ref<uint8>(0x28) |= PMob->health.hp > 0 && PMob->animation == ANIMATION_DEATH ? 0x08 : 0;
                 ref<uint8>(0x28) |= PMob->status == STATUS_TYPE::NORMAL && PMob->objtype == TYPE_MOB ? 0x40 : 0; // Make the entity triggerable if a mob and normal status
                 ref<uint8>(0x29) = static_cast<uint8>(PEntity->allegiance);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enable hack for Pso'Xja mobs sometimes not being visible
See below:

No hack:
![image](https://github.com/LandSandBoat/server/assets/60417494/7932f660-7ff1-49da-b206-a79de9eed6c9)
Hack enabled:
![image](https://github.com/LandSandBoat/server/assets/60417494/f8b2f783-4e9b-4b07-b0e2-b12f92a3434a)


## Steps to test these changes

Go to Pso'Xja, see more mobs than before (closer to retail)
