### PR TITLE
[core] Fix several pet issues with charming and moving

### DIFF
--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -31,7 +31,7 @@ CPetController::CPetController(CPetEntity* _PPet)
 : CMobController(_PPet)
 , PPet(_PPet)
 {
-    //#TODO: this probably will have to depend on pet type (automaton does WS on its own..)
+    // #TODO: this probably will have to depend on pet type (automaton does WS on its own..)
     SetWeaponSkillEnabled(false);
 }
 
@@ -50,9 +50,15 @@ void CPetController::Tick(time_point tick)
 
 void CPetController::DoRoamTick(time_point tick)
 {
-    if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive())
+    if ((PPet->PMaster == nullptr || PPet->PMaster->isDead()) && PPet->isAlive() && PPet->objtype != TYPE_MOB)
     {
         PPet->Die();
+        return;
+    }
+
+    // if pet cannot change state (for example because pet is asleep) then just return
+    if (!PPet->PAI->CanChangeState())
+    {
         return;
     }
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1259,6 +1259,8 @@ namespace petutils
                 if (PMob->PEnmityContainer->IsWithinEnmityRange(PMob->PMaster))
                 {
                     PMob->PEnmityContainer->UpdateEnmity(PChar, 0, 0);
+                    // need to set battle target to prevent mob enmity clear if in attack state when uncharming
+                    PMob->SetBattleTargetID(PChar->targid);
                 }
                 else
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several small pet issues:
1. Fixes an issue where charmed mobs would die if the player died. With this PR the mobs now just revert to normal mobs (like if the player used leave).
3. Fixes an issue where if the pet decharms while attacking another mob the pet would not attack the player and if far from home it would despawn (see a more detailed explanation at https://github.com/AirSkyBoat/AirSkyBoat/pull/2969). This PR fixes by setting the player as battle target right away when adding the enmity.
5. Fixes an issue whereby pets with a status effect such as sleep would still move around and follow their master. This PR adds a check (with `PPet->PAI->CanChangeState()`) to prevent this.

These are all ASB fixes coming upstream.

## Steps to test these changes
1. Charm a mob, then do !hp 0 to yourself and see that the mob does not die
2. Charm a mob and have it fight another mob, wait until it decharms due to charm timer being up, watch mob start to attack the player rather than just stand there or despawn.
3. Call wyvern, add sleep status effect to wyvern, walk away and watch wyvern stay put until it wakes up.
