### PR TITLE
[core] Make Enmity Cap configurable via map settings.

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -51,6 +51,12 @@ xi.settings.map =
     -- If this is the case, consider using the ah_pagination module
     AH_LIST_LIMIT = 7,
 
+    -- The total enmity cap for a given entity on the enmity table.
+    -- 30,000 is believed to be approximately current retail cap.
+    -- This directly affects a tank's ability to hold enmity over time.
+    -- The lower the value, the faster damage dealers will reach the cap and the mob will bounce.
+    ENMITY_CAP = 30000,
+
     -- Misc EXP related settings
     EXP_RATE                = 1.0,
     EXP_LOSS_RATE           = 1.0,

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -41,7 +41,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/
  ************************************************************************/
 
 CEnmityContainer::CEnmityContainer(CMobEntity* holder)
-: m_EnmityHolder(holder)
+: EnmityCap{ settings::get<int32>("map.ENMITY_CAP") }
+, m_EnmityHolder(holder)
 {
 }
 

--- a/src/map/enmity_container.h
+++ b/src/map/enmity_container.h
@@ -39,10 +39,10 @@ struct EnmityObject_t
 
 typedef std::unordered_map<uint32, EnmityObject_t> EnmityList_t;
 
-constexpr int32 EnmityCap = 30000;
-
 class CEnmityContainer
 {
+    int32 EnmityCap;
+
 public:
     CEnmityContainer(CMobEntity* holder);
     ~CEnmityContainer();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Instead of hardcoding the enmity cap, allows the setting to be both mutable and configurable.

## Steps to test these changes

Change the `ENMITY_CAP` setting in `settings/map.lua` then set multiple character's enmity values to the limit +1 and observe that they cannot receive any more enmity through actions.
