### PR TITLE
Adds offset IDs for Campaign NPCs and messages

### DIFF
--- a/scripts/zones/Bastok_Markets_[S]/IDs.lua
+++ b/scripts/zones/Bastok_Markets_[S]/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.BASTOK_MARKETS_S] =
         HOMEPOINT_SET                 = 10844, -- Home point set!
         KARLOTTE_DELIVERY_DIALOG      = 10878, -- I am here to help with all your parcel delivery needs.
         WELDON_DELIVERY_DIALOG        = 10879, -- Do you have something you wish to send?
+        CAMPAIGN_RESULTS_TALLIED      = 11763, -- Campaign results tallied.
         ALLIED_SIGIL                  = 12367, -- You have received the Allied Sigil!
         SILKE_SHOP_DIALOG             = 12819, -- You wouldn't happen to be a fellow scholar, by any chance? The contents of these pages are beyond me, but perhaps you might glean something from them. They could be yours...for a nominal fee.
         KEVAN_TURN_IN                 = 13566, -- Just as we suspected. This contains a great deal of information that will prove vital to our cause. Hm, what's this? Not sure what to make of this... Doesn't seem to be terribly important. Here, why don't you hang onto it? See if you can't get some use out of it down the road.
@@ -39,7 +40,8 @@ zones[xi.zone.BASTOK_MARKETS_S] =
     },
     npc =
     {
-        SHENNI = 17134281,
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Hostarfaux_TK'), -- San, Bas, Win, Flag +4, CA
+        SHENNI              = 17134281,
     },
 }
 

--- a/scripts/zones/Batallia_Downs_[S]/IDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/IDs.lua
@@ -20,6 +20,7 @@ zones[xi.zone.BATALLIA_DOWNS_S] =
         UNABLE_TO_PROGRESS            = 7047, -- ou are unable to make further progress in Rhapsodies of Vana'diel due to an event occurring in the [Chains of Promathia/Treasures of Aht Urhgan/Wings of the Goddess/Seekers of Adoulin/Rise of the Zilart] missions.
         LYCOPODIUM_ENTRANCED          = 7068, -- The lycopodium is entranced by a sparkling light...
         FISHING_MESSAGE_OFFSET        = 7081, -- You can't fish here.
+        CAMPAIGN_RESULTS_TALLIED      = 7618, -- Campaign results tallied.
         NO_RESPONSE                   = 7703, -- There is no response...
         VOIDWALKER_DESPAWN            = 8267, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 8314, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
@@ -87,6 +88,7 @@ zones[xi.zone.BATALLIA_DOWNS_S] =
 
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Myllue_RK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Beadeaux_[S]/IDs.lua
+++ b/scripts/zones/Beadeaux_[S]/IDs.lua
@@ -15,6 +15,7 @@ zones[xi.zone.BEADEAUX_S] =
         LOGIN_CAMPAIGN_UNDERWAY       = 7002, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
+        CAMPAIGN_RESULTS_TALLIED      = 7498, -- Campaign results tallied.
         PARTY_MEMBERS_HAVE_FALLEN     = 7933, -- All party members have fallen in battle. Now leaving the battlefield.
         THE_PARTY_WILL_BE_REMOVED     = 7940, -- If all party members' HP are still zero after # minute[/s], the party will be removed from the battlefield.
     },
