### PR TITLE
[SQL][Items] Item mods 10447-21348

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -25,6 +25,9 @@ INSERT INTO `item_latents` VALUES (10293,26,50,50,31);   -- Under Lv.31 : Rng. A
 INSERT INTO `item_latents` VALUES (10293,30,50,50,31);   -- Under Lv.31 : Mag. Acc.+50
 -- INSERT INTO `item_latents` VALUES (10293,??,-1,50,31); -- Initiate and below: Likelihood of synthesis material loss -1%
 
+-- Pyracmon Cap (10447)
+-- TODO: Full Moon + Darksday + Nighttime: REFRESH: 2
+
 INSERT INTO `item_latents` VALUES (10670,68,10,13,58);  -- WAR AF2 +2 Body Reduces evasion penalty by 10 if Aggressor Active
 
 INSERT INTO `item_latents` VALUES (10679,8,10,10,0);
@@ -41,9 +44,9 @@ INSERT INTO `item_latents` VALUES (10730,63,15,13,56);  -- WAR AF2 +2 Feet Reduc
 -- Abyss Sollerets +2
 INSERT INTO `item_latents` VALUES (10737,63,10,13,64);   -- +2: Enhances "Last Resort" effect
 
--- Lunette ring
-INSERT INTO `item_latents` VALUES (10766,29,5,10,0);     -- MDEF+7
-INSERT INTO `item_latents` VALUES (10766,369,-2,10,0);   -- Latent is active when engaged and drains 2mp/tick.
+-- Lunette Ring
+INSERT INTO `item_latents` VALUES (10766,29,7,56,0);   -- WEAPON_DRAWN_MP_OVER: 0 - MDEF: 7
+INSERT INTO `item_latents` VALUES (10766,369,-2,56,0); -- WEAPON_DRAWN_MP_OVER: 0 - REFRESH: -2
 
 -- Mandraguard
 INSERT INTO `item_latents` VALUES (10807,370,1,26,0);    -- Regen 1/tick during Daytime
@@ -123,9 +126,29 @@ INSERT INTO `item_latents` VALUES (11589,116,3,32,0);    -- Dark magic skill +7 
 INSERT INTO `item_latents` VALUES (11590,112,3,36,0);    -- Healing magic skill +10 On Lightsdays
 INSERT INTO `item_latents` VALUES (11590,113,3,36,0);    -- Enhancing magic skill +10 On Lightsdays
 
+-- Artemis's Medal
+INSERT INTO `item_latents` VALUES (11607,30,10,37,0); -- MOON_PHASE: New Moon: 0 - MACC: 10
+INSERT INTO `item_latents` VALUES (11607,28,1,37,1);  -- MOON_PHASE: Waxing Crescent: 1 - MATT: 1
+INSERT INTO `item_latents` VALUES (11607,30,8,37,1);  -- MOON_PHASE: Waxing Crescent: 1 - MACC: 8
+INSERT INTO `item_latents` VALUES (11607,28,5,37,2);  -- MOON_PHASE: First Quarter:   2 - MATT: 5
+INSERT INTO `item_latents` VALUES (11607,30,5,37,2);  -- MOON_PHASE: First Quarter:   2 - MACC: 5
+INSERT INTO `item_latents` VALUES (11607,28,6,37,3);  -- MOON_PHASE: Waxing Gibbous:  3 - MATT: 6
+INSERT INTO `item_latents` VALUES (11607,30,3,37,3);  -- MOON_PHASE: Waxing Gibbous:  3 - MACC: 3
+INSERT INTO `item_latents` VALUES (11607,28,10,37,4); -- MOON_PHASE: Full Moon: 4 - MATT: 10
+INSERT INTO `item_latents` VALUES (11607,28,8,37,5);  -- MOON_PHASE: Waning Gibbous:  5 - MATT: 8
+INSERT INTO `item_latents` VALUES (11607,30,1,37,5);  -- MOON_PHASE: Waning Gibbous:  5 - MACC: 1
+INSERT INTO `item_latents` VALUES (11607,28,5,37,6);  -- MOON_PHASE: Last Quarter:    6 - MATT: 5
+INSERT INTO `item_latents` VALUES (11607,30,5,37,6);  -- MOON_PHASE: Last Quarter:    6 - MACC: 5
+INSERT INTO `item_latents` VALUES (11607,28,3,37,7);  -- MOON_PHASE: Waning Crescent: 7 - MATT: 3
+INSERT INTO `item_latents` VALUES (11607,30,6,37,7);  -- MOON_PHASE: Waning Crescent: 7 - MACC: 6
+
 -- Chrys. Torque
 INSERT INTO `item_latents` VALUES (11621,368,-1,7,0);    -- Drains 1 TP/tick and gives 1 MP/tick
 INSERT INTO `item_latents` VALUES (11621,369,1,7,0);     -- Latent Effect is active when you have TP.
