### PR TITLE
Correct mistake in Gavial Cuisses row

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -3493,7 +3493,7 @@ INSERT INTO `synth_recipes` VALUES (54525,0,0,0,0,0,0,0,94,0,0,4099,4241,1395,91
 INSERT INTO `synth_recipes` VALUES (54526,0,0,0,0,0,0,0,94,0,0,4098,4240,1517,0,0,0,0,0,0,0,1458,1458,1458,1458,1,1,1,1,'Mammoth Tusk');
 INSERT INTO `synth_recipes` VALUES (54527,0,0,0,0,0,0,52,94,0,0,4099,4241,866,1629,1771,0,0,0,0,0,14823,14824,14824,14824,1,1,1,1,'Dragon Mittens');
 INSERT INTO `synth_recipes` VALUES (54528,0,0,0,0,0,0,0,95,0,0,4099,4241,850,851,851,1193,1193,1193,1193,0,13789,13790,13790,13790,1,1,1,1,'Carapace Breastplate');
-INSERT INTO `synth_recipes` VALUES (54529,0,0,0,0,0,0,255,95,0,0,4099,4241,821,1586,1587,12824,0,0,0,0,12821,14313,14313,14313,1,1,1,1,'Gavial Cuisses');  -- 2021.11.10 All agree on Bonecraft 95.  FFXIclopedia shows Leathercraft 1 where BGWiki states 1-15 and JPWiki states 5.  Implimented @ 15 to err on the side of more difficult.
+INSERT INTO `synth_recipes` VALUES (54529,0,0,0,0,0,0,15,95,0,0,4099,4241,821,1586,1587,12824,0,0,0,0,12821,14313,14313,14313,1,1,1,1,'Gavial Cuisses');  -- 2021.11.10 All agree on Bonecraft 95.  FFXIclopedia shows Leathercraft 1 where BGWiki states 1-15 and JPWiki states 5.  Implemented @ 15 to err on the side of more difficult.
 INSERT INTO `synth_recipes` VALUES (54530,0,0,0,0,0,0,0,95,0,0,4099,4241,9513,0,0,0,0,0,0,0,13789,13789,13789,13789,1,1,1,1,'Carapace Breastplate');
 INSERT INTO `synth_recipes` VALUES (54531,0,0,0,0,0,0,54,95,0,0,4099,4241,823,862,866,1841,0,0,0,0,14055,14056,14056,14056,1,1,1,1,'Unicorn Mittens');
 INSERT INTO `synth_recipes` VALUES (54532,0,0,0,0,0,0,50,95,0,0,4099,4241,506,927,1622,1680,1719,0,0,0,15309,15310,15310,15310,1,1,1,1,'Igqira Huaraches');
@@ -3504,7 +3504,7 @@ INSERT INTO `synth_recipes` VALUES (54536,0,0,0,0,0,0,53,96,0,0,4099,4241,866,16
 INSERT INTO `synth_recipes` VALUES (54537,0,0,0,0,0,0,0,96,0,0,4099,4241,1473,1473,12696,12696,0,0,0,0,12751,12717,12717,12717,1,1,1,1,'Scorpion Gauntlets');
 INSERT INTO `synth_recipes` VALUES (54538,0,0,0,0,0,0,0,96,0,0,4099,4241,851,908,908,0,0,0,0,0,12385,12386,12386,12386,1,1,1,1,'Acheron Shield');
 INSERT INTO `synth_recipes` VALUES (54539,0,0,0,0,0,0,0,96,0,0,4098,4240,5466,5466,0,0,0,0,0,0,15813,15814,15814,15814,1,1,1,1,'Trumpet Ring');
-INSERT INTO `synth_recipes` VALUES (54540,0,0,0,0,0,0,15,96,0,0,4099,4241,821,1586,2172,12824,0,0,0,0,15615,15616,15616,15616,1,1,1,1,'Hydra Cuisses');  -- 2021.11.10 All agree Bonecraft 96.  BGWiki shows 1-15 Leathercraft where JPWiki shows amateur 5.  Implimented @ 15 to err on the side of more difficult.
+INSERT INTO `synth_recipes` VALUES (54540,0,0,0,0,0,0,15,96,0,0,4099,4241,821,1586,2172,12824,0,0,0,0,15615,15616,15616,15616,1,1,1,1,'Hydra Cuisses');  -- 2021.11.10 All agree Bonecraft 96.  BGWiki shows 1-15 Leathercraft where JPWiki shows amateur 5.  Implemented @ 15 to err on the side of more difficult.
 INSERT INTO `synth_recipes` VALUES (54541,0,0,0,0,0,0,0,97,0,0,4099,4241,821,1586,1587,12696,0,0,0,0,12693,14829,14829,14829,1,1,1,1,'Gavial Finger Gauntlets');
 INSERT INTO `synth_recipes` VALUES (54542,0,0,0,0,0,0,46,97,0,0,4099,4241,506,927,1117,1618,1680,1718,0,0,14321,14322,14322,14322,1,1,1,1,'Igqira Lappas');
 INSERT INTO `synth_recipes` VALUES (54543,0,0,0,0,0,0,0,97,0,0,4099,4241,1312,12452,0,0,0,0,0,0,1394,1395,1395,1395,1,1,1,1,'Cursed Cap');
@@ -3539,7 +3539,7 @@ INSERT INTO `synth_recipes` VALUES (55002,0,0,49,37,0,0,0,101,0,0,4098,4240,651,
 INSERT INTO `synth_recipes` VALUES (55003,0,0,0,0,0,0,0,102,50,0,4098,4240,1311,1715,4154,4154,5306,0,0,0,10794,10795,10795,10795,1,1,1,1,'Blenmot\'s Ring');
 -- INSERT INTO `synth_recipes` VALUES (55004,0,0,0,0,0,0,255,102,0,0,4099,4241,830,836,8708,8982,8982,8983,8983,0,26883,26884,26884,26884,1,1,1,1,'Sombra Harness');  -- 2021.11.10 All agree on Bonecraft 102 with unknown Leathercraft and Clothcraft.
 INSERT INTO `synth_recipes` VALUES (55005,0,0,0,0,0,0,60,102,0,0,4099,4241,823,855,862,1841,1841,0,0,0,14448,14449,14449,14449,1,1,1,1,'Unicorn Harness');  -- 2021.11.10 Allakhazam, JPWiki, and BGWiki agree 102/60.  Others show unknown sub level.
-INSERT INTO `synth_recipes` VALUES (55006,0,0,0,0,0,0,27,103,0,0,4099,4241,821,850,1586,1586,1587,1587,12568,0,12565,13747,13747,13747,1,1,1,1,'Gavial Mail');  -- 2021.11.10 Allakhazam and JPWiki show no subcraft.  FFXIAH and FFXIclopedia show unknown Leathercraft sub.  BGWiki shows Leathercraft 1-27.  Implimented recipe w @ level 27.
+INSERT INTO `synth_recipes` VALUES (55006,0,0,0,0,0,0,27,103,0,0,4099,4241,821,850,1586,1586,1587,1587,12568,0,12565,13747,13747,13747,1,1,1,1,'Gavial Mail');  -- 2021.11.10 Allakhazam and JPWiki show no subcraft.  FFXIAH and FFXIclopedia show unknown Leathercraft sub.  BGWiki shows Leathercraft 1-27.  Implemented recipe w @ level 27.
 INSERT INTO `synth_recipes` VALUES (55007,0,0,0,0,0,0,0,103,0,0,4099,4241,823,850,867,885,3445,3552,0,0,10346,10347,10347,10347,1,1,1,1,'Dux Cuisses');
 INSERT INTO `synth_recipes` VALUES (55008,0,0,0,0,0,0,0,104,0,0,4099,4241,821,879,1586,1586,2172,2172,12568,0,14537,14538,14538,14538,1,1,1,1,'Hydra Mail');  -- 2021.11.09 BGWiki shows Bonecraft 104 with 1-27 Leathercraft.  FFXIclopedia and JPWiki shows no sub.
 INSERT INTO `synth_recipes` VALUES (55009,0,0,0,0,0,0,0,104,0,0,4098,4240,2654,0,0,0,0,0,0,0,2735,2735,2735,2735,1,2,3,4,'Dark Ixion Ferrule');


### PR DESCRIPTION
and also some comment typos.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Comment said gavial cuisses were set to 15, but the row still had 255. So now its 15.

## Steps to test these changes
attempt craft
