### PR TITLE
Fix gilfinder to distribute gil equally to party

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3957,12 +3957,23 @@ namespace charutils
             // all members might not be in range
             if (!members.empty())
             {
-                // distribute gil
-                int32 gilPerPerson = static_cast<int32>(gil / members.size());
-                for (auto* PMember : members)
+                // Check for highest gilfinder tier
+                uint16 gilFinderActive = 0;
+
+                for (auto PMember : members)
                 {
-                    // Check for gilfinder
-                    gilPerPerson += gilPerPerson * PMember->getMod(Mod::GILFINDER) / 100;
+                    if (PMember->getMod(Mod::GILFINDER) > gilFinderActive)
+                    {
+                        gilFinderActive = PMember->getMod(Mod::GILFINDER);
+                    }
+                }
+
+                // Calculate gil for each party member.
+                uint32 gilPerPerson = static_cast<uint32>(gil / members.size());
+                gilPerPerson        = gilPerPerson * (100 + gilFinderActive) / 100;
+
+                for (auto PMember : members)
+                {
                     UpdateItem(PMember, LOC_INVENTORY, 0, gilPerPerson);
                     PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, gilPerPerson, 0, 565));
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the gil distribution to party members when one or more members has a gilfinder trait. Currently, each player with gilfinder trait gets extra gil relative to their gilfinder level (while players without gilfinder get no extra gil). However retail testing (can also see [JP wiki](https://wiki.ffo.jp/html/1677.html)) shows that each player (even those without gilfinder) should get extra gil relative to the highest gilfinder level across the entire party (thus all party members should get equal gil).

This is an ASB fix coming upstream.

## Steps to test these changes
Go to a zone with two players (one with gilfinder and one without) in a party and kill beastmen. Notice that each player gets an equal amuont of gilfinder-boosted gil. Also can kill them with players with different gilfinder levels and notice that the highest level applies to both players.
