### PR TITLE
Prevent getStorageItem() on non players inside criticalRateFromFencer()

### DIFF
--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -552,6 +552,11 @@ xi.aftermath.effects =
 }
 
 xi.aftermath.addStatusEffect = function(player, tp, weaponSlot, aftermathType)
+    -- Players only!
+    if player:getObjType() ~= xi.objType.PC then
+        return
+    end
+
     local weapon = player:getStorageItem(0, 0, weaponSlot)
     if not weapon then
         return

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -565,18 +565,19 @@ end
 -- Fencer: Critical hit rate bonus when actor is only wielding with main hand.
 xi.combat.physical.criticalRateFromFencer = function(actor)
     local fencerBonus = 0
+    -- TODO: do any Trusts or mobs ever get Fencer bonuses?
 
-    local mainEquip = actor:getStorageItem(0, 0, xi.slot.MAIN)
-    local subEquip  = actor:getStorageItem(0, 0, xi.slot.SUB)
-
-    if
-        actor:getObjType() == xi.objType.PC and
-        mainEquip and
-        not mainEquip:isTwoHanded() and                                                      -- No 2 handed weapons.
-        not mainEquip:isHandToHand() and                                                     -- No 2 handed weapons.
-        (subEquip == nil or subEquip:getSkillType() == xi.skill.NONE or subEquip:isShield()) -- Only shields allowed in sub.
-    then
-        fencerBonus = actor:getMod(xi.mod.FENCER_CRITHITRATE) / 100
+    if actor:getObjType() == xi.objType.PC then
+        local mainEquip = actor:getStorageItem(0, 0, xi.slot.MAIN)
+        local subEquip  = actor:getStorageItem(0, 0, xi.slot.SUB)
+        if
+            mainEquip and
+            not mainEquip:isTwoHanded() and                                                      -- No 2 handed weapons.
+            not mainEquip:isHandToHand() and                                                     -- No 2 handed weapons.
+            (subEquip == nil or subEquip:getSkillType() == xi.skill.NONE or subEquip:isShield()) -- Only shields allowed in sub.
+        then
+            fencerBonus = actor:getMod(xi.mod.FENCER_CRITHITRATE) / 100
+        end
     end
 
     return fencerBonus


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Some trusts (mainly Naji and Ferrous Coffin, see #2751) were tripping an error about getting inventory when they do not have one. because only players have inventories. This PR moves those inside the existing object type check and the other checks follow after. 

For Naji its a check Fencer. for Ferrous its a check in Aftermath handling.

## Steps to test these changes
1. Summon Naji before applying this change: watch log error happen.
2. Rebuild server with this change. Observe Naji no longer errors. 
3. Mock the "doorman" (optional)
