### PR TITLE
[core] Fix several ranged state issues

### DIFF
--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -104,7 +104,7 @@ bool CRangeState::Update(time_point tick)
         auto* PTarget = m_PEntity->IsValidTarget(m_targid, TARGET_ENEMY, m_errorMsg);
 
         CanUseRangedAttack(PTarget, true);
-        if (m_startPos.x != m_PEntity->loc.p.x || m_startPos.y != m_PEntity->loc.p.y)
+        if (HasMoved())
         {
             m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, 0, 0, MSGBASIC_MOVE_AND_INTERRUPT);
         }
@@ -126,6 +126,8 @@ bool CRangeState::Update(time_point tick)
             {
                 PChar->pushPacket(m_errorMsg.release());
             }
+            // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
+            m_aimTime = std::chrono::seconds(0);
             m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, new CActionPacket(action));
         }
         else
@@ -138,7 +140,16 @@ bool CRangeState::Update(time_point tick)
         Complete();
     }
 
-    return IsCompleted() && tick > GetEntryTime() + m_aimTime + 1.5s;
+    if (IsCompleted() && tick > GetEntryTime() + m_aimTime + m_returnWeaponDelay)
+    {
+        if (auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
+        {
+            PChar->m_LastRangedAttackTime = GetEntryTime() + m_aimTime + m_returnWeaponDelay;
+        }
+        return true;
+    }
+
+    return false;
 }
 
 void CRangeState::Cleanup(time_point tick)
@@ -208,6 +219,16 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
         return false;
     }
 
+    // make sure player is waiting the appropriate time between ranged attacks
+    if (auto PChar = dynamic_cast<CCharEntity*>(m_PEntity))
+    {
+        if (m_PEntity->PAI->getTick() - PChar->m_LastRangedAttackTime < m_freePhaseTime)
+        {
+            m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, 0, 0, MSGBASIC_WAIT_LONGER);
+            return false;
+        }
+    }
+
     uint8 anim = m_PEntity->animation;
     if (anim != ANIMATION_NONE && anim != ANIMATION_ATTACK)
     {
@@ -216,4 +237,11 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
     }
 
     return true;
+}
+
+bool CRangeState::HasMoved()
+{
+    return floorf(m_startPos.x * 10 + 0.5f) / 10 != floorf(m_PEntity->loc.p.x * 10 + 0.5f) / 10 ||
+           floorf(m_startPos.y * 10 + 0.5f) / 10 != floorf(m_PEntity->loc.p.y * 10 + 0.5f) / 10 ||
+           floorf(m_startPos.z * 10 + 0.5f) / 10 != floorf(m_PEntity->loc.p.z * 10 + 0.5f) / 10;
 }

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -49,10 +49,13 @@ protected:
     virtual bool Update(time_point tick) override;
     virtual void Cleanup(time_point tick) override;
     bool         CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack);
+    bool         HasMoved();
 
 private:
     CBattleEntity* const m_PEntity;
-    duration             m_aimTime{};
+    duration             m_aimTime{};                                           // The calculated "phase 1" delay based on weapon and job trait reductions
+    const duration       m_returnWeaponDelay = std::chrono::milliseconds(1500); // Phase 2: Putting the weapon back after a shot
+    const duration       m_freePhaseTime     = std::chrono::milliseconds(1100); // Phase 3: The cooldown after a ranged attack is executed.
     bool                 m_rapidShot{ false };
     position_t           m_startPos;
 };

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -495,6 +495,7 @@ public:
     bool       m_EquipSwap; // true if equipment was recently changed
     bool       m_EffectsChanged;
     time_point m_LastSynthTime;
+    time_point m_LastRangedAttackTime;
 
     CHAR_SUBSTATE m_Substate;
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -37,6 +37,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/
 #include "ai/ai_container.h"
 #include "ai/states/attack_state.h"
 #include "ai/states/item_state.h"
+#include "ai/states/range_state.h"
 
 #include "packets/char_abilities.h"
 #include "packets/char_appearance.h"
@@ -2607,6 +2608,16 @@ namespace charutils
         if (PItem && PItem == PChar->getEquip((SLOTTYPE)equipSlotID))
         {
             return;
+        }
+
+        // if player attempts to change thier ranged weapon during a ranged state then prevent equip
+        // this prevents players from starting a RA with short delay x-bow and ending with high dmg longbow
+        if (equipSlotID == SLOT_RANGED || (equipSlotID == SLOT_AMMO && !PChar->getEquip(SLOT_RANGED)))
+        {
+            if (PChar->PAI && PChar->PAI->IsCurrentState<CRangeState>())
+            {
+                return;
+            }
         }
 
         if (equipSlotID == SLOT_SUB && PItem && !PItem->IsShield())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes several issues with the ranged state:
1. The PR adds code to prevent players from swapping ranged weapons and ammo (if no ranged weapon) if the player is in the middle of a ranged attack. This prevents players from starting a RA with a low delay x-bow and ending with a high damage gun (thus gaining the benefit of both). This has been seen in practice on servers.
2. The PR adds a check to make sure players are waiting the appropriate time between ranged attacks and thus not gaming the system through client manipulation.
3. The PR adds a reset of the aim time in cases of RA interrupt so the player does not need to wait the entire duration of a RA until the player can try a RA again.
4. The PR adds a hasMoved function to ranged state (similar to magic state) so that there can be a micro-movement when using RA (as blinking from gear change can cause a movement of less than 0.001).

## Steps to test these changes
1. Start a RA with a xbox and try changing to a gun midway through aiming, you should be prevented from changing.
2. Try to use RAs very quickly
3. Interrupt an RA my some means and see that you only have to wait 2.7 seconds until trying again (even if the weapon has a very large delay like a gun).
4. Use an RA and change gear while aiming and see that you will not be interrupted