+
+-- Miseria Ring
+INSERT INTO `item_latents` VALUES (11652,13,6,4,51); -- MP_UNDER_PERCENT: 51 - MND:  6
+INSERT INTO `item_latents` VALUES (11652,30,3,4,51); -- MP_UNDER_PERCENT: 51 - MACC: 3
 
 -- Rollers Ring
 INSERT INTO `item_latents` VALUES (11667,368,10,57,0);   -- Rollers Ring Regain +10 with Eleven COR Roll
@@ -920,6 +943,10 @@ INSERT INTO `item_latents` VALUES (14509,11,8,10,0);
 -- Shadow Ring
 INSERT INTO `item_latents` VALUES (14646,29,10,32,0);    -- Darksday: MDB+10
 
+-- Atlaua's Ring
+INSERT INTO `item_latents` VALUES (14658,304,4,59,1); -- VS_ECOSYSTEM: AMORPH - TAME: 4
+INSERT INTO `item_latents` VALUES (14658,304,4,59,2); -- VS_ECOSYSTEM: AQUAN  - TAME: 4
+
 -- Hercules' Ring
 INSERT INTO `item_latents` VALUES (14659,369,1,0,50);    -- Refresh+1 when HP <=50%
 INSERT INTO `item_latents` VALUES (14659,370,3,0,50);    -- Regen+3 when HP <=50%
@@ -1019,6 +1046,9 @@ INSERT INTO `item_latents` VALUES (14953,384,100,14,0);  -- Haste+1%
 INSERT INTO `item_latents` VALUES (14954,5,35,14,0);
 INSERT INTO `item_latents` VALUES (14954,71,1,14,0);
 INSERT INTO `item_latents` VALUES (14954,168,-5,14,0);
+
+-- Trainee Gloves
+INSERT INTO `item_latents` VALUES (15008,133,1,24,54); -- SYNTH_TRAINEE: BONE - BONE: 1
 
 -- Serpentes Cuffs
 INSERT INTO `item_latents` VALUES (15019,369,1,26,1);    -- Nighttime: Adds "Regen" effect
@@ -1204,6 +1234,14 @@ INSERT INTO `item_latents` VALUES (15516,26,-16,52,8);   -- cumulative ranged ac
 INSERT INTO `item_latents` VALUES (15519,370,1,58,0);    -- storm muffler regen +1
 INSERT INTO `item_latents` VALUES (15520,68,7,58,0);     -- storm torque eva +7
 
+-- Sacrifice Torque
+INSERT INTO `item_latents` VALUES (15528,369,-3,21,21); -- AVATAR_IN_PARTY: 21 - REFRESH: -3
+INSERT INTO `item_latents` VALUES (15528,370,-8,21,21); -- AVATAR_IN_PARTY: 21 - REGEN:   -8
+-- TODO: INSERT INTO `item_latents` VALUES (15528,??,3,21,21); -- AVATAR_IN_PARTY: 21 - Avatar ATT: 3
+
+-- Ace's Locket
+INSERT INTO `item_latents` VALUES (15529,291,5,0,25); -- HP_UNDER_PERCENT: 25 - COUNTER: 5
+
 -- Berserker's Torque
 INSERT INTO `item_latents` VALUES (15530,368,10,10,0);   -- HP-50/Tick of TP while weapon drawn
 INSERT INTO `item_latents` VALUES (15530,404,50,10,0);
@@ -1269,6 +1307,9 @@ INSERT INTO `item_latents` VALUES (15692,76,12,58,0);   -- storm crackows MOVE_S
 -- Marabout Sandals
 INSERT INTO `item_latents` VALUES (15760,5,15,28,0);     -- Firesday: MP +15
 INSERT INTO `item_latents` VALUES (15760,28,4,28,0);     -- Firesday: MATT +4
