### PR TITLE
[core] Ensure correct functioning of changing guild point item

### DIFF
--- a/src/map/utils/guildutils.cpp
+++ b/src/map/utils/guildutils.cpp
@@ -139,13 +139,13 @@ namespace guildutils
     {
         // TODO: This function can be faulty when dealing with multiple processes. Needs to be synchronized properly across servers.
 
-        bool doUpdate = static_cast<uint32>(serverutils::GetServerVar("[GUILD]pattern_update")) != CVanaTime::getInstance()->getSysYearDay();
+        bool doUpdate = static_cast<uint32>(serverutils::GetServerVar("[GUILD]pattern_update")) != CVanaTime::getInstance()->getJstYearDay();
 
         uint8 pattern = xirand::GetRandomNumber(8);
         if (doUpdate)
         {
             // write the new pattern and update time to try to prevent other servers from updating the pattern
-            serverutils::SetServerVar("[GUILD]pattern_update", CVanaTime::getInstance()->getSysYearDay());
+            serverutils::SetServerVar("[GUILD]pattern_update", CVanaTime::getInstance()->getJstYearDay());
             serverutils::SetServerVar("[GUILD]pattern", pattern);
             charutils::ClearCharVarFromAll("[GUILD]daily_points");
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR ensures correct guild trade-in timing by using JST instead of system time for changing the GP item. This is required because the client has certain hard coded assumptions regarding the changing. Current servers must have the system time set to JST for this to work correctly, this makes sure that even if the system time is not JST the GP item changing will still work. For servers with system time already set to JST (which should be all servers with correct GP item changing), this change should have no impact.

I am original author of fix code and it is a fix from ASB coming upstream.

Closes https://github.com/LandSandBoat/server/issues/3500

## Steps to test these changes
On a server with system time not set to JST, trade in guild items and see the correct behavior even if the system day is different from the JST day.
