### PR TITLE
Table BLU tp mod globals, remove CI exceptions

### DIFF
--- a/scripts/actions/spells/blue/1000_needles.lua
+++ b/scripts/actions/spells/blue/1000_needles.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.LIGHT
     params.skillType = xi.skill.BLUE_MAGIC

--- a/scripts/actions/spells/blue/asuran_claws.lua
+++ b/scripts/actions/spells/blue/asuran_claws.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/battle_dance.lua
+++ b/scripts/actions/spells/blue/battle_dance.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.IMPACTION

--- a/scripts/actions/spells/blue/bludgeon.lua
+++ b/scripts/actions/spells/blue/bludgeon.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.ARCANA
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/body_slam.lua
+++ b/scripts/actions/spells/blue/body_slam.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.DRAGON
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.IMPACTION

--- a/scripts/actions/spells/blue/cannonball.lua
+++ b/scripts/actions/spells/blue/cannonball.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.FUSION

--- a/scripts/actions/spells/blue/claw_cyclone.lua
+++ b/scripts/actions/spells/blue/claw_cyclone.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.SCISSION

--- a/scripts/actions/spells/blue/death_scissors.lua
+++ b/scripts/actions/spells/blue/death_scissors.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.COMPRESSION

--- a/scripts/actions/spells/blue/dimensional_death.lua
+++ b/scripts/actions/spells/blue/dimensional_death.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.H2H
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/disseverment.lua
+++ b/scripts/actions/spells/blue/disseverment.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.LUMINIAN
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/feather_storm.lua
+++ b/scripts/actions/spells/blue/feather_storm.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = xi.spells.blue.tpMod.CRITICAL
     params.critchance = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.critchance = 55

--- a/scripts/actions/spells/blue/foot_kick.lua
+++ b/scripts/actions/spells/blue/foot_kick.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = xi.spells.blue.tpMod.CRITICAL
     params.critchance = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.critchance = 55

--- a/scripts/actions/spells/blue/frenetic_rip.lua
+++ b/scripts/actions/spells/blue/frenetic_rip.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.DEMON
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.H2H
     params.scattr = xi.skillchainType.INDURATION

--- a/scripts/actions/spells/blue/frypan.lua
+++ b/scripts/actions/spells/blue/frypan.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/grand_slam.lua
+++ b/scripts/actions/spells/blue/grand_slam.lua
@@ -20,7 +20,7 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.H2H
     params.scattr = xi.skillchainType.INDURATION

--- a/scripts/actions/spells/blue/head_butt.lua
+++ b/scripts/actions/spells/blue/head_butt.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.IMPACTION

--- a/scripts/actions/spells/blue/helldive.lua
+++ b/scripts/actions/spells/blue/helldive.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BIRD
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/hydro_shot.lua
+++ b/scripts/actions/spells/blue/hydro_shot.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_CHANCE
+    params.tpmod = xi.spells.blue.tpMod.EFFECT_CHANCE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.REVERBERATION

--- a/scripts/actions/spells/blue/hysteric_barrage.lua
+++ b/scripts/actions/spells/blue/hysteric_barrage.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.DETONATION

--- a/scripts/actions/spells/blue/jet_stream.lua
+++ b/scripts/actions/spells/blue/jet_stream.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BIRD
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/mandibular_bite.lua
+++ b/scripts/actions/spells/blue/mandibular_bite.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.INDURATION

--- a/scripts/actions/spells/blue/pinecone_bomb.lua
+++ b/scripts/actions/spells/blue/pinecone_bomb.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.RANGED
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.LIQUEFACTION

--- a/scripts/actions/spells/blue/power_attack.lua
+++ b/scripts/actions/spells/blue/power_attack.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = xi.spells.blue.tpMod.CRITICAL
     params.critchance = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.critchance = 55

--- a/scripts/actions/spells/blue/queasyshroom.lua
+++ b/scripts/actions/spells/blue/queasyshroom.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.RANGED
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.COMPRESSION

--- a/scripts/actions/spells/blue/ram_charge.lua
+++ b/scripts/actions/spells/blue/ram_charge.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.FRAGMENTATION

--- a/scripts/actions/spells/blue/screwdriver.lua
+++ b/scripts/actions/spells/blue/screwdriver.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.AQUAN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = xi.spells.blue.tpMod.CRITICAL
     params.critchance = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.critchance = 55

--- a/scripts/actions/spells/blue/seedspray.lua
+++ b/scripts/actions/spells/blue/seedspray.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.INDURATION