+
+-- Imperial Ring
+INSERT INTO `item_latents` VALUES (15773,384,400,58,0); -- IN_ASSAULT - HASTE_GEAR: 4%
 
 INSERT INTO `item_latents` VALUES (15774,25,10,58,0);    -- Storm ring
 

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -3257,6 +3257,10 @@ INSERT INTO `item_mods` VALUES (10781,14,5); -- CHR: 5
 -- Ambuscade Ring
 INSERT INTO `item_mods` VALUES (10782,288,1); -- DOUBLE_ATTACK: 1
 
+-- Veneficium Ring (10783)
+-- TODO: Occ. quickens spellcasting +1%
+-- TODO: Legion: Magic Accuracy+4 Occ. quickens spellcasting +2%
+
 -- Dhanurveda Ring
 INSERT INTO `item_mods` VALUES (10784,24,5);  -- RATT: 5
 INSERT INTO `item_mods` VALUES (10784,25,5);  -- ACC: 5
@@ -8551,6 +8555,18 @@ INSERT INTO `item_mods` VALUES (11766,1,6);    -- DEF: 6
 INSERT INTO `item_mods` VALUES (11766,12,6);   -- INT: 6
 INSERT INTO `item_mods` VALUES (11766,27,-4);  -- ENMITY: -4
 INSERT INTO `item_mods` VALUES (11766,168,10); -- SPELLINTERRUPT: 10
+
+-- Chocobo Rope (11767)
+-- TODO: increases rate of digging skill up
+
+-- Fisher's Rope (11768)
+-- TODO: Angler's Discernment +1: raises the chance to see which fish you are about to catch.
+
+-- Field Rope
+INSERT INTO `item_mods` VALUES (11769,513,1);  -- HARVESTING_RESULT: 1
+INSERT INTO `item_mods` VALUES (11769,514,1);  -- LOGGING_RESULT: 1
+INSERT INTO `item_mods` VALUES (11769,515,1);  -- MINING_RESULT:  1
+-- TODO: Exact values unknown, so giving minimum until better estimate
 
 -- Accursed Belt
 INSERT INTO `item_mods` VALUES (11770,2,-10);   -- HP: -10
@@ -29728,6 +29744,10 @@ INSERT INTO `item_mods` VALUES (15995,296,1); -- CONSERVE_MP: 1
 -- Guignol Earring
 INSERT INTO `item_mods` VALUES (15999,854,20); -- REPAIR_POTENCY: 20
 
+-- Dragoon's Earring
+INSERT INTO `item_mods` VALUES (16000,986,5); -- WYVERN_BREATH_MACC: 5
+-- TODO: Chance to use angon without depleting: 10%
+
 -- Crapaud Earring
 INSERT INTO `item_mods` VALUES (16001,2,5);  -- HP: 5
 INSERT INTO `item_mods` VALUES (16001,5,-5); -- MP: -5
@@ -31442,6 +31462,14 @@ INSERT INTO `item_mods` VALUES (16403,501,10); -- ITEM_ADDEFFECT_CHANCE: 10
 INSERT INTO `item_mods` VALUES (16403,951,3);  -- ITEM_ADDEFFECT_STATUS: 3
 INSERT INTO `item_mods` VALUES (16403,952,4);  -- ITEM_ADDEFFECT_POWER: 4
 INSERT INTO `item_mods` VALUES (16403,953,30); -- ITEM_ADDEFFECT_DURATION: 30
+
+-- Venom Katars
+INSERT INTO `item_mods` VALUES (16404,431,2);  -- ITEM_ADDEFFECT_TYPE: 2
+INSERT INTO `item_mods` VALUES (16404,499,10); -- ITEM_SUBEFFECT: 10
+INSERT INTO `item_mods` VALUES (16404,501,10); -- ITEM_ADDEFFECT_CHANCE: 10
+INSERT INTO `item_mods` VALUES (16404,951,3);  -- ITEM_ADDEFFECT_STATUS: 3
+INSERT INTO `item_mods` VALUES (16404,952,7);  -- ITEM_ADDEFFECT_POWER: 7
+INSERT INTO `item_mods` VALUES (16404,953,30); -- ITEM_ADDEFFECT_DURATION: 30
 
 -- Poison Baghnakhs
 INSERT INTO `item_mods` VALUES (16410,431,2);  -- ITEM_ADDEFFECT_TYPE: 2