@@ -35,6 +36,7 @@ zones[xi.zone.BEADEAUX_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Rouquillot_TK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Castle_Oztroja_[S]/IDs.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/IDs.lua
@@ -16,6 +16,7 @@ zones[xi.zone.CASTLE_OZTROJA_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
+        CAMPAIGN_RESULTS_TALLIED      = 7598, -- Campaign results tallied.
         PARTY_MEMBERS_HAVE_FALLEN     = 8033, -- All party members have fallen in battle. Now leaving the battlefield.
         THE_PARTY_WILL_BE_REMOVED     = 8040, -- If all party members' HP are still zero after # minute[/s], the party will be removed from the battlefield.
     },
@@ -42,6 +43,7 @@ zones[xi.zone.CASTLE_OZTROJA_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Yaibroux_TK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Crawlers_Nest_[S]/IDs.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/IDs.lua
@@ -7,6 +7,7 @@ zones[xi.zone.CRAWLERS_NEST_S] =
 {
     text =
     {
+        CAMPAIGN_RESULTS_TALLIED      = 437,  -- Campaign results tallied.
         ITEM_CANNOT_BE_OBTAINED       = 6906, -- You cannot obtain the <item>. Come back after sorting your inventory.
         ITEM_OBTAINED                 = 6912, -- Obtained: <item>.
         GIL_OBTAINED                  = 6913, -- Obtained <number> gil.
@@ -27,6 +28,7 @@ zones[xi.zone.CRAWLERS_NEST_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Chefroucauld_TK') -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/East_Ronfaure_[S]/IDs.lua
+++ b/scripts/zones/East_Ronfaure_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.EAST_RONFAURE_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         LOGGING_IS_POSSIBLE_HERE      = 7158, -- Logging is possible here if you have <item>.
+        CAMPAIGN_RESULTS_TALLIED      = 7366, -- Campaign results tallied.
         FISHING_MESSAGE_OFFSET        = 7742, -- You can't fish here.
         VOIDWALKER_DESPAWN            = 8004, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 8051, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
@@ -81,7 +82,8 @@ zones[xi.zone.EAST_RONFAURE_S] =
 
     npc =
     {
-        LOGGING = GetTableOfIDs('Logging_Point'),
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Arlayse_RK'), -- San, Bas, Win, Flag +4, CA
+        LOGGING             = GetTableOfIDs('Logging_Point'),
     },
 }
 

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/IDs.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.FORT_KARUGO_NARUGO_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         SPONDULIX_SHOP_DIALOG         = 7216, -- Spondulix comes all the way from Boodlix's Emporium to help Tarutaru and Mithra. I can help you, too! You have gil, no?
+        CAMPAIGN_RESULTS_TALLIED      = 7598, -- Campaign results tallied.
         LOGGING_IS_POSSIBLE_HERE      = 7683, -- Logging is possible here if you have <item>.
         ITEM_DELIVERY_DIALOG          = 8122, -- Deliveries! We're open for business!
         COMMON_SENSE_SURVIVAL         = 9201, -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
@@ -45,6 +46,7 @@ zones[xi.zone.FORT_KARUGO_NARUGO_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Caulaise_RK'), -- San, Bas, Win, Flag +4, CA
         INDESCRIPT_MARKINGS = 17171272,
         LOGGING             = GetTableOfIDs('Logging_Point'),
     },

--- a/scripts/zones/Garlaige_Citadel_[S]/IDs.lua
+++ b/scripts/zones/Garlaige_Citadel_[S]/IDs.lua
@@ -16,6 +16,7 @@ zones[xi.zone.GARLAIGE_CITADEL_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         LYCOPODIUM_ENTRANCED          = 7068, -- The lycopodium is entranced by a sparkling light...
+        CAMPAIGN_RESULTS_TALLIED      = 7530, -- Campaign results tallied.
         COMMON_SENSE_SURVIVAL         = 8891, -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },
     mob =
@@ -23,6 +24,7 @@ zones[xi.zone.GARLAIGE_CITADEL_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Lidaise_TK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Grauberg_[S]/IDs.lua
+++ b/scripts/zones/Grauberg_[S]/IDs.lua
@@ -20,6 +20,7 @@ zones[xi.zone.GRAUBERG_S] =
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
         A_SHIVER_RUNS_DOWN            = 7431, -- A shiver runs down your spine...
         ATTEND_TO_MORE_PRESSING       = 7432, -- Perhaps you should first attend to more pressing matters...
+        CAMPAIGN_RESULTS_TALLIED      = 7598, -- Campaign results tallied.
         HARVESTING_IS_POSSIBLE_HERE   = 7699, -- Harvesting is possible here if you have <item>.
         SUITABLE_PLACE_TO_SOAK        = 8271, -- This seems to be a suitable place to soak <item>.
         MYSTERIOUS_COLUMN_ROTATES     = 8374, -- A mysterious column of floating stones rotates hypnotically before you.
@@ -50,6 +51,7 @@ zones[xi.zone.GRAUBERG_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Ulaciont_RK'), -- San, Bas, Win, Flag +4, CA
         HARVESTING          = GetTableOfIDs('Harvesting_Point'),
         INDESCRIPT_MARKINGS = 17142586,
     },

--- a/scripts/zones/Jugner_Forest_[S]/IDs.lua
+++ b/scripts/zones/Jugner_Forest_[S]/IDs.lua
@@ -19,6 +19,7 @@ zones[xi.zone.JUGNER_FOREST_S] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         LOGGING_IS_POSSIBLE_HERE      = 7081, -- Logging is possible here if you have <item>.
         YOU_FIND_NOTHING_ORDINARY     = 7121, -- You find nothing out of the ordinary.
+        CAMPAIGN_RESULTS_TALLIED      = 7289, -- Campaign results tallied.
         FISHING_MESSAGE_OFFSET        = 7374, -- You can't fish here.
         ALREADY_OBTAINED_TELE         = 7710, -- You already possess the gate crystal for this telepoint.
         YOU_FIND_SPARKLING_STONE      = 7728, -- You find a sparkling stone.
@@ -86,7 +87,8 @@ zones[xi.zone.JUGNER_FOREST_S] =
 
     npc =
     {
-        LOGGING = GetTableOfIDs('Logging_Point'),
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Roiloux_RK'), -- San, Bas, Win, Flag +4, CA
+        LOGGING             = GetTableOfIDs('Logging_Point'),
     },
 }
 

--- a/scripts/zones/La_Vaule_[S]/IDs.lua
+++ b/scripts/zones/La_Vaule_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.LA_VAULE_S] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
         GATE_IS_LOCKED                = 7207, -- The gate is locked.
+        CAMPAIGN_RESULTS_TALLIED      = 7598, -- Campaign results tallied.
         DOOR_IS_LOCKED                = 7728, -- The door is locked.
         PARTY_MEMBERS_HAVE_FALLEN     = 8033, -- All party members have fallen in battle. Now leaving the battlefield.
         THE_PARTY_WILL_BE_REMOVED     = 8040, -- If all party members' HP are still zero after # minute[/s], the party will be removed from the battlefield.
@@ -29,6 +30,7 @@ zones[xi.zone.LA_VAULE_S] =
         {
             [17125431] = 17125433, -- 375.737 0.272 -174.487
         },
+
         ASHMAKER_GOTBLUT_PH =
         {
             [17125450] = 17125452, -- 234.481 3.424 -241.751
@@ -36,6 +38,7 @@ zones[xi.zone.LA_VAULE_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Framaraix_TK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/IDs.lua
@@ -16,6 +16,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS_S] =
         LOGIN_CAMPAIGN_UNDERWAY       = 7002, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
+        CAMPAIGN_RESULTS_TALLIED      = 7518, -- Campaign results tallied.
         ALREADY_OBTAINED_TELE         = 7603, -- You already possess the gate crystal for this telepoint.
         VOIDWALKER_DESPAWN            = 7872, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 7919, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
@@ -72,6 +73,7 @@ zones[xi.zone.MERIPHATAUD_MOUNTAINS_S] =
 
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Raurart_RK'), -- San, Bas, Win, Flag +4, CA
         INDESCRIPT_MARKINGS = 17175342,
     },
 }

--- a/scripts/zones/North_Gustaberg_[S]/IDs.lua
+++ b/scripts/zones/North_Gustaberg_[S]/IDs.lua
@@ -16,6 +16,7 @@ zones[xi.zone.NORTH_GUSTABERG_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         LYCOPODIUM_ENTRANCED          = 7068, -- The lycopodium is entranced by a sparkling light...
+        CAMPAIGN_RESULTS_TALLIED      = 7282, -- Campaign results tallied.
         FISHING_MESSAGE_OFFSET        = 7367, -- You can't fish here.
         MINING_IS_POSSIBLE_HERE       = 7556, -- Mining is possible here if you have <item>.
         VOIDWALKER_DESPAWN            = 8141, -- The monster fades before your eyes, a look of disappointment on its face.
@@ -89,7 +90,8 @@ zones[xi.zone.NORTH_GUSTABERG_S] =
 
     npc =
     {
-        MINING = GetTableOfIDs('Mining_Point'),
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Estineau_RK'), -- San, Bas, Win, Flag +4, CA
+        MINING              = GetTableOfIDs('Mining_Point'),
     },
 }
 

--- a/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7158, -- You can't fish here.
+        CAMPAIGN_RESULTS_TALLIED      = 7618, -- Campaign results tallied.
         ALREADY_OBTAINED_TELE         = 7703, -- You already possess the gate crystal for this telepoint.
         VOIDWALKER_DESPAWN            = 7999, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 8046, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
@@ -96,6 +97,7 @@ zones[xi.zone.PASHHOW_MARSHLANDS_S] =
 
     npc =
     {
+        CAMPAIGN_NPC_OFFSET        = GetFirstID('Yuvalbaux_RK'), -- San, Bas, Win, Flag +4, CA
         INDESCRIPT_MARKINGS_OFFSET = 17146626,
     },
 }

--- a/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         UNABLE_TO_PROGRESS            = 7047, -- ou are unable to make further progress in Rhapsodies of Vana'diel due to an event occurring in the [Chains of Promathia/Treasures of Aht Urhgan/Wings of the Goddess/Seekers of Adoulin/Rise of the Zilart] missions.
         FISHING_MESSAGE_OFFSET        = 7081, -- You can't fish here.
+        CAMPAIGN_RESULTS_TALLIED      = 7618, -- Campaign results tallied.
         VOIDWALKER_DESPAWN            = 7993, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 8048, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
         VOIDWALKER_MOB_TOO_FAR        = 8049, -- The <keyitem> quivers ever so slightly and emits a faint light. There seem to be no monsters in the immediate vicinity.
@@ -70,6 +71,7 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
 
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Hedioste_RK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
@@ -17,6 +17,7 @@ zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
         LOGIN_NUMBER                  = 7003,  -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023,  -- Your party is unable to participate because certain members' levels are restricted.
         UNABLE_TO_PROGRESS            = 7047,  -- ou are unable to make further progress in Rhapsodies of Vana'diel due to an event occurring in the [Chains of Promathia/Treasures of Aht Urhgan/Wings of the Goddess/Seekers of Adoulin/Rise of the Zilart] missions.
+        CAMPAIGN_RESULTS_TALLIED      = 7518,  -- Campaign results tallied.
         DOOR_FIRMLY_SEALED            = 7727,  -- The door is firmly sealed.
         SURRENDER_CEREMONY_HASTE      = 8475,  -- The surrender ceremony is about to commence underground. Make haste before all is lost!
         VOIDWALKER_DESPAWN            = 8487,  -- The monster fades before your eyes, a look of disappointment on its face.
@@ -73,6 +74,7 @@ zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
 
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Alreage_RK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Southern_San_dOria_[S]/IDs.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/IDs.lua
@@ -42,6 +42,7 @@ zones[xi.zone.SOUTHERN_SAN_DORIA_S] =
         YEARS_OF_TRAINING             = 11817, -- After years of training in the Far East, I return only to find my nation burning at the hands of the infernal beastman hordes. The heathens shall pay dearly... My work has only just begun.
         FINE_WARRIOR                  = 11818, -- You have the look of a fine warrior. It is a pity you are not one of my Crimson Wolves.
         EYES_OF_THE_GODDESS           = 11819, -- The eyes of the Goddess are ever upon us. We must remain steadfast against the evils from without, as well as those from within.
+        CAMPAIGN_RESULTS_TALLIED      = 11925, -- Campaign results tallied.
         NOW_ALLIED_WITH               = 12153, -- You are now a member of the [/Knights of the Iron Ram/Republican Legion's Fourth Division/Cobra Unit]!
         ALLIED_SIGIL                  = 12928, -- You have received the Allied Sigil!
         DOOR_IS_FIRMLY_LOCKED         = 13554, -- The door is firmly locked...
@@ -61,7 +62,8 @@ zones[xi.zone.SOUTHERN_SAN_DORIA_S] =
     },
     npc =
     {
-        SHIXO = 17105699,
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Saphiriance_TK'), -- San, Bas, Win, Flag +4, CA
+        SHIXO               = 17105699,
     },
 }
 

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/IDs.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/IDs.lua
@@ -16,6 +16,7 @@ zones[xi.zone.THE_ELDIEME_NECROPOLIS_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         LAYTON_SHOP_DIALOG            = 7115, -- Might you be a student of the same field as I? If that is the case, I might be able to provide you with the proper grimoires...at a price, of course.
+        CAMPAIGN_RESULTS_TALLIED      = 7510, -- Campaign results tallied.
         SARCOPHAGUS_SEALED            = 7609, -- It is a stone sarcophagus with the lid sealed tight. It cannot be opened.
         NAMES_CARVED_ON_STONE         = 7610, -- The names of the deceased in this area are carved upon the stone.
         YOU_CAN_NOW_BECOME_A_SCHOLAR  = 7724, -- You can now become a scholar!
@@ -28,6 +29,7 @@ zones[xi.zone.THE_ELDIEME_NECROPOLIS_S] =
     },
     npc =
     {
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Renvriche_TK'), -- San, Bas, Win, Flag +4, CA
     },
 }
 

