### PR TITLE
[core] Fix issue with dual wield var set to true with shield

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2063,13 +2063,17 @@ namespace charutils
                             case SKILL_KATANA:
                             case SKILL_CLUB:
                             {
-                                if (PItem->isType(ITEM_WEAPON) &&
-                                    (!charutils::hasTrait(PChar, TRAIT_DUAL_WIELD) || ((CItemWeapon*)PItem)->getSkillType() == SKILL_NONE))
+                                bool isWeapon = PItem->isType(ITEM_WEAPON);
+                                if (isWeapon && (!charutils::hasTrait(PChar, TRAIT_DUAL_WIELD) || ((CItemWeapon*)PItem)->getSkillType() == SKILL_NONE))
                                 {
                                     return false;
                                 }
                                 PChar->m_Weapons[SLOT_SUB] = (CItemWeapon*)PItem;
-                                PChar->m_dualWield         = true;
+                                // only set m_dualWield if equipping a weapon (not for example a shield)
+                                if (isWeapon)
+                                {
+                                    PChar->m_dualWield = true;
+                                }
                             }
                             break;
                             default:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue whereby for players the m_dualWield variable in battleentity is set to true when equipping a shield in the sub slot. The fix is to add a check to make sure that the item being equipped in the sub slot is a weapon before setting m_dualWield to true.

## Steps to test these changes
Equip a shield and use the existing Lua function (`player:isDualWielding()`) and see it return false
