### PR TITLE
[search] Add whitelist for search address-in-use checks

### DIFF
--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -22,4 +22,11 @@ xi.settings.search =
 
     -- Interval is in seconds, default is one hour
     EXPIRE_INTERVAL = 3600,
+
+    -- IP address strings in this list won't be subject to 'IPAddressesInUse' rate limiting
+    ACCESS_WHITELIST =
+    {
+        "127.0.0.1",   -- Example, not actually needed
+        "192.168.0.1", -- Example, not actually needed
+    },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [not yet] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/5141

Also gets rid of a raw mutex in favour of the new helper

## Steps to test these changes

- Do search stuff from a whitelisted IP
- Do search stuff from a non-whitelisted IP, get limited
