### PR TITLE
Replace Foxfire mobskill check conditional with table

### DIFF
--- a/scripts/actions/mobskills/foxfire.lua
+++ b/scripts/actions/mobskills/foxfire.lua
@@ -7,20 +7,19 @@
 -----------------------------------
 local mobskillObject = {}
 
-mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    local job = mob:getMainJob()
+local validJobs = set{
+    xi.job.RDM,
+    xi.job.THF,
+    xi.job.PLD,
+    xi.job.BST,
+    xi.job.RNG,
+    xi.job.BRD,
+    xi.job.NIN,
+    xi.job.COR,
+}
 
-    -- TODO: Table this
-    if
-        job == xi.job.RDM or
-        job == xi.job.THF or
-        job == xi.job.PLD or
-        job == xi.job.BST or
-        job == xi.job.RNG or
-        job == xi.job.BRD or
-        job == xi.job.NIN or
-        job == xi.job.COR
-    then
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if validJobs[mob:getMainJob()] then
         return 0
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Addresses an old todo to replace a long conditional of job checks with a set table (keys defined, value = true) that is used for direct lookup.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
No changes should be observed
<!-- Clear and detailed steps to test your changes here -->
