### PR TITLE
Remove zero-value wsc parameters from weaponskill scripts

### DIFF
--- a/scripts/actions/weaponskills/aeolian_edge.lua
+++ b/scripts/actions/weaponskills/aeolian_edge.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 2.75 params.ftp200 = 3.50 params.ftp300 = 4
-    params.str_wsc = 0.0 params.dex_wsc = 0.28 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.28 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.28 params.int_wsc = 0.28
     params.ele = xi.element.WIND
     params.skill = xi.skill.DAGGER
     params.includemab = true

--- a/scripts/actions/weaponskills/apex_arrow.lua
+++ b/scripts/actions/weaponskills/apex_arrow.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 + (player:getMerit(xi.merit.APEX_ARROW) * 0.17) params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.agi_wsc = player:getMerit(xi.merit.APEX_ARROW) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/arching_arrow.lua
+++ b/scripts/actions/weaponskills/arching_arrow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/armor_break.lua
+++ b/scripts/actions/weaponskills/armor_break.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.2 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.vit_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/ascetics_fury.lua
+++ b/scripts/actions/weaponskills/ascetics_fury.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.vit_wsc = 0.5
     params.crit100 = 0.1 params.crit200 = 0.2 params.crit300 = 0.4
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/asuran_fists.lua
+++ b/scripts/actions/weaponskills/asuran_fists.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 8
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.1 params.dex_wsc = 0.0 params.vit_wsc = 0.1 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.1 params.vit_wsc = 0.1
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -25,8 +25,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 1.5
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.4 params.vit_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/avalanche_axe.lua
+++ b/scripts/actions/weaponskills/avalanche_axe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/backhand_blow.lua
+++ b/scripts/actions/weaponskills/backhand_blow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.3
     params.crit100 = 0.4 params.crit200 = 0.6 params.crit300 = 0.8
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/black_halo.lua
+++ b/scripts/actions/weaponskills/black_halo.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1.5 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_chi.lua
+++ b/scripts/actions/weaponskills/blade_chi.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_ei.lua
+++ b/scripts/actions/weaponskills/blade_ei.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.KATANA
     params.includemab = true

--- a/scripts/actions/weaponskills/blade_hi.lua
+++ b/scripts/actions/weaponskills/blade_hi.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 4 params.ftp200 = 4 params.ftp300 = 4
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.6 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.6
     params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_jin.lua
+++ b/scripts/actions/weaponskills/blade_jin.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.3
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_kamu.lua
+++ b/scripts/actions/weaponskills/blade_kamu.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.5
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.int_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_ku.lua
+++ b/scripts/actions/weaponskills/blade_ku.lua
@@ -22,9 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.1 params.dex_wsc = 0.1 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.1 params.dex_wsc = 0.1
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP

--- a/scripts/actions/weaponskills/blade_metsu.lua
+++ b/scripts/actions/weaponskills/blade_metsu.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_retsu.lua
+++ b/scripts/actions/weaponskills/blade_retsu.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_rin.lua
+++ b/scripts/actions/weaponskills/blade_rin.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     -- to do critical hit rate of this ws is base on amount of tp alone, does not consider Critical Hit Rate from dDEX, equipment, or likely merits/base
     -- https://www.bg-wiki.com/ffxi/Blade:_Rin

--- a/scripts/actions/weaponskills/blade_shun.lua
+++ b/scripts/actions/weaponskills/blade_shun.lua
@@ -20,9 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 0.6875 params.ftp200 = 0.6875 params.ftp300 = 0.6875
-    params.str_wsc = 0.0 params.dex_wsc = player:getMerit(xi.merit.BLADE_SHUN) * 0.17 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.dex_wsc = player:getMerit(xi.merit.BLADE_SHUN) * 0.17 -- TODO: base should be 73%
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_teki.lua
+++ b/scripts/actions/weaponskills/blade_teki.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/blade_ten.lua
+++ b/scripts/actions/weaponskills/blade_ten.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 2.75 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/blade_to.lua
+++ b/scripts/actions/weaponskills/blade_to.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/blade_yu.lua
+++ b/scripts/actions/weaponskills/blade_yu.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.28 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.28 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.28 params.int_wsc = 0.28
     -- http://wiki.ffo.jp/html/20351.html
     params.ele = xi.element.WATER
     params.skill = xi.skill.KATANA

