### PR TITLE
Add Sha Wujing's lance

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -688,8 +688,9 @@ xi.mod =
 
     APPRECIATE_GYSAHL_GREENS        = 156, -- Enhances food effect of Gysahl Greens
 
-    EAT_RAW_FISH                    = 412, -- Without this, only Mithra can eat raw fish.
-    EAT_RAW_MEAT                    = 413, -- Without this, only Galka can eat raw meat.
+    EAT_RAW_FISH                    = 412, -- Without this, only Mithra can eat raw fish (item cannot be used)
+    EAT_RAW_MEAT                    = 413, -- Without this, only Galka can eat raw meat (item cannot be used)
+    DRINK_DISTILLED                 = 159, -- Without this, Distilled Water cannot be consumed (item can still be used)
 
     ENHANCES_CURSNA_RCVD            = 67,   -- Potency of "Cursna" effects received
     ENHANCES_CURSNA                 = 310,  -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove

--- a/scripts/items/flask_of_distilled_water.lua
+++ b/scripts/items/flask_of_distilled_water.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- ID: 4509
+-- Item: Flask of distilled water
+-- Item Effect: While Sha Wujing's Lance +1 is equipped:
+--   5m 1HP/tick Regen effect. Lance does not need to remain equipped after use.
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return 0
+end
+
+itemObject.onItemUse = function(target)
+    local mainWeapon = target:getEquipID(xi.slot.MAIN)
+
+    if
+        mainWeapon == xi.item.SHA_WUJINGS_LANCE_P1 and
+        not target:hasStatusEffect(xi.effect.REGEN)
+    then
+        target:addStatusEffect(xi.effect.REGEN, 1, 1, 300)
+    else
+        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    end
+end
+
+return itemObject

--- a/scripts/items/flask_of_distilled_water.lua
+++ b/scripts/items/flask_of_distilled_water.lua
@@ -11,14 +11,13 @@ itemObject.onItemCheck = function(target)
 end
 
 itemObject.onItemUse = function(target)
-    local mainWeapon = target:getEquipID(xi.slot.MAIN)
-
     if
-        mainWeapon == xi.item.SHA_WUJINGS_LANCE_P1 and
+        target:getMod(xi.mod.DRINK_DISTILLED) == 1 and
         not target:hasStatusEffect(xi.effect.REGEN)
     then
         target:addStatusEffect(xi.effect.REGEN, 1, 1, 300)
     else
+        -- Retail will consume the item while doing nothing but telling you there was no effect.
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/sha_wujings_lance_+1.lua
+++ b/scripts/items/sha_wujings_lance_+1.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+--  ID: 21868
+--  Sha Wujing's lance +1
+--  When used, you will obtain a stack of Distilled Water
+-----------------------------------
+local itemObject = {}
+
+itemObject.onItemCheck = function(target)
+    return xi.itemUtils.itemBoxOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    target:addItem(xi.item.FLASK_OF_DISTILLED_WATER, 12)
+end
+
+return itemObject

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -32486,12 +32486,14 @@ INSERT INTO `item_mods` VALUES (16873,11,5); -- AGI: 5
 INSERT INTO `item_mods` VALUES (16879,25,3); -- ACC: 3
 
 -- Calamar
-INSERT INTO `item_mods` VALUES (16882,11,2); -- AGI: 2
-INSERT INTO `item_mods` VALUES (16882,13,2); -- MND: 2
+INSERT INTO `item_mods` VALUES (16882,11,2);  -- AGI: 2
+INSERT INTO `item_mods` VALUES (16882,13,2);  -- MND: 2
+INSERT INTO `item_mods` VALUES (16882,412,1); -- EAT_RAW_FISH: 1
 
 -- Narval
 INSERT INTO `item_mods` VALUES (16884,2,15);   -- HP: 15
 INSERT INTO `item_mods` VALUES (16884,112,10); -- HEALING: 10
+INSERT INTO `item_mods` VALUES (16884,412,1);  -- EAT_RAW_FISH: 1
 
 -- Gae Bolg
 INSERT INTO `item_mods` VALUES (16885,2,10); -- HP: 10
