### PR TITLE
monster auto-spikes adjustments

### DIFF
--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -5,11 +5,10 @@
 mixins = { require('scripts/mixins/rage') }
 -----------------------------------
 local entity = {}
--- Todo: blaze spikes effect only activates while not in casting animation
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
-    mob:addStatusEffect(xi.effect.BLAZE_SPIKES, 250, 0, 0)
+    mob:addStatusEffect(xi.effect.BLAZE_SPIKES, 200, 0, 0) -- Wiki says "180-230" and we have NO DATA! We don't know what the players conditions/gear was.
     mob:getStatusEffect(xi.effect.BLAZE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 300)
 end
@@ -33,26 +32,28 @@ entity.onMobFight = function(mob, target)
 end
 
 entity.onSpikesDamage = function(mob, target, damage)
-    local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+    -- we don't have an "isCasting()" so use getCurrentAction() instead
+    if mob:getCurrentAction() == xi.action.MAGIC_CASTING then
+        -- No spikes when mid-cast.
+        return 0, 0, 0
+    else
+        -- Again per the note above, we have no data for what the actual damage should be.
+        local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+        local dmg = damage + intDiff
+        local params = {}
+        params.bonusmab = 0
+        params.includemab = false
+        dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
+        dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
+        dmg = adjustForTarget(target, dmg, xi.element.FIRE)
+        dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
 
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
+        if dmg < 0 then
+            dmg = 0
+        end
+
+        return xi.subEffect.BLAZE_SPIKES, xi.msg.basic.SPIKES_EFFECT_DMG, dmg
     end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-    dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
-    dmg = adjustForTarget(target, dmg, xi.element.FIRE)
-    dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
-
-    if dmg < 0 then
-        dmg = 0
-    end
-
-    return xi.subEffect.BLAZE_SPIKES, xi.msg.basic.SPIKES_EFFECT_DMG, dmg
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
@@ -17,12 +17,7 @@ end
 
 entity.onSpikesDamage = function(mob, target, damage)
     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
-    end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
+    local dmg = damage + intDiff
     local params = {}
     params.bonusmab = 0
     params.includemab = false

