### PR TITLE
[Lua] Move Aweuvhi logic to family mixin, add animation/aggressive relation

### DIFF
--- a/scripts/mixins/families/aweuvhi.lua
+++ b/scripts/mixins/families/aweuvhi.lua
@@ -1,0 +1,91 @@
+require('scripts/globals/mixins')
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+g_mixins.families.aweuvhi = function(aweuvhiMob)
+    aweuvhiMob:addListener('SPAWN', 'AWEUVHI_SPAWN', function(mob)
+        -- Set a random animation when it spawns
+        mob:setAnimationSub(math.random(0, 3))
+        mob:setLocalVar('roamTime', os.time())
+    end)
+
+    aweuvhiMob:addListener('COMBAT_TICK', 'AWEUVHI_COMBAT', function(mob)
+        -- Forms: 0 = Closed  1 = Closed  2 = Open 3 = Closed
+        -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
+        -- ..when attacked will change states every minute or so..
+        local randomTime = math.random(50, 75)
+        local changeTime = mob:getLocalVar('changeTime')
+
+        if mob:getBattleTime() - changeTime > randomTime then
+            if mob:getAnimationSub() == 2 then
+                mob:setAnimationSub(1)
+            else
+                mob:setAnimationSub(2)
+            end
+
+            mob:setLocalVar('changeTime', mob:getBattleTime())
+
+            -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
+            -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
+            -- Make everything do double
+            if mob:getAnimationSub() == 2 then
+                mob:setMod(xi.mod.HTH_SDT, 2000)
+                mob:setMod(xi.mod.SLASH_SDT, 2000)
+                mob:setMod(xi.mod.PIERCE_SDT, 2000)
+                mob:setMod(xi.mod.IMPACT_SDT, 2000)
+                for n = 1, #xi.magic.resistMod, 1 do
+                    mob:setMod(xi.magic.resistMod[n], 2000)
+                end
+
+                for n = 1, #xi.magic.specificDmgTakenMod, 1 do
+                    mob:setMod(xi.magic.specificDmgTakenMod[n], -10000)
+                end
+            else -- Reset all damage types
+                mob:setMod(xi.mod.HTH_SDT, 1000)
+                mob:setMod(xi.mod.SLASH_SDT, 1000)
+                mob:setMod(xi.mod.PIERCE_SDT, 1000)
+                mob:setMod(xi.mod.IMPACT_SDT, 1000)
+
+                for n = 1, #xi.magic.resistMod, 1 do
+                    mob:setMod(xi.magic.resistMod[n], 1000)
+                end
+
+                for n = 1, #xi.magic.specificDmgTakenMod, 1 do
+                    mob:setMod(xi.magic.specificDmgTakenMod[n], 10000)
+                end
+            end
+        end
+    end)
+
+    aweuvhiMob:addListener('ROAM_TICK', 'AWEUVHI_ROAM', function(mob)
+        local roamTime = mob:getLocalVar('roamTime')
+
+        if os.time() - roamTime > 60 then
+            local randomSub = math.random(0, 2) * 5  -- AnimationSub: 0, 1, or 6 (3-5 don't do anything)
+            mob:setAnimationSub(randomSub)
+            mob:setLocalVar('roamTime', os.time())
+
+            if
+                mob:getZoneID() == xi.zone.THE_GARDEN_OF_RUHMET and
+                randomSub == 0 or
+                randomSub == 5
+            then
+                mob:setAggressive(false)
+            else
+                mob:setAggressive(true)
+            end
+        end
+    end)
+
+    aweuvhiMob:addListener('CRITICAL_TAKE', 'AWEUVHI_CRITICAL_TAKE', function(mob)
+        -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
+        -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
+        -- Crit is really the only thing we can do.
+        if mob:getAnimationSub() == 2 then
+            mob:setAnimationSub(0)
+        end
+    end)
+end
+
+return g_mixins.families.aweuvhi

--- a/scripts/zones/AlTaieu/mobs/Aweuvhi.lua
+++ b/scripts/zones/AlTaieu/mobs/Aweuvhi.lua
@@ -2,6 +2,8 @@
 -- Area: AlTaieu
 --  Mob: Aw'euvhi
 -----------------------------------
+mixins = { require('scripts/mixins/families/aweuvhi') }
+-----------------------------------
 local ID = zones[xi.zone.ALTAIEU]
 -----------------------------------
 local entity = {}

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Aweuvhi.lua
@@ -2,70 +2,14 @@
 -- Area: The Garden of Ru'Hmet
 --  Mob: Aw'euvhi
 -----------------------------------
+mixins = { require('scripts/mixins/families/aweuvhi') }
+-----------------------------------
 local entity = {}
 
 entity.onMobSpawn = function(mob)
-    -- Set a random animation when it spawns
-    mob:setAnimationSub(math.random(1, 4))
 end
 
-entity.onMobFight = function(mob)
-    -- Forms: 0 = Closed  1 = Closed  2 = Open 3 = Closed
-    -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
-    -- ..when attacked will change states every minute or so..
-    local randomTime = math.random(50, 75)
-    local changeTime = mob:getLocalVar('changeTime')
-
-    if mob:getBattleTime() - changeTime > randomTime then
-        if mob:getAnimationSub() == 2 then
-            mob:setAnimationSub(1)
-        else
-            mob:setAnimationSub(2)
-        end
-
-        mob:setLocalVar('changeTime', mob:getBattleTime())
-
-        -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
-        -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
-        -- Make everything do double
-        if mob:getAnimationSub() == 2 then
-            mob:setMod(xi.mod.HTH_SDT, 2000)
-            mob:setMod(xi.mod.SLASH_SDT, 2000)
-            mob:setMod(xi.mod.PIERCE_SDT, 2000)
-            mob:setMod(xi.mod.IMPACT_SDT, 2000)
-            for n = 1, #xi.magic.resistMod, 1 do
-                mob:setMod(xi.magic.resistMod[n], 2000)
-            end
-
-            for n = 1, #xi.magic.specificDmgTakenMod, 1 do
-                mob:setMod(xi.magic.specificDmgTakenMod[n], -10000)
-            end
-        else -- Reset all damage types
-            mob:setMod(xi.mod.HTH_SDT, 1000)
-            mob:setMod(xi.mod.SLASH_SDT, 1000)
-            mob:setMod(xi.mod.PIERCE_SDT, 1000)
-            mob:setMod(xi.mod.IMPACT_SDT, 1000)
-            for n = 1, #xi.magic.resistMod, 1 do
-                mob:setMod(xi.magic.resistMod[n], 1000)
-            end
-
-            for n = 1, #xi.magic.specificDmgTakenMod, 1 do
-                mob:setMod(xi.magic.specificDmgTakenMod[n], 10000)
-            end
-        end
-    end
-end
-
-entity.onCriticalHit = function(target)
-    -- According to http://wiki.ffxiclopedia.org/wiki/Category:Euvhi
-    -- When in an open state, damage taken by the Euvhi is doubled. Inflicting a large amount of damage to an Euvhi in an open state will cause it to close.
-    -- Crit is really the only thing we can do.
-    if target:getAnimationSub() == 2 then
-        target:setAnimationSub(0)
-    end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
+entity.onMobFight = function(mob, target)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Aweuvhi's do not currently change their form while roaming like retail does.
Additionally, we have no existing logic to support these mobs' aggressive states based on their current animationSub.
They should be aggressive while open, and non-aggressive while closed.

I've moved the logic from the mob script into a family mixin and added some new logic for ROAM_TICK to randomly alternate between available forms and set aggressive state based on the animationSub chosen.

I've also added an additional zone check to ensure that the Aweuvhis only become aggressive in The Garden of Ruhmet.

## Steps to test these changes
AlTaieu:
!gotoid 16912811
Follow it around and see it will change forms every periodically, but never aggro you.

Ruhmet:
!gotoid 16920628 with !togglegm on
Take GM status off, and if flower is open, it will aggro, otherwise, it will not.


