### PR TITLE
[core] Unify sneak attack cone definition for added damage versus acc/crit

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -475,7 +475,7 @@ void CAttack::ProcessDamage()
 {
     // Sneak attack.
     if (m_attacker->GetMJob() == JOB_THF && m_isFirstSwing && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK) &&
-        ((abs(m_victim->loc.p.rotation - m_attacker->loc.p.rotation) < 23) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
+        (behind(m_attacker->loc.p, m_victim->loc.p, 64) || m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_HIDE) ||
          m_victim->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBT)))
     {
         m_trickAttackDamage += m_attacker->DEX() * (1.0f + m_attacker->getMod(Mod::SNEAK_ATK_DEX) / 100.0f);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Unify the sneak attack cone definition so as to avoid situations where the critical and 100% accuracy of sneak attack activates but not the added damage (in other words player just gets a normal crit hit for SA). In current code the added damage cone is 46/256 (64°) and the critical cone is 64/256 (90°), this PR changes this so now both are 64/256 (90°). I think the issue originated due to confusion that the degrees are defined in terms of 256 and not 360 (thus the 64/256 vs. 64° confusion).

I am original author of fix code and it is a fix from ASB coming upstream.

## Steps to test these changes
Sneak attack a mob from an angle that is between the 64 degree cone and the 90 degree code, and watch player actually get the additional sneak attack damage.
