### PR TITLE
Remove typeEffect variables, replace with direct enum usage

### DIFF
--- a/scripts/actions/abilities/pets/altana_s_favor.lua
+++ b/scripts/actions/abilities/pets/altana_s_favor.lua
@@ -14,7 +14,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, master, action)
-    local typeEffect = xi.effect.RERAISE
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
         return 0
@@ -24,9 +23,9 @@ abilityObject.onPetAbility = function(target, pet, skill, master, action)
 
     if target:isDead() then
         target:sendRaise(4) -- arise
-    elseif target:addStatusEffect(typeEffect, 3, 0, 0) then -- Infinite duration http://wiki.ffo.jp/html/30976.html
+    elseif target:addStatusEffect(xi.effect.RERAISE, 3, 0, 0) then -- Infinite duration http://wiki.ffo.jp/html/30976.html
         skill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
-        return typeEffect
+        return xi.effect.RERAISE
     else
         skill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
         return 0

--- a/scripts/actions/abilities/pets/mewing_lullaby.lua
+++ b/scripts/actions/abilities/pets/mewing_lullaby.lua
@@ -9,7 +9,6 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, master, action)
-    local typeEffect = xi.effect.SLEEP_I
     local duration = 90
     local dINT = pet:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR)
     local bonus = xi.summon.getSummoningSkillOverCap(pet)
@@ -17,7 +16,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master, action)
     target:setTP(0) -- "The TP lowering seems to be a total reset of TP on the mob, and even if the sleep misses, the TP reset cannot miss."
     if resm < 0.5 then
         skill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
-        return typeEffect
+        return xi.effect.SLEEP_I
     end
 
     duration = duration * resm
@@ -32,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, skill, master, action)
     else
         skill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
 
-        target:addStatusEffect(typeEffect, 1, 0, duration)
+        target:addStatusEffect(xi.effect.SLEEP_I, 1, 0, duration)
     end
 
     return xi.effect.LULLABY

--- a/scripts/actions/abilities/pets/reraise_ii.lua
+++ b/scripts/actions/abilities/pets/reraise_ii.lua
@@ -12,14 +12,16 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, skill, master, action)
-    local typeEffect = xi.effect.RERAISE
-    if not target:isPC() or not target:addStatusEffect(typeEffect, 2, 0, 3600) then
+    if
+        not target:isPC() or
+        not target:addStatusEffect(xi.effect.RERAISE, 2, 0, 3600)
+    then
         skill:setMsg(xi.msg.basic.NO_EFFECT)
         return 0
     end
 
     skill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
-    return typeEffect
+    return xi.effect.RERAISE
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/rolling_thunder.lua
+++ b/scripts/actions/abilities/pets/rolling_thunder.lua
@@ -1,5 +1,5 @@
 -----------------------------------
---
+-- Rolling Thunder
 -----------------------------------
 local abilityObject = {}
 
@@ -18,11 +18,9 @@ abilityObject.onPetAbility = function(target, pet, skill, summoner)
         potency = 5 + ((5 * magicskill) / 100)
     end
 
-    local typeEffect = xi.effect.ENTHUNDER
+    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.ENTHUNDER, potency, 0, duration))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(target, typeEffect, potency, 0, duration))
-
-    return typeEffect
+    return xi.effect.ENTHUNDER
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/soothing_current.lua
+++ b/scripts/actions/abilities/pets/soothing_current.lua
@@ -10,8 +10,7 @@ end
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local typeEffect = xi.effect.CURING_CONDUIT
-    if target:addStatusEffect(typeEffect, 15, 0, 180) then
+    if target:addStatusEffect(xi.effect.CURING_CONDUIT, 15, 0, 180) then
         if target:getID() == action:getPrimaryTargetID() then
             petskill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT_2)
         else
@@ -22,7 +21,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
         return
     end
 
-    return typeEffect
+    return xi.effect.CURING_CONDUIT
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/tidal_roar.lua
+++ b/scripts/actions/abilities/pets/tidal_roar.lua
@@ -10,12 +10,11 @@ end
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
-    local typeEffect = xi.effect.ATTACK_DOWN
-    if not target:getStatusEffect(typeEffect) then
-        target:addStatusEffect(typeEffect, 25, 0, 60)
+    if not target:getStatusEffect(xi.effect.ATTACK_DOWN) then
+        target:addStatusEffect(xi.effect.ATTACK_DOWN, 25, 0, 60)
 
         -- The status effect requires the NO_LOSS_MESSAGE flag to be set
-        local statusEffect = target:getStatusEffect(typeEffect)
+        local statusEffect = target:getStatusEffect(xi.effect.ATTACK_DOWN)
         statusEffect:addEffectFlag(xi.effectFlag.NO_LOSS_MESSAGE)
 
         -- TODO: Verify enmity gain total
@@ -32,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
         return
     end
 
-    return typeEffect
+    return xi.effect.ATTACK_DOWN
 end
 
 return abilityObject

--- a/scripts/actions/mobskills/Immortal_mind.lua
+++ b/scripts/actions/mobskills/Immortal_mind.lua
@@ -11,23 +11,23 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect1 = xi.effect.MAGIC_ATK_BOOST
-    local typeEffect2 = xi.effect.MAGIC_DEF_BOOST
     local mabTotal = 10
     local mdbTotal = 10
 
-    if mob:getStatusEffect(xi.effect.MAGIC_ATK_BOOST) ~= nil then
-        mabTotal = mabTotal:getPower() + 10
+    local mabEffect = mob:getStatusEffect(xi.effect.MAGIC_ATK_BOOST)
+    if mabEffect then
+        mabTotal = mabEffect:getPower() + 10
     end
 
-    if mob:getStatusEffect(xi.effect.MAGIC_DEF_BOOST) ~= nil then
-        mabTotal = mabTotal:getPower() + 10
+    local mdbEffect = mob:getStatusEffect(xi.effect.MAGIC_DEF_BOOST)
+    if mdbEffect then
+        mdbTotal = mdbEffect:getPower() + 10
     end
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect1, mabTotal, 0, 180))
-    xi.mobskills.mobBuffMove(mob, typeEffect2, mdbTotal, 0, 180)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, mabTotal, 0, 180))
+    xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_DEF_BOOST, mdbTotal, 0, 180)
 
-    return typeEffect1
+    return xi.effect.MAGIC_ATK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/baleful_gaze.lua
+++ b/scripts/actions/mobskills/baleful_gaze.lua
@@ -13,12 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    local duration = 45
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 45))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, duration))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/barbed_crescent.lua
+++ b/scripts/actions/mobskills/barbed_crescent.lua
@@ -17,9 +17,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.7
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-    local typeEffect = xi.effect.ACCURACY_DOWN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 50, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/battery_charge.lua
+++ b/scripts/actions/mobskills/battery_charge.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.REFRESH
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REFRESH, 3, 3, 300))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 3, 3, 300))
-
-    return typeEffect
+    return xi.effect.REFRESH
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/battle_dance.lua
+++ b/scripts/actions/mobskills/battle_dance.lua
@@ -17,9 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    local typeEffect = xi.effect.DEX_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 10, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEX_DOWN, 10, 3, 120)
 
     return dmg
 end

--- a/scripts/actions/mobskills/beatdown.lua
+++ b/scripts/actions/mobskills/beatdown.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 20)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 20)
 
     return dmg
 end

--- a/scripts/actions/mobskills/belly_dance.lua
+++ b/scripts/actions/mobskills/belly_dance.lua
@@ -20,14 +20,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     duration = 60
 
     isEnfeeble = true
-    typeEffect = xi.effect.CHARM_I
     statmod = xi.mod.INT
 
-    resist = xi.mobskills.applyPlayerResistance(mob, typeEffect, target, isEnfeeble, typeEffect, statmod)
+    resist = xi.mobskills.applyPlayerResistance(mob, xi.effect.CHARM_I, target, isEnfeeble, xi.effect.CHARM_I, statmod)
     if resist > 0.2 then
-        if target:getStatusEffect(typeEffect) == nil then
+        if target:getStatusEffect(xi.effect.CHARM_I) == nil then
             skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
-            target:addStatusEffect(typeEffect, power, tic, duration)
+            target:addStatusEffect(xi.effect.CHARM_I, power, tic, duration)
         else
             skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
         end
@@ -35,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         skill:setMsg(xi.msg.basic.SKILL_MISS)
     end
 
-    return typeEffect
+    return xi.effect.CHARM_I
     ]]
 end
 

--- a/scripts/actions/mobskills/berserk-ruf.lua
+++ b/scripts/actions/mobskills/berserk-ruf.lua
@@ -8,13 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 25
-    local duration = 180
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.WARCRY, 25, 0, 180))
 
-    local typeEffect = xi.effect.WARCRY
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.WARCRY
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/binding_microtube.lua
+++ b/scripts/actions/mobskills/binding_microtube.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 60)
 
     local dmgmod = 2.45
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.NONE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/binding_wave.lua
+++ b/scripts/actions/mobskills/binding_wave.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.BIND
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/biotic_boomerang.lua
+++ b/scripts/actions/mobskills/biotic_boomerang.lua
@@ -15,9 +15,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-    local typeEffect = xi.effect.PLAGUE
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 18, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/black_cloud.lua
+++ b/scripts/actions/mobskills/black_cloud.lua
@@ -14,9 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 18, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 18, 0, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/blade_metsu.lua
+++ b/scripts/actions/mobskills/blade_metsu.lua
@@ -19,11 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 3, 3, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local duration = 60
-    local typeEffect = xi.effect.PARALYSIS
-    local power = 10
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 10, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/blank_gaze.lua
+++ b/scripts/actions/mobskills/blank_gaze.lua
@@ -11,11 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PARALYSIS, 35, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 35, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/blastbomb.lua
+++ b/scripts/actions/mobskills/blastbomb.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/blaster.lua
+++ b/scripts/actions/mobskills/blaster.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 50, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/blindeye.lua
+++ b/scripts/actions/mobskills/blindeye.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 15, 0, 120)
 
     return dmg
 end

--- a/scripts/actions/mobskills/blitzstrahl.lua
+++ b/scripts/actions/mobskills/blitzstrahl.lua
@@ -11,9 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 4)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/blow.lua
+++ b/scripts/actions/mobskills/blow.lua
@@ -18,8 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     return dmg
 end

--- a/scripts/actions/mobskills/boiling_point.lua
+++ b/scripts/actions/mobskills/boiling_point.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_DEF_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 180))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MAGIC_DEF_DOWN, 20, 0, 180))
+
+    return xi.effect.MAGIC_DEF_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/brain_drain.lua
+++ b/scripts/actions/mobskills/brain_drain.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, info.hitslanded)
 
-    local typeEffect = xi.effect.INT_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 10, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.INT_DOWN, 10, 3, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
 

--- a/scripts/actions/mobskills/brain_spike.lua
+++ b/scripts/actions/mobskills/brain_spike.lua
@@ -21,8 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
-    local typeEffect = xi.effect.PARALYSIS
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 30, 0, 180)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 30, 0, 180)
 
     return dmg
 end

--- a/scripts/actions/mobskills/bubble_armor.lua
+++ b/scripts/actions/mobskills/bubble_armor.lua
@@ -14,12 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SHELL
-    local power      = 5000
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 5000, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
-
-    return typeEffect
+    return xi.effect.SHELL
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/bubble_curtain.lua
+++ b/scripts/actions/mobskills/bubble_curtain.lua
@@ -14,12 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SHELL
-    local power      = 5000
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 5000, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
-
-    return typeEffect
+    return xi.effect.SHELL
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/bubble_shower.lua
+++ b/scripts/actions/mobskills/bubble_shower.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STR_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 120)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.15, 5, xi.element.WATER, 200)
 

--- a/scripts/actions/mobskills/calcifying_deluge.lua
+++ b/scripts/actions/mobskills/calcifying_deluge.lua
@@ -20,8 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.PETRIFICATION
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/call_of_the_grave.lua
+++ b/scripts/actions/mobskills/call_of_the_grave.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.INT_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.INT_DOWN, 10, 3, 120))
 
-    return typeEffect
+    return xi.effect.INT_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chains_of_apathy.lua
+++ b/scripts/actions/mobskills/chains_of_apathy.lua
@@ -24,10 +24,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local power = 30
-    local duration = 30
-
     if
         target:isPC() and
         (
@@ -35,12 +31,12 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             not target:hasKeyItem(xi.ki.LIGHT_OF_VAHZL)
         )
     then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 30, 0, 30))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chains_of_arrogance.lua
+++ b/scripts/actions/mobskills/chains_of_arrogance.lua
@@ -24,10 +24,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local power = 30
-    local duration = 30
-
     if
         target:isPC() and
         (
@@ -35,12 +31,12 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             not target:hasKeyItem(xi.ki.LIGHT_OF_MEA)
         )
     then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 30, 0, 30))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chains_of_cowardice.lua
+++ b/scripts/actions/mobskills/chains_of_cowardice.lua
@@ -24,10 +24,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local power = 30
-    local duration = 30
-
     if
         target:isPC() and
         (
@@ -35,12 +31,12 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
             not target:hasKeyItem(xi.ki.LIGHT_OF_HOLLA)
         )
     then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 30, 0, 30))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chains_of_envy.lua
+++ b/scripts/actions/mobskills/chains_of_envy.lua
@@ -24,21 +24,17 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local power = 30
-    local duration = 30
-
     if
         target:isPC() and
         target:getRace() == xi.race.MITHRA and
         not target:hasKeyItem(xi.ki.LIGHT_OF_DEM)
     then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 30, 0, 30))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chains_of_rage.lua
+++ b/scripts/actions/mobskills/chains_of_rage.lua
@@ -24,21 +24,17 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local power = 30
-    local duration = 30
-
     if
         target:isPC() and
         target:getRace() == xi.race.GALKA and
         not target:hasKeyItem(xi.ki.LIGHT_OF_ALTAIEU)
     then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 30, 0, 30))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chaos_blade.lua
+++ b/scripts/actions/mobskills/chaos_blade.lua
@@ -19,8 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
 
     -- curse LAST so you don't die
-    local typeEffect = xi.effect.CURSE_I
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 420)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 420)
 
     return dmg
 end

--- a/scripts/actions/mobskills/chaotic_eye.lua
+++ b/scripts/actions/mobskills/chaotic_eye.lua
@@ -11,11 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SILENCE, 1, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 120))
-
-    return typeEffect
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chaotic_strike.lua
+++ b/scripts/actions/mobskills/chaotic_strike.lua
@@ -16,8 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 10)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 10)
 
     return dmg
 end

