### PR TITLE
[build] Add /wd5272 for newest MSVC

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -18,6 +18,7 @@ function(set_project_warnings project_name)
       /wd4457 # declaration of 'var' hides function parameter
       /wd4458 # declaration of 'var' hides class member
       /wd4459 # declaration of 'var' hides global declaration
+      /wd5272 # throwing an object of non-copyable type 'type' is non-standard -> CStateInitException
 
       # TODO: concurrentqueue triggers this. Remove once MSVC fixes it.
       # https://developercommunity2.visualstudio.com/t/C4554-triggers-when-both-lhs-and-rhs-is/10034931


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Newest MSVC added a bunch more warnings, one of which we trigger because CStateInitException has a unique_ptr as a member, making it inherently non-copyable.

Will be able to remove after https://github.com/LandSandBoat/server/issues/4024
