### PR TITLE
[AMK, Lua] Mission 13 puzzle 2 - Xarcabard Trivia implemented

### DIFF
--- a/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
+++ b/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
@@ -74,7 +74,7 @@ mission.sections =
                         player:needToZone(true)
                     end
                 end,
-            }
+            },
         },
     },
 
@@ -100,14 +100,14 @@ mission.sections =
             ['Goblin_Grenadier'] =
             {
                 onTrigger = function(player, npc)
-                    local answer = player:getLocalVar('Mission[10][12]pipSet') - 1
+                    local answer = player:getLocalVar('Mission[10][12][p1]pipSet') - 1
 
                     if answer < 0 then
                         return mission:progressEvent(508, xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
                     else
                         local today = VanadielDayOfTheWeek()
                         local tomorrow = (today + 1) % 8
-                        local hintsUsed = player:getLocalVar('Mission[10][12]hintsUsed')
+                        local hintsUsed = player:getLocalVar('Mission[10][12][p1]hintsUsed')
 
                         player:messageSpecial(zones[player:getZoneID()].text.GRENADIER_DAY_HINT, today, tomorrow)
 
@@ -126,108 +126,42 @@ mission.sections =
             ['Northwestern_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][1]
-
-                    return mission:progressEvent(
-                        510,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 1)
                 end,
             },
 
             ['Western_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][2]
-
-                    return mission:progressEvent(
-                        511,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 2)
                 end,
             },
 
             ['Southwestern_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][3]
-
-                    return mission:progressEvent(
-                        512,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 3)
                 end,
             },
 
             ['Northeastern_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][4]
-
-                    return mission:progressEvent(
-                        513,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 4)
                 end,
             },
 
             ['Eastern_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][5]
-
-                    return mission:progressEvent(
-                        514,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 5)
                 end,
             },
 
             ['Southeastern_Pip'] =
             {
                 onTrigger = function(player, npc)
-                    local pipSet = player:getLocalVar('Mission[10][12]pipSet') - 1
-                    local pos = npc:getPos()
-                    local element = xi.amk.helpers.pipSets[pipSet][6]
-
-                    return mission:progressEvent(
-                        515,
-                        pos.x * 1000,
-                        pos.z * 1000,
-                        pos.y * 1000,
-                        element,
-                        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
-                    )
+                    return xi.amk.helpers.puzzleOneOnTrigger(player, npc, mission, 6)
                 end,
             },
 
@@ -249,8 +183,8 @@ mission.sections =
                         option == 1 or -- Used first hint
                         option == 2    -- Used second hint
                     then
-                        local hintsUsed = player:getLocalVar('Mission[10][12]hintsUsed')
-                        player:setLocalVar('Mission[10][12]hintsUsed', hintsUsed + 1)
+                        local hintsUsed = player:getLocalVar('Mission[10][12][p1]hintsUsed')
+                        player:setLocalVar('Mission[10][12][p1]hintsUsed', hintsUsed + 1)
                     elseif option == 3 then
                         -- wrong answer, reset puzzle
                         player:needToZone(false)
@@ -280,7 +214,7 @@ mission.sections =
 
                 [508] = function(player, csid, option, npc)
                     -- Pipset offset by 1 to account for saving 0 as a variable.  When retrieving, subtract 1
-                    player:setLocalVar('Mission[10][12]pipSet', math.random(1, 10)) -- range: 0 - 9
+                    player:setLocalVar('Mission[10][12][p1]pipSet', math.random(1, 10)) -- range: 0 - 9
                 end,
             },
         },
@@ -325,7 +259,7 @@ mission.sections =
     -- Part 3: Xarcabard
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and
+            return currentMission >= mission.missionId and
             player:getCharVar('Mission[10][12]progress') == 2 and
             player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON)
         end,