--- a/scripts/actions/mobskills/charm.lua
+++ b/scripts/actions/mobskills/charm.lua
@@ -8,22 +8,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 150)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 3, 150)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chemical_bomb.lua
+++ b/scripts/actions/mobskills/chemical_bomb.lua
@@ -9,14 +9,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.ELEGY
-    local typeEffectTwo = xi.effect.SLOW
-
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffectOne, 5000, 0, 120))
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffectTwo, 5000, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ELEGY, 5000, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 120))
 
     -- This likely doesn't behave like retail.
-    return typeEffectTwo
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/chomp_rush.lua
+++ b/scripts/actions/mobskills/chomp_rush.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1250, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/cimicine_discharge.lua
+++ b/scripts/actions/mobskills/cimicine_discharge.lua
@@ -10,7 +10,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
     local power = 1950
     local duration = math.random(60, 180)
 
@@ -18,14 +17,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:addStatusEffect(xi.effect.HASTE, 1500, 0, duration)
     end
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, power, 0, duration))
 
-    return typeEffect
+    return xi.effect.SLOW
 
     --[[ Is there suppsoed to be a message about haste?
-    local typeEffect = xi.effect.HASTE
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 150, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 150, 0, duration))
+    return xi.effect.HASTE
     ]]--
 end
 

--- a/scripts/actions/mobskills/circle_of_flames.lua
+++ b/scripts/actions/mobskills/circle_of_flames.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    local typeEffect = xi.effect.WEIGHT
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/claw_storm.lua
+++ b/scripts/actions/mobskills/claw_storm.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    local typeEffect = xi.effect.POISON
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, mob:getMainLvl() / 2.5, 3, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, mob:getMainLvl() / 2.5, 3, 30)
 
     return dmg
 end

--- a/scripts/actions/mobskills/cocoon.lua
+++ b/scripts/actions/mobskills/cocoon.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 50, 0, 60))
-
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cold_breath.lua
+++ b/scripts/actions/mobskills/cold_breath.lua
@@ -11,9 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 20)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 20)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.ICE, 600)
 

--- a/scripts/actions/mobskills/cold_stare.lua
+++ b/scripts/actions/mobskills/cold_stare.lua
@@ -10,9 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SILENCE, 1, 0, 60))
+
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cold_wave.lua
+++ b/scripts/actions/mobskills/cold_wave.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.FROST
-
     local power = mob:getMainLvl() / 5 * 0.6 + 6
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.FROST, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.8, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/colossal_slam.lua
+++ b/scripts/actions/mobskills/colossal_slam.lua
@@ -15,10 +15,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 3.0
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
-    local typeEffect = xi.effect.CURSE_II -- Zombie
 
     -- TODO: The duration needs verification from retail
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 0, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.CURSE_II, 0, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/concussive_oscillation.lua
+++ b/scripts/actions/mobskills/concussive_oscillation.lua
@@ -15,9 +15,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.3
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
-    local typeEffect = xi.effect.WEIGHT
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 300)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 300)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/condemnation.lua
+++ b/scripts/actions/mobskills/condemnation.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1.2
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 1.2, 1.5)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 6)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 6)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/corrosive_ooze.lua
+++ b/scripts/actions/mobskills/corrosive_ooze.lua
@@ -14,12 +14,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.ATTACK_DOWN
-    local typeEffectTwo = xi.effect.DEFENSE_DOWN
-    local duration = 120
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectOne, 15, 0, duration)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectTwo, 15, 0, duration)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 15, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 15, 0, 120)
 
     local dmgmod = 1
     local baseDamage = mob:getWeaponDmg() * 4.2

--- a/scripts/actions/mobskills/crimson_howl.lua
+++ b/scripts/actions/mobskills/crimson_howl.lua
@@ -13,13 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 25
-    local duration = 180
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.WARCRY, 25, 0, 180))
 
-    local typeEffect = xi.effect.WARCRY
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.WARCRY
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cryo_jet.lua
+++ b/scripts/actions/mobskills/cryo_jet.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 1, 3, 60)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/crystal_shield.lua
+++ b/scripts/actions/mobskills/crystal_shield.lua
@@ -9,14 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 50
-    local duration = 300
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 50, 0, 300))
 
-    local typeEffect = xi.effect.PROTECT
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.PROTECT
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/crystaline_cocoon.lua
+++ b/scripts/actions/mobskills/crystaline_cocoon.lua
@@ -13,16 +13,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect1 = xi.effect.PROTECT
-    local typeEffect2 = xi.effect.SHELL
-    local power1      = 50
-    local power2      = 2000
-    local duration    = 300
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 50, 0, 300))
+    xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 2000, 0, 300)
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect1, power1, 0, duration))
-    xi.mobskills.mobBuffMove(mob, typeEffect2, power2, 0, duration)
-
-    return typeEffect1
+    return xi.effect.PROTECT
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/curse.lua
+++ b/scripts/actions/mobskills/curse.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 480))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 480))
-
-    return typeEffect
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cyclonic_torrent.lua
+++ b/scripts/actions/mobskills/cyclonic_torrent.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.MUTE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MUTE, 1, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/damnation_dive.lua
+++ b/scripts/actions/mobskills/damnation_dive.lua
@@ -31,9 +31,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = .8
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/dancing_chains.lua
+++ b/scripts/actions/mobskills/dancing_chains.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DROWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DROWN, 15, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 120))
-    return typeEffect
+    return xi.effect.DROWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/danse_macabre.lua
+++ b/scripts/actions/mobskills/danse_macabre.lua
@@ -13,22 +13,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 3, 60)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dark_mist.lua
+++ b/scripts/actions/mobskills/dark_mist.lua
@@ -19,12 +19,11 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
-    local typeEffect = xi.effect.WEIGHT
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4.0, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/dark_sphere.lua
+++ b/scripts/actions/mobskills/dark_sphere.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/dark_spore.lua
+++ b/scripts/actions/mobskills/dark_spore.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 3, 120)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.25, 2, xi.element.DARK, 800)
 

--- a/scripts/actions/mobskills/dark_wave.lua
+++ b/scripts/actions/mobskills/dark_wave.lua
@@ -14,15 +14,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIO
-
     local cTime = VanadielHour()
     local power = 8
     if 12 <= cTime then
         power = power + (cTime - 11)
     end
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIO, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/deafening_tantara.lua
+++ b/scripts/actions/mobskills/deafening_tantara.lua
@@ -18,10 +18,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-    return typeEffect
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/death_trap.lua
+++ b/scripts/actions/mobskills/death_trap.lua
@@ -14,14 +14,14 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local typeEffect = xi.effect.POISON
-    local duration = 60
-    local power = mob:getMainLvl() / 3
+    local duration   = 60
+    local power      = mob:getMainLvl() / 3
 
     if math.random() <= 0.5 then
         -- stun
         typeEffect = xi.effect.STUN
-        duration = 10
-        power = 1
+        duration   = 10
+        power      = 1
     end
 
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))

--- a/scripts/actions/mobskills/decayed_filament.lua
+++ b/scripts/actions/mobskills/decayed_filament.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
-    local typeEffect = xi.effect.POISON
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 18, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/delta_thrust.lua
+++ b/scripts/actions/mobskills/delta_thrust.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
-    local typeEffect = xi.effect.PLAGUE
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 5, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 5, 3, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/demonic_flower.lua
+++ b/scripts/actions/mobskills/demonic_flower.lua
@@ -11,11 +11,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.WEAKNESS
     local dmg1 = mob:getHP() * 0.24
     local dmg2 = dmg1 * 0.5
+
     -- The dmg amounts and duration are guesstimated based on wiki info.
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 90))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEAKNESS, 1, 0, 90))
 
     mob:takeDamage(dmg1)
     target:takeDamage(dmg2, mob, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL)

--- a/scripts/actions/mobskills/demonic_howl.lua
+++ b/scripts/actions/mobskills/demonic_howl.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/demoralizing_roar.lua
+++ b/scripts/actions/mobskills/demoralizing_roar.lua
@@ -11,11 +11,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ATTACK_DOWN
     local power = 500
     local duration = 60
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, power, 0, duration)
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dice_curse.lua
+++ b/scripts/actions/mobskills/dice_curse.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 30, 0, 300))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 300))
-
-    return typeEffect
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dice_disease.lua
+++ b/scripts/actions/mobskills/dice_disease.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DISEASE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 180))
-
-    return typeEffect
+    return xi.effect.DISEASE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dice_poison.lua
+++ b/scripts/actions/mobskills/dice_poison.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 15, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 60))
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dice_sleep.lua
+++ b/scripts/actions/mobskills/dice_sleep.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dice_stun.lua
+++ b/scripts/actions/mobskills/dice_stun.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 6))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 6))
-
-    return typeEffect
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/discharger.lua
+++ b/scripts/actions/mobskills/discharger.lua
@@ -13,12 +13,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.MAGIC_SHIELD
-    local typeEffectTwo = xi.effect.SHOCK_SPIKES
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_SHIELD, 1, 0, 60))
+    xi.mobskills.mobBuffMove(mob, xi.effect.SHOCK_SPIKES, 25, 0, 60)
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffectOne, 1, 0, 60))
-    xi.mobskills.mobBuffMove(mob, typeEffectTwo, 25, 0, 60)
-    return typeEffectOne
+    return xi.effect.MAGIC_SHIELD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/disorienting_waul.lua
+++ b/scripts/actions/mobskills/disorienting_waul.lua
@@ -12,11 +12,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     -- SubPower is resistance chance vs removal by Ecphoria Ring
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 35, 0, 60, 80))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 35, 0, 60, 80))
 
-    return typeEffect
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/disseverment.lua
+++ b/scripts/actions/mobskills/disseverment.lua
@@ -17,8 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
-    local typeEffect = xi.effect.POISON
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 3, 300)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 18, 3, 300)
 
     return dmg
 end

--- a/scripts/actions/mobskills/dissipation.lua
+++ b/scripts/actions/mobskills/dissipation.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 10)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 1, 0, 10)
 
     local count = target:dispelAllStatusEffect()
 

--- a/scripts/actions/mobskills/doom.lua
+++ b/scripts/actions/mobskills/doom.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DOOM
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DOOM, 10, 3, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 30))
-
-    return typeEffect
+    return xi.effect.DOOM
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/double_kick.lua
+++ b/scripts/actions/mobskills/double_kick.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     return dmg
 end

--- a/scripts/actions/mobskills/dread_shriek.lua
+++ b/scripts/actions/mobskills/dread_shriek.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dreadstorm.lua
+++ b/scripts/actions/mobskills/dreadstorm.lua
@@ -23,10 +23,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local duration = 10
-
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, duration))
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 10))
 
     local dmgmod = 2.5
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/dream_flower.lua
+++ b/scripts/actions/mobskills/dream_flower.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, math.random(20, 30)))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, math.random(20, 30)))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/drill_branch.lua
+++ b/scripts/actions/mobskills/drill_branch.lua
@@ -19,9 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded * math.random(2, 3))
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 15, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/drop_hammer.lua
+++ b/scripts/actions/mobskills/drop_hammer.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded * math.random(2, 3))
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 

--- a/scripts/actions/mobskills/dual_strike.lua
+++ b/scripts/actions/mobskills/dual_strike.lua
@@ -21,9 +21,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     return dmg
 end

--- a/scripts/actions/mobskills/dukkeripen_para.lua
+++ b/scripts/actions/mobskills/dukkeripen_para.lua
@@ -14,15 +14,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    if xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120) then
+    if xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 120) then
         skill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
     else
         skill:setMsg(xi.msg.basic.SKILL_MISS)
     end
 
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/dust_cloud.lua
+++ b/scripts/actions/mobskills/dust_cloud.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/earth_blade.lua
+++ b/scripts/actions/mobskills/earth_blade.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENSTONE
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENSTONE, 65, 0, 60))
+
+    return xi.effect.ENSTONE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/earth_pounder.lua
+++ b/scripts/actions/mobskills/earth_pounder.lua
@@ -12,8 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEX_DOWN
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEX_DOWN, 10, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/earth_shock.lua
+++ b/scripts/actions/mobskills/earth_shock.lua
@@ -17,10 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
-
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/earthbreaker.lua
+++ b/scripts/actions/mobskills/earthbreaker.lua
@@ -12,8 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 8)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 8)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/earthen_ward.lua
+++ b/scripts/actions/mobskills/earthen_ward.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STONESKIN
     local base = mob:getMainLvl() * 2 + 50
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, base, 0, 180))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.STONESKIN, base, 0, 180))
 
     return xi.effect.STONESKIN
 end

--- a/scripts/actions/mobskills/energy_screen.lua
+++ b/scripts/actions/mobskills/energy_screen.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PHYSICAL_SHIELD
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PHYSICAL_SHIELD, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 60))
-
-    return typeEffect
+    return xi.effect.PHYSICAL_SHIELD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/entangle.lua
+++ b/scripts/actions/mobskills/entangle.lua
@@ -28,9 +28,6 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
         return dmg
     elseif mob:getPool() == 671 or mob:getPool() == 1346 then -- Cemetery Cherry and leafless Jidra
-        local typeEffectOne = xi.effect.BIND
-        local typeEffectTwo = xi.effect.POISON
-
         local numhits = 3
         local accmod = 1
         local dmgmod = 2.0
@@ -39,14 +36,13 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
         mob:resetEnmity(target)
         target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffectOne, 1, 0, 30))
-        xi.mobskills.mobStatusEffectMove(mob, target, typeEffectTwo, 50, 0, 60)
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 50, 0, 60)
 
-        return typeEffectOne
+        return xi.effect.BIND
     else
-        local typeEffect = xi.effect.BIND
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-        return typeEffect
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
+        return xi.effect.BIND
     end
 end
 

--- a/scripts/actions/mobskills/entice.lua
+++ b/scripts/actions/mobskills/entice.lua
@@ -12,22 +12,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 1, 30)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 1, 30)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/envoutement.lua
+++ b/scripts/actions/mobskills/envoutement.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.CURSE_I
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 25, 0, 420)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.CURSE_I, 25, 0, 420)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/epoxy_spread.lua
+++ b/scripts/actions/mobskills/epoxy_spread.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.BIND
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/evasion.lua
+++ b/scripts/actions/mobskills/evasion.lua
@@ -17,10 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 25
     local duration = 180
 
