### PR TITLE
[lua] Add event skips for optional cutscenes.

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1175,7 +1175,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
         local a6 = getArg6(player)
         local a7 = player:getCP()
 
-        player:startEvent(guardEvent, a1, 0, a3, 0, 0, a6, a7, 0)
+        player:startOptionalCutscene(guardEvent, a1, 0, a3, 0, 0, a6, a7, 0)
 
     -- CITY AND FOREIGN OVERSEERS
     elseif guardType <= xi.conquest.guard.FOREIGN then
@@ -1188,15 +1188,15 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
         local a7 = player:getCP()
         local a8 = getExForceReward(player, guardNation)
 
-        player:startEvent(guardEvent, a1, a2, a3, a4, a5, a6, a7, a8)
+        player:startOptionalCutscene(guardEvent, a1, a2, a3, a4, a5, a6, a7, a8)
 
     -- OUTPOST AND BORDER OVERSEERS
     elseif guardType >= xi.conquest.guard.OUTPOST then
         local a1 = getArg1(player, guardNation, guardType)
         if a1 == 1808 then -- non-allied nation
-            player:startEvent(guardEvent, a1, 0, 0, 0, 0, player:getRank(player:getNation()), 0, 0)
+            player:startOptionalCutscene(guardEvent, a1, 0, 0, 0, 0, player:getRank(player:getNation()), 0, 0)
         else
-            player:startEvent(guardEvent, a1, 0, 0x3F0000, 0, 0, getArg6(player), 0, 0)
+            player:startOptionalCutscene(guardEvent, a1, 0, 0x3F0000, 0, 0, getArg6(player), 0, 0)
         end
     end
 end
@@ -1430,7 +1430,7 @@ xi.conquest.vendorOnTrigger = function(player, vendorRegion, vendorEvent)
         nation = 2
     end
 
-    player:startEvent(vendorEvent, nation, fee, 0, fee, player:getCP(), 0, 0, 0)
+    player:startOptionalCutscene(vendorEvent, nation, fee, 0, fee, player:getCP(), 0, 0, 0)
 end
 
 xi.conquest.vendorOnEventUpdate = function(player, vendorRegion)

--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -235,6 +235,11 @@ xi.player.onGameIn = function(player, firstLogin, zoning)
         -- Login Campaign rewards points once daily
         xi.events.loginCampaign.onGameIn(playerArg)
     end)
+
+    -- Register listeners for event skips
+    player:addListener('ATTACKED', 'ATTACKED_EVENT_SKIP', xi.player.onTakeAction)
+    player:addListener('ABILITY_TAKE', 'ABILITY_TAKE_EVENT_SKIP', xi.player.onTakeAction)
+    player:addListener('MAGIC_TAKE', 'MAGIC_TAKE_EVENT_SKIP', xi.player.onTakeAction)
 end
 
 xi.player.onPlayerDeath = function(player)
@@ -268,6 +273,12 @@ xi.player.onPlayerEmote = function(player, emoteId)
 end
 
 xi.player.onPlayerVolunteer = function(player, text)
+end
+
+xi.player.onTakeAction = function(player)
+    if player:isInOptionalEvent() then
+        player:release()
+    end
 end
 
 return xi.player