@@ -343,7 +277,40 @@ mission.sections =
 
         [xi.zone.XARCABARD] =
         {
+            ['Option_One'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
 
+            ['Option_Two'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
+
+            ['Option_Three'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [200] = function(player, csid, option, npc)
+                    xi.amk.helpers.puzzleTwoOnEventUpdate(player, csid, option, npc, mission)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [200] = function(player, csid, option, npc)
+                    xi.amk.helpers.puzzleTwoOnEventFinish(player, csid, option, npc, mission)
+                end
+            },
         },
     },
 

--- a/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
+++ b/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
@@ -2,9 +2,16 @@
 -- A Challenge! You Could Be a Winner
 -- A Moogle Kupo d'Etat M13
 -- !addmission 10 12
--- Shadowy Pillar : !pos 374 -12 -15
+-----------------------------------
+-- Puzzle 1 - Beaucedine
+-- Shadowy Pillar   : !pos 374 -12 -15
 -- Lonely Evergreen : !pos -162 -80 178
 -- Goblin Grenadier : !pos -26 -59 -76
+-----------------------------------
+-- Puzzle 2 - Xarcabard
+-- Option_One   : !pos 126 -24 -118
+-- Option_One   : !pos 66 -24 -191 112
+-- Option_Three : !pos 1 -23 -103 112
 -----------------------------------
 -- This mission can be repeated by losing the bncm battle in the subsequent mission
 -- Therefore to remove possible conflicts, the mission progress will be handled
@@ -317,8 +324,33 @@ mission.sections =
     -- Part 4: Castle Zvahl Baileys
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId
+            return currentMission >= mission.missionId and
+            player:getCharVar('Mission[10][12]progress') == 3
         end,
+
+        [xi.zone.XARCABARD] =
+        {
+            ['Option_One'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
+
+            ['Option_Two'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
+
+            ['Option_Three'] =
+            {
+                onTrigger = function(player, npc)
+                    return xi.amk.helpers.puzzleTwoOnTrigger(player, npc, mission)
+                end,
+            },
+        },
 
         [xi.zone.CASTLE_ZVAHL_BAILEYS] =
         {

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- A Moogle Kupo d'Etat Helpers
 -----------------------------------
-XARC = zones[xi.zone.XARCABARD]
------------------------------------
 
 xi = xi or {}
 xi.amk = xi.amk or {}
@@ -225,7 +223,7 @@ xi.amk.helpers.digSites =
             { x = 392.970, z = 157.610 },   -- (J-7) NE corner
             { x = -32.940, z = 251.870 },   -- (H-6) Green patch on ground
             { x = -275.140, z = -258.90 },  -- (F-9) Center of grid (kind of impossible)
-            { x = 426.50, z = -231.660 },   -- (K-9) Few feet west of randomSign post
+            { x = 426.50, z = -231.660 },   -- (K-9) Few feet west of sign post
         },
     },
     [xi.zone.MERIPHATAUD_MOUNTAINS] =
@@ -523,12 +521,12 @@ end
 -- trivia locations: 0 = option one, 1 = option two, 2 = option three
 -- Stooge CS locations: 1 = option one, 2 = option two, 3 = option three
 -- Variables are named as 'option' if 0-indexed, as 'stooge' if 1-indexed
--- TODO: Figure out way to add questions 4, 6, 7, 8, and 9
-------------------------
+-----------------------------------
+local xarc = zones[xi.zone.XARCABARD]
 
 local randomSign = function()
     -- returns -1 or 1 to offset the wrong answer randomly
-    return math.random(1,2) == 1 and -1 or 1
+    return math.random(1, 2) == 1 and 1 or -1
 end
 
 -- Structured list of the trivia questions
@@ -537,61 +535,156 @@ xi.amk.helpers.triviaQuestions =
     -- 0 : Add your current hit points to your current magic points, and you get…?
     [0] = function(player)
         local right = player:getHP() + player:getMP()
-        local wrong = right + (randomSign() * 10)
-        return {right, wrong}
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- player has 1 hp 0 mp
+            wrong = 2
+        end
+
+        return { right, wrong }
     end,
 
     -- 1 : The sum total of each and every one of your job levels is?
     [1] = function(player)
-        local job_total = 0
+        local jobTotal = 0
         for i = xi.job.WAR, xi.job.RUN do
-            job_total = job_total + player:getJobLevel(i)
+            jobTotal = jobTotal + player:getJobLevel(i)
         end
-        local right = job_total
-        local wrong = right + (randomSign() * math.random(1, 15))
-        return {right, wrong}
+
+        local right = jobTotal -- minimum 15
+        local wrong = right + (randomSign() * math.floor(right / 2))
+        return { right, wrong }
     end,
 
     -- 2 : The sum total of each of your crafting skill levels is?
     [2] = function(player)
-        local craft_total = 0
-        for i = xi.skill.FISHING, xi.skill.COOKING do
-            craft_total = craft_total + math.floor(player:getCharSkillLevel(i) / 10)
+        local craftTotal = 0
+        for craft = xi.skill.FISHING, xi.skill.SYNERGY do
+            craftTotal = craftTotal + math.floor(player:getCharSkillLevel(craft) / 10)
         end
-        local right = craft_total
-        local wrong = right + (randomSign() * math.random(1, 10))
-        if right == 0 then
-            wrong = math.random(1, 10)
-        else
-            wrong = utils.clamp(wrong, 0, wrong)
+
+        local right = craftTotal
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            if wrong == 0 then
+                wrong = 1
+            elseif wrong == 1 then
+                wrong = wrong + randomSign()
+            end
         end
-        return {right, wrong}
+
+        return { right, wrong }
     end,
 
     -- 3 : The sum total of each one of your current elemental resistance levels is?
     [3] = function(player)
-        local element_total = 0
-        for i = xi.mod.FIRE_RES_RANK, xi.mod.DARK_RES_RANK do
-            element_total = element_total + player:getMod(i)
+        local elementTotal = 0
+        for mod = xi.mod.FIRE_MEVA, xi.mod.DARK_MEVA do
+            elementTotal = elementTotal + player:getMod(mod)
         end
-        local right = element_total
-        local wrong = right + (randomSign() * math.random(1, 10))
-        return {right, wrong}
+
+        local right = elementTotal
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            wrong = wrong + randomSign()
+        end
+
+        return { right, wrong }
     end,
 
     -- 4 : The total number of foes you’ve felled is?
+    [4] = function(player)
+        local right = player:getHistory(xi.history.ENEMIES_DEFEATED)
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            wrong = right + 1
+        end
+
+        return { right, wrong }
+    end,
 
     -- 5 : Multiply your current attack and defense, and what do you get!?
     [5] = function(player)
         local right = player:getStat(xi.mod.ATT) * player:getStat(xi.mod.DEF)
-        local wrong = right + (randomSign() * math.random(21, 88))
-        return {right, wrong}
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            if wrong == 0 then
+                wrong = 1
+            elseif wrong == 1 then
+                wrong = wrong + randomSign()
+            end
+        end
+
+        return { right, wrong }
     end,
 
     -- 6 : The total number of times you’ve strolled through the doors of your Mog House is?
+    [6] = function(player)
+        local right = player:getHistory(xi.history.MH_ENTRANCES)
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        return { right, wrong }
+    end,
+
     -- 7 : The total number of times you’ve been incapacitated by your enemies is?
+    [7] = function(player)
+        local right = player:getHistory(xi.history.TIMES_KNOCKED_OUT)
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            if wrong == 0 then
+                wrong = 1
+            elseif wrong == 1 then
+                wrong = wrong + randomSign()
+            end
+        end
+
+        return { right, wrong }
+    end,
+
     -- 8 : The total number of times you’ve participated in a party is?
+    [8] = function(player)
+        local right = player:getHistory(xi.history.JOINED_PARTIES)
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            if wrong == 0 then
+                wrong = 1
+            elseif wrong == 1 then
+                wrong = wrong + randomSign()
+            end
+        end
+
+        return { right, wrong }
+    end,
+
     -- 9 : The total number of times you’ve affiliated yourself with an alliance is?
+    [9] = function(player)
+        local right = player:getHistory(xi.history.JOINED_ALLIANCES)
+        local wrong = right + (randomSign() * math.floor(right / 2))
+
+        if wrong == right then
+            -- right is 0 or 1
+            if wrong == 0 then
+                wrong = 1
+            elseif wrong == 1 then
+                wrong = wrong + randomSign()
+            end
+        end
+
+        return { right, wrong }
+    end,
 }
 
 local assignRandomTriviaQuestions = function(player)
@@ -619,17 +712,32 @@ end
 
 local stooges =
 {
-    [XARC.npc.OPTION_ONE]   = { option = 0, stoogeNum = 1, answerOne = 1, answerTwo = 2},
-    [XARC.npc.OPTION_TWO]   = { option = 1, stoogeNum = 2, answerOne = 0, answerTwo = 2},
-    [XARC.npc.OPTION_THREE] = { option = 2, stoogeNum = 3, answerOne = 0, answerTwo = 1},
+    -- Answer numbers are 0-indexed references to Option_[One/two/three].
+    -- AnswerOne/Two are used in onEventUpdate to determine which Option
+    -- to point to for wrong and right answers. ie: answerOne = 0 points to Option_One
+    -- StoogeNum is used in onEventTrigger to determine which npc visual
+    -- to show
+    [xarc.npc.OPTION_ONE]   = { stoogeNum = 1, answerOne = 1, answerTwo = 2 },
+    [xarc.npc.OPTION_TWO]   = { stoogeNum = 2, answerOne = 0, answerTwo = 2 },
+    [xarc.npc.OPTION_THREE] = { stoogeNum = 3, answerOne = 0, answerTwo = 1 },
 }
 
 xi.amk.helpers.puzzleTwoOnTrigger = function(player, npc, mission)
     local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+
+    -- Starting puzzle, assign questions
     if p2Progress == 0 then
         p2Progress = 1
         player:setLocalVar('Mission[10][12][p2]progress', p2Progress)
         assignRandomTriviaQuestions(player)
+    end
+
+    -- Puzzle already beaten, show flavor text
+    if
+        player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON) or
+        player:getCharVar('Mission[10][12]progress') == 3
+    then
+        p2Progress = 10
     end
 
     local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. p2Progress)