--- a/scripts/actions/weaponskills/blast_arrow.lua
+++ b/scripts/actions/weaponskills/blast_arrow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/blast_shot.lua
+++ b/scripts/actions/weaponskills/blast_shot.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/bora_axe.lua
+++ b/scripts/actions/weaponskills/bora_axe.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/brainshaker.lua
+++ b/scripts/actions/weaponskills/brainshaker.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/burning_blade.lua
+++ b/scripts/actions/weaponskills/burning_blade.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.FIRE
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/calamity.lua
+++ b/scripts/actions/weaponskills/calamity.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 4
-    params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.32 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.32 params.vit_wsc = 0.32
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/camlanns_torment.lua
+++ b/scripts/actions/weaponskills/camlanns_torment.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/cataclysm.lua
+++ b/scripts/actions/weaponskills/cataclysm.lua
@@ -19,7 +19,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/catastrophe.lua
+++ b/scripts/actions/weaponskills/catastrophe.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.4 params.int_wsc = 0.4 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.4 params.int_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/chant_du_cygne.lua
+++ b/scripts/actions/weaponskills/chant_du_cygne.lua
@@ -15,9 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.dex_wsc = 0.6
     params.crit100 = 0.15 params.crit200 = 0.25 params.crit300 = 0.4
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/circle_blade.lua
+++ b/scripts/actions/weaponskills/circle_blade.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/cloudsplitter.lua
+++ b/scripts/actions/weaponskills/cloudsplitter.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 3.75 params.ftp200 = 5.0 params.ftp300 = 6.0
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
+    params.str_wsc = 0.4 params.mnd_wsc = 0.4
     params.ele = xi.element.THUNDER
     params.skill = xi.skill.AXE
     params.includemab = true

--- a/scripts/actions/weaponskills/combo.lua
+++ b/scripts/actions/weaponskills/combo.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/coronach.lua
+++ b/scripts/actions/weaponskills/coronach.lua
@@ -21,9 +21,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.4 params.vit_wsc = 0.0
-    params.agi_wsc = 0.4 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.dex_wsc = 0.4
+    params.agi_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/crescent_moon.lua
+++ b/scripts/actions/weaponskills/crescent_moon.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 2.5
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/cross_reaper.lua
+++ b/scripts/actions/weaponskills/cross_reaper.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 2.0 params.ftp200 = 2.25 params.ftp300 = 2.5
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/cyclone.lua
+++ b/scripts/actions/weaponskills/cyclone.lua
@@ -17,7 +17,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.375 params.ftp300 = 2.875
-    params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.25 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.3 params.int_wsc = 0.25
     params.ele = xi.element.WIND
     params.skill = xi.skill.DAGGER
     params.includemab = true

--- a/scripts/actions/weaponskills/dancing_edge.lua
+++ b/scripts/actions/weaponskills/dancing_edge.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1.1875 params.ftp200 = 1.1875 params.ftp300 = 1.1875
-    params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.4
+    params.dex_wsc = 0.3 params.chr_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/dark_harvest.lua
+++ b/scripts/actions/weaponskills/dark_harvest.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/death_blossom.lua
+++ b/scripts/actions/weaponskills/death_blossom.lua
@@ -20,8 +20,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.125 params.ftp200 = 1.125 params.ftp300 = 1.125
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.5
     -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/decimation.lua
+++ b/scripts/actions/weaponskills/decimation.lua
@@ -18,9 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/detonator.lua
+++ b/scripts/actions/weaponskills/detonator.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/dimidiation.lua
+++ b/scripts/actions/weaponskills/dimidiation.lua
@@ -6,7 +6,7 @@
 -- Will stack with Sneak Attack.
 -- Element: None
 -- Skillchain Elements: Light/Fragmentation (Fire, Thunder, Wind, Light gorget/belt aligned)
--- Modifiers: VIT:80% DEX
+-- Modifiers: DEX:80%
 -- 1000 TP   2000 TP   3000 TP
 -- 2.25      4.5       6.75
 -----------------------------------
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 2.25 params.ftp200 = 4.5 params.ftp300 = 6.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.8 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.8
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/double_thrust.lua
+++ b/scripts/actions/weaponskills/double_thrust.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/dragon_kick.lua
+++ b/scripts/actions/weaponskills/dragon_kick.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3.5
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.vit_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/drakesbane.lua
+++ b/scripts/actions/weaponskills/drakesbane.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/dulling_arrow.lua
+++ b/scripts/actions/weaponskills/dulling_arrow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/earth_crusher.lua
+++ b/scripts/actions/weaponskills/earth_crusher.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.3125 params.ftp300 = 3.625
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.ele = xi.element.EARTH
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/empyreal_arrow.lua
+++ b/scripts/actions/weaponskills/empyreal_arrow.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.75 params.ftp300 = 3
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/entropy.lua
+++ b/scripts/actions/weaponskills/entropy.lua
@@ -18,9 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 2.0
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = player:getMerit(xi.merit.ENTROPY) * 0.17 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.int_wsc = player:getMerit(xi.merit.ENTROPY) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/evisceration.lua
+++ b/scripts/actions/weaponskills/evisceration.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.3
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/exenterator.lua
+++ b/scripts/actions/weaponskills/exenterator.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 + (player:getMerit(xi.merit.EXENTERATOR) * 0.17) params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = player:getMerit(xi.merit.EXENTERATOR) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/expiacion.lua
+++ b/scripts/actions/weaponskills/expiacion.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/fast_blade.lua
+++ b/scripts/actions/weaponskills/fast_blade.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/fell_cleave.lua
+++ b/scripts/actions/weaponskills/fell_cleave.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.0 params.ftp200 = 2.0 params.ftp300 = 2.0
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/final_heaven.lua
+++ b/scripts/actions/weaponskills/final_heaven.lua
@@ -15,10 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- number of normal hits for ws
     params.numHits = 2
     -- stat-modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
