### PR TITLE
[cpp] avoid null pointer exception when checking entity

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1275,6 +1275,13 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
                                     }
                                 }
 
+                                // If everything else failed
+                                if (!entity)
+                                {
+                                    // No target entity in spawnlists found, so we're just going to skip this packet
+                                    break;
+                                }
+
                                 auto pushPacketIfInSpawnList = [&](CCharEntity* PChar, SpawnIDList_t const& spawnlist)
                                 {
                                     SpawnIDList_t::const_iterator iter = spawnlist.lower_bound(id);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a check on the pointer "entity" at line 1279 that prevents a server crash with null pointer exception.

This appears to be necessary as the switch statement at line 1294 (in the current PR) tries to use the pointer which in some (rare) case ends up being null.
This is very likely due to the fact that the pointer "entity" is declared as "nullptr" at line 1257 and then assigned the pointer returned by GetEntity (line 937) which can actually return null in some cases effectively leaving the pointer at null.

## Steps to test these changes

This has been tested in production for the past 24 hours and the issue has been resolved.
