### PR TITLE
[Fix] [c++] Message used when non-players start casting

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -84,7 +84,12 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     actionTarget.speceffect = SPECEFFECT::NONE;
     actionTarget.animation  = 0;
     actionTarget.param      = static_cast<uint16>(m_PSpell->getID());
-    actionTarget.messageID  = 327; // starts casting
+    actionTarget.messageID  = 327; // <caster> starts casting <spell> on <target>.
+
+    if (PEntity->objtype != TYPE_PC)
+    {
+        actionTarget.messageID = 3; // <caster> starts casting <spell>.
+    }
 
     // TODO: weaponskill lua object
     m_PEntity->PAI->EventHandler.triggerListener("MAGIC_START", CLuaBaseEntity(m_PEntity), CLuaSpell(m_PSpell.get()), CLuaAction(&action));


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements this kind of messaging when non-players cast.
![imagen](https://github.com/LandSandBoat/server/assets/60053999/de13eec3-61a1-4446-b369-9274dd8394a9)

^ This is retail.

## Steps to test these changes
Cast as a player. See target in the casting message.
Agro a mage. See casting message not having a target.