-    params.str_wsc = 0.0        params.dex_wsc = 0.0
-    params.vit_wsc = 0.6        params.agi_wsc = 0.0
-    params.int_wsc = 0.0        params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.vit_wsc = 0.6
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function params.ftp)
     params.ftp100 = 3.0 params.ftp200 = 3.0 params.ftp300 = 3.0
     -- critical modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)

--- a/scripts/actions/weaponskills/final_paradise.lua
+++ b/scripts/actions/weaponskills/final_paradise.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/flaming_arrow.lua
+++ b/scripts/actions/weaponskills/flaming_arrow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/flash_nova.lua
+++ b/scripts/actions/weaponskills/flash_nova.lua
@@ -19,7 +19,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.CLUB
     params.includemab = true

--- a/scripts/actions/weaponskills/flat_blade.lua
+++ b/scripts/actions/weaponskills/flat_blade.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/freezebite.lua
+++ b/scripts/actions/weaponskills/freezebite.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.2
     params.ele = xi.element.ICE
     params.skill = xi.skill.GREAT_SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/frostbite.lua
+++ b/scripts/actions/weaponskills/frostbite.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.ICE
     params.skill = xi.skill.GREAT_SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/full_break.lua
+++ b/scripts/actions/weaponskills/full_break.lua
@@ -21,8 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
+    params.str_wsc = 0.5 params.vit_wsc = 0.5
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1

--- a/scripts/actions/weaponskills/full_swing.lua
+++ b/scripts/actions/weaponskills/full_swing.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 3 params.ftp300 = 5
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/gale_axe.lua
+++ b/scripts/actions/weaponskills/gale_axe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/garland_of_bliss.lua
+++ b/scripts/actions/weaponskills/garland_of_bliss.lua
@@ -17,8 +17,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.4 params.chr_wsc = 0.0
+    params.mnd_wsc = 0.4
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/gate_of_tartarus.lua
+++ b/scripts/actions/weaponskills/gate_of_tartarus.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.6
+    params.chr_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/geirskogul.lua
+++ b/scripts/actions/weaponskills/geirskogul.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.6 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/glory_slash.lua
+++ b/scripts/actions/weaponskills/glory_slash.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3.5 params.ftp300 = 4
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/ground_strike.lua
+++ b/scripts/actions/weaponskills/ground_strike.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 3.0
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.5 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.int_wsc = 0.5
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/guillotine.lua
+++ b/scripts/actions/weaponskills/guillotine.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 0.875 params.ftp200 = 0.875 params.ftp300 = 0.875
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.25 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.25 params.chr_wsc = 0.0
+    params.str_wsc = 0.25 params.mnd_wsc = 0.25
     -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/gust_slash.lua
+++ b/scripts/actions/weaponskills/gust_slash.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.WIND
     params.skill = xi.skill.DAGGER
     params.includemab = true