--- a/scripts/zones/Vunkerl_Inlet_[S]/IDs.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.VUNKERL_INLET_S] =
         LOGIN_NUMBER                  = 7003, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7023, -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET        = 7061, -- You can't fish here.
+        CAMPAIGN_RESULTS_TALLIED      = 7598, -- Campaign results tallied.
         COMMON_SENSE_SURVIVAL         = 9030, -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },
     mob =
@@ -31,6 +32,7 @@ zones[xi.zone.VUNKERL_INLET_S] =
     npc =
     {
         INDESCRIPT_MARKINGS = 17118008,
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Toulsard_RK'), -- RK, LC, MC, flag +4, CA
     },
 }
 

--- a/scripts/zones/West_Sarutabaruta_[S]/IDs.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.WEST_SARUTABARUTA_S] =
         HARVESTING_IS_POSSIBLE_HERE   = 7081, -- Harvesting is possible here if you have <item>.
         FISHING_MESSAGE_OFFSET        = 7088, -- You can't fish here.
         DOOR_OFFSET                   = 7446, -- The door is sealed shut...
+        CAMPAIGN_RESULTS_TALLIED      = 7788, -- Campaign results tallied.
         VOIDWALKER_DESPAWN            = 7972, -- The monster fades before your eyes, a look of disappointment on its face.
         VOIDWALKER_NO_MOB             = 8370, -- The <keyitem> quivers ever so slightly, but emits no light. There seem to be no monsters in the area.
         VOIDWALKER_MOB_TOO_FAR        = 8371, -- The <keyitem> quivers ever so slightly and emits a faint light. There seem to be no monsters in the immediate vicinity.
