### PR TITLE
[lua] [sql] Audit & fix Altepa Gate

### DIFF
--- a/scripts/zones/Western_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Western_Altepa_Desert/Zone.lua
@@ -78,4 +78,13 @@ zoneObject.onZoneWeatherChange = function(weather)
     end
 end
 
+zoneObject.afterZoneIn = function(player)
+    -- Send players who zone in an update for the Altepa Gate "doors" so you can see the state from further away
+    -- TODO: these NPCs should be "permanently" in the NPC spawn list for all players -- there's a bug if you get too close and move away they revert to the "needs to be opened" state.
+    -- This currently acts as a small QoL from a long distance, better than nothing, but closer to retail.
+    for i = ID.npc.ALTEPA_GATE, ID.npc.ALTEPA_GATE + 8 do
+        player:sendEntityUpdateToPlayer(GetNPCByID(i), xi.entityUpdate.ENTITY_UPDATE, xi.updateType.UPDATE_COMBAT)
+    end
+end
+
 return zoneObject

--- a/scripts/zones/Western_Altepa_Desert/npcs/_3h5.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/_3h5.lua
@@ -13,8 +13,11 @@ end
 
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() ~= xi.anim.OPEN_DOOR then
-        npc:setAnimation(xi.anim.OPEN_DOOR)
-        GetNPCByID(npc:getID() - 4):setAnimation(xi.anim.OPEN_DOOR)
+        npc:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        local column = GetNPCByID(npc:getID() - 4)
+        if column then
+            column:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        end
     else
         player:messageSpecial(ID.text.DOES_NOT_RESPOND)
     end
@@ -25,9 +28,19 @@ entity.onTrigger = function(player, npc)
         GetNPCByID(ID.npc.ALTEPA_GATE + 7):getAnimation() == xi.anim.OPEN_DOOR and
         GetNPCByID(ID.npc.ALTEPA_GATE + 8):getAnimation() == xi.anim.OPEN_DOOR
     then
-        local openTime = math.random(15, 30) * 60
+        local openTime = math.random(15, 30) * 1000 * 60
+
         for i = ID.npc.ALTEPA_GATE, ID.npc.ALTEPA_GATE + 8 do
-            GetNPCByID(i):openDoor(openTime)
+            local door = GetNPCByID(i)
+
+            -- openDoor used to (read: a decade ish ago before Sol) allow calls to doors already open and set a timer to close them
+            -- This snippet reproduces this behavor AND updates everyone in the zone on the status of the doors.
+            if door then
+                door:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+                door:timer(openTime, function(doorArg)
+                    doorArg:updateToEntireZone(xi.status.NORMAL, xi.anim.CLOSE_DOOR)
+                end)
+            end
         end
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/npcs/_3h6.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/_3h6.lua
@@ -13,8 +13,11 @@ end
 
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() ~= xi.anim.OPEN_DOOR then
-        npc:setAnimation(xi.anim.OPEN_DOOR)
-        GetNPCByID(npc:getID() - 4):setAnimation(xi.anim.OPEN_DOOR)
+        npc:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        local column = GetNPCByID(npc:getID() - 4)
+        if column then
+            column:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        end
     else
         player:messageSpecial(ID.text.DOES_NOT_RESPOND)
     end
@@ -25,9 +28,19 @@ entity.onTrigger = function(player, npc)
         GetNPCByID(ID.npc.ALTEPA_GATE + 7):getAnimation() == xi.anim.OPEN_DOOR and
         GetNPCByID(ID.npc.ALTEPA_GATE + 8):getAnimation() == xi.anim.OPEN_DOOR
     then
-        local openTime = math.random(15, 30) * 60
+        local openTime = math.random(15, 30) * 1000 * 60
+
         for i = ID.npc.ALTEPA_GATE, ID.npc.ALTEPA_GATE + 8 do