--- a/scripts/actions/weaponskills/hard_slash.lua
+++ b/scripts/actions/weaponskills/hard_slash.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 2.0
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     -- critical mods, again in % (ONLY USE FOR params.critICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/heavy_shot.lua
+++ b/scripts/actions/weaponskills/heavy_shot.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/heavy_swing.lua
+++ b/scripts/actions/weaponskills/heavy_swing.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 2.25
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/herculean_slash.lua
+++ b/scripts/actions/weaponskills/herculean_slash.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.6
     params.ele = xi.element.ICE
     params.skill = xi.skill.GREAT_SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/hexa_strike.lua
+++ b/scripts/actions/weaponskills/hexa_strike.lua
@@ -17,9 +17,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 6
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.2
+    params.mnd_wsc = 0.2
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/hot_shot.lua
+++ b/scripts/actions/weaponskills/hot_shot.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/howling_fist.lua
+++ b/scripts/actions/weaponskills/howling_fist.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 2.75 params.ftp300 = 3
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.vit_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
@@ -27,7 +27,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/2422.html
         params.ftp100 = 2.05 params.ftp200 = 3.55 params.ftp300 = 5.75
-        params.str_wsc = 0.2 params.vit_wsc = 0.5
     end
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/impulse_drive.lua
+++ b/scripts/actions/weaponskills/impulse_drive.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2.5
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/infernal_scythe.lua
+++ b/scripts/actions/weaponskills/infernal_scythe.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/insurgency.lua
+++ b/scripts/actions/weaponskills/insurgency.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/iron_tempest.lua
+++ b/scripts/actions/weaponskills/iron_tempest.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/jishnus_radiance.lua
+++ b/scripts/actions/weaponskills/jishnus_radiance.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.60 params.vit_wsc = 0.0
-    params.agi_wsc = 0.00 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.dex_wsc = 0.60
     params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/judgment.lua
+++ b/scripts/actions/weaponskills/judgment.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 4
-    params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.32 params.chr_wsc = 0.0
+    params.str_wsc = 0.32 params.mnd_wsc = 0.32
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/keen_edge.lua
+++ b/scripts/actions/weaponskills/keen_edge.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/kings_justice.lua
+++ b/scripts/actions/weaponskills/kings_justice.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 1.5
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
+    params.str_wsc = 0.5
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/knights_of_rotund.lua
+++ b/scripts/actions/weaponskills/knights_of_rotund.lua
@@ -9,9 +9,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0
-    params.vit_wsc = 0.0 params.agi_wsc = 0.0
-    params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/knights_of_round.lua
+++ b/scripts/actions/weaponskills/knights_of_round.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
+    params.str_wsc = 0.4 params.mnd_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/last_stand.lua
+++ b/scripts/actions/weaponskills/last_stand.lua
@@ -21,9 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.125 params.ftp300 = 2.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 + (player:getMerit(xi.merit.LAST_STAND) * 0.17) params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.agi_wsc = player:getMerit(xi.merit.LAST_STAND) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/leaden_salute.lua
+++ b/scripts/actions/weaponskills/leaden_salute.lua
@@ -16,8 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 4 params.ftp200 = 4.25 params.ftp300 = 4.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.MARKSMANSHIP
     params.includemab = true

--- a/scripts/actions/weaponskills/leg_sweep.lua
+++ b/scripts/actions/weaponskills/leg_sweep.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/mandalic_stab.lua
+++ b/scripts/actions/weaponskills/mandalic_stab.lua
@@ -19,8 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.13 params.ftp300 = 2.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/mercy_stroke.lua
+++ b/scripts/actions/weaponskills/mercy_stroke.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/metatron_torment.lua
+++ b/scripts/actions/weaponskills/metatron_torment.lua
@@ -23,7 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/mistral_axe.lua
+++ b/scripts/actions/weaponskills/mistral_axe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 3 params.ftp300 = 3.5
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/mordant_rime.lua
+++ b/scripts/actions/weaponskills/mordant_rime.lua
@@ -18,8 +18,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.5
+    params.dex_wsc = 0.3
+    params.chr_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/mystic_boon.lua
+++ b/scripts/actions/weaponskills/mystic_boon.lua
@@ -17,8 +17,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/namas_arrow.lua
+++ b/scripts/actions/weaponskills/namas_arrow.lua
@@ -17,9 +17,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.4 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.4
+    params.agi_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/nightmare_scythe.lua
+++ b/scripts/actions/weaponskills/nightmare_scythe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/numbing_shot.lua
+++ b/scripts/actions/weaponskills/numbing_shot.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.6 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/omniscience.lua
+++ b/scripts/actions/weaponskills/omniscience.lua
@@ -17,8 +17,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.mnd_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/one_inch_punch.lua
+++ b/scripts/actions/weaponskills/one_inch_punch.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.4 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/onslaught.lua
+++ b/scripts/actions/weaponskills/onslaught.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/penta_thrust.lua
+++ b/scripts/actions/weaponskills/penta_thrust.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/piercing_arrow.lua
+++ b/scripts/actions/weaponskills/piercing_arrow.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/power_slash.lua
+++ b/scripts/actions/weaponskills/power_slash.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.2 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.vit_wsc = 0.2
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.2 params.crit200 = 0.4 params.crit300 = 0.6
     params.canCrit = true

--- a/scripts/actions/weaponskills/primal_rend.lua
+++ b/scripts/actions/weaponskills/primal_rend.lua
@@ -16,8 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 4 params.ftp200 = 4.25 params.ftp300 = 4.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.3
+    params.chr_wsc = 0.3
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.AXE
     params.includemab = true

--- a/scripts/actions/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/actions/weaponskills/pyrrhic_kleos.lua
@@ -19,8 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1.5 params.ftp200 = 1.5 params.ftp300 = 1.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/quietus.lua
+++ b/scripts/actions/weaponskills/quietus.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3.0 params.ftp200 = 3.0 params.ftp300 = 3.0
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
+    params.str_wsc = 0.4 params.mnd_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/raging_axe.lua
+++ b/scripts/actions/weaponskills/raging_axe.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/raging_fists.lua
+++ b/scripts/actions/weaponskills/raging_fists.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.2 params.dex_wsc = 0.2 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.dex_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/raging_rush.lua
+++ b/scripts/actions/weaponskills/raging_rush.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/raiden_thrust.lua
+++ b/scripts/actions/weaponskills/raiden_thrust.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.ele = xi.element.THUNDER
     params.skill = xi.skill.POLEARM
     params.includemab = true

--- a/scripts/actions/weaponskills/rampage.lua
+++ b/scripts/actions/weaponskills/rampage.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 0.5 params.ftp200 = 0.5 params.ftp300 = 0.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.10 params.crit200 = 0.30 params.crit300 = 0.50
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/randgrith.lua
+++ b/scripts/actions/weaponskills/randgrith.lua
@@ -21,7 +21,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.0
+    params.str_wsc = 0.4 params.mnd_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/realmrazer.lua
+++ b/scripts/actions/weaponskills/realmrazer.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 7
     params.ftp100 = 0.88 params.ftp200 = 0.88 params.ftp300 = 0.88
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
-    params.chr_wsc = 0.0
+    params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/red_lotus_blade.lua
+++ b/scripts/actions/weaponskills/red_lotus_blade.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.38 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.2
     params.ele = xi.element.FIRE
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/refulgent_arrow.lua
+++ b/scripts/actions/weaponskills/refulgent_arrow.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 3 params.ftp200 = 4.25 params.ftp300 = 5
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/requiescat.lua
+++ b/scripts/actions/weaponskills/requiescat.lua
@@ -14,9 +14,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = player:getMerit(xi.merit.REQUIESCAT) * 0.17
-    params.chr_wsc = 0.0
+    params.mnd_wsc = player:getMerit(xi.merit.REQUIESCAT) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/resolution.lua
+++ b/scripts/actions/weaponskills/resolution.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 0.71875 params.ftp200 = 0.84375 params.ftp300 = 0.96875
-    params.str_wsc = 0.0 + (player:getMerit(xi.merit.RESOLUTION) * 0.17) params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = player:getMerit(xi.merit.RESOLUTION) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/retribution.lua
+++ b/scripts/actions/weaponskills/retribution.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/rock_crusher.lua
+++ b/scripts/actions/weaponskills/rock_crusher.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.EARTH
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/rudras_storm.lua
+++ b/scripts/actions/weaponskills/rudras_storm.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3.25 params.ftp200 = 4.25 params.ftp300 = 5.25
-    params.str_wsc = 0.0 params.dex_wsc = 0.6 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/ruinator.lua
+++ b/scripts/actions/weaponskills/ruinator.lua
@@ -18,9 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1.08 params.ftp200 = 1.08 params.ftp300 = 1.08
-    params.str_wsc = player:getMerit(xi.merit.RUINATOR) * 0.17 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = player:getMerit(xi.merit.RUINATOR) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/sanguine_blade.lua
+++ b/scripts/actions/weaponskills/sanguine_blade.lua
@@ -16,19 +16,10 @@
 local weaponskillObject = {}
 
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
-    local drain = 0
-
-    if tp >= 1000 and tp <= 1999 then
-        drain = 50
-    elseif tp >= 2000 and tp <= 2999 then
-        drain = 75
-    elseif tp == 3000 then
-        drain = 100
-    end
-
+    local drain = 25 + math.floor(tp / 3) * 25
     local params = {}
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.5
     params.ele = xi.element.DARK
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/savage_blade.lua
+++ b/scripts/actions/weaponskills/savage_blade.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 3.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/scourge.lua
+++ b/scripts/actions/weaponskills/scourge.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.4 params.chr_wsc = 0.4
+    params.mnd_wsc = 0.4 params.chr_wsc = 0.4
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/seraph_blade.lua
+++ b/scripts/actions/weaponskills/seraph_blade.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/seraph_strike.lua
+++ b/scripts/actions/weaponskills/seraph_strike.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.CLUB
     params.includemab = true

--- a/scripts/actions/weaponskills/shadow_of_death.lua
+++ b/scripts/actions/weaponskills/shadow_of_death.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.SCYTHE
     params.includemab = true

--- a/scripts/actions/weaponskills/shadowstitch.lua
+++ b/scripts/actions/weaponskills/shadowstitch.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.3
+    params.chr_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shark_bite.lua
+++ b/scripts/actions/weaponskills/shark_bite.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.0 params.dex_wsc = 0.5 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shattersoul.lua
+++ b/scripts/actions/weaponskills/shattersoul.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 + (player:getMerit(xi.merit.SHATTERSOUL) * 0.17) params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.int_wsc = player:getMerit(xi.merit.SHATTERSOUL) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shell_crusher.lua
+++ b/scripts/actions/weaponskills/shell_crusher.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shield_break.lua
+++ b/scripts/actions/weaponskills/shield_break.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.2 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.vit_wsc = 0.2
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shijin_spiral.lua
+++ b/scripts/actions/weaponskills/shijin_spiral.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 1.0625 params.ftp200 = 1.0625 params.ftp300 = 1.0625
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 + (player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17) params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.dex_wsc = player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shining_blade.lua
+++ b/scripts/actions/weaponskills/shining_blade.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.mnd_wsc = 0.2
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/shining_strike.lua
+++ b/scripts/actions/weaponskills/shining_strike.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.2 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.mnd_wsc = 0.2
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.CLUB
     params.includemab = true

--- a/scripts/actions/weaponskills/shockwave.lua
+++ b/scripts/actions/weaponskills/shockwave.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.mnd_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/shoulder_tackle.lua
+++ b/scripts/actions/weaponskills/shoulder_tackle.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.3 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/sickle_moon.lua
+++ b/scripts/actions/weaponskills/sickle_moon.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.75
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.2 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.agi_wsc = 0.2
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/sidewinder.lua
+++ b/scripts/actions/weaponskills/sidewinder.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
-    params.str_wsc = 0.16 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.25 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.16 params.agi_wsc = 0.25
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/skewer.lua
+++ b/scripts/actions/weaponskills/skewer.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/skullbreaker.lua
+++ b/scripts/actions/weaponskills/skullbreaker.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/slice.lua
+++ b/scripts/actions/weaponskills/slice.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 2.0
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/slug_shot.lua
+++ b/scripts/actions/weaponskills/slug_shot.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/smash_axe.lua
+++ b/scripts/actions/weaponskills/smash_axe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/sniper_shot.lua
+++ b/scripts/actions/weaponskills/sniper_shot.lua
@@ -16,7 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/sonic_thrust.lua
+++ b/scripts/actions/weaponskills/sonic_thrust.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3.25 params.ftp300 = 3.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.3 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.dex_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/spinning_attack.lua
+++ b/scripts/actions/weaponskills/spinning_attack.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/spinning_axe.lua
+++ b/scripts/actions/weaponskills/spinning_axe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/spinning_scythe.lua
+++ b/scripts/actions/weaponskills/spinning_scythe.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/spinning_slash.lua
+++ b/scripts/actions/weaponskills/spinning_slash.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 2.5 params.ftp200 = 3 params.ftp300 = 3.5
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3 params.int_wsc = 0.3
     -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/spiral_hell.lua
+++ b/scripts/actions/weaponskills/spiral_hell.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.375 params.ftp200 = 1.875 params.ftp300 = 3.625
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.5 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.int_wsc = 0.5
     -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false

--- a/scripts/actions/weaponskills/spirit_taker.lua
+++ b/scripts/actions/weaponskills/spirit_taker.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.5 params.mnd_wsc = 0.5 params.chr_wsc = 0.0
+    params.int_wsc = 0.5 params.mnd_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/split_shot.lua
+++ b/scripts/actions/weaponskills/split_shot.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/starburst.lua
+++ b/scripts/actions/weaponskills/starburst.lua
@@ -15,10 +15,6 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0
-    params.vit_wsc = 0.0 params.agi_wsc = 0.0
-    params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
     params.skill = xi.skill.STAFF
     params.includemab = true
     -- 50/50 shot of being light or dark

--- a/scripts/actions/weaponskills/stardiver.lua
+++ b/scripts/actions/weaponskills/stardiver.lua
@@ -15,9 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 1.75
-    params.str_wsc = player:getMerit(xi.merit.STARDIVER) * 0.17 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = player:getMerit(xi.merit.STARDIVER) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/steel_cyclone.lua
+++ b/scripts/actions/weaponskills/steel_cyclone.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 3
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.vit_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/stringing_pummel.lua
+++ b/scripts/actions/weaponskills/stringing_pummel.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 6
     params.ftp100 = 0.75 params.ftp200 = 0.75 params.ftp300 = 0.75
-    params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.32 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.32 params.vit_wsc = 0.32
     params.crit100 = 0.15 params.crit200 = 0.30 params.crit300 = 0.45
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/sturmwind.lua
+++ b/scripts/actions/weaponskills/sturmwind.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/sunburst.lua
+++ b/scripts/actions/weaponskills/sunburst.lua
@@ -15,10 +15,8 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1 params.ftp200 = 2.5 params.ftp300 = 4
-    params.str_wsc = 0.4 params.dex_wsc = 0.0
-    params.vit_wsc = 0.0 params.agi_wsc = 0.0
-    params.int_wsc = 0.0 params.mnd_wsc = 0.4
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.4
+    params.mnd_wsc = 0.4
     params.skill = xi.skill.STAFF
     params.includemab = true
     -- 50/50 shot of being light or dark

--- a/scripts/actions/weaponskills/swift_blade.lua
+++ b/scripts/actions/weaponskills/swift_blade.lua
@@ -17,9 +17,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1.5 params.ftp200 = 1.5 params.ftp300 = 1.5
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP

--- a/scripts/actions/weaponskills/tachi_ageha.lua
+++ b/scripts/actions/weaponskills/tachi_ageha.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 2.80 params.ftp200 = 2.80 params.ftp300 = 2.80
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.50
+    params.chr_wsc = 0.50
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_enpi.lua
+++ b/scripts/actions/weaponskills/tachi_enpi.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_fudo.lua
+++ b/scripts/actions/weaponskills/tachi_fudo.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3.75 params.ftp200 = 4.75 params.ftp300 = 5.75
-    params.str_wsc = 0.60 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.60
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_gekko.lua
+++ b/scripts/actions/weaponskills/tachi_gekko.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.5625 params.ftp200 = 1.88 params.ftp300 = 2.5
-    params.str_wsc = 0.75 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.75
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_goten.lua
+++ b/scripts/actions/weaponskills/tachi_goten.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_hobaku.lua
+++ b/scripts/actions/weaponskills/tachi_hobaku.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_jinpu.lua
+++ b/scripts/actions/weaponskills/tachi_jinpu.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.4 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.4
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/tachi_kagero.lua
+++ b/scripts/actions/weaponskills/tachi_kagero.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_kaiten.lua
+++ b/scripts/actions/weaponskills/tachi_kaiten.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_kasha.lua
+++ b/scripts/actions/weaponskills/tachi_kasha.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.56 params.ftp200 = 1.88 params.ftp300 = 2.5
-    params.str_wsc = 0.75 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.75
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_koki.lua
+++ b/scripts/actions/weaponskills/tachi_koki.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.3 params.chr_wsc = 0.0
+    params.str_wsc = 0.5 params.mnd_wsc = 0.3
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_rana.lua
+++ b/scripts/actions/weaponskills/tachi_rana.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/tachi_shoha.lua
+++ b/scripts/actions/weaponskills/tachi_shoha.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1.375 params.ftp200 = 2.1875 params.ftp300 = 2.6875
-    params.str_wsc = 0.0 + (player:getMerit(xi.merit.TACHI_SHOHA) * 0.17) params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = player:getMerit(xi.merit.TACHI_SHOHA) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_suikawari.lua
+++ b/scripts/actions/weaponskills/tachi_suikawari.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tachi_yukikaze.lua
+++ b/scripts/actions/weaponskills/tachi_yukikaze.lua
@@ -19,7 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.5625 params.ftp200 = 1.88 params.ftp300 = 2.5
-    params.str_wsc = 0.75 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.75
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/thunder_thrust.lua
+++ b/scripts/actions/weaponskills/thunder_thrust.lua
@@ -15,7 +15,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.int_wsc = 0.2
     params.ele = xi.element.THUNDER
     params.skill = xi.skill.POLEARM
     params.includemab = true

--- a/scripts/actions/weaponskills/torcleaver.lua
+++ b/scripts/actions/weaponskills/torcleaver.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 4.75 params.ftp200 = 5.75 params.ftp300 = 6.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.6 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = 0.6
     params.crit100 = 0.00 params.crit200 = 0.00 params.crit300 = 0.00
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/tornado_kick.lua
+++ b/scripts/actions/weaponskills/tornado_kick.lua
@@ -14,10 +14,8 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- number of normal hits for ws
     params.numHits = 3
     -- stat-modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
-    params.str_wsc = 0.32        params.dex_wsc = 0.0
-    params.vit_wsc = 0.32        params.agi_wsc = 0.0
-    params.int_wsc = 0.0         params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.32
+    params.vit_wsc = 0.32
 
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function ftp)
     params.ftp100 = 2.25 params.ftp200 = 2.75 params.ftp300 = 3.5

