### PR TITLE
[core] Use bcrypt instead of MariaDB PASSWORD() + automatic migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,6 +421,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y software-properties-common cmake mariadb-client-10.6 libmariadb-dev-compat libluajit-5.1-dev libzmq3-dev zlib1g-dev libssl-dev luarocks binutils-dev
+        pip install bcrypt
     - name: Verify MySQL connection from container
       run: |
         mysql -h 127.0.0.1 -uroot -proot -e "SHOW DATABASES"
@@ -489,8 +490,9 @@ jobs:
           mysqlcmd "DELETE FROM char_unlocks;"
 
           # Create an account
+          PASSWORD_HASH=\$2a\$12\$piFoDKvu80KK68xLgQFpt.ZCqVPTjPmhSUfA31.Yw9n404dTsrR6q
           mysqlcmd "INSERT INTO accounts (id, login, password, timecreate, timelastmodify, status, priv)
-          VALUES(1000, 'admin', PASSWORD('admin'), NOW(), NOW(), 1, 1);
+          VALUES(1000, 'admin1', '$PASSWORD_HASH', NOW(), NOW(), 1, 1);
           SELECT id, login, content_ids FROM accounts;"
 
           # Create a character
@@ -529,7 +531,7 @@ jobs:
           import time
           try:
               from tools.headlessxi.hxiclient import HXIClient
-              hxi_client = HXIClient('admin', 'admin', 'localhost')
+              hxi_client = HXIClient('admin1', 'admin1', 'localhost')
               hxi_client.login()
               print('Sleeping 60s')
               time.sleep(60)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -150,9 +150,7 @@ CPMAddPackage(
     GITHUB_REPOSITORY imneme/pcg-cpp
     GIT_TAG 428802d1a5634f96bcd0705fab379ff0113bcf13
 ) # defines: pcg-cpp
-
-# pcg-cpp does not include cmake
-if(pcg-cpp_ADDED)
+if(pcg-cpp_ADDED) # pcg-cpp does not include cmake
     add_library(pcg-cpp INTERFACE)
     target_include_directories(pcg-cpp SYSTEM INTERFACE ${pcg-cpp_SOURCE_DIR}/include/)
 endif()
@@ -211,6 +209,28 @@ if(asio_ADDED)
     endif()
 endif()
 
+CPMAddPackage(
+    NAME bcrypt
+    GITHUB_REPOSITORY zach2good/libbcrypt
+    GIT_TAG fb50b847ae760f16ab84a367452027b246df13e1
+    DOWNLOAD_ONLY ON
+) # defines: bcrypt
+if(bcrypt_ADDED) # bcrypt's cmake isn't suitable for us
+    add_library(bcrypt
+        STATIC
+            ${bcrypt_SOURCE_DIR}/src/bcrypt.c
+            ${bcrypt_SOURCE_DIR}/src/crypt_blowfish.c
+            ${bcrypt_SOURCE_DIR}/src/crypt_gensalt.c
+            ${bcrypt_SOURCE_DIR}/src/wrapper.c
+            ${bcrypt_SOURCE_DIR}/src/x86.S
+    )
+    target_include_directories(bcrypt
+        SYSTEM INTERFACE
+            ${bcrypt_SOURCE_DIR}/include/
+            $<$<PLATFORM_ID:Linux>:${bcrypt_SOURCE_DIR}/include/bcrypt/>
+    )
+endif()
+
 set(EXTERNAL_LIBS
     fmt::fmt
     spdlog
@@ -229,6 +249,7 @@ set(EXTERNAL_LIBS
     nlohmann_json::nlohmann_json
     pcg-cpp
     asio
+    bcrypt
 )
 
 if(WIN32)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Stops using Maria's `PASSWORD()` for hashing and storage in the db. Instead uses bcrypt.
- Offers an automatic migration path for users. New accounts will start using bcrypt right away, users logging in or changing their PW will be migrated to the new system seamlessly.
- Update CI in the one place where we make a fake account to login

:star: another PR while I'm packed into a train under the channel tunnel