-            GetNPCByID(i):openDoor(openTime)
+            local door = GetNPCByID(i)
+
+            -- openDoor used to (read: a decade ish ago before Sol) allow calls to doors already open and set a timer to close them
+            -- This snippet reproduces this behavor AND updates everyone in the zone on the status of the doors.
+            if door then
+                door:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+                door:timer(openTime, function(doorArg)
+                    doorArg:updateToEntireZone(xi.status.NORMAL, xi.anim.CLOSE_DOOR)
+                end)
+            end
         end
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/npcs/_3h7.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/_3h7.lua
@@ -13,8 +13,11 @@ end
 
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() ~= xi.anim.OPEN_DOOR then
-        npc:setAnimation(xi.anim.OPEN_DOOR)
-        GetNPCByID(npc:getID() - 4):setAnimation(xi.anim.OPEN_DOOR)
+        npc:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        local column = GetNPCByID(npc:getID() - 4)
+        if column then
+            column:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        end
     else
         player:messageSpecial(ID.text.DOES_NOT_RESPOND)
     end
@@ -25,9 +28,19 @@ entity.onTrigger = function(player, npc)
         GetNPCByID(ID.npc.ALTEPA_GATE + 7):getAnimation() == xi.anim.OPEN_DOOR and
         GetNPCByID(ID.npc.ALTEPA_GATE + 8):getAnimation() == xi.anim.OPEN_DOOR
     then
-        local openTime = math.random(15, 30) * 60
+        local openTime = math.random(15, 30) * 1000 * 60
+
         for i = ID.npc.ALTEPA_GATE, ID.npc.ALTEPA_GATE + 8 do
-            GetNPCByID(i):openDoor(openTime)
+            local door = GetNPCByID(i)
+
+            -- openDoor used to (read: a decade ish ago before Sol) allow calls to doors already open and set a timer to close them
+            -- This snippet reproduces this behavor AND updates everyone in the zone on the status of the doors.
+            if door then
+                door:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+                door:timer(openTime, function(doorArg)
+                    doorArg:updateToEntireZone(xi.status.NORMAL, xi.anim.CLOSE_DOOR)
+                end)
+            end
         end
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/npcs/_3h8.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/_3h8.lua
@@ -13,8 +13,11 @@ end
 
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() ~= xi.anim.OPEN_DOOR then
-        npc:setAnimation(xi.anim.OPEN_DOOR)
-        GetNPCByID(npc:getID() - 4):setAnimation(xi.anim.OPEN_DOOR)
+        npc:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        local column = GetNPCByID(npc:getID() - 4)
+        if column then
+            column:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+        end
     else
         player:messageSpecial(ID.text.DOES_NOT_RESPOND)
     end
@@ -25,9 +28,19 @@ entity.onTrigger = function(player, npc)
         GetNPCByID(ID.npc.ALTEPA_GATE + 7):getAnimation() == xi.anim.OPEN_DOOR and
         GetNPCByID(ID.npc.ALTEPA_GATE + 8):getAnimation() == xi.anim.OPEN_DOOR
     then
-        local openTime = math.random(15, 30) * 60
+        local openTime = math.random(15, 30) * 1000 * 60
+
         for i = ID.npc.ALTEPA_GATE, ID.npc.ALTEPA_GATE + 8 do
-            GetNPCByID(i):openDoor(openTime)
+            local door = GetNPCByID(i)
+
+            -- openDoor used to (read: a decade ish ago before Sol) allow calls to doors already open and set a timer to close them
+            -- This snippet reproduces this behavor AND updates everyone in the zone on the status of the doors.
+            if door then
+                door:updateToEntireZone(xi.status.NORMAL, xi.anim.OPEN_DOOR)
+                door:timer(openTime, function(doorArg)
+                    doorArg:updateToEntireZone(xi.status.NORMAL, xi.anim.CLOSE_DOOR)
+                end)
+            end
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Altepa Gate was broken and didn't reset properly. This PR fixes it and adds some QoL for players to see the state of the columns better.

## Steps to test these changes
Use Altepa Gate, see it reset properly, have other players see the changes from a long distance.
