### PR TITLE
[core] Add interruption of fishing on zoning to prevent monsters from leaving pool

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -456,6 +456,12 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     m_charList.erase(PChar->targid);
     charTargIds.erase(PChar->targid);
 
+    // Need to interupt fishing on zone out otherwise fished up mobs get stuck in hooked state
+    if (PChar->hookedFish && PChar->hookedFish->hooked == true)
+    {
+        fishingutils::InterruptFishing(PChar);
+    }
+
     ShowDebug("CZone:: %s DecreaseZoneCounter <%u> %s", m_zone->getName(), m_charList.size(), PChar->getName());
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The fishing change prevents mobs being removed (until zone restart) from the catchable monster pool if the mob is being caught when the player zones (such as boat docking). This occurs because the mob's local variable hooked is set when initially hooked but is never set back to zero because the mob is neither caught nor unhooked. Thus the fix is calling the interrupt fishing method on zoning which unhooks the mob.

I am original author of fix code and it is a fix from ASB coming upstream.

## Steps to test these changes
1. Edit zone to remove all fish and items except a single monster (like an NM)
2. Bring two characters to the zone including one blm with warp II
3. Start fishing on the other char and hook the monster then have the first character warp the fishing char while reeling in
4. Have the blm char start fishing and see that the mob is still in the pool (as opposed to being removed from the pool because it was never unhooked)

