### PR TITLE
[AMK, Lua] Implements mission 13 puzzle 3 - Castle Zvahl fun run

### DIFF
--- a/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
+++ b/scripts/missions/amk/13_A_Challenge_You_Could_Be_a_Winner.lua
@@ -4,14 +4,18 @@
 -- !addmission 10 12
 -----------------------------------
 -- Puzzle 1 - Beaucedine
--- Shadowy Pillar   : !pos 374 -12 -15
--- Lonely Evergreen : !pos -162 -80 178
--- Goblin Grenadier : !pos -26 -59 -76
+-- Shadowy Pillar   : !pos 374 -12 -15 161
+-- Lonely Evergreen : !pos -162 -80 178 111
+-- Goblin Grenadier : !pos -26 -59 -76 111
 -----------------------------------
 -- Puzzle 2 - Xarcabard
--- Option_One   : !pos 126 -24 -118
+-- Option_One   : !pos 126 -24 -118 112
 -- Option_One   : !pos 66 -24 -191 112
 -- Option_Three : !pos 1 -23 -103 112
+-----------------------------------
+-- Puzzle 3 - Castle Zvahl Baileys
+-- Shadowy Pillar : !pos 374 -12 -15 161
+-- Flame Of Fate  : !pos -155 -24 17 161
 -----------------------------------
 -- This mission can be repeated by losing the bncm battle in the subsequent mission
 -- Therefore to remove possible conflicts, the mission progress will be handled
@@ -49,7 +53,7 @@ mission.sections =
             onEventFinish =
             {
                 [100] = function(player, csid, option, npc)
-                    player:setCharVar('Mission[10][12]progress', 1)
+                    mission:setVar(player, 'progress', 1)
                 end,
             },
         },
@@ -59,7 +63,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            player:getCharVar('Mission[10][12]progress') == 1 and
+            mission:getVar(player, 'progress') == 1 and
             not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
             not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
             player:needToZone() == false
@@ -89,7 +93,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            player:getCharVar('Mission[10][12]progress') == 1 and
+            mission:getVar(player, 'progress') == 1 and
             not player:hasKeyItem(xi.ki.POCKET_MOGBOMB) and
             not player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON) and
             player:needToZone() == true
@@ -107,14 +111,14 @@ mission.sections =
             ['Goblin_Grenadier'] =
             {
                 onTrigger = function(player, npc)
-                    local answer = player:getLocalVar('Mission[10][12][p1]pipSet') - 1
+                    local answer = mission:getLocalVar(player, '[p1]pipSet') - 1
 
                     if answer < 0 then
                         return mission:progressEvent(508, xi.ki.MAP_OF_THE_NORTHLANDS_AREA)
                     else
                         local today = VanadielDayOfTheWeek()
                         local tomorrow = (today + 1) % 8
-                        local hintsUsed = player:getLocalVar('Mission[10][12][p1]hintsUsed')
+                        local hintsUsed = mission:getLocalVar(player, '[p1]hintsUsed')
 
                         player:messageSpecial(zones[player:getZoneID()].text.GRENADIER_DAY_HINT, today, tomorrow)
 
@@ -190,8 +194,8 @@ mission.sections =
                         option == 1 or -- Used first hint
                         option == 2    -- Used second hint
                     then
-                        local hintsUsed = player:getLocalVar('Mission[10][12][p1]hintsUsed')
-                        player:setLocalVar('Mission[10][12][p1]hintsUsed', hintsUsed + 1)
+                        local hintsUsed = mission:getLocalVar(player, '[p1]hintsUsed')
+                        mission:setLocalVar(player, '[p1]hintsUsed', hintsUsed + 1)
                     elseif option == 3 then
                         -- wrong answer, reset puzzle
                         player:needToZone(false)
@@ -221,7 +225,7 @@ mission.sections =
 
                 [508] = function(player, csid, option, npc)
                     -- Pipset offset by 1 to account for saving 0 as a variable.  When retrieving, subtract 1
-                    player:setLocalVar('Mission[10][12][p1]pipSet', math.random(1, 10)) -- range: 0 - 9
+                    mission:setLocalVar(player, '[p1]pipSet', math.random(1, 10)) -- range: 0 - 9
                 end,
             },
         },
