### PR TITLE
[core, sql] Add damage types (such as slashing) to auto attacks of pets

### DIFF
--- a/sql/pet_list.sql
+++ b/sql/pet_list.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS `pet_list` (
   `maxLevel` tinyint(2) unsigned NOT NULL DEFAULT '0',
   `time` int(10) unsigned NOT NULL DEFAULT '0',
   `element` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `damageType` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`petid`)
 ) ENGINE=Aria TRANSACTIONAL=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -25,80 +26,86 @@ CREATE TABLE IF NOT EXISTS `pet_list` (
 -- Contenu de la table `pet_list`
 --
 
-INSERT INTO `pet_list` VALUES (0,'FireSpirit',5830,1,99,0,1);
-INSERT INTO `pet_list` VALUES (1,'IceSpirit',5831,1,99,0,2);
-INSERT INTO `pet_list` VALUES (2,'AirSpirit',5832,1,99,0,3);
-INSERT INTO `pet_list` VALUES (3,'EarthSpirit',5833,1,99,0,4);
-INSERT INTO `pet_list` VALUES (4,'ThunderSpirit',5834,1,99,0,5);
-INSERT INTO `pet_list` VALUES (5,'WaterSpirit',5835,1,99,0,6);
-INSERT INTO `pet_list` VALUES (6,'LightSpirit',5836,1,99,0,7);
-INSERT INTO `pet_list` VALUES (7,'DarkSpirit',5837,1,99,0,8);
-INSERT INTO `pet_list` VALUES (8,'Carbuncle',4588,1,99,0,7);
-INSERT INTO `pet_list` VALUES (9,'Fenrir',4581,1,99,0,8);
-INSERT INTO `pet_list` VALUES (10,'Ifrit',4582,1,99,0,1);
-INSERT INTO `pet_list` VALUES (11,'Titan',4583,1,99,0,4);
-INSERT INTO `pet_list` VALUES (12,'Leviathan',4584,1,99,0,6);
-INSERT INTO `pet_list` VALUES (13,'Garuda',4585,1,99,0,3);
-INSERT INTO `pet_list` VALUES (14,'Shiva',4586,1,99,0,2);
-INSERT INTO `pet_list` VALUES (15,'Ramuh',4587,1,99,0,5);
-INSERT INTO `pet_list` VALUES (16,'Diabolos',4590,1,99,0,8);
-INSERT INTO `pet_list` VALUES (17,'Alexander',4589,1,99,0,7);
-INSERT INTO `pet_list` VALUES (18,'Odin',4591,1,99,0,8);
-INSERT INTO `pet_list` VALUES (19,'Atomos',1,1,99,0,0);
-INSERT INTO `pet_list` VALUES (20,'Cait Sith',5775,1,99,0,7);
-INSERT INTO `pet_list` VALUES (21,'SheepFamiliar',4598,23,35,3600,0);
-INSERT INTO `pet_list` VALUES (22,'HareFamiliar',4641,23,35,5400,0);
-INSERT INTO `pet_list` VALUES (23,'CrabFamiliar',4610,23,55,1800,0);
-INSERT INTO `pet_list` VALUES (24,'CourierCarrie',4611,23,75,1800,0);
-INSERT INTO `pet_list` VALUES (25,'Homunculus',4616,23,75,3600,0);
-INSERT INTO `pet_list` VALUES (26,'FlytrapFamiliar',4619,28,40,3600,0);
-INSERT INTO `pet_list` VALUES (27,'TigerFamiliar',4604,28,40,3600,0);
-INSERT INTO `pet_list` VALUES (28,'FlowerpotBill',4602,28,40,3600,0);
-INSERT INTO `pet_list` VALUES (29,'EftFamiliar',4621,33,45,3600,0);
-INSERT INTO `pet_list` VALUES (30,'LizardFamiliar',4600,33,45,3600,0);
-INSERT INTO `pet_list` VALUES (31,'MayflyFamiliar',4596,33,45,3600,0);
-INSERT INTO `pet_list` VALUES (32,'FunguarFamiliar',4614,33,65,3600,0);
-INSERT INTO `pet_list` VALUES (33,'BeetleFamiliar',4606,38,45,3600,0);
-INSERT INTO `pet_list` VALUES (34,'AntlionFamiliar',4625,38,50,3600,0);
-INSERT INTO `pet_list` VALUES (35,'MiteFamiliar',4623,43,55,3600,0);
-INSERT INTO `pet_list` VALUES (36,'LullabyMelodia',4599,43,55,3600,0);
-INSERT INTO `pet_list` VALUES (37,'KeenearedSteffi',4595,43,55,5400,0);
-INSERT INTO `pet_list` VALUES (38,'FlowerpotBen',4603,51,63,3600,0);
-INSERT INTO `pet_list` VALUES (39,'SaberSiravarde',4605,51,63,3600,0);
-INSERT INTO `pet_list` VALUES (40,'ColdbloodComo',4601,53,65,3600,0);
-INSERT INTO `pet_list` VALUES (41,'ShellbusterOrob',4597,53,65,3600,0);
-INSERT INTO `pet_list` VALUES (42,'VoraciousAudrey',4620,53,75,3600,0);
-INSERT INTO `pet_list` VALUES (43,'AmbusherAllie',4622,58,75,3600,0);
-INSERT INTO `pet_list` VALUES (44,'LifedrinkerLars',4624,63,75,3600,0);
-INSERT INTO `pet_list` VALUES (45,'PanzerGalahad',4607,63,75,3600,0);
-INSERT INTO `pet_list` VALUES (46,'ChopsueyChucky',4626,63,85,1800,0);
-INSERT INTO `pet_list` VALUES (47,'AmigoSabotender',4618,75,85,1200,0);
-INSERT INTO `pet_list` VALUES (48,'Wyvern',5551,1,99,0,0);
-INSERT INTO `pet_list` VALUES (49,'Crafty Clyvonne',4608,76,90,7200,0);
-INSERT INTO `pet_list` VALUES (50,'Bloodclaw Shasr',4609,90,99,7200,0);
-INSERT INTO `pet_list` VALUES (51,'Lucky Lulush',4612,76,99,7200,0);
-INSERT INTO `pet_list` VALUES (52,'Fatso Fargann',4613,81,99,7200,0);
-INSERT INTO `pet_list` VALUES (53,'Discreet Louise',4615,79,99,7200,0);
-INSERT INTO `pet_list` VALUES (54,'Swift Sieghard',4617,86,94,7200,0);
-INSERT INTO `pet_list` VALUES (55,'Dipper Yuly',4627,76,99,7200,0);
-INSERT INTO `pet_list` VALUES (56,'Flowerpot Merle',4628,76,99,10800,0);
-INSERT INTO `pet_list` VALUES (57,'Nursery Nazuna',4629,76,86,7200,0);
-INSERT INTO `pet_list` VALUES (58,'Mailbuster Ceta',4630,85,95,7200,0);
-INSERT INTO `pet_list` VALUES (59,'Audacious Anna',4631,85,95,7200,0);
-INSERT INTO `pet_list` VALUES (60,'Presto Julio',4632,83,93,7200,0);
-INSERT INTO `pet_list` VALUES (61,'Bugeyed Broncha',4633,90,99,7200,0);
-INSERT INTO `pet_list` VALUES (62,'Gooey Gerard',4634,95,99,5400,0);
-INSERT INTO `pet_list` VALUES (63,'Gorefang Hobs',4635,93,99,7200,0);
-INSERT INTO `pet_list` VALUES (64,'Faithful Falcor',4636,86,99,5400,0);
-INSERT INTO `pet_list` VALUES (65,'Crude Raphie',4637,96,99,5400,0);
-INSERT INTO `pet_list` VALUES (66,'Dapper Mac',4638,76,99,7200,0);
-INSERT INTO `pet_list` VALUES (67,'Slippery Silas',4639,23,99,1800,0);
-INSERT INTO `pet_list` VALUES (68,'Turbid Toloi',4640,23,99,3600,0);
-INSERT INTO `pet_list` VALUES (69,'HarlequinFrame',5124,1,99,0,0);
-INSERT INTO `pet_list` VALUES (70,'ValoredgeFrame',5125,1,99,0,0);
-INSERT INTO `pet_list` VALUES (71,'SharpshotFrame',5126,1,99,0,0);
-INSERT INTO `pet_list` VALUES (72,'StormwakerFrame',5127,1,99,0,0);
+--    NONE      = 0,
+--    PIERCING  = 1,
+--    SLASHING  = 2,
+--    IMPACT    = 3,
+--    HTH       = 4,
+
+INSERT INTO `pet_list` VALUES (0,'FireSpirit',5830,1,99,0,1,2);
+INSERT INTO `pet_list` VALUES (1,'IceSpirit',5831,1,99,0,2,2);
+INSERT INTO `pet_list` VALUES (2,'AirSpirit',5832,1,99,0,3,2);
+INSERT INTO `pet_list` VALUES (3,'EarthSpirit',5833,1,99,0,4,2);
+INSERT INTO `pet_list` VALUES (4,'ThunderSpirit',5834,1,99,0,5,2);
+INSERT INTO `pet_list` VALUES (5,'WaterSpirit',5835,1,99,0,6,2);
+INSERT INTO `pet_list` VALUES (6,'LightSpirit',5836,1,99,0,7,2);
+INSERT INTO `pet_list` VALUES (7,'DarkSpirit',5837,1,99,0,8,2);
+INSERT INTO `pet_list` VALUES (8,'Carbuncle',4588,1,99,0,7,2);
+INSERT INTO `pet_list` VALUES (9,'Fenrir',4581,1,99,0,8,2);
+INSERT INTO `pet_list` VALUES (10,'Ifrit',4582,1,99,0,1,2);
+INSERT INTO `pet_list` VALUES (11,'Titan',4583,1,99,0,4,2);
+INSERT INTO `pet_list` VALUES (12,'Leviathan',4584,1,99,0,6,2);
+INSERT INTO `pet_list` VALUES (13,'Garuda',4585,1,99,0,3,2);
+INSERT INTO `pet_list` VALUES (14,'Shiva',4586,1,99,0,2,2);
+INSERT INTO `pet_list` VALUES (15,'Ramuh',4587,1,99,0,5,2);
+INSERT INTO `pet_list` VALUES (16,'Diabolos',4590,1,99,0,8,2);
+INSERT INTO `pet_list` VALUES (17,'Alexander',4589,1,99,0,7,2);
+INSERT INTO `pet_list` VALUES (18,'Odin',4591,1,99,0,8,2);
+INSERT INTO `pet_list` VALUES (19,'Atomos',1,1,99,0,0,2);
+INSERT INTO `pet_list` VALUES (20,'Cait Sith',5775,1,99,0,7,2);
+INSERT INTO `pet_list` VALUES (21,'SheepFamiliar',4598,23,35,3600,0,3);
+INSERT INTO `pet_list` VALUES (22,'HareFamiliar',4641,23,35,5400,0,3);
+INSERT INTO `pet_list` VALUES (23,'CrabFamiliar',4610,23,55,1800,0,3);
+INSERT INTO `pet_list` VALUES (24,'CourierCarrie',4611,23,75,1800,0,3);
+INSERT INTO `pet_list` VALUES (25,'Homunculus',4616,23,75,3600,0,3);
+INSERT INTO `pet_list` VALUES (26,'FlytrapFamiliar',4619,28,40,3600,0,3);
+INSERT INTO `pet_list` VALUES (27,'TigerFamiliar',4604,28,40,3600,0,3);
+INSERT INTO `pet_list` VALUES (28,'FlowerpotBill',4602,28,40,3600,0,3);
+INSERT INTO `pet_list` VALUES (29,'EftFamiliar',4621,33,45,3600,0,3);
+INSERT INTO `pet_list` VALUES (30,'LizardFamiliar',4600,33,45,3600,0,3);
+INSERT INTO `pet_list` VALUES (31,'MayflyFamiliar',4596,33,45,3600,0,3);
+INSERT INTO `pet_list` VALUES (32,'FunguarFamiliar',4614,33,65,3600,0,3);
+INSERT INTO `pet_list` VALUES (33,'BeetleFamiliar',4606,38,45,3600,0,3);
+INSERT INTO `pet_list` VALUES (34,'AntlionFamiliar',4625,38,50,3600,0,3);
+INSERT INTO `pet_list` VALUES (35,'MiteFamiliar',4623,43,55,3600,0,3);
+INSERT INTO `pet_list` VALUES (36,'LullabyMelodia',4599,43,55,3600,0,3);
+INSERT INTO `pet_list` VALUES (37,'KeenearedSteffi',4595,43,55,5400,0,3);
+INSERT INTO `pet_list` VALUES (38,'FlowerpotBen',4603,51,63,3600,0,3);
+INSERT INTO `pet_list` VALUES (39,'SaberSiravarde',4605,51,63,3600,0,3);
+INSERT INTO `pet_list` VALUES (40,'ColdbloodComo',4601,53,65,3600,0,3);
+INSERT INTO `pet_list` VALUES (41,'ShellbusterOrob',4597,53,65,3600,0,3);
+INSERT INTO `pet_list` VALUES (42,'VoraciousAudrey',4620,53,75,3600,0,3);
+INSERT INTO `pet_list` VALUES (43,'AmbusherAllie',4622,58,75,3600,0,3);
+INSERT INTO `pet_list` VALUES (44,'LifedrinkerLars',4624,63,75,3600,0,3);
+INSERT INTO `pet_list` VALUES (45,'PanzerGalahad',4607,63,75,3600,0,3);
+INSERT INTO `pet_list` VALUES (46,'ChopsueyChucky',4626,63,85,1800,0,3);
+INSERT INTO `pet_list` VALUES (47,'AmigoSabotender',4618,75,85,1200,0,3);
+INSERT INTO `pet_list` VALUES (48,'Wyvern',5551,1,99,0,0,2);
+INSERT INTO `pet_list` VALUES (49,'Crafty Clyvonne',4608,76,90,7200,0,2);
+INSERT INTO `pet_list` VALUES (50,'Bloodclaw Shasr',4609,90,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (51,'Lucky Lulush',4612,76,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (52,'Fatso Fargann',4613,81,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (53,'Discreet Louise',4615,79,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (54,'Swift Sieghard',4617,86,94,7200,0,2);
+INSERT INTO `pet_list` VALUES (55,'Dipper Yuly',4627,76,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (56,'Flowerpot Merle',4628,76,99,10800,0,3);
+INSERT INTO `pet_list` VALUES (57,'Nursery Nazuna',4629,76,86,7200,0,2);
+INSERT INTO `pet_list` VALUES (58,'Mailbuster Ceta',4630,85,95,7200,0,2);
+INSERT INTO `pet_list` VALUES (59,'Audacious Anna',4631,85,95,7200,0,2);
+INSERT INTO `pet_list` VALUES (60,'Presto Julio',4632,83,93,7200,0,2);
+INSERT INTO `pet_list` VALUES (61,'Bugeyed Broncha',4633,90,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (62,'Gooey Gerard',4634,95,99,5400,0,2);
+INSERT INTO `pet_list` VALUES (63,'Gorefang Hobs',4635,93,99,7200,0,2);
+INSERT INTO `pet_list` VALUES (64,'Faithful Falcor',4636,86,99,5400,0,2);
+INSERT INTO `pet_list` VALUES (65,'Crude Raphie',4637,96,99,5400,0,2);
+INSERT INTO `pet_list` VALUES (66,'Dapper Mac',4638,76,99,7200,0,3);
+INSERT INTO `pet_list` VALUES (67,'Slippery Silas',4639,23,99,1800,0,2);
+INSERT INTO `pet_list` VALUES (68,'Turbid Toloi',4640,23,99,3600,0,2);
+INSERT INTO `pet_list` VALUES (69,'HarlequinFrame',5124,1,99,0,0,3);
+INSERT INTO `pet_list` VALUES (70,'ValoredgeFrame',5125,1,99,0,0,2);
+INSERT INTO `pet_list` VALUES (71,'SharpshotFrame',5126,1,99,0,0,3);
+INSERT INTO `pet_list` VALUES (72,'StormwakerFrame',5127,1,99,0,0,3);
 -- INSERT INTO `pet_list` VALUES (73, 'AdventuringFellow', 0, 1, 99, 0, 0);
 -- 74 is Chocobo in the enum..
-INSERT INTO `pet_list` VALUES (75,'Luopan',6040,1,99,0,0);
-INSERT INTO `pet_list` VALUES (76,'Siren',7047,1,99,0,0);
+INSERT INTO `pet_list` VALUES (75,'Luopan',6040,1,99,0,0,0);
+INSERT INTO `pet_list` VALUES (76,'Siren',7047,1,99,0,0,2);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -98,7 +98,7 @@ namespace petutils
                 slash_sdt, pierce_sdt, h2h_sdt, impact_sdt, \
                 magical_sdt, fire_sdt, ice_sdt, wind_sdt, earth_sdt, lightning_sdt, water_sdt, light_sdt, dark_sdt, \
                 fire_res_rank, ice_res_rank, wind_res_rank, earth_res_rank, lightning_res_rank, water_res_rank, light_res_rank, dark_res_rank, \
-                cmbDelay, name_prefix, mob_pools.skill_list_id \
+                cmbDelay, name_prefix, mob_pools.skill_list_id, damageType \
                 FROM pet_list, mob_pools, mob_resistances, mob_family_system \
                 WHERE pet_list.poolid = mob_pools.poolid AND mob_resistances.resist_id = mob_pools.resist_id AND mob_pools.familyid = mob_family_system.familyID";
 
@@ -176,6 +176,7 @@ namespace petutils
                 Pet->cmbDelay       = (uint16)sql->GetIntData(49);
                 Pet->name_prefix    = (uint8)sql->GetUIntData(50);
                 Pet->m_MobSkillList = (uint16)sql->GetUIntData(51);
+                Pet->m_dmgType      = (DAMAGE_TYPE)sql->GetUIntData(52);
 
                 g_PPetList.emplace_back(Pet);
             }
@@ -549,6 +550,7 @@ namespace petutils
 
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setSkillType(SKILL_AUTOMATON_RANGED);
         static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_RANGED) / 9) * 2 + 3);
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_RANGED])->setDmgType(DAMAGE_TYPE::PIERCING);
 
         CAutomatonEntity* PAutomaton = static_cast<CAutomatonEntity*>(PPet);
 
@@ -1787,6 +1789,8 @@ namespace petutils
         PPet->status        = STATUS_TYPE::NORMAL;
         PPet->m_ModelRadius = PPetData->radius;
         PPet->m_EcoSystem   = PPetData->EcoSystem;
+        // set the damage type of the pet
+        static_cast<CItemWeapon*>(PPet->m_Weapons[SLOT_MAIN])->setDmgType(PPetData->m_dmgType);
 
         PMaster->PPet = PPet;
     }

