### PR TITLE
Fix incorrect table reference for wsc mods

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -406,7 +406,7 @@ local function calculateWsMods(attacker, calcParams, wsParams)
     local wsMods = 0
 
     for parameterName, modList in pairs(modParameters) do
-        local paramValue = calcParams[parameterName] and calcParams[parameterName] or 0
+        local paramValue = wsParams[parameterName] and wsParams[parameterName] or 0
 
         wsMods = wsMods + attacker:getStat(modList[1]) * paramValue
     end
@@ -871,7 +871,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
         end
 
         for parameterName, modList in pairs(modParameters) do
-            local paramValue = calcParams[parameterName] and calcParams[parameterName] or 0
+            local paramValue = wsParams[parameterName] and wsParams[parameterName] or 0
 
             dmg = dmg + attacker:getStat(modList[1]) * paramValue
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Incorrectly used calcParams table instead of wsParams for wsc variables which caused mods to never be applied.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Weaponskills should apply their appropriate stat mod increases
<!-- Clear and detailed steps to test your changes here -->