-    local typeEffect = xi.effect.EVASION_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, power, 0, duration))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/eye_scratch.lua
+++ b/scripts/actions/mobskills/eye_scratch.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 15, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/fanatic_dance.lua
+++ b/scripts/actions/mobskills/fanatic_dance.lua
@@ -18,22 +18,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 3, 60)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/faze.lua
+++ b/scripts/actions/mobskills/faze.lua
@@ -14,12 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local duration = 5
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 5))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, duration))
-
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/fear_touch.lua
+++ b/scripts/actions/mobskills/fear_touch.lua
@@ -15,12 +15,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1250, 0, 120)
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 128, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 120)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/feather_barrier.lua
+++ b/scripts/actions/mobskills/feather_barrier.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 120))
-
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/feather_maelstrom.lua
+++ b/scripts/actions/mobskills/feather_maelstrom.lua
@@ -10,16 +10,16 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect1 = xi.effect.BIO
-    local typeEffect2 = xi.effect.AMNESIA
     local numhits = 1
     local accmod = 2
     local dmgmod = 2.8
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect1, 6, 3, 60)
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect2, 1, 0, 60)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIO, 6, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.AMNESIA, 1, 0, 60)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/feather_storm.lua
+++ b/scripts/actions/mobskills/feather_storm.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.POISON
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, mob:getMainLvl() / 7, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, mob:getMainLvl() / 7, 3, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/feeble_bleat.lua
+++ b/scripts/actions/mobskills/feeble_bleat.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 120))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/filamented_hold.lua
+++ b/scripts/actions/mobskills/filamented_hold.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 2500, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 2500, 0, 120))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/final_retribution.lua
+++ b/scripts/actions/mobskills/final_retribution.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/fire_blade.lua
+++ b/scripts/actions/mobskills/fire_blade.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENFIRE
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENFIRE, 65, 0, 60))
+
+    return xi.effect.ENFIRE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/flame_armor.lua
+++ b/scripts/actions/mobskills/flame_armor.lua
@@ -14,11 +14,10 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 50
     local duration = 180
-    local typeEffect = xi.effect.BLAZE_SPIKES
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, power, 0, duration))
 
-    return typeEffect
+    return xi.effect.BLAZE_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/flame_thrower.lua
+++ b/scripts/actions/mobskills/flame_thrower.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 5, 3, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 5, 3, 30)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/fortifying_wail.lua
+++ b/scripts/actions/mobskills/fortifying_wail.lua
@@ -14,12 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 60
-    local duration = 300
-    local typeEffect = xi.effect.PROTECT
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 60, 0, 300))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    return xi.effect.PROTECT
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/fossilizing_breath.lua
+++ b/scripts/actions/mobskills/fossilizing_breath.lua
@@ -22,14 +22,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    local power = 1
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 60))
 
-    local duration = 60
-
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/foul_breath.lua
+++ b/scripts/actions/mobskills/foul_breath.lua
@@ -15,8 +15,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DISEASE
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 300)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 300)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 0.625, xi.element.FIRE, 500)
 

--- a/scripts/actions/mobskills/foxfire.lua
+++ b/scripts/actions/mobskills/foxfire.lua
@@ -34,9 +34,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 6)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 6)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/frenzied_rage.lua
+++ b/scripts/actions/mobskills/frenzied_rage.lua
@@ -17,10 +17,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 20
     local duration = 120
 
-    local typeEffect = xi.effect.ATTACK_BOOST
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ATTACK_BOOST, power, 0, duration))
+    return xi.effect.ATTACK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frightful_roar.lua
+++ b/scripts/actions/mobskills/frightful_roar.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 0, 180))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 10, 0, 180))
+
+    return xi.effect.DEFENSE_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frigid_shuffle.lua
+++ b/scripts/actions/mobskills/frigid_shuffle.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 50, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frog_cheer.lua
+++ b/scripts/actions/mobskills/frog_cheer.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_ATK_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, 25, 0, 300))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 25, 0, 300))
-    return typeEffect
+    return xi.effect.MAGIC_ATK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frost_armor.lua
+++ b/scripts/actions/mobskills/frost_armor.lua
@@ -8,13 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 10
-    local duration = 180
-    local typeEffect = xi.effect.ICE_SPIKES
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ICE_SPIKES, 10, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.ICE_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frost_blade.lua
+++ b/scripts/actions/mobskills/frost_blade.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENBLIZZARD
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENBLIZZARD, 65, 0, 60))
+
+    return xi.effect.ENBLIZZARD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/frost_breath.lua
+++ b/scripts/actions/mobskills/frost_breath.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, 120)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.333, 0.625, xi.element.ICE, 500)
 

--- a/scripts/actions/mobskills/frypan.lua
+++ b/scripts/actions/mobskills/frypan.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/fuscous_ooze.lua
+++ b/scripts/actions/mobskills/fuscous_ooze.lua
@@ -14,10 +14,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     -- TODO: Encumberance seems to do nothing?
-    local typeEffect = xi.effect.WEIGHT
-    local duration = 45
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, duration)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 45)
 
     local dmgmod = 1
     local baseDamage = mob:getWeaponDmg() * 3.7

--- a/scripts/actions/mobskills/gala_macabre.lua
+++ b/scripts/actions/mobskills/gala_macabre.lua
@@ -14,22 +14,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 3, 60)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/gas_shell.lua
+++ b/scripts/actions/mobskills/gas_shell.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-        local power = math.random(23, 24)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, 60))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, math.random(23, 24), 0, 60))
 
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/gastric_bomb.lua
+++ b/scripts/actions/mobskills/gastric_bomb.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ATTACK_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 50, 0, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/gate_of_tartarus.lua
+++ b/scripts/actions/mobskills/gate_of_tartarus.lua
@@ -21,10 +21,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
     local duration = 60
-    local typeEffect = xi.effect.ATTACK_DOWN
     local power = 20
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ATTACK_DOWN, power, 0, duration)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/gates_of_hades.lua
+++ b/scripts/actions/mobskills/gates_of_hades.lua
@@ -30,10 +30,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BURN
-    local power = 21
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, 21, 3, 60)
 
     local dmgmod = 1.8
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/geocrush.lua
+++ b/scripts/actions/mobskills/geocrush.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 6)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 6)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/gerjis_grip.lua
+++ b/scripts/actions/mobskills/gerjis_grip.lua
@@ -10,9 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 10))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 10))
+
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/glacier_splitter.lua
+++ b/scripts/actions/mobskills/glacier_splitter.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 15, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/gliding_spike.lua
+++ b/scripts/actions/mobskills/gliding_spike.lua
@@ -15,9 +15,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/gorgon_dance.lua
+++ b/scripts/actions/mobskills/gorgon_dance.lua
@@ -19,9 +19,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, math.random(60, 180)))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, math.random(60, 180)))
+
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/gravity_field.lua
+++ b/scripts/actions/mobskills/gravity_field.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/great_bleat.lua
+++ b/scripts/actions/mobskills/great_bleat.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAX_HP_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MAX_HP_DOWN, 30, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 60))
-
-    return typeEffect
+    return xi.effect.MAX_HP_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/great_sandstorm.lua
+++ b/scripts/actions/mobskills/great_sandstorm.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/great_whirlwind.lua
+++ b/scripts/actions/mobskills/great_whirlwind.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHOKE
     local power = mob:getMainLvl() / 4 * 0.6 + 4
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHOKE, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/gregale_wing.lua
+++ b/scripts/actions/mobskills/gregale_wing.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 40, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/gregale_wing_air.lua
+++ b/scripts/actions/mobskills/gregale_wing_air.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 40, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/hane_fubuki.lua
+++ b/scripts/actions/mobskills/hane_fubuki.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.POISON
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, mob:getMainLvl() / 7, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, mob:getMainLvl() / 7, 3, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/happobarai.lua
+++ b/scripts/actions/mobskills/happobarai.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/hard_membrane.lua
+++ b/scripts/actions/mobskills/hard_membrane.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 25, 0, 60))
-
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/harden_shell.lua
+++ b/scripts/actions/mobskills/harden_shell.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 100, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 100, 0, 60))
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/head_butt.lua
+++ b/scripts/actions/mobskills/head_butt.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/head_butt_turtle.lua
+++ b/scripts/actions/mobskills/head_butt_turtle.lua
@@ -15,10 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    -- Large Knockdown
-    local typeEffect = xi.effect.ACCURACY_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 50, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/healing_stomp.lua
+++ b/scripts/actions/mobskills/healing_stomp.lua
@@ -14,13 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 25
-    local duration = 180
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, 25, 3, 180))
 
-    local typeEffect = xi.effect.REGEN
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 3, duration))
-    return typeEffect
+    return xi.effect.REGEN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/heat_barrier.lua
+++ b/scripts/actions/mobskills/heat_barrier.lua
@@ -14,13 +14,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     -- TODO: Enfire power, Blaze Spikes reduced power in Salvage zones
-    local typeEffectOne = xi.effect.BLAZE_SPIKES
-    -- local typeEffectTwo = xi.effect.ENFIRE
-    local randy = math.random(50, 67)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffectOne, randy, 0, 180))
-    -- xi.mobskills.mobBuffMove(mob, typeEffectTwo, ???, 0, 180)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, math.random(50, 67), 0, 180))
+    -- xi.mobskills.mobBuffMove(mob, xi.effect.ENFIRE, ???, 0, 180)
 
-    return typeEffectOne
+    return xi.effect.BLAZE_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/heavy_bellow.lua
+++ b/scripts/actions/mobskills/heavy_bellow.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 6))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 6))
-
-    return typeEffect
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/heavy_stomp.lua
+++ b/scripts/actions/mobskills/heavy_stomp.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 360)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 15, 0, 360)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/heavy_strike.lua
+++ b/scripts/actions/mobskills/heavy_strike.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1250, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/hecatomb_wave.lua
+++ b/scripts/actions/mobskills/hecatomb_wave.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 180)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.5, xi.element.WIND, 400)
 

--- a/scripts/actions/mobskills/hellclap.lua
+++ b/scripts/actions/mobskills/hellclap.lua
@@ -34,9 +34,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 4.0
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * math.random(2, 3))
-    local typeEffect = xi.effect.WEIGHT
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 40, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/hellfire_arrow.lua
+++ b/scripts/actions/mobskills/hellfire_arrow.lua
@@ -8,10 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BURN
     local power = math.random(10, 30)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.7, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/hex_eye.lua
+++ b/scripts/actions/mobskills/hex_eye.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 25, 0, 120))
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PARALYSIS, 25, 0, 120))
 
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hexagon_belt.lua
+++ b/scripts/actions/mobskills/hexagon_belt.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 20, 0, 120))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hi-freq_field.lua
+++ b/scripts/actions/mobskills/hi-freq_field.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 50, 0, 120))
 
-    return typeEffect
+    return xi.effect.EVASION_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hiden_sokyaku.lua
+++ b/scripts/actions/mobskills/hiden_sokyaku.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     return dmg
 end

--- a/scripts/actions/mobskills/high-tension_discharger.lua
+++ b/scripts/actions/mobskills/high-tension_discharger.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 3, 2)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 3, 2)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/homing_missle.lua
+++ b/scripts/actions/mobskills/homing_missle.lua
@@ -11,10 +11,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local targetcurrentHP = target:getHP()
     local targetmaxHP = target:getMaxHP()
     local hpset = targetmaxHP * 0.20
-    local typeEffect = xi.effect.BIND
     local dmg = 0
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     if targetcurrentHP > hpset then
         dmg = targetcurrentHP - hpset

--- a/scripts/actions/mobskills/horror_cloud.lua
+++ b/scripts/actions/mobskills/horror_cloud.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 180))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/howl.lua
+++ b/scripts/actions/mobskills/howl.lua
@@ -13,13 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 25
-    local duration = 180
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.WARCRY, 25, 0, 180))
 
-    local typeEffect = xi.effect.WARCRY
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.WARCRY
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/howling.lua
+++ b/scripts/actions/mobskills/howling.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 60))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 60))
 
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hurricane_wing.lua
+++ b/scripts/actions/mobskills/hurricane_wing.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 60, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 60, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/hydro_ball.lua
+++ b/scripts/actions/mobskills/hydro_ball.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STR_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.5, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/hydro_canon.lua
+++ b/scripts/actions/mobskills/hydro_canon.lua
@@ -11,9 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-    local power = 40
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 40, 3, 60)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/hydro_shot.lua
+++ b/scripts/actions/mobskills/hydro_shot.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, info.hitslanded)
 
-    local typeEffect = xi.effect.ENMITY_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 10, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ENMITY_DOWN, 10, 3, 120)
     mob:resetEnmity(target)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)

--- a/scripts/actions/mobskills/hypnosis.lua
+++ b/scripts/actions/mobskills/hypnosis.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLEEP_I, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/hypnotic_sway.lua
+++ b/scripts/actions/mobskills/hypnotic_sway.lua
@@ -11,12 +11,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     local power = 1
     local duration = 60
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, power, 0, duration))
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ice_break.lua
+++ b/scripts/actions/mobskills/ice_break.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/ichor_stream.lua
+++ b/scripts/actions/mobskills/ichor_stream.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 5, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 120))
-
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/immortal_anathema.lua
+++ b/scripts/actions/mobskills/immortal_anathema.lua
@@ -12,13 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 300))
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 300)
-
-    skill:setMsg(msg)
-
-    return typeEffect
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/impact_stream.lua
+++ b/scripts/actions/mobskills/impact_stream.lua
@@ -12,11 +12,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect1 = xi.effect.STUN
-    local typeEffect2 = xi.effect.DEFENSE_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect1, 1, 0, 4)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect2, 50, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 50, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.LIGHT, dmgmod, 0, 1)

--- a/scripts/actions/mobskills/infernal_pestilence.lua
+++ b/scripts/actions/mobskills/infernal_pestilence.lua
@@ -14,9 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DISEASE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 360)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 360)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/infrasonics.lua
+++ b/scripts/actions/mobskills/infrasonics.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 20, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120))
-
-    return typeEffect
+    return xi.effect.EVASION_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ink_cloud.lua
+++ b/scripts/actions/mobskills/ink_cloud.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 120))
 
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ink_jet.lua
+++ b/scripts/actions/mobskills/ink_jet.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/intimidate.lua
+++ b/scripts/actions/mobskills/intimidate.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1250, 0, 120))
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ion_efflux.lua
+++ b/scripts/actions/mobskills/ion_efflux.lua
@@ -15,11 +15,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ion_shower.lua
+++ b/scripts/actions/mobskills/ion_shower.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 5)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 5)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.5, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/ix_aern_mnk.lua
+++ b/scripts/actions/mobskills/ix_aern_mnk.lua
@@ -17,11 +17,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.HUNDRED_FISTS
-    xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 45)
+    xi.mobskills.mobBuffMove(mob, xi.effect.HUNDRED_FISTS, 1, 0, 45)
     mob:setLocalVar('BracerMode', 2)
     skill:setMsg(xi.msg.basic.USES)
