### PR TITLE
Rename xi.cutscene.params to xi.cutsceneFlag, move to enum

### DIFF
--- a/scripts/enum/cutscene_flag.lua
+++ b/scripts/enum/cutscene_flag.lua
@@ -1,9 +1,10 @@
-xi = xi or {}
-xi.cutscenes = {}
-
+-----------------------------------
 -- Flags during events
+-----------------------------------
+xi = xi or {}
+
 -- Note: events have opcodes that can set flags internally, these can be ignored or set for each unique cutscene.
-xi.cutscenes.params =
+xi.cutsceneFlag =
 {
     UNKNOWN_1       = 0x01, -- Commonly set, effect unknown
     NO_PCS          = 0x02, -- Do not display other Player Characters

--- a/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
+++ b/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
@@ -21,9 +21,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 0, -1, cutsceneFlags } -- CS 0 is not a typo.
@@ -38,9 +38,9 @@ quest.sections =
                     -- TODO: research if there was some purpose to the zoning.
 
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     player:startEvent(7, { flags = cutsceneFlags })
@@ -66,9 +66,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
                     return { 1, -1, cutsceneFlags }
                 end
@@ -96,9 +96,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
                     return { 1, -1, cutsceneFlags }
                 end
@@ -126,9 +126,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 535, -1, cutsceneFlags }
@@ -157,9 +157,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 503, -1, cutsceneFlags }
@@ -188,9 +188,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 500, -1, cutsceneFlags }
@@ -219,10 +219,10 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.NO_NPCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.NO_NPCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 531, -1, cutsceneFlags }
@@ -262,10 +262,10 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.NO_NPCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.NO_NPCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
                     return { 367, -1, cutsceneFlags }
                 end
@@ -293,9 +293,9 @@ quest.sections =
             {
                 function(player, prevZone)
                     local cutsceneFlags = bit.bor(
-                        xi.cutscenes.params.UNKNOWN_1,
-                        xi.cutscenes.params.NO_PCS,
-                        xi.cutscenes.params.UNKNOWN_2
+                        xi.cutsceneFlag.UNKNOWN_1,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
                     )
 
                     return { 305, -1, cutsceneFlags }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves xi.cutscene.params to xi.cutsceneFlag enum and updates references to table
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed, only utilized in new character CSs at this time
<!-- Clear and detailed steps to test your changes here -->
