### PR TITLE
[weaponskills] Replace critN variables with critVaries table in scripts

### DIFF
--- a/scripts/actions/abilities/eagle_eye_shot.lua
+++ b/scripts/actions/abilities/eagle_eye_shot.lua
@@ -45,7 +45,7 @@ abilityObject.onUseAbility = function(player, target, ability, action)
 
     -- TP params.
     params.ftp100  = 5 params.ftp200  = 5 params.ftp300  = 5
-    params.crit100 = 0 params.crit200 = 0 params.crit300 = 0
+    params.critVaries = { 0.0, 0.0, 0.0 }
     params.acc100  = 0 params.acc200  = 0 params.acc300  = 0
     params.atk100  = 1 params.atk200  = 1 params.atk300  = 1
 
@@ -58,7 +58,6 @@ abilityObject.onUseAbility = function(player, target, ability, action)
     params.mnd_wsc = 0
     params.chr_wsc = 0
 
-    params.canCrit    = true
     params.enmityMult = 0.5
 
     -- Job Point Bonus Damage

--- a/scripts/actions/abilities/pets/automaton/string_shredder.lua
+++ b/scripts/actions/abilities/pets/automaton/string_shredder.lua
@@ -20,17 +20,8 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
         acc100 = 0.0,
         acc200 = 0.0,
         acc300 = 0.0,
-        canCrit = true,
-        crit100 = 0.2,
-        crit200 = 0.4,
-        crit300 = 0.7,
-        str_wsc = 0.0,
-        dex_wsc = 0.0,
+        critVaries = { 0.2, 0.4, 0.7 },
         vit_wsc = 0.5,
-        agi_wsc = 0.0,
-        int_wsc = 0.0,
-        mnd_wsc = 0.0,
-        chr_wsc = 0.0
     }
 
     local damage = xi.autows.doAutoPhysicalWeaponskill(automaton, target, 0, skill:getTP(), true, action, false, params, skill)

--- a/scripts/actions/mobskills/freezebite.lua
+++ b/scripts/actions/mobskills/freezebite.lua
@@ -20,9 +20,7 @@ mobskillObject.onMobWeaponSkill = function(target, mob, skill)
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 3
-    params.str_wsc = 0.3 params.dex_wsc = 0.0 params.vit_wsc = 0.0 params.agi_wsc = 0.0 params.int_wsc = 0.2 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
+    params.str_wsc = 0.3 params.int_wsc = 0.2
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, _, _, _ = xi.weaponskills.doPhysicalWeaponskill(mob, target, 0, params, 0, nil, true, nil)

--- a/scripts/actions/weaponskills/README.md
+++ b/scripts/actions/weaponskills/README.md
@@ -1,0 +1,8 @@
+#Weaponskill Parameter Tables
+----------------------------
+
+NOTE: The below modifiers should _ONLY_ be set if applicable to the WS.
+
+`critVaries` : Table of 3 floating point elements to represent points on the piecemeal function for modifiers (points at 1000, 2000, and 3000 TP).
+
+Example: `critVaries = { 0.15, 0.2, 0.25 }`

--- a/scripts/actions/weaponskills/apex_arrow.lua
+++ b/scripts/actions/weaponskills/apex_arrow.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.agi_wsc = player:getMerit(xi.merit.APEX_ARROW) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.ignoresDef = true

--- a/scripts/actions/weaponskills/arching_arrow.lua
+++ b/scripts/actions/weaponskills/arching_arrow.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/armor_break.lua
+++ b/scripts/actions/weaponskills/armor_break.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.vit_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/ascetics_fury.lua
+++ b/scripts/actions/weaponskills/ascetics_fury.lua
@@ -18,14 +18,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5 params.vit_wsc = 0.5
-    params.crit100 = 0.1 params.crit200 = 0.2 params.crit300 = 0.4
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.2, 0.4 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.multiHitfTP = true -- http://wiki.ffo.jp/html/15880.html
-        params.crit100 = 0.2 params.crit200 = 0.3 params.crit300 = 0.5
+        params.critVaries = { 0.2, 0.3, 0.5 }
         params.atk100 = 2.5 params.atk200 = 2.5 params.atk300 = 2.5
     end
 

--- a/scripts/actions/weaponskills/asuran_fists.lua
+++ b/scripts/actions/weaponskills/asuran_fists.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 8
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.1 params.vit_wsc = 0.1
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -26,8 +26,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 1.5
     params.str_wsc = 0.4 params.vit_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.enmityMult = 1