-    return typeEffect
+    return xi.effect.HUNDRED_FISTS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/jamming_wave.lua
+++ b/scripts/actions/mobskills/jamming_wave.lua
@@ -11,10 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 45))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 45))
-    return typeEffect
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/jettatura.lua
+++ b/scripts/actions/mobskills/jettatura.lua
@@ -13,12 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local duration = 10
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 10))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, duration))
-
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/kibosh.lua
+++ b/scripts/actions/mobskills/kibosh.lua
@@ -13,13 +13,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     local power = 1
     local duration = 60
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, power, 0, duration))
 
-    return typeEffect
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/kick_out.lua
+++ b/scripts/actions/mobskills/kick_out.lua
@@ -24,9 +24,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, info.hitslanded)
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 20, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 20, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)
     return dmg

--- a/scripts/actions/mobskills/lamentation.lua
+++ b/scripts/actions/mobskills/lamentation.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DIA
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 3, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DIA, 3, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/lateral_slash.lua
+++ b/scripts/actions/mobskills/lateral_slash.lua
@@ -20,8 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.DEFENSE_DOWN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 75, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 75, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/lead_breath.lua
+++ b/scripts/actions/mobskills/lead_breath.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.WEIGHT
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 300))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 300))
-
-    return typeEffect
+    return xi.effect.WEIGHT
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/leaf_dagger.lua
+++ b/scripts/actions/mobskills/leaf_dagger.lua
@@ -19,11 +19,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1.4
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
-
-    local typeEffect = xi.effect.POISON
     local power = math.max(1, mob:getMainLvl() / 10)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 18)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 18)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/level_5_petrify.lua
+++ b/scripts/actions/mobskills/level_5_petrify.lua
@@ -12,16 +12,15 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
     if target:getMainLvl() % 5 == 0 then
         local power = math.random(2, 30)
 
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, power))
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, power))
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT) -- no effect
     end
 
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/lightning_armor.lua
+++ b/scripts/actions/mobskills/lightning_armor.lua
@@ -8,13 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 10
-    local duration = 180
-    local typeEffect = xi.effect.SHOCK_SPIKES
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHOCK_SPIKES, 10, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.SHOCK_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/lightning_blade.lua
+++ b/scripts/actions/mobskills/lightning_blade.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENTHUNDER
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENTHUNDER, 65, 0, 60))
+
+    return xi.effect.ENTHUNDER
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/lowing.lua
+++ b/scripts/actions/mobskills/lowing.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 60))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 0, 60))
 
-    return typeEffect
+    return xi.effect.PLAGUE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/luminous_drape.lua
+++ b/scripts/actions/mobskills/luminous_drape.lua
@@ -13,22 +13,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
     local power = 0
 
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, power, 3, 60)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/lunatic_voice.lua
+++ b/scripts/actions/mobskills/lunatic_voice.lua
@@ -8,11 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MUTE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MUTE, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60))
-
-    return typeEffect
+    return xi.effect.MUTE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/maats_bash.lua
+++ b/scripts/actions/mobskills/maats_bash.lua
@@ -14,9 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/maelstrom.lua
+++ b/scripts/actions/mobskills/maelstrom.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STR_DOWN
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.5, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/magic_barrier.lua
+++ b/scripts/actions/mobskills/magic_barrier.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_SHIELD
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_SHIELD, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 60))
-
-    return typeEffect
+    return xi.effect.MAGIC_SHIELD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/magma_hoplon.lua
+++ b/scripts/actions/mobskills/magma_hoplon.lua
@@ -10,15 +10,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.STONESKIN
-    local typeEffectTwo = xi.effect.BLAZE_SPIKES
-    local randy = math.random(20, 30)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffectOne, 1000, 0, 300))
-    xi.mobskills.mobBuffMove(mob, typeEffectTwo, randy, 0, 180)
-    local effect1 = mob:getStatusEffect(typeEffectOne)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.STONESKIN, 1000, 0, 300))
+    xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, math.random(20, 30), 0, 180)
+    local effect1 = mob:getStatusEffect(xi.effect.STONESKIN)
     effect1:delEffectFlag(xi.effectFlag.DISPELABLE)
 
-    return typeEffectOne
+    return xi.effect.STONESKIN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/magnetite_cloud.lua
+++ b/scripts/actions/mobskills/magnetite_cloud.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.WEIGHT
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 120)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.167, 1.875, xi.element.EARTH, 509)
 

--- a/scripts/actions/mobskills/malevolent_blessing.lua
+++ b/scripts/actions/mobskills/malevolent_blessing.lua
@@ -8,9 +8,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 35, 0, 45)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 35, 0, 45)
 
     local dmgmod = 1.25
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/mana_screen.lua
+++ b/scripts/actions/mobskills/mana_screen.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_SHIELD
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_SHIELD, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 60))
-
-    return typeEffect
+    return xi.effect.MAGIC_SHIELD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mantle_pierce.lua
+++ b/scripts/actions/mobskills/mantle_pierce.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.WEIGHT
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/material_fend.lua
+++ b/scripts/actions/mobskills/material_fend.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 35, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 35, 0, 120))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/medusa_javelin.lua
+++ b/scripts/actions/mobskills/medusa_javelin.lua
@@ -17,9 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
-    local typeEffect = xi.effect.PETRIFICATION
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/megalith_throw.lua
+++ b/scripts/actions/mobskills/megalith_throw.lua
@@ -15,11 +15,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobRangedMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1000, 0, 120)
-
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1000, 0, 120)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/memento_mori.lua
+++ b/scripts/actions/mobskills/memento_mori.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_ATK_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 300))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, 20, 0, 300))
+
+    return xi.effect.MAGIC_ATK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/metatron_torment.lua
+++ b/scripts/actions/mobskills/metatron_torment.lua
@@ -20,10 +20,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
     local duration = 60
-    local typeEffect = xi.effect.DEFENSE_DOWN
     local power = 19
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, power, 0, duration)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/mind_blast.lua
+++ b/scripts/actions/mobskills/mind_blast.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/mind_break.lua
+++ b/scripts/actions/mobskills/mind_break.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAX_MP_DOWN
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.MAX_MP_DOWN, 42, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 42, 0, 120))
-
-    return typeEffect
+    return xi.effect.MAX_MP_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mind_drain.lua
+++ b/scripts/actions/mobskills/mind_drain.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MND_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MND_DOWN, 10, 3, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
-    return typeEffect
+    return xi.effect.MND_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mirage.lua
+++ b/scripts/actions/mobskills/mirage.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 60))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/molluscous_mutation.lua
+++ b/scripts/actions/mobskills/molluscous_mutation.lua
@@ -15,10 +15,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 75, 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 75, 0, 60))
 
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mortal_ray.lua
+++ b/scripts/actions/mobskills/mortal_ray.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DOOM
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.DOOM, 10, 3, 30))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 10, 3, 30))
-
-    return typeEffect
+    return xi.effect.DOOM
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mountain_buster.lua
+++ b/scripts/actions/mobskills/mountain_buster.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/mow.lua
+++ b/scripts/actions/mobskills/mow.lua
@@ -19,11 +19,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 4 + 3
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/mucus_spread.lua
+++ b/scripts/actions/mobskills/mucus_spread.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 2500, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 2500, 0, 30))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/mysterious_light.lua
+++ b/scripts/actions/mobskills/mysterious_light.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.WEIGHT
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 50, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.5, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/negative_whirl.lua
+++ b/scripts/actions/mobskills/negative_whirl.lua
@@ -12,14 +12,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120)
 
     local dmgmod = 1
-
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.WIND, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
+
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.WIND)
     return dmg
 end

--- a/scripts/actions/mobskills/nepenthean_hum.lua
+++ b/scripts/actions/mobskills/nepenthean_hum.lua
@@ -15,10 +15,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     -- Subpower 100 prevents removal by Ecphoria Ring
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60, 100))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 1, 0, 60, 100))
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/netherspikes.lua
+++ b/scripts/actions/mobskills/netherspikes.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * 3)
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/noisome_powder.lua
+++ b/scripts/actions/mobskills/noisome_powder.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ATTACK_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 40, 0, 120))
 
-    return typeEffect
+    return xi.effect.ATTACK_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/nuclear_waste.lua
+++ b/scripts/actions/mobskills/nuclear_waste.lua
@@ -10,16 +10,15 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:setLocalVar('nuclearWaste', 1)
-    local typeEffect = xi.effect.ELEMENTALRES_DOWN
-    local resist = xi.mobskills.applyPlayerResistance(mob, typeEffect, target, mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0, 0)
+    local resist = xi.mobskills.applyPlayerResistance(mob, xi.effect.ELEMENTALRES_DOWN, target, mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0, 0)
     if resist >= 0.25 then
-        target:addStatusEffectEx(typeEffect, 0, 50, 0, 60)
+        target:addStatusEffectEx(xi.effect.ELEMENTALRES_DOWN, 0, 50, 0, 60)
         skill:setMsg(xi.msg.basic.NONE)
     else
         skill:setMsg(xi.msg.basic.SKILL_MISS)
     end
 
-    return typeEffect
+    return xi.effect.ELEMENTALRES_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/numbing_breath.lua
+++ b/scripts/actions/mobskills/numbing_breath.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 60)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 1.875, xi.element.ICE, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/numbing_glare.lua
+++ b/scripts/actions/mobskills/numbing_glare.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PARALYSIS, 25, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 25, 0, 180))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/numbing_noise.lua
+++ b/scripts/actions/mobskills/numbing_noise.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 5))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 5))
-
-    return typeEffect
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/numbshroom.lua
+++ b/scripts/actions/mobskills/numbshroom.lua
@@ -23,9 +23,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 35, 0, 180)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 35, 0, 180)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/obfuscate.lua
+++ b/scripts/actions/mobskills/obfuscate.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120))
-
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/occultation.lua
+++ b/scripts/actions/mobskills/occultation.lua
@@ -12,10 +12,9 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local base = math.random(10, 25)
-    local typeEffect = xi.effect.BLINK
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, base, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLINK, base, 0, 120))
+    return xi.effect.BLINK
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/onslaught.lua
+++ b/scripts/actions/mobskills/onslaught.lua
@@ -20,10 +20,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
     local duration = 60
-    local typeEffect = xi.effect.ACCURACY_DOWN
     local power = 30
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, power, 0, duration)
 
     -- About 300-400 to a DD.
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/actions/mobskills/optic_induration.lua
+++ b/scripts/actions/mobskills/optic_induration.lua
@@ -22,9 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/orcish_counterstance.lua
+++ b/scripts/actions/mobskills/orcish_counterstance.lua
@@ -16,15 +16,14 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     -- local power = 10
     -- local duration = 60
-    local typeEffect = xi.effect.COUNTERSTANCE
 
     -- if Conquerer Bakgodek then
         -- power = 50? He's not implemented yet anyway :P
     -- end
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 10, 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.COUNTERSTANCE, 10, 0, 60))
 
-    return typeEffect
+    return xi.effect.COUNTERSTANCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/palsy_pollen.lua
+++ b/scripts/actions/mobskills/palsy_pollen.lua
@@ -11,11 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 60))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/palsynyxis.lua
+++ b/scripts/actions/mobskills/palsynyxis.lua
@@ -19,9 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 25, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 25, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/paralysis_shower.lua
+++ b/scripts/actions/mobskills/paralysis_shower.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/paralyzing_microtube.lua
+++ b/scripts/actions/mobskills/paralyzing_microtube.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 60)
 
     local dmgmod = 2.45
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.NONE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/parry.lua
+++ b/scripts/actions/mobskills/parry.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 15, 0, 300))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 15, 0, 300))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/particle_shield.lua
+++ b/scripts/actions/mobskills/particle_shield.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 100, 0, 300))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 100, 0, 300))
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pestilent_penance.lua
+++ b/scripts/actions/mobskills/pestilent_penance.lua
@@ -8,9 +8,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/petribreath.lua
+++ b/scripts/actions/mobskills/petribreath.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/petrifaction.lua
+++ b/scripts/actions/mobskills/petrifaction.lua
@@ -12,9 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 25))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 25))
+
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/petrifactive_breath.lua
+++ b/scripts/actions/mobskills/petrifactive_breath.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, math.random(15, 45)))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, math.random(15, 45)))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/petro_eyes.lua
+++ b/scripts/actions/mobskills/petro_eyes.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 60))
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/petro_gaze.lua
+++ b/scripts/actions/mobskills/petro_gaze.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 25))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 25))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/phantasmal_dance.lua
+++ b/scripts/actions/mobskills/phantasmal_dance.lua
@@ -10,13 +10,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
     local numhits = 1
     local accmod = 1
     local dmgmod = 2.0
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 30)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg
 end

--- a/scripts/actions/mobskills/photosynthesis.lua
+++ b/scripts/actions/mobskills/photosynthesis.lua
@@ -21,11 +21,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = mob:getMainLvl() / 10 * 4 + 5
-    local duration = 30
 
-    local typeEffect = xi.effect.REGEN
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 0, 30))
+
+    return xi.effect.REGEN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pile_pitch.lua
+++ b/scripts/actions/mobskills/pile_pitch.lua
@@ -12,9 +12,8 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local currentHP = target:getHP()
     local damage = currentHP * .90
-    local typeEffect = xi.effect.BIND
     local dmg = xi.mobskills.mobFinalAdjustments(damage, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.NONE)
     mob:resetEnmity(target)
     return dmg

--- a/scripts/actions/mobskills/pinning_shot.lua
+++ b/scripts/actions/mobskills/pinning_shot.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/pl_chaos_blade.lua
+++ b/scripts/actions/mobskills/pl_chaos_blade.lua
@@ -24,8 +24,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.DARK)
 
     -- curse LAST so you don't die
-    local typeEffect = xi.effect.CURSE_I
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 60)
 
     return dmg
 end

--- a/scripts/actions/mobskills/pl_heavy_stomp.lua
+++ b/scripts/actions/mobskills/pl_heavy_stomp.lua
@@ -25,9 +25,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = .7
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
-    local typeEffect = xi.effect.PARALYSIS
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 360)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 15, 0, 360)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
     return dmg