--- a/scripts/actions/weaponskills/true_strike.lua
+++ b/scripts/actions/weaponskills/true_strike.lua
@@ -18,7 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 1.0 params.crit200 = 1.0 params.crit300 = 1.0
     params.canCrit = true
     params.acc100 = 0.5 params.acc200 = 0.7 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.

--- a/scripts/actions/weaponskills/trueflight.lua
+++ b/scripts/actions/weaponskills/trueflight.lua
@@ -20,9 +20,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 4 params.ftp200 = 4.25 params.ftp300 = 4.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.3 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.agi_wsc = 0.3
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.MARKSMANSHIP
     params.includemab = true

--- a/scripts/actions/weaponskills/ukkos_fury.lua
+++ b/scripts/actions/weaponskills/ukkos_fury.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.20 params.crit200 = 0.35 params.crit300 = 0.55
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/upheaval.lua
+++ b/scripts/actions/weaponskills/upheaval.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 3.5 params.ftp300 = 6.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 + (player:getMerit(xi.merit.UPHEAVAL) * 0.17) params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.vit_wsc = player:getMerit(xi.merit.UPHEAVAL) * 0.17
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/uriel_blade.lua
+++ b/scripts/actions/weaponskills/uriel_blade.lua
@@ -16,7 +16,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 4.5 params.ftp200 = 6 params.ftp300 = 7.5
-    params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.32 params.chr_wsc = 0.0
+    params.str_wsc = 0.32 params.mnd_wsc = 0.32
     params.ele = xi.element.LIGHT
     params.skill = xi.skill.SWORD
     params.includemab = true