@@ -654,31 +762,33 @@ xi.amk.helpers.puzzleTwoOnTrigger = function(player, npc, mission)
             os.time()
         )
     end
-
 end
 
 xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, mission)
-    local stooge = stooges[npc:getID()]
-
     if option >= 1 and option <= 3 then
+        local stooge = stooges[npc:getID()]
         local timeLimit = os.time() + 180 -- Three minutes
-        local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. player:getLocalVar('Mission[10][12][p2]progress'))
+        local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+        local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. p2Progress)
         local answers = xi.amk.helpers.triviaQuestions[currentQuestion](player)
 
-        -- Randomize which of the two other options is correct.  Set vars to default, then swap only when answerOne is 1
-        local answerOne = math.random(1,2)
-        local answerTwo = 1
-        local correctOption = stooge.answerTwo
+        -- Right and wrong answer/stooge has to be randomized in terms of order given to updateEvent
+        -- Randomize which of the two other options is correct.  Set vars to a default choice, then swap only when answerOne is 2
+        local answerOne = math.random(1, 2)
 
-        if answerOne == 1 then
-            -- Swap variables
-            answerTwo = 2
-            correctOption = stooge.answerOne
+        -- Default: answerOne == 1
+        local correctOption = stooge.answerOne
+        local answerTwo = 2
+
+        if answerOne == 2 then
+            correctOption = stooge.answerTwo
+            answerTwo = 1
         end
 