--- a/src/map/utils/petutils.h
+++ b/src/map/utils/petutils.h
@@ -82,8 +82,9 @@ struct Pet_t
     float HPscale; // HP boost percentage
     float MPscale; // MP boost percentage
 
-    uint16 cmbDelay;
-    uint8  speed;
+    uint16      cmbDelay;
+    DAMAGE_TYPE m_dmgType;
+    uint8       speed;
     // stat ranks
     uint8 strRank;
     uint8 dexRank;
@@ -144,6 +145,7 @@ struct Pet_t
     , HPscale(0.f)
     , MPscale(0.f)
     , cmbDelay(0)
+    , m_dmgType(DAMAGE_TYPE::NONE)
     , speed(0)
     , strRank(0)
     , dexRank(0)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR add the appropriate damage type (slashing, blunt, etc.) to auto-attacks of pets. As this varies for different pets a column is added to the petlist.sql called damageType and then the loader extracts this and sets the pets weapon to this damage type.

The types and sources for the different pet auto-attack damage types are below:

- Avatars: slashing (Jimmayus retail testing, see his testing spreadsheet)
- Jug Pets: some blunt and some slashing (SE [update](http://forum.square-enix.com/ffxi/threads/45365-Dec-10-2014-%28JST%29-Version-Update) and [ffxi wiki](https://ffxiclopedia.fandom.com/wiki/Category:Familiars))
- Wyvern: slashing ([bg-wiki](https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)))
- Pup frames: some slashing, some blunt, and piecing for RA of Sharpshot ([bg-wiki](https://www.bg-wiki.com/ffxi/Automaton))
- Luopan: unknown so kept as none (same as without this PR)

## Steps to test these changes
Find a mob weak to for example slashing and then parse pet (for example wyvern) damage both with and without this PR. 