@@ -76,7 +77,8 @@ zones[xi.zone.WEST_SARUTABARUTA_S] =
 
     npc =
     {
-        HARVESTING = GetTableOfIDs('Harvesting_Point'),
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Madelleon_RK'), -- San, Bas, Win, Flag +4 (NOT_CAPTURED), CA
+        HARVESTING          = GetTableOfIDs('Harvesting_Point'),
     },
 }
 

--- a/scripts/zones/Windurst_Waters_[S]/IDs.lua
+++ b/scripts/zones/Windurst_Waters_[S]/IDs.lua
@@ -34,6 +34,7 @@ zones[xi.zone.WINDURST_WATERS_S] =
         DOOR_ACOLYTE_HOSTEL_LOCKED    = 11341, -- The door appears to be locked...
         MIKHE_ARYOHCHA_DIALOG         = 12478, -- Do you like the headpiece? I made it from my firrrst victim. I wear it to let everrryone know what happens when they cross Mikhe Aryohcha!
         LUTETE_DIALOG                 = 12480, -- <Yaaawn>... Mastering these Near Eastern magics can be quite taxing. If I had a choice, I'd rather be back in bed, relaxing...
+        CAMPAIGN_RESULTS_TALLIED      = 12566, -- Campaign results tallied.
         ALLIED_SIGIL                  = 12924, -- You have received the Allied Sigil!
         POGIGI_TURN_IN                = 13418, -- Just as we suspected. This contains a great deal of information that will prove vital to our cause. Hm, what's this? Not sure what to make of this... Doesn't seem to be terribly important. Here, why don't you hang onto it? See if you can't get some use out of it down the road.
         RETRIEVE_DIALOG_ID            = 14995, -- You retrieve <item> from the porter moogle's care.