+        -- Store important information for next CS parameters
         player:setLocalVar('Mission[10][12][p2]correctStooge', correctOption + 1) -- Stooge num is always 1 more than the option
-        player:setLocalVar('Mission[10][12][p2]timeLimit', timeLimit)
-        player:setLocalVar('Mission[10][12][p2]previousStooge', stooge.option + 1)
+        player:setLocalVar('Mission[10][12][p2]timeLimit', timeLimit) -- Time limit - > 3 minutes fails
+        player:setLocalVar('Mission[10][12][p2]previousStooge', stooge.stoogeNum) -- this tells the stooge that he is or isn't supposed to talk
 
         player:updateEvent(
             answers[answerOne],
@@ -690,13 +800,12 @@ xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, miss
             os.time()
         )
     elseif option == 11 then
-        -- Incorrect Answer, reset all vars (no need to zone)
-        resetPuzzleVars(player)
-        local randomFlavorText = math.random(1,2)
+        -- Incorrect Answer
+        local randomFlavorText = math.random(1, 2)
         if randomFlavorText == 1 then
-            player:messageSpecial(XARC.text.INCORRECT_NO_GIFTS)
+            player:messageSpecial(xarc.text.INCORRECT_NO_GIFTS)
         else
-            player:messageSpecial(XARC.text.EXACTLY_WRONG)
+            player:messageSpecial(xarc.text.EXACTLY_WRONG)
         end
     end
 end
@@ -704,17 +813,19 @@ end
 xi.amk.helpers.puzzleTwoOnEventFinish = function(player, csid, option, npc, mission)
     local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
     if csid == 200 then