@@ -231,7 +235,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            player:getCharVar('Mission[10][12]progress') == 1 and
+            mission:getVar(player, 'progress') == 1 and
             player:hasKeyItem(xi.ki.POCKET_MOGBOMB)
         end,
 
@@ -257,7 +261,7 @@ mission.sections =
                 [502] = function(player, csid, option, npc)
                     player:delKeyItem(xi.ki.POCKET_MOGBOMB)
                     npcUtil.giveKeyItem(player, xi.ki.TRIVIA_CHALLENGE_KUPON)
-                    player:setCharVar('Mission[10][12]progress', 2)
+                    mission:setVar(player, 'progress', 2)
                 end,
             },
         },
@@ -267,7 +271,7 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            player:getCharVar('Mission[10][12]progress') == 2 and
+            mission:getVar(player, 'progress') == 2 and
             player:hasKeyItem(xi.ki.TRIVIA_CHALLENGE_KUPON)
         end,
 
@@ -325,7 +329,8 @@ mission.sections =
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission >= mission.missionId and
-            player:getCharVar('Mission[10][12]progress') == 3
+            mission:getVar(player, 'progress') == 3 and
+            player:hasKeyItem(xi.ki.GAUNTLET_CHALLENGE_KUPON)
         end,
 
         [xi.zone.XARCABARD] =
@@ -354,15 +359,90 @@ mission.sections =
 
         [xi.zone.CASTLE_ZVAHL_BAILEYS] =
         {
+            ['Shadowy_Pillar'] =
+            {
+                onTrigger = function(player, npc)
+                    if not player:needToZone() then
+                        return mission:progressEvent(100, 1)
+                    else
+                        return mission:progressEvent(100, 2)
+                    end
+                end,
+            },
 
+            ['Flame_of_Fate'] =
+            {
+                onTrigger = function(player, npc)
+                    player:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
+
+                    if not player:needToZone() then
+                        return mission:progressEvent(101, 4)
+                    elseif mission:getLocalVar(player, '[p3]timeLimit') < os.time() then
+                        return mission:progressEvent(101, 1)
+                    else
+                        return mission:progressEvent(101, 2)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [100] = function(player, csid, option, npc)
+                    if option == 1 then
+                        -- Start run
+                        player:needToZone(true)
+                        mission:setLocalVar(player, '[p3]timeLimit', os.time() + utils.minutes(8))
+                        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, 1, 0, 0)
+
+                        -- https://www.bg-wiki.com/ffxi/Kupo_Mission_13 : "The effect durations are random. They can be 3-7 minutes long. "
+                        local buffDuration = math.floor(utils.minutes(math.random(3, 7)) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER)
+                        player:addStatusEffect(xi.effect.INVISIBLE, 1, 10, buffDuration)
+                        player:addStatusEffect(xi.effect.DEODORIZE, 1, 10, buffDuration)
+                        player:addStatusEffect(xi.effect.SNEAK, 1, 10, buffDuration)
+                    elseif option == 2 then
+                        -- Player came back to refresh buffs
+                        local buffDuration = math.floor(utils.minutes(math.random(3, 7)) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER)
+                        player:addStatusEffect(xi.effect.INVISIBLE, 1, 10, buffDuration)
+                        player:addStatusEffect(xi.effect.DEODORIZE, 1, 10, buffDuration)
+                        player:addStatusEffect(xi.effect.SNEAK, 1, 10, buffDuration)
+                    end
+                end,
+
+                [101] = function(player, csid, option, npc)
+                    if option == 1 then
+                        -- Won the game!
+                        npcUtil.giveKeyItem(player, xi.ki.FESTIVAL_SOUVENIR_KUPON)
+                        mission:setVar(player, 'progress', 4)
+                    end
+
+                    if mission:getLocalVar(player, '[p3]timeLimit') > 0 then
+                        player:setMP(player:getMaxMP())
+                        player:setHP(player:getMaxHP())
+                        mission:setLocalVar(player, '[p3]timeLimit', 0)
+                    end
+                end,
+            },
         },
     },
 
     -- Part 5: Castle Zvahl Keep
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId
+            return currentMission == mission.missionId and
+            mission:getVar(player, 'progress') == 4 and
+            player:hasKeyItem(xi.ki.FESTIVAL_SOUVENIR_KUPON)
         end,