@@ -33897,11 +33899,13 @@ INSERT INTO `item_mods` VALUES (17502,23,10); -- ATT: 10
 INSERT INTO `item_mods` VALUES (17503,9,1);  -- DEX: 1
 INSERT INTO `item_mods` VALUES (17503,11,1); -- AGI: 1
 INSERT INTO `item_mods` VALUES (17503,20,9); -- WATER_RES: 9
+INSERT INTO `item_mods` VALUES (17503,412,1); -- EAT_RAW_FISH: 1
 
 -- Pagures
 INSERT INTO `item_mods` VALUES (17504,10,3);  -- VIT: 3
 INSERT INTO `item_mods` VALUES (17504,20,11); -- WATER_RES: 11
 INSERT INTO `item_mods` VALUES (17504,25,2);  -- ACC: 2
+INSERT INTO `item_mods` VALUES (17504,412,1); -- EAT_RAW_FISH: 1
 
 -- Narasimhas Cesti
 INSERT INTO `item_mods` VALUES (17505,8,1);   -- STR: 1
@@ -35473,8 +35477,10 @@ INSERT INTO `item_mods` VALUES (18027,24,5);  -- RATT: 5
 INSERT INTO `item_mods` VALUES (18027,110,5); -- PARRY: 5
 INSERT INTO `item_mods` VALUES (18027,291,1); -- COUNTER: 1
 
--- Matrons Knife
-INSERT INTO `item_mods` VALUES (18028,9,4); -- DEX: 4
+-- Matron's Knife
+INSERT INTO `item_mods` VALUES (18028,9,4);   -- DEX: 4
+INSERT INTO `item_mods` VALUES (18028,412,1); -- EAT_RAW_FISH: 1
+INSERT INTO `item_mods` VALUES (18028,413,1); -- EAT_RAW_MEAT: 1
 
 -- Khimaira Jambiya
 INSERT INTO `item_mods` VALUES (18030,2,15); -- HP: 15
@@ -44881,6 +44887,9 @@ INSERT INTO `item_mods` VALUES (21866,9,17);     -- DEX: 17
 INSERT INTO `item_mods` VALUES (21866,10,17);    -- VIT: 17
 INSERT INTO `item_mods` VALUES (21866,23,20);    -- ATT: 20
 INSERT INTO `item_mods` VALUES (21866,163,-800); -- DMGMAGIC: -800
+
+-- Sha Wujing's lance +1
+INSERT INTO `item_mods` VALUES (21868,159,1);    -- DRINK_DISTILLED: 1
 
 -- Exalted Spear
 INSERT INTO `item_mods` VALUES (21869,8,15);    -- STR: 15
@@ -65545,6 +65554,7 @@ INSERT INTO `item_mods` VALUES (26963,160,-1000); -- DMG: -1000
 INSERT INTO `item_mods` VALUES (26963,251,90);    -- STUNRES: 90
 INSERT INTO `item_mods` VALUES (26963,288,10);    -- DOUBLE_ATTACK: 10
 INSERT INTO `item_mods` VALUES (26963,384,1600);  -- HASTE_GEAR: 1600
