### PR TITLE
[core] Fix barrage and shadows interaction message

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1812,10 +1812,12 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
                 {
                     charutils::TrySkillUP(this, (SKILLTYPE)PAmmo->getSkillType(), PTarget->GetMLevel());
                 }
+                totalDamage += damage;
             }
         }
         else // miss
         {
+            damage                  = 0;
             actionTarget.reaction   = REACTION::EVADE;
             actionTarget.speceffect = SPECEFFECT::NONE;
             actionTarget.messageID  = 354;
@@ -1851,7 +1853,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
                 hitCount = i;
             }
         }
-        totalDamage += damage;
     }
 
     // if a hit did occur (even without barrage)
@@ -1867,12 +1868,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
         actionTarget.param =
             battleutils::TakePhysicalDamage(this, PTarget, PHYSICAL_ATTACK_TYPE::RANGED, totalDamage, false, slot, realHits, nullptr, true, true);
-
-        // lower damage based on shadows taken
-        if (shadowsTaken)
-        {
-            actionTarget.param = (int32)(actionTarget.param * (1 - ((float)shadowsTaken / realHits)));
-        }
 
         // absorb message
         if (actionTarget.param < 0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue when mobs have shadows and the player uses barrage. This would sometimes result in the mob being reported as healed (though not actually healed), for example when barrage hit 4 shadows and the last shot hit the mob. The issue can be seen in the code snippet discussed below. Also in cases of blink where only some shots are blocked the damage from the previous hit shot would still be added even if blink blocked the next (since damage variable was never cleared and always added). 

In the code snippet [here](https://github.com/LandSandBoat/server/blob/defa464f7c1746277ad1e37fbe495c950d941135/src/map/entities/charentity.cpp#L1872) you can see that if the number of shadows taken is more than the number of real hits then the param will be negative and the message will be incorrectly set to absorb.

I am original author of fix code and it is a fix from ASB coming upstream.

## Steps to test these changes
Fight a mob with shadows (like Tonberry Slasher) and use barrage and then RA. The shadows should absorb 4 ranged attacks and the final shot should show correct damage message (and not a healing message).