+
+        [xi.zone.CASTLE_ZVAHL_BAILEYS] =
+        {
+            ['Flame_of_Fate'] =
+            {
+                onTrigger = function(player, npc)
+                    -- Reminder text
+                    return mission:progressEvent(101, 3)
+                end,
+            },
+        },
 
         [xi.zone.CASTLE_ZVAHL_KEEP] =
         {

--- a/scripts/missions/amk/helpers.lua
+++ b/scripts/missions/amk/helpers.lua
@@ -501,7 +501,7 @@ xi.amk.helpers.pipSets =
 }
 
 xi.amk.helpers.puzzleOneOnTrigger = function(player, npc, mission, offset)
-    local pipSet = player:getLocalVar('Mission[10][12][p1]pipSet') - 1
+    local pipSet = mission:getLocalVar(player, '[p1]pipSet') - 1
     local pos = npc:getPos()
     local element = xi.amk.helpers.pipSets[pipSet][offset]
 
@@ -524,8 +524,8 @@ end
 -----------------------------------
 local xarc = zones[xi.zone.XARCABARD]
 
+-- returns -1 or 1 to offset the wrong answer randomly
 local randomSign = function()
-    -- returns -1 or 1 to offset the wrong answer randomly
     return math.random(1, 2) == 1 and 1 or -1
 end
 
@@ -687,7 +687,7 @@ xi.amk.helpers.triviaQuestions =
     end,
 }
 
-local assignRandomTriviaQuestions = function(player)
+local assignRandomTriviaQuestions = function(player, mission)
     local questions = {}
     for i, _ in pairs(xi.amk.helpers.triviaQuestions) do
         table.insert(questions, i)
@@ -695,19 +695,19 @@ local assignRandomTriviaQuestions = function(player)
 
     for i = 1, 3 do
         local index = math.random(1, #questions)
-        player:setLocalVar('Mission[10][12][p2]question' .. i, questions[index])
+        mission:setLocalVar(player, '[p2]question' .. i, questions[index])
         table.remove(questions, index)
     end
 end
 
-local resetPuzzleVars = function(player)
-    player:setLocalVar('Mission[10][12][p2]progress', 0)
-    player:setLocalVar('Mission[10][12][p2]timeLimit', 0)
-    player:setLocalVar('Mission[10][12][p2]question1', 0)
-    player:setLocalVar('Mission[10][12][p2]question2', 0)
-    player:setLocalVar('Mission[10][12][p2]question3', 0)
-    player:setLocalVar('Mission[10][12][p2]correctStooge', 0)
-    player:setLocalVar('Mission[10][12][p2]previousStooge', 0)
+local resetPuzzleVars = function(player, mission)
+    mission:setLocalVar(player, '[p2]progress', 0)
+    mission:setLocalVar(player, '[p2]timeLimit', 0)
+    mission:setLocalVar(player, '[p2]question1', 0)
+    mission:setLocalVar(player, '[p2]question2', 0)
+    mission:setLocalVar(player, '[p2]question3', 0)
+    mission:setLocalVar(player, '[p2]correctStooge', 0)
+    mission:setLocalVar(player, '[p2]previousStooge', 0)
 end
 
 local stooges =
@@ -723,13 +723,13 @@ local stooges =
 }
 
 xi.amk.helpers.puzzleTwoOnTrigger = function(player, npc, mission)
-    local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+    local p2Progress = mission:getLocalVar(player, '[p2]progress')
 
     -- Starting puzzle, assign questions
     if p2Progress == 0 then
         p2Progress = 1
-        player:setLocalVar('Mission[10][12][p2]progress', p2Progress)
-        assignRandomTriviaQuestions(player)
+        mission:setLocalVar(player, '[p2]progress', p2Progress)
+        assignRandomTriviaQuestions(player, mission)
     end
 
     -- Puzzle already beaten, show flavor text
@@ -740,11 +740,11 @@ xi.amk.helpers.puzzleTwoOnTrigger = function(player, npc, mission)
         p2Progress = 10
     end
 
-    local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. p2Progress)
-    local correctStooge = player:getLocalVar('Mission[10][12][p2]correctStooge')
-    local previousStooge = player:getLocalVar('Mission[10][12][p2]previousStooge')
+    local currentQuestion = mission:getLocalVar(player, '[p2]question' .. p2Progress)
+    local correctStooge = mission:getLocalVar(player, '[p2]correctStooge')
+    local previousStooge = mission:getLocalVar(player, '[p2]previousStooge')
     local stoogeNum = stooges[npc:getID()].stoogeNum
