### PR TITLE
Return out of SmallPacket0x00A when tripping nullptr check

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -302,9 +302,10 @@ void SmallPacket0x00A(map_session_data_t* const PSession, CCharEntity* const PCh
         if (destination >= MAX_ZONEID || destZone == nullptr)
         {
             // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
-            ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone out of range: %d", destination);
+            ShowWarning("packet_system::SmallPacket0x00A player tried to enter zone that was invalid or out of range");
             ShowWarning("packet_system::SmallPacket0x00A dumping player `%s` to homepoint!", PChar->getName());
             charutils::HomePoint(PChar);
+            return;
         }
 
         destZone->IncreaseZoneCounter(PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
May or may not fix  #5156 I can't tell as I couldn't get the crash to happen at all in the 1st place

## Steps to test these changes
Uncertain, could not reproduce but seems like a return should be here. The line the crash occurs on is immediately following this - perhaps its depends on how fast the homepoint call processes, perhaps this is entirely unrelated.
