### PR TITLE
[core, lua] Fix issues with healing dead players and reraise after moving players

### DIFF
--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared_helper.lua
@@ -10,9 +10,18 @@ local oneToBeFeared = {}
 -- Not to be confused with an actual instance.
 
 local function healCharacter(player)
-    player:setHP(player:getMaxHP())
-    player:setMP(player:getMaxMP())
-    player:setTP(0)
+    -- only heal players if alive otherwise bugs out player
+    if player:isAlive() then
+        player:setHP(player:getMaxHP())
+        player:setMP(player:getMaxMP())
+        player:setTP(0)
+        if player:getPet() ~= nil then
+            local pet = player:getPet()
+            pet:setHP(pet:getMaxHP())
+            pet:setMP(pet:getMaxMP())
+            pet:setTP(0)
+        end
+    end
 end
 
 local function returnToAirship(player)
@@ -25,6 +34,12 @@ local function returnToAirship(player)
         player:setPos(-140.029, -23.348, -446.376, 193)
     elseif instance == 3 then
         player:setPos(499.969, 56.652, -806.132, 193)
+    end
+
+    -- allow resending raise/reraise prompt since we moved player
+    -- which removes the prompt from player screen
+    if player:isDead() then
+        player:allowSendRaisePrompt()
     end
 end
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11157,6 +11157,28 @@ void CLuaBaseEntity::sendTractor(float xPos, float yPos, float zPos, uint8 rotat
 }
 
 /************************************************************************
+ *  Function: allowSendRaisePrompt()
+ *  Purpose : Allows the raise prompt to be sent again to client
+ *            if for example player was moved while dead (thus removing the prompt)
+ *  Example : player:allowSendRaisePrompt()
+ ************************************************************************/
+
+void CLuaBaseEntity::allowSendRaisePrompt()
+{
+    if (m_PBaseEntity == nullptr || m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowError("m_PBaseEntity is null or not a Player.");
+        return;
+    }
+
+    if (m_PBaseEntity->PAI->IsCurrentState<CDeathState>())
+    {
+        auto deathState = static_cast<CDeathState*>(m_PBaseEntity->PAI->GetCurrentState());
+        deathState->allowSendRaise();
+    }
+}
+
+/************************************************************************
  *  Function: countdown()
  *  Purpose : Starts or clears a visible countdown bar for player
  *  Example : player:countdown(60)
@@ -17585,6 +17607,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("sendRaise", CLuaBaseEntity::sendRaise);
     SOL_REGISTER("sendReraise", CLuaBaseEntity::sendReraise);
     SOL_REGISTER("sendTractor", CLuaBaseEntity::sendTractor);
+    SOL_REGISTER("allowSendRaisePrompt", CLuaBaseEntity::allowSendRaisePrompt);
 
     SOL_REGISTER("countdown", CLuaBaseEntity::countdown);
     SOL_REGISTER("enableEntities", CLuaBaseEntity::enableEntities);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -570,6 +570,7 @@ public:
     void sendRaise(uint8 raiseLevel);
     void sendReraise(uint8 raiseLevel);
     void sendTractor(float xPos, float yPos, float zPos, uint8 rotation);
+    void allowSendRaisePrompt();
 
     void countdown(sol::object const& secondsObj,
                    sol::object const& bar1NameObj, sol::object const& bar1ValObj,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -896,8 +896,9 @@ namespace charutils
 
         charutils::LoadEquip(PChar);
         charutils::EmptyRecycleBin(PChar);
-        PChar->health.hp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxHP() : HP;
-        PChar->health.mp = zoneutils::IsResidentialArea(PChar) ? PChar->GetMaxMP() : MP;
+        bool canRestore  = zoneutils::IsResidentialArea(PChar) && HP > 0;
+        PChar->health.hp = canRestore ? PChar->GetMaxHP() : HP;
+        PChar->health.mp = canRestore ? PChar->GetMaxMP() : MP;
         PChar->UpdateHealth();
 
         luautils::OnZoneIn(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The PR fixes several issues related to healing dead players and reraise:
1. In The CoP 6-4 battlefield helper, the player should only be healed if they are actually alive. Otherwise the player is dead (death animation and cannot move) but appears to have positive HP in the client
2. Relatedly, in places where the player is moved within the same zone (like between deck and airship in CoP 6-4), the player can die with RR and then be moved (after beating mammets for example), but the reraise prompt is lost and the player cannot be raised normally (because m_raiseSent is already set). This adds a method for players called allowSendRaisePrompt that resets the m_raiseSent variable so raise and reraise can be sent. This method is now called after players are moved in CoP 6-4 battlefield.
3. Similar to 1, adds logic for MH healing to only heal if the player actually has HP > 0, this prevents issues when players die while zoning into MH

## Steps to test these changes
1. Enter CoP 6-4 fight, die in fight and then have second character kill the mammets, when dead player is sent back to ship deck they should still look dead with zero HP
2. In CoP 6-4 fight, have one player put up RR and then die to mammets, then have second player kill mammets, when sent back to ship deck the player with RR should get the prompt again despite being moved
3. Use a poison potion with very little HP right outside MH and then run into moghouse as you die, you should be dead in MH with zero HP