### PR TITLE
[core] Convert utils.cpp "match" function to use regex for matching

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -829,14 +829,10 @@ void rtrim(std::string& s)
     // clang-format on
 }
 
-// Returns true if the given str matches the given pattern.
+// Returns true if the given str matches the given pattern using standard regex
 bool matches(std::string const& target, std::string const& pattern)
 {
-    if (std::regex_match(target, std::regex(pattern)))
-    {
-        return true;
-    }
-    return false;
+    return std::regex_match(target, std::regex(pattern));
 }
 
 bool starts_with(std::string const& target, std::string const& pattern)

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -830,60 +830,13 @@ void rtrim(std::string& s)
 }
 
 // Returns true if the given str matches the given pattern.
-// Wildcards can be used in the pattern to match "any character"
-// e.g: %anto% matches Shantotto or Canto-Ranto
-// Modification of https://www.geeksforgeeks.org/wildcard-character-matching/
-bool matches(std::string const& target, std::string const& pattern, std::string const& wildcard)
+bool matches(std::string const& target, std::string const& pattern)
 {
-    auto matchesRecur = [&](const char* target, const char* pattern, const char* wildcard, auto&& matchesRecur)
+    if (std::regex_match(target, std::regex(pattern)))
     {
-        // This should never happen as we call this lambda from std::strings converted to const char*,
-        // but good to be safe.
-        if (pattern == nullptr || target == nullptr)
-        {
-            return false;
-        }
-
-        // If we reach at the end of both strings, we are done
-        if (*pattern == '\0' && *target == '\0')
-        {
-            return true;
-        }
-
-        // Make sure to eliminate consecutive '*'
-        if (*pattern == *wildcard)
-        {
-            while (*(pattern + 1) == '*')
-            {
-                pattern++;
-            }
-        }
-
-        // Make sure that the characters after '*' are present
-        // in target string.
-        if (*pattern == *wildcard && *(pattern + 1) != '\0' && *target == '\0')
-        {
-            return false;
-        }
-
-        // If the current characters of both strings match
-        if (*pattern == *target)
-        {
-            return matchesRecur(target + 1, pattern + 1, wildcard, matchesRecur);
-        }
-
-        // If there is *, then there are two possibilities
-        // a) We consider current character of target string
-        // b) We ignore current character of target string.
-        if (*pattern == *wildcard)
-        {
-            return matchesRecur(target + 1, pattern, wildcard, matchesRecur) || matchesRecur(target, pattern + 1, wildcard, matchesRecur);
-        }
-
-        return false;
-    };
-
-    return matchesRecur(target.c_str(), pattern.c_str(), wildcard.c_str(), matchesRecur);
+        return true;
+    }
+    return false;
 }
 
 bool starts_with(std::string const& target, std::string const& pattern)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -94,7 +94,7 @@ auto to_lower(std::string const& s) -> std::string;
 auto to_upper(std::string const& s) -> std::string;
 auto trim(const std::string& str, const std::string& whitespace = " \t") -> std::string;
 void rtrim(std::string& s);
-bool matches(std::string const& target, std::string const& pattern, std::string const& wildcard = "%");
+bool matches(std::string const& target, std::string const& pattern);
 bool starts_with(std::string const& target, std::string const& pattern);
 auto replace(std::string const& target, std::string const& search, std::string const& replace) -> std::string;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Does what it says on the tin, convert utils.cpp "match" function to use regex for matching.
Also fixes a windows-only crash when using `!gotoname Rock.*` in La Theine 

## Steps to test these changes

Use `!gotoname Rock.*` in La Theine, don't crash. 