-    local timeLimit = player:getLocalVar('Mission[10][12][p2]timeLimit')
+    local timeLimit = mission:getLocalVar(player, '[p2]timeLimit')
 
     -- DEBUG
     -- player:PrintToPlayer(string.format("p2Progress: %s, time_limit: %s, currentQuestion: %s, correctStooge: %s, previousStooge: %s, stoogeNum: %s",
@@ -768,8 +768,8 @@ xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, miss
     if option >= 1 and option <= 3 then
         local stooge = stooges[npc:getID()]
         local timeLimit = os.time() + 180 -- Three minutes
-        local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
-        local currentQuestion = player:getLocalVar('Mission[10][12][p2]question' .. p2Progress)
+        local p2Progress = mission:getLocalVar(player, '[p2]progress')
+        local currentQuestion = mission:getLocalVar(player, '[p2]question' .. p2Progress)
         local answers = xi.amk.helpers.triviaQuestions[currentQuestion](player)
 
         -- Right and wrong answer/stooge has to be randomized in terms of order given to updateEvent
@@ -786,9 +786,9 @@ xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, miss
         end
 
         -- Store important information for next CS parameters
-        player:setLocalVar('Mission[10][12][p2]correctStooge', correctOption + 1) -- Stooge num is always 1 more than the option
-        player:setLocalVar('Mission[10][12][p2]timeLimit', timeLimit) -- Time limit - > 3 minutes fails
-        player:setLocalVar('Mission[10][12][p2]previousStooge', stooge.stoogeNum) -- this tells the stooge that he is or isn't supposed to talk
+        mission:setLocalVar(player, '[p2]correctStooge', correctOption + 1) -- Stooge num is always 1 more than the option
+        mission:setLocalVar(player, '[p2]timeLimit', timeLimit) -- Time limit - > 3 minutes fails
+        mission:setLocalVar(player, '[p2]previousStooge', stooge.stoogeNum) -- this tells the stooge that he is or isn't supposed to talk
 
         player:updateEvent(
             answers[answerOne],
@@ -811,21 +811,20 @@ xi.amk.helpers.puzzleTwoOnEventUpdate = function(player, csid, option, npc, miss
 end
 
 xi.amk.helpers.puzzleTwoOnEventFinish = function(player, csid, option, npc, mission)
-    local p2Progress = player:getLocalVar('Mission[10][12][p2]progress')
+    local p2Progress = mission:getLocalVar(player, '[p2]progress')
     if csid == 200 then
         if option == 0 then
             -- lost the game, via time or wrong answer - reset vars
-            resetPuzzleVars(player)
+            resetPuzzleVars(player, mission)
         elseif option == 1 then
-            player:setLocalVar('Mission[10][12][p2]progress', p2Progress + 1)
+            mission:setLocalVar(player, '[p2]progress', p2Progress + 1)
         elseif option == 2 and p2Progress == 4 then
             -- Won game, reset all vars
-            resetPuzzleVars(player)
+            resetPuzzleVars(player, mission)
             npcUtil.giveKeyItem(player, xi.ki.GAUNTLET_CHALLENGE_KUPON)
 
             -- Advance to puzzle 3
-            player:setCharVar('Mission[10][12]progress', 3)
-            player:setCharVar('Mission[10][12][p3]stoogeArg', 1)
+            mission:setVar(player, 'progress', 3)
         end
     end
 end


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements mission 13's puzzle 3, the noob run through castle zvahl baileys.  Information sourced from both [wiki](https://ffxiclopedia.fandom.com/wiki/A_Challenge!_You_Could_Be_a_Winner) and [bg-wiki](https://www.bg-wiki.com/ffxi/Kupo_Mission_13) as well as capture.  Previous implementation used additional charVars, but I don't believe they're necessary, deleted charVar "stoogeArg".

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
`!addmission 10 12`
Advance through first two puzzles, talk to shadowy pillar in baileys
Get lvl capped, sneak/invis/deo, walk to flame of fate, try a number of outcomes:
- let 8 minutes pass - lose (time)
- zone - lose (magic gone)
- logout - lose (magic gone)
- Don't do any of those things - win
- Don't do any of those things, die and rr - win