@@ -41474,10 +41502,34 @@ INSERT INTO `item_mods` VALUES (20625,68,10);  -- EVA: 10
 INSERT INTO `item_mods` VALUES (20625,113,10); -- ENHANCE: 10
 INSERT INTO `item_mods` VALUES (20625,432,8);  -- ENSPELL_DMG_BONUS: 8
 
+-- Blitto Needle
+INSERT INTO `item_mods` VALUES (20626,25,12);  -- ACC: 12
+INSERT INTO `item_mods` VALUES (20626,68,12);  -- EVA: 12
+INSERT INTO `item_mods` VALUES (20626,289,10); -- SUBTLE_BLOW: 10
+INSERT INTO `item_mods` VALUES (20626,491,3);  -- WALTZ_POTENCY: 3
+
+-- Surcoufs Jambiya
+INSERT INTO `item_mods` VALUES (20627,5,30);   -- MP: 30
+INSERT INTO `item_mods` VALUES (20627,26,8);   -- RACC: 8
+INSERT INTO `item_mods` VALUES (20627,68,10);  -- EVA: 10
+INSERT INTO `item_mods` VALUES (20627,305,20); -- RECYCLE: 20
+-- TODO: Occasionally allows the use of abilities without expending cards
+
+-- Surcoufs Jambiya +1
+INSERT INTO `item_mods` VALUES (20628,68,12); -- EVA: 12
+INSERT INTO `item_mods` VALUES (20628,25,12); -- ACC: 12
+
 -- Legato Dagger
 INSERT INTO `item_mods` VALUES (20629,25,12); -- ACC: 12
 INSERT INTO `item_mods` VALUES (20629,68,12); -- EVA: 12
 INSERT INTO `item_mods` VALUES (20629,454,5); -- SONG_DURATION_BONUS: 5
+
+-- Atoyac
+INSERT INTO `item_mods` VALUES (20630,9,12);  -- DEX: 12
+INSERT INTO `item_mods` VALUES (20630,11,12); -- AGI: 12
+INSERT INTO `item_mods` VALUES (20630,20,20); -- WATER_MEVA: 20
+INSERT INTO `item_mods` VALUES (20630,68,17); -- EVA: 17
+INSERT INTO `item_mods` VALUES (20630,289,7); -- SUBTLE_BLOW: 7
 
 -- Vanir Knife
 INSERT INTO `item_mods` VALUES (20632,25,13);    -- ACC: 13
@@ -41502,8 +41554,36 @@ INSERT INTO `item_mods` VALUES (20636,302,2); -- TRIPLE_ATTACK: 2
 -- Coalition Dirk
 INSERT INTO `item_mods` VALUES (20638,25,10); -- ACC: 10
 
+-- Nitric Baselard
+INSERT INTO `item_mods` VALUES (20640,9,7);     -- DEX: 7
+INSERT INTO `item_mods` VALUES (20640,25,14);   -- ACC: 14
+INSERT INTO `item_mods` VALUES (20640,431,2);   -- ITEM_ADDEFFECT_TYPE: DEBUFF: 2
+INSERT INTO `item_mods` VALUES (20640,951,2);   -- ITEM_ADDEFFECT_STATUS: EFFECT_DEFENSE_DOWN: 149
+INSERT INTO `item_mods` VALUES (20640,952,19);  -- ITEM_ADDEFFECT_POWER: 19
+INSERT INTO `item_mods` VALUES (20640,953,180); -- ITEM_ADDEFFECT_DURATION: 180
+
 -- Leisilonu
