### PR TITLE
[core] Widen Trick Attack world angle check

### DIFF
--- a/scripts/commands/getta.lua
+++ b/scripts/commands/getta.lua
@@ -14,8 +14,12 @@ commandObj.cmdprops =
 commandObj.onTrigger = function(player)
     local targ = player:getCursorTarget()
     if targ ~= nil then
-        local tatarget = player:getTrickAttackChar(targ)
-        if tatarget ~= nil then
+        local tatarget    = player:getTrickAttackChar(targ)
+        local trickAttack = player:getStatusEffect(xi.effect.TRICK_ATTACK)
+
+        if not trickAttack then
+            player:printToPlayer('You do not have Trick Attack active, !getta will fail.')
+        elseif tatarget ~= nil then
             player:printToPlayer(string.format('Trick attack would select: %s', tatarget:getName()))
         else
             player:printToPlayer('No valid TA target found.')

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -97,7 +97,7 @@ namespace battleutils
 {
 
     const float worldAngleMinDistance = 0.5f;
-    const uint8 worldAngleMaxDeviance = 4;
+    const uint8 worldAngleMaxDeviance = 8;
 
     void LoadSkillTable()
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Doubles the trick attack world angle check so more trick attacks can pass the checks
Updates !getta to warn you if you're going to fail !getta automatically

## Steps to test these changes

Test TA angles with !getta, see it be slightly less restrictive
