### PR TITLE
[core] Fix enmity ties to prefer current battle target

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -438,6 +438,14 @@ CBattleEntity* CEnmityContainer::GetHighestEnmity()
             auto* POwner = PEnmityObject.PEnmityOwner;
             if (!POwner || (POwner->allegiance != m_EnmityHolder->allegiance))
             {
+                // Deal with ties by preferring current battle target
+                // Check if there is a tie, the current highest entity is valid, the mob has a battle target,
+                if (Enmity == HighestEnmity && highest != m_EnmityList.end() && m_EnmityHolder->GetBattleTargetID() != 0 &&
+                    // the current highest entity is the current battle target
+                    highest->second.PEnmityOwner && highest->second.PEnmityOwner->targid == m_EnmityHolder->GetBattleTargetID())
+                {
+                    continue;
+                }
                 active        = PEnmityObject.active;
                 HighestEnmity = Enmity;
                 highest       = it;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds a check in GetHighestEnmity to prefer the mobs current battle target in the event of a tie in terms of total enmity between one or more potential targets. 

The motivation is that in cases with jobs like SMN where both the player and the summon might have 0 enmity (typically the player has 0 enmity due to only using assault and the summon can get to 0 enmity by being significantly outdamaged). This tie situation leads to issue where the mob can bounce back and forth between summon and player arbitrarily (based on entity ordering of enmity list) even without the player performing any enmity generating action. As far as I know and have seen from retail videos of pet jobs, this should not happen.

I think this might be not so noticeable on LSB because potentially SMN pets do not lose enmity upon being hit, I will check into that further as I also have fix (I can add to separate PR) for that if it is the case.

## Steps to test these changes
As SMN fight a mob with carby like 10 levels higher than the SMN, specifically:
- Assault the mob (gives carby active enmity and puts carby on enmity list first then the player second)
- Then retreat (so carby loses enmity faster as carby loses from taking damage but does not gain from attacks)
- Then cast a enmity generating spell (not dia) on the mob (gives player active enmity, now both carby and player have active enmity)
- The mob should attack the player for a hit or two (and player should go to 0 total enmity) and carby should auto-attack the mob
- Now the mob should stay on carby as long as player does nothing (despite the player being second on the enmity list and thus hate would normally bounce back and forth between player and carby)