--- a/scripts/actions/mobskills/pl_hellclap.lua
+++ b/scripts/actions/mobskills/pl_hellclap.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 4.0
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * math.random(2, 3))
-    local typeEffect = xi.effect.BIND
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 4)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
     return dmg

--- a/scripts/actions/mobskills/pl_hellsnap.lua
+++ b/scripts/actions/mobskills/pl_hellsnap.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 4.0
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * math.random(2, 3))
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
 
     return dmg

--- a/scripts/actions/mobskills/pl_petro_eyes.lua
+++ b/scripts/actions/mobskills/pl_petro_eyes.lua
@@ -18,10 +18,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 30))
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pl_vulcanian_impact.lua
+++ b/scripts/actions/mobskills/pl_vulcanian_impact.lua
@@ -17,9 +17,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local targetcurrentHP = target:getHP()
     local targetmaxHP = target:getMaxHP()
     local hpset = targetmaxHP * 0.10
-    local typeEffect = xi.effect.BIND
     local dmg = 0
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     if targetcurrentHP > hpset then
         dmg = targetcurrentHP - hpset

--- a/scripts/actions/mobskills/plague_breath.lua
+++ b/scripts/actions/mobskills/plague_breath.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 4 + 1
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 2, xi.element.WATER, 250)
 

--- a/scripts/actions/mobskills/plasma_charge.lua
+++ b/scripts/actions/mobskills/plasma_charge.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SHOCK_SPIKES
-    local randy = math.random(15, 30)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, randy, 0, 180))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHOCK_SPIKES, math.random(15, 30), 0, 180))
 
-    return typeEffect
+    return xi.effect.SHOCK_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/poison_breath.lua
+++ b/scripts/actions/mobskills/poison_breath.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
     local power = math.ceil(mob:getMainLvl() / 5)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.1, 1.25, xi.element.WATER, 200)
 

--- a/scripts/actions/mobskills/poison_nails.lua
+++ b/scripts/actions/mobskills/poison_nails.lua
@@ -14,10 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    local typeEffect = xi.effect.POISON
-    local power = 1
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 1, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/poison_pick.lua
+++ b/scripts/actions/mobskills/poison_pick.lua
@@ -17,11 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
-
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 5 + 3
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/poison_sting.lua
+++ b/scripts/actions/mobskills/poison_sting.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 10 + 3
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/primal_drill.lua
+++ b/scripts/actions/mobskills/primal_drill.lua
@@ -20,8 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 45)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 45)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/promyvion_barrier.lua
+++ b/scripts/actions/mobskills/promyvion_barrier.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 17.5, 0, 300))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 17.5, 0, 300))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/promyvion_brume.lua
+++ b/scripts/actions/mobskills/promyvion_brume.lua
@@ -14,8 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 3, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 5, 3, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/pw_acheron_flame.lua
+++ b/scripts/actions/mobskills/pw_acheron_flame.lua
@@ -19,17 +19,15 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BURN
-    local statmod = xi.mod.INT
-    local element = mob:getStatusEffectElement(typeEffect)
-    local resist = xi.mobskills.applyPlayerResistance(mob, typeEffect, target, mob:getStat(statmod)-target:getStat(statmod), 0, element)
+    local element = mob:getStatusEffectElement(xi.effect.BURN)
+    local resist = xi.mobskills.applyPlayerResistance(mob, xi.effect.BURN, target, mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT), 0, element)
 
     local power = ((resist * 10) - 5) * math.random(1, 2) + 19 -- makes dot damage between 20 - 28, based off resistance and random variable.
     local dmgmod = 3
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 6, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, power, 3, 60)
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
 
     return dmg

--- a/scripts/actions/mobskills/pw_calcifying_deluge.lua
+++ b/scripts/actions/mobskills/pw_calcifying_deluge.lua
@@ -25,9 +25,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
-    local typeEffect = xi.effect.PETRIFICATION
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 0, 30)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
 
     return dmg

--- a/scripts/actions/mobskills/pw_fossilizing_breath.lua
+++ b/scripts/actions/mobskills/pw_fossilizing_breath.lua
@@ -19,13 +19,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    local power = 1
-    local duration = 30
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pw_gorgon_dance.lua
+++ b/scripts/actions/mobskills/pw_gorgon_dance.lua
@@ -19,9 +19,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, math.random(60, 180)))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.PETRIFICATION, 1, 0, math.random(60, 180)))
+
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/pw_pinning_shot.lua
+++ b/scripts/actions/mobskills/pw_pinning_shot.lua
@@ -25,9 +25,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.PIERCING, info.hitslanded)
-    local typeEffect = xi.effect.BIND
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 30)
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.PIERCING)
 
     return dmg

--- a/scripts/actions/mobskills/qn_aern_rdm.lua
+++ b/scripts/actions/mobskills/qn_aern_rdm.lua
@@ -13,11 +13,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHAINSPELL
-    xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 60)
+    xi.mobskills.mobBuffMove(mob, xi.effect.CHAINSPELL, 1, 0, 60)
 
     skill:setMsg(xi.msg.basic.USES)
-    return typeEffect
+    return xi.effect.CHAINSPELL
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/quake_stomp.lua
+++ b/scripts/actions/mobskills/quake_stomp.lua
@@ -25,10 +25,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 1
     local duration = 60
 
-    local typeEffect = xi.effect.BOOST
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BOOST, power, 0, duration))
+    return xi.effect.BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/queasyshroom.lua
+++ b/scripts/actions/mobskills/queasyshroom.lua
@@ -25,11 +25,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
-
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 4 + 1
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/radiant_breath.lua
+++ b/scripts/actions/mobskills/radiant_breath.lua
@@ -10,11 +10,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.SLOW
-    local typeEffectTwo = xi.effect.SILENCE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectOne, 1250, 0, 120)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectTwo, 1, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 120)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.LIGHT, 700)
 

--- a/scripts/actions/mobskills/rage.lua
+++ b/scripts/actions/mobskills/rage.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local duration = 60
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BERSERK, 1, 0, 60))
 
-    local typeEffect = xi.effect.BERSERK
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, duration))
-    return typeEffect
+    return xi.effect.BERSERK
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/rail_cannon.lua
+++ b/scripts/actions/mobskills/rail_cannon.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/rail_cannon_1.lua
+++ b/scripts/actions/mobskills/rail_cannon_1.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/rail_cannon_2.lua
+++ b/scripts/actions/mobskills/rail_cannon_2.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/rail_cannon_3.lua
+++ b/scripts/actions/mobskills/rail_cannon_3.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.LIGHT, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/rampant_gnaw.lua
+++ b/scripts/actions/mobskills/rampant_gnaw.lua
@@ -17,9 +17,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 20, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 20, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/randgrith.lua
+++ b/scripts/actions/mobskills/randgrith.lua
@@ -19,11 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 3, 3, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local duration = 60
-    local typeEffect = xi.effect.EVASION_DOWN
-    local power = 32
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.EVASION_DOWN, 32, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/rapid_dance.lua
+++ b/scripts/actions/mobskills/rapid_dance.lua
@@ -13,9 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 60))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/rapid_molt.lua
+++ b/scripts/actions/mobskills/rapid_molt.lua
@@ -21,10 +21,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     mob:eraseAllStatusEffect()
-    local typeEffect = xi.effect.REGEN
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 10, 3, 180))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, 10, 3, 180))
+
+    return xi.effect.REGEN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/reactive_armor.lua
+++ b/scripts/actions/mobskills/reactive_armor.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = math.random(20, 30)
-    local duration = 180
-    local typeEffect = xi.effect.SHOCK_SPIKES
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHOCK_SPIKES, math.random(20, 30), 0, 180))
+
+    return xi.effect.SHOCK_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/reactive_shield.lua
+++ b/scripts/actions/mobskills/reactive_shield.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = math.random(20, 30)
-    -- local duration = 180
-    local typeEffect = xi.effect.SHOCK_SPIKES
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHOCK_SPIKES, math.random(20, 30), 0, 180))
+
+    return xi.effect.SHOCK_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/reactor_cool.lua
+++ b/scripts/actions/mobskills/reactor_cool.lua
@@ -13,17 +13,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect  = xi.effect.ICE_SPIKES
-    local typeEffect2 = xi.effect.DEFENSE_BOOST
-
-    skill:setMsg(xi.mobskills.MobBuffMove(mob, typeEffect, math.random(15, 30), 0, 60))
+    skill:setMsg(xi.mobskills.MobBuffMove(mob, xi.effect.ICE_SPIKES, math.random(15, 30), 0, 60))
     local effect1 = mob:getStatusEffect(xi.effect.ICE_SPIKES)
     effect1:delEffectFlag(xi.effectFlag.DISPELABLE)
-    xi.mobskills.mobBuffMove(mob, typeEffect2, 26, 0, 60)
+    xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 26, 0, 60)
     local effect2 = mob:getStatusEffect(xi.effect.DEFENSE_BOOST)
     effect2:delEffectFlag(xi.effectFlag.DISPELABLE)
 
-    return typeEffect
+    return xi.effect.ICE_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/reactor_overheat.lua
+++ b/scripts/actions/mobskills/reactor_overheat.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.FIRE, info.hitslanded)
-    local typeEffect = xi.effect.PLAGUE
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.MAGICAL, xi.damageType.FIRE)
     return dmg

--- a/scripts/actions/mobskills/reactor_overload.lua
+++ b/scripts/actions/mobskills/reactor_overload.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
-    local typeEffect = xi.effect.SILENCE
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SILENCE, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/rear_lasers.lua
+++ b/scripts/actions/mobskills/rear_lasers.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/refueling.lua
+++ b/scripts/actions/mobskills/refueling.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.HASTE
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1000, 0, 300))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 1000, 0, 300))
+
+    return xi.effect.HASTE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/regeneration.lua
+++ b/scripts/actions/mobskills/regeneration.lua
@@ -14,12 +14,10 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = mob:getMainLvl() / 10 * 4 + 5
-    local duration = 60
 
-    local typeEffect = xi.effect.REGEN
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.REGEN, power, 3, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 3, duration))
-    return typeEffect
+    return xi.effect.REGEN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/regurgitation.lua
+++ b/scripts/actions/mobskills/regurgitation.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/rhino_guard.lua
+++ b/scripts/actions/mobskills/rhino_guard.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 30, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 30, 0, 60))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/riddle.lua
+++ b/scripts/actions/mobskills/riddle.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAX_MP_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MAX_MP_DOWN, 42, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 42, 0, 120))
-
-    return typeEffect
+    return xi.effect.MAX_MP_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/rime_spray.lua
+++ b/scripts/actions/mobskills/rime_spray.lua
@@ -12,8 +12,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- local typeEffect = xi.effect.FROST
-
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.FROST, 15, 3, 120)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 20, 3, 60)
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 20, 3, 60)

--- a/scripts/actions/mobskills/rinpyotosha.lua
+++ b/scripts/actions/mobskills/rinpyotosha.lua
@@ -13,13 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 25
-    local duration = 180
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.WARCRY, 25, 0, 180))
 
-    local typeEffect = xi.effect.WARCRY
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.WARCRY
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ripper_fang.lua
+++ b/scripts/actions/mobskills/ripper_fang.lua
@@ -16,12 +16,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.SLOW
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1250, 0, 120)
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 128, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 120)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
+
     return dmg
 end
 

--- a/scripts/actions/mobskills/roar.lua
+++ b/scripts/actions/mobskills/roar.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 35, 0, 60))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 35, 0, 60))
 
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/rock_smash.lua
+++ b/scripts/actions/mobskills/rock_smash.lua
@@ -27,11 +27,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 3
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
-
-    local typeEffect = xi.effect.PETRIFICATION
     local power = math.random(25, 40) + mob:getMainLvl() / 3
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, power)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 0, power)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/rot_gas.lua
+++ b/scripts/actions/mobskills/rot_gas.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DISEASE
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 180))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 180))
 
-    return typeEffect
+    return xi.effect.DISEASE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/royal_bash.lua
+++ b/scripts/actions/mobskills/royal_bash.lua
@@ -14,9 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -9,14 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local power = 175
-    local duration = 300
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 175, 0, 300))
 
-    local typeEffect = xi.effect.PROTECT
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.PROTECT
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/rumble.lua
+++ b/scripts/actions/mobskills/rumble.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 50, 0, 120))
 
-    return typeEffect
+    return xi.effect.EVASION_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/saline_coat.lua
+++ b/scripts/actions/mobskills/saline_coat.lua
@@ -15,10 +15,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_DEF_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 50, 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_DEF_BOOST, 50, 0, 60))
 
-    return typeEffect
+    return xi.effect.MAGIC_DEF_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_blast.lua
+++ b/scripts/actions/mobskills/sand_blast.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120))
 
     if mob:getPool() == 1318 and mob:getLocalVar('SAND_BLAST') == 1 then -- Feeler Anltion
         local alastorId = mob:getID() + 6
@@ -23,7 +22,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         end
     end
 
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_breath.lua
+++ b/scripts/actions/mobskills/sand_breath.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 180)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.2, 0.75, xi.element.EARTH, 800)
 

--- a/scripts/actions/mobskills/sand_pit.lua
+++ b/scripts/actions/mobskills/sand_pit.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 30))
 
     -- Different mechanics based on the antlion using it
     local poolID = mob:getPool()
@@ -51,7 +50,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:delStatusEffectsByFlag(xi.effectFlag.ERASABLE)
     end
 
-    return typeEffect
+    return xi.effect.BIND
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_shield.lua
+++ b/scripts/actions/mobskills/sand_shield.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 50, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_trap.lua
+++ b/scripts/actions/mobskills/sand_trap.lua
@@ -12,14 +12,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, math.random(12, 20)))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, math.random(12, 20)))
 
     -- reset everyones enmity
     mob:resetEnmity(target)
 
-    return typeEffect
+    return xi.effect.PETRIFICATION
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sand_veil.lua
+++ b/scripts/actions/mobskills/sand_veil.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 60))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sandspin.lua
+++ b/scripts/actions/mobskills/sandspin.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ACCURACY_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 50, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.3, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/sandspray.lua
+++ b/scripts/actions/mobskills/sandspray.lua
@@ -13,13 +13,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
     local power = 25
     local duration = 90
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, power, 0, duration))
 
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sandstorm.lua
+++ b/scripts/actions/mobskills/sandstorm.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 15, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 15, 0, 120))
 
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/scissor_guard.lua
+++ b/scripts/actions/mobskills/scissor_guard.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 100, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 100, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/scratch.lua
+++ b/scripts/actions/mobskills/scratch.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 18, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/scream.lua
+++ b/scripts/actions/mobskills/scream.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MND_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MND_DOWN, 10, 3, 120))
 