-        if option == 1 then
+        if option == 0 then
+            -- lost the game, via time or wrong answer - reset vars
+            resetPuzzleVars(player)
+        elseif option == 1 then
             player:setLocalVar('Mission[10][12][p2]progress', p2Progress + 1)
         elseif option == 2 and p2Progress == 4 then
             -- Won game, reset all vars
             resetPuzzleVars(player)
             npcUtil.giveKeyItem(player, xi.ki.GAUNTLET_CHALLENGE_KUPON)
-            player:setLocalVar('Mission[10][12][p2]progress', 10)
 
             -- Advance to puzzle 3
-            -- player:setCharVar('Mission[10][12]progress', 3)
-            -- player:setCharVar('Mission[10][12][p3]stoogeArg', 1)
+            player:setCharVar('Mission[10][12]progress', 3)
+            player:setCharVar('Mission[10][12][p3]stoogeArg', 1)
         end
     end
 end

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -1,6 +1,9 @@
 -----------------------------------
 -- A Moogle Kupo d'Etat Helpers
 -----------------------------------
+XARC = zones[xi.zone.XARCABARD]
+-----------------------------------
+
 xi = xi or {}
 xi.amk = xi.amk or {}
 xi.amk.helpers = xi.amk.helpers or {}
@@ -222,7 +225,7 @@ xi.amk.helpers.digSites =
             { x = 392.970, z = 157.610 },   -- (J-7) NE corner
             { x = -32.940, z = 251.870 },   -- (H-6) Green patch on ground
             { x = -275.140, z = -258.90 },  -- (F-9) Center of grid (kind of impossible)
-            { x = 426.50, z = -231.660 },   -- (K-9) Few feet west of sign post
+            { x = 426.50, z = -231.660 },   -- (K-9) Few feet west of randomSign post
         },
     },
     [xi.zone.MERIPHATAUD_MOUNTAINS] =
@@ -417,10 +420,13 @@ xi.amk.helpers.chocoboDig = function(player, zoneId, text)
 end
 
 -- Mission 13 (index 12) - Puzzles!!!
