### PR TITLE
[core] Fix shadow issue for single target ignore shadow magic spells

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1580,7 +1580,8 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
         }
 
         // TODO: this is really hacky and should eventually be moved into lua, and spellFlags should probably be in the spells table..
-        if (PSpell->canHitShadow() && aoeType == SPELLAOE_NONE && battleutils::IsAbsorbByShadow(PTarget) && !(PSpell->getFlag() & SPELLFLAG_IGNORE_SHADOWS))
+        // Also need to have IsAbsorbByShadow last in conditional because that has side effects including removing a shadow
+        if (PSpell->canHitShadow() && aoeType == SPELLAOE_NONE && !(PSpell->getFlag() & SPELLFLAG_IGNORE_SHADOWS) && battleutils::IsAbsorbByShadow(PTarget))
         {
             // take shadow
             msg                = MSGBASIC_SHADOW_ABSORB;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This fixes an issue whereby single target spells with a `SPELLFLAG_IGNORE_SHADOWS` flag will both remove a shadow and hit the player. This is because the code calls `battleutils::IsAbsorbByShadow` before the check of `SPELLFLAG_IGNORE_SHADOWS`, yet 
`battleutils::IsAbsorbByShadow` has the side effect of removing a shadow. The fix is to reverse the ordering so if the condition early terminates it will not call `battleutils::IsAbsorbByShadow`.

This is a fix from ASB coming upstream.

## Steps to test these changes
Cast a single target spell with  `SPELLFLAG_IGNORE_SHADOWS` flag on a player with shadows and note that they retain all their shadows.
