### PR TITLE
[core, lua] Add utility methods for clearing AI queues (timer and action queues) from lua

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -185,7 +185,7 @@ bool CAIContainer::Untargetable(duration _duration, bool canChangeState)
 
 bool CAIContainer::Internal_Engage(uint16 targetid)
 {
-    //#TODO: pet engage/disengage
+    // #TODO: pet engage/disengage
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
 
     if (entity && entity->PAI->IsEngaged())
@@ -197,12 +197,12 @@ bool CAIContainer::Internal_Engage(uint16 targetid)
         }
         return false;
     }
-    //#TODO: use valid target stuff from spell
+    // #TODO: use valid target stuff from spell
     if (entity)
     {
-        //#TODO: remove m_battleTarget if possible (need to check disengage)
-        // Check if an entity can change to the attack state
-        // Allow entity with prevent action effect to very briefly switch to the attack state to be properly engaged
+        // #TODO: remove m_battleTarget if possible (need to check disengage)
+        //  Check if an entity can change to the attack state
+        //  Allow entity with prevent action effect to very briefly switch to the attack state to be properly engaged
         if (CanChangeState() || (GetCurrentState() && GetCurrentState()->IsCompleted()) || entity->StatusEffectContainer->HasPreventActionEffect(true))
         {
             if (ForceChangeState<CAttackState>(entity, targetid))
@@ -417,11 +417,11 @@ void CAIContainer::Tick(time_point _tick)
     m_PrevTick = m_Tick;
     m_Tick     = _tick;
 
-    //#TODO: timestamp in the event?
+    // #TODO: timestamp in the event?
     EventHandler.triggerListener("TICK", CLuaBaseEntity(PEntity));
     PEntity->Tick(_tick);
 
-    //#TODO: check this in the controller instead maybe? (might not want to check every tick)
+    // #TODO: check this in the controller instead maybe? (might not want to check every tick)
     ActionQueue.checkAction(_tick);
 
     // check pathfinding only if there is no controller to do it
@@ -527,6 +527,16 @@ void CAIContainer::QueueAction(queueAction_t&& action)
 bool CAIContainer::QueueEmpty()
 {
     return ActionQueue.isEmpty();
+}
+
+void CAIContainer::ClearActionQueue()
+{
+    ActionQueue.clearActionQueue();
+}
+
+void CAIContainer::ClearTimerQueue()
+{
+    ActionQueue.clearTimerQueue();
 }
 
 void CAIContainer::checkQueueImmediately()

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -122,6 +122,8 @@ public:
 
     void QueueAction(queueAction_t&&);
     bool QueueEmpty();
+    void ClearActionQueue();
+    void ClearTimerQueue();
     void checkQueueImmediately();
 
     // stores all events and their associated lua callbacks

--- a/src/map/ai/helpers/action_queue.cpp
+++ b/src/map/ai/helpers/action_queue.cpp
@@ -96,3 +96,19 @@ bool CAIActionQueue::isEmpty()
 {
     return actionQueue.empty() && timerQueue.empty();
 }
+
+void CAIActionQueue::clearActionQueue()
+{
+    while (!actionQueue.empty())
+    {
+        actionQueue.pop();
+    }
+}
+
+void CAIActionQueue::clearTimerQueue()
+{
+    while (!timerQueue.empty())
+    {
+        timerQueue.pop();
+    }
+}

--- a/src/map/ai/helpers/action_queue.h
+++ b/src/map/ai/helpers/action_queue.h
@@ -84,6 +84,8 @@ public:
 
     void handleAction(queueAction_t& action);
 
+    void clearActionQueue();
+    void clearTimerQueue();
     bool isEmpty();
 
 private:

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -17019,6 +17019,22 @@ bool CLuaBaseEntity::deleteRaisedChocobo()
     return true;
 }
 
+void CLuaBaseEntity::clearActionQueue()
+{
+    if (m_PBaseEntity->PAI)
+    {
+        m_PBaseEntity->PAI->ClearActionQueue();
+    }
+}
+
+void CLuaBaseEntity::clearTimerQueue()
+{
+    if (m_PBaseEntity->PAI)
+    {
+        m_PBaseEntity->PAI->ClearTimerQueue();
+    }
+}
+
 void CLuaBaseEntity::setMannequinPose(uint16 itemID, uint8 race, uint8 pose)
 {
     TracyZoneScoped;
@@ -17919,6 +17935,9 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setClaimedTraverserStones", CLuaBaseEntity::setClaimedTraverserStones);
 
     SOL_REGISTER("getHistory", CLuaBaseEntity::getHistory);
+
+    SOL_REGISTER("clearActionQueue", CLuaBaseEntity::clearActionQueue);
+    SOL_REGISTER("clearTimerQueue", CLuaBaseEntity::clearTimerQueue);
 
     SOL_REGISTER("getChocoboRaisingInfo", CLuaBaseEntity::getChocoboRaisingInfo);
     SOL_REGISTER("setChocoboRaisingInfo", CLuaBaseEntity::setChocoboRaisingInfo);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -881,6 +881,9 @@ public:
     bool setChocoboRaisingInfo(sol::table const& table);
     bool deleteRaisedChocobo();
 
+    void clearActionQueue();
+    void clearTimerQueue();
+
     void  setMannequinPose(uint16 itemID, uint8 race, uint8 pose);
     uint8 getMannequinPose(uint16 itemID);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR adds utility methods for clearing the AI queues (action and timer queues) of entities. These methods are useful, for example, when an entity (often NPCs) has some periodic timed action(s) that might need to be canceled if some other event occurs. 

For example, ASB uses the clearTimerQueue function for Morion Worm ??? behavior. Specifically the ??? uses an `npc:timer()` function to move every 30 minutes but if a player pops the Morion Worm then we need to need to clear the future movement action in the timer queue otherwise the timing of the 30 min repop and future movements will not align with the death of Morion Worm.

If there is a better and also simple way to achieve the same type of logical outcome for such situations, then I am also open to such suggestions.

I am original author of fix code and it is a fix from ASB coming upstream.

## Steps to test these changes
Add a timer function (to move for example) to an npc and then use clearTimerQueue on that npc and notice that the npc never moves because the action was removed from the queue 