--- a/scripts/actions/weaponskills/avalanche_axe.lua
+++ b/scripts/actions/weaponskills/avalanche_axe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/backhand_blow.lua
+++ b/scripts/actions/weaponskills/backhand_blow.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3 params.dex_wsc = 0.3
-    params.crit100 = 0.4 params.crit200 = 0.6 params.crit300 = 0.8
-    params.canCrit = true
+    params.critVaries = { 0.4, 0.6, 0.8 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/black_halo.lua
+++ b/scripts/actions/weaponskills/black_halo.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1.5 params.ftp200 = 2.5 params.ftp300 = 3
     params.str_wsc = 0.3 params.mnd_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blade_chi.lua
+++ b/scripts/actions/weaponskills/blade_chi.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
     params.str_wsc = 0.2 params.int_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/blade_hi.lua
+++ b/scripts/actions/weaponskills/blade_hi.lua
@@ -23,8 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 4 params.ftp200 = 4 params.ftp300 = 4
     params.agi_wsc = 0.6
-    params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
-    params.canCrit = true
+    params.critVaries = { 0.15, 0.20, 0.25 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blade_jin.lua
+++ b/scripts/actions/weaponskills/blade_jin.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.3 params.dex_wsc = 0.3
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/blade_kamu.lua
+++ b/scripts/actions/weaponskills/blade_kamu.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5 params.int_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.3 params.atk200 = 1.3 params.atk300 = 1.3
 

--- a/scripts/actions/weaponskills/blade_ku.lua
+++ b/scripts/actions/weaponskills/blade_ku.lua
@@ -23,8 +23,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.1 params.dex_wsc = 0.1
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP
     -- http://wiki.ffo.jp/html/732.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Blade:_Ku does not list ACC Bonus

--- a/scripts/actions/weaponskills/blade_metsu.lua
+++ b/scripts/actions/weaponskills/blade_metsu.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.dex_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blade_retsu.lua
+++ b/scripts/actions/weaponskills/blade_retsu.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blade_rin.lua
+++ b/scripts/actions/weaponskills/blade_rin.lua
@@ -18,10 +18,9 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
-    -- to do critical hit rate of this ws is base on amount of tp alone, does not consider Critical Hit Rate from dDEX, equipment, or likely merits/base
+    -- TODO: critical hit rate of this ws is base on amount of tp alone, does not consider Critical Hit Rate from dDEX, equipment, or likely merits/base
     -- https://www.bg-wiki.com/ffxi/Blade:_Rin
-    params.canCrit = true
+    params.critVaries = { 0.3, 0.6, 0.9 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blade_shun.lua
+++ b/scripts/actions/weaponskills/blade_shun.lua
@@ -20,9 +20,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 5
     params.ftp100 = 0.6875 params.ftp200 = 0.6875 params.ftp300 = 0.6875
-    params.dex_wsc = player:getMerit(xi.merit.BLADE_SHUN) * 0.17 -- TODO: base should be 73%
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
+    params.dex_wsc = player:getMerit(xi.merit.BLADE_SHUN) * 0.17
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/blade_ten.lua
+++ b/scripts/actions/weaponskills/blade_ten.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 2.75 params.ftp300 = 3
     params.str_wsc = 0.3 params.dex_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blast_arrow.lua
+++ b/scripts/actions/weaponskills/blast_arrow.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/blast_shot.lua
+++ b/scripts/actions/weaponskills/blast_shot.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/bora_axe.lua
+++ b/scripts/actions/weaponskills/bora_axe.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.dex_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 3.5 params.atk200 = 3.5 params.atk300 = 3.5
 

--- a/scripts/actions/weaponskills/brainshaker.lua
+++ b/scripts/actions/weaponskills/brainshaker.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/calamity.lua
+++ b/scripts/actions/weaponskills/calamity.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 4
     params.str_wsc = 0.32 params.vit_wsc = 0.32
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/camlanns_torment.lua
+++ b/scripts/actions/weaponskills/camlanns_torment.lua
@@ -16,8 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.vit_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.ignoresDef = true

--- a/scripts/actions/weaponskills/catastrophe.lua
+++ b/scripts/actions/weaponskills/catastrophe.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.agi_wsc = 0.4 params.int_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/chant_du_cygne.lua
+++ b/scripts/actions/weaponskills/chant_du_cygne.lua
@@ -16,8 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
     params.dex_wsc = 0.6
-    params.crit100 = 0.15 params.crit200 = 0.25 params.crit300 = 0.4
-    params.canCrit = true
+    params.critVaries = { 0.15, 0.25, 0.4 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/circle_blade.lua
+++ b/scripts/actions/weaponskills/circle_blade.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/combo.lua
+++ b/scripts/actions/weaponskills/combo.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/coronach.lua
+++ b/scripts/actions/weaponskills/coronach.lua
@@ -23,8 +23,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.dex_wsc = 0.4
     params.agi_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.overrideCE = 80

--- a/scripts/actions/weaponskills/crescent_moon.lua
+++ b/scripts/actions/weaponskills/crescent_moon.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 2.5
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.35
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- params.accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/cross_reaper.lua
+++ b/scripts/actions/weaponskills/cross_reaper.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 2.0 params.ftp200 = 2.25 params.ftp300 = 2.5
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3 params.mnd_wsc = 0.3
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- params.accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/dancing_edge.lua
+++ b/scripts/actions/weaponskills/dancing_edge.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1.1875 params.ftp200 = 1.1875 params.ftp300 = 1.1875
     params.dex_wsc = 0.3 params.chr_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/death_blossom.lua
+++ b/scripts/actions/weaponskills/death_blossom.lua
@@ -22,9 +22,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3
     params.mnd_wsc = 0.5
-    -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/decimation.lua
+++ b/scripts/actions/weaponskills/decimation.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/detonator.lua
+++ b/scripts/actions/weaponskills/detonator.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/dimidiation.lua
+++ b/scripts/actions/weaponskills/dimidiation.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 2.25 params.ftp200 = 4.5 params.ftp300 = 6.75
     params.dex_wsc = 0.8
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.25 params.atk200 = 1.25 params.atk300 = 1.25
     params.ignoresDef = false

--- a/scripts/actions/weaponskills/double_thrust.lua
+++ b/scripts/actions/weaponskills/double_thrust.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/dragon_kick.lua
+++ b/scripts/actions/weaponskills/dragon_kick.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3.5
     params.str_wsc = 0.5 params.vit_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.kick = true -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150

--- a/scripts/actions/weaponskills/drakesbane.lua
+++ b/scripts/actions/weaponskills/drakesbane.lua
@@ -18,13 +18,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 0.8125 params.atk200 = 0.8125 params.atk300 = 0.8125
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.4
+        params.critVaries = { 0.1, 0.25, 0.4 }
     end
 
     -- Apply Aftermath

--- a/scripts/actions/weaponskills/dulling_arrow.lua
+++ b/scripts/actions/weaponskills/dulling_arrow.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/empyreal_arrow.lua
+++ b/scripts/actions/weaponskills/empyreal_arrow.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.75 params.ftp300 = 3
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/entropy.lua
+++ b/scripts/actions/weaponskills/entropy.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 2.0
     params.int_wsc = player:getMerit(xi.merit.ENTROPY) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/evisceration.lua
+++ b/scripts/actions/weaponskills/evisceration.lua
@@ -19,8 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.dex_wsc = 0.3
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/exenterator.lua
+++ b/scripts/actions/weaponskills/exenterator.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.agi_wsc = player:getMerit(xi.merit.EXENTERATOR) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/expiacion.lua
+++ b/scripts/actions/weaponskills/expiacion.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.5
     params.str_wsc = 0.3 params.int_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/fast_blade.lua
+++ b/scripts/actions/weaponskills/fast_blade.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/fell_cleave.lua
+++ b/scripts/actions/weaponskills/fell_cleave.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.0 params.ftp200 = 2.0 params.ftp300 = 2.0
     params.str_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/final_heaven.lua
+++ b/scripts/actions/weaponskills/final_heaven.lua
@@ -18,9 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.vit_wsc = 0.6
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function params.ftp)
     params.ftp100 = 3.0 params.ftp200 = 3.0 params.ftp300 = 3.0
-    -- critical modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc) Keep 0 if ws doesn't have accuracy modification.
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/final_paradise.lua
+++ b/scripts/actions/weaponskills/final_paradise.lua
@@ -16,8 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.vit_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/flaming_arrow.lua
+++ b/scripts/actions/weaponskills/flaming_arrow.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/flat_blade.lua
+++ b/scripts/actions/weaponskills/flat_blade.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/full_break.lua
+++ b/scripts/actions/weaponskills/full_break.lua
@@ -22,7 +22,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5 params.vit_wsc = 0.5
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/full_swing.lua
+++ b/scripts/actions/weaponskills/full_swing.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 3 params.ftp300 = 5
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/gale_axe.lua
+++ b/scripts/actions/weaponskills/gale_axe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/gate_of_tartarus.lua
+++ b/scripts/actions/weaponskills/gate_of_tartarus.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.chr_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/geirskogul.lua
+++ b/scripts/actions/weaponskills/geirskogul.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.agi_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/glory_slash.lua
+++ b/scripts/actions/weaponskills/glory_slash.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3.5 params.ftp300 = 4
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/ground_strike.lua
+++ b/scripts/actions/weaponskills/ground_strike.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 3.0
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.5 params.int_wsc = 0.5
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the params.acc at those %s NOT the penalty values. Leave 0 if params.acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/guillotine.lua
+++ b/scripts/actions/weaponskills/guillotine.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 0.875 params.ftp200 = 0.875 params.ftp300 = 0.875
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.25 params.mnd_wsc = 0.25
-    -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the params.acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/hard_slash.lua
+++ b/scripts/actions/weaponskills/hard_slash.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 2.0
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3
-    -- critical mods, again in % (ONLY USE FOR params.critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/heavy_shot.lua
+++ b/scripts/actions/weaponskills/heavy_shot.lua
@@ -17,8 +17,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3.5 params.ftp200 = 3.5 params.ftp300 = 3.5
     params.agi_wsc = 0.3
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/heavy_swing.lua
+++ b/scripts/actions/weaponskills/heavy_swing.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 2.25
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/hexa_strike.lua
+++ b/scripts/actions/weaponskills/hexa_strike.lua
@@ -19,8 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.2
     params.mnd_wsc = 0.2
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/hot_shot.lua
+++ b/scripts/actions/weaponskills/hot_shot.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/howling_fist.lua
+++ b/scripts/actions/weaponskills/howling_fist.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 2.75 params.ftp300 = 3
     params.str_wsc = 0.2 params.vit_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/impulse_drive.lua
+++ b/scripts/actions/weaponskills/impulse_drive.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2.5
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/insurgency.lua
+++ b/scripts/actions/weaponskills/insurgency.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
     params.str_wsc = 0.2 params.int_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/iron_tempest.lua
+++ b/scripts/actions/weaponskills/iron_tempest.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 2 params.atk300 = 3.5
 

--- a/scripts/actions/weaponskills/jishnus_radiance.lua
+++ b/scripts/actions/weaponskills/jishnus_radiance.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
     params.dex_wsc = 0.60
-    params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
-    params.canCrit = true
+    params.critVaries = { 0.15, 0.2, 0.25 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.multiHitfTP = true

--- a/scripts/actions/weaponskills/judgment.lua
+++ b/scripts/actions/weaponskills/judgment.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 4
     params.str_wsc = 0.32 params.mnd_wsc = 0.32
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/keen_edge.lua
+++ b/scripts/actions/weaponskills/keen_edge.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
-    params.canCrit = true
+    params.critVaries = { 0.3, 0.6, 0.9 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/kings_justice.lua
+++ b/scripts/actions/weaponskills/kings_justice.lua
@@ -19,9 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1.25 params.ftp300 = 1.5
     params.str_wsc = 0.5
-    params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/knights_of_rotund.lua
+++ b/scripts/actions/weaponskills/knights_of_rotund.lua
@@ -9,8 +9,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/knights_of_round.lua
+++ b/scripts/actions/weaponskills/knights_of_round.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.str_wsc = 0.4 params.mnd_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/last_stand.lua
+++ b/scripts/actions/weaponskills/last_stand.lua
@@ -22,8 +22,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.125 params.ftp300 = 2.25
     params.agi_wsc = player:getMerit(xi.merit.LAST_STAND) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.multiHitfTP = true

--- a/scripts/actions/weaponskills/leg_sweep.lua
+++ b/scripts/actions/weaponskills/leg_sweep.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/mandalic_stab.lua
+++ b/scripts/actions/weaponskills/mandalic_stab.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.13 params.ftp300 = 2.5
     params.dex_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.66 params.atk200 = 1.66 params.atk300 = 1.66
 

--- a/scripts/actions/weaponskills/mercy_stroke.lua
+++ b/scripts/actions/weaponskills/mercy_stroke.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.str_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/metatron_torment.lua
+++ b/scripts/actions/weaponskills/metatron_torment.lua
@@ -24,8 +24,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.str_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/mistral_axe.lua
+++ b/scripts/actions/weaponskills/mistral_axe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.5 params.ftp200 = 3 params.ftp300 = 3.5
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/mordant_rime.lua
+++ b/scripts/actions/weaponskills/mordant_rime.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.dex_wsc = 0.3
     params.chr_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/mystic_boon.lua
+++ b/scripts/actions/weaponskills/mystic_boon.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.3
     params.mnd_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/namas_arrow.lua
+++ b/scripts/actions/weaponskills/namas_arrow.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.str_wsc = 0.4
     params.agi_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.overrideCE = 160

--- a/scripts/actions/weaponskills/nightmare_scythe.lua
+++ b/scripts/actions/weaponskills/nightmare_scythe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3 params.mnd_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/numbing_shot.lua
+++ b/scripts/actions/weaponskills/numbing_shot.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.agi_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/one_inch_punch.lua
+++ b/scripts/actions/weaponskills/one_inch_punch.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.vit_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     -- Defense ignored is 0%, 30%, 50% as per http://www.bg-wiki.com/bg/One_Inch_Punch

--- a/scripts/actions/weaponskills/onslaught.lua
+++ b/scripts/actions/weaponskills/onslaught.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.dex_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/penta_thrust.lua
+++ b/scripts/actions/weaponskills/penta_thrust.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 0.875 params.atk200 = 0.875 params.atk300 = 0.875
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/piercing_arrow.lua
+++ b/scripts/actions/weaponskills/piercing_arrow.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     -- Defense ignored is 0%, 35%, 50% as per wiki.bluegartr.com

--- a/scripts/actions/weaponskills/power_slash.lua
+++ b/scripts/actions/weaponskills/power_slash.lua
@@ -16,9 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.2 params.vit_wsc = 0.2
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.2 params.crit200 = 0.4 params.crit300 = 0.6
-    params.canCrit = true
+    params.critVaries = { 0.2, 0.4, 0.6 }
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/actions/weaponskills/pyrrhic_kleos.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1.5 params.ftp200 = 1.5 params.ftp300 = 1.5
     params.str_wsc = 0.2 params.dex_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/quietus.lua
+++ b/scripts/actions/weaponskills/quietus.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3.0 params.ftp200 = 3.0 params.ftp300 = 3.0
     params.str_wsc = 0.4 params.mnd_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.ignoresDef = true

--- a/scripts/actions/weaponskills/raging_axe.lua
+++ b/scripts/actions/weaponskills/raging_axe.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/raging_fists.lua
+++ b/scripts/actions/weaponskills/raging_fists.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.2 params.dex_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/raging_rush.lua
+++ b/scripts/actions/weaponskills/raging_rush.lua
@@ -18,13 +18,12 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.crit100 = 0.15
+        params.critVaries = { 0.15, 0.3, 0.5 }
         params.str_wsc = 0.5
     end
 

--- a/scripts/actions/weaponskills/rampage.lua
+++ b/scripts/actions/weaponskills/rampage.lua
@@ -18,15 +18,14 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 0.5 params.ftp200 = 0.5 params.ftp300 = 0.5
     params.str_wsc = 0.3
-    params.crit100 = 0.10 params.crit200 = 0.30 params.crit300 = 0.50
-    params.canCrit = true
+    params.critVaries = { 0.10, 0.30, 0.50 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 
     if xi.settings.main.USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
         params.str_wsc = 0.5
-        params.crit100 = 0.0 params.crit200 = 0.20 params.crit300 = 0.40
+        params.critVaries = { 0.0, 0.20, 0.40 }
         params.multiHitfTP = true
     end
 

--- a/scripts/actions/weaponskills/randgrith.lua
+++ b/scripts/actions/weaponskills/randgrith.lua
@@ -22,8 +22,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75
     params.str_wsc = 0.4 params.mnd_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/realmrazer.lua
+++ b/scripts/actions/weaponskills/realmrazer.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 7
     params.ftp100 = 0.88 params.ftp200 = 0.88 params.ftp300 = 0.88
     params.mnd_wsc = player:getMerit(xi.merit.REALMRAZER) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/refulgent_arrow.lua
+++ b/scripts/actions/weaponskills/refulgent_arrow.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 3 params.ftp200 = 4.25 params.ftp300 = 5
     params.str_wsc = 0.16
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/requiescat.lua
+++ b/scripts/actions/weaponskills/requiescat.lua
@@ -15,8 +15,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.mnd_wsc = player:getMerit(xi.merit.REQUIESCAT) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 0.8 params.atk200 = 0.9 params.atk300 = 1.0
     -- TODO: Verify the params.formless check

--- a/scripts/actions/weaponskills/resolution.lua
+++ b/scripts/actions/weaponskills/resolution.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 0.71875 params.ftp200 = 0.84375 params.ftp300 = 0.96875
     params.str_wsc = player:getMerit(xi.merit.RESOLUTION) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 0.85 params.atk200 = 0.85 params.atk300 = 0.85
     params.multiHitfTP = true

--- a/scripts/actions/weaponskills/retribution.lua
+++ b/scripts/actions/weaponskills/retribution.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
     params.str_wsc = 0.3 params.mnd_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/rudras_storm.lua
+++ b/scripts/actions/weaponskills/rudras_storm.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3.25 params.ftp200 = 4.25 params.ftp300 = 5.25
     params.dex_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/ruinator.lua
+++ b/scripts/actions/weaponskills/ruinator.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1.08 params.ftp200 = 1.08 params.ftp300 = 1.08
     params.str_wsc = player:getMerit(xi.merit.RUINATOR) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1.0 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1.1 params.atk200 = 1.1 params.atk300 = 1.1
 

--- a/scripts/actions/weaponskills/savage_blade.lua
+++ b/scripts/actions/weaponskills/savage_blade.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.75 params.ftp300 = 3.5
     params.str_wsc = 0.3 params.mnd_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/scourge.lua
+++ b/scripts/actions/weaponskills/scourge.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.mnd_wsc = 0.4 params.chr_wsc = 0.4
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shadowstitch.lua
+++ b/scripts/actions/weaponskills/shadowstitch.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.chr_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shark_bite.lua
+++ b/scripts/actions/weaponskills/shark_bite.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
     params.dex_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shattersoul.lua
+++ b/scripts/actions/weaponskills/shattersoul.lua
@@ -23,8 +23,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375
     params.int_wsc = player:getMerit(xi.merit.SHATTERSOUL) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shell_crusher.lua
+++ b/scripts/actions/weaponskills/shell_crusher.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shield_break.lua
+++ b/scripts/actions/weaponskills/shield_break.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.vit_wsc = 0.2
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/shijin_spiral.lua
+++ b/scripts/actions/weaponskills/shijin_spiral.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 5
     params.ftp100 = 1.0625 params.ftp200 = 1.0625 params.ftp300 = 1.0625
     params.dex_wsc = player:getMerit(xi.merit.SHIJIN_SPIRAL) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.05 params.atk200 = 1.05 params.atk300 = 1.05
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/shockwave.lua
+++ b/scripts/actions/weaponskills/shockwave.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3 params.mnd_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/shoulder_tackle.lua
+++ b/scripts/actions/weaponskills/shoulder_tackle.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.vit_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/sickle_moon.lua
+++ b/scripts/actions/weaponskills/sickle_moon.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.5 params.ftp200 = 2 params.ftp300 = 2.75
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.2 params.agi_wsc = 0.2
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/sidewinder.lua
+++ b/scripts/actions/weaponskills/sidewinder.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
     params.str_wsc = 0.16 params.agi_wsc = 0.25
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/skewer.lua
+++ b/scripts/actions/weaponskills/skewer.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/skullbreaker.lua
+++ b/scripts/actions/weaponskills/skullbreaker.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/slice.lua
+++ b/scripts/actions/weaponskills/slice.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 2.0
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3
-    -- critical mods, again in % (ONLY USE FOR CRITICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/slug_shot.lua
+++ b/scripts/actions/weaponskills/slug_shot.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/smash_axe.lua
+++ b/scripts/actions/weaponskills/smash_axe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/sniper_shot.lua
+++ b/scripts/actions/weaponskills/sniper_shot.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/sonic_thrust.lua
+++ b/scripts/actions/weaponskills/sonic_thrust.lua
@@ -16,8 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3.25 params.ftp300 = 3.5
     params.str_wsc = 0.3 params.dex_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/spinning_attack.lua
+++ b/scripts/actions/weaponskills/spinning_attack.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/spinning_axe.lua
+++ b/scripts/actions/weaponskills/spinning_axe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3
     params.str_wsc = 0.35
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/spinning_scythe.lua
+++ b/scripts/actions/weaponskills/spinning_scythe.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/spinning_slash.lua
+++ b/scripts/actions/weaponskills/spinning_slash.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 2.5 params.ftp200 = 3 params.ftp300 = 3.5
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.3 params.int_wsc = 0.3
-    -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- params.accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/spiral_hell.lua
+++ b/scripts/actions/weaponskills/spiral_hell.lua
@@ -16,9 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.375 params.ftp200 = 1.875 params.ftp300 = 3.625
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.5 params.int_wsc = 0.5
-    -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/spirit_taker.lua
+++ b/scripts/actions/weaponskills/spirit_taker.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.int_wsc = 0.5 params.mnd_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)

--- a/scripts/actions/weaponskills/split_shot.lua
+++ b/scripts/actions/weaponskills/split_shot.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.agi_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/stardiver.lua
+++ b/scripts/actions/weaponskills/stardiver.lua
@@ -16,8 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 0.75 params.ftp200 = 1.25 params.ftp300 = 1.75
     params.str_wsc = player:getMerit(xi.merit.STARDIVER) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/steel_cyclone.lua
+++ b/scripts/actions/weaponskills/steel_cyclone.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 3
     params.str_wsc = 0.5 params.vit_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.66 params.atk200 = 1.66 params.atk300 = 1.66
 

--- a/scripts/actions/weaponskills/stringing_pummel.lua
+++ b/scripts/actions/weaponskills/stringing_pummel.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 6
     params.ftp100 = 0.75 params.ftp200 = 0.75 params.ftp300 = 0.75
     params.str_wsc = 0.32 params.vit_wsc = 0.32
-    params.crit100 = 0.15 params.crit200 = 0.30 params.crit300 = 0.45
-    params.canCrit = true
+    params.critVaries = { 0.15, 0.30, 0.45 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/sturmwind.lua
+++ b/scripts/actions/weaponskills/sturmwind.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 2 params.atk300 = 3.5
 

--- a/scripts/actions/weaponskills/swift_blade.lua
+++ b/scripts/actions/weaponskills/swift_blade.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.5 params.ftp200 = 1.5 params.ftp300 = 1.5
     params.str_wsc = 0.3
     params.mnd_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     -- Sufficient data for ACC bonus/penalty does not exist; assuming no penalty and 10% increase per 1000 TP
     -- http://wiki.ffo.jp/html/382.html does not list ACC Bonus
     -- https://www.bg-wiki.com/ffxi/Swift_Blade does not list ACC Bonus

--- a/scripts/actions/weaponskills/tachi_ageha.lua
+++ b/scripts/actions/weaponskills/tachi_ageha.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 2.80 params.ftp200 = 2.80 params.ftp300 = 2.80
     params.chr_wsc = 0.50
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_enpi.lua
+++ b/scripts/actions/weaponskills/tachi_enpi.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_fudo.lua
+++ b/scripts/actions/weaponskills/tachi_fudo.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3.75 params.ftp200 = 4.75 params.ftp300 = 5.75
     params.str_wsc = 0.60
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 2 params.atk200 = 2 params.atk300 = 2
 

--- a/scripts/actions/weaponskills/tachi_gekko.lua
+++ b/scripts/actions/weaponskills/tachi_gekko.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.5625 params.ftp200 = 1.88 params.ftp300 = 2.5
     params.str_wsc = 0.75
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 2 params.atk200 = 2 params.atk300 = 2
 

--- a/scripts/actions/weaponskills/tachi_goten.lua
+++ b/scripts/actions/weaponskills/tachi_goten.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/tachi_hobaku.lua
+++ b/scripts/actions/weaponskills/tachi_hobaku.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_kagero.lua
+++ b/scripts/actions/weaponskills/tachi_kagero.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/tachi_kaiten.lua
+++ b/scripts/actions/weaponskills/tachi_kaiten.lua
@@ -23,8 +23,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 3 params.ftp200 = 3 params.ftp300 = 3
     params.str_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_kasha.lua
+++ b/scripts/actions/weaponskills/tachi_kasha.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.56 params.ftp200 = 1.88 params.ftp300 = 2.5
     params.str_wsc = 0.75
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.5 params.atk200 = 1.5 params.atk300 = 1.5
 

--- a/scripts/actions/weaponskills/tachi_koki.lua
+++ b/scripts/actions/weaponskills/tachi_koki.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1
     params.str_wsc = 0.5 params.mnd_wsc = 0.3
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     params.hybridWS = true

--- a/scripts/actions/weaponskills/tachi_rana.lua
+++ b/scripts/actions/weaponskills/tachi_rana.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 3
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.35
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_shoha.lua
+++ b/scripts/actions/weaponskills/tachi_shoha.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1.375 params.ftp200 = 2.1875 params.ftp300 = 2.6875
     params.str_wsc = player:getMerit(xi.merit.TACHI_SHOHA) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.375 params.atk200 = 1.375 params.atk300 = 1.375
 

--- a/scripts/actions/weaponskills/tachi_suikawari.lua
+++ b/scripts/actions/weaponskills/tachi_suikawari.lua
@@ -16,8 +16,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 1 params.ftp200 = 1.5 params.ftp300 = 2
     params.str_wsc = 0.6
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tachi_yukikaze.lua
+++ b/scripts/actions/weaponskills/tachi_yukikaze.lua
@@ -20,8 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.5625 params.ftp200 = 1.88 params.ftp300 = 2.5
     params.str_wsc = 0.75
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.33 params.atk200 = 1.33 params.atk300 = 1.33
 

--- a/scripts/actions/weaponskills/torcleaver.lua
+++ b/scripts/actions/weaponskills/torcleaver.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 4.75 params.ftp200 = 5.75 params.ftp300 = 6.5
     params.vit_wsc = 0.6
-    params.crit100 = 0.00 params.crit200 = 0.00 params.crit300 = 0.00
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/tornado_kick.lua
+++ b/scripts/actions/weaponskills/tornado_kick.lua
@@ -20,10 +20,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     -- ftp damage mods (for Damage Varies with TP lines are calculated in the function ftp)
     params.ftp100 = 2.25 params.ftp200 = 2.75 params.ftp300 = 3.5
 
-    -- critical modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc)
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
-
     -- params.accuracy modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc) Keep 0 if ws doesn't have accuracy modification.
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
 

--- a/scripts/actions/weaponskills/true_strike.lua
+++ b/scripts/actions/weaponskills/true_strike.lua
@@ -19,8 +19,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.5
-    params.crit100 = 1.0 params.crit200 = 1.0 params.crit300 = 1.0
-    params.canCrit = true
+    params.critVaries = { 1.0, 1.0, 1.0 }
     params.acc100 = 0.5 params.acc200 = 0.7 params.acc300 = 1 -- TODO: verify -- "Accuracy varies with TP" in retail. All current evidence points to that this modifier is static values, not percentages.
     params.atk100 = 2 params.atk200 = 2 params.atk300 = 2
 

--- a/scripts/actions/weaponskills/ukkos_fury.lua
+++ b/scripts/actions/weaponskills/ukkos_fury.lua
@@ -23,8 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 2
     params.ftp100 = 2 params.ftp200 = 2 params.ftp300 = 2
     params.str_wsc = 0.6
-    params.crit100 = 0.20 params.crit200 = 0.35 params.crit300 = 0.55
-    params.canCrit = true
+    params.critVaries = { 0.20, 0.35, 0.55 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/upheaval.lua
+++ b/scripts/actions/weaponskills/upheaval.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 3.5 params.ftp300 = 6.5
     params.vit_wsc = player:getMerit(xi.merit.UPHEAVAL) * 0.17
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/victory_smite.lua
+++ b/scripts/actions/weaponskills/victory_smite.lua
@@ -23,8 +23,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 2.25 params.ftp200 = 2.25 params.ftp300 = 2.25
     params.str_wsc = 0.6
-    params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.45
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.25, 0.45 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/viper_bite.lua
+++ b/scripts/actions/weaponskills/viper_bite.lua
@@ -19,8 +19,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 2 params.atk200 = 2 params.atk300 = 2
 

--- a/scripts/actions/weaponskills/vorpal_blade.lua
+++ b/scripts/actions/weaponskills/vorpal_blade.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 4
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     params.str_wsc = 0.3
-    params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
-    params.canCrit = true
+    params.critVaries = { 0.1, 0.3, 0.5 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1.0 params.atk200 = 1.0 params.atk300 = 1.0
 

--- a/scripts/actions/weaponskills/vorpal_scythe.lua
+++ b/scripts/actions/weaponskills/vorpal_scythe.lua
@@ -16,9 +16,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.ftp100 = 1.0 params.ftp200 = 1.0 params.ftp300 = 1.0
     -- wscs are in % so 0.2=20%
     params.str_wsc = 0.35
-    -- critical mods, again in % (ONLY USE FOR critICAL HIT VARIES WITH TP)
-    params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
-    params.canCrit = true
+    params.critVaries = { 0.3, 0.6, 0.9 }
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200 = 0 params.acc300 = 0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.

--- a/scripts/actions/weaponskills/vorpal_thrust.lua
+++ b/scripts/actions/weaponskills/vorpal_thrust.lua
@@ -18,8 +18,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.2 params.agi_wsc = 0.2
-    params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
-    params.canCrit = true
+    params.critVaries = { 0.3, 0.6, 0.9 }
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/wasp_sting.lua
+++ b/scripts/actions/weaponskills/wasp_sting.lua
@@ -17,8 +17,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local params = {}
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/weapon_break.lua
+++ b/scripts/actions/weaponskills/weapon_break.lua
@@ -21,8 +21,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
     params.str_wsc = 0.32 params.vit_wsc = 0.32
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 

--- a/scripts/actions/weaponskills/wheeling_thrust.lua
+++ b/scripts/actions/weaponskills/wheeling_thrust.lua
@@ -18,8 +18,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     params.numHits = 1
     params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75
     params.str_wsc = 0.5
-    params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
-    params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
     -- Defense ignored is 50%, 75%, 100% (50% at 100 TP is accurate, other values are guesses)

--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -165,7 +165,7 @@ local function getMeleeCRatio(attacker, defender, params, ignoredDef)
     return pdif, pdifcrit
 end
 
--- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
+-- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, critVaries, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
 xi.autows.doAutoPhysicalWeaponskill = function(attacker, target, wsID, tp, primaryMsg, action, taChar, wsParams, skill)
     -- Determine cratio and ccritratio
     local ignoredDef = 0
@@ -255,7 +255,7 @@ xi.autows.doAutoPhysicalWeaponskill = function(attacker, target, wsID, tp, prima
     return finaldmg, calcParams.criticalHit, calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.shadowsAbsorbed
 end
 
--- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, accBonus, weaponDamage
+-- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, critVaries, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, accBonus, weaponDamage
 xi.autows.doAutoRangedWeaponskill = function(attacker, target, wsID, wsParams, tp, primaryMsg, skill, action)
     -- Determine cratio and ccritratio
     local ignoredDef = 0

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -219,7 +219,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     params.bonusacc     = params.bonusacc == nil and 0 or params.bonusacc
 
     -- params.critchance will only be non-nil if base critchance is passed from spell lua
-    local nativecrit  = xi.combat.physical.calculateSwingCriticalRate(caster, target, false, 0, 0, 0)
+    local nativecrit  = xi.combat.physical.calculateSwingCriticalRate(caster, target)
     params.critchance = params.critchance == nil and 0 or utils.clamp(params.critchance / 100 + nativecrit, 0.05, 0.95)
 
     local cratio  = calculatecRatio(params.offcratiomod / target:getStat(xi.mod.DEF), caster:getMainLvl(), target:getMainLvl())

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -207,14 +207,14 @@ xi.combat.physical.calculateWSC = function(actor, wsSTRmod, wsDEXmod, wsVITmod, 
 end
 
 -- TP factor equation. Used to determine TP modifer across all cases of 'X varies with TP'
-xi.combat.physical.calculateTPfactor = function(actor, TP1000, TP2000, TP3000)
+xi.combat.physical.calculateTPfactor = function(actor, tpModifierTable)
     local tpFactor = 1
     local actorTP  = actor:getTP()
 
     if actorTP >= 2000 then
-        tpFactor = TP2000 + (actorTP - 2000) * (TP3000 - TP2000) / 1000
+        tpFactor = tpModifierTable[2] + (actorTP - 2000) * (tpModifierTable[3] - tpModifierTable[2]) / 1000
     elseif actorTP >= 1000 then
-        tpFactor = TP1000 + (actorTP - 1000) * (TP2000 - TP1000) / 1000
+        tpFactor = tpModifierTable[1] + (actorTP - 1000) * (tpModifierTable[2] - tpModifierTable[1]) / 1000
     end
 
     return tpFactor
@@ -600,7 +600,7 @@ xi.combat.physical.criticalRateFromFlourish = function(actor)
 end
 
 -- Critical rate master function.
-xi.combat.physical.calculateSwingCriticalRate = function(actor, target, isWeaponskill, TP1000, TP2000, TP3000)
+xi.combat.physical.calculateSwingCriticalRate = function(actor, target, optCritModTable)
     -- See reference at https://www.bg-wiki.com/ffxi/Critical_Hit_Rate
     local finalCriticalRate     = 0
     local baseCriticalRate      = 0.05
@@ -615,8 +615,8 @@ xi.combat.physical.calculateSwingCriticalRate = function(actor, target, isWeapon
     local tpFactor              = 0
 
     -- For weaponskills.
-    if isWeaponskill then
-        tpFactor = xi.combat.physical.calculateTPfactor(actor, TP1000, TP2000, TP3000)
+    if optCritModTable then
+        tpFactor = xi.combat.physical.calculateTPfactor(actor, optCritModTable)
     end
 
     -- Add all different bonuses and clamp.

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -20,18 +20,8 @@ local function getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
         ftp200  = 1,
         ftp300  = 1,
 
-        str_wsc = 0.0,
-        dex_wsc = 0.0,
-        vit_wsc = 0.0,
-        agi_wsc = 0.0,
-        int_wsc = 0.0,
-        mnd_wsc = 0.0,
-        chr_wsc = 0.0,
-
-        crit100 = 0.0,
-        crit200 = 0.0,
-        crit300 = 0.0,
-        canCrit = true,
+        -- NOTE: critVaries exists without values since while no modifier, it can crit.
+        critVaries = { 0.0, 0.0, 0.0 },
 
         acc100 = 0.0,
         acc200 = 0.0,
@@ -49,9 +39,7 @@ local function getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
     }
 
     if player:getMod(xi.mod.FORCE_JUMP_CRIT) > 0 or forceCrit then
-        params.crit100 = 1.0
-        params.crit200 = 1.0
-        params.crit300 = 1.0
+        params.critVaries = { 1.0, 1.0, 1.0 }
     end
 
     return params

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -341,7 +341,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
     then
         if not shadowAbsorb(target) then
             local critChance = math.random() -- See if we land a critical hit
-            criticalHit = (wsParams.canCrit and critChance <= calcParams.critRate) or
+            criticalHit = (wsParams.critMod and critChance <= calcParams.critRate) or
                 calcParams.forcedFirstCrit or
                 calcParams.mightyStrikesApplicable
 
@@ -497,14 +497,11 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     local ftp = xi.weaponskills.fTP(tp, wsParams.ftp100, wsParams.ftp200, wsParams.ftp300) + calcParams.bonusfTP
 
     -- Calculate critrates
-    local criticalRate = 0
-
     -- TODO: calc per-hit with weapon crit+% on each hand (if dual wielding)
-    if wsParams.canCrit then -- Work out critical hit ratios
-        criticalRate = xi.combat.physical.calculateSwingCriticalRate(attacker, target, true, wsParams.crit100, wsParams.crit200, wsParams.crit300)
+    calcParams.critRate = 0
+    if wsParams.critMod then -- Work out critical hit ratios
+        calcParams.critRate = xi.combat.physical.calculateSwingCriticalRate(attacker, target, wsParams.critMod)
     end
-
-    calcParams.critRate = criticalRate
 
     -- Start the WS
     local hitsDone                = 1

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -341,7 +341,7 @@ local function getSingleHitDamage(attacker, target, dmg, wsParams, calcParams)
     then
         if not shadowAbsorb(target) then
             local critChance = math.random() -- See if we land a critical hit
-            criticalHit = (wsParams.critMod and critChance <= calcParams.critRate) or
+            criticalHit = (wsParams.critVaries and critChance <= calcParams.critRate) or
                 calcParams.forcedFirstCrit or
                 calcParams.mightyStrikesApplicable
 
@@ -451,7 +451,7 @@ end
 -- Behavior of damage calculations can vary based on the passed in calcParams, which are determined by the calling function
 -- depending on the type of weaponskill being done, and any special cases for that weaponskill
 --
--- wsParams can contain: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300,
+-- wsParams can contain: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, critVaries,
 -- acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atk100, atk200, atk300, kick, hybridWS, hitsHigh, formless
 --
 -- See xi.weaponskills.doPhysicalWeaponskill or xi.weaponskills.doRangedWeaponskill for how calcParams are determined.
@@ -499,8 +499,8 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     -- Calculate critrates
     -- TODO: calc per-hit with weapon crit+% on each hand (if dual wielding)
     calcParams.critRate = 0
-    if wsParams.critMod then -- Work out critical hit ratios
-        calcParams.critRate = xi.combat.physical.calculateSwingCriticalRate(attacker, target, wsParams.critMod)
+    if wsParams.critVaries then -- Work out critical hit ratios
+        calcParams.critRate = xi.combat.physical.calculateSwingCriticalRate(attacker, target, wsParams.critVaries)
     end
 
     -- Start the WS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
* Removes the 4 variables used in weaponskill scripts in favor of a single 3-value table (canCrit, crit100, crit200, crit300 -> critVaries{})
* Updates all references to use this new table, and removes 0-value entries from ws's where canCrit is false
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
* Use WS that can crit
* Use WS that cannot crit
* Use ranged WS
* Use Jump

<!-- Clear and detailed steps to test your changes here -->