--- Puzzle 1
+-----------------------------------
+-- Puzzle 1 - Elemental Numbers!
+-----------------------------------
 xi.amk.helpers.pipSets =
 {
-    -- [Answer]: 0-9 {
+    -- [Answer]: 0-9
+    -- {
     --     [1] = NW, [4] = NE,
     --     [2] = W,  [5] = E,
     --     [3] = SW, [6] = SE,
@@ -495,3 +501,220 @@ xi.amk.helpers.pipSets =
         [3] = 1, [6] = 3,
     },
 }
+
+xi.amk.helpers.puzzleOneOnTrigger = function(player, npc, mission, offset)
+    local pipSet = player:getLocalVar('Mission[10][12][p1]pipSet') - 1
+    local pos = npc:getPos()
+    local element = xi.amk.helpers.pipSets[pipSet][offset]
+
+    return mission:progressEvent(509 + offset,
+        pos.x * 1000,
+        pos.z * 1000,
+        pos.y * 1000,
+        element,
+        xi.ki.MAP_OF_THE_NORTHLANDS_AREA
+    )
+end
+
+-----------------------------------
+-- Puzzle 2 - Trivia!
+-- CSID 200 trigger params: question number, correct answer (stoogeNum), previous stooge, stooge location, time limit, current time, player ID?
+-- CSID 200 update params:  answer 1, location 1, answer 2, location 2, cs moogle location, time limit, current time, player id?
+-- trivia locations: 0 = option one, 1 = option two, 2 = option three
+-- Stooge CS locations: 1 = option one, 2 = option two, 3 = option three
+-- Variables are named as 'option' if 0-indexed, as 'stooge' if 1-indexed
+-- TODO: Figure out way to add questions 4, 6, 7, 8, and 9
+------------------------
+
+local randomSign = function()
+    -- returns -1 or 1 to offset the wrong answer randomly
+    return math.random(1,2) == 1 and -1 or 1
+end
+
+-- Structured list of the trivia questions
+xi.amk.helpers.triviaQuestions =
+{
+    -- 0 : Add your current hit points to your current magic points, and you get…?
+    [0] = function(player)
+        local right = player:getHP() + player:getMP()
+        local wrong = right + (randomSign() * 10)
+        return {right, wrong}
+    end,
+
+    -- 1 : The sum total of each and every one of your job levels is?
+    [1] = function(player)
+        local job_total = 0
+        for i = xi.job.WAR, xi.job.RUN do
+            job_total = job_total + player:getJobLevel(i)
+        end
+        local right = job_total
+        local wrong = right + (randomSign() * math.random(1, 15))
+        return {right, wrong}
+    end,
+
+    -- 2 : The sum total of each of your crafting skill levels is?
+    [2] = function(player)
+        local craft_total = 0
+        for i = xi.skill.FISHING, xi.skill.COOKING do
+            craft_total = craft_total + math.floor(player:getCharSkillLevel(i) / 10)
+        end
+        local right = craft_total
+        local wrong = right + (randomSign() * math.random(1, 10))
+        if right == 0 then
+            wrong = math.random(1, 10)
+        else
+            wrong = utils.clamp(wrong, 0, wrong)
+        end
+        return {right, wrong}
+    end,
+
+    -- 3 : The sum total of each one of your current elemental resistance levels is?
+    [3] = function(player)
+        local element_total = 0
+        for i = xi.mod.FIRE_RES_RANK, xi.mod.DARK_RES_RANK do
+            element_total = element_total + player:getMod(i)
+        end
+        local right = element_total
+        local wrong = right + (randomSign() * math.random(1, 10))
+        return {right, wrong}
+    end,
+
+    -- 4 : The total number of foes you’ve felled is?
+
+    -- 5 : Multiply your current attack and defense, and what do you get!?
+    [5] = function(player)
+        local right = player:getStat(xi.mod.ATT) * player:getStat(xi.mod.DEF)
+        local wrong = right + (randomSign() * math.random(21, 88))
+        return {right, wrong}
+    end,
+
+    -- 6 : The total number of times you’ve strolled through the doors of your Mog House is?
+    -- 7 : The total number of times you’ve been incapacitated by your enemies is?
+    -- 8 : The total number of times you’ve participated in a party is?
+    -- 9 : The total number of times you’ve affiliated yourself with an alliance is?
+}
+
+local assignRandomTriviaQuestions = function(player)
+    local questions = {}
+    for i, _ in pairs(xi.amk.helpers.triviaQuestions) do
+        table.insert(questions, i)
+    end
+
+    for i = 1, 3 do
+        local index = math.random(1, #questions)
+        player:setLocalVar('Mission[10][12][p2]question' .. i, questions[index])
+        table.remove(questions, index)
+    end
+end
+
+local resetPuzzleVars = function(player)
+    player:setLocalVar('Mission[10][12][p2]progress', 0)
+    player:setLocalVar('Mission[10][12][p2]timeLimit', 0)
+    player:setLocalVar('Mission[10][12][p2]question1', 0)
+    player:setLocalVar('Mission[10][12][p2]question2', 0)
+    player:setLocalVar('Mission[10][12][p2]question3', 0)
+    player:setLocalVar('Mission[10][12][p2]correctStooge', 0)
+    player:setLocalVar('Mission[10][12][p2]previousStooge', 0)
+end
+
+local stooges =
+{
+    [XARC.npc.OPTION_ONE]   = { option = 0, stoogeNum = 1, answerOne = 1, answerTwo = 2},
+    [XARC.npc.OPTION_TWO]   = { option = 1, stoogeNum = 2, answerOne = 0, answerTwo = 2},
+    [XARC.npc.OPTION_THREE] = { option = 2, stoogeNum = 3, answerOne = 0, answerTwo = 1},
+}
+
+xi.amk.helpers.puzzleTwoOnTrigger = function(player, npc, mission)
+    local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+    if p2Progress == 0 then
+        p2Progress = 1
+        player:setLocalVar('Mission[10][12][p2]progress', p2Progress)
+        assignRandomTriviaQuestions(player)
+    end
+
+    local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. p2Progress)
+    local correctStooge = player:getLocalVar('Mission[10][12][p2]correctStooge')
+    local previousStooge = player:getLocalVar('Mission[10][12][p2]previousStooge')
+    local stoogeNum = stooges[npc:getID()].stoogeNum
+    local timeLimit = player:getLocalVar('Mission[10][12][p2]timeLimit')
+
+    -- DEBUG
+    -- player:PrintToPlayer(string.format("p2Progress: %s, time_limit: %s, currentQuestion: %s, correctStooge: %s, previousStooge: %s, stoogeNum: %s",
+    --                                     p2Progress,     timeLimit,      currentQuestion,     correctStooge,       previousStooge,    stoogeNum))
+
+    if previousStooge ~= stoogeNum then
+        return mission:progressEvent(
+            200,
+            p2Progress,
+            currentQuestion,
+            correctStooge,
+            previousStooge,
+            stoogeNum,
+            timeLimit,
+            os.time()
+        )
+    end
+
+end
+
+xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, mission)
+    local stooge = stooges[npc:getID()]
+
+    if option >= 1 and option <= 3 then
+        local timeLimit = os.time() + 180 -- Three minutes
+        local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. player:getLocalVar('Mission[10][12][p2]progress'))
+        local answers = xi.amk.helpers.triviaQuestions[currentQuestion](player)
+
+        -- Randomize which of the two other options is correct.  Set vars to default, then swap only when answerOne is 1
+        local answerOne = math.random(1,2)
+        local answerTwo = 1
+        local correctOption = stooge.answerTwo
+
+        if answerOne == 1 then
+            -- Swap variables
+            answerTwo = 2
+            correctOption = stooge.answerOne
+        end
+
+        player:setLocalVar('Mission[10][12][p2]correctStooge', correctOption + 1) -- Stooge num is always 1 more than the option
+        player:setLocalVar('Mission[10][12][p2]timeLimit', timeLimit)
+        player:setLocalVar('Mission[10][12][p2]previousStooge', stooge.option + 1)
+
+        player:updateEvent(
+            answers[answerOne],
+            stooge.answerOne,
+            answers[answerTwo],
+            stooge.answerTwo,
+            currentQuestion,
+            timeLimit,
+            os.time()
+        )
+    elseif option == 11 then
+        -- Incorrect Answer, reset all vars (no need to zone)
+        resetPuzzleVars(player)
+        local randomFlavorText = math.random(1,2)
+        if randomFlavorText == 1 then
+            player:messageSpecial(XARC.text.INCORRECT_NO_GIFTS)
+        else
+            player:messageSpecial(XARC.text.EXACTLY_WRONG)
+        end
+    end
+end
+
+xi.amk.helpers.puzzleTwoOnEventFinish = function(player, csid, option, npc, mission)
+    local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+    if csid == 200 then
+        if option == 1 then
+            player:setLocalVar('Mission[10][12][p2]progress', p2Progress + 1)
+        elseif option == 2 and p2Progress == 4 then
+            -- Won game, reset all vars
+            resetPuzzleVars(player)
+            npcUtil.giveKeyItem(player, xi.ki.GAUNTLET_CHALLENGE_KUPON)
+            player:setLocalVar('Mission[10][12][p2]progress', 10)
+
+            -- Advance to puzzle 3
+            -- player:setCharVar('Mission[10][12]progress', 3)
+            -- player:setCharVar('Mission[10][12][p3]stoogeArg', 1)
+        end
+    end
+end

