### PR TITLE
Spawnmoblist crash fix

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1275,46 +1275,34 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                     }
                                 }
 
-                                // No real reason to pick SpawnMOBList, just need a reference here initially.
-                                SpawnIDList_t& spawnlist = PCurrentChar->SpawnMOBList;
+                                auto pushPacketIfInSpawnList = [&](CCharEntity* PChar, SpawnIDList_t const& spawnlist)
+                                {
+                                    SpawnIDList_t::const_iterator iter = spawnlist.lower_bound(id);
+                                    if (!(iter == spawnlist.end() || spawnlist.key_comp()(id, iter->first)))
+                                    {
+                                        PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                                    }
+                                };
 
-                                if (entity)
+                                switch(entity->objtype)
                                 {
-                                    if (entity->objtype == TYPE_MOB)
-                                    {
-                                        spawnlist = PCurrentChar->SpawnMOBList;
-                                    }
-                                    else if (entity->objtype == TYPE_NPC)
-                                    {
-                                        spawnlist = PCurrentChar->SpawnNPCList;
-                                    }
-                                    else if (entity->objtype == TYPE_PET)
-                                    {
-                                        spawnlist = PCurrentChar->SpawnPETList;
-                                    }
-                                    else if (entity->objtype == TYPE_TRUST)
-                                    {
-                                        spawnlist = PCurrentChar->SpawnTRUSTList;
-                                    }
-                                    else if (entity->objtype == TYPE_PC)
-                                    {
-                                        spawnlist = PCurrentChar->SpawnPCList;
-                                    }
-                                    else
-                                    {
-                                        entity = nullptr;
-                                    }
-                                }
-                                if (!entity)
-                                {
-                                    // No target entity in spawnlists found, so we're just going to skip this packet
-                                    break;
-                                }
-                                SpawnIDList_t::iterator iter = spawnlist.lower_bound(id);
-
-                                if (!(iter == spawnlist.end() || spawnlist.key_comp()(id, iter->first)))
-                                {
-                                    PCurrentChar->pushPacket(new CBasicPacket(*packet));
+                                    case TYPE_MOB:
+                                        pushPacketIfInSpawnList(PCurrentChar, PCurrentChar->SpawnMOBList);
+                                        break;
+                                    case TYPE_NPC:
+                                        pushPacketIfInSpawnList(PCurrentChar, PCurrentChar->SpawnNPCList);
+                                        break;
+                                    case TYPE_PET:
+                                        pushPacketIfInSpawnList(PCurrentChar, PCurrentChar->SpawnPETList);
+                                        break;
+                                    case TYPE_TRUST:
+                                        pushPacketIfInSpawnList(PCurrentChar, PCurrentChar->SpawnTRUSTList);
+                                        break;
+                                    case TYPE_PC:
+                                        pushPacketIfInSpawnList(PCurrentChar, PCurrentChar->SpawnPCList);
+                                        break;
+                                    default:
+                                        break;
                                 }
                             }
                             else


### PR DESCRIPTION
**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

Fixes a crash when engaging a group of monsters as a party

## What does this pull request do? (Please be technical)

Do not reuse spawnlist reference, avoiding a crash.

## Steps to test these changes

Party up with at least 1 other person.
Engage any mob while both members in zone.