### PR TITLE
Add fence color option  to ObjectiveUtility

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11189,7 +11189,8 @@ void CLuaBaseEntity::countdown(sol::object const& secondsObj)
             fence = {
                 pos = {x = 0.000, y = 0.000}, -- center of fence
                 radius = 25.00, -- radius from pos in yalms
-                render = 25.00 -- distance from fence it becomes visible
+                render = 25.00, -- distance from fence it becomes visible
+                blue = true -- optional, turns default red fence bars blue
             },
             help = {
                 title = 1, -- string index from ROM\333\16.DAT
@@ -11259,13 +11260,19 @@ void CLuaBaseEntity::objectiveUtility(sol::object const& obj)
         if (fenceObj.valid() && fenceObj.is<sol::table>())
         {
             sol::object fencePosObj = fenceObj.as<sol::table>()["pos"];
+            float       posX        = 0.000;
+            float       posY        = 0.000;
+            if (fencePosObj.valid() && fencePosObj.is<sol::table>())
+            {
+                posX = fencePosObj.as<sol::table>().get<float>("x");
+                posY = fencePosObj.as<sol::table>().get<float>("y");
+            }
 
-            float posX   = fencePosObj.as<sol::table>().get_or<float>("x", 0.000);
-            float posY   = fencePosObj.as<sol::table>().get_or<float>("y", 0.000);
             float radius = fenceObj.as<sol::table>().get_or<float>("radius", 0.00);
             float render = fenceObj.as<sol::table>().get_or<float>("render", 25.00);
+            bool  blue   = fenceObj.as<sol::table>()["blue"].valid() ? fenceObj.as<sol::table>()["blue"].get<bool>() : false;
 
-            packet->addFence(posX, posY, radius, render);
+            packet->addFence(posX, posY, radius, render, blue);
         }
 
         sol::object helpObj = obj.as<sol::table>()["help"];

--- a/src/map/packets/objective_utility.cpp
+++ b/src/map/packets/objective_utility.cpp
@@ -9,7 +9,7 @@ CObjectiveUtilityPacket::CObjectiveUtilityPacket()
     this->setType(0x75);
     this->setSize(0xAC);
 
-    // ref<uint8>(0x25) = ; // Flags value with multiple usages.
+    // ref<uint8>(0x26) = ; // Unknown. Flags value with multiple usages.
 }
 
 void CObjectiveUtilityPacket::addCountdown(uint32 duration, uint32 warning /* = 0 */)
@@ -39,14 +39,14 @@ void CObjectiveUtilityPacket::addBars(std::vector<std::pair<std::string, uint32>
     }
 }
 
-void CObjectiveUtilityPacket::addFence(float x, float y, float radius, float render)
+void CObjectiveUtilityPacket::addFence(float x, float y, float radius, float render, bool blue /* = false */)
 {
     ref<int32>(0x14)  = static_cast<int32>(x * 1000);
     ref<int32>(0x18)  = static_cast<int32>(y * 1000);
     ref<uint32>(0x1C) = static_cast<uint32>(radius * 1000);
     ref<uint32>(0x20) = static_cast<uint32>(render * 1000);
     ref<uint8>(0x24) |= OBJECTIVEUTILITY_FENCE;
-    // ref<uint8>(0x26) = ; // Flags value with multiple usages.
+    ref<bool>(0x25) = blue; // Changes the color of the fence from red to blue.
 }
 
 void CObjectiveUtilityPacket::addHelpText(uint16 title, uint16 description)

--- a/src/map/packets/objective_utility.h
+++ b/src/map/packets/objective_utility.h
@@ -22,7 +22,7 @@ public:
 
     void addCountdown(uint32 duration, uint32 warning = 0);
     void addBars(std::vector<std::pair<std::string, uint32>>&& bars);
-    void addFence(float x, float y, float radius, float render);
+    void addFence(float x, float y, float radius, float render, bool blue = false);
     void addHelpText(uint16 title, uint16 description);
 };
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a toggle to turn the fence from red (default) to blue (seemingly only used during DI).

## Steps to test these changes

With a level 4 or higher GM in game:
```
!zone 210
!exec player:objectiveUtility({fence={radius=25,blue=true}})
!exec player:objectiveUtility({fence={radius=25}})
```
![image](https://github.com/LandSandBoat/server/assets/2593549/3d5fcb91-9b6f-4728-b1f0-94fc9d6962a0)
![image](https://github.com/LandSandBoat/server/assets/2593549/c2aa169d-a0a0-4550-9d6a-4ffd0039eb62)
