### PR TITLE
Correct tickrate of distilled water regen effect

### DIFF
--- a/scripts/items/flask_of_distilled_water.lua
+++ b/scripts/items/flask_of_distilled_water.lua
@@ -15,7 +15,7 @@ itemObject.onItemUse = function(target)
         target:getMod(xi.mod.DRINK_DISTILLED) == 1 and
         not target:hasStatusEffect(xi.effect.REGEN)
     then
-        target:addStatusEffect(xi.effect.REGEN, 1, 1, 300)
+        target:addStatusEffect(xi.effect.REGEN, 1, 3, 300)
     else
         -- Retail will consume the item while doing nothing but telling you there was no effect.
         target:messageBasic(xi.msg.basic.NO_EFFECT)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I missed this in the PR that added it. It should be 100hp over the span of 5min, at 1 hp per 3 seconds. We were giving 3x that by ticking 3x faster. Or we _would have_ except minimum tickrate was enforced in core (nothing can tick faster than 3 seconds as part of an older bugfix by DSP). Still, we should have the script correct.

## Steps to test these changes
1. set HP lower than max by more than 100.
2. Equp Sh Wujin lance +1, drink distilled water
3. notice no real changes do to the aforementioned minimum tickrate, but you will have recovered 100hp