-    return typeEffect
+    return xi.effect.MND_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/scutum.lua
+++ b/scripts/actions/mobskills/scutum.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 30, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 30, 0, 120))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/seal_of_quiescence.lua
+++ b/scripts/actions/mobskills/seal_of_quiescence.lua
@@ -11,13 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MUTE
-    local power = 30
-    local duration = 75
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MUTE, 30, 0, 75))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, duration))
-
-    return typeEffect
+    return xi.effect.MUTE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/secretion.lua
+++ b/scripts/actions/mobskills/secretion.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 25, 0, 60))
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/seismostomp.lua
+++ b/scripts/actions/mobskills/seismostomp.lua
@@ -21,9 +21,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info           = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES)
     local shadowsRemoved = math.random(1, 2)
     local dmg            = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, shadowsRemoved)
-    local typeEffect     = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
 
     return dmg

--- a/scripts/actions/mobskills/shadow_claw.lua
+++ b/scripts/actions/mobskills/shadow_claw.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 20, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BLINDNESS, 20, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/shakeshroom.lua
+++ b/scripts/actions/mobskills/shakeshroom.lua
@@ -23,9 +23,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.DISEASE
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 180)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DISEASE, 1, 0, 180)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/sharp_strike.lua
+++ b/scripts/actions/mobskills/sharp_strike.lua
@@ -17,10 +17,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 50
     local duration = 180
 
-    local typeEffect = xi.effect.ATTACK_BOOST
-
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ATTACK_BOOST, power, 0, duration))
+    return xi.effect.ATTACK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sheep_bleat.lua
+++ b/scripts/actions/mobskills/sheep_bleat.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sheep_song.lua
+++ b/scripts/actions/mobskills/sheep_song.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, 20))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 20))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/shell_bash.lua
+++ b/scripts/actions/mobskills/shell_bash.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/shell_guard.lua
+++ b/scripts/actions/mobskills/shell_guard.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local base = 100
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, base, 0, 180))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 100, 0, 180))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/shibaraku.lua
+++ b/scripts/actions/mobskills/shibaraku.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/shiko_no_mitate.lua
+++ b/scripts/actions/mobskills/shiko_no_mitate.lua
@@ -10,8 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 15, 0, 300))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 15, 0, 300))
 
     -- Extra stuff for Trust: Gessho
     if mob:getObjType() == xi.objType.TRUST then
@@ -19,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
         mob:addStatusEffect(xi.effect.STONESKIN, 300, 0, 300)
     end
 
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sigh.lua
+++ b/scripts/actions/mobskills/sigh.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 50, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 50, 0, 30))
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/silence_seal.lua
+++ b/scripts/actions/mobskills/silence_seal.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60))
-
-    return typeEffect
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/silencing_microtube.lua
+++ b/scripts/actions/mobskills/silencing_microtube.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
 
     local dmgmod = 2.45
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.NONE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/slam_dunk.lua
+++ b/scripts/actions/mobskills/slam_dunk.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.H2H, info.hitslanded)
 
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 20)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 20)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.H2H)
     return dmg

--- a/scripts/actions/mobskills/slaverous_gale.lua
+++ b/scripts/actions/mobskills/slaverous_gale.lua
@@ -11,10 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffectOne = xi.effect.PLAGUE
-    local typeEffectTwo = xi.effect.SLOW
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectOne, 1, 3, 60)
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffectTwo, 1250, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 1, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 60)
+
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * math.random(4, 6), xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/slumber_powder.lua
+++ b/scripts/actions/mobskills/slumber_powder.lua
@@ -9,12 +9,11 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
     local power = math.random(15, 20) + mob:getMainLvl() / 4
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, power))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, power))
 
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/smoke_discharger.lua
+++ b/scripts/actions/mobskills/smoke_discharger.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PETRIFICATION
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 3, 15)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PETRIFICATION, 1, 3, 15)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/smokebomb.lua
+++ b/scripts/actions/mobskills/smokebomb.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120))
-
-    return typeEffect
+    return xi.effect.BLINDNESS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/snow_cloud.lua
+++ b/scripts/actions/mobskills/snow_cloud.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.ICE, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/sonic_boom.lua
+++ b/scripts/actions/mobskills/sonic_boom.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ATTACK_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 50, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 50, 0, 120))
 
-    return typeEffect
+    return xi.effect.ATTACK_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sonic_wave.lua
+++ b/scripts/actions/mobskills/sonic_wave.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 30, 0, 120))
 
-    return typeEffect
+    return xi.effect.DEFENSE_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/soothing_aroma.lua
+++ b/scripts/actions/mobskills/soothing_aroma.lua
@@ -16,21 +16,19 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
-
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 0, 3, 150)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, 0, 3, 150)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/soporific.lua
+++ b/scripts/actions/mobskills/soporific.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/soulshattering_roar.lua
+++ b/scripts/actions/mobskills/soulshattering_roar.lua
@@ -8,11 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    -- local duration = 10
     local dmgmod = 2.0
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.TERROR, 1, 0, 30)
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.WIPE_SHADOWS)

--- a/scripts/actions/mobskills/sound_blast.lua
+++ b/scripts/actions/mobskills/sound_blast.lua
@@ -9,10 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.INT_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.INT_DOWN, 10, 3, 120))
 
-    return typeEffect
+    return xi.effect.INT_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sound_vacuum.lua
+++ b/scripts/actions/mobskills/sound_vacuum.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 45))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 45))
-
-    return typeEffect
+    return xi.effect.SILENCE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/spectral_barrier.lua
+++ b/scripts/actions/mobskills/spectral_barrier.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.MAGIC_SHIELD
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_SHIELD, 1, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 1, 0, 60))
-    return typeEffect
+    return xi.effect.MAGIC_SHIELD
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/spider_web.lua
+++ b/scripts/actions/mobskills/spider_web.lua
@@ -9,12 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-    local power = 3000
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 3000, 0, 90))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 0, 90))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/spine_lash.lua
+++ b/scripts/actions/mobskills/spine_lash.lua
@@ -10,15 +10,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-
     local numhits = 1
     local accmod = 1
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PLAGUE, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/spinning_fin.lua
+++ b/scripts/actions/mobskills/spinning_fin.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/spiral_spin.lua
+++ b/scripts/actions/mobskills/spiral_spin.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.ACCURACY_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 50, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/spoil.lua
+++ b/scripts/actions/mobskills/spoil.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STR_DOWN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 120))
 
-    return typeEffect
+    return xi.effect.STR_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/spore.lua
+++ b/scripts/actions/mobskills/spore.lua
@@ -12,9 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 120))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, 120))
+
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sprout_smack.lua
+++ b/scripts/actions/mobskills/sprout_smack.lua
@@ -16,11 +16,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.SLOW
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1000, 0, 120)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1000, 0, 120)
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 100, 0, 120)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg
 end

--- a/scripts/actions/mobskills/stasis.lua
+++ b/scripts/actions/mobskills/stasis.lua
@@ -14,13 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local shadows = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     -- local dmg = xi.mobskills.mobFinalAdjustments(10, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, shadows)
-    local typeEffect = xi.effect.PARALYSIS
 
     mob:resetEnmity(target)
 
     if xi.mobskills.mobPhysicalHit(skill) then
-        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 40, 0, 60))
-        return typeEffect
+        skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 40, 0, 60))
+
+        return xi.effect.PARALYSIS
     end
 
     return shadows

--- a/scripts/actions/mobskills/static_filament.lua
+++ b/scripts/actions/mobskills/static_filament.lua
@@ -19,9 +19,8 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
-    local typeEffect = xi.effect.STUN
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/sticky_thread.lua
+++ b/scripts/actions/mobskills/sticky_thread.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120))
-
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/stinking_gas.lua
+++ b/scripts/actions/mobskills/stinking_gas.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.VIT_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 3, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
-
-    return typeEffect
+    return xi.effect.VIT_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/stone_throw.lua
+++ b/scripts/actions/mobskills/stone_throw.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.RANGED, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 20, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 20, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.RANGED, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/stun_cannon.lua
+++ b/scripts/actions/mobskills/stun_cannon.lua
@@ -16,9 +16,8 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 1.5
-    local typeEffect = xi.effect.PARALYSIS
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, 120)
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.MAGICAL, xi.damageType.DARK, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 

--- a/scripts/actions/mobskills/stunbolt.lua
+++ b/scripts/actions/mobskills/stunbolt.lua
@@ -10,10 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 10))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 10))
 
-    return typeEffect
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/stygian_flatus.lua
+++ b/scripts/actions/mobskills/stygian_flatus.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 120))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/stygian_vapor.lua
+++ b/scripts/actions/mobskills/stygian_vapor.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 0, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 0, 60))
-
-    return typeEffect
+    return xi.effect.PLAGUE
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/subsonics.lua
+++ b/scripts/actions/mobskills/subsonics.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 25, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 180))
-    return typeEffect
+    return xi.effect.DEFENSE_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/suction.lua
+++ b/scripts/actions/mobskills/suction.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/suctorial_tentacle.lua
+++ b/scripts/actions/mobskills/suctorial_tentacle.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 5, 3, 180))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 5, 3, 180))
-
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/sudden_lunge.lua
+++ b/scripts/actions/mobskills/sudden_lunge.lua
@@ -15,8 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     local currentHP = mob:getHP()
     local newHP = currentHP - (currentHP * (math.random(5, 15) / 100))

--- a/scripts/actions/mobskills/sweep.lua
+++ b/scripts/actions/mobskills/sweep.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/tackle.lua
+++ b/scripts/actions/mobskills/tackle.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/tail_blow.lua
+++ b/scripts/actions/mobskills/tail_blow.lua
@@ -18,8 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/tail_crush.lua
+++ b/scripts/actions/mobskills/tail_crush.lua
@@ -17,10 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local dmgmod = 2.5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
-
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 10 + 10
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, power, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/tail_slap.lua
+++ b/scripts/actions/mobskills/tail_slap.lua
@@ -26,9 +26,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.ATK_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/tail_swing.lua
+++ b/scripts/actions/mobskills/tail_swing.lua
@@ -18,8 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.BIND
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/tail_thrust.lua
+++ b/scripts/actions/mobskills/tail_thrust.lua
@@ -20,8 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.PIERCING, info.hitslanded)
 
-    local typeEffect = xi.effect.PARALYSIS
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.PARALYSIS, 15, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.PIERCING)
     return dmg

--- a/scripts/actions/mobskills/tail_whip.lua
+++ b/scripts/actions/mobskills/tail_whip.lua
@@ -14,8 +14,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 1.5, 2)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_3)
 
-    local typeEffect = xi.effect.WEIGHT
-        xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/tebbad_wing.lua
+++ b/scripts/actions/mobskills/tebbad_wing.lua
@@ -22,9 +22,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/tebbad_wing_air.lua
+++ b/scripts/actions/mobskills/tebbad_wing_air.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PLAGUE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 0, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/temporal_shift.lua
+++ b/scripts/actions/mobskills/temporal_shift.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 5))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 5))
-
-    return typeEffect
+    return xi.effect.STUN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/terror_eye.lua
+++ b/scripts/actions/mobskills/terror_eye.lua
@@ -18,12 +18,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-    local duration = 30
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.TERROR, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, duration))
-
-    return typeEffect
+    return xi.effect.TERROR
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/terror_touch.lua
+++ b/scripts/actions/mobskills/terror_touch.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.ACC_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.ATTACK_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 75, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ATTACK_DOWN, 75, 0, 30)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/the_wrath_of_gudha.lua
+++ b/scripts/actions/mobskills/the_wrath_of_gudha.lua
@@ -8,15 +8,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.WEIGHT
-
     local numhits = 1
     local accmod = 1
     local dmgmod = 5
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, 0, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 80, 0, 10)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 80, 0, 10)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/thermal_pulse.lua
+++ b/scripts/actions/mobskills/thermal_pulse.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/thornsong.lua
+++ b/scripts/actions/mobskills/thornsong.lua
@@ -22,9 +22,8 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = mob:getMainLvl() * 2
     local duration = 180
-    local typeEffect = xi.effect.BLAZE_SPIKES
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLAZE_SPIKES, power, 0, duration))
+    return xi.effect.BLAZE_SPIKES
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/thunder_break.lua
+++ b/scripts/actions/mobskills/thunder_break.lua
@@ -9,9 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 4)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3.2, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/thunderbolt.lua
+++ b/scripts/actions/mobskills/thunderbolt.lua
@@ -11,9 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 4)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/thunderous_yowl.lua
+++ b/scripts/actions/mobskills/thunderous_yowl.lua
@@ -9,13 +9,10 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect1 = xi.effect.PLAGUE
-    local typeEffect2 = xi.effect.CURSE_I
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, 60)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 60))
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect1, 5, 3, 60)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect2, 25, 0, 60))
-
-    return typeEffect2
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/thunderspark.lua
+++ b/scripts/actions/mobskills/thunderspark.lua
@@ -9,8 +9,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/thundris_shriek.lua
+++ b/scripts/actions/mobskills/thundris_shriek.lua
@@ -34,9 +34,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.TERROR
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 15)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.TERROR, 1, 0, 15)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.THUNDER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/tidal_dive.lua
+++ b/scripts/actions/mobskills/tidal_dive.lua
@@ -14,18 +14,14 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
     local numhits = math.random(2, 3)
     local accmod = 1
     local dmgmod = .8
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 30)
-
-    typeEffect = xi.effect.WEIGHT
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 50, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/tormentful_glare.lua
+++ b/scripts/actions/mobskills/tormentful_glare.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.CURSE_I, 30, 0, 360))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 30, 0, 360))
-
-    return typeEffect
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/torpid_glare.lua
+++ b/scripts/actions/mobskills/torpid_glare.lua
@@ -13,11 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLEEP_I, 1, 0, 30))
 
-    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, typeEffect, 1, 0, 30))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/tortoise_stomp.lua
+++ b/scripts/actions/mobskills/tortoise_stomp.lua
@@ -18,8 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.DEFENSE_DOWN
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 30, 0, 180)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, 30, 0, 180)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/toxic_spit.lua
+++ b/scripts/actions/mobskills/toxic_spit.lua
@@ -13,10 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
     local power = mob:getMainLvl() / 5 + 3
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/trample.lua
+++ b/scripts/actions/mobskills/trample.lua
@@ -12,9 +12,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
     local duration = 30
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, duration)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, duration)
 
     local numhits = 1
     local accmod = 1