--- a/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
@@ -6,7 +6,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
-    mob:addStatusEffect(xi.effect.ICE_SPIKES, 45, 0, 0)
+    mob:addStatusEffect(xi.effect.ICE_SPIKES, 50, 0, 0)
     mob:getStatusEffect(xi.effect.ICE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
 end
 
@@ -16,12 +16,7 @@ end
 
 entity.onSpikesDamage = function(mob, target, damage)
     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
-    end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
+    local dmg = damage + intDiff
     local params = {}
     params.bonusmab = 0
     params.includemab = false

--- a/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
@@ -6,18 +6,13 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
-    mob:addStatusEffect(xi.effect.ICE_SPIKES, 45, 0, 0)
+    mob:addStatusEffect(xi.effect.ICE_SPIKES, 50, 0, 0)
     mob:getStatusEffect(xi.effect.ICE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
 end
 
 entity.onSpikesDamage = function(mob, target, damage)
     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
-    end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
+    local dmg = damage + intDiff
     local params = {}
     params.bonusmab = 0
     params.includemab = false

--- a/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
@@ -5,10 +5,28 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    -- TODO: Revisit spikes damage for this NM after duplicate spikes issue is resolved with onSpikesDamage
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
     mob:addStatusEffect(xi.effect.BLAZE_SPIKES, 15, 0, 0)
     mob:getStatusEffect(xi.effect.BLAZE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
+end
+
+entity.onSpikesDamage = function(mob, target, damage)
+    -- "Damage" is the power of the status effect up in onMobinitialize.
+    local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+    local dmg = damage + intDiff
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(mob, xi.element.FIRE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.FIRE, 0)
+    dmg = adjustForTarget(target, dmg, xi.element.FIRE)
+    dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.FIRE, dmg)
+
+    if dmg < 0 then
+        dmg = 0
+    end
+
+    return xi.subEffect.BLAZE_SPIKES, xi.msg.basic.SPIKES_EFFECT_DMG, dmg
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/RoMaeve/mobs/Martinet.lua
+++ b/scripts/zones/RoMaeve/mobs/Martinet.lua
@@ -6,18 +6,13 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
-    mob:addStatusEffect(xi.effect.SHOCK_SPIKES, 55, 0, 0)
+    mob:addStatusEffect(xi.effect.SHOCK_SPIKES, 60, 0, 0)
     mob:getStatusEffect(xi.effect.SHOCK_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
 end
 
 entity.onSpikesDamage = function(mob, target, damage)
     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
-    end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
+    local dmg = damage + intDiff
     local params = {}
     params.bonusmab = 0
     params.includemab = false
@@ -39,7 +34,7 @@ end
 
 entity.onMobDespawn = function(mob)
     -- UpdateNMSpawnPoint(mob:getID())
-    -- mob:setRespawnTime(math.random((?), (?))) -- Uncertain repop time
+    -- mob:setRespawnTime(math.random(?, ?)) -- Uncertain repop time
 end
 
 return entity

--- a/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
@@ -6,35 +6,30 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.AUTO_SPIKES, 1)
-    mob:addStatusEffect(xi.effect.ICE_SPIKES, 45, 0, 0)
+    mob:addStatusEffect(xi.effect.ICE_SPIKES, 50, 0, 0)
     mob:getStatusEffect(xi.effect.ICE_SPIKES):setEffectFlags(xi.effectFlag.DEATH)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMod(xi.mod.ICE_MEVA, 100)
 end
 
--- TODO: Fix onSpikesDamage bug causing spikes to apply damage twice. Commented out until it is resolved.
--- entity.onSpikesDamage = function(mob, target, damage)
---     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+entity.onSpikesDamage = function(mob, target, damage)
+    -- "damage" is the power of the status effect up in onMobinitialize.
+    local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+    local dmg = damage + intDiff
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
+    dmg = adjustForTarget(target, dmg, xi.element.ICE)
+    dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
 
---     if intDiff > 20 then
---         intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
---     end
+    if dmg < 0 then
+        dmg = 0
+    end
 
---     local dmg = (damage + intDiff) * 1.3 -- INT adjustment and base damage averaged together.
---     local params = {}
---     params.bonusmab = 0
---     params.includemab = false
---     dmg = addBonusesAbility(mob, xi.element.ICE, target, dmg, params)
---     dmg = dmg * applyResistanceAddEffect(mob, target, xi.element.ICE, 0)
---     dmg = adjustForTarget(target, dmg, xi.element.ICE)
---     dmg = finalMagicNonSpellAdjustments(mob, target, xi.element.ICE, dmg)
-
---     if dmg < 0 then
---         dmg = 0
---     end
-
---     return xi.subEffect.ICE_SPIKES, xi.msg.basic.SPIKES_EFFECT_DMG, dmg
--- end
+    return xi.subEffect.ICE_SPIKES, xi.msg.basic.SPIKES_EFFECT_DMG, dmg
+end
 
 entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.ENBLIZZARD)

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
@@ -11,13 +11,9 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onSpikesDamage = function(mob, target, damage)
+    -- "damage" is the power of the status effect up in onMobinitialize.
     local intDiff = mob:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
-
-    if intDiff > 20 then
-        intDiff = 20 + (intDiff - 20) * 0.5 -- INT above 20 is half as effective.
-    end
-
-    local dmg = (damage + intDiff) * 0.5 -- INT adjustment and base damage averaged together.
+    local dmg = damage + intDiff
     local params = {}
     params.bonusmab = 0
     params.includemab = false


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Velionis should only have spikes when not casting a spell
- The issue that caused Brazen Bones code to be commented out was already corrected, so this is un-commented now
- Base powers and INT usage adjusted.

## Steps to test these changes
Slap a mob that has auto spikes. see character ask "why I hurt?" and be injured. See damage scale up/down based on player int vs mob int.

Note: we have no freaking data for any of it, its all guessed at and shitWikiSays, all of it, always has been, and a lot of what's here wasn't even sourced and past me is mainly responsible for it being used since the example I copied was where I directed others so they copied it too. The original example we all copied? No idea what it source that was from and there was no info to support any of what it did. We were even guessing what the intent was and I probably got that wrong too. I did get on retail and compare a naked lv 99 there to a naked lv 99 on this code, and its close but not perfect. **Our resists happen more often and vary more widely.**

In the future these will get refactored anyway, but  wanted to at least have better example code for newcomers in the meantime.