--- a/scripts/actions/spells/blue/sickle_slash.lua
+++ b/scripts/actions/spells/blue/sickle_slash.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_CRITICAL
+    params.tpmod = xi.spells.blue.tpMod.CRITICAL
     params.critchance = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.critchance = 55

--- a/scripts/actions/spells/blue/smite_of_rage.lua
+++ b/scripts/actions/spells/blue/smite_of_rage.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.ARCANA
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.DETONATION

--- a/scripts/actions/spells/blue/spinal_cleave.lua
+++ b/scripts/actions/spells/blue/spinal_cleave.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/spiral_spin.lua
+++ b/scripts/actions/spells/blue/spiral_spin.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/actions/spells/blue/sprout_smack.lua
+++ b/scripts/actions/spells/blue/sprout_smack.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.REVERBERATION

--- a/scripts/actions/spells/blue/sub-zero_smash.lua
+++ b/scripts/actions/spells/blue/sub-zero_smash.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.AQUAN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.BLUNT
     params.scattr = xi.skillchainType.FRAGMENTATION

--- a/scripts/actions/spells/blue/sudden_lunge.lua
+++ b/scripts/actions/spells/blue/sudden_lunge.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = TPMOD_DAMAGE
+    params.tpmod = xi.spells.blue.tpMod.DAMAGE
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.DETONATION

--- a/scripts/actions/spells/blue/tail_slap.lua
+++ b/scripts/actions/spells/blue/tail_slap.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.HTH
     params.scattr = xi.skillchainType.REVERBERATION

--- a/scripts/actions/spells/blue/terror_touch.lua
+++ b/scripts/actions/spells/blue/terror_touch.lua
@@ -22,7 +22,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod = TPMOD_ACC
+    params.tpmod = xi.spells.blue.tpMod.ACC
     params.bonusacc = 0
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
         params.bonusacc = 70

--- a/scripts/actions/spells/blue/uppercut.lua
+++ b/scripts/actions/spells/blue/uppercut.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.H2H
     params.scattr = xi.skillchainType.LIQUEFACTION

--- a/scripts/actions/spells/blue/vertical_cleave.lua
+++ b/scripts/actions/spells/blue/vertical_cleave.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.LUMINIAN
-    params.tpmod = TPMOD_ATTACK
+    params.tpmod = xi.spells.blue.tpMod.ATTACK
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.SLASHING
     params.scattr = xi.skillchainType.GRAVITATION

--- a/scripts/actions/spells/blue/wild_oats.lua
+++ b/scripts/actions/spells/blue/wild_oats.lua
@@ -21,7 +21,7 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = TPMOD_DURATION
+    params.tpmod = xi.spells.blue.tpMod.DURATION
     params.attackType = xi.attackType.PHYSICAL
     params.damageType = xi.damageType.PIERCING
     params.scattr = xi.skillchainType.TRANSFIXION

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -12,12 +12,16 @@ xi.spells.blue = xi.spells.blue or {}
 -----------------------------------
 
 -- The TP modifier (currently unused)
-TPMOD_NONE     = 0
-TPMOD_CRITICAL = 1
-TPMOD_DAMAGE   = 2
-TPMOD_ACC      = 3
-TPMOD_ATTACK   = 4
-TPMOD_DURATION = 5
+xi.spells.blue.tpMod =
+{
+    NONE          = 0,
+    CRITICAL      = 1,
+    DAMAGE        = 2,
+    ACC           = 3,
+    ATTACK        = 4,
+    DURATION      = 5,
+    EFFECT_CHANCE = 6,
+}
 
 -----------------------------------
 -- Local functions

--- a/tools/ci/lua.sh
+++ b/tools/ci/lua.sh
@@ -101,14 +101,6 @@ global_objects=(
     handleThrenody
     isValidHealTarget
 
-    TPMOD_NONE
-    TPMOD_CHANCE
-    TPMOD_CRITICAL
-    TPMOD_DAMAGE
-    TPMOD_ACC
-    TPMOD_ATTACK
-    TPMOD_DURATION
-
     ForceCrash
     BuildString
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Moves `TPMOD_x` globals in bluemagic.lua to xi.spells.blue.tpMod (remains in that file since it is only used in blu scripts, and currently unused in calculations.
* Adds `EFFECT_CHANCE` tpmod to replace nil value in hydro shot
* Removes CI exceptions in luacheck for `TPMOD_x`
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