--- a/scripts/actions/mobskills/tremorous_tread.lua
+++ b/scripts/actions/mobskills/tremorous_tread.lua
@@ -19,9 +19,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, xi.mobskills.shadowBehavior.NUMSHADOWS_2)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 3)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 3)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg
 end

--- a/scripts/actions/mobskills/tremors.lua
+++ b/scripts/actions/mobskills/tremors.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEX_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEX_DOWN, 10, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.EARTH, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/triclip.lua
+++ b/scripts/actions/mobskills/triclip.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.DEX_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 10, 3, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.DEX_DOWN, 10, 3, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/triumphant_roar.lua
+++ b/scripts/actions/mobskills/triumphant_roar.lua
@@ -20,11 +20,10 @@ end
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = 15
     local duration = 90
-    local typeEffect = xi.effect.ATTACK_BOOST
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, duration))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ATTACK_BOOST, power, 0, duration))
 
-    return typeEffect
+    return xi.effect.ATTACK_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/turbofan.lua
+++ b/scripts/actions/mobskills/turbofan.lua
@@ -11,8 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 3, 30)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SILENCE, 1, 3, 30)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 3, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.MAB_BONUS, 1)

--- a/scripts/actions/mobskills/typhoon_wing.lua
+++ b/scripts/actions/mobskills/typhoon_wing.lua
@@ -21,9 +21,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BLINDNESS
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 60, 0, 30)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 60, 0, 30)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 5, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/ultrasonics.lua
+++ b/scripts/actions/mobskills/ultrasonics.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 25, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 180))
-
-        return typeEffect
+    return xi.effect.EVASION_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/ululation.lua
+++ b/scripts/actions/mobskills/ululation.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.PARALYSIS
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, math.random(18, 22), 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, math.random(18, 22), 0, 120))
-
-    return typeEffect
+    return xi.effect.PARALYSIS
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/unblessed_armor.lua
+++ b/scripts/actions/mobskills/unblessed_armor.lua
@@ -14,12 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SHELL
-    local power      = 5000
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.SHELL, 5000, 0, 180))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, power, 0, 180))
-
-    return typeEffect
+    return xi.effect.SHELL
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/undead_mold.lua
+++ b/scripts/actions/mobskills/undead_mold.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DISEASE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 180)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DISEASE, 1, 0, 180)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.DARK, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/vanity_strike.lua
+++ b/scripts/actions/mobskills/vanity_strike.lua
@@ -16,9 +16,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.physicalTpBonus.DMG_VARIES, 1, 2, 3)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/venom.lua
+++ b/scripts/actions/mobskills/venom.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-            local power = mob:getMainLvl() / 6 + 1
+    local power = mob:getMainLvl() / 6 + 1
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 1.5, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/venom_breath.lua
+++ b/scripts/actions/mobskills/venom_breath.lua
@@ -8,8 +8,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, math.random(20, 40), 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, math.random(20, 40), 3, 60)
 
     local dmgmod = xi.mobskills.mobBreathMove(mob, target, 0.3, 1.875, xi.element.WATER, 500)
     local dmg = xi.mobskills.mobFinalAdjustments(dmgmod, mob, skill, target, xi.attackType.BREATH, xi.damageType.ICE, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)

--- a/scripts/actions/mobskills/venom_shell.lua
+++ b/scripts/actions/mobskills/venom_shell.lua
@@ -14,11 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 12, 0, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 12, 0, 120))
-
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/venom_spray.lua
+++ b/scripts/actions/mobskills/venom_spray.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
-            local power = mob:getMainLvl() / 8 + 10
+    local power = mob:getMainLvl() / 8 + 10
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 1.8, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/venom_sting.lua
+++ b/scripts/actions/mobskills/venom_sting.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.POISON
-    local power = 100
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 100, 3, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/venom_storm.lua
+++ b/scripts/actions/mobskills/venom_storm.lua
@@ -8,10 +8,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.POISON
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, math.random(20, 30), 3, 60))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, math.random(20, 30), 3, 60))
-    return typeEffect
+    return xi.effect.POISON
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/vertical_slash.lua
+++ b/scripts/actions/mobskills/vertical_slash.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded)
 
-    local typeEffect = xi.effect.ACCURACY_DOWN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 25, 0, 120)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.ACCURACY_DOWN, 25, 0, 120)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/viscid_emission.lua
+++ b/scripts/actions/mobskills/viscid_emission.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     -- Subpower 100 prevents removal by Ecphoria Ring
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60, 100))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 1, 0, 60, 100))
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/viscid_nectar.lua
+++ b/scripts/actions/mobskills/viscid_nectar.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1250, 0, 120))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 120))
 
-    return typeEffect
+    return xi.effect.SLOW
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/vitriolic_barrage.lua
+++ b/scripts/actions/mobskills/vitriolic_barrage.lua
@@ -15,9 +15,8 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local needles = 1000 / skill:getTotalTargets()
-    local typeEffect = xi.effect.POISON
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 20, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 20, 3, 60)
 
     local dmg = xi.mobskills.mobFinalAdjustments(needles, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.WATER, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 

--- a/scripts/actions/mobskills/vitriolic_shower.lua
+++ b/scripts/actions/mobskills/vitriolic_shower.lua
@@ -12,10 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BURN
     local power = math.random(15, 35)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, power, 3, 60)
 
     local dmgmod = 2
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.7, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/vitriolic_spray.lua
+++ b/scripts/actions/mobskills/vitriolic_spray.lua
@@ -14,10 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BURN
     local power = math.random(10, 30)
 
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BURN, power, 3, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.7, xi.element.FIRE, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/voiceless_storm.lua
+++ b/scripts/actions/mobskills/voiceless_storm.lua
@@ -9,15 +9,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
-
     local numhits = 1
     local accmod = 1
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, xi.mobskills.shadowBehavior.WIPE_SHADOWS)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SILENCE, 1, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/water_blade.lua
+++ b/scripts/actions/mobskills/water_blade.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENWATER
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENWATER, 65, 0, 60))
+
+    return xi.effect.ENWATER
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/water_bomb.lua
+++ b/scripts/actions/mobskills/water_bomb.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SILENCE
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 60)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 2.5, xi.element.WATER, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/water_shield.lua
+++ b/scripts/actions/mobskills/water_shield.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 20, 0, 30))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 30))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/water_wall.lua
+++ b/scripts/actions/mobskills/water_wall.lua
@@ -9,9 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.DEFENSE_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 100, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 100, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wheel_of_impregnability.lua
+++ b/scripts/actions/mobskills/wheel_of_impregnability.lua
@@ -18,8 +18,6 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    -- local typeEffect = xi.effect.PHYSICAL_SHIELD
-
     mob:addStatusEffect(xi.effect.PHYSICAL_SHIELD, 1, 0, 0)
     mob:setAnimationSub(1)
 

--- a/scripts/actions/mobskills/whip_tongue.lua
+++ b/scripts/actions/mobskills/whip_tongue.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/whirl_of_rage.lua
+++ b/scripts/actions/mobskills/whirl_of_rage.lua
@@ -15,9 +15,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.SLASHING, info.hitslanded * math.random(2, 3))
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)
     return dmg

--- a/scripts/actions/mobskills/whirlwind.lua
+++ b/scripts/actions/mobskills/whirlwind.lua
@@ -10,9 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.VIT_DOWN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 3, 120)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/whistle.lua
+++ b/scripts/actions/mobskills/whistle.lua
@@ -17,11 +17,9 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local power = target:getMainLvl() / 10 * 3.75 + 5
     local duration = 60
 
-    local typeEffect = xi.effect.AGI_BOOST
+    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.AGI_BOOST, power, 3, duration))
 
-    skill:setMsg(xi.mobskills.mobBuffMove(target, typeEffect, power, 3, duration))
-
-    return typeEffect
+    return xi.effect.AGI_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wild_oats.lua
+++ b/scripts/actions/mobskills/wild_oats.lua
@@ -10,11 +10,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.VIT_DOWN
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.VIT_DOWN, 10, 3, 120))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 10, 3, 120))
-
-    return typeEffect
+    return xi.effect.VIT_DOWN
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wild_rage.lua
+++ b/scripts/actions/mobskills/wild_rage.lua
@@ -35,9 +35,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
 
     -- king vinegrroon
     if mob:getPool() == 2262 then
-        local typeEffect = xi.effect.POISON
-        local power = 25
-        xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, power, 3, 60)
+        xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.POISON, 25, 3, 60)
     end
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.SLASHING)

--- a/scripts/actions/mobskills/wind_blade2.lua
+++ b/scripts/actions/mobskills/wind_blade2.lua
@@ -11,9 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.ENAERO
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 65, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ENAERO, 65, 0, 60))
+
+    return xi.effect.ENAERO
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wind_wall.lua
+++ b/scripts/actions/mobskills/wind_wall.lua
@@ -14,9 +14,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.EVASION_BOOST
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, 50, 0, 60))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 50, 0, 60))
+
+    return xi.effect.EVASION_BOOST
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/winds_of_oblivion.lua
+++ b/scripts/actions/mobskills/winds_of_oblivion.lua
@@ -11,10 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.AMNESIA
     -- Subpower 100 prevents removal by Ecphoria Ring
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 30, 0, 75, 100))
-    return typeEffect
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 30, 0, 75, 100))
+    return xi.effect.AMNESIA
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/wing_slap.lua
+++ b/scripts/actions/mobskills/wing_slap.lua
@@ -18,9 +18,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
 
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.STUN, 1, 0, 4)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     return dmg

--- a/scripts/actions/mobskills/wing_thrust.lua
+++ b/scripts/actions/mobskills/wing_thrust.lua
@@ -13,15 +13,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLOW
-
     local numhits = 4
     local accmod = 1
     local dmgmod = 1
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info.dmg, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
-    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1250, 0, 60)
+    xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.SLOW, 1250, 0, 60)
 
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.NONE)
     return dmg

--- a/scripts/actions/mobskills/wings_of_gehenna.lua
+++ b/scripts/actions/mobskills/wings_of_gehenna.lua
@@ -13,10 +13,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     -- KNOCKBACK
-
-    local typeEffect = xi.effect.STUN
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 4)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
 
     local dmgmod = 1
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 4, xi.element.WIND, dmgmod, xi.mobskills.magicalTpBonus.NO_EFFECT)

--- a/scripts/actions/mobskills/wisecrack.lua
+++ b/scripts/actions/mobskills/wisecrack.lua
@@ -11,21 +11,19 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CHARM_I
-
     if not target:isPC() then
         skill:setMsg(xi.msg.basic.SKILL_MISS)
-        return typeEffect
+        return xi.effect.CHARM_I
     end
 
-    local msg = xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 0, 3, 60)
+    local msg = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHARM_I, 0, 3, 60)
     if msg == xi.msg.basic.SKILL_ENFEEB_IS then
         mob:charm(target)
     end
 
     skill:setMsg(msg)
 
-    return typeEffect
+    return xi.effect.CHARM_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/words_of_bane.lua
+++ b/scripts/actions/mobskills/words_of_bane.lua
@@ -12,11 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.CURSE_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 360))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 25, 0, 360))
-
-    return typeEffect
+    return xi.effect.CURSE_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/yawn.lua
+++ b/scripts/actions/mobskills/yawn.lua
@@ -9,11 +9,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.SLEEP_I
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLEEP_I, 1, 0, math.random(30, 60)))
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, math.random(30, 60)))
-
-    return typeEffect
+    return xi.effect.SLEEP_I
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/zephyr_arrow.lua
+++ b/scripts/actions/mobskills/zephyr_arrow.lua
@@ -12,9 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
-    local typeEffect = xi.effect.BIND
-
-    xi.mobskills.mobStatusEffectMove(mob, target, typeEffect, 1, 0, 120)
+    xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 120)
 
     local numhits = 1
     local accmod = 4

--- a/scripts/actions/mobskills/zephyr_mantle.lua
+++ b/scripts/actions/mobskills/zephyr_mantle.lua
@@ -11,9 +11,9 @@ end
 
 mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local base = math.random(4, 10)
-    local typeEffect = xi.effect.BLINK
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, typeEffect, base, 0, 180))
-    return typeEffect
+
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BLINK, base, 0, 180))
+    return xi.effect.BLINK
 end
 
 return mobskillObject

--- a/scripts/actions/spells/black/dread_spikes.lua
+++ b/scripts/actions/spells/black/dread_spikes.lua
@@ -9,18 +9,17 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local duration = calculateDuration(xi.settings.main.SPIKE_EFFECT_DURATION, spell:getSkillType(), spell:getSpellGroup(), caster, target)
-    local typeEffect = xi.effect.DREAD_SPIKES
     local drainAmount = target:getMaxHP() / 2
 
     drainAmount = drainAmount * (1 + (caster:getMod(xi.mod.DREAD_SPIKES_EFFECT) / 100))
 
-    if target:addStatusEffect(typeEffect, 0, 0, duration, 0, drainAmount, 1) then
+    if target:addStatusEffect(xi.effect.DREAD_SPIKES, 0, 0, duration, 0, drainAmount, 1) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.DREAD_SPIKES
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/amplification.lua
+++ b/scripts/actions/spells/blue/amplification.lua
@@ -20,21 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.MAGIC_ATK_BOOST
-    local typeEffectTwo = xi.effect.MAGIC_DEF_BOOST
-    local power = 10
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 90)
-    local returnEffect = typeEffectOne
+    local returnEffect = xi.effect.MAGIC_ATK_BOOST
 
-    local actionOne = target:addStatusEffect(typeEffectOne, power, 0, duration)
-    local actionTwo = target:addStatusEffect(typeEffectTwo, power, 0, duration)
+    local actionOne = target:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, 10, 0, duration)
+    local actionTwo = target:addStatusEffect(xi.effect.MAGIC_DEF_BOOST, 10, 0, duration)
 
     if not actionOne and not actionTwo then -- both statuses fail to apply
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     elseif not actionOne and actionTwo then -- the first status fails to apply
-        returnEffect = typeEffectTwo
+        returnEffect = xi.effect.MAGIC_DEF_BOOST
     elseif actionOne and not actionTwo then -- the second status fails to apply
-        returnEffect = typeEffectOne
+        returnEffect = xi.effect.MAGIC_ATK_BOOST
     end
 
     return returnEffect