--- a/scripts/globals/teleports/eschan_portals.lua
+++ b/scripts/globals/teleports/eschan_portals.lua
@@ -86,7 +86,7 @@ xi.escha.portals.eschanPortalOnTrigger = function(player, npc, portalGlobalNumbe
         end
     end
 
-    player:startEvent(9100, 0, portalBitMask, zoneId, portalGlobalNumber, lockValue, player:getCurrency('escha_silt'), getPortalCost(player), 0)
+    player:startOptionalCutscene(9100, 0, portalBitMask, zoneId, portalGlobalNumber, lockValue, player:getCurrency('escha_silt'), getPortalCost(player), 0)
 end
 
 xi.escha.portals.eschanPortalEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Riverne-Site_A01/globals.lua
+++ b/scripts/zones/Riverne-Site_A01/globals.lua
@@ -22,7 +22,7 @@ local riverneA01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startOptionalCutscene(event)
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/Riverne-Site_B01/globals.lua
+++ b/scripts/zones/Riverne-Site_B01/globals.lua
@@ -22,7 +22,7 @@ local riverneB01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startOptionalCutscene(event)
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/RuAun_Gardens/Zone.lua
+++ b/scripts/zones/RuAun_Gardens/Zone.lua
@@ -54,7 +54,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     if p['green'] ~= nil then -- green portal
         if player:getCharVar('skyShortcut') == 1 then
-            player:startEvent(42)
+            player:startOptionalCutscene(42)
         else
             local title = player:getTitle()
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1178,6 +1178,23 @@ bool CLuaBaseEntity::isInEvent()
 }
 
 /************************************************************************
+ *  Function: isInOptionalEvent()
+ *  Purpose : Returns true if the player is in an optional event
+ *  Example : if player:isInOptionalEvent() then
+ *  Notes   : Primarily used to "event skip" a player.
+ ************************************************************************/
+
+bool CLuaBaseEntity::isInOptionalEvent()
+{
+    if (auto player = dynamic_cast<CCharEntity*>(m_PBaseEntity))
+    {
+        return player->isInEvent() && player->currentEvent->type == EVENT_TYPE::OPTIONAL_CUTSCENE;
+    }
+
+    return false;
+}
+
+/************************************************************************
  *  Function: release()
  *  Purpose : Ends an event for a PC; releases from cutscene
  *  Example : player:release()
@@ -17152,6 +17169,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("updateEventString", CLuaBaseEntity::updateEventString);
     SOL_REGISTER("getEventTarget", CLuaBaseEntity::getEventTarget);
     SOL_REGISTER("isInEvent", CLuaBaseEntity::isInEvent);
+    SOL_REGISTER("isInOptionalEvent", CLuaBaseEntity::isInOptionalEvent);
     SOL_REGISTER("release", CLuaBaseEntity::release);
     SOL_REGISTER("startSequence", CLuaBaseEntity::startSequence);
     SOL_REGISTER("didGetMessage", CLuaBaseEntity::didGetMessage);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -93,11 +93,12 @@ public:
     void updateEvent(sol::variadic_args va);
     void updateEventString(sol::variadic_args va); // (string, string, string, string, uint32, ...)
     auto getEventTarget() -> std::optional<CLuaBaseEntity>;
-    bool isInEvent();       // Returns true if the player is in an event
-    void release();         // Stops event
-    bool startSequence();   // Flags the player as being in a sequence
-    bool didGetMessage();   // Used by interaction framework to determine if player triggered something else
-    void resetGotMessage(); // Used by interaction framework to reset if player triggered something else
+    bool isInEvent();         // Returns true if the player is in an event
+    bool isInOptionalEvent(); // Returns true if the player is in an optional event
+    void release();           // Stops event
+    bool startSequence();     // Flags the player as being in a sequence
+    bool didGetMessage();     // Used by interaction framework to determine if player triggered something else
+    void resetGotMessage();   // Used by interaction framework to reset if player triggered something else
 
     void   setFlag(uint32 flags);
     uint16 getMoghouseFlag();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds "Event Skipped" to cutscenes started with the `player:startOptionalCutscene()` lua function.

Most field/dungeon menu interactions fall under the category of being "optional", however, town menus do not.

The retail logic for being event skipped boils down to "If an action will take effect on you, then skip event".
- Taking Direct Damage *~ Damage over time effects have no effect on event skips outside of the initial application*
- Having an Ability take effect on you *~ Example: Receiving the effect of Warcry*
- Having a spell take effect on you *~ Example: Receiving a cure, protect, or bard song cast on you*

Example: Buffing Actions
![event_skipped_buffing_action](https://github.com/LandSandBoat/server/assets/121089569/82013570-01c9-4810-bf25-928a18e14766)

Example: Taking Damage
![event_skipped_taking_damage](https://github.com/LandSandBoat/server/assets/121089569/e3a315b4-a85b-487d-b6dd-cae8ade550d9)

Even with shadows, field menus are optional.
![event_skipped_shadows](https://github.com/LandSandBoat/server/assets/121089569/899195ff-f4d7-40ec-9b9e-1a02b1901638)

Town menus are not optional.
![some_menus_not_optional](https://github.com/LandSandBoat/server/assets/121089569/724d2883-6db2-4ad8-9f71-9e3e29bef422)

---

Several events have been included in this PR, but there are more that need to be fixed and updated. It's outside the scope of this PR to track down all event skippable dialogs as this aims to provide a framework for doing it.

## Steps to test these changes

Before testing, create two accounts with individual characters.

Test case 1: Taking Direct Damage
1. Teleport to Reisenjima
2. Apply Shadows, Turn on God Mode
3. Gain enmity on a Chapuli
4. Talk to the Ethereal Ingress 1 and wait to be attacked
Expected result: When attacked, you should be event skipped.

Test case 2: Receiving a spell action
1. Teleport to Reseinjima on two characters.
2. Talk to the Ethereal Ingress 1 on one character
3. On the other character, cast a spell such as Cure, Valor Minuet, Protect, etc
Expected result: When the spell lands, you should be event skipped.

Test case 3: Standard Cutscenes
1. Teleport to Mhaura on two characters.
2. Interact with either the Homepoint, Ambuscade Tome, or a Shop.
3. On the other character, cast a spell such as Cure, Valor Minuet, Protect, etc
Expected result: When the spell lands, you will not be event skipped.