--- a/scripts/zones/Xarcabard/DefaultActions.lua
+++ b/scripts/zones/Xarcabard/DefaultActions.lua
@@ -1,8 +1,11 @@
 local ID = zones[xi.zone.XARCABARD]
 
 return {
-    ['qm2']  = { messageSpecial = ID.text.ONLY_SHARDS },
-    ['qm3']  = { messageSpecial = ID.text.ONLY_SHARDS },
-    ['qm4']  = { messageSpecial = ID.text.ONLY_SHARDS },
-    ['qm5']  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Option_One']   = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Option_Two']   = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Option_Three'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm2']          = { messageSpecial = ID.text.ONLY_SHARDS },
+    ['qm3']          = { messageSpecial = ID.text.ONLY_SHARDS },
+    ['qm4']          = { messageSpecial = ID.text.ONLY_SHARDS },
+    ['qm5']          = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Xarcabard/IDs.lua
+++ b/scripts/zones/Xarcabard/IDs.lua
@@ -31,6 +31,8 @@ zones[xi.zone.XARCABARD] =
         PLAYERS_HAVE_NOT_REACHED_LEVEL = 7855,  -- Players who have not reached level <number> are prohibited from entering Dynamis.
         DYNA_NPC_DEFAULT_MESSAGE       = 7892,  -- There is a symbol carved into the rock here.
         GARRISON_BASE                  = 8047,  -- Hm? What is this? %? How do I know this is not some [San d'Orian/Bastokan/Windurstian] trick?
+        INCORRECT_NO_GIFTS             = 8153,  -- <Bzzzzzzt!> Ohhhhhh, I'm sorry, that's incorrect. But don't worry, we have some lovely parting gifts for-- What's that? We don't?
+        EXACTLY_WRONG                  = 8154,  -- Why that's exactly rrr-wrong! I'm soooooo sorry, but it looks like you'll have to start all over again! But you'll get 'em next time. Right, kupo?
         PLAYER_OBTAINS_ITEM            = 8170,  -- <name> obtains <item>!
         UNABLE_TO_OBTAIN_ITEM          = 8171,  -- You were unable to obtain the item.
         PLAYER_OBTAINS_TEMP_ITEM       = 8172,  -- <name> obtains the temporary item: <item>!
@@ -112,10 +114,13 @@ zones[xi.zone.XARCABARD] =
     },
     npc =
     {
-        OVERSEER_BASE      = GetFirstID('Jeantelas_RK'),
-        BOREAL_TIGER_QM    = GetFirstID('qm_boreal_tiger'),
-        BOREAL_COEURL_QM   = GetFirstID('qm_boreal_coeurl'),
-        BOREAL_HOUND_QM    = GetFirstID('qm_boreal_hound'),
+        OVERSEER_BASE    = GetFirstID('Jeantelas_RK'),
+        BOREAL_TIGER_QM  = GetFirstID('qm_boreal_tiger'),
+        BOREAL_COEURL_QM = GetFirstID('qm_boreal_coeurl'),
+        BOREAL_HOUND_QM  = GetFirstID('qm_boreal_hound'),
+        OPTION_ONE       = GetFirstID('Option_One'),
+        OPTION_TWO       = GetFirstID('Option_Two'),
+        OPTION_THREE     = GetFirstID('Option_Three'),
     },
 }
 