@@ -45,7 +46,8 @@ zones[xi.zone.WINDURST_WATERS_S] =
     },
     npc =
     {
-        SHUVO = 17163023,
+        CAMPAIGN_NPC_OFFSET = GetFirstID('Dynause_TK'), -- San, Bas, Win, Flag +4, CA
+        SHUVO               = 17163023,
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds initial offset IDs for Campaign for the first 21 zones (Northlands excluded). The purpose of this PR is to lay down the minimal amount of offsets needed to support a basic, functional Campaign system. The system is not proposed at this time but this ID grunt work was essential for building any functionality, regardless of what form it takes.

### Mobs
Areas have mobs based on their native region, and the same 5 groups of Allies and Beastmen are present in each. Additional, area specific mobs are omitted at this stage for the sake of simplicity. The leader of each group is used as an offset and is followed by 9 or more helper mobs which are specified with their offset in the comments for each entry.

### NPCs
NPCs and flags are laid out in the following configuration for all sets of IDs. Therefore, the first entry (San d'Oria) is the only one explicitly required, and the rest can be inferred from this initial offset.
- San d'Oria NPC
- Bastok NPC
- Windurst NPC
- Flag
- Flag
- Flag
- Flag
- C.A. NPC

### Messages
As there are multiple `Tallying Campaign Results...` messages per zone, the `Campaign results tallied.` message is used as a reliable offset for important Campaign related messages: `A Campaign battle has begun.`, `The Campaign battle has ended.`, `The Beastman Confederate forces have retreated!`, `The Allied Forces of Altana have retreated...`. This dialog table pattern is consistent across over all Campaign zones.

## Steps to test these changes

I wrote a custom command to print out all of the IDs in each area, spawn the NPCs and print the special messages. This was tested across all 21 zones multiple times.