-INSERT INTO `item_mods` VALUES (20641,68,15); -- EVA: 15
+INSERT INTO `item_mods` VALUES (20641,68,5); -- EVA: 5
+
+-- Tzustes Knife +1
+INSERT INTO `item_mods` VALUES (20642,2,65);    -- HP:  65
+INSERT INTO `item_mods` VALUES (20642,23,11);   -- ATT: 11
+INSERT INTO `item_mods` VALUES (20642,25,11);   -- ACC: 11
+INSERT INTO `item_mods` VALUES (20642,68,6);    -- EVA: 6
+INSERT INTO `item_mods` VALUES (20642,384,200); -- HASTE_GEAR: 2%
+
+-- Macoquetza
+INSERT INTO `item_mods` VALUES (20643,11,8);  -- AGI: 8
+INSERT INTO `item_mods` VALUES (20643,20,20); -- WATER_MEVA: 20
+INSERT INTO `item_mods` VALUES (20643,68,6);  -- EVA: 6
+INSERT INTO `item_mods` VALUES (20643,289,7); -- SUBTLE_BLOW: 7
+
+-- Tzustes Knife
+INSERT INTO `item_mods` VALUES (20644,2,60);    -- HP: 60
+INSERT INTO `item_mods` VALUES (20644,23,10);   -- ATT: 10
+INSERT INTO `item_mods` VALUES (20644,25,10);   -- ACC: 10
+INSERT INTO `item_mods` VALUES (20644,68,5);    -- EVA: 5
+INSERT INTO `item_mods` VALUES (20644,384,100); -- HASTE_GEAR: 1%
 
 -- Excalibur
 INSERT INTO `item_mods` VALUES (20645,23,40);   -- ATT: 40
@@ -43374,9 +43454,22 @@ INSERT INTO `item_mods` VALUES (21337,26,20); -- RACC: 20
 INSERT INTO `item_mods` VALUES (21340,25,5); -- ACC: 5
 INSERT INTO `item_mods` VALUES (21340,26,5); -- RACC: 5
 
+-- Oreiad's Tathlum
+INSERT INTO `item_mods` VALUES (21341,13,4); -- MND:  4
+INSERT INTO `item_mods` VALUES (21341,30,1); -- MACC: 1
+
 -- Erlenes Notebook
 INSERT INTO `item_mods` VALUES (21342,27,-2); -- ENMITY: -2
 INSERT INTO `item_mods` VALUES (21342,28,3);  -- MATT: 3
+
+-- Ghastly Tathlum
+INSERT INTO `item_mods` VALUES (21343,5,30);   -- MP: 30
+INSERT INTO `item_mods` VALUES (21343,311,10); -- MAGIC_DAMAGE: 10
+-- TODO: Unity Ranking: INT: 2～6
+
+-- Ghastly Tathlum +1
+INSERT INTO `item_mods` VALUES (21344,5,35);   -- MP: 35
+INSERT INTO `item_mods` VALUES (21344,311,11); -- MAGIC_DAMAGE: 11
 
 -- Focal Orb
 INSERT INTO `item_mods` VALUES (21345,23,10);  -- ATT: 10
@@ -43387,6 +43480,11 @@ INSERT INTO `item_mods` VALUES (21345,288,2);  -- DOUBLE_ATTACK: 2
 INSERT INTO `item_mods` VALUES (21347,2,25);  -- HP: 25
 INSERT INTO `item_mods` VALUES (21347,10,2);  -- VIT: 2
 INSERT INTO `item_mods` VALUES (21347,27,1);  -- ENMITY: 1
+-- TODO: Unity Ranking: INT: 2～6
+
+-- Narmar Boomerang
+INSERT INTO `item_mods` VALUES (21348,23,10); -- ATT:  10
+INSERT INTO `item_mods` VALUES (21348,24,10); -- RATT: 10
 
 -- Wingcutter +1
 INSERT INTO `item_mods` VALUES (21350,9,5);   -- DEX: 5


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds item mods and latents to multiple items between item ID 10447-21348.

## Steps to test these changes

As GM, !additem 10766 (Weapon drawn)|11607 (Varies by moon phase)|11652 (MP ≤ 50%)|14658 (works against aquan and amorph)|15008 (Bone skill under 40 and no synth support)|15528 (avatar summoned in party)|15529 (HP ≤ 25%)|15773 (In assault)
Equip the item, then make sure the listed condition is met. See if the proper effect takes place.

As GM, !additem 11769|16000|16404|20626|20627|20628|20630|20640|20641|20642|20643|20644|21341|21343|21344|21348
Equip item, make sure proper stats change.