### PR TITLE
[core] Prevent relic weapon extra damage procs on additional hits (such as DA)

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -547,7 +547,7 @@ void CAttack::ProcessDamage()
 
     // Get damage multipliers.
     m_damage =
-        attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot);
+        attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot, m_isFirstSwing);
 
     // Apply Sneak Attack Augment Mod
     if (m_attacker->getMod(Mod::AUGMENTS_SA) > 0 && m_trickAttackDamage > 0 && m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_SNEAK_ATTACK))

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1794,15 +1794,6 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
 
                 if (slot == SLOT_RANGED)
                 {
-                    if (state.IsRapidShot())
-                    {
-                        damage = attackutils::CheckForDamageMultiplier(this, PItem, damage, PHYSICAL_ATTACK_TYPE::RAPID_SHOT, SLOT_RANGED);
-                    }
-                    else
-                    {
-                        damage = attackutils::CheckForDamageMultiplier(this, PItem, damage, PHYSICAL_ATTACK_TYPE::RANGED, SLOT_RANGED);
-                    }
-
                     if (PItem != nullptr)
                     {
                         charutils::TrySkillUP(this, (SKILLTYPE)PItem->getSkillType(), PTarget->GetMLevel());
@@ -1866,6 +1857,11 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             actionTarget.speceffect = SPECEFFECT::CRITICAL_HIT;
         }
 
+        if (slot == SLOT_RANGED)
+        {
+            auto attackType = (state.IsRapidShot()) ? PHYSICAL_ATTACK_TYPE::RAPID_SHOT : PHYSICAL_ATTACK_TYPE::RANGED;
+            totalDamage     = attackutils::CheckForDamageMultiplier(this, PItem, totalDamage, attackType, true);
+        }
         actionTarget.param =
             battleutils::TakePhysicalDamage(this, PTarget, PHYSICAL_ATTACK_TYPE::RANGED, totalDamage, false, slot, realHits, nullptr, true, true);
 

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -262,7 +262,7 @@ namespace attackutils
      *  Check for damage multiplier, relic weapons etc.                      *
      *                                                                       *
      ************************************************************************/
-    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot)
+    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weaponSlot, bool allowRelicOccDamageProc)
     {
         if (PWeapon == nullptr)
         {
@@ -294,25 +294,28 @@ namespace attackutils
         float occ_extra_dmg        = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::OCC_DO_EXTRA_DMG) / 100.f;
         int16 occ_extra_dmg_chance = battleutils::GetScaledItemModifier(PChar, PWeapon, Mod::EXTRA_DMG_CHANCE) / 10;
 
-        if (occ_extra_dmg > 3.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+        if (allowRelicOccDamageProc)
         {
-            return (uint32)(damage * occ_extra_dmg);
-        }
-        else if (occ_do_triple_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_triple_dmg)
-        {
-            return (uint32)(damage * 3.f);
-        }
-        else if (occ_extra_dmg > 2.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
-        {
-            return (uint32)(damage * occ_extra_dmg);
-        }
-        else if (occ_do_double_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_double_dmg)
-        {
-            return (uint32)(damage * 2.f);
-        }
-        else if (occ_extra_dmg > 0 && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
-        {
-            return (uint32)(damage * occ_extra_dmg);
+            if (occ_extra_dmg > 3.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
+            else if (occ_do_triple_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_triple_dmg)
+            {
+                return (uint32)(damage * 3.f);
+            }
+            else if (occ_extra_dmg > 2.f && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
+            else if (occ_do_double_dmg > 0 && xirand::GetRandomNumber(100) <= occ_do_double_dmg)
+            {
+                return (uint32)(damage * 2.f);
+            }
+            else if (occ_extra_dmg > 0 && occ_extra_dmg_chance > 0 && xirand::GetRandomNumber(100) <= occ_extra_dmg_chance)
+            {
+                return (uint32)(damage * occ_extra_dmg);
+            }
         }
 
         switch (attackType)

--- a/src/map/utils/attackutils.h
+++ b/src/map/utils/attackutils.h
@@ -33,7 +33,7 @@ enum class PHYSICAL_ATTACK_TYPE;
 namespace attackutils
 {
     uint8  getHitCount(uint8 hits); // The multihit calculator.
-    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weapnSlot);
+    uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32 damage, PHYSICAL_ATTACK_TYPE attackType, uint8 weapnSlot, bool allowRelicOccDamageProc = false);
 
     bool IsParried(CBattleEntity* PAttacker, CBattleEntity* PDefender); // Is the attack parried.
     bool IsGuarded(CBattleEntity* PAttacker, CBattleEntity* PDefender); // Is the attack guarded.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes an issue whereby relic weapons incorrectly had a chance to proc extra damage (2-3x depending on the relic) on every hit (on a triple attack for example). Wikis (see [here](https://www.bg-wiki.com/ffxi/Mandau_(Level_75))) and I think retail testing (by Siknoz) shows that relic weapons should only be able to proc on the first hit of a given attack round. 

The PR also moves the extra damage proc for barrage to the total barrage damage rather than on each barrage hit. This gives the same estimated total damage over time but when it does proc it shows large spikes (and more regular barrages) as seen on retail.

## Steps to test these changes
Use a relic weapon, set the extra damage proc rate at 100%, set player to have 100% double attack or triple attack, watch that relic procs only occur on the first hit of an attack round.

Use a relic bow, set the extra damage proc rate at like 10%, and see the large spikes followed by normal barrages (as compared to previously with more frequent medium damage barrages).