+INSERT INTO `item_mods` VALUES (26963,413,1);     -- EAT_RAW_MEAT: 1
 
 -- Vrikodara Jupon
 INSERT INTO `item_mods` VALUES (26969,1,135);   -- DEF: 135

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -2342,7 +2342,7 @@ INSERT INTO `item_usable` VALUES (21266,'gastraphetes',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21267,'annihilator',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21268,'death_penalty',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21269,'armageddon',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (21868,'sha_wujings_la._+1',1,3,0,0,1,30,72000,0); -- Dispenses: Distilled Water x 12 (TODO: Verify animation)
+INSERT INTO `item_usable` VALUES (21868,'sha_wujings_la._+1',1,55,0,0,1,30,72000,0); -- Dispenses: Distilled Water x 12
 -- INSERT INTO `item_usable` VALUES (22018,'seika_uchiwa_+1',1,1,55,0,1,30,300,0);  -- Enchantment: Cool Breeze
 -- INSERT INTO `item_usable` VALUES (22020,'jingly_rod_+1',1,1,55,0,1,30,3600,0);   -- Costume: lamb or Chacharoon
 INSERT INTO `item_usable` VALUES (22115,'yoichinoyumi',1,1,55,0,1,10,3600,0);

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -447,6 +447,7 @@ INSERT INTO `item_usable` VALUES (4505,'handful_of_sunflower_seeds',1,1,24,0,0,0
 INSERT INTO `item_usable` VALUES (4506,'mutton_tortilla',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4507,'rarab_meatball',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4508,'serving_of_royal_jelly',1,1,24,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4509,'flask_of_distilled_water',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4510,'acorn_cookie',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4511,'bowl_of_ambrosia',1,1,10,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4512,'bottle_of_vampire_juice',1,1,26,0,0,0,0,0);
@@ -2341,6 +2342,7 @@ INSERT INTO `item_usable` VALUES (21266,'gastraphetes',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21267,'annihilator',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21268,'death_penalty',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (21269,'armageddon',1,1,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (21868,'sha_wujings_la._+1',1,3,0,0,1,30,72000,0); -- Dispenses: Distilled Water x 12 (TODO: Verify animation)
 -- INSERT INTO `item_usable` VALUES (22018,'seika_uchiwa_+1',1,1,55,0,1,30,300,0);  -- Enchantment: Cool Breeze
 -- INSERT INTO `item_usable` VALUES (22020,'jingly_rod_+1',1,1,55,0,1,30,3600,0);   -- Costume: lamb or Chacharoon
 INSERT INTO `item_usable` VALUES (22115,'yoichinoyumi',1,1,55,0,1,10,3600,0);

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -4638,6 +4638,8 @@ INSERT INTO `item_weapon` VALUES (21863,'tzee_xicus_blade',8,0,0,0,0,2,1,480,1,0
 INSERT INTO `item_weapon` VALUES (21864,'voluspa_lance',8,0,215,215,215,1,1,492,266,0);
 INSERT INTO `item_weapon` VALUES (21865,'arasy_lance',8,0,242,242,188,1,1,492,252,0);     -- DMG:252 Delay:492
 INSERT INTO `item_weapon` VALUES (21866,'arasy_lance_+1',8,0,242,242,188,1,1,478,253,0);  -- MG:253 Delay:478
+INSERT INTO `item_weapon` VALUES (21867,'sha_wujings_lance',8,0,0,0,0,1,1,396,1,0);       -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21868,'sha_wujings_la._+1',8,0,0,0,0,1,1,385,2,0);      -- DMG:2 Delay:385
 INSERT INTO `item_weapon` VALUES (21869,'exalted_spear',8,0,228,228,188,1,1,396,258,0);   -- DMG:258 Delay:396
 INSERT INTO `item_weapon` VALUES (21870,'exalted_spear_+1',8,0,228,228,188,1,1,385,259,0); -- DMG:259 Delay:385
 INSERT INTO `item_weapon` VALUES (21871,'raetic_halberd',8,0,242,242,215,1,1,396,264,0);  -- DMG:264 Delay:396

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -857,8 +857,9 @@ enum class Mod
 
     APPRECIATE_GYSAHL_GREENS = 156, // Enhances food effect of Gysahl Greens
 
-    EAT_RAW_FISH = 412, // Without this, only Mithra can eat raw fish.
-    EAT_RAW_MEAT = 413, // Without this, only Galka can eat raw meat.
+    EAT_RAW_FISH    = 412, // Without this, only Mithra can eat raw fish (item cannot be used)
+    EAT_RAW_MEAT    = 413, // Without this, only Galka can eat raw meat (item cannot be used)
+    DRINK_DISTILLED = 159, // Without this, Distilled Water cannot be consumed (item can still be used)
 
     ENHANCES_CURSNA_RCVD     = 67,   // Potency of "Cursna" effects received
     ENHANCES_CURSNA          = 310,  // Used by gear with the "Enhances Cursna" or "Cursna+" attribute
@@ -1000,7 +1001,6 @@ enum class Mod
     //
     // SPARE IDs:
     // 141 to 143
-    // 159
     // 217 to 223
     // 273 to 280
     //


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds functionality to Sha Wujing's lance / +1 as well as distilled water.
I was not able to obtain this item in retail to gather the correct animation for use, not currently in login points
https://www.bg-wiki.com/ffxi/Sha_Wujing%27s_La._%2B1

## Steps to test these changes
Use distilled water without lance +1 equipped, get no effect message
equip lance and use another water, get regen.
use lance +1 and obtain 12 distilled waters.