--- a/scripts/actions/weaponskills/victory_smite.lua
+++ b/scripts/actions/weaponskills/victory_smite.lua
@@ -22,7 +22,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
-    params.str_wsc = 0.6 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.6
     params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.45
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/vidohunir.lua
+++ b/scripts/actions/weaponskills/vidohunir.lua
@@ -17,8 +17,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.3
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.int_wsc = 0.3
     params.ele = xi.element.DARK
     params.skill = xi.skill.STAFF
     params.includemab = true

--- a/scripts/actions/weaponskills/viper_bite.lua
+++ b/scripts/actions/weaponskills/viper_bite.lua
@@ -19,7 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/vorpal_blade.lua
+++ b/scripts/actions/weaponskills/vorpal_blade.lua
@@ -17,9 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.str_wsc = 0.3
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/vorpal_scythe.lua
+++ b/scripts/actions/weaponskills/vorpal_scythe.lua
@@ -15,7 +15,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     -- wscs are in % so 0.2=20%
-    params.str_wsc = 0.35 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.35
     -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true

--- a/scripts/actions/weaponskills/vorpal_thrust.lua
+++ b/scripts/actions/weaponskills/vorpal_thrust.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.2 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.2 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.2 params.agi_wsc = 0.2
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/wasp_sting.lua
+++ b/scripts/actions/weaponskills/wasp_sting.lua
@@ -17,7 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/weapon_break.lua
+++ b/scripts/actions/weaponskills/weapon_break.lua
@@ -20,7 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.32 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.32 params.vit_wsc = 0.32
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/wheeling_thrust.lua
+++ b/scripts/actions/weaponskills/wheeling_thrust.lua
@@ -17,7 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
-    params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
+    params.str_wsc = 0.5
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0

--- a/scripts/actions/weaponskills/wildfire.lua
+++ b/scripts/actions/weaponskills/wildfire.lua
@@ -18,9 +18,7 @@ local weaponskillObject = {}
 weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.ftp100 = 5.5 params.ftp200 = 5.5 params.ftp300 = 5.5
-    params.str_wsc = 0.0 params.dex_wsc = 0.0 params.vit_wsc = 0.0
-    params.agi_wsc = 0.6 params.int_wsc = 0.0 params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.agi_wsc = 0.6
     params.ele = xi.element.FIRE
     params.skill = xi.skill.MARKSMANSHIP
     params.includemab = true


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes zero-value wsc parameters from scripts (future cleanup to come) since a nil value will now default to 0.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use various WS's and see the same behavior as before and no map log errors
<!-- Clear and detailed steps to test your changes here -->