--- a/scripts/zones/Xarcabard/npcs/Option_One.lua
+++ b/scripts/zones/Xarcabard/npcs/Option_One.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: Xarcabard
+-- NPC: Option One
+-- Involved in Mission: A Moogle Kupo d'Etat mission 13 - A Challenge! You Could Be a Winner
+-- !pos 126 -24 -118 112
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.amk.helpers.assignRandomTriviaQuestions(player)
+end
+
+entity.onEventUpdate = function(player, csid, option, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/npcs/Option_One.lua
+++ b/scripts/zones/Xarcabard/npcs/Option_One.lua
@@ -10,7 +10,6 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    xi.amk.helpers.assignRandomTriviaQuestions(player)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Xarcabard/npcs/Option_Three.lua
+++ b/scripts/zones/Xarcabard/npcs/Option_Three.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Xarcabard
+-- NPC: Option Three
+-- Involved in Mission: A Moogle Kupo d'Etat mission 13 - A Challenge! You Could Be a Winner
+-- !pos 1 -23 -103 112
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/npcs/Option_Two.lua
+++ b/scripts/zones/Xarcabard/npcs/Option_Two.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Xarcabard
+-- NPC: Option Two
+-- Involved in Mission: A Moogle Kupo d'Etat mission 13 - A Challenge! You Could Be a Winner
+-- !pos 66 -24 -191 112
+-----------------------------------
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option, npc)
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+end
+
+return entity


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements puzzle two of AMK mission 13, trivia challenge in Xarcabard.  This one uses a complex system of CS args to convey correct/incorrect answers and npc ids into the cutscene to have the event run properly.  To confuse things, there are two sets of indices for labeling the three stooge npcs, one starting at 0 and one starting at 1.  Both are required and used separately to determine different things in the event.  0-indexed val refers to which Option npc to point to for correct/wrong answers, and 1-indexed stoogeNum tells cutscene which stooge moogle location to animate.

## Steps to test these changes
`!addmission 10 12`
Beat the first puzzle in beauc, head to an Option npc in xarc
Answer the trivia questions, right and wrong.
Right - Should recieve Guantlet Challenge Kupon after three right answers
Wrong - Have to start the trivia questions over, no need to zone


By the way, huge shout out to player Raguza for posting excellent captures to FFXI Captures discord (for all of AMK!).  Couldn't have done this without those.