--- a/scripts/actions/spells/blue/animating_wail.lua
+++ b/scripts/actions/spells/blue/animating_wail.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.HASTE
     local power = 1500 -- 15%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.HASTE, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.HASTE
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/battery_charge.lua
+++ b/scripts/actions/spells/blue/battery_charge.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.REFRESH
     local power = 3 -- 10%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.REFRESH, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.REFRESH
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/cocoon.lua
+++ b/scripts/actions/spells/blue/cocoon.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.DEFENSE_BOOST
     local power = 50 -- 50%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 90)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.DEFENSE_BOOST, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/corrosive_ooze.lua
+++ b/scripts/actions/spells/blue/corrosive_ooze.lua
@@ -36,12 +36,6 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
 
-    local typeEffectOne = xi.effect.DEFENSE_DOWN
-    local typeEffectTwo = xi.effect.ATTACK_DOWN
-    local power = 5
-    local tick = 0
-    local duration = 90
-
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)
 
     params.attribute = xi.mod.INT
@@ -49,8 +43,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resist = applyResistanceEffect(caster, target, spell, params)
 
     if resist >= 0.5 then
-        target:addStatusEffect(typeEffectOne, power, tick, duration * resist)
-        target:addStatusEffect(typeEffectTwo, power, tick, duration * resist)
+        target:addStatusEffect(xi.effect.DEFENSE_DOWN, 5, 0, 90 * resist)
+        target:addStatusEffect(xi.effect.ATTACK_DOWN, 5, 0, 90 * resist)
     end
 
     return damage

--- a/scripts/actions/spells/blue/diamondhide.lua
+++ b/scripts/actions/spells/blue/diamondhide.lua
@@ -20,16 +20,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.STONESKIN
     local blueSkill = utils.clamp(caster:getSkillLevel(xi.skill.BLUE_MAGIC), 0, 500)
     local power = (blueSkill / 3) * 2
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, 2) then
+    if not target:addStatusEffect(xi.effect.STONESKIN, power, 0, duration, 0, 0, 2) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.STONESKIN
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/enervation.lua
+++ b/scripts/actions/spells/blue/enervation.lua
@@ -19,22 +19,20 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.DEFENSE_DOWN
-    local typeEffectTwo = xi.effect.MAGIC_DEF_DOWN
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.effect = typeEffectOne
+    params.effect = xi.effect.DEFENSE_DOWN
     params.attribute = xi.mod.INT
     params.skillType = xi.skill.BLUE_MAGIC
     local duration = 30
     local resistThreshold = 0.5
-    local returnEffect = typeEffectOne
+    local returnEffect = xi.effect.DEFENSE_DOWN
 
     local resist = applyResistance(caster, target, spell, params)
     if resist >= resistThreshold then
 
-        local actionOne = target:addStatusEffect(typeEffectOne, 10, 0, duration * resist)
-        local actionTwo = target:addStatusEffect(typeEffectTwo, 8, 0, duration * resist)
+        local actionOne = target:addStatusEffect(xi.effect.DEFENSE_DOWN, 10, 0, duration * resist)
+        local actionTwo = target:addStatusEffect(xi.effect.MAGIC_DEF_DOWN, 8, 0, duration * resist)
 
         -- If at least one of effects got applied, set the message type
         if actionOne or actionTwo then
@@ -43,7 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
         -- Set the returnEffect to effectTwo if the first one failed
         if not actionOne and actionTwo then
-            returnEffect = typeEffectTwo
+            returnEffect = xi.effect.MAGIC_DEF_DOWN
         end
 
     else

--- a/scripts/actions/spells/blue/feather_barrier.lua
+++ b/scripts/actions/spells/blue/feather_barrier.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.EVASION_BOOST
     local power = 20
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 30)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.EVASION_BOOST, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.EVASION_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/light_of_penance.lua
+++ b/scripts/actions/spells/blue/light_of_penance.lua
@@ -19,24 +19,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.BLINDNESS
-    local typeEffectTwo = xi.effect.BIND
     local params = {}
     params.ecosystem = xi.ecosystem.BEASTMEN
-    params.effect = typeEffectOne
+    params.effect = xi.effect.BLINDNESS
     params.attribute = xi.mod.INT
     params.skillType = xi.skill.BLUE_MAGIC
     local duration = 30
-    local resistThreshold = 0.5
-    local returnEffect = typeEffectOne
+    local returnEffect = xi.effect.BLINDNESS
 
     local resist = applyResistance(caster, target, spell, params)
-    if resist >= resistThreshold then
+    if resist >= 0.5 then
 
         spell:setMsg(xi.msg.basic.MAGIC_TP_REDUCE) -- this doesn't seem to do much
         target:delTP(100)
-        local actionOne = target:addStatusEffect(typeEffectOne, 10, 0, duration * resist)
-        local actionTwo = target:addStatusEffect(typeEffectTwo, 1, 0, duration * resist)
+        local actionOne = target:addStatusEffect(xi.effect.BLINDNESS, 10, 0, duration * resist)
+        local actionTwo = target:addStatusEffect(xi.effect.BIND, 1, 0, duration * resist)
 
         -- Gaze move
         if target:isFacing(caster) and caster:isFacing(target) then
@@ -48,7 +45,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
             -- Set the returnEffect to effectTwo if the first one failed
             if not actionOne and actionTwo then
-                returnEffect = typeEffectTwo
+                returnEffect = xi.effect.BIND
             end
 
         else

--- a/scripts/actions/spells/blue/memento_mori.lua
+++ b/scripts/actions/spells/blue/memento_mori.lua
@@ -19,15 +19,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.MAGIC_ATK_BOOST
     local power = 20
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.MAGIC_ATK_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/metallic_body.lua
+++ b/scripts/actions/spells/blue/metallic_body.lua
@@ -20,16 +20,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.STONESKIN
     local blueSkill = utils.clamp(caster:getSkillLevel(xi.skill.BLUE_MAGIC), 0, 500)
     local power = utils.clamp(0.375 * blueSkill + 12.5, 0, 150)
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration, 0, 0, 2) then
+    if not target:addStatusEffect(xi.effect.STONESKIN, power, 0, duration, 0, 0, 2) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.STONESKIN
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/occultation.lua
+++ b/scripts/actions/spells/blue/occultation.lua
@@ -19,9 +19,8 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.BLINK
-    local skill = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
-    local power = skill / 50
+    local skill    = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
+    local power    = skill / 50
     local duration = 300
 
     -- 400 skill = 8 shadows, 450 = 9 shadows, so I am assuming every 50 skill is a shadow.
@@ -41,11 +40,11 @@ spellObject.onSpellCast = function(caster, target, spell)
         caster:delStatusEffect(xi.effect.DIFFUSION)
     end
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.BLINK, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.BLINK
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/plasma_charge.lua
+++ b/scripts/actions/spells/blue/plasma_charge.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.SHOCK_SPIKES
     local power = 5 -- 5 dmg
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.SHOCK_SPIKES, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.SHOCK_SPIKES
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/reactor_cool.lua
+++ b/scripts/actions/spells/blue/reactor_cool.lua
@@ -20,27 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.DEFENSE_BOOST
-    local typeEffectTwo = xi.effect.ICE_SPIKES
-    local powerOne = 12 -- 12%
-    local powerTwo = 5 -- 5 dmg
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 120)
-    local returnEffect = typeEffectOne
 
     -- Reactor Cool Will Overwrite Ice Spikes and Def Boost regardless of Power
     if
-        target:hasStatusEffect(typeEffectOne) or
-        target:hasStatusEffect(typeEffectTwo)
+        target:hasStatusEffect(xi.effect.DEFENSE_BOOST) or
+        target:hasStatusEffect(xi.effect.ICE_SPIKES)
     then
-        target:delStatusEffectSilent(typeEffectOne)
-        target:delStatusEffectSilent(typeEffectTwo)
+        target:delStatusEffectSilent(xi.effect.DEFENSE_BOOST)
+        target:delStatusEffectSilent(xi.effect.ICE_SPIKES)
     end
 
-    target:addStatusEffect(typeEffectOne, powerOne, 0, duration)
-    target:addStatusEffect(typeEffectTwo, powerTwo, 0, duration)
+    target:addStatusEffect(xi.effect.DEFENSE_BOOST, 12, 0, duration)
+    target:addStatusEffect(xi.effect.ICE_SPIKES, 5, 0, duration)
     spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
 
-    return returnEffect
+    return xi.effect.DEFENSE_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/refueling.lua
+++ b/scripts/actions/spells/blue/refueling.lua
@@ -20,15 +20,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.HASTE
     local power = 1000 -- 10%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.HASTE, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.HASTE
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/regeneration.lua
+++ b/scripts/actions/spells/blue/regeneration.lua
@@ -20,7 +20,6 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.REGEN
     local power = 25
     local duration = 90
 
@@ -41,11 +40,11 @@ spellObject.onSpellCast = function(caster, target, spell)
         target:delStatusEffect(xi.effect.REGEN)
     end
 
-    if not target:addStatusEffect(typeEffect, power, 3, duration, 0, 0, 0) then
+    if not target:addStatusEffect(xi.effect.REGEN, power, 3, duration, 0, 0, 0) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.REGEN
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/saline_coat.lua
+++ b/scripts/actions/spells/blue/saline_coat.lua
@@ -20,16 +20,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.MAGIC_DEF_BOOST
     local power = 50
     local tick = 4 -- decay by 1 every 4 seconds
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 180)
 
-    if not target:addStatusEffect(typeEffect, power, tick, duration) then
+    if not target:addStatusEffect(xi.effect.MAGIC_DEF_BOOST, power, tick, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.MAGIC_DEF_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/triumphant_roar.lua
+++ b/scripts/actions/spells/blue/triumphant_roar.lua
@@ -19,15 +19,14 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.ATTACK_BOOST
     local power = 15
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
-    if not target:addStatusEffect(typeEffect, power, 0, duration) then
+    if not target:addStatusEffect(xi.effect.ATTACK_BOOST, power, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.ATTACK_BOOST
 end
 
 return spellObject

--- a/scripts/actions/spells/blue/warm-up.lua
+++ b/scripts/actions/spells/blue/warm-up.lua
@@ -20,21 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffectOne = xi.effect.ACCURACY_BOOST
-    local typeEffectTwo = xi.effect.EVASION_BOOST
-    local power = 10
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 180)
-    local returnEffect = typeEffectOne
+    local returnEffect = xi.effect.ACCURACY_BOOST
 
-    local actionOne = target:addStatusEffect(typeEffectOne, power, 0, duration)
-    local actionTwo = target:addStatusEffect(typeEffectTwo, power, 0, duration)
+    local actionOne = target:addStatusEffect(xi.effect.ACCURACY_BOOST, 10, 0, duration)
+    local actionTwo = target:addStatusEffect(xi.effect.EVASION_BOOST, 10, 0, duration)
 
     if not actionOne and not actionTwo then -- both statuses fail to apply
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     elseif not actionOne and actionTwo then -- the first status fails to apply
-        returnEffect = typeEffectTwo
+        returnEffect = xi.effect.EVASION_BOOST
     elseif actionOne and not actionTwo then -- the second status fails to apply
-        returnEffect = typeEffectOne
+        returnEffect = xi.effect.ACCURACY_BOOST
     end
 
     return returnEffect

--- a/scripts/actions/spells/blue/zephyr_mantle.lua
+++ b/scripts/actions/spells/blue/zephyr_mantle.lua
@@ -20,16 +20,15 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local typeEffect = xi.effect.BLINK
     local power = 4
     local tick = 0
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
-    if not target:addStatusEffect(typeEffect, power, tick, duration) then
+    if not target:addStatusEffect(xi.effect.BLINK, power, tick, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.BLINK
 end
 
 return spellObject

--- a/scripts/actions/spells/white/reprisal.lua
+++ b/scripts/actions/spells/white/reprisal.lua
@@ -10,15 +10,14 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local duration         = calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local reflectedPercent = 33
-    local typeEffect       = xi.effect.REPRISAL
 
-    if target:addStatusEffect(typeEffect, reflectedPercent, 0, duration) then
+    if target:addStatusEffect(xi.effect.REPRISAL, reflectedPercent, 0, duration) then
         spell:setMsg(xi.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
-    return typeEffect
+    return xi.effect.REPRISAL
 end
 
 return spellObject

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -521,17 +521,16 @@ end
 
 -- https://www.bg-wiki.com/ffxi/Angon
 xi.job_utils.dragoon.useAngon = function(player, target, ability)
-    local typeEffect = xi.effect.DEFENSE_DOWN
     local duration   = 15 + player:getMerit(xi.merit.ANGON) -- This will return 30 sec at one investment because merit power is 15.
 
-    if not target:addStatusEffect(typeEffect, 20, 0, duration) then
+    if not target:addStatusEffect(xi.effect.DEFENSE_DOWN, 20, 0, duration) then
         ability:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
     end
 
     target:updateClaim(player)
     player:removeAmmo()
 
-    return typeEffect
+    return xi.effect.DEFENSE_DOWN
 end
 
 xi.job_utils.dragoon.useDeepBreathing = function(player, target, ability)

--- a/scripts/globals/job_utils/summoner.lua
+++ b/scripts/globals/job_utils/summoner.lua
@@ -194,11 +194,11 @@ xi.job_utils.summoner.useSoothingRuby = function(target, pet, petskill, summoner
 
     -- Erase effects.
     local effectsErased = math.min(#erasableEffectTable, soothingRubyPower)
-    local index         = 0
 
     if effectsErased > 0 then
         for i = 1, effectsErased do
-            index = math.random(1, #erasableEffectTable)
+            local index = math.random(1, #erasableEffectTable)
+
             target:delStatusEffect(erasableEffectTable[index])
             table.remove(erasableEffectTable, index)
         end

--- a/scripts/items/olde_rarab_tail.lua
+++ b/scripts/items/olde_rarab_tail.lua
@@ -10,17 +10,15 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local typeEffect = xi.effect.TERROR
-    local duration = 90
     local ID = zones[target:getZoneID()]
 
     if
-        not target:hasStatusEffect(typeEffect) and
+        not target:hasStatusEffect(xi.effect.TERROR) and
         (target:getID() == ID.mob.ATORI_TUTORI_QM[1] or
         target:getID() == ID.mob.ATORI_TUTORI_QM[2] or
         target:getID() == ID.mob.ATORI_TUTORI_QM[3])
     then
-        target:addStatusEffect(typeEffect, 1, 3, duration)
+        target:addStatusEffect(xi.effect.TERROR, 1, 3, 90)
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Removes variables (specifically typeEffect) that were not manipulated in favor of using the appropriate enum or value for clarity
* Fixes Immortal Mind effect power references

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed, Immortal Mind should now work appropriately if the Soulflayer has a current buff
<!-- Clear and detailed steps to test your changes here -->
